### PR TITLE
fix: allow accordion opened to be null

### DIFF
--- a/packages/vaadin-accordion/src/vaadin-accordion.d.ts
+++ b/packages/vaadin-accordion/src/vaadin-accordion.d.ts
@@ -74,7 +74,7 @@ declare class AccordionElement extends ElementMixin(ThemableMixin(HTMLElement)) 
    * default. Only one panel can be opened at the same time.
    * Setting null or undefined closes all the accordion panels.
    */
-  opened: number;
+  opened: number | null;
 
   /**
    * The list of `<vaadin-accordion-panel>` child elements.

--- a/packages/vaadin-accordion/test/typings/accordion.types.ts
+++ b/packages/vaadin-accordion/test/typings/accordion.types.ts
@@ -6,6 +6,8 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 
 const accordion = document.createElement('vaadin-accordion');
 
+accordion.opened = null;
+
 accordion.addEventListener('opened-changed', (event) => {
   assertType<AccordionOpenedChangedEvent>(event);
   assertType<number | null>(event.detail.value);


### PR DESCRIPTION
## Description

There was a mismatch for this property and corresponding event (I couldn't find any other affected properties).

Fixes #272

## Type of change

- [x] Bugfix