### PR TITLE
fix: clear row details opened attribute when item is removed

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -807,6 +807,7 @@ class GridElement extends ElementMixin(
     this._a11yUpdateRowSelected(row, model.selected);
     this._a11yUpdateRowLevel(row, model.level);
     this._toggleAttribute('expanded', model.expanded, row);
+    this._toggleAttribute('details-opened', this._isDetailsOpened(item), row);
     if (this._rowDetailsTemplate || this.rowDetailsRenderer) {
       this._toggleDetailsCell(row, item);
     }


### PR DESCRIPTION
## Description

ATM the grid does not update a rows `details-opened` attribute when the data provider changes. This PR fixes that by updating the attribute in the `_updateItem` method which should be run when the data provider changes.

Fixes https://github.com/vaadin/vaadin-grid/issues/2129

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.