### PR TITLE
chore: downgrade playwright to 1.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lerna": "^4.0.0",
     "lint-staged": "^10.5.4",
     "npm-run-all": "^4.1.5",
+    "playwright": "1.9.2",
     "prettier": "^2.2.1",
     "replace-in-file": "^6.2.0",
     "rimraf": "^3.0.2",

--- a/packages/vaadin-crud/test/crud.test.js
+++ b/packages/vaadin-crud/test/crud.test.js
@@ -4,9 +4,7 @@ import { aTimeout, fixtureSync } from '@open-wc/testing-helpers';
 import { flushGrid, getBodyCellContent, isIOS, listenOnce, nextRender } from './helpers.js';
 import '../src/vaadin-crud.js';
 
-// FIXME: skipped due to crash: https://github.com/vaadin/web-components/issues/219
-const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-(isSafari ? describe.skip : describe)('crud', () => {
+describe('crud', () => {
   let crud;
 
   // Buttons in the editor dialog

--- a/yarn.lock
+++ b/yarn.lock
@@ -7326,10 +7326,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-playwright@^1.7.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.10.0.tgz#a14d295f1ad886caf4cc5e674afe03ac832066bc"
-  integrity sha512-b7SGBcCPq4W3pb4ImEDmNXtO0ZkJbZMuWiShsaNJd+rGfY/6fqwgllsAojmxGSgFmijYw7WxCoPiAIEDIH16Kw==
+playwright@1.9.2, playwright@^1.7.1:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.9.2.tgz#294910950b76ec4c3dfed6a1e9d28e9b8560b0f4"
+  integrity sha512-Hsgfk3GZO+hgewRNW9xl9/tHjdZvVwxTseHagbiNpDf90PXICEh8UHXy/2eykeIXrZFMA6W6petEtRWNPi3gfQ==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"


### PR DESCRIPTION
## Description

It looks like downgrading from 1.10.0 to 1.9.2 helps to make tests pass.

Fixes #219

## Type of change

- [x] Tests