### PR TITLE
test: fix login form submission tests

### DIFF
--- a/packages/vaadin-login/test/login-form.test.js
+++ b/packages/vaadin-login/test/login-form.test.js
@@ -21,7 +21,7 @@ describe('login form', () => {
   var login, formWrapper, submitStub;
 
   before(() => {
-    submitStub = sinon.stub(HTMLFormElement.prototype, 'submit').callsFake(() => {});
+    submitStub = sinon.stub(HTMLFormElement.prototype, 'submit');
   });
 
   after(() => {

--- a/packages/vaadin-login/test/login-overlay.test.js
+++ b/packages/vaadin-login/test/login-overlay.test.js
@@ -26,7 +26,7 @@ describe('opened overlay', () => {
   let overlay, submitStub;
 
   before(() => {
-    submitStub = sinon.stub(HTMLFormElement.prototype, 'submit').callsFake(() => {});
+    submitStub = sinon.stub(HTMLFormElement.prototype, 'submit');
   });
 
   after(() => {

--- a/packages/vaadin-login/test/login-overlay.test.js
+++ b/packages/vaadin-login/test/login-overlay.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync } from '@open-wc/testing-helpers';
-import { tap, pressAndReleaseKeyOn, pressEnter } from '@polymer/iron-test-helpers/mock-interactions.js';
+import { enter, esc, fixtureSync } from '@vaadin/testing-helpers';
+import { tap } from '@polymer/iron-test-helpers/mock-interactions.js';
 import { fillUsernameAndPassword } from './helpers.js';
 import '../vaadin-login-overlay.js';
 
@@ -23,7 +23,11 @@ describe('login overlay', () => {
 });
 
 describe('opened overlay', () => {
-  let overlay;
+  let overlay, submitStub;
+
+  before(() => {
+    submitStub = sinon.stub(HTMLFormElement.prototype, 'submit').callsFake(() => {});
+  });
 
   beforeEach(() => {
     overlay = fixtureSync('<vaadin-login-overlay opened theme="some-theme"></vaadin-login-overlay>');
@@ -31,6 +35,7 @@ describe('opened overlay', () => {
 
   afterEach(() => {
     overlay.opened = false;
+    submitStub.resetHistory();
   });
 
   it('should set opened using attribute', () => {
@@ -49,7 +54,7 @@ describe('opened overlay', () => {
   });
 
   it('should not close on ESC key', () => {
-    pressAndReleaseKeyOn(document.body, 27, [], 'Escape');
+    esc(document.body);
 
     expect(overlay.opened).to.be.true;
   });
@@ -64,7 +69,7 @@ describe('opened overlay', () => {
     const loginSpy = sinon.spy(overlay, '_retargetEvent');
     const { vaadinLoginUsername } = fillUsernameAndPassword(overlay.$.vaadinLoginForm);
 
-    pressEnter(vaadinLoginUsername);
+    enter(vaadinLoginUsername);
     expect(loginSpy.called).to.be.true;
 
     const { type } = loginSpy.args[0][0];
@@ -78,7 +83,7 @@ describe('opened overlay', () => {
 
     const { vaadinLoginUsername } = fillUsernameAndPassword(overlay.$.vaadinLoginForm);
 
-    pressEnter(vaadinLoginUsername);
+    enter(vaadinLoginUsername);
     expect(loginSpy.called).to.be.true;
 
     const { type } = loginSpy.args[0][0];
@@ -86,16 +91,13 @@ describe('opened overlay', () => {
   });
 
   it('should be able to prevent default to `login` event', () => {
-    const nativeForm = overlay.$['vaadinLoginForm'].querySelector('[part=vaadin-login-native-form]');
-    const submitSpy = sinon.spy(nativeForm, 'submit');
-
     overlay.action = 'login';
     overlay.addEventListener('login', (e) => e.preventDefault());
 
     const { vaadinLoginUsername } = fillUsernameAndPassword(overlay.$.vaadinLoginForm);
 
-    pressEnter(vaadinLoginUsername);
-    expect(submitSpy.called).to.be.false;
+    enter(vaadinLoginUsername);
+    expect(submitStub.called).to.be.false;
   });
 });
 

--- a/packages/vaadin-login/test/login-overlay.test.js
+++ b/packages/vaadin-login/test/login-overlay.test.js
@@ -29,6 +29,10 @@ describe('opened overlay', () => {
     submitStub = sinon.stub(HTMLFormElement.prototype, 'submit').callsFake(() => {});
   });
 
+  after(() => {
+    submitStub.restore();
+  });
+
   beforeEach(() => {
     overlay = fixtureSync('<vaadin-login-overlay opened theme="some-theme"></vaadin-login-overlay>');
   });


### PR DESCRIPTION
## Description

First of all, existing tests were using `pressEnter` which in turn uses `pressAndReleaseKeyON` helper that contains a [setTimeout](https://github.com/PolymerElements/iron-test-helpers/blob/8c6ad1d3fa3b73d38f4b63da785344c7ab99a5a6/mock-interactions.js#L442-L446) for `keyup`. We should not use that helper to avoid this problem (even though it's not the case here). 

To make the test reliable I have updated them to use [enter](https://github.com/vaadin/testing-helpers/blob/cad53ff9d6db5c4118cdaa3e5e91fcebf2ec74fd/src/keyboard.ts#L154-L157) helper instead (which is synchronous).
I believe the original `pressAndReleaseKeyOn` was async because of IE11 which had a somewhat related problem.

But the actual problem was that the tests were lacking `action` attribute on the `vaadin-login-form`.
This was missed during review, and adding the attribute would cause navigating to a page as per native submission.

I decided to stub `submit` method on the `HTMLFormElement.prototype` to avoid accessing native form directly.
This should potentially help to avoid rewriting the tests in case if we change a DOM structure in future.

Closes #213

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.