### PR TITLE
chore: run tests after lint workflow

### DIFF
--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Unit tests
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -2,7 +2,8 @@ name: Chrome
 
 on:
   workflow_run:
-    workflows: ["Lint"]
+    workflows:
+      - Lint
     types:
       - completed
 
@@ -15,6 +16,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - run: git branch
+      - run: env
 
       - name: Setup Node 14.x
         uses: actions/setup-node@v2

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -1,9 +1,14 @@
 name: Firefox
 
-on: pull_request
+on:
+  workflow_run:
+    workflows: ["Lint"]
+    types:
+      - completed
 
 jobs:
   tests:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Unit tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Unit tests
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -2,7 +2,8 @@ name: Firefox
 
 on:
   workflow_run:
-    workflows: ["Lint"]
+    workflows:
+      - Lint
     types:
       - completed
 
@@ -15,6 +16,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - run: git branch
+      - run: env
 
       - name: Setup Node 14.x
         uses: actions/setup-node@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,15 +1,10 @@
-name: Chrome
+name: Lint
 
-on:
-  workflow_run:
-    workflows: ["Lint"]
-    types:
-      - completed
+on: pull_request
 
 jobs:
-  tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    name: Unit tests
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,5 +26,5 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
-      - name: Test
-        run: yarn test
+      - name: Lint
+        run: yarn lint

--- a/.github/workflows/lumo.yml
+++ b/.github/workflows/lumo.yml
@@ -2,7 +2,8 @@ name: Lumo
 
 on:
   workflow_run:
-    workflows: ["Lint"]
+    workflows:
+      - Lint
     types:
       - completed
 
@@ -17,6 +18,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - run: git branch
+      - run: env
 
       - name: Setup Node 14.x
         uses: actions/setup-node@v2

--- a/.github/workflows/lumo.yml
+++ b/.github/workflows/lumo.yml
@@ -9,10 +9,9 @@ on:
 
 jobs:
   tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Visual tests
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'vaadin'
+    if: ${{ github.repository_owner == 'vaadin' && github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lumo.yml
+++ b/.github/workflows/lumo.yml
@@ -1,9 +1,14 @@
 name: Lumo
 
-on: pull_request
+on:
+  workflow_run:
+    workflows: ["Lint"]
+    types:
+      - completed
 
 jobs:
   tests:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Visual tests
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vaadin'

--- a/.github/workflows/material.yml
+++ b/.github/workflows/material.yml
@@ -2,7 +2,8 @@ name: Material
 
 on:
   workflow_run:
-    workflows: ["Lint"]
+    workflows:
+      - Lint
     types:
       - completed
 
@@ -17,6 +18,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - run: git branch
+      - run: env
 
       - name: Setup Node 14.x
         uses: actions/setup-node@v2

--- a/.github/workflows/material.yml
+++ b/.github/workflows/material.yml
@@ -9,10 +9,9 @@ on:
 
 jobs:
   tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Visual tests
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'vaadin'
+    if: ${{ github.repository_owner == 'vaadin' && github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/material.yml
+++ b/.github/workflows/material.yml
@@ -1,9 +1,14 @@
 name: Material
 
-on: pull_request
+on:
+  workflow_run:
+    workflows: ["Lint"]
+    types:
+      - completed
 
 jobs:
   tests:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Visual tests
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vaadin'

--- a/.github/workflows/webkit.yml
+++ b/.github/workflows/webkit.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Unit tests
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/webkit.yml
+++ b/.github/workflows/webkit.yml
@@ -1,9 +1,14 @@
 name: WebKit
 
-on: pull_request
+on:
+  workflow_run:
+    workflows: ["Lint"]
+    types:
+      - completed
 
 jobs:
   tests:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Unit tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/webkit.yml
+++ b/.github/workflows/webkit.yml
@@ -2,7 +2,8 @@ name: WebKit
 
 on:
   workflow_run:
-    workflows: ["Lint"]
+    workflows:
+      - Lint
     types:
       - completed
 
@@ -15,6 +16,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - run: git branch
+      - run: env
 
       - name: Setup Node 14.x
         uses: actions/setup-node@v2


### PR DESCRIPTION
## Description

Create a separate `Lint` workflow, make it run first and then run all the `Test` workflows only if `Lint` succeeded.

Fixes #294

## Type of change

- [x] Internal change