### PR TITLE
Fix dir-mixin not respecting native HTMLElement API

### DIFF
--- a/packages/vaadin-element-mixin/test/dir-mixin.test.js
+++ b/packages/vaadin-element-mixin/test/dir-mixin.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DirMixin } from '../vaadin-dir-mixin.js';
+import sinon from 'sinon';
 
 class DirMixinElement extends DirMixin(PolymerElement) {
   static get is() {
@@ -27,27 +28,38 @@ describe('DirMixin', () => {
       expect(element.dir).to.equal('');
       expect(element.hasAttribute('dir')).to.be.false;
     });
+
     it('should match native behavior when setting property', () => {
       element.dir = 'rtl';
       expect(element.dir).to.equal('rtl');
       expect(element.getAttribute('dir')).to.equal('rtl');
     });
+
     it('should match native behavior when setting attribute', () => {
       element.setAttribute('dir', 'rtl');
       expect(element.dir).to.equal('rtl');
       expect(element.getAttribute('dir')).to.equal('rtl');
     });
+
     it('should match native behavior when clearing property', () => {
       element.dir = 'rtl';
       element.dir = '';
       expect(element.dir).to.equal('');
       expect(element.hasAttribute('dir')).to.be.false;
     });
+
     it('should match native behavior when clearing attribute', () => {
       element.setAttribute('dir', 'rtl');
       element.removeAttribute('dir');
       expect(element.dir).to.equal('');
       expect(element.hasAttribute('dir')).to.be.false;
+    });
+
+    it('should not call removeAttribute twice when clearing value', () => {
+      element.dir = 'rtl';
+      const spy = sinon.spy(element, 'removeAttribute');
+      element.removeAttribute('dir');
+      expect(spy.calledOnce).to.be.true;
     });
   });
 

--- a/packages/vaadin-element-mixin/test/dir-mixin.test.js
+++ b/packages/vaadin-element-mixin/test/dir-mixin.test.js
@@ -11,121 +11,163 @@ class DirMixinElement extends DirMixin(PolymerElement) {
 customElements.define(DirMixinElement.is, DirMixinElement);
 
 describe('DirMixin', () => {
-  const element = document.createElement('dir-mixin-element');
+  describe('Native HTMLElement.dir API', () => {
+    let element;
 
-  before(() => {
-    document.body.appendChild(element);
+    beforeEach(() => {
+      element = document.createElement('dir-mixin-element');
+      document.body.appendChild(element);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(element);
+    });
+
+    it('should match native behavior for initial values of property and attribute', () => {
+      expect(element.dir).to.equal('');
+      expect(element.hasAttribute('dir')).to.be.false;
+    });
+    it('should match native behavior when setting property', () => {
+      element.dir = 'rtl';
+      expect(element.dir).to.equal('rtl');
+      expect(element.getAttribute('dir')).to.equal('rtl');
+    });
+    it('should match native behavior when setting attribute', () => {
+      element.setAttribute('dir', 'rtl');
+      expect(element.dir).to.equal('rtl');
+      expect(element.getAttribute('dir')).to.equal('rtl');
+    });
+    it('should match native behavior when clearing property', () => {
+      element.dir = 'rtl';
+      element.dir = '';
+      expect(element.dir).to.equal('');
+      expect(element.hasAttribute('dir')).to.be.false;
+    });
+    it('should match native behavior when clearing attribute', () => {
+      element.setAttribute('dir', 'rtl');
+      element.removeAttribute('dir');
+      expect(element.dir).to.equal('');
+      expect(element.hasAttribute('dir')).to.be.false;
+    });
   });
 
-  after(() => {
-    document.body.removeChild(element);
-  });
+  describe('Document dir sync', () => {
+    const element = document.createElement('dir-mixin-element');
 
-  beforeEach(() => {
-    // Clean up the dir attribute
-    document.documentElement.removeAttribute('dir');
-    element.removeAttribute('dir');
-  });
+    before(() => {
+      document.body.appendChild(element);
+    });
 
-  // Check that for each `documentDirections` value set, `element` dir
-  // attribute value equals to the corresponding `elementDirections` value.
-  async function expectDirections(documentDirections, elementDirections) {
-    for (let index = 0; index < documentDirections.length; index++) {
-      setDir(documentDirections[index]);
-      await Promise.resolve();
-      expect(element.getAttribute('dir')).to.equal(elementDirections[index]);
-    }
-  }
+    after(() => {
+      document.body.removeChild(element);
+    });
 
-  // Toggle document dir attribute value
-  function setDir(direction) {
-    if (direction) {
-      document.documentElement.setAttribute('dir', direction);
-    } else {
+    beforeEach(() => {
+      // Clean up the dir attribute
       document.documentElement.removeAttribute('dir');
+      element.removeAttribute('dir');
+    });
+
+    // Check that for each `documentDirections` value set, `element` dir
+    // attribute value equals to the corresponding `elementDirections` value.
+    async function expectDirections(documentDirections, elementDirections) {
+      for (let index = 0; index < documentDirections.length; index++) {
+        setDir(documentDirections[index]);
+        await Promise.resolve();
+        expect(element.getAttribute('dir')).to.equal(elementDirections[index]);
+      }
     }
-  }
 
-  it('should propagate direction as dir attribute to the element from the documentElement', async () => {
-    await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['rtl', 'ltr', null, 'rtl', null]);
-  });
+    // Toggle document dir attribute value
+    function setDir(direction) {
+      if (direction) {
+        document.documentElement.setAttribute('dir', direction);
+      } else {
+        document.documentElement.removeAttribute('dir');
+      }
+    }
 
-  it('should preserve direction if was set by the user with setAttribute', async () => {
-    element.setAttribute('dir', 'ltr');
+    it('should propagate direction as dir attribute to the element from the documentElement', async () => {
+      await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['rtl', 'ltr', null, 'rtl', null]);
+    });
 
-    await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
-  });
+    it('should preserve direction if was set by the user with setAttribute', async () => {
+      element.setAttribute('dir', 'ltr');
 
-  it('should preserve direction if was set by the user with property', async () => {
-    element.dir = 'ltr';
+      await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
+    });
 
-    await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
-  });
+    it('should preserve direction if was set by the user with property', async () => {
+      element.dir = 'ltr';
 
-  it('should subscribe to the changes if set to equal the document direction using setAttribute', async () => {
-    element.setAttribute('dir', 'ltr');
+      await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
+    });
 
-    await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+    it('should subscribe to the changes if set to equal the document direction using setAttribute', async () => {
+      element.setAttribute('dir', 'ltr');
 
-    element.setAttribute('dir', 'rtl');
+      await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
-    await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
-  });
+      element.setAttribute('dir', 'rtl');
 
-  it('should subscribe to the changes if set to equal the document direction using property', async () => {
-    element.dir = 'ltr';
+      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+    });
 
-    await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+    it('should subscribe to the changes if set to equal the document direction using property', async () => {
+      element.dir = 'ltr';
 
-    element.dir = 'rtl';
+      await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
-    await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
-  });
+      element.dir = 'rtl';
 
-  it('should subscribe to the changes if attribute removed', async () => {
-    element.setAttribute('dir', 'ltr');
+      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+    });
 
-    await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+    it('should subscribe to the changes if attribute removed', async () => {
+      element.setAttribute('dir', 'ltr');
 
-    element.removeAttribute('dir');
+      await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
-    await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
-  });
+      element.removeAttribute('dir');
 
-  it('should subscribe to the changes if property cleared', async () => {
-    element.dir = 'ltr';
+      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+    });
 
-    await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+    it('should subscribe to the changes if property cleared', async () => {
+      element.dir = 'ltr';
 
-    element.dir = '';
+      await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
-    await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
-  });
+      element.dir = '';
 
-  it('should unsubscribe if attribute set by the user with setAttribute', async () => {
-    await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
+      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+    });
 
-    element.setAttribute('dir', 'ltr');
+    it('should unsubscribe if attribute set by the user with setAttribute', async () => {
+      await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
 
-    await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
-  });
+      element.setAttribute('dir', 'ltr');
 
-  it('should unsubscribe if attribute set by the user with property', async () => {
-    await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
+      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
+    });
 
-    element.dir = 'ltr';
+    it('should unsubscribe if attribute set by the user with property', async () => {
+      await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
 
-    await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
-  });
+      element.dir = 'ltr';
 
-  it('should clean up the changes after unsubscribing', async () => {
-    // Emulating overlay behavior
-    setDir('rtl');
-    await Promise.resolve();
-    document.body.appendChild(element);
+      await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
+    });
 
-    setDir('ltr');
-    await Promise.resolve();
-    expect(element.getAttribute('dir')).to.eql('ltr');
+    it('should clean up the changes after unsubscribing', async () => {
+      // Emulating overlay behavior
+      setDir('rtl');
+      await Promise.resolve();
+      document.body.appendChild(element);
+
+      setDir('ltr');
+      await Promise.resolve();
+      expect(element.getAttribute('dir')).to.eql('ltr');
+    });
   });
 });

--- a/packages/vaadin-element-mixin/test/dir-mixin.test.js
+++ b/packages/vaadin-element-mixin/test/dir-mixin.test.js
@@ -50,18 +50,34 @@ describe('DirMixin', () => {
     await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['rtl', 'ltr', null, 'rtl', null]);
   });
 
-  it('should preserve direction if was set by the user', async () => {
+  it('should preserve direction if was set by the user with setAttribute', async () => {
     element.setAttribute('dir', 'ltr');
 
     await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
   });
 
-  it('should subscribe to the changes if set to equal the document direction', async () => {
+  it('should preserve direction if was set by the user with property', async () => {
+    element.dir = 'ltr';
+
+    await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
+  });
+
+  it('should subscribe to the changes if set to equal the document direction using setAttribute', async () => {
     element.setAttribute('dir', 'ltr');
 
     await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
     element.setAttribute('dir', 'rtl');
+
+    await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+  });
+
+  it('should subscribe to the changes if set to equal the document direction using property', async () => {
+    element.dir = 'ltr';
+
+    await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+
+    element.dir = 'rtl';
 
     await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
   });
@@ -76,10 +92,28 @@ describe('DirMixin', () => {
     await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
   });
 
-  it('should unsubscribe if attribute set by the user', async () => {
+  it('should subscribe to the changes if property cleared', async () => {
+    element.dir = 'ltr';
+
+    await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
+
+    element.dir = '';
+
+    await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
+  });
+
+  it('should unsubscribe if attribute set by the user with setAttribute', async () => {
     await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
 
     element.setAttribute('dir', 'ltr');
+
+    await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
+  });
+
+  it('should unsubscribe if attribute set by the user with property', async () => {
+    await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
+
+    element.dir = 'ltr';
 
     await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
   });

--- a/packages/vaadin-element-mixin/vaadin-dir-mixin.d.ts
+++ b/packages/vaadin-element-mixin/vaadin-dir-mixin.d.ts
@@ -4,14 +4,13 @@ declare function DirMixin<T extends new (...args: any[]) => {}>(base: T): T & Di
 
 interface DirMixinConstructor {
   new (...args: any[]): DirMixin;
+
   finalize(): void;
 }
 
 export { DirMixinConstructor };
 
 interface DirMixin {
-  readonly dir: string | null | undefined;
-
   __getNormalizedScrollLeft(element: Element | null): number;
 
   __setNormalizedScrollLeft(element: Element | null, scrollLeft: number): void;

--- a/packages/vaadin-element-mixin/vaadin-dir-mixin.js
+++ b/packages/vaadin-element-mixin/vaadin-dir-mixin.js
@@ -21,12 +21,10 @@ let scrollType;
 const directionObserver = new MutationObserver(directionUpdater);
 directionObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['dir'] });
 
-const alignDirs = function (element, documentDir) {
-  const elementDir = element.getAttribute('dir');
-  if (elementDir === documentDir) return;
+const alignDirs = function (element, documentDir, elementDir = element.getAttribute('dir')) {
   if (documentDir) {
     element.setAttribute('dir', documentDir);
-  } else {
+  } else if (elementDir != null) {
     element.removeAttribute('dir');
   }
 };
@@ -68,7 +66,7 @@ export const DirMixin = (superClass) =>
 
       if (!this.hasAttribute('dir')) {
         this.__subscribe();
-        alignDirs(this, getDocumentDir());
+        alignDirs(this, getDocumentDir(), null);
       }
     }
 
@@ -79,16 +77,18 @@ export const DirMixin = (superClass) =>
         return;
       }
 
+      const documentDir = getDocumentDir();
+
       // New value equals to the document direction and the element is not subscribed to the changes
-      const newValueEqlDocDir = newValue === getDocumentDir() && directionSubscribers.indexOf(this) === -1;
+      const newValueEqlDocDir = newValue === documentDir && directionSubscribers.indexOf(this) === -1;
       // Value was emptied and the element is not subscribed to the changes
       const newValueEmptied = !newValue && oldValue && directionSubscribers.indexOf(this) === -1;
       // New value is different and the old equals to document direction and the element is not subscribed to the changes
-      const newDiffValue = newValue !== getDocumentDir() && oldValue === getDocumentDir();
+      const newDiffValue = newValue !== documentDir && oldValue === documentDir;
 
       if (newValueEqlDocDir || newValueEmptied) {
         this.__subscribe();
-        alignDirs(this, getDocumentDir());
+        alignDirs(this, documentDir, newValue);
       } else if (newDiffValue) {
         this.__subscribe(false);
       }

--- a/packages/vaadin-element-mixin/vaadin-dir-mixin.js
+++ b/packages/vaadin-element-mixin/vaadin-dir-mixin.js
@@ -22,6 +22,8 @@ const directionObserver = new MutationObserver(directionUpdater);
 directionObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['dir'] });
 
 const alignDirs = function (element, documentDir) {
+  const elementDir = element.getAttribute('dir');
+  if (elementDir === documentDir) return;
   if (documentDir) {
     element.setAttribute('dir', documentDir);
   } else {

--- a/packages/vaadin-element-mixin/vaadin-dir-mixin.js
+++ b/packages/vaadin-element-mixin/vaadin-dir-mixin.js
@@ -45,7 +45,7 @@ export const DirMixin = (superClass) =>
          */
         dir: {
           type: String,
-          readOnly: true
+          reflectToAttribute: true
         }
       };
     }

--- a/packages/vaadin-element-mixin/vaadin-dir-mixin.js
+++ b/packages/vaadin-element-mixin/vaadin-dir-mixin.js
@@ -45,6 +45,7 @@ export const DirMixin = (superClass) =>
          */
         dir: {
           type: String,
+          value: '',
           reflectToAttribute: true
         }
       };
@@ -96,6 +97,27 @@ export const DirMixin = (superClass) =>
       super.disconnectedCallback();
       this.__subscribe(false);
       this.removeAttribute('dir');
+    }
+
+    /** @protected */
+    _valueToNodeAttribute(node, value, attribute) {
+      // Override default Polymer attribute reflection to match native behavior of HTMLElement.dir property
+      // If the property contains an empty string then it should not create an empty attribute
+      if (attribute === 'dir' && value === '' && !node.hasAttribute('dir')) {
+        return;
+      }
+      super._valueToNodeAttribute(node, value, attribute);
+    }
+
+    /** @protected */
+    _attributeToProperty(attribute, value, type) {
+      // Override default Polymer attribute reflection to match native behavior of HTMLElement.dir property
+      // If the attribute is removed, then the dir property should contain an empty string instead of null
+      if (attribute === 'dir' && !value) {
+        this.dir = '';
+      } else {
+        super._attributeToProperty(attribute, value, type);
+      }
     }
 
     /** @private */


### PR DESCRIPTION
The current DirMixin implementation basically reimplements the native `HTMLElement.dir` property and makes it readonly, which breaks the native API which allows you to set the direction through the property directly:
```
element.dir = 'rtl';
```

This PR fixes it by allowing write access to the property, while syncing changes from the property to the attribute, which is also native behavior.

I also removed the incompatible `dir` property declaration in the typings as it should now match the property inherited from `HTMLElement`.