### PR TITLE
test: use vaadin testing helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@open-wc/rollup-plugin-html": "^1.2.5",
     "@polymer/iron-component-page": "^4.0.0",
-    "@vaadin/testing-helpers": "^0.1.3",
+    "@vaadin/testing-helpers": "^0.1.4",
     "@web/dev-server": "^0.1.8",
     "@web/test-runner": "^0.12.17",
     "@web/test-runner-playwright": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@open-wc/rollup-plugin-html": "^1.2.5",
     "@polymer/iron-component-page": "^4.0.0",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "@web/dev-server": "^0.1.8",
     "@web/test-runner": "^0.12.17",
     "@web/test-runner-playwright": "^0.8.4",

--- a/packages/vaadin-accordion/package.json
+++ b/packages/vaadin-accordion/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-accordion/package.json
+++ b/packages/vaadin-accordion/package.json
@@ -34,8 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@open-wc/testing-helpers": "^1.8.12",
-    "@polymer/iron-test-helpers": "^3.0.0",
+    "@vaadin/testing-helpers": "^0.1.4",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-accordion/test/accordion.test.js
+++ b/packages/vaadin-accordion/test/accordion.test.js
@@ -1,28 +1,16 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync } from '@open-wc/testing-helpers';
-import { keyboardEventFor, keyDownOn } from '@polymer/iron-test-helpers/mock-interactions.js';
+import {
+  isIOS,
+  fixtureSync,
+  arrowDownKeyDown,
+  arrowUpKeyDown,
+  keyboardEventFor,
+  homeKeyDown,
+  endKeyDown
+} from '@vaadin/testing-helpers';
+
 import '../vaadin-accordion.js';
-
-const iOS =
-  (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream) ||
-  (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-
-function arrowDown(target) {
-  keyDownOn(target, 40, [], 'ArrowDown');
-}
-
-function arrowUp(target) {
-  keyDownOn(target, 38, [], 'ArrowUp');
-}
-
-function home(target) {
-  keyDownOn(target, 36, [], 'Home');
-}
-
-function end(target) {
-  keyDownOn(target, 35, [], 'End');
-}
 
 describe('vaadin-accordion', () => {
   let accordion, heading;
@@ -138,7 +126,7 @@ describe('vaadin-accordion', () => {
     });
   });
 
-  (iOS ? describe.skip : describe)('focus', () => {
+  (isIOS ? describe.skip : describe)('focus', () => {
     it('should focus the first panel heading by default', () => {
       accordion.focus();
       expect(accordion.items[0].hasAttribute('focused')).to.be.true;
@@ -148,7 +136,7 @@ describe('vaadin-accordion', () => {
       accordion.items[0].disabled = true;
       const focusSpy = sinon.spy(accordion.items[1], 'focus');
       accordion.focus();
-      expect(focusSpy.called).to.be.true;
+      expect(focusSpy.calledOnce).to.be.true;
     });
 
     it('should not focus any panel if all the panels are disabled', () => {
@@ -166,7 +154,7 @@ describe('vaadin-accordion', () => {
     });
   });
 
-  (iOS ? describe.skip : describe)('keyboard navigation', () => {
+  (isIOS ? describe.skip : describe)('keyboard navigation', () => {
     beforeEach(() => {
       accordion.focus();
     });
@@ -174,16 +162,16 @@ describe('vaadin-accordion', () => {
     describe('moving focus', () => {
       it('should move focus to the next panel on "arrow-down" keydown', () => {
         heading = getHeading(0);
-        arrowDown(heading);
+        arrowDownKeyDown(heading);
         expect(accordion.items[1].hasAttribute('focused')).to.be.true;
         expect(accordion.items[1].hasAttribute('focus-ring')).to.be.true;
       });
 
       it('should move focus to the previous panel on "arrow-up" keydown', () => {
         heading = getHeading(0);
-        arrowDown(heading);
+        arrowDownKeyDown(heading);
         heading = getHeading(1);
-        arrowUp(heading);
+        arrowUpKeyDown(heading);
         expect(accordion.items[0].hasAttribute('focused')).to.be.true;
         expect(accordion.items[0].hasAttribute('focus-ring')).to.be.true;
       });
@@ -191,7 +179,7 @@ describe('vaadin-accordion', () => {
       it('should move focus to the first panel on "home" keydown', () => {
         accordion.items[2].focus();
         heading = getHeading(2);
-        home(heading);
+        homeKeyDown(heading);
         expect(accordion.items[0].hasAttribute('focused')).to.be.true;
         expect(accordion.items[0].hasAttribute('focus-ring')).to.be.true;
       });
@@ -200,13 +188,13 @@ describe('vaadin-accordion', () => {
         accordion.items[0].disabled = true;
         accordion.items[2].focus();
         heading = getHeading(2);
-        home(heading);
+        homeKeyDown(heading);
         expect(accordion.items[1].hasAttribute('focused')).to.be.true;
       });
 
       it('should move focus to the last panel on "end" keydown', () => {
         heading = getHeading(0);
-        end(heading);
+        endKeyDown(heading);
         expect(accordion.items[2].hasAttribute('focused')).to.be.true;
         expect(accordion.items[2].hasAttribute('focus-ring')).to.be.true;
       });
@@ -214,20 +202,20 @@ describe('vaadin-accordion', () => {
       it('should move focus to the closest enabled panel if last is disabled on "end" keydown', () => {
         accordion.items[2].disabled = true;
         heading = getHeading(0);
-        end(heading);
+        endKeyDown(heading);
         expect(accordion.items[1].hasAttribute('focused')).to.be.true;
       });
 
       it('should move focus to first panel on "arrow-down", if last element has focus', () => {
         accordion.items[2].focus();
         heading = getHeading(2);
-        arrowDown(heading);
+        arrowDownKeyDown(heading);
         expect(accordion.items[0].hasAttribute('focused')).to.be.true;
       });
 
       it('should move focus to last panel on "arrow-up", if first element has focus', () => {
         heading = getHeading(0);
-        arrowUp(heading);
+        arrowUpKeyDown(heading);
         expect(accordion.items[2].hasAttribute('focused')).to.be.true;
       });
 
@@ -240,7 +228,8 @@ describe('vaadin-accordion', () => {
 
       it('should not move focus on keydown event from the panel content', () => {
         const spy = sinon.spy(accordion.items[1], 'focus');
-        arrowDown(accordion.items[0].querySelector('input'));
+        const input = accordion.items[0].querySelector('input');
+        arrowDownKeyDown(input);
         expect(spy.called).to.be.false;
       });
     });
@@ -262,7 +251,7 @@ describe('vaadin-accordion', () => {
         accordion.items[2].disabled = true;
         heading = getHeading(0);
         heading.dispatchEvent(event);
-        expect(preventSpy.called).to.be.true;
+        expect(preventSpy.calledOnce).to.be.true;
       });
 
       it('should not prevent default on keydown event from the panel content', () => {

--- a/packages/vaadin-app-layout/package.json
+++ b/packages/vaadin-app-layout/package.json
@@ -34,8 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@open-wc/testing-helpers": "^1.8.12",
-    "@polymer/iron-test-helpers": "^3.0.1",
+    "@vaadin/testing-helpers": "^0.1.4",
     "@vaadin/vaadin-icons": "^20.0.0-alpha5",
     "@vaadin/vaadin-tabs": "^20.0.0-alpha5",
     "sinon": "^9.2.1"

--- a/packages/vaadin-app-layout/package.json
+++ b/packages/vaadin-app-layout/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "@vaadin/vaadin-icons": "^20.0.0-alpha5",
     "@vaadin/vaadin-tabs": "^20.0.0-alpha5",
     "sinon": "^9.2.1"

--- a/packages/vaadin-app-layout/test/app-layout.test.js
+++ b/packages/vaadin-app-layout/test/app-layout.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync, nextFrame } from '@open-wc/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-app-layout.js';
 import '../vaadin-drawer-toggle.js';
 

--- a/packages/vaadin-app-layout/test/drawer-toggle.test.js
+++ b/packages/vaadin-app-layout/test/drawer-toggle.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync } from '@open-wc/testing-helpers';
-import { keyDownOn, keyUpOn } from '@polymer/iron-test-helpers/mock-interactions.js';
+import { fixtureSync, enter, space } from '@vaadin/testing-helpers';
+
 import '../vaadin-drawer-toggle.js';
 
 describe('drawer-toggle', () => {
@@ -42,14 +42,12 @@ describe('drawer-toggle', () => {
       });
 
       it('should fire "drawer-toggle-click" event on Enter', () => {
-        keyDownOn(toggle, 13, [], 'Enter');
-        keyUpOn(toggle, 13, [], 'Enter');
+        enter(toggle);
         expect(spy.calledOnce).to.be.true;
       });
 
       it('should fire "drawer-toggle-click" event on Space', () => {
-        keyDownOn(toggle, 32, [], ' ');
-        keyUpOn(toggle, 32, [], ' ');
+        space(toggle);
         expect(spy.calledOnce).to.be.true;
       });
     });
@@ -69,14 +67,12 @@ describe('drawer-toggle', () => {
       });
 
       it('should not fire "drawer-toggle-click" event on Enter when disabled', () => {
-        keyDownOn(toggle, 13, [], 'Enter');
-        keyUpOn(toggle, 13, [], 'Enter');
+        enter(toggle);
         expect(spy.called).to.be.false;
       });
 
       it('should not fire "drawer-toggle-click" event on Space when disabled', () => {
-        keyDownOn(toggle, 32, [], ' ');
-        keyUpOn(toggle, 32, [], ' ');
+        space(toggle);
         expect(spy.called).to.be.false;
       });
     });

--- a/packages/vaadin-avatar/package.json
+++ b/packages/vaadin-avatar/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-avatar/package.json
+++ b/packages/vaadin-avatar/package.json
@@ -38,8 +38,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@open-wc/testing-helpers": "^1.8.12",
-    "@polymer/iron-test-helpers": "^3.0.0",
+    "@vaadin/testing-helpers": "^0.1.4",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-avatar/test/avatar.test.js
+++ b/packages/vaadin-avatar/test/avatar.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync } from '@open-wc/testing-helpers';
-import { keyDownOn } from '@polymer/iron-test-helpers/mock-interactions.js';
+import { fixtureSync, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
+
 import '../vaadin-avatar.js';
 
 describe('vaadin-avatar', () => {
@@ -217,7 +217,7 @@ describe('vaadin-avatar', () => {
     });
 
     it('should set focus-ring attribute on avatar focusin after Tab', () => {
-      keyDownOn(document.body, 9);
+      tabKeyDown(document.body);
       focusin(avatar);
       expect(avatar.hasAttribute('focus-ring')).to.be.true;
       focusout(avatar);
@@ -225,8 +225,8 @@ describe('vaadin-avatar', () => {
     });
 
     it('should not set the focus-ring attribute on avatar mousedown', () => {
-      keyDownOn(document.body, 9);
-      document.body.dispatchEvent(new MouseEvent('mousedown'));
+      tabKeyDown(document.body);
+      mousedown(document.body);
       focusin(avatar);
       expect(avatar.hasAttribute('focus-ring')).to.be.false;
     });

--- a/packages/vaadin-board/package.json
+++ b/packages/vaadin-board/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-board/package.json
+++ b/packages/vaadin-board/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@open-wc/testing-helpers": "^1.8.12",
+    "@vaadin/testing-helpers": "^0.1.4",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-board/test/basic.test.js
+++ b/packages/vaadin-board/test/basic.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board.js';
 
 describe('vaadin-details', () => {

--- a/packages/vaadin-board/test/board-cols.test.js
+++ b/packages/vaadin-board/test/board-cols.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync } from '@open-wc/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board-row.js';
 
 describe('board-cols', () => {

--- a/packages/vaadin-board/test/board-row.test.js
+++ b/packages/vaadin-board/test/board-row.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board.js';
 
 describe('vaadin-board-row', () => {

--- a/packages/vaadin-board/test/light-dom.test.js
+++ b/packages/vaadin-board/test/light-dom.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@open-wc/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-board-row.js';
 
 describe('light DOM children', () => {

--- a/packages/vaadin-board/test/redraw.test.js
+++ b/packages/vaadin-board/test/redraw.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board.js';
 
 describe('redraw', () => {

--- a/packages/vaadin-board/test/size.test.js
+++ b/packages/vaadin-board/test/size.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board.js';
 
 describe('size', () => {

--- a/packages/vaadin-board/test/template.test.js
+++ b/packages/vaadin-board/test/template.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync } from '@open-wc/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '@polymer/polymer/lib/elements/dom-bind.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
 import '@polymer/polymer/lib/elements/dom-repeat.js';

--- a/packages/vaadin-button/package.json
+++ b/packages/vaadin-button/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
     "@polymer/iron-icon": "^3.0.0",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-button/package.json
+++ b/packages/vaadin-button/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
     "@polymer/iron-icon": "^3.0.0",
-    "@vaadin/testing-helpers": "^0.1.3",
+    "@vaadin/testing-helpers": "^0.1.4",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-charts/package.json
+++ b/packages/vaadin-charts/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@open-wc/testing-helpers": "^1.8.12",
+    "@vaadin/testing-helpers": "^0.1.4",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-charts/package.json
+++ b/packages/vaadin-charts/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-charts/test/chart-element.test.js
+++ b/packages/vaadin-charts/test/chart-element.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, oneEvent } from '@open-wc/testing-helpers';
+import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart', () => {

--- a/packages/vaadin-charts/test/chart-properties.test.js
+++ b/packages/vaadin-charts/test/chart-properties.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, oneEvent } from '@open-wc/testing-helpers';
+import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart properties', () => {

--- a/packages/vaadin-charts/test/chart-series.test.js
+++ b/packages/vaadin-charts/test/chart-series.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync, oneEvent } from '@open-wc/testing-helpers';
-import { nextRender } from './helpers.js';
+import { aTimeout, fixtureSync, oneEvent, nextRender } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart-series', () => {

--- a/packages/vaadin-charts/test/dom-repeat.test.js
+++ b/packages/vaadin-charts/test/dom-repeat.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, oneEvent } from '@open-wc/testing-helpers';
+import { fixtureSync, oneEvent, nextRender } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
-import { nextRender } from './helpers.js';
 import '../vaadin-chart.js';
 
 customElements.define(

--- a/packages/vaadin-charts/test/events.test.js
+++ b/packages/vaadin-charts/test/events.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync, oneEvent } from '@open-wc/testing-helpers';
+import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart events', () => {

--- a/packages/vaadin-charts/test/exporting.test.js
+++ b/packages/vaadin-charts/test/exporting.test.js
@@ -2,8 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-import { fixtureSync, oneEvent } from '@open-wc/testing-helpers';
-import { nextRender } from './helpers.js';
+import { fixtureSync, oneEvent, nextRender } from '@vaadin/testing-helpers';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 import '../vaadin-chart.js';
 

--- a/packages/vaadin-charts/test/helpers.js
+++ b/packages/vaadin-charts/test/helpers.js
@@ -1,9 +1,0 @@
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-
-export const nextRender = (target) => {
-  return new Promise((resolve) => {
-    afterNextRender(target, () => {
-      resolve();
-    });
-  });
-};

--- a/packages/vaadin-charts/test/private-api.test.js
+++ b/packages/vaadin-charts/test/private-api.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, oneEvent } from '@open-wc/testing-helpers';
+import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart private API', () => {

--- a/packages/vaadin-charts/test/styling.test.js
+++ b/packages/vaadin-charts/test/styling.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-import { fixtureSync, oneEvent } from '@open-wc/testing-helpers';
+import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 
 registerStyles(

--- a/packages/vaadin-checkbox/package.json
+++ b/packages/vaadin-checkbox/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@open-wc/testing-helpers": "^1.8.0",
+    "@vaadin/testing-helpers": "^1.0.4",
     "@polymer/iron-test-helpers": "^3.0.0",
     "sinon": "^9.2.0"
   },

--- a/packages/vaadin-checkbox/package.json
+++ b/packages/vaadin-checkbox/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^1.0.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "@polymer/iron-test-helpers": "^3.0.0",
     "sinon": "^9.2.0"
   },

--- a/packages/vaadin-checkbox/test/a11y.test.js
+++ b/packages/vaadin-checkbox/test/a11y.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-checkbox.js';
 
 describe('a11y', () => {

--- a/packages/vaadin-checkbox/test/checkbox-group.test.js
+++ b/packages/vaadin-checkbox/test/checkbox-group.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync, focusin, focusout } from '@vaadin/testing-helpers';
 import '@polymer/polymer/lib/elements/dom-bind.js';
 import '../vaadin-checkbox-group.js';
 
@@ -140,25 +140,25 @@ describe('vaadin-checkbox-group', () => {
   });
 
   it('should set focused attribute on focusin event dispatched', () => {
-    checkboxes[0].dispatchEvent(new CustomEvent('focusin', { composed: true, bubbles: true }));
+    focusin(checkboxes[0]);
     expect(group.hasAttribute('focused')).to.be.true;
   });
 
   it('should not set focused attribute on focusin event dispatched when disabled', () => {
     group.disabled = true;
-    checkboxes[0].dispatchEvent(new CustomEvent('focusin', { composed: true, bubbles: true }));
+    focusin(checkboxes[0]);
     expect(group.hasAttribute('focused')).to.be.false;
   });
 
   it('should remove focused attribute on checkbox focusout', () => {
-    checkboxes[0].dispatchEvent(new CustomEvent('focusin', { composed: true, bubbles: true }));
-    checkboxes[0].dispatchEvent(new CustomEvent('focusout', { composed: true, bubbles: true }));
+    focusin(checkboxes[0]);
+    focusout(checkboxes[0]);
     expect(group.hasAttribute('focused')).to.be.false;
   });
 
   it('should remove focused attribute on checkbox-group focusout', () => {
-    checkboxes[0].dispatchEvent(new CustomEvent('focusin', { composed: true, bubbles: true }));
-    group.dispatchEvent(new CustomEvent('focusout', { composed: true, bubbles: true }));
+    focusin(checkboxes[0]);
+    focusout(group);
     expect(group.hasAttribute('focused')).to.be.false;
   });
 
@@ -289,12 +289,6 @@ describe('vaadin-checkbox-group', () => {
 });
 
 describe('validation', () => {
-  function blur(target, relatedTarget) {
-    const event = new CustomEvent('focusout', { bubbles: true, composed: true });
-    event.relatedTarget = relatedTarget;
-    target.dispatchEvent(event);
-  }
-
   let group, checkboxes;
 
   beforeEach(() => {
@@ -338,21 +332,21 @@ describe('validation', () => {
 
   it('should pass validation and set invalid when field is required and user blurs out of the group', () => {
     group.required = true;
-    blur(group, document.body);
+    focusout(group, document.body);
     expect(group.invalid).to.be.true;
   });
 
   it('should not run validation while user is tabbing between checkboxes inside of the group', () => {
     group.required = true;
     const spy = sinon.spy(group, 'validate');
-    blur(group, checkboxes[1]);
+    focusout(group, checkboxes[1]);
     expect(spy.called).to.be.false;
   });
 
   it('should not run validation while user is tabbing between checkboxes and focus moves to native checkbox', () => {
     group.required = true;
     const spy = sinon.spy(group, 'validate');
-    blur(group, checkboxes[1].focusElement);
+    focusout(group, checkboxes[1].focusElement);
     expect(spy.called).to.be.false;
   });
 

--- a/packages/vaadin-checkbox/test/checkbox.test.js
+++ b/packages/vaadin-checkbox/test/checkbox.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync, nextFrame } from '@open-wc/testing-helpers';
-import { downAndUp, keyDownOn, keyUpOn } from '@polymer/iron-test-helpers/mock-interactions.js';
+import { click, fixtureSync, mousedown, mouseup, nextFrame, space, spaceKeyDown } from '@vaadin/testing-helpers';
 import '../vaadin-checkbox.js';
 
 describe('checkbox', () => {
@@ -43,11 +42,15 @@ describe('checkbox', () => {
     expect(checkbox.value).to.be.eql('on');
   });
 
-  it('fires click event', (done) => {
-    checkbox.addEventListener('click', () => {
-      done();
-    });
-    downAndUp(checkbox);
+  it('fires click event', () => {
+    const spy = sinon.spy();
+    checkbox.addEventListener('click', spy);
+
+    mousedown(checkbox);
+    mouseup(checkbox);
+    click(checkbox);
+
+    expect(spy.calledOnce).to.be.true;
   });
 
   it('should have proper name', () => {
@@ -134,15 +137,13 @@ describe('checkbox', () => {
   });
 
   it('should have active attribute on space', () => {
-    keyDownOn(checkbox, 32);
+    spaceKeyDown(checkbox);
 
     expect(checkbox.hasAttribute('active')).to.be.true;
   });
 
   it('should not have active attribute after space', () => {
-    keyDownOn(checkbox, 32);
-
-    keyUpOn(checkbox, 32);
+    space(checkbox);
 
     expect(checkbox.hasAttribute('active')).to.be.false;
   });
@@ -151,8 +152,7 @@ describe('checkbox', () => {
     checkbox.checked = false;
     checkbox.indeterminate = true;
 
-    keyDownOn(checkbox, 32);
-    keyUpOn(checkbox, 32);
+    space(checkbox);
 
     expect(checkbox.checked).to.be.true;
     expect(checkbox.indeterminate).to.be.false;
@@ -163,8 +163,7 @@ describe('checkbox', () => {
     checkbox.checked = true;
     checkbox.indeterminate = true;
 
-    keyDownOn(checkbox, 32);
-    keyUpOn(checkbox, 32);
+    space(checkbox);
 
     expect(checkbox.checked).to.be.false;
     expect(checkbox.indeterminate).to.be.false;
@@ -204,41 +203,43 @@ describe('checkbox', () => {
   });
 
   describe('change event', () => {
+    let changeSpy;
+
+    beforeEach(() => {
+      changeSpy = sinon.spy();
+      checkbox.addEventListener('change', changeSpy);
+    });
+
     it('should not fire change-event when changing checked value programmatically', () => {
-      checkbox.addEventListener('change', () => {
-        throw new Error('Should not come here!');
-      });
       checkbox.checked = true;
+
+      expect(changeSpy.called).to.be.false;
     });
 
-    it('should fire change-event when user checks the element', (done) => {
-      checkbox.addEventListener('change', () => done());
+    it('should fire change-event when user checks the element', () => {
       checkbox.click();
+
+      expect(changeSpy.calledOnce).to.be.true;
     });
 
-    it('should fire change-event when user unchecks the element', (done) => {
+    it('should fire change-event when user unchecks the element', () => {
       checkbox.checked = true;
-      checkbox.addEventListener('change', () => done());
       checkbox.click();
+
+      expect(changeSpy.calledOnce).to.be.true;
     });
 
     it('should bubble', () => {
-      const spy = sinon.spy();
-      checkbox.addEventListener('change', spy);
-
       checkbox.click();
 
-      const event = spy.getCall(0).args[0];
+      const event = changeSpy.getCall(0).args[0];
       expect(event).to.have.property('bubbles', true);
     });
 
     it('should not be composed', () => {
-      const spy = sinon.spy();
-      checkbox.addEventListener('change', spy);
-
       checkbox.click();
 
-      const event = spy.getCall(0).args[0];
+      const event = changeSpy.getCall(0).args[0];
       expect(event).to.have.property('composed', false);
     });
   });

--- a/packages/vaadin-combo-box/package.json
+++ b/packages/vaadin-combo-box/package.json
@@ -39,9 +39,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "4.3.0",
-    "@open-wc/testing-helpers": "^1.8.0",
+    "@vaadin/testing-helpers": "^0.1.5",
     "@polymer/iron-input": "^3.0.1",
-    "@polymer/iron-test-helpers": "^3.0.0",
     "@polymer/paper-input": "^3.0.0",
     "@vaadin/vaadin-dialog": "^20.0.0-alpha5",
     "sinon": "^9.2.0"

--- a/packages/vaadin-combo-box/test/aria.test.js
+++ b/packages/vaadin-combo-box/test/aria.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@open-wc/testing-helpers';
-import { keyDownOn } from '@polymer/iron-test-helpers/mock-interactions.js';
+import { fixtureSync, arrowDownKeyDown, escKeyDown } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
@@ -9,14 +8,6 @@ describe('ARIA', () => {
 
   function getItemElement(i) {
     return comboBox.$.overlay._selector.querySelectorAll('vaadin-combo-box-item')[i];
-  }
-
-  function arrowDown() {
-    keyDownOn(comboBox.inputElement, 40);
-  }
-
-  function esc() {
-    keyDownOn(comboBox.inputElement, 27);
   }
 
   beforeEach(() => {
@@ -42,7 +33,7 @@ describe('ARIA', () => {
 
   describe('when overlay opens or close', () => {
     beforeEach(() => {
-      arrowDown();
+      arrowDownKeyDown(comboBox.inputElement);
     });
 
     it('should set role listbox on the iron-list', () => {
@@ -55,7 +46,7 @@ describe('ARIA', () => {
     });
 
     it('should unset aria-expanded attribute when closed', () => {
-      esc();
+      escKeyDown(comboBox.inputElement);
 
       expect(input.getAttribute('aria-expanded')).to.equal('false');
       expect(toggle.getAttribute('aria-expanded')).to.equal('false');
@@ -64,12 +55,12 @@ describe('ARIA', () => {
 
   describe('navigating the items', () => {
     beforeEach(() => {
-      arrowDown();
+      arrowDownKeyDown(comboBox.inputElement);
     });
 
     it('should set selection aria attributes when focusing an item', () => {
       comboBox.value = 'foo';
-      arrowDown(); // 'focus moves to 2nd item'
+      arrowDownKeyDown(comboBox.inputElement); // 'focus moves to 2nd item'
 
       expect(getItemElement(0).getAttribute('role')).to.equal('option');
       expect(getItemElement(0).getAttribute('aria-selected')).to.equal('false');

--- a/packages/vaadin-combo-box/test/basic.test.js
+++ b/packages/vaadin-combo-box/test/basic.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync, nextFrame } from '@open-wc/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 

--- a/packages/vaadin-combo-box/test/dialog.test.js
+++ b/packages/vaadin-combo-box/test/dialog.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@open-wc/testing-helpers';
+import { fixtureSync, mousedown, touchstart, nextFrame } from '@vaadin/testing-helpers';
 import '@vaadin/vaadin-dialog/src/vaadin-dialog.js';
 import '../src/vaadin-combo-box.js';
 
@@ -19,27 +19,19 @@ describe('dialog', () => {
     comboBox = dialog.$.overlay.querySelector('vaadin-combo-box');
   });
 
-  function touchstart(node) {
-    const event = new CustomEvent('touchstart', { bubbles: true, cancelable: true });
-
-    const nodeRect = node.getBoundingClientRect();
-    const clientX = nodeRect.left;
-    const clientY = nodeRect.top;
-
-    event.touches = event.changedTouches = event.targetTouches = [{ clientX, clientY }];
-    node.dispatchEvent(event);
-  }
-
   it('should not end up behind the dialog overlay on mousedown', async () => {
     comboBox.open();
-    comboBox.dispatchEvent(new CustomEvent('mousedown', { bubbles: true, composed: true }));
+    mousedown(comboBox);
     await nextFrame();
     expect(comboBox.$.overlay.$.dropdown.$.overlay._last).to.be.true;
   });
 
   it('should not end up behind the dialog overlay on touchstart', async () => {
     comboBox.open();
-    touchstart(comboBox);
+
+    const { left: x, top: y } = comboBox.getBoundingClientRect();
+    touchstart(comboBox, { x, y });
+
     await nextFrame();
     expect(comboBox.$.overlay.$.dropdown.$.overlay._last).to.be.true;
   });

--- a/packages/vaadin-combo-box/test/dropdown.test.js
+++ b/packages/vaadin-combo-box/test/dropdown.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import '../src/vaadin-combo-box-dropdown.js';
 
 describe('dropdown', () => {

--- a/packages/vaadin-combo-box/test/dynamic-size.test.js
+++ b/packages/vaadin-combo-box/test/dynamic-size.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@open-wc/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../src/vaadin-combo-box.js';
 
 describe('dynamic size change', () => {

--- a/packages/vaadin-combo-box/test/filtering.test.js
+++ b/packages/vaadin-combo-box/test/filtering.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { onceOpened } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';

--- a/packages/vaadin-combo-box/test/form-input.test.js
+++ b/packages/vaadin-combo-box/test/form-input.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { createEventSpy } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';

--- a/packages/vaadin-combo-box/test/helpers.js
+++ b/packages/vaadin-combo-box/test/helpers.js
@@ -1,4 +1,4 @@
-export const IOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+import { click, mousedown, mouseup } from '@vaadin/testing-helpers';
 
 export const TOUCH_DEVICE = (() => {
   try {
@@ -27,9 +27,9 @@ export const fire = (type, node, detail) => {
 };
 
 export const fireDownUpClick = (node) => {
-  fire('mousedown', node);
-  fire('mouseup', node);
-  fire('click', node);
+  mousedown(node);
+  mouseup(node);
+  click(node);
 };
 
 export const onceOpened = (element) => {

--- a/packages/vaadin-combo-box/test/item-renderer.test.js
+++ b/packages/vaadin-combo-box/test/item-renderer.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 

--- a/packages/vaadin-combo-box/test/item-template.test.js
+++ b/packages/vaadin-combo-box/test/item-template.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync } from '@open-wc/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { keyDownOn } from '@polymer/iron-test-helpers/mock-interactions.js';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';

--- a/packages/vaadin-combo-box/test/lazy-loading.test.js
+++ b/packages/vaadin-combo-box/test/lazy-loading.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync, nextFrame } from '@open-wc/testing-helpers';
-import { keyDownOn } from '@polymer/iron-test-helpers/mock-interactions.js';
+import { fixtureSync, nextFrame, enterKeyDown, fire } from '@vaadin/testing-helpers';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import '@polymer/iron-input/iron-input.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
@@ -40,10 +39,6 @@ describe('lazy loading', () => {
     });
     callback(dataProviderItems, SIZE);
   };
-
-  function enter() {
-    keyDownOn(comboBox.inputElement, 13);
-  }
 
   const setInputValue = (value) => {
     if (comboBox.inputElement.tagName === 'IRON-INPUT') {
@@ -131,7 +126,7 @@ describe('lazy loading', () => {
           expect(comboBox.opened).to.be.false;
           comboBox.dataProvider = spyDataProvider;
           setInputValue('item 1');
-          comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
+          fire(comboBox.inputElement, 'input');
           comboBox.opened = true;
           flush();
           expect(comboBox.filter).to.equal('item 1');
@@ -323,7 +318,7 @@ describe('lazy loading', () => {
         // FIXME: fails for combo-box-light (items are not updated)
         (isComboBoxLight ? it.skip : it)('should not be invoked if items are filtered', () => {
           setInputValue('1');
-          comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
+          fire(comboBox.inputElement, 'input');
 
           flush();
           spyDataProvider.resetHistory();
@@ -387,9 +382,9 @@ describe('lazy loading', () => {
           comboBox.opened = true;
 
           setInputValue('custom value');
-          comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
+          fire(comboBox.inputElement, 'input');
 
-          enter();
+          enterKeyDown(comboBox.inputElement);
           expect(comboBox.value).to.eql('custom value');
         });
       });
@@ -938,7 +933,7 @@ describe('lazy loading', () => {
           comboBox.allowCustomValue = true;
           comboBox.open();
           setInputValue('other value');
-          comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
+          fire(comboBox.inputElement, 'input');
           comboBox.close();
           expect(comboBox.value).to.eql('other value');
 

--- a/packages/vaadin-combo-box/test/object-values.test.js
+++ b/packages/vaadin-combo-box/test/object-values.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync } from '@open-wc/testing-helpers';
+import { aTimeout, fixtureSync, fire } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
@@ -9,7 +9,9 @@ describe('object values', () => {
 
   function selectItem(index) {
     // simulates clicking on the overlay items, but it more reliable in tests.
-    comboBox.$.overlay.dispatchEvent(new CustomEvent('selection-changed', { detail: { item: comboBox.items[index] } }));
+    fire(comboBox.$.overlay, 'selection-changed', {
+      item: comboBox.items[index]
+    });
   }
 
   describe('label and value paths', () => {

--- a/packages/vaadin-combo-box/test/overlay-position.test.js
+++ b/packages/vaadin-combo-box/test/overlay-position.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync } from '@open-wc/testing-helpers';
+import { aTimeout, fixtureSync, isIOS, fire } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { fire, IOS, makeItems } from './helpers.js';
+import { makeItems } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
@@ -113,7 +113,7 @@ describe('overlay', () => {
       comboBox.opened = true;
       comboBox.$.overlay.updateViewportBoundaries = sinon.spy();
 
-      fire('scroll', document);
+      fire(document, 'scroll');
 
       expect(comboBox.$.overlay.updateViewportBoundaries.callCount).to.eql(1);
     });
@@ -170,7 +170,7 @@ describe('overlay', () => {
     });
   });
 
-  (IOS ? describe.skip : describe)('overlay alignment', () => {
+  (isIOS ? describe.skip : describe)('overlay alignment', () => {
     it('should be above input', async () => {
       moveComboBox(xCenter, yBottom, 300);
 
@@ -184,7 +184,7 @@ describe('overlay', () => {
       moveComboBox(xCenter, yBottom, 300);
 
       comboBox.inputElement.value = 'item 1';
-      comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
+      fire(comboBox.inputElement, 'input');
 
       comboBox.open();
       await aTimeout(0);

--- a/packages/vaadin-combo-box/test/scrolling.test.js
+++ b/packages/vaadin-combo-box/test/scrolling.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@open-wc/testing-helpers';
-import { IOS, onceOpened, onceScrolled } from './helpers.js';
+import { fixtureSync, focusout, isIOS } from '@vaadin/testing-helpers';
+import { onceOpened, onceScrolled } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
@@ -11,7 +11,7 @@ describe('scrolling', () => {
     comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
   });
 
-  (IOS ? describe : describe.skip)('iOS', () => {
+  (isIOS ? describe : describe.skip)('iOS', () => {
     it('should have momentum scrolling enabled', () => {
       comboBox.open();
 
@@ -107,19 +107,13 @@ describe('scrolling', () => {
 
     it('should not close the items when touching scroll bar', () => {
       comboBox.open();
-      const e = new CustomEvent('focusout', { bubbles: true, composed: true });
-      e.relatedTarget = comboBox.$.overlay.$.dropdown.$.overlay;
-      comboBox.inputElement.dispatchEvent(e);
-
+      focusout(comboBox.inputElement, comboBox.$.overlay.$.dropdown.$.overlay);
       expect(comboBox.opened).to.be.true;
     });
 
     it('should keep the input focused while scrolling', () => {
       comboBox.open();
-      const e = new CustomEvent('focusout', { bubbles: true, composed: true });
-      e.relatedTarget = comboBox.$.overlay.$.dropdown.$.overlay;
-      comboBox.inputElement.dispatchEvent(e);
-
+      focusout(comboBox.inputElement, comboBox.$.overlay.$.dropdown.$.overlay);
       expect(comboBox.inputElement.hasAttribute('focused')).to.be.true;
     });
   });

--- a/packages/vaadin-combo-box/test/selecting-items.test.js
+++ b/packages/vaadin-combo-box/test/selecting-items.test.js
@@ -1,22 +1,13 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync } from '@open-wc/testing-helpers';
+import { aTimeout, click, fixtureSync, fire } from '@vaadin/testing-helpers';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
-import { fire } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
 describe('selecting items', () => {
   let comboBox;
   let valueChangedSpy, selectedItemChangedSpy, selectionChangedSpy, changeSpy;
-
-  function dispatchClick(elm) {
-    elm.dispatchEvent(
-      new CustomEvent('click', {
-        bubbles: true
-      })
-    );
-  }
 
   beforeEach(() => {
     comboBox = fixtureSync('<vaadin-combo-box style="width: 320px"></vaadin-combo-box>');
@@ -41,12 +32,7 @@ describe('selecting items', () => {
 
     const clickSpy = sinon.spy();
     document.addEventListener('click', clickSpy);
-    comboBox.$.overlay._selector.dispatchEvent(
-      new CustomEvent('click', {
-        bubbles: true,
-        composed: true
-      })
-    );
+    click(comboBox.$.overlay._selector);
     document.removeEventListener('click', clickSpy);
     expect(clickSpy.calledOnce).not.to.be.true;
   });
@@ -54,13 +40,7 @@ describe('selecting items', () => {
   it('should fire `selection-changed` when clicked on an item', () => {
     comboBox.opened = true;
     flush();
-
-    comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item').dispatchEvent(
-      new CustomEvent('click', {
-        bubbles: true
-      })
-    );
-
+    click(comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item'));
     expect(selectionChangedSpy.calledOnce).to.be.true;
     expect(selectionChangedSpy.args[0][0].detail.item).to.eql(comboBox.items[0]);
   });
@@ -84,7 +64,7 @@ describe('selecting items', () => {
 
       setTimeout(() => {
         const firstItem = comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
-        dispatchClick(firstItem);
+        click(firstItem);
 
         expect(selectionChangedSpy.calledOnce).to.be.true;
         done();
@@ -124,14 +104,14 @@ describe('selecting items', () => {
   it('should close the dropdown when reselecting the current value', () => {
     comboBox.value = 'foo';
     comboBox.open();
-    comboBox.$.overlay.dispatchEvent(new CustomEvent('selection-changed', { detail: { item: comboBox.items[0] } }));
+    fire(comboBox.$.overlay, 'selection-changed', { item: comboBox.items[0] });
     expect(comboBox.opened).to.be.false;
   });
 
   it('should not fire an event when reselecting the current value', () => {
     comboBox.value = 'foo';
     valueChangedSpy.resetHistory();
-    comboBox.$.overlay.dispatchEvent(new CustomEvent('selection-changed', { detail: { item: comboBox.items[0] } }));
+    fire(comboBox.$.overlay, 'selection-changed', { item: comboBox.items[0] });
     expect(valueChangedSpy.callCount).to.equal(0);
   });
 
@@ -229,7 +209,7 @@ describe('selecting items', () => {
 
     it('should fire on clear', () => {
       comboBox.value = 'foo';
-      fire('click', comboBox.$.input.$.clearButton);
+      click(comboBox.$.input.$.clearButton);
 
       expect(changeSpy.callCount).to.equal(1);
     });
@@ -260,7 +240,7 @@ describe('selecting items', () => {
     });
 
     it('should stop input `change` event from bubbling', () => {
-      comboBox.inputElement.dispatchEvent(new CustomEvent('change'));
+      fire(comboBox.inputElement, 'change');
 
       expect(changeSpy.callCount).to.equal(0);
     });
@@ -279,7 +259,7 @@ describe('selecting items', () => {
     it('should fire when selecting an item via click', () => {
       comboBox.open();
       const firstItem = comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
-      fire('click', firstItem);
+      click(firstItem);
 
       expect(changeSpy.callCount).to.equal(1);
     });
@@ -308,7 +288,7 @@ describe('clearing a selection', () => {
   it('should clear the selection when clicking on the icon', () => {
     comboBox.open();
 
-    fire('click', clearIcon);
+    click(clearIcon);
 
     expect(comboBox.value).to.eql('');
     expect(comboBox.$.overlay._selectedItem).to.be.null;
@@ -318,13 +298,13 @@ describe('clearing a selection', () => {
   it('should not close the dropdown after clearing a selection', () => {
     comboBox.open();
 
-    fire('click', clearIcon);
+    click(clearIcon);
 
     expect(comboBox.opened).to.eql(true);
   });
 
   it('should not open the dropdown after clearing a selection', () => {
-    fire('click', clearIcon);
+    click(clearIcon);
 
     expect(comboBox.opened).to.eql(false);
   });
@@ -332,7 +312,7 @@ describe('clearing a selection', () => {
   it('should cancel click event to avoid input blur', () => {
     comboBox.open();
 
-    const event = fire('click', clearIcon);
+    const event = click(clearIcon);
 
     expect(event.defaultPrevented).to.eql(true);
   });
@@ -343,7 +323,7 @@ describe('selecting a custom value', () => {
 
   function filter(value) {
     comboBox.inputElement.value = value;
-    comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
+    fire(comboBox.inputElement, 'input');
   }
 
   beforeEach(async () => {

--- a/packages/vaadin-combo-box/test/toggling-dropdown.test.js
+++ b/packages/vaadin-combo-box/test/toggling-dropdown.test.js
@@ -1,9 +1,10 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { aTimeout, fixtureSync } from '@open-wc/testing-helpers';
-import { createEventSpy, fire, fireDownUpClick, TOUCH_DEVICE } from './helpers.js';
+import { createEventSpy, fireDownUpClick, TOUCH_DEVICE } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { click, focusout } from '@vaadin/testing-helpers';
 
 describe('toggling dropdown', () => {
   let comboBox;
@@ -147,7 +148,7 @@ describe('toggling dropdown', () => {
         const event = createEventSpy('mousedown', preventDefaultSpy);
         comboBox.$.overlay.$.dropdown.$.overlay.dispatchEvent(event);
 
-        expect(preventDefaultSpy.called).to.be.true;
+        expect(preventDefaultSpy.calledOnce).to.be.true;
       });
     });
   });
@@ -156,7 +157,7 @@ describe('toggling dropdown', () => {
     (TOUCH_DEVICE ? it : it.skip)('should close popup when clicking outside overlay', () => {
       comboBox.open();
 
-      fire('click', document.body);
+      click(document.body);
 
       expect(comboBox.opened).to.be.false;
     });
@@ -172,7 +173,7 @@ describe('toggling dropdown', () => {
     it('should not close when clicking on the overlay', () => {
       comboBox.open();
 
-      fire('click', comboBox.$.overlay.$.dropdown.$.overlay);
+      click(comboBox.$.overlay.$.dropdown.$.overlay);
 
       expect(comboBox.opened).to.be.true;
     });
@@ -196,7 +197,7 @@ describe('toggling dropdown', () => {
     it('should close the overlay when focus is lost', () => {
       comboBox.open();
 
-      fire('focusout', comboBox.inputElement);
+      focusout(comboBox.inputElement);
 
       expect(comboBox.opened).to.equal(false);
     });
@@ -223,7 +224,7 @@ describe('toggling dropdown', () => {
         expect(comboBox.inputElement.value).to.equal('3');
         expect(comboBox.value).to.be.empty;
 
-        fire('focusout', comboBox.inputElement);
+        focusout(comboBox.inputElement);
         expect(comboBox.inputElement.value).to.be.empty;
       });
     });
@@ -239,7 +240,7 @@ describe('toggling dropdown', () => {
     });
 
     it('dropdown should not be shown when disabled', () => {
-      comboBox.inputElement.dispatchEvent(new CustomEvent('click', { bubbles: true, composed: true }));
+      click(comboBox.inputElement);
       expect(comboBox.opened).to.be.false;
     });
   });
@@ -254,7 +255,7 @@ describe('toggling dropdown', () => {
     });
 
     it('dropdown should not be shown when read-only', () => {
-      comboBox.inputElement.dispatchEvent(new CustomEvent('click', { bubbles: true, composed: true }));
+      click(comboBox.inputElement);
       expect(comboBox.opened).to.be.false;
     });
   });
@@ -308,7 +309,7 @@ describe('toggling dropdown', () => {
 
     it('should blur previously focused element when clicking on toggle button', () => {
       clickToggleIcon();
-      expect(blurSpy.called).to.be.true;
+      expect(blurSpy.calledOnce).to.be.true;
     });
   });
 });

--- a/packages/vaadin-context-menu/package.json
+++ b/packages/vaadin-context-menu/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.3",
+    "@vaadin/testing-helpers": "^0.1.4",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-context-menu/package.json
+++ b/packages/vaadin-context-menu/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-date-time-picker/package.json
+++ b/packages/vaadin-date-time-picker/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-date-time-picker/package.json
+++ b/packages/vaadin-date-time-picker/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.3",
+    "@vaadin/testing-helpers": "^0.1.4",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-radio-button/package.json
+++ b/packages/vaadin-radio-button/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.4",
+    "@vaadin/testing-helpers": "^0.1.5",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-radio-button/package.json
+++ b/packages/vaadin-radio-button/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
-    "@vaadin/testing-helpers": "^0.1.3",
+    "@vaadin/testing-helpers": "^0.1.4",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,10 +1974,10 @@
     "@typescript-eslint/types" "4.22.0"
     eslint-visitor-keys "^2.0.0"
 
-"@vaadin/testing-helpers@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.1.3.tgz#439a6371da0c6ce103dfa6be477fda79282c4674"
-  integrity sha512-W6ui9t0WdXX1FdMtvp6w+45iEG18KcZ/6Bl5zwrhEfyCwwH178Ufh9q9V7In197Z9YWPklnWAw5p4ubisOw9ig==
+"@vaadin/testing-helpers@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.1.4.tgz#214c9d5e49f2240a4d7e979a2972a36500119dbd"
+  integrity sha512-Ifh9e9VCvxgZ18GjvjTTXjszyJG4fQkfXXPVO7dTZJCKqhtgzNZPS9Hco2bH5WeoUbd3zDEV2Z0C6tPS6SlC6w==
   dependencies:
     "@polymer/polymer" "^3.4.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,10 +1974,10 @@
     "@typescript-eslint/types" "4.22.0"
     eslint-visitor-keys "^2.0.0"
 
-"@vaadin/testing-helpers@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.1.4.tgz#214c9d5e49f2240a4d7e979a2972a36500119dbd"
-  integrity sha512-Ifh9e9VCvxgZ18GjvjTTXjszyJG4fQkfXXPVO7dTZJCKqhtgzNZPS9Hco2bH5WeoUbd3zDEV2Z0C6tPS6SlC6w==
+"@vaadin/testing-helpers@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.1.5.tgz#f148db53c5cb41250cfaaa7e00134a5552801989"
+  integrity sha512-XiRR/z4nVCGUTe7uNqpayjGHOR15MgKtwko/Zd0Oo5mNumVKmhPf/WNBDmwAa1axA3rEr8urFewDGm2ou5l4pA==
   dependencies:
     "@polymer/polymer" "^3.4.1"
 


### PR DESCRIPTION
## Description

Refuses the `Polymer`/`Open-WC` testing helpers in favor of using `@vaadin/testing-helpers`. 

The main reason is that the legacy testing helpers fire some keyboard events asynchronously. That, in turn, can cause some misleading/wrong results while testing.

- [x] vaadin-accordion
- [x] vaadin-app-layout
- [x] vaadin-avatar
- [x] vaadin-board
- [x] vaadin-charts
- [x] vaadin-checkbox
- [x] vaadin-combo-box

Related to #66, #218

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
