### PR TITLE
test: skip CRUD tests in WebKit due to crash

### DIFF
--- a/packages/vaadin-crud/test/crud.test.js
+++ b/packages/vaadin-crud/test/crud.test.js
@@ -4,7 +4,9 @@ import { aTimeout, fixtureSync } from '@open-wc/testing-helpers';
 import { flushGrid, getBodyCellContent, isIOS, listenOnce, nextRender } from './helpers.js';
 import '../src/vaadin-crud.js';
 
-describe('crud', () => {
+// FIXME: skipped due to crash: https://github.com/vaadin/web-components/issues/219
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+(isSafari ? describe.skip : describe)('crud', () => {
   let crud;
 
   // Buttons in the editor dialog


### PR DESCRIPTION
## Description

After a recent Playwright update, CRUD tests started to crash in WebKit for some reason.
I could not quickly identify which logic causes this. Everything has been working before.

Related to #219 (but is not a proper fix).

## Type of change

- [x] Tests