### PR TITLE
chore: upload screenshots that failed during visual tests to Github

### DIFF
--- a/.github/workflows/lumo.yml
+++ b/.github/workflows/lumo.yml
@@ -33,3 +33,9 @@ jobs:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: yarn test:lumo
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: screenshots
+          path: screenshots/lumo/chrome/failed/**/*.png

--- a/.github/workflows/material.yml
+++ b/.github/workflows/material.yml
@@ -33,3 +33,9 @@ jobs:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: yarn test:material
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: screenshots
+          path: screenshots/material/chrome/failed/**/*.png


### PR DESCRIPTION
## Description

This PR is intended to provide access to screenshots that failed during visual regression tests in CI.

It uses `actions/upload-artifact@2` for uploading failed screenshots to Github. So that they become available to download from the build report:

![image](https://user-images.githubusercontent.com/5039436/115443350-cfdb3b00-a21b-11eb-8eb8-af986f9f6654.png)

Related to #235 (issue)

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
