### PR TITLE
feat: allow passing specific item type to Grid component types

### DIFF
--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -1,6 +1,6 @@
 import { GridColumnElement } from '@vaadin/vaadin-grid/src/vaadin-grid-column.js';
 
-import { GridBodyRenderer, GridItemModel } from '@vaadin/vaadin-grid';
+import { DefaultGridItem, GridBodyRenderer, GridItemModel } from '@vaadin/vaadin-grid';
 
 import { GridProEditorType } from './interfaces';
 
@@ -19,7 +19,7 @@ import { GridProEditorType } from './interfaces';
  *    ...
  * ```
  */
-declare class GridProEditColumnElement extends GridColumnElement {
+declare class GridProEditColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
   /**
    * JS Path of the property in the item used for the editable content.
    */
@@ -39,7 +39,7 @@ declare class GridProEditColumnElement extends GridColumnElement {
    *   - `rowData.level` Level of the tree represented with a horizontal offset of the toggle button.
    *   - `rowData.selected` Selected state.
    */
-  editModeRenderer: GridBodyRenderer | null | undefined;
+  editModeRenderer: GridBodyRenderer<TItem> | null | undefined;
 
   /**
    * The list of options which should be passed to cell editor component.
@@ -86,14 +86,14 @@ declare class GridProEditColumnElement extends GridColumnElement {
 
   _getEditorValue(editor: HTMLElement): unknown | null;
 
-  _startCellEdit(cell: HTMLElement, model: GridItemModel): void;
+  _startCellEdit(cell: HTMLElement, model: GridItemModel<TItem>): void;
 
-  _stopCellEdit(cell: HTMLElement, model: GridItemModel): void;
+  _stopCellEdit(cell: HTMLElement, model: GridItemModel<TItem>): void;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-pro-edit-column': GridProEditColumnElement;
+    'vaadin-grid-pro-edit-column': GridProEditColumnElement<DefaultGridItem>;
   }
 }
 

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -1,6 +1,6 @@
 import { GridColumnElement } from '@vaadin/vaadin-grid/src/vaadin-grid-column.js';
 
-import { DefaultGridItem, GridBodyRenderer, GridItemModel } from '@vaadin/vaadin-grid';
+import { GridDefaultItem, GridBodyRenderer, GridItemModel } from '@vaadin/vaadin-grid';
 
 import { GridProEditorType } from './interfaces';
 
@@ -19,7 +19,7 @@ import { GridProEditorType } from './interfaces';
  *    ...
  * ```
  */
-declare class GridProEditColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
+declare class GridProEditColumnElement<TItem = GridDefaultItem> extends GridColumnElement<TItem> {
   /**
    * JS Path of the property in the item used for the editable content.
    */
@@ -93,7 +93,7 @@ declare class GridProEditColumnElement<TItem = DefaultGridItem> extends GridColu
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-pro-edit-column': GridProEditColumnElement<DefaultGridItem>;
+    'vaadin-grid-pro-edit-column': GridProEditColumnElement<GridDefaultItem>;
   }
 }
 

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
@@ -1,11 +1,9 @@
-import { GridItem } from '@vaadin/vaadin-grid';
-
-declare function InlineEditingMixin<T extends new (...args: any[]) => {}>(base: T): T & InlineEditingMixinConstructor;
-interface InlineEditingMixinConstructor {
-  new (...args: any[]): InlineEditingMixin;
+declare function InlineEditingMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & InlineEditingMixinConstructor<TItem>;
+interface InlineEditingMixinConstructor<TItem> {
+  new (...args: any[]): InlineEditingMixin<TItem>;
 }
 
-interface InlineEditingMixin {
+interface InlineEditingMixin<TItem> {
   /**
    * When true, pressing Enter while in cell edit mode
    * will move focus to the editable cell in the next row
@@ -36,8 +34,6 @@ interface InlineEditingMixin {
   _stopEdit(shouldCancel?: boolean, shouldRestoreFocus?: boolean): void;
 
   _switchEditCell(e: KeyboardEvent): void;
-
-  _updateItem(row: HTMLElement, item: GridItem | null): void;
 }
 
 export { InlineEditingMixin, InlineEditingMixinConstructor };

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
@@ -1,12 +1,10 @@
-declare function InlineEditingMixin<TItem, T extends new (...args: any[]) => {}>(
-  base: T
-): T & InlineEditingMixinConstructor<TItem>;
+declare function InlineEditingMixin<T extends new (...args: any[]) => {}>(base: T): T & InlineEditingMixinConstructor;
 
-interface InlineEditingMixinConstructor<TItem> {
-  new (...args: any[]): InlineEditingMixin<TItem>;
+interface InlineEditingMixinConstructor {
+  new (...args: any[]): InlineEditingMixin;
 }
 
-interface InlineEditingMixin<TItem> {
+interface InlineEditingMixin {
   /**
    * When true, pressing Enter while in cell edit mode
    * will move focus to the editable cell in the next row

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
@@ -1,4 +1,7 @@
-declare function InlineEditingMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & InlineEditingMixinConstructor<TItem>;
+declare function InlineEditingMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & InlineEditingMixinConstructor<TItem>;
+
 interface InlineEditingMixinConstructor<TItem> {
   new (...args: any[]): InlineEditingMixin<TItem>;
 }

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
@@ -1,16 +1,15 @@
+import { DefaultGridItem } from '@vaadin/vaadin-grid';
 import { GridElement, GridElementEventMap } from '@vaadin/vaadin-grid/src/vaadin-grid';
-
-import { GridItem } from '@vaadin/vaadin-grid';
 
 import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
 
 /**
  * Fired when the user starts editing a grid cell.
  */
-export type GridProCellEditStartedEvent = CustomEvent<{
+export type GridProCellEditStartedEvent<TItem> = CustomEvent<{
   value: {
     index: number;
-    item: GridItem;
+    item: TItem;
     path: string;
   };
 }>;
@@ -18,22 +17,27 @@ export type GridProCellEditStartedEvent = CustomEvent<{
 /**
  * Fired before exiting the cell edit mode, if the value has been changed.
  */
-export type GridProItemPropertyChangedEvent = CustomEvent<{
+export type GridProItemPropertyChangedEvent<TItem> = CustomEvent<{
   value: {
     index: number;
-    item: GridItem;
+    item: TItem;
     path: string;
     value: string | boolean;
   };
 }>;
 
-export interface GridProElementEventMap {
-  'cell-edit-started': GridProCellEditStartedEvent;
+export interface GridProElementEventMap<TItem> {
+  'cell-edit-started': GridProCellEditStartedEvent<TItem>;
 
-  'item-property-changed': GridProItemPropertyChangedEvent;
+  'item-property-changed': GridProItemPropertyChangedEvent<TItem>;
 }
 
-export interface GridProEventMap extends HTMLElementEventMap, GridProElementEventMap, GridElementEventMap {}
+export interface GridProEventMap<TItem>
+  extends HTMLElementEventMap,
+    GridProElementEventMap<TItem>,
+    GridElementEventMap<TItem> {}
+
+interface GridProElement<TItem = DefaultGridItem> extends InlineEditingMixin<TItem> {}
 
 /**
  * `<vaadin-grid-pro>` is a high quality data grid / data table Web Component with extended functionality.
@@ -67,25 +71,25 @@ export interface GridProEventMap extends HTMLElementEventMap, GridProElementEven
  * @fires {CustomEvent} loading-changed - Fired when the `loading` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  */
-declare class GridProElement extends InlineEditingMixin(GridElement) {
+declare class GridProElement<TItem = DefaultGridItem> extends GridElement {
   static _finalizeClass(): void;
 
-  addEventListener<K extends keyof GridProEventMap>(
+  addEventListener<K extends keyof GridProEventMap<TItem>>(
     type: K,
-    listener: (this: GridProElement, ev: GridProEventMap[K]) => void,
+    listener: (this: GridProElement<TItem>, ev: GridProEventMap<TItem>[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
-  removeEventListener<K extends keyof GridProEventMap>(
+  removeEventListener<K extends keyof GridProEventMap<TItem>>(
     type: K,
-    listener: (this: GridProElement, ev: GridProEventMap[K]) => void,
+    listener: (this: GridProElement<TItem>, ev: GridProEventMap<TItem>[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-pro': GridProElement;
+    'vaadin-grid-pro': GridProElement<DefaultGridItem>;
   }
 }
 

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
@@ -37,8 +37,6 @@ export interface GridProEventMap<TItem>
     GridProElementEventMap<TItem>,
     GridElementEventMap<TItem> {}
 
-interface GridProElement<TItem = DefaultGridItem> extends InlineEditingMixin<TItem> {}
-
 /**
  * `<vaadin-grid-pro>` is a high quality data grid / data table Web Component with extended functionality.
  * It extends `<vaadin-grid>` and adds extra features on top of the basic ones.
@@ -86,6 +84,8 @@ declare class GridProElement<TItem = DefaultGridItem> extends GridElement {
     options?: boolean | EventListenerOptions
   ): void;
 }
+
+interface GridProElement<TItem = DefaultGridItem> extends InlineEditingMixin<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
@@ -1,5 +1,4 @@
-import { GridDefaultItem } from '@vaadin/vaadin-grid';
-import { GridElement, GridElementEventMap } from '@vaadin/vaadin-grid/src/vaadin-grid';
+import { GridDefaultItem , GridElement, GridElementEventMap } from '@vaadin/vaadin-grid';
 
 import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
 

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
@@ -1,4 +1,4 @@
-import { DefaultGridItem } from '@vaadin/vaadin-grid';
+import { GridDefaultItem } from '@vaadin/vaadin-grid';
 import { GridElement, GridElementEventMap } from '@vaadin/vaadin-grid/src/vaadin-grid';
 
 import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
@@ -69,7 +69,7 @@ export interface GridProEventMap<TItem>
  * @fires {CustomEvent} loading-changed - Fired when the `loading` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  */
-declare class GridProElement<TItem = DefaultGridItem> extends GridElement {
+declare class GridProElement<TItem = GridDefaultItem> extends GridElement {
   static _finalizeClass(): void;
 
   addEventListener<K extends keyof GridProEventMap<TItem>>(
@@ -85,11 +85,11 @@ declare class GridProElement<TItem = DefaultGridItem> extends GridElement {
   ): void;
 }
 
-interface GridProElement<TItem = DefaultGridItem> extends InlineEditingMixin<TItem> {}
+interface GridProElement<TItem = GridDefaultItem> extends InlineEditingMixin<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-pro': GridProElement<DefaultGridItem>;
+    'vaadin-grid-pro': GridProElement<GridDefaultItem>;
   }
 }
 

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
@@ -1,4 +1,4 @@
-import { GridDefaultItem , GridElement, GridElementEventMap } from '@vaadin/vaadin-grid';
+import { GridDefaultItem, GridElement, GridElementEventMap } from '@vaadin/vaadin-grid';
 
 import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
 

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
@@ -69,7 +69,7 @@ export interface GridProEventMap<TItem>
  * @fires {CustomEvent} loading-changed - Fired when the `loading` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  */
-declare class GridProElement<TItem = GridDefaultItem> extends GridElement {
+declare class GridProElement<TItem = GridDefaultItem> extends GridElement<TItem> {
   static _finalizeClass(): void;
 
   addEventListener<K extends keyof GridProEventMap<TItem>>(
@@ -85,7 +85,7 @@ declare class GridProElement<TItem = GridDefaultItem> extends GridElement {
   ): void;
 }
 
-interface GridProElement<TItem = GridDefaultItem> extends InlineEditingMixin<TItem> {}
+interface GridProElement extends InlineEditingMixin {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
@@ -1,7 +1,6 @@
 import {
   GridColumnElement,
   GridDropLocation,
-  GridItem,
   GridItemModel,
   GridActiveItemChangedEvent,
   GridCellActivateEvent,
@@ -14,50 +13,53 @@ import {
   GridSelectedItemsChangedEvent
 } from '@vaadin/vaadin-grid';
 
-import '../../vaadin-grid-pro.js';
 import '../../vaadin-grid-pro-edit-column.js';
 
-import { GridProCellEditStartedEvent, GridProItemPropertyChangedEvent } from '../../vaadin-grid-pro.js';
+import { GridProElement, GridProCellEditStartedEvent, GridProItemPropertyChangedEvent } from '../../vaadin-grid-pro.js';
+
+interface TestGridItem {
+  testProperty: string;
+}
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-const grid = document.createElement('vaadin-grid-pro');
+const grid = document.createElement('vaadin-grid-pro') as GridProElement<TestGridItem>;
 
 /* grid-pro events */
 grid.addEventListener('cell-edit-started', (event) => {
-  assertType<GridProCellEditStartedEvent>(event);
+  assertType<GridProCellEditStartedEvent<TestGridItem>>(event);
   assertType<string>(event.detail.value.path);
   assertType<number>(event.detail.value.index);
-  assertType<GridItem>(event.detail.value.item);
+  assertType<TestGridItem>(event.detail.value.item);
 });
 
 grid.addEventListener('item-property-changed', (event) => {
-  assertType<GridProItemPropertyChangedEvent>(event);
+  assertType<GridProItemPropertyChangedEvent<TestGridItem>>(event);
   assertType<string>(event.detail.value.path);
   assertType<number>(event.detail.value.index);
-  assertType<GridItem>(event.detail.value.item);
+  assertType<TestGridItem>(event.detail.value.item);
   assertType<string | boolean>(event.detail.value.value);
 });
 
 /* grid events */
 grid.addEventListener('active-item-changed', (event) => {
-  assertType<GridActiveItemChangedEvent>(event);
-  assertType<GridItem>(event.detail.value);
+  assertType<GridActiveItemChangedEvent<TestGridItem>>(event);
+  assertType<TestGridItem>(event.detail.value);
 });
 
 grid.addEventListener('cell-activate', (event) => {
-  assertType<GridCellActivateEvent>(event);
-  assertType<GridItemModel>(event.detail.model);
+  assertType<GridCellActivateEvent<TestGridItem>>(event);
+  assertType<GridItemModel<TestGridItem>>(event.detail.model);
 });
 
 grid.addEventListener('column-reorder', (event) => {
-  assertType<GridColumnReorderEvent>(event);
-  assertType<GridColumnElement[]>(event.detail.columns);
+  assertType<GridColumnReorderEvent<TestGridItem>>(event);
+  assertType<GridColumnElement<TestGridItem>[]>(event.detail.columns);
 });
 
 grid.addEventListener('column-resize', (event) => {
-  assertType<GridColumnResizeEvent>(event);
-  assertType<GridColumnElement>(event.detail.resizedColumn);
+  assertType<GridColumnResizeEvent<TestGridItem>>(event);
+  assertType<GridColumnElement<TestGridItem>>(event.detail.resizedColumn);
 });
 
 grid.addEventListener('loading-changed', (event) => {
@@ -66,22 +68,25 @@ grid.addEventListener('loading-changed', (event) => {
 });
 
 grid.addEventListener('expanded-items-changed', (event) => {
-  assertType<GridExpandedItemsChangedEvent>(event);
-  assertType<GridItem[]>(event.detail.value);
+  assertType<GridExpandedItemsChangedEvent<TestGridItem>>(event);
+  assertType<TestGridItem[]>(event.detail.value);
 });
 
 grid.addEventListener('selected-items-changed', (event) => {
-  assertType<GridSelectedItemsChangedEvent>(event);
-  assertType<GridItem[]>(event.detail.value);
+  assertType<GridSelectedItemsChangedEvent<TestGridItem>>(event);
+  assertType<TestGridItem[]>(event.detail.value);
 });
 
 grid.addEventListener('grid-dragstart', (event) => {
-  assertType<GridDragStartEvent>(event);
-  assertType<GridItem[]>(event.detail.draggedItems);
+  assertType<GridDragStartEvent<TestGridItem>>(event);
+  assertType<TestGridItem[]>(event.detail.draggedItems);
 });
 
 grid.addEventListener('grid-drop', (event) => {
-  assertType<GridDropEvent>(event);
-  assertType<GridItem>(event.detail.dropTargetItem);
+  assertType<GridDropEvent<TestGridItem>>(event);
+  assertType<TestGridItem>(event.detail.dropTargetItem);
   assertType<GridDropLocation>(event.detail.dropLocation);
 });
+
+assertType<GridElement<TestGridItem>>(grid);
+assertType<InlineEditingMixin<TestGridItem>>(grid);

--- a/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
@@ -1,4 +1,17 @@
-import { GridElement } from '@vaadin/vaadin-grid';
+import {
+  GridActiveItemChangedEvent,
+  GridCellActivateEvent,
+  GridColumnReorderEvent,
+  GridColumnResizeEvent,
+  GridDragStartEvent,
+  GridDropEvent,
+  GridDropLocation,
+  GridElement,
+  GridExpandedItemsChangedEvent,
+  GridItemModel,
+  GridLoadingChangedEvent,
+  GridSelectedItemsChangedEvent
+} from '@vaadin/vaadin-grid';
 import { GridColumnElement } from '@vaadin/vaadin-grid/vaadin-grid-column';
 import { InlineEditingMixin } from '../../src/vaadin-grid-pro-inline-editing-mixin';
 import { GridProElement } from '../../vaadin-grid-pro';
@@ -16,7 +29,7 @@ assertType<GridProElement>(genericGrid);
 
 const narrowedGrid = genericGrid as GridProElement<TestGridItem>;
 assertType<GridElement<TestGridItem>>(narrowedGrid);
-assertType<InlineEditingMixin<TestGridItem>>(narrowedGrid);
+assertType<InlineEditingMixin>(narrowedGrid);
 
 narrowedGrid.addEventListener('cell-edit-started', (event) => {
   assertType<string>(event.detail.value.path);

--- a/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
@@ -1,7 +1,8 @@
-import { GridColumnElement, GridElement } from '@vaadin/vaadin-grid';
-import { GridProElement } from '../../src/vaadin-grid-pro';
-import { GridProEditColumnElement } from '../../src/vaadin-grid-pro-edit-column';
+import { GridElement } from '@vaadin/vaadin-grid';
+import { GridColumnElement } from '@vaadin/vaadin-grid/vaadin-grid-column';
 import { InlineEditingMixin } from '../../src/vaadin-grid-pro-inline-editing-mixin';
+import { GridProElement } from '../../vaadin-grid-pro';
+import { GridProEditColumnElement } from '../../vaadin-grid-pro-edit-column';
 
 interface TestGridItem {
   testProperty: string;

--- a/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
@@ -1,21 +1,7 @@
-import {
-  GridColumnElement,
-  GridDropLocation,
-  GridItemModel,
-  GridActiveItemChangedEvent,
-  GridCellActivateEvent,
-  GridColumnReorderEvent,
-  GridColumnResizeEvent,
-  GridDragStartEvent,
-  GridDropEvent,
-  GridExpandedItemsChangedEvent,
-  GridLoadingChangedEvent,
-  GridSelectedItemsChangedEvent
-} from '@vaadin/vaadin-grid';
-
-import '../../vaadin-grid-pro-edit-column.js';
-
-import { GridProElement, GridProCellEditStartedEvent, GridProItemPropertyChangedEvent } from '../../vaadin-grid-pro.js';
+import { GridColumnElement, GridElement } from '@vaadin/vaadin-grid';
+import { GridProElement } from '../../src/vaadin-grid-pro';
+import { GridProEditColumnElement } from '../../src/vaadin-grid-pro-edit-column';
+import { InlineEditingMixin } from '../../src/vaadin-grid-pro-inline-editing-mixin';
 
 interface TestGridItem {
   testProperty: string;
@@ -23,70 +9,76 @@ interface TestGridItem {
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-const grid = document.createElement('vaadin-grid-pro') as GridProElement<TestGridItem>;
+/* GridProElement */
+const genericGrid = document.createElement('vaadin-grid-pro');
+assertType<GridProElement>(genericGrid);
 
-/* grid-pro events */
-grid.addEventListener('cell-edit-started', (event) => {
-  assertType<GridProCellEditStartedEvent<TestGridItem>>(event);
+const narrowedGrid = genericGrid as GridProElement<TestGridItem>;
+assertType<GridElement<TestGridItem>>(narrowedGrid);
+assertType<InlineEditingMixin<TestGridItem>>(narrowedGrid);
+
+narrowedGrid.addEventListener('cell-edit-started', (event) => {
   assertType<string>(event.detail.value.path);
   assertType<number>(event.detail.value.index);
   assertType<TestGridItem>(event.detail.value.item);
 });
 
-grid.addEventListener('item-property-changed', (event) => {
-  assertType<GridProItemPropertyChangedEvent<TestGridItem>>(event);
+narrowedGrid.addEventListener('item-property-changed', (event) => {
   assertType<string>(event.detail.value.path);
   assertType<number>(event.detail.value.index);
   assertType<TestGridItem>(event.detail.value.item);
   assertType<string | boolean>(event.detail.value.value);
 });
 
-/* grid events */
-grid.addEventListener('active-item-changed', (event) => {
+narrowedGrid.addEventListener('active-item-changed', (event) => {
   assertType<GridActiveItemChangedEvent<TestGridItem>>(event);
   assertType<TestGridItem>(event.detail.value);
 });
 
-grid.addEventListener('cell-activate', (event) => {
+narrowedGrid.addEventListener('cell-activate', (event) => {
   assertType<GridCellActivateEvent<TestGridItem>>(event);
   assertType<GridItemModel<TestGridItem>>(event.detail.model);
 });
 
-grid.addEventListener('column-reorder', (event) => {
+narrowedGrid.addEventListener('column-reorder', (event) => {
   assertType<GridColumnReorderEvent<TestGridItem>>(event);
   assertType<GridColumnElement<TestGridItem>[]>(event.detail.columns);
 });
 
-grid.addEventListener('column-resize', (event) => {
+narrowedGrid.addEventListener('column-resize', (event) => {
   assertType<GridColumnResizeEvent<TestGridItem>>(event);
   assertType<GridColumnElement<TestGridItem>>(event.detail.resizedColumn);
 });
 
-grid.addEventListener('loading-changed', (event) => {
+narrowedGrid.addEventListener('loading-changed', (event) => {
   assertType<GridLoadingChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
-grid.addEventListener('expanded-items-changed', (event) => {
+narrowedGrid.addEventListener('expanded-items-changed', (event) => {
   assertType<GridExpandedItemsChangedEvent<TestGridItem>>(event);
   assertType<TestGridItem[]>(event.detail.value);
 });
 
-grid.addEventListener('selected-items-changed', (event) => {
+narrowedGrid.addEventListener('selected-items-changed', (event) => {
   assertType<GridSelectedItemsChangedEvent<TestGridItem>>(event);
   assertType<TestGridItem[]>(event.detail.value);
 });
 
-grid.addEventListener('grid-dragstart', (event) => {
+narrowedGrid.addEventListener('grid-dragstart', (event) => {
   assertType<GridDragStartEvent<TestGridItem>>(event);
   assertType<TestGridItem[]>(event.detail.draggedItems);
 });
 
-grid.addEventListener('grid-drop', (event) => {
+narrowedGrid.addEventListener('grid-drop', (event) => {
   assertType<GridDropEvent<TestGridItem>>(event);
   assertType<TestGridItem>(event.detail.dropTargetItem);
   assertType<GridDropLocation>(event.detail.dropLocation);
 });
 
-assertType<GridElement<TestGridItem>>(grid);
-assertType<InlineEditingMixin<TestGridItem>>(grid);
+/* GridProEditColumnElement */
+const genericEditColumn = document.createElement('vaadin-grid-pro-edit-column');
+assertType<GridProEditColumnElement>(genericEditColumn);
+
+const narrowedEditColumn = genericEditColumn as GridProEditColumnElement<TestGridItem>;
+assertType<GridColumnElement<TestGridItem>>(narrowedEditColumn);

--- a/packages/vaadin-grid-pro/vaadin-grid-pro-edit-column.js
+++ b/packages/vaadin-grid-pro/vaadin-grid-pro-edit-column.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-pro-edit-column.js';
+
 export * from './src/vaadin-grid-pro-edit-column.js';

--- a/packages/vaadin-grid-pro/vaadin-grid-pro.js
+++ b/packages/vaadin-grid-pro/vaadin-grid-pro.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-pro.js';
+
 export * from './src/vaadin-grid-pro.js';

--- a/packages/vaadin-grid/src/interfaces.d.ts
+++ b/packages/vaadin-grid/src/interfaces.d.ts
@@ -59,7 +59,7 @@ export type GridHeaderFooterRenderer<TItem> = (
   column?: GridColumnElement<TItem>
 ) => void;
 
-export type DefaultGridItem = any;
+export type GridDefaultItem = any;
 
 export interface GridItemModel<TItem> {
   index: number;

--- a/packages/vaadin-grid/src/interfaces.d.ts
+++ b/packages/vaadin-grid/src/interfaces.d.ts
@@ -1,25 +1,38 @@
 import { GridColumnElement } from './vaadin-grid-column.js';
 import { GridElement } from './vaadin-grid.js';
 
-export type GridBodyRenderer = (root: HTMLElement, column?: GridColumnElement, model?: GridItemModel) => void;
+export type GridBodyRenderer<TItem> = (
+  root: HTMLElement,
+  column?: GridColumnElement<TItem>,
+  model?: GridItemModel<TItem>
+) => void;
 
-export type GridCellClassNameGenerator = (column: GridColumnElement, model: GridItemModel) => string;
+export type GridCellClassNameGenerator<TItem> = (
+  column: GridColumnElement<TItem>,
+  model: GridItemModel<TItem>
+) => string;
 
 export type GridColumnTextAlign = 'start' | 'center' | 'end' | null;
 
-export type GridDataProviderCallback = (items: Array<GridItem>, size?: number) => void;
+export type GridDataProviderCallback<TItem> = (
+  items: Array<TItem>,
+  size?: number
+) => void;
 
-export type GridDataProviderParams = {
+export type GridDataProviderParams<TItem> = {
   page: number;
   pageSize: number;
   filters: Array<GridFilter>;
   sortOrders: Array<GridSorter>;
-  parentItem?: GridItem;
+  parentItem?: TItem;
 };
 
-export type GridDataProvider = (params: GridDataProviderParams, callback: GridDataProviderCallback) => void;
+export type GridDataProvider = <TItem>(
+  params: GridDataProviderParams<TItem>,
+  callback: GridDataProviderCallback<TItem>
+) => void;
 
-export type GridDragAndDropFilter = (model: GridItemModel) => boolean;
+export type GridDragAndDropFilter = <TItem>(model: GridItemModel<TItem>) => boolean;
 
 export type GridDropLocation = 'above' | 'on-top' | 'below' | 'empty';
 
@@ -30,10 +43,10 @@ export interface GridFilter {
   value: string;
 }
 
-export interface GridEventContext {
-  section: 'body' | 'header' | 'footer' | 'details';
-  item?: GridItem;
-  column?: GridColumnElement;
+export interface GridEventContext<TItem> {
+  section: 'body' | 'header' | 'footer' | 'details';
+  item?: TItem;
+  column?: GridColumnElement<TItem>;
   index?: number;
   selected?: boolean;
   detailsOpened?: boolean;
@@ -41,20 +54,27 @@ export interface GridEventContext {
   level?: number;
 }
 
-export type GridHeaderFooterRenderer = (root: HTMLElement, column?: GridColumnElement) => void;
+export type GridHeaderFooterRenderer<TItem> = (
+  root: HTMLElement,
+  column?: GridColumnElement<TItem>
+) => void;
 
-export type GridItem = unknown;
+export type DefaultGridItem = any;
 
-export interface GridItemModel {
+export interface GridItemModel<TItem> {
   index: number;
-  item: GridItem;
+  item: TItem;
   selected?: boolean;
   expanded?: boolean;
   level?: number;
   detailsOpened?: boolean;
 }
 
-export type GridRowDetailsRenderer = (root: HTMLElement, grid?: GridElement, model?: GridItemModel) => void;
+export type GridRowDetailsRenderer<TItem> = (
+  root: HTMLElement,
+  grid?: GridElement<TItem>,
+  model?: GridItemModel<TItem>
+) => void;
 
 export type GridSorterDirection = 'asc' | 'desc' | null;
 

--- a/packages/vaadin-grid/src/interfaces.d.ts
+++ b/packages/vaadin-grid/src/interfaces.d.ts
@@ -82,5 +82,3 @@ export interface GridSorter {
   path: string;
   direction: GridSorterDirection;
 }
-
-export { GridColumnElement };

--- a/packages/vaadin-grid/src/interfaces.d.ts
+++ b/packages/vaadin-grid/src/interfaces.d.ts
@@ -14,10 +14,7 @@ export type GridCellClassNameGenerator<TItem> = (
 
 export type GridColumnTextAlign = 'start' | 'center' | 'end' | null;
 
-export type GridDataProviderCallback<TItem> = (
-  items: Array<TItem>,
-  size?: number
-) => void;
+export type GridDataProviderCallback<TItem> = (items: Array<TItem>, size?: number) => void;
 
 export type GridDataProviderParams<TItem> = {
   page: number;
@@ -44,7 +41,7 @@ export interface GridFilter {
 }
 
 export interface GridEventContext<TItem> {
-  section: 'body' | 'header' | 'footer' | 'details';
+  section: 'body' | 'header' | 'footer' | 'details';
   item?: TItem;
   column?: GridColumnElement<TItem>;
   index?: number;
@@ -54,10 +51,7 @@ export interface GridEventContext<TItem> {
   level?: number;
 }
 
-export type GridHeaderFooterRenderer<TItem> = (
-  root: HTMLElement,
-  column?: GridColumnElement<TItem>
-) => void;
+export type GridHeaderFooterRenderer<TItem> = (root: HTMLElement, column?: GridColumnElement<TItem>) => void;
 
 export type GridDefaultItem = any;
 

--- a/packages/vaadin-grid/src/iron-list.js
+++ b/packages/vaadin-grid/src/iron-list.js
@@ -1,30 +1,31 @@
 /**
-@license
-Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
-This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
-The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
-The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
-Code distributed by Google as part of the polymer project is also
-subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
-*/
+ @license
+ Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ Code distributed by Google as part of the polymer project is also
+ subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
 
 /**
 
-This is a fork of <iron-list> for <vaadin-grid>'s internal purposes only!
-To update:
-1. Get the most recent code from https://github.com/PolymerElements/iron-list/
-2. Remove `is: 'iron-list'` and `_template` to avoid collisions with actual <iron-list>
-3. Change "Polymer({" to "export const PolymerIronList = Class({" to expose the class
+ This is a fork of <iron-list> for <vaadin-grid>'s internal purposes only!
+ To update:
+ 1. Get the most recent code from https://github.com/PolymerElements/iron-list/
+ 2. Remove `is: 'iron-list'` and `_template` to avoid collisions with actual <iron-list>
+ 3. Change "Polymer({" to "export const PolymerIronList = Class({" to expose the class
 4. Optional: Remove all properties and functions not needed by <vaadin-grid>
 5. Profit!
 
-*/
+ */
 import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
 import { IronScrollTargetBehavior } from '@polymer/iron-scroll-target-behavior/iron-scroll-target-behavior.js';
 import { animationFrame, idlePeriod, microTask } from '@polymer/polymer/lib/utils/async.js';
 import { Class } from '@polymer/polymer/lib/legacy/class.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { Debouncer, enqueueDebouncer } from '@polymer/polymer/lib/utils/debounce.js';
+
 const IOS = navigator.userAgent.match(/iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/);
 const IOS_TOUCH_SCROLLING = IOS && IOS[1] >= 8;
 const DEFAULT_PHYSICAL_COUNT = 3;

--- a/packages/vaadin-grid/src/vaadin-grid-active-item-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-active-item-mixin.d.ts
@@ -1,17 +1,16 @@
-import { GridItem } from './interfaces';
 
-declare function ActiveItemMixin<T extends new (...args: any[]) => {}>(base: T): T & ActiveItemMixinConstructor;
+declare function ActiveItemMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & ActiveItemMixinConstructor<TItem>;
 
-interface ActiveItemMixinConstructor {
-  new (...args: any[]): ActiveItemMixin;
+interface ActiveItemMixinConstructor<TItem> {
+  new (...args: any[]): ActiveItemMixin<TItem>;
 }
 
-interface ActiveItemMixin {
+interface ActiveItemMixin<TItem> {
   /**
    * The item user has last interacted with. Turns to `null` after user deactivates
    * the item by re-interacting with the currently active item.
    */
-  activeItem: GridItem | null;
+  activeItem: TItem | null;
 
   /**
    * We need to listen to click instead of tap because on mobile safari, the

--- a/packages/vaadin-grid/src/vaadin-grid-active-item-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-active-item-mixin.d.ts
@@ -1,5 +1,6 @@
-
-declare function ActiveItemMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & ActiveItemMixinConstructor<TItem>;
+declare function ActiveItemMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & ActiveItemMixinConstructor<TItem>;
 
 interface ActiveItemMixinConstructor<TItem> {
   new (...args: any[]): ActiveItemMixin<TItem>;

--- a/packages/vaadin-grid/src/vaadin-grid-array-data-provider-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-array-data-provider-mixin.d.ts
@@ -1,21 +1,21 @@
-import { GridDataProviderCallback, GridDataProviderParams, GridItem, GridFilter, GridSorter } from './interfaces';
+import { GridDataProviderCallback, GridDataProviderParams, GridFilter, GridSorter } from './interfaces';
 
-declare function ArrayDataProviderMixin<T extends new (...args: any[]) => {}>(
+declare function ArrayDataProviderMixin<TItem, T extends new (...args: any[]) => {}>(
   base: T
-): T & ArrayDataProviderMixinConstructor;
+): T & ArrayDataProviderMixinConstructor<TItem>;
 
-interface ArrayDataProviderMixinConstructor {
-  new (...args: any[]): ArrayDataProviderMixin;
+interface ArrayDataProviderMixinConstructor<TItem> {
+  new (...args: any[]): ArrayDataProviderMixin<TItem>;
 }
 
-interface ArrayDataProviderMixin {
+declare class ArrayDataProviderMixin<TItem> {
   /**
    * An array containing the items which will be stamped to the column template
    * instances.
    */
-  items: GridItem[] | null | undefined;
+  items: TItem[] | null | undefined;
 
-  _arrayDataProvider(opts: GridDataProviderParams | null, cb: GridDataProviderCallback | null): void;
+  _arrayDataProvider(opts: GridDataProviderParams<TItem> | null, cb: GridDataProviderCallback<TItem> | null): void;
 
   /**
    * Check array of filters/sorters for paths validity, console.warn invalid items
@@ -23,7 +23,7 @@ interface ArrayDataProviderMixin {
    * @param arrayToCheck The array of filters/sorters to check
    * @param action The name of action to include in warning (filtering, sorting)
    */
-  _checkPaths(arrayToCheck: Array<GridFilter | GridSorter>, action: string, items: GridItem[]): any;
+  _checkPaths(arrayToCheck: Array<GridFilter | GridSorter>, action: string, items: TItem[]): any;
 
   _multiSort(a: unknown | null, b: unknown | null): number;
 
@@ -31,7 +31,7 @@ interface ArrayDataProviderMixin {
 
   _compare(a: unknown | null, b: unknown | null): number;
 
-  _filter(items: GridItem[]): GridItem[];
+  _filter(items: TItem[]): TItem[];
 }
 
 export { ArrayDataProviderMixin, ArrayDataProviderMixinConstructor };

--- a/packages/vaadin-grid/src/vaadin-grid-array-data-provider-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-array-data-provider-mixin.d.ts
@@ -8,7 +8,7 @@ interface ArrayDataProviderMixinConstructor<TItem> {
   new (...args: any[]): ArrayDataProviderMixin<TItem>;
 }
 
-declare class ArrayDataProviderMixin<TItem> {
+declare interface ArrayDataProviderMixin<TItem> {
   /**
    * An array containing the items which will be stamped to the column template
    * instances.

--- a/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
@@ -1,8 +1,6 @@
 import {DefaultGridItem} from './interfaces';
 import { ColumnBaseMixin, GridColumnElement } from './vaadin-grid-column.js';
 
-interface GridColumnGroupElement<TItem = DefaultGridItem> extends ColumnBaseMixin<TItem> {}
-
 /**
  * A `<vaadin-grid-column-group>` is used to make groups of columns in `<vaadin-grid>` and
  * to configure additional headers and footers.
@@ -47,6 +45,8 @@ declare class GridColumnGroupElement<TItem = DefaultGridItem> extends HTMLElemen
 
   _isColumnElement(node: Node): boolean;
 }
+
+interface GridColumnGroupElement<TItem = DefaultGridItem> extends ColumnBaseMixin<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
@@ -1,4 +1,7 @@
+import {DefaultGridItem} from './interfaces';
 import { ColumnBaseMixin, GridColumnElement } from './vaadin-grid-column.js';
+
+interface GridColumnGroupElement<TItem = DefaultGridItem> extends ColumnBaseMixin<TItem> {}
 
 /**
  * A `<vaadin-grid-column-group>` is used to make groups of columns in `<vaadin-grid>` and
@@ -24,7 +27,7 @@ import { ColumnBaseMixin, GridColumnElement } from './vaadin-grid-column.js';
  * </vaadin-grid-column-group>
  * ```
  */
-declare class GridColumnGroupElement extends ColumnBaseMixin(HTMLElement) {
+declare class GridColumnGroupElement<TItem = DefaultGridItem> extends HTMLElement {
   /**
    * Flex grow ratio for the column group as the sum of the ratios of its child columns.
    * @attr {number} flex-grow
@@ -40,14 +43,14 @@ declare class GridColumnGroupElement extends ColumnBaseMixin(HTMLElement) {
 
   _updateFlexAndWidth(): void;
 
-  _getChildColumns(el: GridColumnGroupElement): GridColumnElement[];
+  _getChildColumns(el: GridColumnGroupElement<TItem>): GridColumnElement<TItem>[];
 
   _isColumnElement(node: Node): boolean;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-column-group': GridColumnGroupElement;
+    'vaadin-grid-column-group': GridColumnGroupElement<DefaultGridItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
@@ -1,4 +1,4 @@
-import {DefaultGridItem} from './interfaces';
+import {GridDefaultItem} from './interfaces';
 import { ColumnBaseMixin, GridColumnElement } from './vaadin-grid-column.js';
 
 /**
@@ -25,7 +25,7 @@ import { ColumnBaseMixin, GridColumnElement } from './vaadin-grid-column.js';
  * </vaadin-grid-column-group>
  * ```
  */
-declare class GridColumnGroupElement<TItem = DefaultGridItem> extends HTMLElement {
+declare class GridColumnGroupElement<TItem = GridDefaultItem> extends HTMLElement {
   /**
    * Flex grow ratio for the column group as the sum of the ratios of its child columns.
    * @attr {number} flex-grow
@@ -46,11 +46,11 @@ declare class GridColumnGroupElement<TItem = DefaultGridItem> extends HTMLElemen
   _isColumnElement(node: Node): boolean;
 }
 
-interface GridColumnGroupElement<TItem = DefaultGridItem> extends ColumnBaseMixin<TItem> {}
+interface GridColumnGroupElement<TItem = GridDefaultItem> extends ColumnBaseMixin<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-column-group': GridColumnGroupElement<DefaultGridItem>;
+    'vaadin-grid-column-group': GridColumnGroupElement<GridDefaultItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
@@ -1,4 +1,4 @@
-import {GridDefaultItem} from './interfaces';
+import { GridDefaultItem } from './interfaces';
 import { ColumnBaseMixin, GridColumnElement } from './vaadin-grid-column.js';
 
 /**

--- a/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.d.ts
@@ -1,23 +1,23 @@
 import { GridColumnElement } from './vaadin-grid-column.js';
 
-declare function ColumnReorderingMixin<T extends new (...args: any[]) => {}>(
+declare function ColumnReorderingMixin<TItem, T extends new (...args: any[]) => {}>(
   base: T
-): T & ColumnReorderingMixinConstructor;
+): T & ColumnReorderingMixinConstructor<TItem>;
 
-interface ColumnReorderingMixinConstructor {
-  new (...args: any[]): ColumnReorderingMixin;
+interface ColumnReorderingMixinConstructor<TItem> {
+  new (...args: any[]): ColumnReorderingMixin<TItem>;
 }
 
 export { ColumnReorderingMixinConstructor };
 
-interface ColumnReorderingMixin {
+interface ColumnReorderingMixin<TItem> {
   /**
    * Set to true to allow column reordering.
    * @attr {boolean} column-reordering-allowed
    */
   columnReorderingAllowed: boolean;
 
-  _getColumnsInOrder(): GridColumnElement[];
+  _getColumnsInOrder(): GridColumnElement<TItem>[];
 
   _cellFromPoint(x: number, y: number): HTMLElement | null | undefined;
 
@@ -25,23 +25,23 @@ interface ColumnReorderingMixin {
 
   _updateGhost(cell: HTMLElement): HTMLElement;
 
-  _setSiblingsReorderStatus(column: GridColumnElement, status: string): void;
+  _setSiblingsReorderStatus(column: GridColumnElement<TItem>, status: string): void;
 
   _autoScroller(): void;
 
   _isSwapAllowed(
-    column1: GridColumnElement | null | undefined,
-    column2: GridColumnElement | null | undefined
+    column1: GridColumnElement<TItem> | null | undefined,
+    column2: GridColumnElement<TItem> | null | undefined
   ): boolean | undefined;
 
-  _isSwappableByPosition(targetColumn: GridColumnElement, clientX: number): boolean;
+  _isSwappableByPosition(targetColumn: GridColumnElement<TItem>, clientX: number): boolean;
 
-  _swapColumnOrders(column1: GridColumnElement, column2: GridColumnElement): void;
+  _swapColumnOrders(column1: GridColumnElement<TItem>, column2: GridColumnElement<TItem>): void;
 
   _getTargetColumn(
     targetCell: HTMLElement | null | undefined,
-    draggedColumn: GridColumnElement | null
-  ): GridColumnElement | null | undefined;
+    draggedColumn: GridColumnElement<TItem> | null
+  ): GridColumnElement<TItem> | null | undefined;
 }
 
 export { ColumnReorderingMixin };

--- a/packages/vaadin-grid/src/vaadin-grid-column-resizing-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column-resizing-mixin.d.ts
@@ -6,8 +6,6 @@ interface ColumnResizingMixinConstructor {
 
 export { ColumnResizingMixinConstructor };
 
-interface ColumnResizingMixin {
-  ready(): void;
-}
+interface ColumnResizingMixin {}
 
 export { ColumnResizingMixin };

--- a/packages/vaadin-grid/src/vaadin-grid-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column.d.ts
@@ -2,12 +2,10 @@ import { GridElement } from './vaadin-grid.js';
 
 import { GridBodyRenderer, GridColumnTextAlign, GridHeaderFooterRenderer, DefaultGridItem } from './interfaces';
 
-type TypedConstructor<T> = new (...args: any[]) => T;
+declare function ColumnBaseMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & ColumnBaseMixinConstructor<TItem>;
 
-declare function ColumnBaseMixin<TItem, TBase>(base: TypedConstructor<TBase>): ColumnBaseMixinConstructor<TBase, TItem>;
-
-export interface ColumnBaseMixinConstructor<TBase, TItem> {
-  new (...args: any[]): TBase & ColumnBaseMixin<TItem>;
+export interface ColumnBaseMixinConstructor<TItem> {
+  new (...args: any[]): ColumnBaseMixin<TItem>;
 }
 
 interface ColumnBaseMixin<TItem> {

--- a/packages/vaadin-grid/src/vaadin-grid-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column.d.ts
@@ -101,8 +101,6 @@ interface ColumnBaseMixin<TItem> {
   _toggleAttribute(name: string, bool: boolean, node: Element): void;
 }
 
-interface GridColumnElement<TItem = DefaultGridItem> extends ColumnBaseMixin<TItem> {}
-
 /**
  * A `<vaadin-grid-column>` is used to configure how a column in `<vaadin-grid>`
  * should look like.
@@ -166,6 +164,8 @@ declare class GridColumnElement<TItem = DefaultGridItem> extends HTMLElement {
 
   _cells: HTMLElement[] | null;
 }
+
+interface GridColumnElement<TItem = DefaultGridItem> extends ColumnBaseMixin<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/vaadin-grid/src/vaadin-grid-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column.d.ts
@@ -1,17 +1,17 @@
 import { GridElement } from './vaadin-grid.js';
 
-import { GridBodyRenderer, GridColumnTextAlign, GridHeaderFooterRenderer } from './interfaces';
+import { GridBodyRenderer, GridColumnTextAlign, GridHeaderFooterRenderer, DefaultGridItem } from './interfaces';
 
-declare function ColumnBaseMixin<T extends new (...args: any[]) => {}>(base: T): T & ColumnBaseMixinConstructor;
+type TypedConstructor<T> = new (...args: any[]) => T;
 
-interface ColumnBaseMixinConstructor {
-  new (...args: any[]): ColumnBaseMixin;
+declare function ColumnBaseMixin<TItem, TBase>(base: TypedConstructor<TBase>): ColumnBaseMixinConstructor<TBase, TItem>;
+
+export interface ColumnBaseMixinConstructor<TBase, TItem> {
+  new (...args: any[]): TBase & ColumnBaseMixin<TItem>;
 }
 
-export { ColumnBaseMixinConstructor };
-
-interface ColumnBaseMixin {
-  readonly _grid: GridElement | undefined;
+interface ColumnBaseMixin<TItem> {
+  readonly _grid: GridElement<TItem> | undefined;
   readonly _allCells: HTMLElement[];
 
   /**
@@ -32,7 +32,7 @@ interface ColumnBaseMixin {
   /**
    * When set to true, the cells for this column are hidden.
    */
-  hidden: boolean | null | undefined;
+  hidden: boolean;
 
   /**
    * Text content to display in the header cell of the column.
@@ -59,7 +59,7 @@ interface ColumnBaseMixin {
    * - `root` The header cell content DOM element. Append your content to it.
    * - `column` The `<vaadin-grid-column>` element.
    */
-  headerRenderer: GridHeaderFooterRenderer | null | undefined;
+  headerRenderer: GridHeaderFooterRenderer<TItem> | null | undefined;
 
   /**
    * Custom function for rendering the footer content.
@@ -68,9 +68,9 @@ interface ColumnBaseMixin {
    * - `root` The footer cell content DOM element. Append your content to it.
    * - `column` The `<vaadin-grid-column>` element.
    */
-  footerRenderer: GridHeaderFooterRenderer | null | undefined;
+  footerRenderer: GridHeaderFooterRenderer<TItem> | null | undefined;
 
-  _findHostGrid(): GridElement | undefined;
+  _findHostGrid(): GridElement<TItem> | undefined;
 
   _prepareHeaderTemplate(): HTMLTemplateElement | null;
 
@@ -92,8 +92,8 @@ interface ColumnBaseMixin {
     headerCell: HTMLTableCellElement | undefined,
     footerCell: HTMLTableCellElement | undefined,
     cells: object | undefined,
-    renderer: GridBodyRenderer | null | undefined,
-    headerRenderer: GridHeaderFooterRenderer | null | undefined,
+    renderer: GridBodyRenderer<TItem> | null | undefined,
+    headerRenderer: GridHeaderFooterRenderer<TItem> | null | undefined,
     bodyTemplate: HTMLTemplateElement | null | undefined,
     headerTemplate: HTMLTemplateElement | null | undefined
   ): void;
@@ -103,6 +103,8 @@ interface ColumnBaseMixin {
   _toggleAttribute(name: string, bool: boolean, node: Element): void;
 }
 
+interface GridColumnElement<TItem = DefaultGridItem> extends ColumnBaseMixin<TItem> {}
+
 /**
  * A `<vaadin-grid-column>` is used to configure how a column in `<vaadin-grid>`
  * should look like.
@@ -110,7 +112,7 @@ interface ColumnBaseMixin {
  * See [`<vaadin-grid>`](#/elements/vaadin-grid) documentation for instructions on how
  * to configure the `<vaadin-grid-column>`.
  */
-declare class GridColumnElement extends ColumnBaseMixin(HTMLElement) {
+declare class GridColumnElement<TItem = DefaultGridItem> extends HTMLElement {
   /**
    * Width of the cells for this column.
    */
@@ -136,7 +138,7 @@ declare class GridColumnElement extends ColumnBaseMixin(HTMLElement) {
    *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
    *   - `model.selected` Selected state.
    */
-  renderer: GridBodyRenderer | null | undefined;
+  renderer: GridBodyRenderer<TItem> | null | undefined;
 
   /**
    * Path to an item sub-property whose value gets displayed in the column body cells.
@@ -169,7 +171,7 @@ declare class GridColumnElement extends ColumnBaseMixin(HTMLElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-column': GridColumnElement;
+    'vaadin-grid-column': GridColumnElement<DefaultGridItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column.d.ts
@@ -2,7 +2,9 @@ import { GridElement } from './vaadin-grid.js';
 
 import { GridBodyRenderer, GridColumnTextAlign, GridHeaderFooterRenderer, GridDefaultItem } from './interfaces';
 
-declare function ColumnBaseMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & ColumnBaseMixinConstructor<TItem>;
+declare function ColumnBaseMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & ColumnBaseMixinConstructor<TItem>;
 
 export interface ColumnBaseMixinConstructor<TItem> {
   new (...args: any[]): ColumnBaseMixin<TItem>;

--- a/packages/vaadin-grid/src/vaadin-grid-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column.d.ts
@@ -1,6 +1,6 @@
 import { GridElement } from './vaadin-grid.js';
 
-import { GridBodyRenderer, GridColumnTextAlign, GridHeaderFooterRenderer, DefaultGridItem } from './interfaces';
+import { GridBodyRenderer, GridColumnTextAlign, GridHeaderFooterRenderer, GridDefaultItem } from './interfaces';
 
 declare function ColumnBaseMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & ColumnBaseMixinConstructor<TItem>;
 
@@ -108,7 +108,7 @@ interface ColumnBaseMixin<TItem> {
  * See [`<vaadin-grid>`](#/elements/vaadin-grid) documentation for instructions on how
  * to configure the `<vaadin-grid-column>`.
  */
-declare class GridColumnElement<TItem = DefaultGridItem> extends HTMLElement {
+declare class GridColumnElement<TItem = GridDefaultItem> extends HTMLElement {
   /**
    * Width of the cells for this column.
    */
@@ -165,11 +165,11 @@ declare class GridColumnElement<TItem = DefaultGridItem> extends HTMLElement {
   _cells: HTMLElement[] | null;
 }
 
-interface GridColumnElement<TItem = DefaultGridItem> extends ColumnBaseMixin<TItem> {}
+interface GridColumnElement<TItem = GridDefaultItem> extends ColumnBaseMixin<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-column': GridColumnElement<DefaultGridItem>;
+    'vaadin-grid-column': GridColumnElement<GridDefaultItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -67,7 +67,8 @@ export const ColumnBaseMixin = (superClass) =>
          * When set to true, the cells for this column are hidden.
          */
         hidden: {
-          type: Boolean
+          type: Boolean,
+          value: false
         },
 
         /**

--- a/packages/vaadin-grid/src/vaadin-grid-data-provider-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-data-provider-mixin.d.ts
@@ -1,29 +1,29 @@
-import { GridDataProvider, GridItem } from './interfaces';
+import { GridDataProvider } from './interfaces';
 
-declare class ItemCache {
+declare class ItemCache<TItem> {
   grid: HTMLElement;
-  parentCache: ItemCache | undefined;
-  parentItem: GridItem | undefined;
+  parentCache: ItemCache<TItem> | undefined;
+  parentItem: TItem | undefined;
   itemCaches: object | null;
   items: object | null;
   effectiveSize: number;
   size: number;
   pendingRequests: object | null;
-  constructor(grid: HTMLElement, parentCache: ItemCache | undefined, parentItem: GridItem | undefined);
+  constructor(grid: HTMLElement, parentCache: ItemCache<TItem> | undefined, parentItem: TItem | undefined);
   isLoading(): boolean;
-  getItemForIndex(index: number): GridItem | undefined;
+  getItemForIndex(index: number): TItem | undefined;
   updateSize(): void;
   ensureSubCacheForScaledIndex(scaledIndex: number): void;
-  getCacheAndIndex(index: number): { cache: ItemCache; scaledIndex: number };
+  getCacheAndIndex(index: number): { cache: ItemCache<TItem>; scaledIndex: number };
 }
 
-declare function DataProviderMixin<T extends new (...args: any[]) => {}>(base: T): T & DataProviderMixinConstructor;
+declare function DataProviderMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & DataProviderMixinConstructor<TItem>;
 
-interface DataProviderMixinConstructor {
-  new (...args: any[]): DataProviderMixin;
+interface DataProviderMixinConstructor<TItem> {
+  new (...args: any[]): DataProviderMixin<TItem>;
 }
 
-interface DataProviderMixin {
+interface DataProviderMixin<TItem> {
   /**
    * Number of items fetched at a time from the dataprovider.
    * @attr {number} page-size
@@ -58,7 +58,7 @@ interface DataProviderMixin {
    */
   readonly loading: boolean | null | undefined;
 
-  _cache: ItemCache;
+  _cache: ItemCache<TItem>;
 
   /**
    * Path to an item sub-property that identifies the item.
@@ -69,7 +69,7 @@ interface DataProviderMixin {
   /**
    * An array that contains the expanded items.
    */
-  expandedItems: GridItem[];
+  expandedItems: TItem[];
 
   _getItem(index: number, el: HTMLElement | null): void;
 
@@ -77,25 +77,25 @@ interface DataProviderMixin {
    * Returns a value that identifies the item. Uses `itemIdPath` if available.
    * Can be customized by overriding.
    */
-  getItemId(item: GridItem): GridItem | unknown;
+  getItemId(item: TItem): TItem | unknown;
 
-  _isExpanded(item: GridItem): boolean;
+  _isExpanded(item: TItem): boolean;
 
   /**
    * Expands the given item tree.
    */
-  expandItem(item: GridItem): void;
+  expandItem(item: TItem): void;
 
   /**
    * Collapses the given item tree.
    */
-  collapseItem(item: GridItem): void;
+  collapseItem(item: TItem): void;
 
   _getIndexLevel(index: number): number;
 
   _canPopulate(): boolean;
 
-  _loadPage(page: number, cache: ItemCache | null): void;
+  _loadPage(page: number, cache: ItemCache<TItem> | null): void;
 
   /**
    * Clears the cached pages and reloads data from dataprovider when needed.
@@ -106,9 +106,9 @@ interface DataProviderMixin {
 
   _ensureFirstPageLoaded(): void;
 
-  _itemsEqual(item1: GridItem, item2: GridItem): boolean;
+  _itemsEqual(item1: TItem, item2: TItem): boolean;
 
-  _getItemIndexInArray(item: GridItem, array: GridItem[]): number;
+  _getItemIndexInArray(item: TItem, array: TItem[]): number;
 }
 
 export { DataProviderMixin, DataProviderMixinConstructor, ItemCache };

--- a/packages/vaadin-grid/src/vaadin-grid-data-provider-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-data-provider-mixin.d.ts
@@ -9,15 +9,23 @@ declare class ItemCache<TItem> {
   effectiveSize: number;
   size: number;
   pendingRequests: object | null;
+
   constructor(grid: HTMLElement, parentCache: ItemCache<TItem> | undefined, parentItem: TItem | undefined);
+
   isLoading(): boolean;
+
   getItemForIndex(index: number): TItem | undefined;
+
   updateSize(): void;
+
   ensureSubCacheForScaledIndex(scaledIndex: number): void;
+
   getCacheAndIndex(index: number): { cache: ItemCache<TItem>; scaledIndex: number };
 }
 
-declare function DataProviderMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & DataProviderMixinConstructor<TItem>;
+declare function DataProviderMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & DataProviderMixinConstructor<TItem>;
 
 interface DataProviderMixinConstructor<TItem> {
   new (...args: any[]): DataProviderMixin<TItem>;

--- a/packages/vaadin-grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
@@ -1,12 +1,12 @@
 import { GridDragAndDropFilter, GridDropMode, GridItemModel } from './interfaces';
 
-declare function DragAndDropMixin<T extends new (...args: any[]) => {}>(base: T): T & DragAndDropMixinConstructor;
+declare function DragAndDropMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & DragAndDropMixinConstructor<TItem>;
 
-interface DragAndDropMixinConstructor {
-  new (...args: any[]): DragAndDropMixin;
+interface DragAndDropMixinConstructor<TItem> {
+  new (...args: any[]): DragAndDropMixin<TItem>;
 }
 
-interface DragAndDropMixin {
+interface DragAndDropMixin<TItem> {
   /**
    * Defines the locations within the Grid row where an element can be dropped.
    *
@@ -65,7 +65,7 @@ interface DragAndDropMixin {
    */
   filterDragAndDrop(): void;
 
-  _filterDragAndDrop(row: HTMLElement, model: GridItemModel): void;
+  _filterDragAndDrop(row: HTMLElement, model: GridItemModel<TItem>): void;
 }
 
 export { DragAndDropMixin, DragAndDropMixinConstructor };

--- a/packages/vaadin-grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
@@ -1,6 +1,8 @@
 import { GridDragAndDropFilter, GridDropMode, GridItemModel } from './interfaces';
 
-declare function DragAndDropMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & DragAndDropMixinConstructor<TItem>;
+declare function DragAndDropMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & DragAndDropMixinConstructor<TItem>;
 
 interface DragAndDropMixinConstructor<TItem> {
   new (...args: any[]): DragAndDropMixin<TItem>;

--- a/packages/vaadin-grid/src/vaadin-grid-dynamic-columns-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-dynamic-columns-mixin.d.ts
@@ -2,7 +2,9 @@ import { GridColumnGroupElement } from './vaadin-grid-column-group.js';
 
 import { GridColumnElement } from './vaadin-grid-column.js';
 
-declare function DynamicColumnsMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & DynamicColumnsMixinConstructor<TItem>;
+declare function DynamicColumnsMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & DynamicColumnsMixinConstructor<TItem>;
 
 interface DynamicColumnsMixinConstructor<TItem> {
   new (...args: any[]): DynamicColumnsMixin<TItem>;

--- a/packages/vaadin-grid/src/vaadin-grid-dynamic-columns-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-dynamic-columns-mixin.d.ts
@@ -2,14 +2,14 @@ import { GridColumnGroupElement } from './vaadin-grid-column-group.js';
 
 import { GridColumnElement } from './vaadin-grid-column.js';
 
-declare function DynamicColumnsMixin<T extends new (...args: any[]) => {}>(base: T): T & DynamicColumnsMixinConstructor;
+declare function DynamicColumnsMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & DynamicColumnsMixinConstructor<TItem>;
 
-interface DynamicColumnsMixinConstructor {
-  new (...args: any[]): DynamicColumnsMixin;
+interface DynamicColumnsMixinConstructor<TItem> {
+  new (...args: any[]): DynamicColumnsMixin<TItem>;
 }
 
-interface DynamicColumnsMixin {
-  _getChildColumns(el: GridColumnGroupElement): GridColumnElement[];
+interface DynamicColumnsMixin<TItem> {
+  _getChildColumns(el: GridColumnGroupElement<TItem>): GridColumnElement<TItem>[];
 
   _updateColumnTree(): void;
 

--- a/packages/vaadin-grid/src/vaadin-grid-event-context-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-event-context-mixin.d.ts
@@ -1,6 +1,8 @@
 import { GridEventContext } from './interfaces';
 
-declare function EventContextMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & EventContextMixinConstructor<TItem>;
+declare function EventContextMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & EventContextMixinConstructor<TItem>;
 
 interface EventContextMixinConstructor<TItem> {
   new (...args: any[]): EventContextMixin<TItem>;

--- a/packages/vaadin-grid/src/vaadin-grid-event-context-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-event-context-mixin.d.ts
@@ -1,12 +1,12 @@
 import { GridEventContext } from './interfaces';
 
-declare function EventContextMixin<T extends new (...args: any[]) => {}>(base: T): T & EventContextMixinConstructor;
+declare function EventContextMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & EventContextMixinConstructor<TItem>;
 
-interface EventContextMixinConstructor {
-  new (...args: any[]): EventContextMixin;
+interface EventContextMixinConstructor<TItem> {
+  new (...args: any[]): EventContextMixin<TItem>;
 }
 
-interface EventContextMixin {
+interface EventContextMixin<TItem> {
   /**
    * Returns an object with context information about the event target:
    * - `item`: the data object corresponding to the targeted row (not specified when targeting header or footer)
@@ -25,7 +25,7 @@ interface EventContextMixin {
    * This may be the case eg. if the event is fired on the `<vaadin-grid>` element and not any deeper in the DOM, or if
    * the event targets the empty part of the grid body.
    */
-  getEventContext(event: Event): GridEventContext | object | null;
+  getEventContext(event: Event): GridEventContext<TItem> | object | null;
 }
 
 export { EventContextMixin, EventContextMixinConstructor };

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
@@ -1,3 +1,4 @@
+import {DefaultGridItem} from './interfaces';
 import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**
@@ -13,7 +14,7 @@ import { GridColumnElement } from './vaadin-grid-column.js';
  *    ...
  * ```
  */
-declare class GridFilterColumnElement extends GridColumnElement {
+declare class GridFilterColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
   /**
    * Text to display as the label of the column filter text-field.
    */
@@ -27,7 +28,7 @@ declare class GridFilterColumnElement extends GridColumnElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-filter-column': GridFilterColumnElement;
+    'vaadin-grid-filter-column': GridFilterColumnElement<DefaultGridItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
@@ -1,4 +1,4 @@
-import {DefaultGridItem} from './interfaces';
+import {GridDefaultItem} from './interfaces';
 import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**
@@ -14,7 +14,7 @@ import { GridColumnElement } from './vaadin-grid-column.js';
  *    ...
  * ```
  */
-declare class GridFilterColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
+declare class GridFilterColumnElement<TItem = GridDefaultItem> extends GridColumnElement<TItem> {
   /**
    * Text to display as the label of the column filter text-field.
    */
@@ -28,7 +28,7 @@ declare class GridFilterColumnElement<TItem = DefaultGridItem> extends GridColum
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-filter-column': GridFilterColumnElement<DefaultGridItem>;
+    'vaadin-grid-filter-column': GridFilterColumnElement<GridDefaultItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
@@ -1,4 +1,4 @@
-import {GridDefaultItem} from './interfaces';
+import { GridDefaultItem } from './interfaces';
 import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**

--- a/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.d.ts
@@ -1,14 +1,14 @@
 import { GridColumnElement } from './vaadin-grid-column.js';
 
-declare function KeyboardNavigationMixin<T extends new (...args: any[]) => {}>(
+declare function KeyboardNavigationMixin<TItem, T extends new (...args: any[]) => {}>(
   base: T
-): T & KeyboardNavigationMixinConstructor;
+): T & KeyboardNavigationMixinConstructor<TItem>;
 
-interface KeyboardNavigationMixinConstructor {
-  new (...args: any[]): KeyboardNavigationMixin;
+interface KeyboardNavigationMixinConstructor<TItem> {
+  new (...args: any[]): KeyboardNavigationMixin<TItem>;
 }
 
-interface KeyboardNavigationMixin {
+interface KeyboardNavigationMixin<TItem> {
   _itemsFocusable: HTMLElement | undefined;
 
   _focusedItemIndex: number;
@@ -21,7 +21,7 @@ interface KeyboardNavigationMixin {
 
   _preventScrollerRotatingCellFocus(row: HTMLTableRowElement, index: number): void;
 
-  _getColumns(rowGroup?: HTMLTableSectionElement | null, rowIndex?: number): GridColumnElement[];
+  _getColumns(rowGroup?: HTMLTableSectionElement | null, rowIndex?: number): GridColumnElement<TItem>[];
 
   _resetKeyboardNavigation(): void;
 

--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.d.ts
@@ -1,16 +1,16 @@
-import { GridItem, GridRowDetailsRenderer } from './interfaces';
+import { GridRowDetailsRenderer } from './interfaces';
 
-declare function RowDetailsMixin<T extends new (...args: any[]) => {}>(base: T): T & RowDetailsMixinConstructor;
+declare function RowDetailsMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & RowDetailsMixinConstructor<TItem>;
 
-interface RowDetailsMixinConstructor {
-  new (...args: any[]): RowDetailsMixin;
+interface RowDetailsMixinConstructor<TItem> {
+  new (...args: any[]): RowDetailsMixin<TItem>;
 }
 
-interface RowDetailsMixin {
+interface RowDetailsMixin<TItem> {
   /**
    * An array containing references to items with open row details.
    */
-  detailsOpenedItems: Array<GridItem | null> | null | undefined;
+  detailsOpenedItems: Array<TItem | null> | null | undefined;
 
   _rowDetailsTemplate: HTMLTemplateElement | null;
 
@@ -25,27 +25,27 @@ interface RowDetailsMixin {
    *   - `model.index` The index of the item.
    *   - `model.item` The item.
    */
-  rowDetailsRenderer: GridRowDetailsRenderer | null | undefined;
+  rowDetailsRenderer: GridRowDetailsRenderer<TItem> | null | undefined;
 
   _detailsCells: HTMLElement[] | undefined;
 
   _configureDetailsCell(cell: HTMLElement): void;
 
-  _toggleDetailsCell(row: HTMLElement, item: GridItem): void;
+  _toggleDetailsCell(row: HTMLElement, item: TItem): void;
 
   _updateDetailsCellHeights(): void;
 
-  _isDetailsOpened(item: GridItem): boolean;
+  _isDetailsOpened(item: TItem): boolean;
 
   /**
    * Open the details row of a given item.
    */
-  openItemDetails(item: GridItem): void;
+  openItemDetails(item: TItem): void;
 
   /**
    * Close the details row of a given item.
    */
-  closeItemDetails(item: GridItem): void;
+  closeItemDetails(item: TItem): void;
 }
 
 export { RowDetailsMixin, RowDetailsMixinConstructor };

--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.d.ts
@@ -1,6 +1,8 @@
 import { GridRowDetailsRenderer } from './interfaces';
 
-declare function RowDetailsMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & RowDetailsMixinConstructor<TItem>;
+declare function RowDetailsMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & RowDetailsMixinConstructor<TItem>;
 
 interface RowDetailsMixinConstructor<TItem> {
   new (...args: any[]): RowDetailsMixin<TItem>;

--- a/packages/vaadin-grid/src/vaadin-grid-scroller.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-scroller.d.ts
@@ -20,7 +20,7 @@ declare class ScrollerElement extends PolymerIronList {
 
   _createScrollerRows(): void;
 
-  _canPopulate(): void;
+  _canPopulate(): boolean;
 
   scrollToIndex(index: number): void;
 

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
@@ -1,3 +1,4 @@
+import {DefaultGridItem} from './interfaces';
 import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**
@@ -35,7 +36,7 @@ export interface GridSelectionColumnEventMap extends HTMLElementEventMap, GridSe
  *
  * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
-declare class GridSelectionColumnElement extends GridColumnElement {
+declare class GridSelectionColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
   /**
    * Width of the cells for this column.
    */
@@ -61,20 +62,20 @@ declare class GridSelectionColumnElement extends GridColumnElement {
 
   addEventListener<K extends keyof GridSelectionColumnEventMap>(
     type: K,
-    listener: (this: GridSelectionColumnElement, ev: GridSelectionColumnEventMap[K]) => void,
+    listener: (this: GridSelectionColumnElement<TItem>, ev: GridSelectionColumnEventMap[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
   removeEventListener<K extends keyof GridSelectionColumnEventMap>(
     type: K,
-    listener: (this: GridSelectionColumnElement, ev: GridSelectionColumnEventMap[K]) => void,
+    listener: (this: GridSelectionColumnElement<TItem>, ev: GridSelectionColumnEventMap[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-selection-column': GridSelectionColumnElement;
+    'vaadin-grid-selection-column': GridSelectionColumnElement<DefaultGridItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
@@ -1,4 +1,4 @@
-import {DefaultGridItem} from './interfaces';
+import {GridDefaultItem} from './interfaces';
 import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**
@@ -36,7 +36,7 @@ export interface GridSelectionColumnEventMap extends HTMLElementEventMap, GridSe
  *
  * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
-declare class GridSelectionColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
+declare class GridSelectionColumnElement<TItem = GridDefaultItem> extends GridColumnElement<TItem> {
   /**
    * Width of the cells for this column.
    */
@@ -75,7 +75,7 @@ declare class GridSelectionColumnElement<TItem = DefaultGridItem> extends GridCo
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-selection-column': GridSelectionColumnElement<DefaultGridItem>;
+    'vaadin-grid-selection-column': GridSelectionColumnElement<GridDefaultItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
@@ -1,4 +1,4 @@
-import {GridDefaultItem} from './interfaces';
+import { GridDefaultItem } from './interfaces';
 import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**

--- a/packages/vaadin-grid/src/vaadin-grid-selection-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-mixin.d.ts
@@ -1,38 +1,36 @@
-import { GridItem } from './interfaces';
+declare function SelectionMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & SelectionMixinConstructor<TItem>;
 
-declare function SelectionMixin<T extends new (...args: any[]) => {}>(base: T): T & SelectionMixinConstructor;
-
-interface SelectionMixinConstructor {
-  new (...args: any[]): SelectionMixin;
+interface SelectionMixinConstructor<TItem> {
+  new (...args: any[]): SelectionMixin<TItem>;
 }
 
-interface SelectionMixin {
+interface SelectionMixin<TItem> {
   /**
    * An array that contains the selected items.
    */
-  selectedItems: Array<GridItem | null> | null;
-  _isSelected(item: GridItem): boolean;
+  selectedItems: Array<TItem | null> | null;
+  _isSelected(item: TItem): boolean;
 
   /**
    * Selects the given item.
    *
    * @param item The item object
    */
-  selectItem(item: GridItem): void;
+  selectItem(item: TItem): void;
 
   /**
    * Deselects the given item if it is already selected.
    *
    * @param item The item object
    */
-  deselectItem(item: GridItem): void;
+  deselectItem(item: TItem): void;
 
   /**
    * Toggles the selected state of the given item.
    *
    * @param item The item object
    */
-  _toggleItem(item: GridItem): void;
+  _toggleItem(item: TItem): void;
 }
 
 export { SelectionMixin, SelectionMixinConstructor };

--- a/packages/vaadin-grid/src/vaadin-grid-selection-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-mixin.d.ts
@@ -1,4 +1,6 @@
-declare function SelectionMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & SelectionMixinConstructor<TItem>;
+declare function SelectionMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & SelectionMixinConstructor<TItem>;
 
 interface SelectionMixinConstructor<TItem> {
   new (...args: any[]): SelectionMixin<TItem>;
@@ -9,6 +11,7 @@ interface SelectionMixin<TItem> {
    * An array that contains the selected items.
    */
   selectedItems: Array<TItem | null> | null;
+
   _isSelected(item: TItem): boolean;
 
   /**

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
@@ -1,4 +1,4 @@
-import {DefaultGridItem, GridSorterDirection} from './interfaces';
+import {GridDefaultItem, GridSorterDirection} from './interfaces';
 
 import { GridColumnElement } from './vaadin-grid-column.js';
 
@@ -28,7 +28,7 @@ export interface GridSortColumnEventMap extends HTMLElementEventMap, GridSortCol
  *
  * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  */
-declare class GridSortColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
+declare class GridSortColumnElement<TItem = GridDefaultItem> extends GridColumnElement<TItem> {
   /**
    * JS Path of the property in the item used for sorting the data.
    */
@@ -56,7 +56,7 @@ declare class GridSortColumnElement<TItem = DefaultGridItem> extends GridColumnE
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-sort-column': GridSortColumnElement<DefaultGridItem>;
+    'vaadin-grid-sort-column': GridSortColumnElement<GridDefaultItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
@@ -1,4 +1,4 @@
-import {GridDefaultItem, GridSorterDirection} from './interfaces';
+import { GridDefaultItem, GridSorterDirection } from './interfaces';
 
 import { GridColumnElement } from './vaadin-grid-column.js';
 

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
@@ -1,4 +1,4 @@
-import { GridSorterDirection } from './interfaces';
+import {DefaultGridItem, GridSorterDirection} from './interfaces';
 
 import { GridColumnElement } from './vaadin-grid-column.js';
 
@@ -28,7 +28,7 @@ export interface GridSortColumnEventMap extends HTMLElementEventMap, GridSortCol
  *
  * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  */
-declare class GridSortColumnElement extends GridColumnElement {
+declare class GridSortColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
   /**
    * JS Path of the property in the item used for sorting the data.
    */
@@ -43,20 +43,20 @@ declare class GridSortColumnElement extends GridColumnElement {
 
   addEventListener<K extends keyof GridSortColumnEventMap>(
     type: K,
-    listener: (this: GridSortColumnElement, ev: GridSortColumnEventMap[K]) => void,
+    listener: (this: GridSortColumnElement<TItem>, ev: GridSortColumnEventMap[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
   removeEventListener<K extends keyof GridSortColumnEventMap>(
     type: K,
-    listener: (this: GridSortColumnElement, ev: GridSortColumnEventMap[K]) => void,
+    listener: (this: GridSortColumnElement<TItem>, ev: GridSortColumnEventMap[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-sort-column': GridSortColumnElement;
+    'vaadin-grid-sort-column': GridSortColumnElement<DefaultGridItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-styling-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-styling-mixin.d.ts
@@ -1,12 +1,12 @@
 import { GridCellClassNameGenerator } from './interfaces';
 
-declare function StylingMixin<T extends new (...args: any[]) => {}>(base: T): T & StylingMixinConstructor;
+declare function StylingMixin<TItem, T extends new (...args: any[]) => {}>(base: T): T & StylingMixinConstructor<TItem>;
 
-interface StylingMixinConstructor {
-  new (...args: any[]): StylingMixin;
+interface StylingMixinConstructor<TItem> {
+  new (...args: any[]): StylingMixin<TItem>;
 }
 
-interface StylingMixin {
+interface StylingMixin<TItem> {
   /**
    * A function that allows generating CSS class names for grid cells
    * based on their row and column. The return value should be the generated
@@ -23,7 +23,7 @@ interface StylingMixin {
    *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
    *   - `model.selected` Selected state.
    */
-  cellClassNameGenerator: GridCellClassNameGenerator | null | undefined;
+  cellClassNameGenerator: GridCellClassNameGenerator<TItem> | null | undefined;
 
   /**
    * Runs the `cellClassNameGenerator` for the visible cells.

--- a/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
@@ -1,4 +1,4 @@
-import {DefaultGridItem} from './interfaces';
+import {GridDefaultItem} from './interfaces';
 import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**
@@ -14,7 +14,7 @@ import { GridColumnElement } from './vaadin-grid-column.js';
  *    ...
  * ```
  */
-declare class GridTreeColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
+declare class GridTreeColumnElement<TItem = GridDefaultItem> extends GridColumnElement<TItem> {
   /**
    * JS Path of the property in the item used as text content for the tree toggle.
    */
@@ -29,7 +29,7 @@ declare class GridTreeColumnElement<TItem = DefaultGridItem> extends GridColumnE
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-tree-column': GridTreeColumnElement<DefaultGridItem>;
+    'vaadin-grid-tree-column': GridTreeColumnElement<GridDefaultItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
@@ -1,4 +1,4 @@
-import {GridDefaultItem} from './interfaces';
+import { GridDefaultItem } from './interfaces';
 import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**

--- a/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
@@ -1,3 +1,4 @@
+import {DefaultGridItem} from './interfaces';
 import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**
@@ -13,7 +14,7 @@ import { GridColumnElement } from './vaadin-grid-column.js';
  *    ...
  * ```
  */
-declare class GridTreeColumnElement extends GridColumnElement {
+declare class GridTreeColumnElement<TItem = DefaultGridItem> extends GridColumnElement<TItem> {
   /**
    * JS Path of the property in the item used as text content for the tree toggle.
    */
@@ -28,7 +29,7 @@ declare class GridTreeColumnElement extends GridColumnElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid-tree-column': GridTreeColumnElement;
+    'vaadin-grid-tree-column': GridTreeColumnElement<DefaultGridItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -2,7 +2,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
 
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-import { GridDropLocation, GridItem, GridItemModel } from './interfaces';
+import { DefaultGridItem, GridDropLocation, GridItemModel } from './interfaces';
 
 import { ScrollerElement } from './vaadin-grid-scroller.js';
 
@@ -43,33 +43,33 @@ import { GridColumnElement } from './vaadin-grid-column.js';
 /**
  * Fired when the `activeItem` property changes.
  */
-export type GridActiveItemChangedEvent = CustomEvent<{ value: GridItem }>;
+export type GridActiveItemChangedEvent<TItem> = CustomEvent<{ value: TItem }>;
 
 /**
  * Fired when the cell is activated with click or keyboard.
  */
-export type GridCellActivateEvent = CustomEvent<{ model: GridItemModel }>;
+export type GridCellActivateEvent<TItem> = CustomEvent<{ model: GridItemModel<TItem> }>;
 
 /**
  * Fired when the columns in the grid are reordered.
  */
-export type GridColumnReorderEvent = CustomEvent<{ columns: GridColumnElement[] }>;
+export type GridColumnReorderEvent<TItem> = CustomEvent<{ columns: GridColumnElement<TItem>[] }>;
 
 /**
  * Fired when the grid column resize is finished.
  */
-export type GridColumnResizeEvent = CustomEvent<{ resizedColumn: GridColumnElement }>;
+export type GridColumnResizeEvent<TItem> = CustomEvent<{ resizedColumn: GridColumnElement<TItem> }>;
 
 /**
  * Fired when the `expandedItems` property changes.
  */
-export type GridExpandedItemsChangedEvent = CustomEvent<{ value: GridItem[] }>;
+export type GridExpandedItemsChangedEvent<TItem> = CustomEvent<{ value: TItem[] }>;
 
 /**
  * Fired when starting to drag grid rows.
  */
-export type GridDragStartEvent = CustomEvent<{
-  draggedItems: GridItem[];
+export type GridDragStartEvent<TItem> = CustomEvent<{
+  draggedItems: TItem[];
   setDraggedItemsCount: (count: number) => void;
   setDragData: (type: string, data: string) => void;
 }>;
@@ -77,8 +77,8 @@ export type GridDragStartEvent = CustomEvent<{
 /**
  * Fired when a drop occurs on top of the grid.
  */
-export type GridDropEvent = CustomEvent<{
-  dropTargetItem: GridItem;
+export type GridDropEvent<TItem> = CustomEvent<{
+  dropTargetItem: TItem;
   dropLocation: GridDropLocation;
   dragData: Array<{ type: string; data: string }>;
 }>;
@@ -91,31 +91,52 @@ export type GridLoadingChangedEvent = CustomEvent<{ value: boolean }>;
 /**
  * Fired when the `selectedItems` property changes.
  */
-export type GridSelectedItemsChangedEvent = CustomEvent<{ value: GridItem[] }>;
+export type GridSelectedItemsChangedEvent<TItem> = CustomEvent<{ value: TItem[] }>;
 
-export interface GridElementEventMap {
-  'active-item-changed': GridActiveItemChangedEvent;
+export interface GridElementEventMap<TItem> {
+  'active-item-changed': GridActiveItemChangedEvent<TItem>;
 
-  'cell-activate': GridCellActivateEvent;
+  'cell-activate': GridCellActivateEvent<TItem>;
 
-  'column-reorder': GridColumnReorderEvent;
+  'column-reorder': GridColumnReorderEvent<TItem>;
 
-  'column-resize': GridColumnResizeEvent;
+  'column-resize': GridColumnResizeEvent<TItem>;
 
-  'expanded-items-changed': GridExpandedItemsChangedEvent;
+  'expanded-items-changed': GridExpandedItemsChangedEvent<TItem>;
 
-  'grid-dragstart': GridDragStartEvent;
+  'grid-dragstart': GridDragStartEvent<TItem>;
 
   'grid-dragend': Event;
 
-  'grid-drop': GridDropEvent;
+  'grid-drop': GridDropEvent<TItem>;
 
   'loading-changed': GridLoadingChangedEvent;
 
-  'selected-items-changed': GridSelectedItemsChangedEvent;
+  'selected-items-changed': GridSelectedItemsChangedEvent<TItem>;
 }
 
-export interface GridEventMap extends HTMLElementEventMap, GridElementEventMap {}
+export interface GridEventMap<TItem> extends HTMLElementEventMap, GridElementEventMap<TItem> {}
+
+interface GridElement<TItem = DefaultGridItem> extends ElementMixin
+    , ThemableMixin
+    , A11yMixin
+    , ActiveItemMixin<TItem>
+    , ArrayDataProviderMixin<TItem>
+    , ColumnResizingMixin
+    , DataProviderMixin<TItem>
+    , DynamicColumnsMixin<TItem>
+    , FilterMixin
+    , RowDetailsMixin<TItem>
+    , ScrollMixin
+    , SelectionMixin<TItem>
+    , SortMixin
+    , KeyboardNavigationMixin<TItem>
+    , ColumnReorderingMixin<TItem>
+    , EventContextMixin<TItem>
+    , StylingMixin<TItem>
+    , DragAndDropMixin<TItem> {
+    readonly dir: string; // Fix DirMixin.dir clashing with HTMLElement.dir declaration
+}
 
 /**
  * `<vaadin-grid>` is a free, high quality data grid / data table Web Component. The content of the
@@ -341,35 +362,7 @@ export interface GridEventMap extends HTMLElementEventMap, GridElementEventMap {
  * @fires {CustomEvent} loading-changed - Fired when the `loading` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  */
-declare class GridElement extends ElementMixin(
-  ThemableMixin(
-    A11yMixin(
-      ActiveItemMixin(
-        ArrayDataProviderMixin(
-          ColumnResizingMixin(
-            DataProviderMixin(
-              DynamicColumnsMixin(
-                FilterMixin(
-                  RowDetailsMixin(
-                    ScrollMixin(
-                      SelectionMixin(
-                        SortMixin(
-                          KeyboardNavigationMixin(
-                            ColumnReorderingMixin(EventContextMixin(StylingMixin(DragAndDropMixin(ScrollerElement))))
-                          )
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-      )
-    )
-  )
-) {
+declare class GridElement<TItem = DefaultGridItem> extends ScrollerElement {
   /**
    * If true, the grid's height is defined by its rows.
    *
@@ -388,7 +381,7 @@ declare class GridElement extends ElementMixin(
 
   _updateRow(
     row: HTMLTableRowElement,
-    columns: GridColumnElement[],
+    columns: GridColumnElement<TItem>[],
     section: string | null,
     isColumnRow: boolean,
     noNotify: boolean
@@ -396,13 +389,13 @@ declare class GridElement extends ElementMixin(
 
   __updateHeaderFooterRowVisibility(row: HTMLTableRowElement | null): void;
 
-  _renderColumnTree(columnTree: GridColumnElement[]): void;
+  _renderColumnTree(columnTree: GridColumnElement<TItem>[]): void;
 
-  _updateItem(row: HTMLElement, item: GridItem | null): void;
+  _updateItem(row: HTMLElement, item: TItem | null): void;
 
   _toggleAttribute(name: string, bool: boolean, node: Element): void;
 
-  __getRowModel(row: HTMLTableRowElement): GridItemModel;
+  __getRowModel(row: HTMLTableRowElement): GridItemModel<TItem>;
 
   /**
    * Manually invoke existing renderers for all the columns
@@ -420,22 +413,22 @@ declare class GridElement extends ElementMixin(
 
   __forceReflow(): void;
 
-  addEventListener<K extends keyof GridEventMap>(
+  addEventListener<K extends keyof GridEventMap<TItem>>(
     type: K,
-    listener: (this: GridElement, ev: GridEventMap[K]) => void,
+    listener: (this: GridElement<TItem>, ev: GridEventMap<TItem>[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
-  removeEventListener<K extends keyof GridEventMap>(
+  removeEventListener<K extends keyof GridEventMap<TItem>>(
     type: K,
-    listener: (this: GridElement, ev: GridEventMap[K]) => void,
+    listener: (this: GridElement<TItem>, ev: GridEventMap<TItem>[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid': GridElement;
+    'vaadin-grid': GridElement<DefaultGridItem>;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -423,9 +423,7 @@ interface GridElement<TItem = GridDefaultItem>
     ColumnReorderingMixin<TItem>,
     EventContextMixin<TItem>,
     StylingMixin<TItem>,
-    DragAndDropMixin<TItem> {
-  readonly dir: string; // Fix DirMixin.dir clashing with HTMLElement.dir declaration
-}
+    DragAndDropMixin<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -2,7 +2,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
 
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-import { DefaultGridItem, GridDropLocation, GridItemModel } from './interfaces';
+import { GridDefaultItem, GridDropLocation, GridItemModel } from './interfaces';
 
 import { ScrollerElement } from './vaadin-grid-scroller.js';
 
@@ -405,24 +405,25 @@ declare class GridElement<TItem = GridDefaultItem> extends ScrollerElement {
   ): void;
 }
 
-interface GridElement<TItem = GridDefaultItem> extends ElementMixin
-  , ThemableMixin
-  , A11yMixin
-  , ActiveItemMixin<TItem>
-  , ArrayDataProviderMixin<TItem>
-  , ColumnResizingMixin
-  , DataProviderMixin<TItem>
-  , DynamicColumnsMixin<TItem>
-  , FilterMixin
-  , RowDetailsMixin<TItem>
-  , ScrollMixin
-  , SelectionMixin<TItem>
-  , SortMixin
-  , KeyboardNavigationMixin<TItem>
-  , ColumnReorderingMixin<TItem>
-  , EventContextMixin<TItem>
-  , StylingMixin<TItem>
-  , DragAndDropMixin<TItem> {
+interface GridElement<TItem = GridDefaultItem>
+  extends ElementMixin,
+    ThemableMixin,
+    A11yMixin,
+    ActiveItemMixin<TItem>,
+    ArrayDataProviderMixin<TItem>,
+    ColumnResizingMixin,
+    DataProviderMixin<TItem>,
+    DynamicColumnsMixin<TItem>,
+    FilterMixin,
+    RowDetailsMixin<TItem>,
+    ScrollMixin,
+    SelectionMixin<TItem>,
+    SortMixin,
+    KeyboardNavigationMixin<TItem>,
+    ColumnReorderingMixin<TItem>,
+    EventContextMixin<TItem>,
+    StylingMixin<TItem>,
+    DragAndDropMixin<TItem> {
   readonly dir: string; // Fix DirMixin.dir clashing with HTMLElement.dir declaration
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -117,27 +117,6 @@ export interface GridElementEventMap<TItem> {
 
 export interface GridEventMap<TItem> extends HTMLElementEventMap, GridElementEventMap<TItem> {}
 
-interface GridElement<TItem = DefaultGridItem> extends ElementMixin
-    , ThemableMixin
-    , A11yMixin
-    , ActiveItemMixin<TItem>
-    , ArrayDataProviderMixin<TItem>
-    , ColumnResizingMixin
-    , DataProviderMixin<TItem>
-    , DynamicColumnsMixin<TItem>
-    , FilterMixin
-    , RowDetailsMixin<TItem>
-    , ScrollMixin
-    , SelectionMixin<TItem>
-    , SortMixin
-    , KeyboardNavigationMixin<TItem>
-    , ColumnReorderingMixin<TItem>
-    , EventContextMixin<TItem>
-    , StylingMixin<TItem>
-    , DragAndDropMixin<TItem> {
-    readonly dir: string; // Fix DirMixin.dir clashing with HTMLElement.dir declaration
-}
-
 /**
  * `<vaadin-grid>` is a free, high quality data grid / data table Web Component. The content of the
  * the grid can be populated in two ways: imperatively by using renderer callback function and
@@ -424,6 +403,27 @@ declare class GridElement<TItem = DefaultGridItem> extends ScrollerElement {
     listener: (this: GridElement<TItem>, ev: GridEventMap<TItem>[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
+}
+
+interface GridElement<TItem = DefaultGridItem> extends ElementMixin
+  , ThemableMixin
+  , A11yMixin
+  , ActiveItemMixin<TItem>
+  , ArrayDataProviderMixin<TItem>
+  , ColumnResizingMixin
+  , DataProviderMixin<TItem>
+  , DynamicColumnsMixin<TItem>
+  , FilterMixin
+  , RowDetailsMixin<TItem>
+  , ScrollMixin
+  , SelectionMixin<TItem>
+  , SortMixin
+  , KeyboardNavigationMixin<TItem>
+  , ColumnReorderingMixin<TItem>
+  , EventContextMixin<TItem>
+  , StylingMixin<TItem>
+  , DragAndDropMixin<TItem> {
+  readonly dir: string; // Fix DirMixin.dir clashing with HTMLElement.dir declaration
 }
 
 declare global {

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -341,7 +341,7 @@ export interface GridEventMap<TItem> extends HTMLElementEventMap, GridElementEve
  * @fires {CustomEvent} loading-changed - Fired when the `loading` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  */
-declare class GridElement<TItem = DefaultGridItem> extends ScrollerElement {
+declare class GridElement<TItem = GridDefaultItem> extends ScrollerElement {
   /**
    * If true, the grid's height is defined by its rows.
    *
@@ -405,7 +405,7 @@ declare class GridElement<TItem = DefaultGridItem> extends ScrollerElement {
   ): void;
 }
 
-interface GridElement<TItem = DefaultGridItem> extends ElementMixin
+interface GridElement<TItem = GridDefaultItem> extends ElementMixin
   , ThemableMixin
   , A11yMixin
   , ActiveItemMixin<TItem>
@@ -428,7 +428,7 @@ interface GridElement<TItem = DefaultGridItem> extends ElementMixin
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-grid': GridElement<DefaultGridItem>;
+    'vaadin-grid': GridElement<GridDefaultItem>;
   }
 }
 

--- a/packages/vaadin-grid/test/column.test.js
+++ b/packages/vaadin-grid/test/column.test.js
@@ -107,8 +107,8 @@ describe('column', () => {
     });
 
     describe('hidden', () => {
-      it('should default to undefined', () => {
-        expect(column.hidden).to.eql(undefined);
+      it('should default to false', () => {
+        expect(column.hidden).to.be.false;
       });
 
       it('should not be bound to column-group header cells', () => {
@@ -156,7 +156,7 @@ describe('column', () => {
 
       it('should not notify resize', () => {
         const spy = sinon.spy(grid, 'notifyResize');
-        expect(column.hidden).to.be.undefined;
+        expect(column.hidden).to.be.false;
         column.hidden = false;
         expect(spy.called).to.be.false;
       });

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -8,7 +8,7 @@ import '../../vaadin-grid-tree-toggle.js';
 import {
   GridColumnElement,
   GridDropLocation,
-  GridItem,
+  GridElement,
   GridItemModel,
   GridSorterDirection,
   GridActiveItemChangedEvent,
@@ -26,29 +26,52 @@ import { GridSorterDirectionChangedEvent } from '../../vaadin-grid-sorter.js';
 import { GridSortColumnDirectionChangedEvent } from '../../vaadin-grid-sort-column.js';
 import { GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
 import { GridSelectionColumnSelectAllChangedEvent } from '../../vaadin-grid-selection-column.js';
+import { ElementMixin } from '@vaadin/vaadin-element-mixin';
+import { ScrollerElement } from "../../src/vaadin-grid-scroller";
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
+import { A11yMixin } from '../../src/vaadin-grid-a11y-mixin';
+import { ActiveItemMixin } from '../../src/vaadin-grid-active-item-mixin';
+import { ArrayDataProviderMixin } from '../../src/vaadin-grid-array-data-provider-mixin';
+import { ColumnReorderingMixin } from '../../src/vaadin-grid-column-reordering-mixin';
+import { ColumnResizingMixin } from '../../src/vaadin-grid-column-resizing-mixin';
+import { DataProviderMixin } from '../../src/vaadin-grid-data-provider-mixin';
+import { DragAndDropMixin } from '../../src/vaadin-grid-drag-and-drop-mixin';
+import { DynamicColumnsMixin } from '../../src/vaadin-grid-dynamic-columns-mixin';
+import { EventContextMixin } from '../../src/vaadin-grid-event-context-mixin';
+import { FilterMixin } from '../../src/vaadin-grid-filter-mixin';
+import { KeyboardNavigationMixin } from '../../src/vaadin-grid-keyboard-navigation-mixin';
+import { RowDetailsMixin } from '../../src/vaadin-grid-row-details-mixin';
+import { ScrollMixin } from '../../src/vaadin-grid-scroll-mixin';
+import { SelectionMixin } from '../../src/vaadin-grid-selection-mixin';
+import { SortMixin } from '../../src/vaadin-grid-sort-mixin';
+import { StylingMixin } from '../../src/vaadin-grid-styling-mixin';
+
+interface TestGridItem {
+  testProperty: string;
+}
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-const grid = document.createElement('vaadin-grid');
+const grid = document.createElement('vaadin-grid') as GridElement<TestGridItem>;
 
 grid.addEventListener('active-item-changed', (event) => {
   assertType<GridActiveItemChangedEvent>(event);
-  assertType<GridItem>(event.detail.value);
+  assertType<TestGridItem>(event.detail.value);
 });
 
 grid.addEventListener('cell-activate', (event) => {
   assertType<GridCellActivateEvent>(event);
-  assertType<GridItemModel>(event.detail.model);
+  assertType<GridItemModel<TestGridItem>>(event.detail.model);
 });
 
 grid.addEventListener('column-reorder', (event) => {
   assertType<GridColumnReorderEvent>(event);
-  assertType<GridColumnElement[]>(event.detail.columns);
+  assertType<GridColumnElement<TestGridItem>[]>(event.detail.columns);
 });
 
 grid.addEventListener('column-resize', (event) => {
   assertType<GridColumnResizeEvent>(event);
-  assertType<GridColumnElement>(event.detail.resizedColumn);
+  assertType<GridColumnElement<TestGridItem>>(event.detail.resizedColumn);
 });
 
 grid.addEventListener('loading-changed', (event) => {
@@ -58,22 +81,22 @@ grid.addEventListener('loading-changed', (event) => {
 
 grid.addEventListener('expanded-items-changed', (event) => {
   assertType<GridExpandedItemsChangedEvent>(event);
-  assertType<GridItem[]>(event.detail.value);
+  assertType<TestGridItem[]>(event.detail.value);
 });
 
 grid.addEventListener('selected-items-changed', (event) => {
   assertType<GridSelectedItemsChangedEvent>(event);
-  assertType<GridItem[]>(event.detail.value);
+  assertType<TestGridItem[]>(event.detail.value);
 });
 
 grid.addEventListener('grid-dragstart', (event) => {
   assertType<GridDragStartEvent>(event);
-  assertType<GridItem[]>(event.detail.draggedItems);
+  assertType<TestGridItem[]>(event.detail.draggedItems);
 });
 
 grid.addEventListener('grid-drop', (event) => {
   assertType<GridDropEvent>(event);
-  assertType<GridItem>(event.detail.dropTargetItem);
+  assertType<TestGridItem>(event.detail.dropTargetItem);
   assertType<GridDropLocation>(event.detail.dropLocation);
 });
 
@@ -111,3 +134,24 @@ treeToggle.addEventListener('expanded-changed', (event) => {
   assertType<GridTreeToggleExpandedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
+
+// Verify mixins are correctly extended
+assertType<ScrollerElement>(grid);
+assertType<ElementMixin>(grid);
+assertType<ThemableMixin>(grid);
+assertType<A11yMixin>(grid);
+assertType<ActiveItemMixin<TestGridItem>>(grid);
+assertType<ArrayDataProviderMixin<TestGridItem>>(grid);
+assertType<ColumnResizingMixin>(grid);
+assertType<DataProviderMixin<TestGridItem>>(grid);
+assertType<DynamicColumnsMixin<TestGridItem>>(grid);
+assertType<FilterMixin>(grid);
+assertType<RowDetailsMixin<TestGridItem>>(grid);
+assertType<ScrollMixin>(grid);
+assertType<SelectionMixin<TestGridItem>>(grid);
+assertType<SortMixin>(grid);
+assertType<KeyboardNavigationMixin<TestGridItem>>(grid);
+assertType<ColumnReorderingMixin<TestGridItem>>(grid);
+assertType<EventContextMixin<TestGridItem>>(grid);
+assertType<StylingMixin<TestGridItem>>(grid);
+assertType<DragAndDropMixin<TestGridItem>>(grid);

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -1,10 +1,33 @@
-import '../../vaadin-grid.js';
-import '../../vaadin-grid-filter.js';
-import '../../vaadin-grid-selection-column.js';
-import '../../vaadin-grid-sorter.js';
-import '../../vaadin-grid-sort-column.js';
-import '../../vaadin-grid-tree-toggle.js';
-
+import { ElementMixin } from '@vaadin/vaadin-element-mixin';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
+import { GridColumnElement, GridDropLocation, GridItemModel, GridSorterDirection } from '../../src/interfaces';
+import { GridElement } from '../../src/vaadin-grid';
+import { A11yMixin } from '../../src/vaadin-grid-a11y-mixin';
+import { ActiveItemMixin } from '../../src/vaadin-grid-active-item-mixin';
+import { ArrayDataProviderMixin } from '../../src/vaadin-grid-array-data-provider-mixin';
+import { ColumnBaseMixin } from '../../src/vaadin-grid-column';
+import { GridColumnGroupElement } from '../../src/vaadin-grid-column-group';
+import { ColumnReorderingMixin } from '../../src/vaadin-grid-column-reordering-mixin';
+import { ColumnResizingMixin } from '../../src/vaadin-grid-column-resizing-mixin';
+import { DataProviderMixin } from '../../src/vaadin-grid-data-provider-mixin';
+import { DragAndDropMixin } from '../../src/vaadin-grid-drag-and-drop-mixin';
+import { DynamicColumnsMixin } from '../../src/vaadin-grid-dynamic-columns-mixin';
+import { EventContextMixin } from '../../src/vaadin-grid-event-context-mixin';
+import { GridFilterElement } from '../../src/vaadin-grid-filter';
+import { GridFilterColumnElement } from '../../src/vaadin-grid-filter-column';
+import { FilterMixin } from '../../src/vaadin-grid-filter-mixin';
+import { KeyboardNavigationMixin } from '../../src/vaadin-grid-keyboard-navigation-mixin';
+import { RowDetailsMixin } from '../../src/vaadin-grid-row-details-mixin';
+import { ScrollMixin } from '../../src/vaadin-grid-scroll-mixin';
+import { ScrollerElement } from '../../src/vaadin-grid-scroller';
+import { GridSelectionColumnElement } from '../../src/vaadin-grid-selection-column';
+import { SelectionMixin } from '../../src/vaadin-grid-selection-mixin';
+import { GridSortColumnElement } from '../../src/vaadin-grid-sort-column';
+import { SortMixin } from '../../src/vaadin-grid-sort-mixin';
+import { GridSorterElement } from '../../src/vaadin-grid-sorter';
+import { StylingMixin } from '../../src/vaadin-grid-styling-mixin';
+import { GridTreeColumnElement } from '../../src/vaadin-grid-tree-column';
+import { GridTreeToggleElement } from '../../src/vaadin-grid-tree-toggle';
 import {
   GridColumnElement,
   GridDropLocation,
@@ -26,25 +49,6 @@ import { GridSorterDirectionChangedEvent } from '../../vaadin-grid-sorter.js';
 import { GridSortColumnDirectionChangedEvent } from '../../vaadin-grid-sort-column.js';
 import { GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
 import { GridSelectionColumnSelectAllChangedEvent } from '../../vaadin-grid-selection-column.js';
-import { ElementMixin } from '@vaadin/vaadin-element-mixin';
-import { ScrollerElement } from "../../src/vaadin-grid-scroller";
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
-import { A11yMixin } from '../../src/vaadin-grid-a11y-mixin';
-import { ActiveItemMixin } from '../../src/vaadin-grid-active-item-mixin';
-import { ArrayDataProviderMixin } from '../../src/vaadin-grid-array-data-provider-mixin';
-import { ColumnReorderingMixin } from '../../src/vaadin-grid-column-reordering-mixin';
-import { ColumnResizingMixin } from '../../src/vaadin-grid-column-resizing-mixin';
-import { DataProviderMixin } from '../../src/vaadin-grid-data-provider-mixin';
-import { DragAndDropMixin } from '../../src/vaadin-grid-drag-and-drop-mixin';
-import { DynamicColumnsMixin } from '../../src/vaadin-grid-dynamic-columns-mixin';
-import { EventContextMixin } from '../../src/vaadin-grid-event-context-mixin';
-import { FilterMixin } from '../../src/vaadin-grid-filter-mixin';
-import { KeyboardNavigationMixin } from '../../src/vaadin-grid-keyboard-navigation-mixin';
-import { RowDetailsMixin } from '../../src/vaadin-grid-row-details-mixin';
-import { ScrollMixin } from '../../src/vaadin-grid-scroll-mixin';
-import { SelectionMixin } from '../../src/vaadin-grid-selection-mixin';
-import { SortMixin } from '../../src/vaadin-grid-sort-mixin';
-import { StylingMixin } from '../../src/vaadin-grid-styling-mixin';
 
 interface TestGridItem {
   testProperty: string;
@@ -52,106 +56,156 @@ interface TestGridItem {
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-const grid = document.createElement('vaadin-grid') as GridElement<TestGridItem>;
+/* GridElement */
+const genericGrid = document.createElement('vaadin-grid');
+assertType<GridElement>(genericGrid);
 
-grid.addEventListener('active-item-changed', (event) => {
+const narrowedGrid = genericGrid as GridElement<TestGridItem>;
+assertType<ScrollerElement>(narrowedGrid);
+assertType<ElementMixin>(narrowedGrid);
+assertType<ThemableMixin>(narrowedGrid);
+assertType<A11yMixin>(narrowedGrid);
+assertType<ActiveItemMixin<TestGridItem>>(narrowedGrid);
+assertType<ArrayDataProviderMixin<TestGridItem>>(narrowedGrid);
+assertType<ColumnResizingMixin>(narrowedGrid);
+assertType<DataProviderMixin<TestGridItem>>(narrowedGrid);
+assertType<DynamicColumnsMixin<TestGridItem>>(narrowedGrid);
+assertType<FilterMixin>(narrowedGrid);
+assertType<RowDetailsMixin<TestGridItem>>(narrowedGrid);
+assertType<ScrollMixin>(narrowedGrid);
+assertType<SelectionMixin<TestGridItem>>(narrowedGrid);
+assertType<SortMixin>(narrowedGrid);
+assertType<KeyboardNavigationMixin<TestGridItem>>(narrowedGrid);
+assertType<ColumnReorderingMixin<TestGridItem>>(narrowedGrid);
+assertType<EventContextMixin<TestGridItem>>(narrowedGrid);
+assertType<StylingMixin<TestGridItem>>(narrowedGrid);
+assertType<DragAndDropMixin<TestGridItem>>(narrowedGrid);
+
+narrowedGrid.addEventListener('active-item-changed', (event) => {
   assertType<GridActiveItemChangedEvent>(event);
   assertType<TestGridItem>(event.detail.value);
 });
 
-grid.addEventListener('cell-activate', (event) => {
+narrowedGrid.addEventListener('cell-activate', (event) => {
   assertType<GridCellActivateEvent>(event);
   assertType<GridItemModel<TestGridItem>>(event.detail.model);
 });
 
-grid.addEventListener('column-reorder', (event) => {
+narrowedGrid.addEventListener('column-reorder', (event) => {
   assertType<GridColumnReorderEvent>(event);
   assertType<GridColumnElement<TestGridItem>[]>(event.detail.columns);
 });
 
-grid.addEventListener('column-resize', (event) => {
+narrowedGrid.addEventListener('column-resize', (event) => {
   assertType<GridColumnResizeEvent>(event);
   assertType<GridColumnElement<TestGridItem>>(event.detail.resizedColumn);
 });
 
-grid.addEventListener('loading-changed', (event) => {
+narrowedGrid.addEventListener('loading-changed', (event) => {
   assertType<GridLoadingChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
-grid.addEventListener('expanded-items-changed', (event) => {
+narrowedGrid.addEventListener('expanded-items-changed', (event) => {
   assertType<GridExpandedItemsChangedEvent>(event);
   assertType<TestGridItem[]>(event.detail.value);
 });
 
-grid.addEventListener('selected-items-changed', (event) => {
+narrowedGrid.addEventListener('selected-items-changed', (event) => {
   assertType<GridSelectedItemsChangedEvent>(event);
   assertType<TestGridItem[]>(event.detail.value);
 });
 
-grid.addEventListener('grid-dragstart', (event) => {
+narrowedGrid.addEventListener('grid-dragstart', (event) => {
   assertType<GridDragStartEvent>(event);
   assertType<TestGridItem[]>(event.detail.draggedItems);
 });
 
-grid.addEventListener('grid-drop', (event) => {
+narrowedGrid.addEventListener('grid-drop', (event) => {
   assertType<GridDropEvent>(event);
   assertType<TestGridItem>(event.detail.dropTargetItem);
   assertType<GridDropLocation>(event.detail.dropLocation);
 });
 
+/* GridColumnElement */
+const genericColumn = document.createElement('vaadin-grid-column');
+assertType<GridColumnElement>(genericColumn);
+
+const narrowedColumn = genericColumn as GridColumnElement<TestGridItem>;
+assertType<HTMLElement>(narrowedColumn);
+assertType<ColumnBaseMixin<TestGridItem>>(narrowedColumn);
+
+/* GridColumnGroupElement */
+const genericColumnGroup = document.createElement('vaadin-grid-column-group');
+assertType<GridColumnGroupElement>(genericColumnGroup);
+
+const narrowedColumnGroup = genericColumnGroup as GridColumnGroupElement<TestGridItem>;
+assertType<HTMLElement>(narrowedColumnGroup);
+assertType<ColumnBaseMixin<TestGridItem>>(narrowedColumnGroup);
+
+/* GridFilterElement */
 const filter = document.createElement('vaadin-grid-filter');
+assertType<GridFilterElement>(filter);
+assertType<HTMLElement>(filter);
 
 filter.addEventListener('value-changed', (event) => {
   assertType<GridFilterValueChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
 
-const selectionColumn = document.createElement('vaadin-grid-selection-column');
+/* GridFilterColumnElement */
+const genericFilterColumn = document.createElement('vaadin-grid-filter-column');
+assertType<GridFilterColumnElement>(genericFilterColumn);
 
-selectionColumn.addEventListener('select-all-changed', (event) => {
+const narrowedFilterColumn = genericFilterColumn as GridFilterColumnElement<TestGridItem>;
+assertType<GridColumnElement<TestGridItem>>(narrowedFilterColumn);
+
+/* GridSelectionColumnElement */
+const genericSelectionColumn = document.createElement('vaadin-grid-selection-column');
+assertType<GridSelectionColumnElement>(genericSelectionColumn);
+
+const narrowedSelectionColumn = genericSelectionColumn as GridSelectionColumnElement<TestGridItem>;
+assertType<GridColumnElement<TestGridItem>>(narrowedSelectionColumn);
+
+narrowedSelectionColumn.addEventListener('select-all-changed', (event) => {
   assertType<GridSelectionColumnSelectAllChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
+/* GridSortColumnElement */
+const genericSortColumn = document.createElement('vaadin-grid-sort-column');
+assertType<GridSortColumnElement>(genericSortColumn);
+
+const narrowedSortColumn = genericSortColumn as GridSortColumnElement<TestGridItem>;
+assertType<GridColumnElement<TestGridItem>>(narrowedSortColumn);
+
+narrowedSortColumn.addEventListener('direction-changed', (event) => {
+  assertType<GridSortColumnDirectionChangedEvent>(event);
+  assertType<GridSorterDirection>(event.detail.value);
+});
+
+/* GridSorterElement */
 const sorter = document.createElement('vaadin-grid-sorter');
+assertType<GridSorterElement>(sorter);
 
 sorter.addEventListener('direction-changed', (event) => {
   assertType<GridSorterDirectionChangedEvent>(event);
   assertType<GridSorterDirection>(event.detail.value);
 });
 
-const sortColumn = document.createElement('vaadin-grid-sort-column');
+/* GridTreeColumnElement */
+const genericTreeColumn = document.createElement('vaadin-grid-tree-column');
+assertType<GridTreeColumnElement>(genericTreeColumn);
 
-sortColumn.addEventListener('direction-changed', (event) => {
-  assertType<GridSortColumnDirectionChangedEvent>(event);
-  assertType<GridSorterDirection>(event.detail.value);
-});
+const narrowedTreeColumn = genericTreeColumn as GridTreeColumnElement<TestGridItem>;
+assertType<GridColumnElement<TestGridItem>>(narrowedTreeColumn);
 
+/* GridTreeToggleElement */
 const treeToggle = document.createElement('vaadin-grid-tree-toggle');
+assertType<GridTreeToggleElement>(treeToggle);
+assertType<ThemableMixin>(treeToggle);
 
 treeToggle.addEventListener('expanded-changed', (event) => {
   assertType<GridTreeToggleExpandedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
-
-// Verify mixins are correctly extended
-assertType<ScrollerElement>(grid);
-assertType<ElementMixin>(grid);
-assertType<ThemableMixin>(grid);
-assertType<A11yMixin>(grid);
-assertType<ActiveItemMixin<TestGridItem>>(grid);
-assertType<ArrayDataProviderMixin<TestGridItem>>(grid);
-assertType<ColumnResizingMixin>(grid);
-assertType<DataProviderMixin<TestGridItem>>(grid);
-assertType<DynamicColumnsMixin<TestGridItem>>(grid);
-assertType<FilterMixin>(grid);
-assertType<RowDetailsMixin<TestGridItem>>(grid);
-assertType<ScrollMixin>(grid);
-assertType<SelectionMixin<TestGridItem>>(grid);
-assertType<SortMixin>(grid);
-assertType<KeyboardNavigationMixin<TestGridItem>>(grid);
-assertType<ColumnReorderingMixin<TestGridItem>>(grid);
-assertType<EventContextMixin<TestGridItem>>(grid);
-assertType<StylingMixin<TestGridItem>>(grid);
-assertType<DragAndDropMixin<TestGridItem>>(grid);

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -28,27 +28,6 @@ import { GridSorterElement } from '../../src/vaadin-grid-sorter';
 import { StylingMixin } from '../../src/vaadin-grid-styling-mixin';
 import { GridTreeColumnElement } from '../../src/vaadin-grid-tree-column';
 import { GridTreeToggleElement } from '../../src/vaadin-grid-tree-toggle';
-import {
-  GridColumnElement,
-  GridDropLocation,
-  GridElement,
-  GridItemModel,
-  GridSorterDirection,
-  GridActiveItemChangedEvent,
-  GridCellActivateEvent,
-  GridColumnReorderEvent,
-  GridColumnResizeEvent,
-  GridLoadingChangedEvent,
-  GridExpandedItemsChangedEvent,
-  GridSelectedItemsChangedEvent,
-  GridDragStartEvent,
-  GridDropEvent
-} from '../../vaadin-grid.js';
-import { GridFilterValueChangedEvent } from '../../vaadin-grid-filter.js';
-import { GridSorterDirectionChangedEvent } from '../../vaadin-grid-sorter.js';
-import { GridSortColumnDirectionChangedEvent } from '../../vaadin-grid-sort-column.js';
-import { GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
-import { GridSelectionColumnSelectAllChangedEvent } from '../../vaadin-grid-selection-column.js';
 
 interface TestGridItem {
   testProperty: string;

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -1,33 +1,47 @@
 import { ElementMixin } from '@vaadin/vaadin-element-mixin';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
-import { GridColumnElement, GridDropLocation, GridItemModel, GridSorterDirection } from '../../src/interfaces';
-import { GridElement } from '../../src/vaadin-grid';
+import { GridDropLocation, GridItemModel, GridSorterDirection } from '../../src/interfaces';
 import { A11yMixin } from '../../src/vaadin-grid-a11y-mixin';
 import { ActiveItemMixin } from '../../src/vaadin-grid-active-item-mixin';
 import { ArrayDataProviderMixin } from '../../src/vaadin-grid-array-data-provider-mixin';
-import { ColumnBaseMixin } from '../../src/vaadin-grid-column';
-import { GridColumnGroupElement } from '../../src/vaadin-grid-column-group';
 import { ColumnReorderingMixin } from '../../src/vaadin-grid-column-reordering-mixin';
 import { ColumnResizingMixin } from '../../src/vaadin-grid-column-resizing-mixin';
 import { DataProviderMixin } from '../../src/vaadin-grid-data-provider-mixin';
 import { DragAndDropMixin } from '../../src/vaadin-grid-drag-and-drop-mixin';
 import { DynamicColumnsMixin } from '../../src/vaadin-grid-dynamic-columns-mixin';
 import { EventContextMixin } from '../../src/vaadin-grid-event-context-mixin';
-import { GridFilterElement } from '../../src/vaadin-grid-filter';
-import { GridFilterColumnElement } from '../../src/vaadin-grid-filter-column';
 import { FilterMixin } from '../../src/vaadin-grid-filter-mixin';
 import { KeyboardNavigationMixin } from '../../src/vaadin-grid-keyboard-navigation-mixin';
 import { RowDetailsMixin } from '../../src/vaadin-grid-row-details-mixin';
 import { ScrollMixin } from '../../src/vaadin-grid-scroll-mixin';
 import { ScrollerElement } from '../../src/vaadin-grid-scroller';
-import { GridSelectionColumnElement } from '../../src/vaadin-grid-selection-column';
 import { SelectionMixin } from '../../src/vaadin-grid-selection-mixin';
-import { GridSortColumnElement } from '../../src/vaadin-grid-sort-column';
 import { SortMixin } from '../../src/vaadin-grid-sort-mixin';
-import { GridSorterElement } from '../../src/vaadin-grid-sorter';
 import { StylingMixin } from '../../src/vaadin-grid-styling-mixin';
-import { GridTreeColumnElement } from '../../src/vaadin-grid-tree-column';
-import { GridTreeToggleElement } from '../../src/vaadin-grid-tree-toggle';
+import { ColumnBaseMixin, GridColumnElement } from '../../vaadin-grid-column';
+import { GridColumnGroupElement } from '../../vaadin-grid-column-group';
+import { GridFilterColumnElement } from '../../vaadin-grid-filter-column';
+import { GridFilterElement, GridFilterValueChangedEvent } from '../../vaadin-grid-filter.js';
+import {
+  GridSelectionColumnElement,
+  GridSelectionColumnSelectAllChangedEvent
+} from '../../vaadin-grid-selection-column.js';
+import { GridSortColumnDirectionChangedEvent, GridSortColumnElement } from '../../vaadin-grid-sort-column.js';
+import { GridSorterDirectionChangedEvent, GridSorterElement } from '../../vaadin-grid-sorter.js';
+import { GridTreeColumnElement } from '../../vaadin-grid-tree-column';
+import { GridTreeToggleElement, GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
+import {
+  GridActiveItemChangedEvent,
+  GridCellActivateEvent,
+  GridColumnReorderEvent,
+  GridColumnResizeEvent,
+  GridDragStartEvent,
+  GridDropEvent,
+  GridElement,
+  GridExpandedItemsChangedEvent,
+  GridLoadingChangedEvent,
+  GridSelectedItemsChangedEvent
+} from '../../vaadin-grid.js';
 
 interface TestGridItem {
   testProperty: string;
@@ -61,22 +75,22 @@ assertType<StylingMixin<TestGridItem>>(narrowedGrid);
 assertType<DragAndDropMixin<TestGridItem>>(narrowedGrid);
 
 narrowedGrid.addEventListener('active-item-changed', (event) => {
-  assertType<GridActiveItemChangedEvent>(event);
+  assertType<GridActiveItemChangedEvent<TestGridItem>>(event);
   assertType<TestGridItem>(event.detail.value);
 });
 
 narrowedGrid.addEventListener('cell-activate', (event) => {
-  assertType<GridCellActivateEvent>(event);
+  assertType<GridCellActivateEvent<TestGridItem>>(event);
   assertType<GridItemModel<TestGridItem>>(event.detail.model);
 });
 
 narrowedGrid.addEventListener('column-reorder', (event) => {
-  assertType<GridColumnReorderEvent>(event);
+  assertType<GridColumnReorderEvent<TestGridItem>>(event);
   assertType<GridColumnElement<TestGridItem>[]>(event.detail.columns);
 });
 
 narrowedGrid.addEventListener('column-resize', (event) => {
-  assertType<GridColumnResizeEvent>(event);
+  assertType<GridColumnResizeEvent<TestGridItem>>(event);
   assertType<GridColumnElement<TestGridItem>>(event.detail.resizedColumn);
 });
 
@@ -86,22 +100,22 @@ narrowedGrid.addEventListener('loading-changed', (event) => {
 });
 
 narrowedGrid.addEventListener('expanded-items-changed', (event) => {
-  assertType<GridExpandedItemsChangedEvent>(event);
+  assertType<GridExpandedItemsChangedEvent<TestGridItem>>(event);
   assertType<TestGridItem[]>(event.detail.value);
 });
 
 narrowedGrid.addEventListener('selected-items-changed', (event) => {
-  assertType<GridSelectedItemsChangedEvent>(event);
+  assertType<GridSelectedItemsChangedEvent<TestGridItem>>(event);
   assertType<TestGridItem[]>(event.detail.value);
 });
 
 narrowedGrid.addEventListener('grid-dragstart', (event) => {
-  assertType<GridDragStartEvent>(event);
+  assertType<GridDragStartEvent<TestGridItem>>(event);
   assertType<TestGridItem[]>(event.detail.draggedItems);
 });
 
 narrowedGrid.addEventListener('grid-drop', (event) => {
-  assertType<GridDropEvent>(event);
+  assertType<GridDropEvent<TestGridItem>>(event);
   assertType<TestGridItem>(event.detail.dropTargetItem);
   assertType<GridDropLocation>(event.detail.dropLocation);
 });

--- a/packages/vaadin-grid/vaadin-grid-column-group.js
+++ b/packages/vaadin-grid/vaadin-grid-column-group.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-column-group.js';
+
 export * from './src/vaadin-grid-column-group.js';

--- a/packages/vaadin-grid/vaadin-grid-column.js
+++ b/packages/vaadin-grid/vaadin-grid-column.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-column.js';
+
 export * from './src/vaadin-grid-column.js';

--- a/packages/vaadin-grid/vaadin-grid-filter-column.js
+++ b/packages/vaadin-grid/vaadin-grid-filter-column.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-filter-column.js';
+
 export * from './src/vaadin-grid-filter-column.js';

--- a/packages/vaadin-grid/vaadin-grid-filter.js
+++ b/packages/vaadin-grid/vaadin-grid-filter.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-filter.js';
+
 export * from './src/vaadin-grid-filter.js';

--- a/packages/vaadin-grid/vaadin-grid-selection-column.js
+++ b/packages/vaadin-grid/vaadin-grid-selection-column.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-selection-column.js';
+
 export * from './src/vaadin-grid-selection-column.js';

--- a/packages/vaadin-grid/vaadin-grid-sort-column.js
+++ b/packages/vaadin-grid/vaadin-grid-sort-column.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-sort-column.js';
+
 export * from './src/vaadin-grid-sort-column.js';

--- a/packages/vaadin-grid/vaadin-grid-sorter.js
+++ b/packages/vaadin-grid/vaadin-grid-sorter.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-sorter.js';
+
 export * from './src/vaadin-grid-sorter.js';

--- a/packages/vaadin-grid/vaadin-grid-tree-column.js
+++ b/packages/vaadin-grid/vaadin-grid-tree-column.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-tree-column.js';
+
 export * from './src/vaadin-grid-tree-column.js';

--- a/packages/vaadin-grid/vaadin-grid-tree-toggle.js
+++ b/packages/vaadin-grid/vaadin-grid-tree-toggle.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid-tree-toggle.js';
+
 export * from './src/vaadin-grid-tree-toggle.js';

--- a/packages/vaadin-grid/vaadin-grid.js
+++ b/packages/vaadin-grid/vaadin-grid.js
@@ -1,2 +1,3 @@
 import './theme/lumo/vaadin-grid.js';
+
 export * from './src/vaadin-grid.js';


### PR DESCRIPTION
Made all relevant Grid types generic to allow setting a specific grid item type. The previous issue here was that Typescript does not allow passing a generic type arg to extend expressions, such as the mixin constructor functions that we use:
```
declare class SomeElement<T> extends SomeMixin<T>(HTMLElement) {
...
```
As a workaround I use declaration merging which allows to enhance the class type with an interface with the same name. The interface in turn can extend from all relevant mixin interfaces instead of extending from the mixin constructor functions (not possible with the class, a class can not extend an interface):
```
declare class SomeElement<T> extends HTMLElement {
...
}

interface SomeElement<T> extends SomeMixin<T> {}
```

## Default type param

One question that came up was if the types should use a default type for the type param. For now I only set a default type on element classes. For this I extracted a type `DefaultGridItem` which is simply an alias for `any`. My reasoning was:
- For elements we actually need a fallback in order to get tooling like the VSCode lit plugin to work, see issue [here](https://github.com/vaadin/docs/pull/188#discussion_r611616216)
- For all other types like listeners, events, renderers it is reasonable to force the user to specify a type, which they can still set to any if they don't feel like it

This would be a breaking change. If we want to avoid that we can add a default for any generic type.

## Scope
For now this change covers the following elements:
- Grid
- Grid Pro

Fixes vaadin/vaadin-grid#2104
Fixes vaadin/vaadin-grid#2071

Part of #204 