### PR TITLE
fix: check if grid column is attached

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -508,7 +508,9 @@ class GridElement extends ElementMixin(
     }
 
     if (this._columnTree) {
-      this._columnTree[this._columnTree.length - 1].forEach((c) => c.notifyPath && c.notifyPath('_cells.*', c._cells));
+      this._columnTree[this._columnTree.length - 1].forEach(
+        (c) => c.isConnected && c.notifyPath && c.notifyPath('_cells.*', c._cells)
+      );
     }
 
     beforeNextRender(this, () => {

--- a/packages/vaadin-grid/test/column.test.js
+++ b/packages/vaadin-grid/test/column.test.js
@@ -555,10 +555,10 @@ describe('column', () => {
 
   it('should not throw an exception when size is changed after removing column', () => {
     expect(grid.size).to.equal(10);
-    const column = grid.querySelector('vaadin-grid-column');
     expect(column.isConnected).to.be.true;
     column.remove();
-    grid.size = 11;
     expect(column.isConnected).to.be.false;
+    expect(() => (grid.size = 11)).not.to.throw();
+    expect(grid.size).to.equal(11);
   });
 });

--- a/packages/vaadin-grid/test/column.test.js
+++ b/packages/vaadin-grid/test/column.test.js
@@ -552,4 +552,13 @@ describe('column', () => {
       expect(column._bodyTemplate).to.eql(template2);
     });
   });
+
+  it('should not throw an exception when size is changed after removing column', () => {
+    expect(grid.size).to.equal(10);
+    const column = grid.querySelector('vaadin-grid-column');
+    expect(column.isConnected).to.be.true;
+    column.remove();
+    grid.size = 11;
+    expect(column.isConnected).to.be.false;
+  });
 });


### PR DESCRIPTION
## Description
Fixes vaadin/vaadin-grid#1981

The error is caused by the grid manually invoking notifyPath for all columns regardless if they're detached or not. This fix adds a check that the column is attached.


## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.