### PR TITLE
refactor: cleanup no longer existing listener

### DIFF
--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -49,18 +49,6 @@ export const InteractionsMixin = (superClass) =>
       container.addEventListener('mouseover', (e) => this._onMouseOver(e));
     }
 
-    /** @protected */
-    connectedCallback() {
-      super.connectedCallback();
-      document.addEventListener('click', this.__boundOutsideClickListener, true);
-    }
-
-    /** @protected */
-    disconnectedCallback() {
-      super.disconnectedCallback();
-      document.removeEventListener('click', this.__boundOutsideClickListener, true);
-    }
-
     /** @private */
     get __isRTL() {
       return this.getAttribute('dir') === 'rtl';


### PR DESCRIPTION
## Description

There used to be a global outside click listener which was removed by https://github.com/vaadin/vaadin-menu-bar/pull/77
Let's cleanup the code related to it because it does not do anything.

## Type of change

- [x] Refactor