### PR TITLE
feat: show abbreviation as fallback if image can not be loaded

### DIFF
--- a/packages/vaadin-avatar/src/vaadin-avatar.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar.js
@@ -118,7 +118,7 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           box-shadow: inset 0 0 0 2px var(--vaadin-avatar-user-color);
         }
       </style>
-      <img hidden$="[[!__imgVisible]]" src$="[[img]]" aria-hidden="true" />
+      <img hidden$="[[!__imgVisible]]" src$="[[img]]" aria-hidden="true" on-error="__handleImageLoadError" />
       <svg
         part="icon"
         hidden$="[[!__iconVisible]]"
@@ -157,7 +157,8 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
        */
       img: {
         type: String,
-        reflectToAttribute: true
+        reflectToAttribute: true,
+        observer: '__imgChanged'
       },
 
       /**
@@ -284,6 +285,11 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @private */
+  __imgChanged() {
+    this.__imgFailedToLoad = false;
+  }
+
+  /** @private */
   __imgOrAbbrOrNameChanged(img, abbr, name) {
     this.__updateVisibility();
 
@@ -317,9 +323,9 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   __updateVisibility() {
-    this.__imgVisible = !!this.img;
-    this.__abbrVisible = !this.img && !!this.abbr;
-    this.__iconVisible = !this.img && !this.abbr;
+    this.__imgVisible = !!this.img && !this.__imgFailedToLoad;
+    this.__abbrVisible = !this.__imgVisible && !!this.abbr;
+    this.__iconVisible = !this.__imgVisible && !this.abbr;
   }
 
   /** @private */
@@ -328,6 +334,14 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       this.setAttribute('title', title);
     } else {
       this.setAttribute('title', this.i18n.anonymous);
+    }
+  }
+
+  /** @private */
+  __handleImageLoadError() {
+    this.__imgFailedToLoad = true;
+    if (this.img) {
+      this.__updateVisibility();
     }
   }
 }

--- a/packages/vaadin-avatar/src/vaadin-avatar.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar.js
@@ -339,8 +339,9 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   __handleImageLoadError() {
-    this.__imgFailedToLoad = true;
     if (this.img) {
+      console.warn(`<vaadin-avatar> The specified image could not be loaded: ${this.img}`);
+      this.__imgFailedToLoad = true;
       this.__updateVisibility();
     }
   }

--- a/packages/vaadin-avatar/src/vaadin-avatar.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar.js
@@ -118,7 +118,7 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           box-shadow: inset 0 0 0 2px var(--vaadin-avatar-user-color);
         }
       </style>
-      <img hidden$="[[!__imgVisible]]" src$="[[img]]" aria-hidden="true" on-error="__handleImageLoadError" />
+      <img hidden$="[[!__imgVisible]]" src$="[[img]]" aria-hidden="true" on-error="__onImageLoadError" />
       <svg
         part="icon"
         hidden$="[[!__iconVisible]]"
@@ -338,7 +338,7 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @private */
-  __handleImageLoadError() {
+  __onImageLoadError() {
     if (this.img) {
       console.warn(`<vaadin-avatar> The specified image could not be loaded: ${this.img}`);
       this.__imgFailedToLoad = true;

--- a/packages/vaadin-avatar/test/avatar.test.js
+++ b/packages/vaadin-avatar/test/avatar.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 
 import '../vaadin-avatar.js';
 
@@ -29,34 +29,36 @@ describe('vaadin-avatar', () => {
   });
 
   describe('properties', () => {
-    describe('"img" property', () => {
-      const imgSrc = 'https://vaadin.com/';
+    const validImageSrc =
+      'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiI+PHBhdGggZmlsbD0iIzAyMDIwMSIgZD0iTTQ1NC40MjYgMzkyLjU4MmMtNS40MzktMTYuMzItMTUuMjk4LTMyLjc4Mi0yOS44MzktNDIuMzYyLTI3Ljk3OS0xOC41NzItNjAuNTc4LTI4LjQ3OS05Mi4wOTktMzkuMDg1LTcuNjA0LTIuNjY0LTE1LjMzLTUuNTY4LTIyLjI3OS05LjctNi4yMDQtMy42ODYtOC41MzMtMTEuMjQ2LTkuOTc0LTE3Ljg4Ni0uNjM2LTMuNTEyLTEuMDI2LTcuMTE2LTEuMjI4LTEwLjY2MSAyMi44NTctMzEuMjY3IDM4LjAxOS04Mi4yOTUgMzguMDE5LTEyNC4xMzYgMC02NS4yOTgtMzYuODk2LTgzLjQ5NS04Mi40MDItODMuNDk1LTQ1LjUxNSAwLTgyLjQwMyAxOC4xNy04Mi40MDMgODMuNDY4IDAgNDMuMzM4IDE2LjI1NSA5Ni41IDQwLjQ4OSAxMjcuMzgzLS4yMjEgMi40MzgtLjUxMSA0Ljg3Ni0uOTUgNy4zMDMtMS40NDQgNi42MzktMy43NyAxNC4wNTgtOS45NyAxNy43NDMtNi45NTcgNC4xMzMtMTQuNjgyIDYuNzU2LTIyLjI4NyA5LjQyLTMxLjUyMSAxMC42MDUtNjQuMTE5IDE5Ljk1Ny05Mi4wOTEgMzguNTI5LTE0LjU0OSA5LjU4LTI0LjQwMyAyNy4xNTktMjkuODM4IDQzLjQ3OS01LjU5NyAxNi45MzgtNy44ODYgMzcuOTE3LTcuNTQxIDU0LjkxN2g0MTEuOTMyYy4zNDgtMTYuOTk5LTEuOTQ2LTM3Ljk3OC03LjUzOS01NC45MTd6Ii8+PC9zdmc+Cg==';
+    const invalidImageSrc = 'thisisnotavalidimagesource';
 
+    describe('"img" property', () => {
       it('should have undefined "img" prop by default', () => {
         expect(avatar.img).to.be.undefined;
       });
 
       it('should reflect "img" prop to the attribute', () => {
-        avatar.img = imgSrc;
-        expect(avatar.getAttribute('img')).to.equal(imgSrc);
+        avatar.img = validImageSrc;
+        expect(avatar.getAttribute('img')).to.equal(validImageSrc);
       });
 
       it('should propagate "img" to the internal img', () => {
-        avatar.img = imgSrc;
-        expect(imgElement.src).to.equal(imgSrc);
+        avatar.img = validImageSrc;
+        expect(imgElement.src).to.equal(validImageSrc);
       });
 
       it('img should be visible when "img" property is provided', () => {
         expect(imgElement.hasAttribute('hidden')).to.be.true;
 
-        avatar.img = imgSrc;
+        avatar.img = validImageSrc;
         expect(imgElement.hasAttribute('hidden')).to.be.false;
       });
 
       it('icon should be hidden when "img" property is provided', () => {
         expect(iconElement.hasAttribute('hidden')).to.be.false;
 
-        avatar.img = imgSrc;
+        avatar.img = validImageSrc;
         expect(iconElement.hasAttribute('hidden')).to.be.true;
       });
 
@@ -64,12 +66,12 @@ describe('vaadin-avatar', () => {
         avatar.abbr = 'YY';
         expect(abbrElement.hasAttribute('hidden')).to.be.false;
 
-        avatar.img = imgSrc;
+        avatar.img = validImageSrc;
         expect(abbrElement.hasAttribute('hidden')).to.be.true;
       });
 
       it('should set title when both "img" and "name" are set', () => {
-        avatar.img = imgSrc;
+        avatar.img = validImageSrc;
         avatar.name = 'Foo Bar';
         expect(avatar.getAttribute('title')).to.equal('Foo Bar');
       });
@@ -187,6 +189,26 @@ describe('vaadin-avatar', () => {
       it('should not update title when empty value is set', () => {
         avatar.i18n = null;
         expect(avatar.getAttribute('title')).to.equal('anonymous');
+      });
+    });
+
+    describe('img fallback', () => {
+      it('should display abbr as fallback if image can not be loaded', async () => {
+        avatar.abbr = 'YY';
+        avatar.img = invalidImageSrc;
+        await oneEvent(imgElement, 'error');
+        expect(imgElement.hasAttribute('hidden')).to.be.true;
+        expect(abbrElement.hasAttribute('hidden')).to.be.false;
+      });
+
+      it('should display img when setting a valid source after setting an invalid source', async () => {
+        avatar.abbr = 'YY';
+        avatar.img = invalidImageSrc;
+        await oneEvent(imgElement, 'error');
+        avatar.img = validImageSrc;
+        await oneEvent(imgElement, 'load');
+        expect(imgElement.hasAttribute('hidden')).to.be.false;
+        expect(abbrElement.hasAttribute('hidden')).to.be.true;
       });
     });
   });

--- a/packages/vaadin-avatar/test/avatar.test.js
+++ b/packages/vaadin-avatar/test/avatar.test.js
@@ -193,12 +193,25 @@ describe('vaadin-avatar', () => {
     });
 
     describe('img fallback', () => {
+      beforeEach(() => {
+        sinon.stub(console, 'warn');
+      });
+      afterEach(() => {
+        console.warn.restore();
+      });
+
       it('should display abbr as fallback if image can not be loaded', async () => {
         avatar.abbr = 'YY';
         avatar.img = invalidImageSrc;
         await oneEvent(imgElement, 'error');
         expect(imgElement.hasAttribute('hidden')).to.be.true;
         expect(abbrElement.hasAttribute('hidden')).to.be.false;
+      });
+
+      it('should log a warning if image can not be loaded', async () => {
+        avatar.img = invalidImageSrc;
+        await oneEvent(imgElement, 'error');
+        expect(console.warn.calledOnce).to.be.true;
       });
 
       it('should display img when setting a valid source after setting an invalid source', async () => {

--- a/packages/vaadin-avatar/test/avatar.test.js
+++ b/packages/vaadin-avatar/test/avatar.test.js
@@ -200,12 +200,28 @@ describe('vaadin-avatar', () => {
         console.warn.restore();
       });
 
-      it('should display abbr as fallback if image can not be loaded', async () => {
+      it('should display abbr as fallback if image can not be loaded and an abbreviation was provided', async () => {
         avatar.abbr = 'YY';
         avatar.img = invalidImageSrc;
         await oneEvent(imgElement, 'error');
         expect(imgElement.hasAttribute('hidden')).to.be.true;
         expect(abbrElement.hasAttribute('hidden')).to.be.false;
+      });
+
+      it('should display abbr as fallback if image can not be loaded and a name was provided', async () => {
+        avatar.name = 'Foo Bar';
+        avatar.img = invalidImageSrc;
+        await oneEvent(imgElement, 'error');
+        expect(imgElement.hasAttribute('hidden')).to.be.true;
+        expect(abbrElement.hasAttribute('hidden')).to.be.false;
+      });
+
+      it('should display icon as fallback if image can not be loaded and no other data was provided', async () => {
+        avatar.img = invalidImageSrc;
+        await oneEvent(imgElement, 'error');
+        expect(imgElement.hasAttribute('hidden')).to.be.true;
+        expect(abbrElement.hasAttribute('hidden')).to.be.true;
+        expect(iconElement.hasAttribute('hidden')).to.be.false;
       });
 
       it('should log a warning if image can not be loaded', async () => {


### PR DESCRIPTION
## Description

Currently if the avatar element can not load an image for some reason, it shows a broken image icon, or title (depending on browser).

This change handles image load failures more gracefully:
- [x] show the abbreviation if it is defined, or show the avatar icon if there is no abbreviation either
- [x] log a console warning so that a developer can take action

Fixes https://github.com/vaadin/vaadin-avatar/issues/111

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
  - this was not really done, but seeing that this is a GFI and has a reasonable scope I assume it's OK