### PR TITLE
test: reduce visual regression tests flakiness

### DIFF
--- a/packages/vaadin-context-menu/test/visual/common.js
+++ b/packages/vaadin-context-menu/test/visual/common.js
@@ -1,0 +1,11 @@
+import { oneEvent } from '@vaadin/testing-helpers';
+
+export async function openSubMenus(menu) {
+  await oneEvent(menu.$.overlay, 'vaadin-overlay-open');
+  const itemElement = menu.$.overlay.querySelector('.vaadin-context-menu-parent-item');
+  if (itemElement) {
+    itemElement.dispatchEvent(new CustomEvent('mouseover', { bubbles: true, composed: true }));
+    const subMenu = menu.$.overlay.querySelector('vaadin-context-menu');
+    await openSubMenus(subMenu);
+  }
+}

--- a/packages/vaadin-context-menu/test/visual/lumo/context-menu.test.js
+++ b/packages/vaadin-context-menu/test/visual/lumo/context-menu.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import { openSubMenus } from '../common.js';
 import '../../../theme/lumo/vaadin-context-menu.js';
 
 describe('context-menu', () => {
@@ -92,17 +93,6 @@ describe('context-menu', () => {
           `);
         });
 
-        function openSubMenus(menu) {
-          menu.$.overlay.addEventListener('vaadin-overlay-open', () => {
-            const itemElement = menu.$.overlay.querySelector('.vaadin-context-menu-parent-item');
-            if (itemElement) {
-              itemElement.dispatchEvent(new CustomEvent('mouseover', { bubbles: true, composed: true }));
-              const subMenu = menu.$.overlay.querySelector('vaadin-context-menu');
-              openSubMenus(subMenu);
-            }
-          });
-        }
-
         it('items', async () => {
           element.items = [
             { text: 'Menu Item 1' },
@@ -125,7 +115,7 @@ describe('context-menu', () => {
             { text: 'Menu Item 3', disabled: true }
           ];
           contextmenu(element);
-          openSubMenus(element);
+          await openSubMenus(element);
           await nextRender(element);
           await visualDiff(document.body, `context-menu:${dir}-items`);
         });

--- a/packages/vaadin-context-menu/test/visual/material/context-menu.test.js
+++ b/packages/vaadin-context-menu/test/visual/material/context-menu.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import { openSubMenus } from '../common.js';
 import '../../../theme/material/vaadin-context-menu.js';
 
 describe('context-menu', () => {
@@ -92,17 +93,6 @@ describe('context-menu', () => {
           `);
         });
 
-        function openSubMenus(menu) {
-          menu.$.overlay.addEventListener('vaadin-overlay-open', () => {
-            const itemElement = menu.$.overlay.querySelector('.vaadin-context-menu-parent-item');
-            if (itemElement) {
-              itemElement.dispatchEvent(new CustomEvent('mouseover', { bubbles: true, composed: true }));
-              const subMenu = menu.$.overlay.querySelector('vaadin-context-menu');
-              openSubMenus(subMenu);
-            }
-          });
-        }
-
         it('items', async () => {
           element.items = [
             { text: 'Menu Item 1' },
@@ -125,7 +115,7 @@ describe('context-menu', () => {
             { text: 'Menu Item 3', disabled: true }
           ];
           contextmenu(element);
-          openSubMenus(element);
+          await openSubMenus(element);
           await nextRender(element);
           await visualDiff(document.body, `context-menu:${dir}-items`);
         });

--- a/web-test-runner-lumo.config.js
+++ b/web-test-runner-lumo.config.js
@@ -39,7 +39,7 @@ const config = {
     sauceLabsLauncher({
       browserName: 'chrome',
       platformName: 'Windows 10',
-      browserVersion: 'latest'
+      browserVersion: '88'
     })
   ],
   plugins: [

--- a/web-test-runner-material.config.js
+++ b/web-test-runner-material.config.js
@@ -39,7 +39,7 @@ const config = {
     sauceLabsLauncher({
       browserName: 'chrome',
       platformName: 'Windows 10',
-      browserVersion: 'latest'
+      browserVersion: '88'
     })
   ],
   plugins: [

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -155,14 +155,9 @@ const testRunnerHtml = (testFramework) => `
   </html>
 `;
 
-const getScreenshotFileName = ({ browser, name }, type, diff) => {
+const getScreenshotFileName = ({ name }, type, diff) => {
   const [component, test] = name.split(':');
-  return path.join(
-    browser.replace('Windows 10 ', '').replace(' latest', ''),
-    type,
-    component,
-    diff ? `${test}-diff` : test
-  );
+  return path.join('chrome', type, component, diff ? `${test}-diff` : test);
 };
 
 const getBaselineScreenshotName = (args) => getScreenshotFileName(args, 'baseline');


### PR DESCRIPTION
## Description

It turns out the `openSubMenus` helper was not using promises and the test was apparently passing or failing randomly, most likely depending on the network latency (in some cases, the screenshot was taken before last menu was opened).

Fixes #238

## Type of change

- [x] Internal change