### PR TITLE
chore: update change detection branch to 20.0

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -13,7 +13,7 @@ const NO_UNIT_TESTS = ['vaadin-icons', 'vaadin-lumo-styles', 'vaadin-material-st
  * Get packages changed since master.
  */
 const getChangedPackages = () => {
-  const output = execSync('./node_modules/.bin/lerna ls --since origin/master --json --loglevel silent');
+  const output = execSync('./node_modules/.bin/lerna ls --since origin/20.0 --json --loglevel silent');
   return JSON.parse(output.toString());
 };
 


### PR DESCRIPTION
## Description

Update the web test runner change detection script to use `20.0` as a base branch for Vaadin 20.

Related to #259

## Type of change

- [x] Internal change
- [ ] Feature