### PR TITLE
fix: Allow colored avatar border to respect the host border radius

### DIFF
--- a/packages/vaadin-avatar/src/vaadin-avatar.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar.js
@@ -114,7 +114,7 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           left: 0;
           bottom: 0;
           right: 0;
-          border-radius: 50%;
+          border-radius: inherit;
           box-shadow: inset 0 0 0 2px var(--vaadin-avatar-user-color);
         }
       </style>


### PR DESCRIPTION
## Description

Changing the border radius of the host should affect the colored border as well. Otherwise, when customizing the border radius, you would need to remember to do it for two elements (the host and the `::before` pseudo element).

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
