### PR TITLE
feat!: upgrade to use Lit 2 for css tagged literals

### DIFF
--- a/packages/vaadin-lumo-styles/badge.d.ts
+++ b/packages/vaadin-lumo-styles/badge.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const badge: CSSResult;

--- a/packages/vaadin-lumo-styles/color.d.ts
+++ b/packages/vaadin-lumo-styles/color.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const colorBase: CSSResult;
 

--- a/packages/vaadin-lumo-styles/mixins/field-button.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/field-button.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const fieldButton: CSSResult;

--- a/packages/vaadin-lumo-styles/mixins/menu-overlay.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/menu-overlay.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const menuOverlay: CSSResult;

--- a/packages/vaadin-lumo-styles/mixins/overlay.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/overlay.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const overlay: CSSResult;

--- a/packages/vaadin-lumo-styles/mixins/required-field.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/required-field.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const requiredField: CSSResult;

--- a/packages/vaadin-lumo-styles/sizing.d.ts
+++ b/packages/vaadin-lumo-styles/sizing.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const sizing: CSSResult;

--- a/packages/vaadin-lumo-styles/spacing.d.ts
+++ b/packages/vaadin-lumo-styles/spacing.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const spacing: CSSResult;

--- a/packages/vaadin-lumo-styles/style.d.ts
+++ b/packages/vaadin-lumo-styles/style.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const style: CSSResult;

--- a/packages/vaadin-lumo-styles/typography.d.ts
+++ b/packages/vaadin-lumo-styles/typography.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const font: CSSResult;
 

--- a/packages/vaadin-material-styles/color.d.ts
+++ b/packages/vaadin-material-styles/color.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const colorLight: CSSResult;
 

--- a/packages/vaadin-material-styles/mixins/field-button.d.ts
+++ b/packages/vaadin-material-styles/mixins/field-button.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const fieldButton: CSSResult;

--- a/packages/vaadin-material-styles/mixins/menu-overlay.d.ts
+++ b/packages/vaadin-material-styles/mixins/menu-overlay.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const menuOverlay: CSSResult;

--- a/packages/vaadin-material-styles/mixins/overlay.d.ts
+++ b/packages/vaadin-material-styles/mixins/overlay.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const overlay: CSSResult;

--- a/packages/vaadin-material-styles/mixins/required-field.d.ts
+++ b/packages/vaadin-material-styles/mixins/required-field.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const requiredField: CSSResult;

--- a/packages/vaadin-material-styles/shadow.d.ts
+++ b/packages/vaadin-material-styles/shadow.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const shadow: CSSResult;

--- a/packages/vaadin-material-styles/typography.d.ts
+++ b/packages/vaadin-material-styles/typography.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export const font: CSSResult;
 

--- a/packages/vaadin-select/package.json
+++ b/packages/vaadin-select/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
     "@vaadin/testing-helpers": "^0.2.1",
-    "lit-html": "^1.0.0",
+    "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.0"
   },
   "publishConfig": {

--- a/packages/vaadin-select/test/accessibility.test.js
+++ b/packages/vaadin-select/test/accessibility.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { html, render } from 'lit-html';
+import { html, render } from 'lit';
 import '@vaadin/vaadin-list-box/vaadin-list-box.js';
 import '@vaadin/vaadin-item/vaadin-item.js';
 import '../vaadin-select.js';

--- a/packages/vaadin-select/test/scrollable-viewport.test.js
+++ b/packages/vaadin-select/test/scrollable-viewport.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, enterKeyDown } from '@vaadin/testing-helpers';
-import { html, render } from 'lit-html';
+import { html, render } from 'lit';
 import '@vaadin/vaadin-list-box/vaadin-list-box.js';
 import '@vaadin/vaadin-item/vaadin-item.js';
 import '../vaadin-select.js';

--- a/packages/vaadin-select/test/select.test.js
+++ b/packages/vaadin-select/test/select.test.js
@@ -13,7 +13,7 @@ import {
   keyDownChar,
   spaceKeyDown
 } from '@vaadin/testing-helpers';
-import { html, render } from 'lit-html';
+import { html, render } from 'lit';
 import '@vaadin/vaadin-list-box/vaadin-list-box.js';
 import '@vaadin/vaadin-item/vaadin-item.js';
 import '../vaadin-select.js';

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "lit-element": "^2.0.0"
+    "lit": "^2.0.0-rc.1"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",

--- a/packages/vaadin-themable-mixin/register-styles.d.ts
+++ b/packages/vaadin-themable-mixin/register-styles.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit-element';
+import { CSSResult } from 'lit';
 
 export { css, unsafeCSS } from 'lit-element';
 

--- a/packages/vaadin-themable-mixin/register-styles.d.ts
+++ b/packages/vaadin-themable-mixin/register-styles.d.ts
@@ -1,6 +1,6 @@
 import { CSSResult } from 'lit';
 
-export { css, unsafeCSS } from 'lit-element';
+export { css, unsafeCSS } from 'lit';
 
 /**
  * Registers CSS styles for a component type. Make sure to register the styles before

--- a/packages/vaadin-themable-mixin/register-styles.js
+++ b/packages/vaadin-themable-mixin/register-styles.js
@@ -1,6 +1,6 @@
 import '@polymer/polymer/lib/elements/dom-module.js';
-import { CSSResult } from 'lit-element';
-export { css, unsafeCSS } from 'lit-element';
+import { CSSResult } from 'lit';
+export { css, unsafeCSS } from 'lit';
 
 let moduleIdIndex = 0;
 // Map of <CSSResult, Polymer.DomModule> pairs.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7251,13 +7251,6 @@ listr2@^3.2.2:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lit-element@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.4.0.tgz#b22607a037a8fc08f5a80736dddf7f3f5d401452"
-  integrity sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==
-  dependencies:
-    lit-html "^1.1.1"
-
 lit-element@^3.0.0-rc.1:
   version "3.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.0.0-rc.1.tgz#1d67c835364adc6ca051c68a7699e2123fa1a16c"
@@ -7266,7 +7259,7 @@ lit-element@^3.0.0-rc.1:
     "@lit/reactive-element" "^1.0.0-rc.1"
     lit-html "^2.0.0-rc.1"
 
-lit-html@^1.0.0, lit-html@^1.1.1:
+lit-html@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
   integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,11 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
+"@lit/reactive-element@^1.0.0-rc.1":
+  version "1.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0-rc.1.tgz#3e6639241de1f63f7746b4b410df1c7fb206e15f"
+  integrity sha512-TLRPKOhQLNOMcpCXHiTKrNKX5eNzhf9y07jp27MXkjTH1IbXFvcT9/mVdOG/3qfMkip+iO6CEfv5a+y0wFhQig==
+
 "@mdn/browser-compat-data@^3.0.1":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-3.2.4.tgz#9b015c608eaed5cc47c35bb3d63f6502e5bd88c7"
@@ -1838,6 +1843,11 @@
   dependencies:
     "@types/mime" "^1"
     "@types/node" "*"
+
+"@types/trusted-types@^1.0.1":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/uglify-js@*":
   version "3.13.0"
@@ -7241,17 +7251,41 @@ listr2@^3.2.2:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lit-element@^2.0.0:
+lit-element@^2.2.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.4.0.tgz#b22607a037a8fc08f5a80736dddf7f3f5d401452"
   integrity sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==
   dependencies:
     lit-html "^1.1.1"
 
+lit-element@^3.0.0-rc.1:
+  version "3.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.0.0-rc.1.tgz#1d67c835364adc6ca051c68a7699e2123fa1a16c"
+  integrity sha512-SQH7LODMy+42UTOGiyHUTXronvv8Cud0Y/8Q8/1jd/9Putuh66GjN7FEjyNRxVbpIygnPqMbG854J9Ct9IJlFw==
+  dependencies:
+    "@lit/reactive-element" "^1.0.0-rc.1"
+    lit-html "^2.0.0-rc.1"
+
 lit-html@^1.0.0, lit-html@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
   integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
+
+lit-html@^2.0.0-rc.1:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.0-rc.2.tgz#c7ac652af1df7e5d8e32a3e6130221766d09cbde"
+  integrity sha512-rl3vtIQ0jq6r0GVbg+57Et9ra+iNhiz/v5V7uPTb6VxnjJaCCYKI7WkzKNlyzjMM2N/ytih3Uxb5vyyaOpjb0Q==
+  dependencies:
+    "@types/trusted-types" "^1.0.1"
+
+lit@^2.0.0-rc.1:
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.0-rc.1.tgz#e1cb53ea3ba0f77b5a9235282b4b257efa8b972a"
+  integrity sha512-cf4r18feMhu56sO963a5MaHUn6OX2Am9sj9lzyGTYx2IPDhC9NP/Xh4rj9Ialo9dA+lI4brD7+9cxSzRIWHOmw==
+  dependencies:
+    "@lit/reactive-element" "^1.0.0-rc.1"
+    lit-element "^3.0.0-rc.1"
+    lit-html "^2.0.0-rc.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7259,11 +7259,6 @@ lit-element@^3.0.0-rc.1:
     "@lit/reactive-element" "^1.0.0-rc.1"
     lit-html "^2.0.0-rc.1"
 
-lit-html@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
-  integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
-
 lit-html@^2.0.0-rc.1:
   version "2.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.0-rc.2.tgz#c7ac652af1df7e5d8e32a3e6130221766d09cbde"


### PR DESCRIPTION
## Description

Upgrades from using `lit-element` 2 to `lit` 2 (containing `lit-element` 3)

Fixes #241

## Type of change

- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
