### PR TITLE
fix: notify app-layout children about the resize

### DIFF
--- a/packages/vaadin-app-layout/src/vaadin-app-layout.js
+++ b/packages/vaadin-app-layout/src/vaadin-app-layout.js
@@ -8,6 +8,8 @@ import { beforeNextRender, afterNextRender } from '@polymer/polymer/lib/utils/re
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class';
+import { IronResizableBehavior } from '@polymer/iron-resizable-behavior';
 import './safe-area-inset.js';
 import './detect-ios-navbar.js';
 
@@ -103,7 +105,7 @@ import './detect-ios-navbar.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class AppLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)) {
+class AppLayoutElement extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizableBehavior], PolymerElement))) {
   static get template() {
     return html`
       <style>
@@ -446,6 +448,8 @@ class AppLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         this._updateDrawerHeight();
       }
     }
+
+    this.notifyResize();
   }
 
   /** @protected */
@@ -502,6 +506,8 @@ class AppLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     const drawerRect = drawer.getBoundingClientRect();
 
     this.style.setProperty('--_vaadin-app-layout-drawer-offset-size', drawerRect.width + 'px');
+
+    this.notifyResize();
   }
 
   /** @protected */
@@ -540,6 +546,10 @@ class AppLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
 
     this._updateDrawerHeight();
+
+    if (this.overlay !== overlay) {
+      this.notifyResize();
+    }
 
     // TODO(jouni): ARIA attributes. The drawer should act similar to a modal dialog when in ”overlay” mode
   }

--- a/packages/vaadin-app-layout/test/app-layout.test.js
+++ b/packages/vaadin-app-layout/test/app-layout.test.js
@@ -269,6 +269,7 @@ describe('vaadin-app-layout', () => {
       resizeAwareChild = layout.querySelector('resize-aware');
       sinon.stub(resizeAwareChild, 'notifyResize');
     });
+
     afterEach(() => {
       resizeAwareChild.notifyResize.restore();
     });

--- a/packages/vaadin-app-layout/test/app-layout.test.js
+++ b/packages/vaadin-app-layout/test/app-layout.test.js
@@ -1,6 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { IronResizableBehavior } from '@polymer/iron-resizable-behavior';
+import { PolymerElement } from '@polymer/polymer';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import '../vaadin-app-layout.js';
 import '../vaadin-drawer-toggle.js';
 
@@ -232,6 +235,83 @@ describe('vaadin-app-layout', () => {
         window.dispatchEvent(new CustomEvent('foo-bar'));
         expect(layout.drawerOpened).to.be.false;
       });
+    });
+  });
+
+  describe('notify children about resize', () => {
+    class ResizeAwareElement extends mixinBehaviors([IronResizableBehavior], PolymerElement) {
+      static get is() {
+        return 'resize-aware';
+      }
+    }
+
+    customElements.define(ResizeAwareElement.is, ResizeAwareElement);
+
+    let resizeAwareChild;
+
+    beforeEach(async () => {
+      layout = fixtureSync(`
+        <vaadin-app-layout>
+          <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
+          <h2 slot="navbar">App name</h2>
+          <section slot="drawer">
+            <p>Item 1</p>
+            <p>Item 2</p>
+            <p>Item 3</p>
+          </section>
+          <resize-aware></resize-aware>
+        </vaadin-app-layout>
+      `);
+      // force non-overlay mode as default
+      layout.style.setProperty('--vaadin-app-layout-drawer-overlay', 'false');
+      layout._updateOverlayMode();
+      await nextFrame();
+      resizeAwareChild = layout.querySelector('resize-aware');
+      sinon.stub(resizeAwareChild, 'notifyResize');
+    });
+    afterEach(() => {
+      resizeAwareChild.notifyResize.restore();
+    });
+
+    it('should notify when drawer opens or closes', () => {
+      layout.drawerOpened = false;
+      expect(resizeAwareChild.notifyResize.calledOnce).to.be.true;
+
+      resizeAwareChild.notifyResize.resetHistory();
+      layout.drawerOpened = true;
+      expect(resizeAwareChild.notifyResize.calledOnce).to.be.true;
+    });
+
+    it('should notify when drawer is hidden due to empty content', () => {
+      const section = layout.querySelector('[slot="drawer"]');
+      section.parentNode.removeChild(section);
+      layout._drawerChildObserver.flush();
+
+      expect(resizeAwareChild.notifyResize.calledOnce).to.be.true;
+    });
+
+    it('should notify when content is added to drawer', () => {
+      const newContent = document.createElement('div');
+      newContent.setAttribute('slot', 'drawer');
+      layout.appendChild(newContent);
+      layout._drawerChildObserver.flush();
+
+      expect(resizeAwareChild.notifyResize.calledOnce).to.be.true;
+    });
+
+    it('should notify when switching between regular and overlay mode', () => {
+      // force overlay mode
+      layout.style.setProperty('--vaadin-app-layout-drawer-overlay', 'true');
+      layout._updateOverlayMode();
+
+      expect(resizeAwareChild.notifyResize.calledOnce).to.be.true;
+
+      // remove overlay mode
+      resizeAwareChild.notifyResize.resetHistory();
+      layout.style.setProperty('--vaadin-app-layout-drawer-overlay', 'false');
+      layout._updateOverlayMode();
+
+      expect(resizeAwareChild.notifyResize.calledOnce).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Description

ATM the app layout does not implement the iron resize behaviour, meaning that toggling the drawer, or changing the drawers contents, will not notify children in the main slot about the resize. To fix this I added the iron resize behaviour to the app layout and make it notify about resizes when:
- the drawer is opened / closed
- the drawer switches between regular and overlay mode
- the drawers contents are changed (cleared, which makes the drawer hide; or added, which could result in a size change)

Fixes https://github.com/vaadin/vaadin-app-layout/issues/182

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
