### PR TITLE
chore: use recent tag for release notes

### DIFF
--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -6,8 +6,8 @@
  * Example
  *   ./scripts/generateReleaseNotes.js --from from_tag --to to_tag --compact
  *
- * When --to is not given HEAD is selected.
- * When --from is not given latest tag is selected.
+ * When --to is not given the latest tag is selected.
+ * When --from is not given the previous tag is selected.
  * When --compact is set, components are not listed, default is false
  */
 

--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -51,12 +51,12 @@ async function getReleases() {
   if (!from) {
     const branch = await run(`git rev-parse --abbrev-ref HEAD`);
     await run(`git pull origin ${branch} --tags`);
-    const tags = await run(`git tag --merged ${branch} --sort=-committerdate`);
-    from = tags.split('\n')[0];
+    const tags = await run(`git tag --merged ${branch} --sort='-*committerdate'`);
+    from = tags.split('\n')[1];
   }
 
   if (!to) {
-    to = 'HEAD';
+    to = `v${version}`;
   }
 }
 


### PR DESCRIPTION
Previously, when running `node scripts/generateReleaseNotes.js` without `--from` parameter used the first tag.
It does not make much sense as in practice we want to collect changes since the most recent tag.

This PR changes the script to properly collect changes between last 2 tags for running this script in release build.