### PR TITLE
Cherry-pick fix: update filtering and sorting when grid and columns are attached / detached (#2122)

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -87,11 +87,14 @@ export const DynamicColumnsMixin = (superClass) =>
         if (rowDetailsTemplate && this._rowDetailsTemplate !== rowDetailsTemplate) {
           this._rowDetailsTemplate = rowDetailsTemplate;
         }
+        const hasColumnElements = (nodeCollection) => nodeCollection.filter(this._isColumnElement).length > 0;
+        if (hasColumnElements(info.addedNodes) || hasColumnElements(info.removedNodes)) {
+          const allRemovedCells = info.removedNodes.flatMap((c) => c._allCells);
+          const filterNotConnected = (element) =>
+            allRemovedCells.filter((cell) => cell._content.contains(element)).length;
 
-        if (
-          info.addedNodes.filter(this._isColumnElement).length > 0 ||
-          info.removedNodes.filter(this._isColumnElement).length > 0
-        ) {
+          this.__removeSorters(this._sorters.filter(filterNotConnected));
+          this.__removeFilters(this._filters.filter(filterNotConnected));
           this._updateColumnTree();
         }
 

--- a/packages/vaadin-grid/src/vaadin-grid-filter-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-mixin.js
@@ -29,13 +29,34 @@ export const FilterMixin = (superClass) =>
 
     /** @private */
     _filterChanged(e) {
-      if (this._filters.indexOf(e.target) === -1) {
-        this._filters.push(e.target);
-      }
-
       e.stopPropagation();
 
-      if (this.dataProvider) {
+      this.__addFilter(e.target);
+      this.__applyFilters();
+    }
+
+    /** @private */
+    __removeFilters(filtersToRemove) {
+      if (filtersToRemove.length == 0) {
+        return;
+      }
+
+      this._filters = this._filters.filter((filter) => filtersToRemove.indexOf(filter) < 0);
+      this.__applyFilters();
+    }
+
+    /** @private */
+    __addFilter(filter) {
+      const filterIndex = this._filters.indexOf(filter);
+
+      if (filterIndex === -1) {
+        this._filters.push(filter);
+      }
+    }
+
+    /** @private */
+    __applyFilters() {
+      if (this.dataProvider && this.isAttached) {
         this.clearCache();
       }
     }

--- a/packages/vaadin-grid/src/vaadin-grid-sorter.js
+++ b/packages/vaadin-grid/src/vaadin-grid-sorter.js
@@ -145,13 +145,13 @@ class GridSorterElement extends ThemableMixin(DirMixin(PolymerElement)) {
       /** @private */
       _isConnected: {
         type: Boolean,
-        value: false
+        observer: '__isConnectedChanged'
       }
     };
   }
 
   static get observers() {
-    return ['_pathOrDirectionChanged(path, direction, _isConnected)'];
+    return ['_pathOrDirectionChanged(path, direction)'];
   }
 
   /** @protected */
@@ -173,14 +173,26 @@ class GridSorterElement extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   /** @private */
-  _pathOrDirectionChanged(path, direction, isConnected) {
-    if (path === undefined || direction === undefined || isConnected === undefined) {
+  _pathOrDirectionChanged() {
+    this.__dispatchSorterChangedEvenIfPossible();
+  }
+
+  /** @private */
+  __isConnectedChanged(newValue, oldValue) {
+    if (oldValue === false) {
       return;
     }
 
-    if (isConnected) {
-      this.dispatchEvent(new CustomEvent('sorter-changed', { bubbles: true, composed: true }));
+    this.__dispatchSorterChangedEvenIfPossible();
+  }
+
+  /** @private */
+  __dispatchSorterChangedEvenIfPossible() {
+    if (this.path === undefined || this.direction === undefined || !this._isConnected) {
+      return;
     }
+
+    this.dispatchEvent(new CustomEvent('sorter-changed', { bubbles: true, composed: true }));
   }
 
   /** @private */

--- a/packages/vaadin-grid/test/helpers.js
+++ b/packages/vaadin-grid/test/helpers.js
@@ -113,7 +113,7 @@ export const isVisible = (el) => {
   );
 };
 
-const getVisibleItems = (grid) => {
+export const getVisibleItems = (grid) => {
   flushGrid(grid);
   const rows = grid.$.items.children;
   const visibleRows = [];


### PR DESCRIPTION
Fixes: vaadin/vaadin-grid#1969
Warranty: Fixes exception related to sorting when recreating columns
Cherry-pick: https://github.com/vaadin/vaadin-grid/pull/2122

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes vaadin/vaadin-grid#1969

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.