### PR TITLE
chore: Add .env file support

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,6 @@
+# Template for configuring environment variables used in this repositories scripts
+# To make use of this, copy this file to `.env` and configure the variables below
+
+# Credentials for Sauce Labs (required to run visual tests)
+SAUCE_USERNAME=
+SAUCE_ACCESS_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 dist
 analysis.json
 yarn-error.log
+.env

--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ Setup the repo:
 yarn
 ```
 
+### Environment variables
+Setup the environment variables needed by the scripts below, by copying the `.env.dist` template file to `.env`:
+```
+cp .env.dist .env
+```
+and then configure the individual variable values in the newly created `.env` file.
+
+Not all variables are necessary for all scripts, individual sections below will note which variables are required to run a command.
+
 ### Unit tests
 
 Run all tests in Chrome:
@@ -188,7 +197,7 @@ yarn debug --group vaadin-upload
 
 ### Visual tests
 
-To run the visual tests, please define `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` env variables.
+To run the visual tests, please make sure that the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables are defined.
 
 Run tests for Lumo:
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@web/test-runner-playwright": "^0.8.4",
     "@web/test-runner-saucelabs": "^0.5.0",
     "@web/test-runner-visual-regression": "^0.5.1",
+    "dotenv": "^8.2.0",
     "eslint": "^7.23.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.3.1",

--- a/web-test-runner-firefox.config.js
+++ b/web-test-runner-firefox.config.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+require('dotenv').config();
 const { playwrightLauncher } = require('@web/test-runner-playwright');
 const { filterBrowserLogs, getUnitTestGroups, getUnitTestPackages, testRunnerHtml } = require('./wtr-utils.js');
 

--- a/web-test-runner-lumo.config.js
+++ b/web-test-runner-lumo.config.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+require('dotenv').config();
 const { createSauceLabsLauncher } = require('@web/test-runner-saucelabs');
 const { visualRegressionPlugin } = require('@web/test-runner-visual-regression/plugin');
 const {

--- a/web-test-runner-material.config.js
+++ b/web-test-runner-material.config.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+require('dotenv').config();
 const { createSauceLabsLauncher } = require('@web/test-runner-saucelabs');
 const { visualRegressionPlugin } = require('@web/test-runner-visual-regression/plugin');
 const {

--- a/web-test-runner-webkit.config.js
+++ b/web-test-runner-webkit.config.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+require('dotenv').config();
 const { playwrightLauncher } = require('@web/test-runner-playwright');
 const { filterBrowserLogs, getUnitTestGroups, getUnitTestPackages, testRunnerHtml } = require('./wtr-utils.js');
 

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+require('dotenv').config();
 const { filterBrowserLogs, getUnitTestGroups, getUnitTestPackages, testRunnerHtml } = require('./wtr-utils.js');
 
 const packages = getUnitTestPackages();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3759,6 +3759,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 download@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/download/-/download-7.1.0.tgz#9059aa9d70b503ee76a132897be6dec8e5587233"


### PR DESCRIPTION
While setting up Sauce Labs for visual tests, I was kind of hesitant to add the credentials on a user level. From my previous job I was used to setting up these kind of variables per project.

I would propose to introduce `.env` file support to the repo where we can configure all project-level variables. This would also help as a documentation of all variables that exist in the project on how/where/why they are used.