### PR TITLE
fix: fix clearing uploading status before upload success event

### DIFF
--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -582,7 +582,7 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
 
     const ini = Date.now();
-    const xhr = (file.xhr = this._createXhr(file));
+    const xhr = (file.xhr = this._createXhr());
 
     let stalledId, last;
     // onprogress is called always after onreadystatechange

--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -610,7 +610,6 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         } else {
           file.loadedStr = file.totalStr;
           file.status = this.i18n.uploading.status.processing;
-          file.uploading = false;
         }
       }
 

--- a/packages/vaadin-upload/test/upload.test.js
+++ b/packages/vaadin-upload/test/upload.test.js
@@ -88,7 +88,7 @@ describe('upload', () => {
         expect(f.loaded).to.be.equal(100000);
         expect(f.size).to.be.equal(100000);
         expect(f.speed).to.be.gt(100);
-        expect(f.uploading).not.to.be.ok;
+        expect(f.uploading).to.be.ok;
       });
 
       it('should fire the upload-success', async () => {


### PR DESCRIPTION
## Description

Currently the upload element clears (setting it to `false`) the `uploading` status on a file element when:
- there is a progress event
- and the progress equals 100

...but before the XHR ready state changes, and thus possibly some time before the `upload-success` or `upload-failed` event is sent.

This can be a problem in the Flow component when doing multi-file uploads. Basically whenever the Flow component receives a success or failure event, it will check if all files have `uploading == false` and then report that all uploads are finished. But when using multiple files that state can be true before all files have sent their success event, which can lead to the following observed event flow on the Flow component:
```
File 1 success
File 2 success
All finished
File 3 success
```
In the example above, when File 2 notified about the success event, progress for File 3 was already at 100%, so the `uploading` flag was already set to false which lead to the Flow component reporting all finished. However the ready state of the XHR did not change yet and thus there was no success event for File 3 yet.

This change modifies the behaviour of the `uploading` flag, so that it is only cleared when the XHR ready state changes, which is the same time when the element sends the success or failure event. The meaning of the uploading flag is not 100% clear to me as it is not documented, and maybe it's misused by the Flow component. However there is no other flag that indicates that the upload is finished (either success or failure) and it seems more logical to me to connect this flag to the ready state change event instead of a progress event.

For tests I simply changed the expectations of the existing tests, I could not identify any further tests that would be necessary.

Fixes https://github.com/vaadin/vaadin-upload/issues/368

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
