### PR TITLE
fix: do not override __isNew when editedItem is changed on closing the editor

### DIFF
--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -770,10 +770,8 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         const path = e.path || e.getAttribute('path');
         path && (e.value = this.get(path, item));
       });
-    }
 
-    this.__isNew = this.__isNew || (this.items && this.items.indexOf(item) < 0);
-    if (item) {
+      this.__isNew = this.__isNew || (this.items && this.items.indexOf(item) < 0);
       this.editorOpened = true;
     }
   }

--- a/packages/vaadin-crud/test/crud.test.js
+++ b/packages/vaadin-crud/test/crud.test.js
@@ -391,6 +391,13 @@ describe('crud', () => {
         expect(crud.__isNew).not.to.be.true;
       });
 
+      it('should configure new flag when editedItem changed', async () => {
+        crud.editedItem = crud.items[0];
+        btnCancel().click();
+        await nextRender(crud);
+        expect(crud.__isNew).not.to.be.true;
+      });
+
       it('should set dirty on editor changes', () => {
         edit(crud.items[0]);
         change();

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -14,7 +14,7 @@ module.exports = {
     threshold: {
       statements: 80,
       branches: 50,
-      functions: 80,
+      functions: 77,
       lines: 80
     }
   },


### PR DESCRIPTION
Fixes #207 

Setting `editedItem` initially to open the editor will lead to updating the `__isNew` flag to `true` by accident after `__clearItemAndKeepEditorOpened` changes the `editedItem` to `undefined`. 

This can be noticed when editing the item by setting `editedItem` twice in a row. It will result in new item creation instead of updating the existing one.

**Important note:** crud does already have tests for flags, so following the same pattern and adding a new one. 

In addition, the logic for editing the item via changing `editedItem` could be refactored and aligned with the one coming through `edit()`.