### PR TITLE
chore: fix version getters in components

### DIFF
--- a/packages/vaadin-accordion/src/vaadin-accordion.js
+++ b/packages/vaadin-accordion/src/vaadin-accordion.js
@@ -78,7 +78,7 @@ class AccordionElement extends ThemableMixin(ElementMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-app-layout/src/vaadin-app-layout.js
+++ b/packages/vaadin-app-layout/src/vaadin-app-layout.js
@@ -302,7 +302,7 @@ class AppLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-avatar/src/vaadin-avatar-group.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar-group.js
@@ -164,7 +164,7 @@ class AvatarGroupElement extends ElementMixin(ThemableMixin(mixinBehaviors([Iron
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-avatar/src/vaadin-avatar.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar.js
@@ -147,7 +147,7 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-board/src/vaadin-board.js
+++ b/packages/vaadin-board/src/vaadin-board.js
@@ -49,7 +49,7 @@ class BoardElement extends ElementMixin(mixinBehaviors([IronResizableBehavior], 
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   /**

--- a/packages/vaadin-button/src/vaadin-button.js
+++ b/packages/vaadin-button/src/vaadin-button.js
@@ -128,7 +128,7 @@ class ButtonElement extends ElementMixin(ControlStateMixin(ThemableMixin(Gesture
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   ready() {

--- a/packages/vaadin-charts/src/vaadin-chart.js
+++ b/packages/vaadin-charts/src/vaadin-chart.js
@@ -258,7 +258,7 @@ class ChartElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   /** @private */

--- a/packages/vaadin-checkbox/src/vaadin-checkbox.js
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox.js
@@ -116,7 +116,7 @@ class CheckboxElement extends ElementMixin(ControlStateMixin(ThemableMixin(Gestu
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.js
@@ -256,7 +256,7 @@ class ComboBoxElement extends ElementMixin(
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js
@@ -130,7 +130,7 @@ class ConfirmDialogElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.js
@@ -275,7 +275,7 @@ class ContextMenuElement extends ElementMixin(ThemePropertyMixin(ItemsMixin(Gest
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/vaadin-cookie-consent/src/vaadin-cookie-consent.js
@@ -53,7 +53,7 @@ class CookieConsentElement extends ElementMixin(PolymerElement) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -256,7 +256,7 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-custom-field/src/vaadin-custom-field.js
+++ b/packages/vaadin-custom-field/src/vaadin-custom-field.js
@@ -107,7 +107,7 @@ class CustomFieldElement extends ElementMixin(CustomFieldMixin(ThemableMixin(Pol
     return 'vaadin-custom-field';
   }
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-date-picker/src/vaadin-date-picker.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker.js
@@ -194,7 +194,7 @@ class DatePickerElement extends ElementMixin(
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.js
@@ -150,7 +150,7 @@ class DateTimePickerElement extends ElementMixin(ThemableMixin(PolymerElement)) 
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-details/src/vaadin-details.js
+++ b/packages/vaadin-details/src/vaadin-details.js
@@ -99,7 +99,7 @@ class DetailsElement extends ControlStateMixin(ElementMixin(ThemableMixin(Polyme
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -218,7 +218,7 @@ class DialogElement extends ThemePropertyMixin(
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-form-layout/src/vaadin-form-layout.js
+++ b/packages/vaadin-form-layout/src/vaadin-form-layout.js
@@ -161,7 +161,7 @@ class FormLayoutElement extends ElementMixin(ThemableMixin(mixinBehaviors([IronR
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.js
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.js
@@ -50,7 +50,7 @@ class GridProElement extends InlineEditingMixin(GridElement) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   /**

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -339,7 +339,7 @@ class GridElement extends ElementMixin(
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get observers() {

--- a/packages/vaadin-item/src/vaadin-item.js
+++ b/packages/vaadin-item/src/vaadin-item.js
@@ -71,7 +71,7 @@ class ItemElement extends ItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   constructor() {

--- a/packages/vaadin-list-box/src/vaadin-list-box.js
+++ b/packages/vaadin-list-box/src/vaadin-list-box.js
@@ -69,7 +69,7 @@ class ListBoxElement extends ElementMixin(MultiSelectListMixin(ThemableMixin(Pol
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-login/src/vaadin-login-form.js
+++ b/packages/vaadin-login/src/vaadin-login-form.js
@@ -107,7 +107,7 @@ class LoginFormElement extends LoginMixin(ElementMixin(ThemableMixin(PolymerElem
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   /** @protected */

--- a/packages/vaadin-lumo-styles/version.js
+++ b/packages/vaadin-lumo-styles/version.js
@@ -5,7 +5,7 @@
  */
 class Lumo extends HTMLElement {
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 }
 

--- a/packages/vaadin-material-styles/version.js
+++ b/packages/vaadin-material-styles/version.js
@@ -5,7 +5,7 @@
  */
 class Material extends HTMLElement {
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 }
 

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
@@ -108,7 +108,7 @@ class MenuBarElement extends ButtonsMixin(InteractionsMixin(ElementMixin(Themabl
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-messages/src/vaadin-message-avatar.js
+++ b/packages/vaadin-messages/src/vaadin-message-avatar.js
@@ -29,7 +29,7 @@ class MessageAvatarElement extends AvatarElement {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 }
 

--- a/packages/vaadin-messages/src/vaadin-message-input-button.js
+++ b/packages/vaadin-messages/src/vaadin-message-input-button.js
@@ -28,7 +28,7 @@ class MessageInputButtonElement extends ButtonElement {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 }
 

--- a/packages/vaadin-messages/src/vaadin-message-input-text-area.js
+++ b/packages/vaadin-messages/src/vaadin-message-input-text-area.js
@@ -29,7 +29,7 @@ class MessageInputTextAreaElement extends TextAreaElement {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-messages/src/vaadin-message-input.js
+++ b/packages/vaadin-messages/src/vaadin-message-input.js
@@ -112,7 +112,7 @@ class MessageInputElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   /**

--- a/packages/vaadin-messages/src/vaadin-message-list.js
+++ b/packages/vaadin-messages/src/vaadin-message-list.js
@@ -209,7 +209,7 @@ class MessageListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 }
 

--- a/packages/vaadin-messages/src/vaadin-message.js
+++ b/packages/vaadin-messages/src/vaadin-message.js
@@ -164,7 +164,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   ready() {

--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -269,7 +269,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-ordered-layout/src/vaadin-horizontal-layout.js
+++ b/packages/vaadin-ordered-layout/src/vaadin-horizontal-layout.js
@@ -84,7 +84,7 @@ class HorizontalLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 }
 

--- a/packages/vaadin-ordered-layout/src/vaadin-scroller.js
+++ b/packages/vaadin-ordered-layout/src/vaadin-scroller.js
@@ -68,7 +68,7 @@ class ScrollerElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 }
 

--- a/packages/vaadin-ordered-layout/src/vaadin-vertical-layout.js
+++ b/packages/vaadin-ordered-layout/src/vaadin-vertical-layout.js
@@ -75,7 +75,7 @@ class VerticalLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)) 
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 }
 

--- a/packages/vaadin-progress-bar/src/vaadin-progress-bar.js
+++ b/packages/vaadin-progress-bar/src/vaadin-progress-bar.js
@@ -86,7 +86,7 @@ class ProgressBarElement extends ElementMixin(ThemableMixin(ProgressMixin(Polyme
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 }
 

--- a/packages/vaadin-radio-button/src/vaadin-radio-button.js
+++ b/packages/vaadin-radio-button/src/vaadin-radio-button.js
@@ -108,7 +108,7 @@ class RadioButtonElement extends ElementMixin(ControlStateMixin(ThemableMixin(Ge
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
@@ -362,7 +362,7 @@ class RichTextEditorElement extends ElementMixin(ThemableMixin(PolymerElement)) 
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-select/src/vaadin-select.js
+++ b/packages/vaadin-select/src/vaadin-select.js
@@ -192,7 +192,7 @@ class SelectElement extends ElementMixin(
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-split-layout/src/vaadin-split-layout.js
+++ b/packages/vaadin-split-layout/src/vaadin-split-layout.js
@@ -225,7 +225,7 @@ class SplitLayoutElement extends ElementMixin(
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-tabs/src/vaadin-tab.js
+++ b/packages/vaadin-tabs/src/vaadin-tab.js
@@ -45,7 +45,7 @@ class TabElement extends ElementMixin(ThemableMixin(ItemMixin(PolymerElement))) 
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   ready() {

--- a/packages/vaadin-tabs/src/vaadin-tabs.js
+++ b/packages/vaadin-tabs/src/vaadin-tabs.js
@@ -148,7 +148,7 @@ class TabsElement extends ElementMixin(
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-text-field/src/vaadin-email-field.js
+++ b/packages/vaadin-text-field/src/vaadin-email-field.js
@@ -53,7 +53,7 @@ class EmailFieldElement extends TextFieldElement {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   /** @protected */

--- a/packages/vaadin-text-field/src/vaadin-integer-field.js
+++ b/packages/vaadin-text-field/src/vaadin-integer-field.js
@@ -26,7 +26,7 @@ class IntegerFieldElement extends NumberFieldElement {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-text-field/src/vaadin-number-field.js
+++ b/packages/vaadin-text-field/src/vaadin-number-field.js
@@ -105,7 +105,7 @@ class NumberFieldElement extends TextFieldElement {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-text-field/src/vaadin-password-field.js
+++ b/packages/vaadin-text-field/src/vaadin-password-field.js
@@ -76,7 +76,7 @@ class PasswordFieldElement extends TextFieldElement {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-text-field/src/vaadin-text-area.js
+++ b/packages/vaadin-text-field/src/vaadin-text-area.js
@@ -143,7 +143,7 @@ class TextAreaElement extends ElementMixin(TextFieldMixin(ControlStateMixin(Them
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   /** @protected */

--- a/packages/vaadin-text-field/src/vaadin-text-field.js
+++ b/packages/vaadin-text-field/src/vaadin-text-field.js
@@ -115,7 +115,7 @@ class TextFieldElement extends ElementMixin(TextFieldMixin(ControlStateMixin(The
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-time-picker/src/vaadin-time-picker.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker.js
@@ -135,7 +135,7 @@ class TimePickerElement extends ElementMixin(ControlStateMixin(ThemableMixin(Pol
     return 'vaadin-time-picker';
   }
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {

--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -118,7 +118,7 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get version() {
-    return '20.0.0-alpha1';
+    return '20.0.0-alpha2';
   }
 
   static get properties() {


### PR DESCRIPTION
For some reason this wasn't included to the commit from release build, probably because of using Lerna 4 in TeamCity.