### PR TITLE
feat: add Event suffix to events typings (2) 

### DIFF
--- a/packages/vaadin-date-picker/src/interfaces.d.ts
+++ b/packages/vaadin-date-picker/src/interfaces.d.ts
@@ -22,24 +22,24 @@ export interface DatePickerI18n {
 /**
  * Fired when the `opened` property changes.
  */
-export type DatePickerOpenedChanged = CustomEvent<{ value: boolean }>;
+export type DatePickerOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `invalid` property changes.
  */
-export type DatePickerInvalidChanged = CustomEvent<{ value: boolean }>;
+export type DatePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type DatePickerValueChanged = CustomEvent<{ value: string }>;
+export type DatePickerValueChangedEvent = CustomEvent<{ value: string }>;
 
 export interface DatePickerElementEventMap {
-  'opened-changed': DatePickerOpenedChanged;
+  'opened-changed': DatePickerOpenedChangedEvent;
 
-  'invalid-changed': DatePickerInvalidChanged;
+  'invalid-changed': DatePickerInvalidChangedEvent;
 
-  'value-changed': DatePickerValueChanged;
+  'value-changed': DatePickerValueChangedEvent;
 }
 
 export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerElementEventMap {}

--- a/packages/vaadin-date-picker/src/vaadin-date-picker-legacy-events.d.ts
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker-legacy-events.d.ts
@@ -1,0 +1,20 @@
+import {
+  DatePickerInvalidChangedEvent,
+  DatePickerOpenedChangedEvent,
+  DatePickerValueChangedEvent
+} from './interfaces.js';
+
+/**
+ * @deprecated Please use `DatePickerOpenedChangedEvent` instead.
+ */
+export type DatePickerOpenedChanged = DatePickerOpenedChangedEvent;
+
+/**
+ * @deprecated Please use `DatePickerInvalidChangedEvent` instead.
+ */
+export type DatePickerInvalidChanged = DatePickerInvalidChangedEvent;
+
+/**
+ * @deprecated Please use `DatePickerValueChangedEvent` instead.
+ */
+export type DatePickerValueChanged = DatePickerValueChangedEvent;

--- a/packages/vaadin-date-picker/test/typings/date-picker-legacy-events.types.ts
+++ b/packages/vaadin-date-picker/test/typings/date-picker-legacy-events.types.ts
@@ -1,0 +1,18 @@
+import '../../vaadin-date-picker.js';
+import { DatePickerOpenedChanged, DatePickerInvalidChanged, DatePickerValueChanged } from '../../vaadin-date-picker.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const datePicker = document.createElement('vaadin-date-picker');
+
+datePicker.addEventListener('opened-changed', (event) => {
+  assertType<DatePickerOpenedChanged>(event);
+});
+
+datePicker.addEventListener('invalid-changed', (event) => {
+  assertType<DatePickerInvalidChanged>(event);
+});
+
+datePicker.addEventListener('value-changed', (event) => {
+  assertType<DatePickerValueChanged>(event);
+});

--- a/packages/vaadin-date-picker/test/typings/date-picker.types.ts
+++ b/packages/vaadin-date-picker/test/typings/date-picker.types.ts
@@ -1,17 +1,25 @@
-import '../../src/vaadin-date-picker';
+import '../../vaadin-date-picker.js';
+import {
+  DatePickerOpenedChangedEvent,
+  DatePickerInvalidChangedEvent,
+  DatePickerValueChangedEvent
+} from '../../vaadin-date-picker.js';
 
-const assert = <T>(value: T) => value;
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 const datePicker = document.createElement('vaadin-date-picker');
 
 datePicker.addEventListener('opened-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<DatePickerOpenedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 datePicker.addEventListener('invalid-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<DatePickerInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 datePicker.addEventListener('value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<DatePickerValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
 });

--- a/packages/vaadin-date-picker/vaadin-date-picker.d.ts
+++ b/packages/vaadin-date-picker/vaadin-date-picker.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-date-picker.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-date-picker-legacy-events.js';

--- a/packages/vaadin-date-time-picker/src/interfaces.d.ts
+++ b/packages/vaadin-date-time-picker/src/interfaces.d.ts
@@ -6,17 +6,17 @@ export interface DateTimePickerI18n extends DatePickerI18n, TimePickerI18n {}
 /**
  * Fired when the `invalid` property changes.
  */
-export type DateTimePickerInvalidChanged = CustomEvent<{ value: boolean }>;
+export type DateTimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type DateTimePickerValueChanged = CustomEvent<{ value: string }>;
+export type DateTimePickerValueChangedEvent = CustomEvent<{ value: string }>;
 
 export interface DateTimePickerElementEventMap {
-  'invalid-changed': DateTimePickerInvalidChanged;
+  'invalid-changed': DateTimePickerInvalidChangedEvent;
 
-  'value-changed': DateTimePickerValueChanged;
+  'value-changed': DateTimePickerValueChangedEvent;
 }
 
 export interface DateTimePickerEventMap extends DateTimePickerElementEventMap, HTMLElementEventMap {}

--- a/packages/vaadin-date-time-picker/src/vaadin-date-time-picker-legacy-events.d.ts
+++ b/packages/vaadin-date-time-picker/src/vaadin-date-time-picker-legacy-events.d.ts
@@ -1,0 +1,11 @@
+import { DateTimePickerInvalidChangedEvent, DateTimePickerValueChangedEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `DateTimePickerInvalidChangedEvent` instead;
+ */
+export type DateTimePickerInvalidChanged = DateTimePickerInvalidChangedEvent;
+
+/**
+ * @deprecated Please use `DateTimePickerValueChangedEvent` instead;
+ */
+export type DateTimePickerValueChanged = DateTimePickerValueChangedEvent;

--- a/packages/vaadin-date-time-picker/test/typings/date-time-picker-legacy-events.types.ts
+++ b/packages/vaadin-date-time-picker/test/typings/date-time-picker-legacy-events.types.ts
@@ -1,0 +1,14 @@
+import '../../vaadin-date-time-picker.js';
+import { DateTimePickerValueChanged, DateTimePickerInvalidChanged } from '../../vaadin-date-time-picker.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const picker = document.createElement('vaadin-date-time-picker');
+
+picker.addEventListener('invalid-changed', (event) => {
+  assertType<DateTimePickerInvalidChanged>(event);
+});
+
+picker.addEventListener('value-changed', (event) => {
+  assertType<DateTimePickerValueChanged>(event);
+});

--- a/packages/vaadin-date-time-picker/test/typings/date-time-picker.types.ts
+++ b/packages/vaadin-date-time-picker/test/typings/date-time-picker.types.ts
@@ -1,13 +1,16 @@
-import '../../src/vaadin-date-time-picker';
+import '../../vaadin-date-time-picker.js';
+import { DateTimePickerValueChangedEvent, DateTimePickerInvalidChangedEvent } from '../../vaadin-date-time-picker.js';
 
-const assert = <T>(value: T) => value;
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 const picker = document.createElement('vaadin-date-time-picker');
 
 picker.addEventListener('invalid-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<DateTimePickerInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 picker.addEventListener('value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<DateTimePickerValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
 });

--- a/packages/vaadin-date-time-picker/vaadin-date-time-picker.d.ts
+++ b/packages/vaadin-date-time-picker/vaadin-date-time-picker.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-date-time-picker.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-date-time-picker-legacy-events.js';

--- a/packages/vaadin-details/src/vaadin-details-legacy-events.d.ts
+++ b/packages/vaadin-details/src/vaadin-details-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { DetailsOpenedChangedEvent } from './vaadin-details.js';
+
+/**
+ * @deprecated Please use `DetailsOpenedChangedEvent` instead.
+ */
+export type DetailsOpenedChanged = DetailsOpenedChangedEvent;

--- a/packages/vaadin-details/src/vaadin-details.d.ts
+++ b/packages/vaadin-details/src/vaadin-details.d.ts
@@ -7,10 +7,10 @@ import { ControlStateMixin } from '@vaadin/vaadin-control-state-mixin/vaadin-con
 /**
  * Fired when the `opened` property changes.
  */
-export type DetailsOpenedChanged = CustomEvent<{ value: boolean }>;
+export type DetailsOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
 export interface DetailsElementEventMap {
-  'opened-changed': DetailsOpenedChanged;
+  'opened-changed': DetailsOpenedChangedEvent;
 }
 
 export type DetailsEventMap = HTMLElementEventMap & DetailsElementEventMap;

--- a/packages/vaadin-details/test/typings/details-legacy-events.types.ts
+++ b/packages/vaadin-details/test/typings/details-legacy-events.types.ts
@@ -1,11 +1,10 @@
 import '../../vaadin-details.js';
-import { DetailsOpenedChangedEvent } from '../../vaadin-details.js';
+import { DetailsOpenedChanged } from '../../vaadin-details.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const details = document.createElement('vaadin-details');
 
 details.addEventListener('opened-changed', (event) => {
-  assertType<DetailsOpenedChangedEvent>(event);
-  assertType<boolean>(event.detail.value);
+  assertType<DetailsOpenedChanged>(event);
 });

--- a/packages/vaadin-details/vaadin-details.d.ts
+++ b/packages/vaadin-details/vaadin-details.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-details.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-details-legacy-events.js';

--- a/packages/vaadin-dialog/src/interfaces.d.ts
+++ b/packages/vaadin-dialog/src/interfaces.d.ts
@@ -30,17 +30,17 @@ export type DialogOverlayBoundsParam =
 /**
  * Fired when the `opened` property changes.
  */
-export type DialogOpenedChanged = CustomEvent<{ value: boolean }>;
+export type DialogOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the dialog resize is finished.
  */
-export type DialogResize = CustomEvent<DialogResizeDimensions>;
+export type DialogResizeEvent = CustomEvent<DialogResizeDimensions>;
 
 export interface DialogElementEventMap {
-  'opened-changed': DialogOpenedChanged;
+  'opened-changed': DialogOpenedChangedEvent;
 
-  resize: DialogResize;
+  resize: DialogResizeEvent;
 }
 
 export type DialogEventMap = HTMLElementEventMap & DialogElementEventMap;

--- a/packages/vaadin-dialog/src/vaadin-dialog-legacy-events.d.ts
+++ b/packages/vaadin-dialog/src/vaadin-dialog-legacy-events.d.ts
@@ -1,0 +1,11 @@
+import { DialogOpenedChangedEvent, DialogResizeEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `DialogOpenedChangedEvent` instead.
+ */
+export type DialogOpenedChanged = DialogOpenedChangedEvent;
+
+/**
+ * @deprecated Please use `DialogResizeEvent` instead.
+ */
+export type DialogResize = DialogResizeEvent;

--- a/packages/vaadin-dialog/test/typings/dialog-legacy-events.types.ts
+++ b/packages/vaadin-dialog/test/typings/dialog-legacy-events.types.ts
@@ -1,0 +1,14 @@
+import '../../vaadin-dialog.js';
+import { DialogResize, DialogOpenedChanged } from '../../vaadin-dialog.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const dialog = document.createElement('vaadin-dialog');
+
+dialog.addEventListener('opened-changed', (event) => {
+  assertType<DialogOpenedChanged>(event);
+});
+
+dialog.addEventListener('resize', (event) => {
+  assertType<DialogResize>(event);
+});

--- a/packages/vaadin-dialog/test/typings/dialog.types.ts
+++ b/packages/vaadin-dialog/test/typings/dialog.types.ts
@@ -1,14 +1,16 @@
-import { DialogResizeDimensions } from '../../src/interfaces';
-import '../../src/vaadin-dialog';
+import '../../vaadin-dialog.js';
+import { DialogResizeEvent, DialogOpenedChangedEvent, DialogResizeDimensions } from '../../vaadin-dialog.js';
 
-const assert = <T>(value: T) => value;
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 const dialog = document.createElement('vaadin-dialog');
 
 dialog.addEventListener('opened-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<DialogOpenedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 dialog.addEventListener('resize', (event) => {
-  assert<DialogResizeDimensions>(event.detail);
+  assertType<DialogResizeEvent>(event);
+  assertType<DialogResizeDimensions>(event.detail);
 });

--- a/packages/vaadin-dialog/vaadin-dialog.d.ts
+++ b/packages/vaadin-dialog/vaadin-dialog.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-dialog.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-dialog-legacy-events.js';

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro-legacy-events.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro-legacy-events.d.ts
@@ -1,0 +1,11 @@
+import { GridProCellEditStartedEvent, GridProItemPropertyChangedEvent } from './vaadin-grid-pro.js';
+
+/**
+ * @deprecated Please use `GridProCellEditStartedEvent` instead.
+ */
+export type GridProCellEditStarted = GridProCellEditStartedEvent;
+
+/**
+ * @deprecated Please use `GridProItemPropertyChangedEvent` instead.
+ */
+export type GridProItemPropertyChanged = GridProItemPropertyChangedEvent;

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
@@ -7,7 +7,7 @@ import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
 /**
  * Fired when the user starts editing a grid cell.
  */
-export type GridProCellEditStarted = CustomEvent<{
+export type GridProCellEditStartedEvent = CustomEvent<{
   value: {
     index: number;
     item: GridItem;
@@ -18,7 +18,7 @@ export type GridProCellEditStarted = CustomEvent<{
 /**
  * Fired before exiting the cell edit mode, if the value has been changed.
  */
-export type GridProItemPropertyChanged = CustomEvent<{
+export type GridProItemPropertyChangedEvent = CustomEvent<{
   value: {
     index: number;
     item: GridItem;
@@ -28,9 +28,9 @@ export type GridProItemPropertyChanged = CustomEvent<{
 }>;
 
 export interface GridProElementEventMap {
-  'cell-edit-started': GridProCellEditStarted;
+  'cell-edit-started': GridProCellEditStartedEvent;
 
-  'item-property-changed': GridProItemPropertyChanged;
+  'item-property-changed': GridProItemPropertyChangedEvent;
 }
 
 export interface GridProEventMap extends HTMLElementEventMap, GridProElementEventMap, GridElementEventMap {}

--- a/packages/vaadin-grid-pro/test/typings/grid-pro-legacy-events.types.ts
+++ b/packages/vaadin-grid-pro/test/typings/grid-pro-legacy-events.types.ts
@@ -1,0 +1,66 @@
+import {
+  GridActiveItemChanged,
+  GridCellActivate,
+  GridColumnReorder,
+  GridColumnResize,
+  GridDragStart,
+  GridDrop,
+  GridExpandedItemsChanged,
+  GridLoadingChanged,
+  GridSelectedItemsChanged
+} from '@vaadin/vaadin-grid';
+
+import '../../vaadin-grid-pro.js';
+import '../../vaadin-grid-pro-edit-column.js';
+
+import { GridProCellEditStarted, GridProItemPropertyChanged } from '../../vaadin-grid-pro.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const grid = document.createElement('vaadin-grid-pro');
+
+/* grid-pro events */
+grid.addEventListener('cell-edit-started', (event) => {
+  assertType<GridProCellEditStarted>(event);
+});
+
+grid.addEventListener('item-property-changed', (event) => {
+  assertType<GridProItemPropertyChanged>(event);
+});
+
+/* grid events */
+grid.addEventListener('active-item-changed', (event) => {
+  assertType<GridActiveItemChanged>(event);
+});
+
+grid.addEventListener('cell-activate', (event) => {
+  assertType<GridCellActivate>(event);
+});
+
+grid.addEventListener('column-reorder', (event) => {
+  assertType<GridColumnReorder>(event);
+});
+
+grid.addEventListener('column-resize', (event) => {
+  assertType<GridColumnResize>(event);
+});
+
+grid.addEventListener('loading-changed', (event) => {
+  assertType<GridLoadingChanged>(event);
+});
+
+grid.addEventListener('expanded-items-changed', (event) => {
+  assertType<GridExpandedItemsChanged>(event);
+});
+
+grid.addEventListener('selected-items-changed', (event) => {
+  assertType<GridSelectedItemsChanged>(event);
+});
+
+grid.addEventListener('grid-dragstart', (event) => {
+  assertType<GridDragStart>(event);
+});
+
+grid.addEventListener('grid-drop', (event) => {
+  assertType<GridDrop>(event);
+});

--- a/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/vaadin-grid-pro/test/typings/grid-pro.types.ts
@@ -1,59 +1,87 @@
-import '../../src/vaadin-grid-pro';
-import '../../src/vaadin-grid-pro-edit-column';
-import { GridColumnElement, GridDropLocation, GridItem, GridItemModel } from '@vaadin/vaadin-grid';
+import {
+  GridColumnElement,
+  GridDropLocation,
+  GridItem,
+  GridItemModel,
+  GridActiveItemChangedEvent,
+  GridCellActivateEvent,
+  GridColumnReorderEvent,
+  GridColumnResizeEvent,
+  GridDragStartEvent,
+  GridDropEvent,
+  GridExpandedItemsChangedEvent,
+  GridLoadingChangedEvent,
+  GridSelectedItemsChangedEvent
+} from '@vaadin/vaadin-grid';
 
-const assert = <T>(value: T) => value;
+import '../../vaadin-grid-pro.js';
+import '../../vaadin-grid-pro-edit-column.js';
+
+import { GridProCellEditStartedEvent, GridProItemPropertyChangedEvent } from '../../vaadin-grid-pro.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 const grid = document.createElement('vaadin-grid-pro');
 
 /* grid-pro events */
 grid.addEventListener('cell-edit-started', (event) => {
-  assert<string>(event.detail.value.path);
-  assert<number>(event.detail.value.index);
-  assert<GridItem>(event.detail.value.item);
+  assertType<GridProCellEditStartedEvent>(event);
+  assertType<string>(event.detail.value.path);
+  assertType<number>(event.detail.value.index);
+  assertType<GridItem>(event.detail.value.item);
 });
 
 grid.addEventListener('item-property-changed', (event) => {
-  assert<string>(event.detail.value.path);
-  assert<number>(event.detail.value.index);
-  assert<GridItem>(event.detail.value.item);
-  assert<string | boolean>(event.detail.value.value);
+  assertType<GridProItemPropertyChangedEvent>(event);
+  assertType<string>(event.detail.value.path);
+  assertType<number>(event.detail.value.index);
+  assertType<GridItem>(event.detail.value.item);
+  assertType<string | boolean>(event.detail.value.value);
 });
 
 /* grid events */
 grid.addEventListener('active-item-changed', (event) => {
-  assert<GridItem>(event.detail.value);
+  assertType<GridActiveItemChangedEvent>(event);
+  assertType<GridItem>(event.detail.value);
 });
 
 grid.addEventListener('cell-activate', (event) => {
-  assert<GridItemModel>(event.detail.model);
+  assertType<GridCellActivateEvent>(event);
+  assertType<GridItemModel>(event.detail.model);
 });
 
 grid.addEventListener('column-reorder', (event) => {
-  assert<GridColumnElement[]>(event.detail.columns);
+  assertType<GridColumnReorderEvent>(event);
+  assertType<GridColumnElement[]>(event.detail.columns);
 });
 
 grid.addEventListener('column-resize', (event) => {
-  assert<GridColumnElement>(event.detail.resizedColumn);
+  assertType<GridColumnResizeEvent>(event);
+  assertType<GridColumnElement>(event.detail.resizedColumn);
 });
 
 grid.addEventListener('loading-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<GridLoadingChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 grid.addEventListener('expanded-items-changed', (event) => {
-  assert<GridItem[]>(event.detail.value);
+  assertType<GridExpandedItemsChangedEvent>(event);
+  assertType<GridItem[]>(event.detail.value);
 });
 
 grid.addEventListener('selected-items-changed', (event) => {
-  assert<GridItem[]>(event.detail.value);
+  assertType<GridSelectedItemsChangedEvent>(event);
+  assertType<GridItem[]>(event.detail.value);
 });
 
 grid.addEventListener('grid-dragstart', (event) => {
-  assert<GridItem[]>(event.detail.draggedItems);
+  assertType<GridDragStartEvent>(event);
+  assertType<GridItem[]>(event.detail.draggedItems);
 });
 
 grid.addEventListener('grid-drop', (event) => {
-  assert<GridItem>(event.detail.dropTargetItem);
-  assert<GridDropLocation>(event.detail.dropLocation);
+  assertType<GridDropEvent>(event);
+  assertType<GridItem>(event.detail.dropTargetItem);
+  assertType<GridDropLocation>(event.detail.dropLocation);
 });

--- a/packages/vaadin-grid-pro/vaadin-grid-pro.d.ts
+++ b/packages/vaadin-grid-pro/vaadin-grid-pro.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-grid-pro.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-grid-pro-legacy-events.js';

--- a/packages/vaadin-grid/src/vaadin-grid-filter-legacy-events.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { GridFilterValueChangedEvent } from './vaadin-grid-filter.js';
+
+/**
+ * @deprecated Please use `GridFilterValueChangedEvent` instead;
+ */
+export type GridFilterValueChanged = GridFilterValueChangedEvent;

--- a/packages/vaadin-grid/src/vaadin-grid-filter.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-filter.d.ts
@@ -1,10 +1,10 @@
 /**
  * Fired when the `value` property changes.
  */
-export type GridFilterValueChanged = CustomEvent<{ value: string }>;
+export type GridFilterValueChangedEvent = CustomEvent<{ value: string }>;
 
 export interface GridFilterElementEventMap {
-  'value-changed': GridFilterValueChanged;
+  'value-changed': GridFilterValueChangedEvent;
 }
 
 export interface GridFilterEventMap extends HTMLElementEventMap, GridFilterElementEventMap {}

--- a/packages/vaadin-grid/src/vaadin-grid-legacy-events.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-legacy-events.ts
@@ -1,0 +1,56 @@
+import {
+  GridActiveItemChangedEvent,
+  GridCellActivateEvent,
+  GridColumnReorderEvent,
+  GridColumnResizeEvent,
+  GridDragStartEvent,
+  GridDropEvent,
+  GridExpandedItemsChangedEvent,
+  GridLoadingChangedEvent,
+  GridSelectedItemsChangedEvent
+} from './vaadin-grid.js';
+
+/**
+ * @deprecated Please use `GridActiveItemChangedEvent` instead.
+ */
+export type GridActiveItemChanged = GridActiveItemChangedEvent;
+
+/**
+ * @deprecated Please use `GridCellActivateEvent` instead.
+ */
+export type GridCellActivate = GridCellActivateEvent;
+
+/**
+ * @deprecated Please use `GridColumnReorderEvent` instead.
+ */
+export type GridColumnReorder = GridColumnReorderEvent;
+
+/**
+ * @deprecated Please use `GridColumnResizeEvent` instead.
+ */
+export type GridColumnResize = GridColumnResizeEvent;
+
+/**
+ * @deprecated Please use `GridExpandedItemsChangedEvent` instead.
+ */
+export type GridExpandedItemsChanged = GridExpandedItemsChangedEvent;
+
+/**
+ * @deprecated Please use `GridDragStartEvent` instead.
+ */
+export type GridDragStart = GridDragStartEvent;
+
+/**
+ * @deprecated Please use `GridDropEvent` instead.
+ */
+export type GridDrop = GridDropEvent;
+
+/**
+ * @deprecated Please use `GridLoadingChangedEvent` instead.
+ */
+export type GridLoadingChanged = GridLoadingChangedEvent;
+
+/**
+ * @deprecated Please use `GridSelectedItemsChangedEvent` instead.
+ */
+export type GridSelectedItemsChanged = GridSelectedItemsChangedEvent;

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column-legacy-events.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { GridSelectionColumnSelectAllChangedEvent } from './vaadin-grid-selection-column.js';
+
+/**
+ * @deprecated Please use `GridSelectionColumnSelectAllChangedEvent` instead.
+ */
+export type GridSelectionColumnSelectAllChanged = GridSelectionColumnSelectAllChangedEvent;

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
@@ -3,10 +3,10 @@ import { GridColumnElement } from './vaadin-grid-column.js';
 /**
  * Fired when the `selectAll` property changes.
  */
-export type GridSelectionColumnSelectAllChanged = CustomEvent<{ value: boolean }>;
+export type GridSelectionColumnSelectAllChangedEvent = CustomEvent<{ value: boolean }>;
 
 export interface GridSelectionColumnElementEventMap {
-  'select-all-changed': GridSelectionColumnSelectAllChanged;
+  'select-all-changed': GridSelectionColumnSelectAllChangedEvent;
 }
 
 export interface GridSelectionColumnEventMap extends HTMLElementEventMap, GridSelectionColumnElementEventMap {}

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column-legacy-events.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { GridSortColumnDirectionChangedEvent } from './vaadin-grid-sort-column.js';
+
+/**
+ * @deprecated Please use `GridSortColumnDirectionChangedEvent` instead.
+ */
+export type GridSortColumnDirectionChanged = GridSortColumnDirectionChangedEvent;

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
@@ -5,10 +5,10 @@ import { GridColumnElement } from './vaadin-grid-column.js';
 /**
  * Fired when the `direction` property changes.
  */
-export type GridSortColumnDirectionChanged = CustomEvent<{ value: GridSorterDirection }>;
+export type GridSortColumnDirectionChangedEvent = CustomEvent<{ value: GridSorterDirection }>;
 
 export interface GridSortColumnElementEventMap {
-  'direction-changed': GridSortColumnDirectionChanged;
+  'direction-changed': GridSortColumnDirectionChangedEvent;
 }
 
 export interface GridSortColumnEventMap extends HTMLElementEventMap, GridSortColumnElementEventMap {}

--- a/packages/vaadin-grid/src/vaadin-grid-sorter-legacy-events.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sorter-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { GridSorterDirectionChangedEvent } from './vaadin-grid-sorter.js';
+
+/**
+ * @deprecated Please use `GridSorterDirectionChangedEvent` instead.
+ */
+export type GridSorterDirectionChanged = GridSorterDirectionChangedEvent;

--- a/packages/vaadin-grid/src/vaadin-grid-sorter.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sorter.d.ts
@@ -3,12 +3,12 @@ import { GridSorterDirection } from './interfaces';
 /**
  * Fired when the `direction` property changes.
  */
-export type GridSorterDirectionChanged = CustomEvent<{ value: GridSorterDirection }>;
+export type GridSorterDirectionChangedEvent = CustomEvent<{ value: GridSorterDirection }>;
 
 export interface GridSorterElementEventMap {
   'sorter-changed': Event;
 
-  'direction-changed': GridSorterDirectionChanged;
+  'direction-changed': GridSorterDirectionChangedEvent;
 }
 
 export interface GridSorterEventMap extends HTMLElementEventMap, GridSorterElementEventMap {}

--- a/packages/vaadin-grid/src/vaadin-grid-tree-toggle-legacy-events.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-toggle-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { GridTreeToggleExpandedChangedEvent } from './vaadin-grid-tree-toggle.js';
+
+/**
+ * @deprecated Please use `GridTreeToggleExpandedChangedEvent` instead.
+ */
+export type GridTreeToggleExpandedChanged = GridTreeToggleExpandedChangedEvent;

--- a/packages/vaadin-grid/src/vaadin-grid-tree-toggle.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-toggle.d.ts
@@ -3,10 +3,10 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * Fired when the `expanded` property changes.
  */
-export type GridTreeToggleExpandedChanged = CustomEvent<{ value: boolean }>;
+export type GridTreeToggleExpandedChangedEvent = CustomEvent<{ value: boolean }>;
 
 export interface GridTreeToggleElementEventMap {
-  'expanded-changed': GridTreeToggleExpandedChanged;
+  'expanded-changed': GridTreeToggleExpandedChangedEvent;
 }
 
 export interface GridTreeToggleEventMap extends HTMLElementEventMap, GridTreeToggleElementEventMap {}

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -43,32 +43,32 @@ import { GridColumnElement } from './vaadin-grid-column.js';
 /**
  * Fired when the `activeItem` property changes.
  */
-export type GridActiveItemChanged = CustomEvent<{ value: GridItem }>;
+export type GridActiveItemChangedEvent = CustomEvent<{ value: GridItem }>;
 
 /**
  * Fired when the cell is activated with click or keyboard.
  */
-export type GridCellActivate = CustomEvent<{ model: GridItemModel }>;
+export type GridCellActivateEvent = CustomEvent<{ model: GridItemModel }>;
 
 /**
  * Fired when the columns in the grid are reordered.
  */
-export type GridColumnReorder = CustomEvent<{ columns: GridColumnElement[] }>;
+export type GridColumnReorderEvent = CustomEvent<{ columns: GridColumnElement[] }>;
 
 /**
  * Fired when the grid column resize is finished.
  */
-export type GridColumnResize = CustomEvent<{ resizedColumn: GridColumnElement }>;
+export type GridColumnResizeEvent = CustomEvent<{ resizedColumn: GridColumnElement }>;
 
 /**
  * Fired when the `expandedItems` property changes.
  */
-export type GridExpandedItemsChanged = CustomEvent<{ value: GridItem[] }>;
+export type GridExpandedItemsChangedEvent = CustomEvent<{ value: GridItem[] }>;
 
 /**
  * Fired when starting to drag grid rows.
  */
-export type GridDragStart = CustomEvent<{
+export type GridDragStartEvent = CustomEvent<{
   draggedItems: GridItem[];
   setDraggedItemsCount: (count: number) => void;
   setDragData: (type: string, data: string) => void;
@@ -77,7 +77,7 @@ export type GridDragStart = CustomEvent<{
 /**
  * Fired when a drop occurs on top of the grid.
  */
-export type GridDrop = CustomEvent<{
+export type GridDropEvent = CustomEvent<{
   dropTargetItem: GridItem;
   dropLocation: GridDropLocation;
   dragData: Array<{ type: string; data: string }>;
@@ -86,33 +86,33 @@ export type GridDrop = CustomEvent<{
 /**
  * Fired when the `loading` property changes.
  */
-export type GridLoadingChanged = CustomEvent<{ value: boolean }>;
+export type GridLoadingChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `selectedItems` property changes.
  */
-export type GridSelectedItemsChanged = CustomEvent<{ value: GridItem[] }>;
+export type GridSelectedItemsChangedEvent = CustomEvent<{ value: GridItem[] }>;
 
 export interface GridElementEventMap {
-  'active-item-changed': GridActiveItemChanged;
+  'active-item-changed': GridActiveItemChangedEvent;
 
-  'cell-activate': GridCellActivate;
+  'cell-activate': GridCellActivateEvent;
 
-  'column-reorder': GridColumnReorder;
+  'column-reorder': GridColumnReorderEvent;
 
-  'column-resize': GridColumnResize;
+  'column-resize': GridColumnResizeEvent;
 
-  'expanded-items-changed': GridExpandedItemsChanged;
+  'expanded-items-changed': GridExpandedItemsChangedEvent;
 
-  'grid-dragstart': GridDragStart;
+  'grid-dragstart': GridDragStartEvent;
 
   'grid-dragend': Event;
 
-  'grid-drop': GridDrop;
+  'grid-drop': GridDropEvent;
 
-  'loading-changed': GridLoadingChanged;
+  'loading-changed': GridLoadingChangedEvent;
 
-  'selected-items-changed': GridSelectedItemsChanged;
+  'selected-items-changed': GridSelectedItemsChangedEvent;
 }
 
 export interface GridEventMap extends HTMLElementEventMap, GridElementEventMap {}

--- a/packages/vaadin-grid/test/typings/grid-legacy-events.types.ts
+++ b/packages/vaadin-grid/test/typings/grid-legacy-events.types.ts
@@ -1,0 +1,93 @@
+import '../../vaadin-grid.js';
+import '../../vaadin-grid-filter.js';
+import '../../vaadin-grid-selection-column.js';
+import '../../vaadin-grid-sorter.js';
+import '../../vaadin-grid-sort-column.js';
+import '../../vaadin-grid-tree-toggle.js';
+
+import {
+  GridActiveItemChanged,
+  GridCellActivate,
+  GridColumnReorder,
+  GridColumnResize,
+  GridLoadingChanged,
+  GridExpandedItemsChanged,
+  GridSelectedItemsChanged,
+  GridDragStart,
+  GridDrop
+} from '../../vaadin-grid.js';
+import { GridFilterValueChanged } from '../../vaadin-grid-filter.js';
+import { GridSorterDirectionChanged } from '../../vaadin-grid-sorter.js';
+import { GridSortColumnDirectionChanged } from '../../vaadin-grid-sort-column.js';
+import { GridTreeToggleExpandedChanged } from '../../vaadin-grid-tree-toggle.js';
+import { GridSelectionColumnSelectAllChanged } from '../../vaadin-grid-selection-column.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const grid = document.createElement('vaadin-grid');
+
+grid.addEventListener('active-item-changed', (event) => {
+  assertType<GridActiveItemChanged>(event);
+});
+
+grid.addEventListener('cell-activate', (event) => {
+  assertType<GridCellActivate>(event);
+});
+
+grid.addEventListener('column-reorder', (event) => {
+  assertType<GridColumnReorder>(event);
+});
+
+grid.addEventListener('column-resize', (event) => {
+  assertType<GridColumnResize>(event);
+});
+
+grid.addEventListener('loading-changed', (event) => {
+  assertType<GridLoadingChanged>(event);
+});
+
+grid.addEventListener('expanded-items-changed', (event) => {
+  assertType<GridExpandedItemsChanged>(event);
+});
+
+grid.addEventListener('selected-items-changed', (event) => {
+  assertType<GridSelectedItemsChanged>(event);
+});
+
+grid.addEventListener('grid-dragstart', (event) => {
+  assertType<GridDragStart>(event);
+});
+
+grid.addEventListener('grid-drop', (event) => {
+  assertType<GridDrop>(event);
+});
+
+const filter = document.createElement('vaadin-grid-filter');
+
+filter.addEventListener('value-changed', (event) => {
+  assertType<GridFilterValueChanged>(event);
+});
+
+const selectionColumn = document.createElement('vaadin-grid-selection-column');
+
+selectionColumn.addEventListener('select-all-changed', (event) => {
+  assertType<GridSelectionColumnSelectAllChanged>(event);
+});
+
+const sorter = document.createElement('vaadin-grid-sorter');
+
+sorter.addEventListener('direction-changed', (event) => {
+  assertType<GridSorterDirectionChanged>(event);
+});
+
+const sortColumn = document.createElement('vaadin-grid-sort-column');
+
+sortColumn.addEventListener('direction-changed', (event) => {
+  assertType<GridSortColumnDirectionChanged>(event);
+});
+
+const treeToggle = document.createElement('vaadin-grid-tree-toggle');
+
+treeToggle.addEventListener('expanded-changed', (event) => {
+  assertType<GridTreeToggleExpandedChanged>(event);
+});

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -1,84 +1,113 @@
-import '../../src/vaadin-grid';
-import '../../src/vaadin-grid-filter';
-import '../../src/vaadin-grid-selection-column';
-import '../../src/vaadin-grid-sorter';
-import '../../src/vaadin-grid-sort-column';
-import '../../src/vaadin-grid-tree-toggle';
+import '../../vaadin-grid.js';
+import '../../vaadin-grid-filter.js';
+import '../../vaadin-grid-selection-column.js';
+import '../../vaadin-grid-sorter.js';
+import '../../vaadin-grid-sort-column.js';
+import '../../vaadin-grid-tree-toggle.js';
+
 import {
   GridColumnElement,
   GridDropLocation,
   GridItem,
   GridItemModel,
-  GridSorterDirection
-} from '../../src/interfaces';
+  GridSorterDirection,
+  GridActiveItemChangedEvent,
+  GridCellActivateEvent,
+  GridColumnReorderEvent,
+  GridColumnResizeEvent,
+  GridLoadingChangedEvent,
+  GridExpandedItemsChangedEvent,
+  GridSelectedItemsChangedEvent,
+  GridDragStartEvent,
+  GridDropEvent
+} from '../../vaadin-grid.js';
+import { GridFilterValueChangedEvent } from '../../vaadin-grid-filter.js';
+import { GridSorterDirectionChangedEvent } from '../../vaadin-grid-sorter.js';
+import { GridSortColumnDirectionChangedEvent } from '../../vaadin-grid-sort-column.js';
+import { GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
+import { GridSelectionColumnSelectAllChangedEvent } from '../../vaadin-grid-selection-column.js';
 
-const assert = <T>(value: T) => value;
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 const grid = document.createElement('vaadin-grid');
 
 grid.addEventListener('active-item-changed', (event) => {
-  assert<GridItem>(event.detail.value);
+  assertType<GridActiveItemChangedEvent>(event);
+  assertType<GridItem>(event.detail.value);
 });
 
 grid.addEventListener('cell-activate', (event) => {
-  assert<GridItemModel>(event.detail.model);
+  assertType<GridCellActivateEvent>(event);
+  assertType<GridItemModel>(event.detail.model);
 });
 
 grid.addEventListener('column-reorder', (event) => {
-  assert<GridColumnElement[]>(event.detail.columns);
+  assertType<GridColumnReorderEvent>(event);
+  assertType<GridColumnElement[]>(event.detail.columns);
 });
 
 grid.addEventListener('column-resize', (event) => {
-  assert<GridColumnElement>(event.detail.resizedColumn);
+  assertType<GridColumnResizeEvent>(event);
+  assertType<GridColumnElement>(event.detail.resizedColumn);
 });
 
 grid.addEventListener('loading-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<GridLoadingChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 grid.addEventListener('expanded-items-changed', (event) => {
-  assert<GridItem[]>(event.detail.value);
+  assertType<GridExpandedItemsChangedEvent>(event);
+  assertType<GridItem[]>(event.detail.value);
 });
 
 grid.addEventListener('selected-items-changed', (event) => {
-  assert<GridItem[]>(event.detail.value);
+  assertType<GridSelectedItemsChangedEvent>(event);
+  assertType<GridItem[]>(event.detail.value);
 });
 
 grid.addEventListener('grid-dragstart', (event) => {
-  assert<GridItem[]>(event.detail.draggedItems);
+  assertType<GridDragStartEvent>(event);
+  assertType<GridItem[]>(event.detail.draggedItems);
 });
 
 grid.addEventListener('grid-drop', (event) => {
-  assert<GridItem>(event.detail.dropTargetItem);
-  assert<GridDropLocation>(event.detail.dropLocation);
+  assertType<GridDropEvent>(event);
+  assertType<GridItem>(event.detail.dropTargetItem);
+  assertType<GridDropLocation>(event.detail.dropLocation);
 });
 
 const filter = document.createElement('vaadin-grid-filter');
 
 filter.addEventListener('value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<GridFilterValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
 });
 
 const selectionColumn = document.createElement('vaadin-grid-selection-column');
 
 selectionColumn.addEventListener('select-all-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<GridSelectionColumnSelectAllChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 const sorter = document.createElement('vaadin-grid-sorter');
 
 sorter.addEventListener('direction-changed', (event) => {
-  assert<GridSorterDirection>(event.detail.value);
+  assertType<GridSorterDirectionChangedEvent>(event);
+  assertType<GridSorterDirection>(event.detail.value);
 });
 
 const sortColumn = document.createElement('vaadin-grid-sort-column');
 
 sortColumn.addEventListener('direction-changed', (event) => {
-  assert<GridSorterDirection>(event.detail.value);
+  assertType<GridSortColumnDirectionChangedEvent>(event);
+  assertType<GridSorterDirection>(event.detail.value);
 });
 
 const treeToggle = document.createElement('vaadin-grid-tree-toggle');
 
 treeToggle.addEventListener('expanded-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<GridTreeToggleExpandedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });

--- a/packages/vaadin-grid/vaadin-grid-filter.d.ts
+++ b/packages/vaadin-grid/vaadin-grid-filter.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-grid-filter.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-grid-filter-legacy-events.js';

--- a/packages/vaadin-grid/vaadin-grid-selection-column.d.ts
+++ b/packages/vaadin-grid/vaadin-grid-selection-column.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-grid-selection-column.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-grid-selection-column-legacy-events.js';

--- a/packages/vaadin-grid/vaadin-grid-sort-column.d.ts
+++ b/packages/vaadin-grid/vaadin-grid-sort-column.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-grid-sort-column.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-grid-sort-column-legacy-events.js';

--- a/packages/vaadin-grid/vaadin-grid-sorter.d.ts
+++ b/packages/vaadin-grid/vaadin-grid-sorter.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-grid-sorter.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-grid-sorter-legacy-events.js';

--- a/packages/vaadin-grid/vaadin-grid-tree-column.d.ts
+++ b/packages/vaadin-grid/vaadin-grid-tree-column.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-grid-tree-column.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-grid-tree-column-legacy-events.js';

--- a/packages/vaadin-grid/vaadin-grid-tree-toggle.d.ts
+++ b/packages/vaadin-grid/vaadin-grid-tree-toggle.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-grid-tree-toggle.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-grid-tree-toggle-legacy-events.js';

--- a/packages/vaadin-grid/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/vaadin-grid.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-grid.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-grid-legacy-events.js';

--- a/packages/vaadin-list-box/src/vaadin-list-box-legacy-events.d.ts
+++ b/packages/vaadin-list-box/src/vaadin-list-box-legacy-events.d.ts
@@ -1,0 +1,20 @@
+import {
+  ListBoxItemsChangedEvent,
+  ListBoxSelectedChangedEvent,
+  ListBoxSelectedValuesChangedEvent
+} from './vaadin-list-box.js';
+
+/**
+ * @deprecated Please use `ListBoxItemsChangedEvent` instead.
+ */
+export type ListBoxItemsChanged = ListBoxItemsChangedEvent;
+
+/**
+ * @deprecated Please use `ListBoxSelectedChangedEvent` instead.
+ */
+export type ListBoxSelectedChanged = ListBoxSelectedChangedEvent;
+
+/**
+ * @deprecated Please use `ListBoxSelectedValuesChangedEvent` instead.
+ */
+export type ListBoxSelectedValuesChanged = ListBoxSelectedValuesChangedEvent;

--- a/packages/vaadin-list-box/src/vaadin-list-box.d.ts
+++ b/packages/vaadin-list-box/src/vaadin-list-box.d.ts
@@ -7,24 +7,24 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
 /**
  * Fired when the `items` property changes.
  */
-export type ListBoxItemsChanged = CustomEvent<{ value: Array<Element> }>;
+export type ListBoxItemsChangedEvent = CustomEvent<{ value: Array<Element> }>;
 
 /**
  * Fired when the `selected` property changes.
  */
-export type ListBoxSelectedChanged = CustomEvent<{ value: number }>;
+export type ListBoxSelectedChangedEvent = CustomEvent<{ value: number }>;
 
 /**
  * Fired when the `selectedValues` property changes.
  */
-export type ListBoxSelectedValuesChanged = CustomEvent<{ value: Array<number> }>;
+export type ListBoxSelectedValuesChangedEvent = CustomEvent<{ value: Array<number> }>;
 
 export interface ListBoxElementEventMap {
-  'items-changed': ListBoxItemsChanged;
+  'items-changed': ListBoxItemsChangedEvent;
 
-  'selected-changed': ListBoxSelectedChanged;
+  'selected-changed': ListBoxSelectedChangedEvent;
 
-  'selected-values-changed': ListBoxSelectedValuesChanged;
+  'selected-values-changed': ListBoxSelectedValuesChangedEvent;
 }
 
 export interface ListBoxEventMap extends HTMLElementEventMap, ListBoxElementEventMap {}

--- a/packages/vaadin-list-box/test/typings/list-box-legacy-events.types.ts
+++ b/packages/vaadin-list-box/test/typings/list-box-legacy-events.types.ts
@@ -1,0 +1,18 @@
+import '../../vaadin-list-box.js';
+import { ListBoxItemsChanged, ListBoxSelectedChanged, ListBoxSelectedValuesChanged } from '../../vaadin-list-box.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const listBox = document.createElement('vaadin-list-box');
+
+listBox.addEventListener('items-changed', (event) => {
+  assertType<ListBoxItemsChanged>(event);
+});
+
+listBox.addEventListener('selected-changed', (event) => {
+  assertType<ListBoxSelectedChanged>(event);
+});
+
+listBox.addEventListener('selected-values-changed', (event) => {
+  assertType<ListBoxSelectedValuesChanged>(event);
+});

--- a/packages/vaadin-list-box/test/typings/list-box.types.ts
+++ b/packages/vaadin-list-box/test/typings/list-box.types.ts
@@ -1,17 +1,25 @@
-import '../../src/vaadin-list-box';
+import '../../vaadin-list-box.js';
+import {
+  ListBoxItemsChangedEvent,
+  ListBoxSelectedChangedEvent,
+  ListBoxSelectedValuesChangedEvent
+} from '../../vaadin-list-box.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 const listBox = document.createElement('vaadin-list-box');
 
-const assert = <T>(value: T) => value;
-
 listBox.addEventListener('items-changed', (event) => {
-  assert<Element[]>(event.detail.value);
+  assertType<ListBoxItemsChangedEvent>(event);
+  assertType<Element[]>(event.detail.value);
 });
 
 listBox.addEventListener('selected-changed', (event) => {
-  assert<number>(event.detail.value);
+  assertType<ListBoxSelectedChangedEvent>(event);
+  assertType<number>(event.detail.value);
 });
 
 listBox.addEventListener('selected-values-changed', (event) => {
-  assert<number[]>(event.detail.value);
+  assertType<ListBoxSelectedValuesChangedEvent>(event);
+  assertType<number[]>(event.detail.value);
 });

--- a/packages/vaadin-list-box/vaadin-list-box.d.ts
+++ b/packages/vaadin-list-box/vaadin-list-box.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-list-box.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-list-box-legacy-events.js';

--- a/packages/vaadin-login/src/interfaces.d.ts
+++ b/packages/vaadin-login/src/interfaces.d.ts
@@ -20,12 +20,12 @@ export interface LoginI18n {
 /**
  * Fired when a user submits the login.
  */
-export type LoginSubmit = CustomEvent<{ username: string; password: string }>;
+export type LoginEvent = CustomEvent<{ username: string; password: string }>;
 
 export interface LoginElementEventMap {
   'forgot-password': Event;
 
-  login: LoginSubmit;
+  login: LoginEvent;
 }
 
 export interface LoginEventMap extends HTMLElementEventMap, LoginElementEventMap {}

--- a/packages/vaadin-login/src/vaadin-login-overlay-legacy-events.ts
+++ b/packages/vaadin-login/src/vaadin-login-overlay-legacy-events.ts
@@ -1,0 +1,6 @@
+import { LoginEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `LoginEvent` instead.
+ */
+export type LoginSubmit = LoginEvent;

--- a/packages/vaadin-login/test/typings/login-legacy-events.types.ts
+++ b/packages/vaadin-login/test/typings/login-legacy-events.types.ts
@@ -1,21 +1,17 @@
 import '../../vaadin-login-form.js';
 
-import { LoginEvent } from '../../vaadin-login-overlay.js';
+import { LoginSubmit } from '../../vaadin-login-overlay.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const overlay = document.createElement('vaadin-login-overlay');
 
 overlay.addEventListener('login', (event) => {
-  assertType<LoginEvent>(event);
-  assertType<string>(event.detail.username);
-  assertType<string>(event.detail.password);
+  assertType<LoginSubmit>(event);
 });
 
 const form = document.createElement('vaadin-login-form');
 
 form.addEventListener('login', (event) => {
-  assertType<LoginEvent>(event);
-  assertType<string>(event.detail.username);
-  assertType<string>(event.detail.password);
+  assertType<LoginSubmit>(event);
 });

--- a/packages/vaadin-login/vaadin-login-overlay.d.ts
+++ b/packages/vaadin-login/vaadin-login-overlay.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-login-overlay.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-login-overlay-legacy-events.js';

--- a/packages/vaadin-menu-bar/src/interfaces.d.ts
+++ b/packages/vaadin-menu-bar/src/interfaces.d.ts
@@ -16,10 +16,10 @@ export interface SubMenuItem {
 /**
  * Fired when a submenu item or menu bar button without children is clicked.
  */
-export type MenuBarItemSelected = CustomEvent<{ value: MenuBarItem }>;
+export type MenuBarItemSelectedEvent = CustomEvent<{ value: MenuBarItem }>;
 
 export interface MenuBarElementEventMap {
-  'item-selected': MenuBarItemSelected;
+  'item-selected': MenuBarItemSelectedEvent;
 }
 
 export interface MenuBarEventMap extends HTMLElementEventMap, MenuBarElementEventMap {}

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-legacy-events.d.ts
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { MenuBarItemSelectedEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `MenuBarItemSelectedEvent` instead.
+ */
+export type MenuBarItemSelected = MenuBarItemSelectedEvent;

--- a/packages/vaadin-menu-bar/test/typings/menu-bar-legacy-events.types.ts
+++ b/packages/vaadin-menu-bar/test/typings/menu-bar-legacy-events.types.ts
@@ -1,12 +1,11 @@
 import '../../vaadin-menu-bar';
 
-import { MenuBarItem, MenuBarItemSelectedEvent } from '../../vaadin-menu-bar';
+import { MenuBarItemSelected } from '../../vaadin-menu-bar';
 
 const menu = document.createElement('vaadin-menu-bar');
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 menu.addEventListener('item-selected', (event) => {
-  assertType<MenuBarItemSelectedEvent>(event);
-  assertType<MenuBarItem>(event.detail.value);
+  assertType<MenuBarItemSelected>(event);
 });

--- a/packages/vaadin-menu-bar/vaadin-menu-bar.d.ts
+++ b/packages/vaadin-menu-bar/vaadin-menu-bar.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-menu-bar.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-menu-bar-legacy-events.js';

--- a/packages/vaadin-messages/src/vaadin-message-input-legacy-events.d.ts
+++ b/packages/vaadin-messages/src/vaadin-message-input-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { MessageInputSubmitEvent } from './vaadin-message-input.js';
+
+/**
+ * @deprecated Please use `MessageInputSubmitEvent` instead.
+ */
+export type MessageInputSubmit = MessageInputSubmitEvent;

--- a/packages/vaadin-messages/src/vaadin-message-input.d.ts
+++ b/packages/vaadin-messages/src/vaadin-message-input.d.ts
@@ -11,10 +11,10 @@ export interface MessageInputI18n {
  * Fired when a new message is submitted with `<vaadin-message-input>`, either
  * by clicking the "send" button, or pressing the Enter key.
  */
-export type MessageInputSubmit = CustomEvent<{ value: string }>;
+export type MessageInputSubmitEvent = CustomEvent<{ value: string }>;
 
 export interface MessageInputElementEventMap {
-  submit: MessageInputSubmit;
+  submit: MessageInputSubmitEvent;
 }
 
 export type MessageInputEventMap = HTMLElementEventMap & MessageInputElementEventMap;

--- a/packages/vaadin-messages/src/vaadin-message-legacy-events.d.ts
+++ b/packages/vaadin-messages/src/vaadin-message-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { MessageSubmitEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `MessageSubmitEvent` instead.
+ */
+export type MessageSubmit = MessageSubmitEvent;

--- a/packages/vaadin-messages/test/typings/message-input-legacy-events.types.ts
+++ b/packages/vaadin-messages/test/typings/message-input-legacy-events.types.ts
@@ -1,12 +1,11 @@
 import '../../vaadin-message-input.js';
 
-import { MessageInputSubmitEvent } from '../../vaadin-message-input.js';
+import { MessageInputSubmit } from '../../vaadin-message-input.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const input = document.createElement('vaadin-message-input');
 
 input.addEventListener('submit', (event) => {
-  assertType<MessageInputSubmitEvent>(event);
-  assertType<string>(event.detail.value);
+  assertType<MessageInputSubmit>(event);
 });

--- a/packages/vaadin-messages/vaadin-message-input.d.ts
+++ b/packages/vaadin-messages/vaadin-message-input.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-message-input.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-message-input-legacy-events.js';

--- a/packages/vaadin-notification/src/interfaces.d.ts
+++ b/packages/vaadin-notification/src/interfaces.d.ts
@@ -16,10 +16,10 @@ export type NotificationRenderer = (root: HTMLElement, notification?: Notificati
 /**
  * Fired when the `opened` property changes.
  */
-export type NotificationOpenedChanged = CustomEvent<{ value: boolean }>;
+export type NotificationOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
 export interface NotificationElementEventMap {
-  'opened-changed': NotificationOpenedChanged;
+  'opened-changed': NotificationOpenedChangedEvent;
 }
 
 export interface NotificationEventMap extends HTMLElementEventMap, NotificationElementEventMap {}

--- a/packages/vaadin-notification/src/vaadin-notification-legacy-events.d.ts
+++ b/packages/vaadin-notification/src/vaadin-notification-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { NotificationOpenedChangedEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `NotificationOpenedChangedEvent` instead.
+ */
+export type NotificationOpenedChanged = NotificationOpenedChangedEvent;

--- a/packages/vaadin-notification/test/typings/notification-legacy-events.types.ts
+++ b/packages/vaadin-notification/test/typings/notification-legacy-events.types.ts
@@ -1,12 +1,12 @@
 import '../../vaadin-notification.js';
 
-import { NotificationOpenedChangedEvent } from '../../vaadin-notification.js';
+import { NotificationOpenedChanged } from '../../vaadin-notification.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 
 const notification = document.createElement('vaadin-notification');
 
 notification.addEventListener('opened-changed', (event) => {
-  assertType<NotificationOpenedChangedEvent>(event);
+  assertType<NotificationOpenedChanged>(event);
   assertType<boolean>(event.detail.value);
 });

--- a/packages/vaadin-notification/vaadin-notification.d.ts
+++ b/packages/vaadin-notification/vaadin-notification.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-notification.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-notification-legacy-events.js';

--- a/packages/vaadin-overlay/src/interfaces.d.ts
+++ b/packages/vaadin-overlay/src/interfaces.d.ts
@@ -3,10 +3,10 @@ export type OverlayRenderer = (root: HTMLElement, owner: HTMLElement, model?: ob
 /**
  * Fired when the `opened` property changes.
  */
-export type OverlayOpenedChanged = CustomEvent<{ value: boolean }>;
+export type OverlayOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
 export interface OverlayElementEventMap {
-  'opened-changed': OverlayOpenedChanged;
+  'opened-changed': OverlayOpenedChangedEvent;
 }
 
 export type OverlayEventMap = HTMLElementEventMap & OverlayElementEventMap;

--- a/packages/vaadin-overlay/src/vaadin-overlay-legacy-events.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { OverlayOpenedChangedEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `OverlayOpenedChangedEvent` instead.
+ */
+export type OverlayOpenedChanged = OverlayOpenedChangedEvent;

--- a/packages/vaadin-overlay/test/typings/overlay-legacy-events.types.ts
+++ b/packages/vaadin-overlay/test/typings/overlay-legacy-events.types.ts
@@ -1,12 +1,11 @@
 import '../../vaadin-overlay.js';
 
-import { OverlayOpenedChangedEvent } from '../../vaadin-overlay.js';
+import { OverlayOpenedChanged } from '../../vaadin-overlay.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const overlay = document.createElement('vaadin-overlay');
 
 overlay.addEventListener('opened-changed', (event) => {
-  assertType<OverlayOpenedChangedEvent>(event);
-  assertType<boolean>(event.detail.value);
+  assertType<OverlayOpenedChanged>(event);
 });

--- a/packages/vaadin-overlay/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/vaadin-overlay.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-overlay.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-overlay-legacy-events.js';

--- a/packages/vaadin-radio-button/src/vaadin-radio-button-legacy-events.d.ts
+++ b/packages/vaadin-radio-button/src/vaadin-radio-button-legacy-events.d.ts
@@ -1,0 +1,6 @@
+import { RadioButtonCheckedChangedEvent } from './vaadin-radio-button.js';
+
+/**
+ * @deprecated Please use `RadioButtonCheckedChangedEvent` instead.
+ */
+export type RadioButtonCheckedChanged = RadioButtonCheckedChangedEvent;

--- a/packages/vaadin-radio-button/src/vaadin-radio-button.d.ts
+++ b/packages/vaadin-radio-button/src/vaadin-radio-button.d.ts
@@ -9,10 +9,10 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
 /**
  * Fired when the `checked` property changes.
  */
-export type RadioButtonCheckedChanged = CustomEvent<{ value: boolean }>;
+export type RadioButtonCheckedChangedEvent = CustomEvent<{ value: boolean }>;
 
 export interface RadioButtonElementEventMap {
-  'checked-changed': RadioButtonCheckedChanged;
+  'checked-changed': RadioButtonCheckedChangedEvent;
 }
 
 export interface RadioButtonEventMap extends HTMLElementEventMap, RadioButtonElementEventMap {}

--- a/packages/vaadin-radio-button/src/vaadin-radio-group-legacy-events.d.ts
+++ b/packages/vaadin-radio-button/src/vaadin-radio-group-legacy-events.d.ts
@@ -1,0 +1,11 @@
+import { RadioGroupInvalidChangedEvent, RadioGroupValueChangedEvent } from './vaadin-radio-group.js';
+
+/**
+ * @deprecated Please use `RadioGroupInvalidChangedEvent` instead.
+ */
+export type RadioGroupInvalidChanged = RadioGroupInvalidChangedEvent;
+
+/**
+ * @deprecated Please use `RadioGroupValueChangedEvent` instead.
+ */
+export type RadioGroupValueChanged = RadioGroupValueChangedEvent;

--- a/packages/vaadin-radio-button/src/vaadin-radio-group.d.ts
+++ b/packages/vaadin-radio-button/src/vaadin-radio-group.d.ts
@@ -7,17 +7,17 @@ import { RadioButtonElement } from './vaadin-radio-button.js';
 /**
  * Fired when the `invalid` property changes.
  */
-export type RadioGroupInvalidChanged = CustomEvent<{ value: boolean }>;
+export type RadioGroupInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type RadioGroupValueChanged = CustomEvent<{ value: string }>;
+export type RadioGroupValueChangedEvent = CustomEvent<{ value: string }>;
 
 export interface RadioGroupElementEventMap {
-  'invalid-changed': RadioGroupInvalidChanged;
+  'invalid-changed': RadioGroupInvalidChangedEvent;
 
-  'value-changed': RadioGroupValueChanged;
+  'value-changed': RadioGroupValueChangedEvent;
 }
 
 export interface RadioGroupEventMap extends HTMLElementEventMap, RadioGroupElementEventMap {}

--- a/packages/vaadin-radio-button/test/typings/radio-button-legacy-events.types.ts
+++ b/packages/vaadin-radio-button/test/typings/radio-button-legacy-events.types.ts
@@ -1,0 +1,23 @@
+import '../../vaadin-radio-button.js';
+import '../../vaadin-radio-group.js';
+
+import { RadioButtonCheckedChanged } from '../../vaadin-radio-button.js';
+import { RadioGroupInvalidChanged, RadioGroupValueChanged } from '../../vaadin-radio-group.js';
+
+const radio = document.createElement('vaadin-radio-button');
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+radio.addEventListener('checked-changed', (event) => {
+  assertType<RadioButtonCheckedChanged>(event);
+});
+
+const group = document.createElement('vaadin-radio-group');
+
+group.addEventListener('invalid-changed', (event) => {
+  assertType<RadioGroupInvalidChanged>(event);
+});
+
+group.addEventListener('value-changed', (event) => {
+  assertType<RadioGroupValueChanged>(event);
+});

--- a/packages/vaadin-radio-button/test/typings/radio-button.types.ts
+++ b/packages/vaadin-radio-button/test/typings/radio-button.types.ts
@@ -1,20 +1,26 @@
-import '../../src/vaadin-radio-button';
-import '../../src/vaadin-radio-group';
+import '../../vaadin-radio-button.js';
+import '../../vaadin-radio-group.js';
+
+import { RadioButtonCheckedChangedEvent } from '../../vaadin-radio-button.js';
+import { RadioGroupInvalidChangedEvent, RadioGroupValueChangedEvent } from '../../vaadin-radio-group.js';
 
 const radio = document.createElement('vaadin-radio-button');
 
-const assert = <T>(value: T) => value;
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 radio.addEventListener('checked-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<RadioButtonCheckedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 const group = document.createElement('vaadin-radio-group');
 
 group.addEventListener('invalid-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<RadioGroupInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 group.addEventListener('value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<RadioGroupValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
 });

--- a/packages/vaadin-radio-button/vaadin-radio-button.d.ts
+++ b/packages/vaadin-radio-button/vaadin-radio-button.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-radio-button.js';
+
+// TODO: Remove from Vaadin 21
+export * from './src/vaadin-radio-button-legacy-events.js';

--- a/packages/vaadin-radio-button/vaadin-radio-group.d.ts
+++ b/packages/vaadin-radio-button/vaadin-radio-group.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-radio-group.js';
+
+// TODO: Remove from Vaadin 21
+export * from './src/vaadin-radio-group-legacy-events.js';

--- a/packages/vaadin-rich-text-editor/src/interfaces.d.ts
+++ b/packages/vaadin-rich-text-editor/src/interfaces.d.ts
@@ -29,17 +29,17 @@ export interface RichTextEditorI18n {
 /**
  * Fired when the `htmlValue` property changes.
  */
-export type RichTextEditorHtmlValueChanged = CustomEvent<{ value: string }>;
+export type RichTextEditorHtmlValueChangedEvent = CustomEvent<{ value: string }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type RichTextEditorValueChanged = CustomEvent<{ value: string }>;
+export type RichTextEditorValueChangedEvent = CustomEvent<{ value: string }>;
 
 export interface RichTextEditorElementEventMap {
-  'html-value-changed': RichTextEditorHtmlValueChanged;
+  'html-value-changed': RichTextEditorHtmlValueChangedEvent;
 
-  'value-changed': RichTextEditorValueChanged;
+  'value-changed': RichTextEditorValueChangedEvent;
 }
 
 export interface RichTextEditorEventMap extends HTMLElementEventMap, RichTextEditorElementEventMap {}

--- a/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor-legacy-events.d.ts
+++ b/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor-legacy-events.d.ts
@@ -1,0 +1,11 @@
+import { RichTextEditorHtmlValueChangedEvent, RichTextEditorValueChangedEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `RichTextEditorValueChangedEvent` instead.
+ */
+export type RichTextEditorHtmlValueChanged = RichTextEditorHtmlValueChangedEvent;
+
+/**
+ * @deprecated Please use `RichTextEditorValueChangedEvent` instead.
+ */
+export type RichTextEditorValueChanged = RichTextEditorValueChangedEvent;

--- a/packages/vaadin-rich-text-editor/test/typings/rich-text-editor-legacy-events.types.ts
+++ b/packages/vaadin-rich-text-editor/test/typings/rich-text-editor-legacy-events.types.ts
@@ -1,0 +1,15 @@
+import '../../vaadin-rich-text-editor.js';
+
+import { RichTextEditorHtmlValueChanged, RichTextEditorValueChanged } from '../../vaadin-rich-text-editor.js';
+
+const customField = document.createElement('vaadin-rich-text-editor');
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+customField.addEventListener('html-value-changed', (event) => {
+  assertType<RichTextEditorHtmlValueChanged>(event);
+});
+
+customField.addEventListener('value-changed', (event) => {
+  assertType<RichTextEditorValueChanged>(event);
+});

--- a/packages/vaadin-rich-text-editor/test/typings/rich-text-editor.types.ts
+++ b/packages/vaadin-rich-text-editor/test/typings/rich-text-editor.types.ts
@@ -1,13 +1,17 @@
-import '../../src/vaadin-rich-text-editor';
+import '../../vaadin-rich-text-editor.js';
+
+import { RichTextEditorHtmlValueChangedEvent, RichTextEditorValueChangedEvent } from '../../vaadin-rich-text-editor.js';
 
 const customField = document.createElement('vaadin-rich-text-editor');
 
-const assert = <T>(value: T) => value;
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 customField.addEventListener('html-value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<RichTextEditorHtmlValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
 });
 
 customField.addEventListener('value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<RichTextEditorValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
 });

--- a/packages/vaadin-rich-text-editor/vaadin-rich-text-editor.d.ts
+++ b/packages/vaadin-rich-text-editor/vaadin-rich-text-editor.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-rich-text-editor.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-rich-text-editor-legacy-events.js';

--- a/packages/vaadin-select/src/interfaces.d.ts
+++ b/packages/vaadin-select/src/interfaces.d.ts
@@ -13,24 +13,24 @@ export type SelectRenderer = (root: HTMLElement, select?: SelectElement) => void
 /**
  * Fired when the `opened` property changes.
  */
-export type SelectOpenedChanged = CustomEvent<{ value: boolean }>;
+export type SelectOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `invalid` property changes.
  */
-export type SelectInvalidChanged = CustomEvent<{ value: boolean }>;
+export type SelectInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type SelectValueChanged = CustomEvent<{ value: string }>;
+export type SelectValueChangedEvent = CustomEvent<{ value: string }>;
 
 export interface SelectElementEventMap {
-  'opened-changed': SelectOpenedChanged;
+  'opened-changed': SelectOpenedChangedEvent;
 
-  'invalid-changed': SelectInvalidChanged;
+  'invalid-changed': SelectInvalidChangedEvent;
 
-  'value-changed': SelectValueChanged;
+  'value-changed': SelectValueChangedEvent;
 }
 
 export interface SelectEventMap extends HTMLElementEventMap, SelectElementEventMap {}

--- a/packages/vaadin-select/src/vaadin-select-legacy-events.d.ts
+++ b/packages/vaadin-select/src/vaadin-select-legacy-events.d.ts
@@ -1,0 +1,16 @@
+import { SelectInvalidChangedEvent, SelectOpenedChangedEvent, SelectValueChangedEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `SelectOpenedChangedEvent` instead.
+ */
+export type SelectOpenedChanged = SelectOpenedChangedEvent;
+
+/**
+ * @deprecated Please use `SelectInvalidChangedEvent` instead.
+ */
+export type SelectInvalidChanged = SelectInvalidChangedEvent;
+
+/**
+ * @deprecated Please use `SelectValueChangedEvent` instead.
+ */
+export type SelectValueChanged = SelectValueChangedEvent;

--- a/packages/vaadin-select/test/typings/select-legacy-events.types.ts
+++ b/packages/vaadin-select/test/typings/select-legacy-events.types.ts
@@ -1,0 +1,19 @@
+import '../../vaadin-select.js';
+
+import { SelectInvalidChanged, SelectOpenedChanged, SelectValueChanged } from '../../vaadin-select.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const select = document.createElement('vaadin-select');
+
+select.addEventListener('opened-changed', (event) => {
+  assertType<SelectOpenedChanged>(event);
+});
+
+select.addEventListener('invalid-changed', (event) => {
+  assertType<SelectInvalidChanged>(event);
+});
+
+select.addEventListener('value-changed', (event) => {
+  assertType<SelectValueChanged>(event);
+});

--- a/packages/vaadin-select/test/typings/select.types.ts
+++ b/packages/vaadin-select/test/typings/select.types.ts
@@ -1,17 +1,22 @@
-import '../../src/vaadin-select';
+import '../../vaadin-select.js';
 
-const assert = <T>(value: T) => value;
+import { SelectInvalidChangedEvent, SelectOpenedChangedEvent, SelectValueChangedEvent } from '../../vaadin-select.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 const select = document.createElement('vaadin-select');
 
 select.addEventListener('opened-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<SelectOpenedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 select.addEventListener('invalid-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<SelectInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 select.addEventListener('value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<SelectValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
 });

--- a/packages/vaadin-select/vaadin-select.d.ts
+++ b/packages/vaadin-select/vaadin-select.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-select.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-select-legacy-events.js';

--- a/packages/vaadin-tabs/src/vaadin-tabs-legacy-events.d.ts
+++ b/packages/vaadin-tabs/src/vaadin-tabs-legacy-events.d.ts
@@ -1,0 +1,11 @@
+import { TabsItemsChangedEvent, TabsSelectedChangedEvent } from './vaadin-tabs.js';
+
+/**
+ * @deprecated Please use `TabsItemsChangedEvent` instead.
+ */
+export type TabsItemsChanged = TabsItemsChangedEvent;
+
+/**
+ * @deprecated Please use `TabsSelectedChangedEvent` instead.
+ */
+export type TabsSelectedChanged = TabsSelectedChangedEvent;

--- a/packages/vaadin-tabs/src/vaadin-tabs.d.ts
+++ b/packages/vaadin-tabs/src/vaadin-tabs.d.ts
@@ -9,17 +9,17 @@ import { ListOrientation } from '@vaadin/vaadin-list-mixin/interfaces';
 /**
  * Fired when the `items` property changes.
  */
-export type TabsItemsChanged = CustomEvent<{ value: Array<Element> }>;
+export type TabsItemsChangedEvent = CustomEvent<{ value: Array<Element> }>;
 
 /**
  * Fired when the `selected` property changes.
  */
-export type TabsSelectedChanged = CustomEvent<{ value: number }>;
+export type TabsSelectedChangedEvent = CustomEvent<{ value: number }>;
 
 export interface TabsElementEventMap {
-  'items-changed': TabsItemsChanged;
+  'items-changed': TabsItemsChangedEvent;
 
-  'selected-changed': TabsSelectedChanged;
+  'selected-changed': TabsSelectedChangedEvent;
 }
 
 export interface TabsEventMap extends HTMLElementEventMap, TabsElementEventMap {}

--- a/packages/vaadin-tabs/test/typings/tabs-legacy-events.types.ts
+++ b/packages/vaadin-tabs/test/typings/tabs-legacy-events.types.ts
@@ -1,0 +1,15 @@
+import '../../vaadin-tabs.js';
+
+import { TabsItemsChanged, TabsSelectedChanged } from '../../vaadin-tabs.js';
+
+const tabs = document.createElement('vaadin-tabs');
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+tabs.addEventListener('items-changed', (event) => {
+  assertType<TabsItemsChanged>(event);
+});
+
+tabs.addEventListener('selected-changed', (event) => {
+  assertType<TabsSelectedChanged>(event);
+});

--- a/packages/vaadin-tabs/test/typings/tabs.types.ts
+++ b/packages/vaadin-tabs/test/typings/tabs.types.ts
@@ -1,13 +1,17 @@
-import '../../src/vaadin-tabs';
+import '../../vaadin-tabs.js';
+
+import { TabsItemsChangedEvent, TabsSelectedChangedEvent } from '../../vaadin-tabs.js';
 
 const tabs = document.createElement('vaadin-tabs');
 
-const assert = <T>(value: T) => value;
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 tabs.addEventListener('items-changed', (event) => {
-  assert<Element[]>(event.detail.value);
+  assertType<TabsItemsChangedEvent>(event);
+  assertType<Element[]>(event.detail.value);
 });
 
 tabs.addEventListener('selected-changed', (event) => {
-  assert<number>(event.detail.value);
+  assertType<TabsSelectedChangedEvent>(event);
+  assertType<number>(event.detail.value);
 });

--- a/packages/vaadin-tabs/vaadin-tabs.d.ts
+++ b/packages/vaadin-tabs/vaadin-tabs.d.ts
@@ -1,1 +1,4 @@
 export * from './src/vaadin-tabs.js';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-tabs-legacy-events.js';

--- a/packages/vaadin-text-field/src/interfaces.d.ts
+++ b/packages/vaadin-text-field/src/interfaces.d.ts
@@ -5,17 +5,17 @@ export type TextFieldAutoCorrect = 'on' | 'off';
 /**
  * Fired when the `invalid` property changes.
  */
-export type TextFieldInvalidChanged = CustomEvent<{ value: boolean }>;
+export type TextFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type TextFieldValueChanged = CustomEvent<{ value: string }>;
+export type TextFieldValueChangedEvent = CustomEvent<{ value: string }>;
 
 export interface TextFieldElementEventMap {
-  'invalid-changed': TextFieldInvalidChanged;
+  'invalid-changed': TextFieldInvalidChangedEvent;
 
-  'value-changed': TextFieldValueChanged;
+  'value-changed': TextFieldValueChangedEvent;
 }
 
 export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldElementEventMap {}

--- a/packages/vaadin-text-field/src/vaadin-text-field-legacy-events.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-text-field-legacy-events.d.ts
@@ -1,0 +1,11 @@
+import { TextFieldInvalidChangedEvent, TextFieldValueChangedEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `TextFieldInvalidChangedEvent` instead.
+ */
+export type TextFieldInvalidChanged = TextFieldInvalidChangedEvent;
+
+/**
+ * @deprecated Please use `TextFieldValueChangedEvent` instead.
+ */
+export type TextFieldValueChanged = TextFieldValueChangedEvent;

--- a/packages/vaadin-text-field/test/typings/text-field-legacy-events.types.ts
+++ b/packages/vaadin-text-field/test/typings/text-field-legacy-events.types.ts
@@ -1,35 +1,37 @@
-import '../../src/vaadin-text-field';
-import '../../src/vaadin-text-area';
-import '../../src/vaadin-password-field';
+import '../../vaadin-text-field.js';
+import '../../vaadin-text-area.js';
+import '../../vaadin-password-field.js';
 
-const assert = <T>(value: T) => value;
+import { TextFieldInvalidChanged, TextFieldValueChanged } from '../../vaadin-text-field.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 const field = document.createElement('vaadin-text-field');
 
 field.addEventListener('invalid-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<TextFieldInvalidChanged>(event);
 });
 
 field.addEventListener('value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<TextFieldValueChanged>(event);
 });
 
 const area = document.createElement('vaadin-text-area');
 
 area.addEventListener('invalid-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<TextFieldInvalidChanged>(event);
 });
 
 area.addEventListener('value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<TextFieldValueChanged>(event);
 });
 
 const password = document.createElement('vaadin-password-field');
 
 password.addEventListener('invalid-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<TextFieldInvalidChanged>(event);
 });
 
 password.addEventListener('value-changed', (event) => {
-  assert<string>(event.detail.value);
+  assertType<TextFieldValueChanged>(event);
 });

--- a/packages/vaadin-text-field/test/typings/text-field.types.ts
+++ b/packages/vaadin-text-field/test/typings/text-field.types.ts
@@ -1,0 +1,43 @@
+import '../../vaadin-text-field.js';
+import '../../vaadin-text-area.js';
+import '../../vaadin-password-field.js';
+
+import { TextFieldInvalidChangedEvent, TextFieldValueChangedEvent } from '../../vaadin-text-field.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const field = document.createElement('vaadin-text-field');
+
+field.addEventListener('invalid-changed', (event) => {
+  assertType<TextFieldInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+field.addEventListener('value-changed', (event) => {
+  assertType<TextFieldValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
+});
+
+const area = document.createElement('vaadin-text-area');
+
+area.addEventListener('invalid-changed', (event) => {
+  assertType<TextFieldInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+area.addEventListener('value-changed', (event) => {
+  assertType<TextFieldValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
+});
+
+const password = document.createElement('vaadin-password-field');
+
+password.addEventListener('invalid-changed', (event) => {
+  assertType<TextFieldInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+password.addEventListener('value-changed', (event) => {
+  assertType<TextFieldValueChangedEvent>(event);
+  assertType<string>(event.detail.value);
+});

--- a/packages/vaadin-text-field/vaadin-text-field.d.ts
+++ b/packages/vaadin-text-field/vaadin-text-field.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-text-field.js';
 export * from './src/interfaces';
+
+// TODO: Remove from Vaadin 21
+export * from './src/vaadin-text-field-legacy-events.js';

--- a/packages/vaadin-time-picker/src/interfaces.d.ts
+++ b/packages/vaadin-time-picker/src/interfaces.d.ts
@@ -15,17 +15,17 @@ export interface TimePickerI18n {
 /**
  * Fired when the `invalid` property changes.
  */
-export type TimePickerInvalidChanged = CustomEvent<{ value: boolean }>;
+export type TimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type TimePickerValueChanged = CustomEvent<{ value: string }>;
+export type TimePickerValueChangedEvent = CustomEvent<{ value: string }>;
 
 export interface TimePickerElementEventMap {
-  'invalid-changed': TimePickerInvalidChanged;
+  'invalid-changed': TimePickerInvalidChangedEvent;
 
-  'value-changed': TimePickerValueChanged;
+  'value-changed': TimePickerValueChangedEvent;
 }
 
 export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerElementEventMap {}

--- a/packages/vaadin-time-picker/src/vaadin-time-picker-legacy-events.d.ts
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker-legacy-events.d.ts
@@ -1,0 +1,11 @@
+import { TimePickerInvalidChangedEvent, TimePickerValueChangedEvent } from './interfaces.js';
+
+/**
+ * @deprecated Please use `TimePickerInvalidChangedEvent` instead.
+ */
+export type TimePickerInvalidChanged = TimePickerInvalidChangedEvent;
+
+/**
+ * @deprecated Please use `TimePickerValueChangedEvent` instead.
+ */
+export type TimePickerValueChanged = TimePickerValueChangedEvent;

--- a/packages/vaadin-time-picker/test/typings/time-picker-legacy-events.types.ts
+++ b/packages/vaadin-time-picker/test/typings/time-picker-legacy-events.types.ts
@@ -1,17 +1,15 @@
 import '../../vaadin-time-picker.js';
 
-import { TimePickerInvalidChangedEvent, TimePickerValueChangedEvent } from '../../vaadin-time-picker.js';
+import { TimePickerInvalidChanged, TimePickerValueChanged } from '../../vaadin-time-picker.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const timePicker = document.createElement('vaadin-time-picker');
 
 timePicker.addEventListener('invalid-changed', (event) => {
-  assertType<TimePickerInvalidChangedEvent>(event);
-  assertType<boolean>(event.detail.value);
+  assertType<TimePickerInvalidChanged>(event);
 });
 
 timePicker.addEventListener('value-changed', (event) => {
-  assertType<TimePickerValueChangedEvent>(event);
-  assertType<string>(event.detail.value);
+  assertType<TimePickerValueChanged>(event);
 });

--- a/packages/vaadin-time-picker/vaadin-time-picker.d.ts
+++ b/packages/vaadin-time-picker/vaadin-time-picker.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-time-picker.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-time-picker-legacy-events.js';

--- a/packages/vaadin-upload/src/interfaces.d.ts
+++ b/packages/vaadin-upload/src/interfaces.d.ts
@@ -62,43 +62,43 @@ export type UploadMethod = 'POST' | 'PUT';
  * Fired when a file cannot be added to the queue due to a constrain:
  * file-size, file-type or maxFiles
  */
-export type UploadFileReject = CustomEvent<{ file: UploadFile; error: string }>;
+export type UploadFileRejectEvent = CustomEvent<{ file: UploadFile; error: string }>;
 
 /**
  * Fired when the `files` property changes.
  */
-export type UploadFilesChanged = CustomEvent<{ value: UploadFile[] }>;
+export type UploadFilesChangedEvent = CustomEvent<{ value: UploadFile[] }>;
 
 /**
  * Fired when the `max-files-reached` property changes.
  */
-export type UploadMaxFilesReachedChanged = CustomEvent<{ value: boolean }>;
+export type UploadMaxFilesReachedChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired before the XHR is opened. Could be used for changing the request
  * URL. If the default is prevented, then XHR would not be opened.
  */
-export type UploadBefore = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadBeforeEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when the XHR is sent.
  */
-export type UploadStart = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadStartEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired as many times as the progress is updated.
  */
-export type UploadProgress = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadProgressEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired in case the upload process succeeded.
  */
-export type UploadSuccess = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadSuccessEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired in case the upload process failed.
  */
-export type UploadError = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadErrorEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when we have the actual server response, and before the component
@@ -110,19 +110,19 @@ export type UploadError = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>
  * with the normal workflow checking the `xhr.status` and `file.error`
  * which also might be modified by the user to force a customized response,
  */
-export type UploadResponse = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadResponseEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when retry upload is requested. If the default is prevented, then
  * retry would not be performed.
  */
-export type UploadRetry = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadRetryEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when upload abort is requested. If the default is prevented, then the
  * file upload would not be aborted.
  */
-export type UploadAbort = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadAbortEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when the XHR has been opened but not sent yet. Useful for appending
@@ -130,32 +130,32 @@ export type UploadAbort = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>
  * headers, etc. If the event is defaultPrevented, `vaadin-upload` will not
  * send the request allowing the user to do something on his own.
  */
-export type UploadRequest = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile; formData: FormData }>;
+export type UploadRequestEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile; formData: FormData }>;
 
 export interface UploadElementEventMap {
-  'file-reject': UploadFileReject;
+  'file-reject': UploadFileRejectEvent;
 
-  'files-changed': UploadFilesChanged;
+  'files-changed': UploadFilesChangedEvent;
 
-  'max-files-reached-changed': UploadMaxFilesReachedChanged;
+  'max-files-reached-changed': UploadMaxFilesReachedChangedEvent;
 
-  'upload-before': UploadBefore;
+  'upload-before': UploadBeforeEvent;
 
-  'upload-start': UploadStart;
+  'upload-start': UploadStartEvent;
 
-  'upload-progress': UploadProgress;
+  'upload-progress': UploadProgressEvent;
 
-  'upload-response': UploadResponse;
+  'upload-response': UploadResponseEvent;
 
-  'upload-success': UploadSuccess;
+  'upload-success': UploadSuccessEvent;
 
-  'upload-error': UploadError;
+  'upload-error': UploadErrorEvent;
 
-  'upload-retry': UploadRetry;
+  'upload-retry': UploadRetryEvent;
 
-  'upload-abort': UploadAbort;
+  'upload-abort': UploadAbortEvent;
 
-  'upload-request': UploadRequest;
+  'upload-request': UploadRequestEvent;
 }
 
 export interface UploadEventMap extends HTMLElementEventMap, UploadElementEventMap {}

--- a/packages/vaadin-upload/src/vaadin-upload-legacy-events.d.ts
+++ b/packages/vaadin-upload/src/vaadin-upload-legacy-events.d.ts
@@ -1,0 +1,74 @@
+import {
+  UploadAbortEvent,
+  UploadBeforeEvent,
+  UploadErrorEvent,
+  UploadFileRejectEvent,
+  UploadFilesChangedEvent,
+  UploadMaxFilesReachedChangedEvent,
+  UploadProgressEvent,
+  UploadRequestEvent,
+  UploadResponseEvent,
+  UploadRetryEvent,
+  UploadStartEvent,
+  UploadSuccessEvent
+} from './interfaces.js';
+
+/**
+ * @deprecated Please use `UploadFileRejectEvent` instead.
+ */
+export type UploadFileReject = UploadFileRejectEvent;
+
+/**
+ * @deprecated Please use `UploadFilesChangedEvent` instead.
+ */
+export type UploadFilesChanged = UploadFilesChangedEvent;
+
+/**
+ * @deprecated Please use `UploadMaxFilesReachedChangedEvent` instead.
+ */
+export type UploadMaxFilesReachedChanged = UploadMaxFilesReachedChangedEvent;
+
+/**
+ * @deprecated Please use `UploadBeforeEvent` instead.
+ */
+export type UploadBefore = UploadBeforeEvent;
+
+/**
+ * @deprecated Please use `UploadStartEvent` instead.
+ */
+export type UploadStart = UploadStartEvent;
+
+/**
+ * @deprecated Please use `UploadProgressEvent` instead.
+ */
+export type UploadProgress = UploadProgressEvent;
+
+/**
+ * @deprecated Please use `UploadSuccessEvent` instead.
+ */
+export type UploadSuccess = UploadSuccessEvent;
+
+/**
+ * @deprecated Please use `UploadErrorEvent` instead.
+ */
+export type UploadError = UploadErrorEvent;
+
+/**
+ * @deprecated Please use `UploadResponseEvent` instead.
+ */
+export type UploadResponse = UploadResponseEvent;
+
+/**
+ * @deprecated Please use `UploadRetryEvent` instead.
+ */
+export type UploadRetry = UploadRetryEvent;
+
+/**
+ * @deprecated Please use `UploadAbortEvent` instead.
+ */
+export type UploadAbort = UploadAbortEvent;
+
+/**
+ * @deprecated Please use `UploadRequestEvent` instead.
+ */
+export type UploadRequest = UploadRequestEvent;

--- a/packages/vaadin-upload/test/typings/upload-legacy-events.types.ts
+++ b/packages/vaadin-upload/test/typings/upload-legacy-events.types.ts
@@ -1,0 +1,68 @@
+import '../../vaadin-upload.js';
+
+import {
+  UploadAbort,
+  UploadBefore,
+  UploadError,
+  UploadFileReject,
+  UploadFilesChanged,
+  UploadMaxFilesReachedChanged,
+  UploadProgress,
+  UploadRequest,
+  UploadResponse,
+  UploadRetry,
+  UploadStart,
+  UploadSuccess
+} from '../../vaadin-upload.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const upload = document.createElement('vaadin-upload');
+
+upload.addEventListener('max-files-reached-changed', (event) => {
+  assertType<UploadMaxFilesReachedChanged>(event);
+});
+
+upload.addEventListener('file-reject', (event) => {
+  assertType<UploadFileReject>(event);
+});
+
+upload.addEventListener('files-changed', (event) => {
+  assertType<UploadFilesChanged>(event);
+});
+
+upload.addEventListener('upload-before', (event) => {
+  assertType<UploadBefore>(event);
+});
+
+upload.addEventListener('upload-start', (event) => {
+  assertType<UploadStart>(event);
+});
+
+upload.addEventListener('upload-progress', (event) => {
+  assertType<UploadProgress>(event);
+});
+
+upload.addEventListener('upload-response', (event) => {
+  assertType<UploadResponse>(event);
+});
+
+upload.addEventListener('upload-success', (event) => {
+  assertType<UploadSuccess>(event);
+});
+
+upload.addEventListener('upload-error', (event) => {
+  assertType<UploadError>(event);
+});
+
+upload.addEventListener('upload-retry', (event) => {
+  assertType<UploadRetry>(event);
+});
+
+upload.addEventListener('upload-abort', (event) => {
+  assertType<UploadAbort>(event);
+});
+
+upload.addEventListener('upload-request', (event) => {
+  assertType<UploadRequest>(event);
+});

--- a/packages/vaadin-upload/test/typings/upload.types.ts
+++ b/packages/vaadin-upload/test/typings/upload.types.ts
@@ -1,64 +1,91 @@
-import { UploadFile } from '../../vaadin-upload';
-import '../../src/vaadin-upload';
+import '../../vaadin-upload.js';
 
-const assert = <T>(value: T) => value;
+import {
+  UploadFile,
+  UploadAbortEvent,
+  UploadBeforeEvent,
+  UploadErrorEvent,
+  UploadFileRejectEvent,
+  UploadFilesChangedEvent,
+  UploadMaxFilesReachedChangedEvent,
+  UploadProgressEvent,
+  UploadRequestEvent,
+  UploadResponseEvent,
+  UploadRetryEvent,
+  UploadStartEvent,
+  UploadSuccessEvent
+} from '../../vaadin-upload.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
 
 const upload = document.createElement('vaadin-upload');
 
 upload.addEventListener('max-files-reached-changed', (event) => {
-  assert<boolean>(event.detail.value);
+  assertType<UploadMaxFilesReachedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 upload.addEventListener('file-reject', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<string>(event.detail.error);
+  assertType<UploadFileRejectEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<string>(event.detail.error);
 });
 
 upload.addEventListener('files-changed', (event) => {
-  assert<UploadFile[]>(event.detail.value);
+  assertType<UploadFilesChangedEvent>(event);
+  assertType<UploadFile[]>(event.detail.value);
 });
 
 upload.addEventListener('upload-before', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<XMLHttpRequest>(event.detail.xhr);
+  assertType<UploadBeforeEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-start', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<XMLHttpRequest>(event.detail.xhr);
+  assertType<UploadStartEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-progress', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<XMLHttpRequest>(event.detail.xhr);
+  assertType<UploadProgressEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-response', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<XMLHttpRequest>(event.detail.xhr);
+  assertType<UploadResponseEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-success', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<XMLHttpRequest>(event.detail.xhr);
+  assertType<UploadSuccessEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-error', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<XMLHttpRequest>(event.detail.xhr);
+  assertType<UploadErrorEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-retry', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<XMLHttpRequest>(event.detail.xhr);
+  assertType<UploadRetryEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-abort', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<XMLHttpRequest>(event.detail.xhr);
+  assertType<UploadAbortEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-request', (event) => {
-  assert<UploadFile>(event.detail.file);
-  assert<FormData>(event.detail.formData);
+  assertType<UploadRequestEvent>(event);
+  assertType<UploadFile>(event.detail.file);
+  assertType<FormData>(event.detail.formData);
 });

--- a/packages/vaadin-upload/vaadin-upload.d.ts
+++ b/packages/vaadin-upload/vaadin-upload.d.ts
@@ -1,2 +1,5 @@
 export * from './src/vaadin-upload.js';
 export * from './src/interfaces';
+
+// TODO: remove from Vaadin 21
+export * from './src/vaadin-upload-legacy-events.js';


### PR DESCRIPTION
## Description

This is one of several PRs which add the `Event` suffix to events typings according to the PiT finding reported at #216.

This PR has covered the following components:

- [x] vaadin-date-picker
- [x] vaadin-date-time-picker 
- [x] vaadin-details 
- [x] vaadin-dialog
- [x] vaadin-grid
- [x] vaadin-grid-pro
- [x] vaadin-list-box
- [x] vaadin-login
- [x] vaadin-menu-bar
- [x] vaadin-notification
- [x] vaadin-overlay
- [x] vaadin-radio-button
- [x] vaadin-rich-text-editor
- [x] vaadin-select
- [x] vaadin-tabs
- [x] vaadin-text-field
- [x] vaadin-time-picker
- [x] vaadin-upload
- [x] vaadin-messages


## How to remove legacy events from Vaadin 21

All legacy events definitions and corresponding tests have been moved to separate files to facilitate their removal from Vaadin 21.

Now if you want to remove legacy definitions, all you have to do is to follow the next steps:

1. Run `rm -rf ./**/*legacy-events*`
2. Remove legacy exports using the `export.+legacy-events.js';` regexp
3. Run ESLint/Prettier for changed files

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.