### PR TITLE
chore: fix version script to run in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lint:css": "stylelint packages/**/src/*.js packages/**/theme/**/*-styles.js",
     "lint:js": "eslint *.js scripts packages",
     "lint:types": "tsc",
-    "preversion": "node scripts/updateVersion.js",
     "serve:dist": "web-dev-server --app-index dist/index.html --open",
     "test": "web-test-runner --coverage",
     "test:firefox": "web-test-runner --config web-test-runner-firefox.config.js",

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const spawn = require('cross-spawn');
 const replace = require('replace-in-file');
+const oldVersion = require('../lerna.json').version;
 
 /**
  * Runs the command without opening a new shell.
@@ -32,16 +33,9 @@ async function exe(cmd, quiet) {
   );
 }
 
-const oldVersion = process.env.npm_config_version;
-if (!oldVersion) {
-  console.log('No old version found');
-  process.exit(1);
-}
-
 const version = process.env.npm_config_bump;
 if (!version) {
-  console.log('No new version found');
-  process.exit(1);
+  throw new Error('No new version found');
 }
 
 async function main() {


### PR DESCRIPTION
The `preversion` lifecycle script does not seem to work in TeamCity:

```
lerna WARN lifecycle vaadin-web-components@undefined~preversion: cannot run in wd vaadin-web-components@undefined node scripts/updateVersion.js 
```

I have tried to solve it as suggested here https://github.com/lerna/lerna/issues/2346#issuecomment-565835855
But still no luck (the error is the same, and version getters are not updated).

So let's remove this from the `preversion` and instead run the script manually before the `lerna version` command.