### PR TITLE
fix(vaadin-accordion): export vaadin-accordion-panel

### DIFF
--- a/packages/vaadin-accordion/test/typings/accordion.types.ts
+++ b/packages/vaadin-accordion/test/typings/accordion.types.ts
@@ -1,5 +1,5 @@
-import '../../src/vaadin-accordion';
-import { AccordionPanelElement } from '../../src/vaadin-accordion-panel';
+import '../../vaadin-accordion';
+import { AccordionPanelElement } from '../../vaadin-accordion-panel';
 
 const assert = <T>(value: T) => value;
 

--- a/packages/vaadin-accordion/vaadin-accordion-panel.d.ts
+++ b/packages/vaadin-accordion/vaadin-accordion-panel.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-accordion-panel.js';

--- a/packages/vaadin-accordion/vaadin-accordion-panel.js
+++ b/packages/vaadin-accordion/vaadin-accordion-panel.js
@@ -1,0 +1,2 @@
+import './theme/lumo/vaadin-accordion-panel.js';
+export * from './src/vaadin-accordion-panel.js';


### PR DESCRIPTION
## Description

This PR adds a missing export of `vaadin-accordion-panel` so it becomes possible to import it from the outside:

```
import '@vaadin/vaadin-accordion';
import '@vaadin/vaadin-accordion-panel';
```

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
