### PR TITLE
feat: include an available CSRF token in login request

### DIFF
--- a/packages/vaadin-login/src/vaadin-login-form.js
+++ b/packages/vaadin-login/src/vaadin-login-form.js
@@ -70,6 +70,7 @@ class LoginFormElement extends LoginMixin(ElementMixin(ThemableMixin(PolymerElem
         on-forgot-password="_retargetEvent"
       >
         <form part="vaadin-login-native-form" method="POST" action$="[[action]]" slot="form">
+          <input id="csrf" type="hidden" />
           <vaadin-text-field
             name="username"
             label="[[i18n.form.username]]"
@@ -155,6 +156,12 @@ class LoginFormElement extends LoginMixin(ElementMixin(ThemableMixin(PolymerElem
 
     const firedEvent = this.dispatchEvent(new CustomEvent('login', loginEventDetails));
     if (this.action && firedEvent) {
+      const csrfMetaName = document.querySelector('meta[name=_csrf_parameter]');
+      const csrfMetaValue = document.querySelector('meta[name=_csrf]');
+      if (csrfMetaName && csrfMetaValue) {
+        this.$.csrf.name = csrfMetaName.content;
+        this.$.csrf.value = csrfMetaValue.content;
+      }
       this.querySelector('[part="vaadin-login-native-form"]').submit();
     }
   }

--- a/packages/vaadin-login/test/login-form.test.js
+++ b/packages/vaadin-login/test/login-form.test.js
@@ -159,6 +159,23 @@ describe('login form', () => {
     expect(submitStub.called).to.be.false;
   });
 
+  it('should include CSRF in submit request if available', () => {
+    const loginWithCSRF = fixtureSync(
+      '<vaadin-login-form></vaadin-login-form><meta name="_csrf_parameter" content="_csrf" /><meta name="_csrf_header" content="X-CSRF-TOKEN" /><meta name="_csrf" content="28e4c684-fb5e-4c79-b8e2-a2177569edfa" />'
+    );
+    loginWithCSRF.action = 'login123';
+    const loginForm = loginWithCSRF.querySelector('[part="vaadin-login-native-form"]');
+    const submit = loginWithCSRF.querySelector('vaadin-button[part="vaadin-login-submit"]');
+    const submitStub = sinon.stub(loginForm, 'submit');
+    fillUsernameAndPassword(loginWithCSRF);
+    tap(submit);
+    expect(submitStub.called).to.be.true;
+    const csrfInput = loginForm.querySelector('#csrf');
+    expect(csrfInput.name).to.equal('_csrf');
+    expect(csrfInput.value).to.equal('28e4c684-fb5e-4c79-b8e2-a2177569edfa');
+    submitStub.restore();
+  });
+
   it('should not disable button on button click if form is invalid', () => {
     const submit = login.querySelector('vaadin-button[part="vaadin-login-submit"]');
     expect(submit.disabled).to.not.be.true;

--- a/packages/vaadin-login/test/login-form.test.js
+++ b/packages/vaadin-login/test/login-form.test.js
@@ -17,6 +17,38 @@ registerStyles(
   `
 );
 
+describe('login form with csrf', () => {
+  var loginForm, submitStub;
+
+  before(() => {
+    submitStub = sinon.stub(HTMLFormElement.prototype, 'submit');
+  });
+
+  after(() => {
+    submitStub.restore();
+  });
+
+  beforeEach(() => {
+    loginForm = fixtureSync(`<vaadin-login-form action='login-action'></vaadin-login-form>
+    <meta name="_csrf_parameter" content="_csrf" />
+    <meta name="_csrf_header" content="X-CSRF-TOKEN" />
+    <meta name="_csrf" content="28e4c684-fb5e-4c79-b8e2-a2177569edfa" />`);
+  });
+
+  afterEach(() => {
+    submitStub.resetHistory();
+  });
+
+  it('should include CSRF in submit request', () => {
+    const { vaadinLoginPassword } = fillUsernameAndPassword(loginForm);
+    enter(vaadinLoginPassword);
+    expect(submitStub.called).to.be.true;
+    const csrfInput = loginForm.querySelector('#csrf');
+    expect(csrfInput.name).to.equal('_csrf');
+    expect(csrfInput.value).to.equal('28e4c684-fb5e-4c79-b8e2-a2177569edfa');
+  });
+});
+
 describe('login form', () => {
   var login, formWrapper, submitStub;
 
@@ -157,23 +189,6 @@ describe('login form', () => {
 
     tap(submit);
     expect(submitStub.called).to.be.false;
-  });
-
-  it('should include CSRF in submit request if available', () => {
-    const loginWithCSRF = fixtureSync(
-      '<vaadin-login-form></vaadin-login-form><meta name="_csrf_parameter" content="_csrf" /><meta name="_csrf_header" content="X-CSRF-TOKEN" /><meta name="_csrf" content="28e4c684-fb5e-4c79-b8e2-a2177569edfa" />'
-    );
-    loginWithCSRF.action = 'login123';
-    const loginForm = loginWithCSRF.querySelector('[part="vaadin-login-native-form"]');
-    const submit = loginWithCSRF.querySelector('vaadin-button[part="vaadin-login-submit"]');
-    const submitStub = sinon.stub(loginForm, 'submit');
-    fillUsernameAndPassword(loginWithCSRF);
-    tap(submit);
-    expect(submitStub.called).to.be.true;
-    const csrfInput = loginForm.querySelector('#csrf');
-    expect(csrfInput.name).to.equal('_csrf');
-    expect(csrfInput.value).to.equal('28e4c684-fb5e-4c79-b8e2-a2177569edfa');
-    submitStub.restore();
   });
 
   it('should not disable button on button click if form is invalid', () => {


### PR DESCRIPTION
## Description

Automatically picks up a CSRF token written by Vaadin to the page if it is present and includes it in the form submission.

Fixes #201

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
