### PR TITLE
test: run all tests in CI and remove updated screenshot detection

### DIFF
--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -30,4 +30,4 @@ jobs:
         run: yarn lint
 
       - name: Test
-        run: yarn test
+        run: yarn test --all

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -33,4 +33,4 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Test
-        run: yarn test:firefox
+        run: yarn test:firefox --all

--- a/.github/workflows/lumo.yml
+++ b/.github/workflows/lumo.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: yarn test:lumo
+        run: yarn test:lumo --all
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/material.yml
+++ b/.github/workflows/material.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: yarn test:material
+        run: yarn test:material --all
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/webkit.yml
+++ b/.github/workflows/webkit.yml
@@ -33,4 +33,4 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Test
-        run: yarn test:webkit
+        run: yarn test:webkit --all

--- a/README.md
+++ b/README.md
@@ -168,22 +168,40 @@ Not all variables are necessary for all scripts, individual sections below will 
 
 ### Unit tests
 
-Run all tests in Chrome:
+Run tests in Chrome (changed packages):
 
 ```sh
 yarn test
 ```
 
-Run all tests in Firefox:
+Run tests in Chrome (all packages):
+
+```sh
+yarn test --all
+```
+
+Run tests in Firefox (changed packages):
 
 ```sh
 yarn test:firefox
 ```
 
-Run all tests in WebKit:
+Run tests in Firefox (all packages):
+
+```sh
+yarn test:firefox --all
+```
+
+Run tests in WebKit (changed packages):
 
 ```sh
 yarn test:webkit
+```
+
+Run tests in WebKit (all packages):
+
+```sh
+yarn test:webkit --all
 ```
 
 Run tests for single package:
@@ -202,16 +220,28 @@ yarn debug --group vaadin-upload
 
 To run the visual tests, please make sure that the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables are defined.
 
-Run tests for Lumo:
+Run tests for Lumo (changed packages):
 
 ```sh
 yarn test:lumo
 ```
 
-Run tests for Material:
+Run tests for Lumo (all packages):
+
+```sh
+yarn test:lumo --all
+```
+
+Run tests for Material (changed packages):
 
 ```sh
 yarn test:material
+```
+
+Run tests for Material (all packages):
+
+```sh
+yarn test:material --all
 ```
 
 Update reference screenshots for Lumo:


### PR DESCRIPTION
## Description

Currently the test scripts try to resolve component packages from updated screenshot names to reduce the number of tests that need to run. This is problematic, as that mechanism relies on the tests being named exactly as the folder of the component package which fails ATM in some cases like [here](https://github.com/vaadin/web-components/pull/212).

Instead of keeping the current mechanism of matching test names to folder names and adapting the incorrect test names, I went with a different solution where we ignore updates to screenshots locally and enforce running all tests in CI to ensure that baseline screenshots and actual results always match.

Changes in this MR:
- remove the check for updated baseline screenshots
- introduce `-all` flag to run all tests, for all test types
- make CI actions always run all tests - this will make the CI take longer than before, but also guarantees 100% correctness and removes possible side effects
- updated README
