### PR TITLE
fix(grid): flush debouncer to fix timing issue with scroll to index

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-data-provider-mixin.js
@@ -512,6 +512,11 @@ export const DataProviderMixin = (superClass) =>
       if (this.__pendingScrollToIndex && this.$.items.children.length) {
         const index = this.__pendingScrollToIndex;
         delete this.__pendingScrollToIndex;
+
+        if (this._debounceIncreasePool) {
+          this._debounceIncreasePool.flush();
+        }
+
         this.scrollToIndex(index);
       }
     }

--- a/packages/vaadin-grid/test/scroll-to-index.test.js
+++ b/packages/vaadin-grid/test/scroll-to-index.test.js
@@ -210,9 +210,14 @@ describe('scroll to index', () => {
     });
   });
   describe('Tree grid', () => {
+    let grid;
+
+    beforeEach(() => {
+      grid = fixtureSync(fixtures.treeGrid);
+    });
+
     // Issue https://github.com/vaadin/vaadin-grid/issues/2107
     it('should display correctly when scrolled to bottom immediately after setting dataProvider', (done) => {
-      const grid = fixtureSync(fixtures.treeGrid);
       grid.size = 1;
       const numberOfChidren = 250;
       grid.itemIdPath = 'name';
@@ -242,7 +247,6 @@ describe('scroll to index', () => {
     });
 
     it('should not reuse rows if subitems are loaded while scrolling to bottom', (done) => {
-      const grid = fixtureSync(fixtures.treeGrid);
       grid.size = 25;
 
       const parents = Array.from({ length: 10 }).map((_, i) => ({ name: i, hasChildren: true }));


### PR DESCRIPTION
## Description

In some cases, the calling `scrollToIndex` with values closer to the end of the Grid, could lead to some rows being mistakenly reused leaving some rows empty.

For instance, if a TreeGrid has an expanded item, but the subitems are not placed yet when the scroll is called.

This change flushes the `_debounceIncreasePool` debouncer before scrolling, so it will be able to place the remaining items properly.

Fixes https://github.com/vaadin/vaadin-grid/issues/2145

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

