### PR TITLE
feat!: remove polymer template api from vaadin-combo-box

### DIFF
--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -99,9 +99,6 @@ interface ComboBoxMixin {
    *
    * The item label is also used for matching items when processing user
    * input, i.e., for filtering and selecting items.
-   *
-   * When using item templates, the property is still needed because it is used
-   * for filtering, and for displaying the selected item value in the input box.
    * @attr {string} item-label-path
    */
   itemLabelPath: string;
@@ -189,8 +186,6 @@ interface ComboBoxMixin {
    * You can override the `checkValidity` method for custom validations.
    */
   checkValidity(): boolean | undefined;
-
-  _ensureTemplatized(): void;
 
   _preventInputBlur(): void;
 

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -299,6 +299,10 @@ export const ComboBoxMixin = (subclass) =>
 
       this.addEventListener('mousedown', bringToFrontListener);
       this.addEventListener('touchstart', bringToFrontListener);
+
+      if (window.Vaadin && window.Vaadin.templateRendererCallback) {
+        window.Vaadin.templateRendererCallback(this);
+      }
     }
 
     /**

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.d.ts
@@ -63,20 +63,7 @@ import { ComboBoxEventMap } from './interfaces';
  * in the next renderer call and will be provided with the `root` argument.
  * On first call it will be empty.
  *
- * ### Item Template
- *
- * Alternatively, the content of the `<vaadin-combo-box-item>` can be populated by using
- * custom item template provided in the light DOM:
- *
- * ```html
- * <vaadin-combo-box items='[{"label": "Hydrogen", "value": "H"}]'>
- *   <template>
- *     [[index]]: [[item.label]] <b>[[item.value]</b>
- *   </template>
- * </vaadin-combo-box>
- * ```
- *
- * The following properties are available for item template bindings:
+ * The following properties are available in the `model` argument:
  *
  * Property name | Type | Description
  * --------------|------|------------

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.js
@@ -376,10 +376,6 @@ class ComboBoxElement extends ElementMixin(
     this._nativeInput.setAttribute('role', 'combobox');
     this._nativeInput.setAttribute('aria-autocomplete', 'list');
     this._updateAriaExpanded();
-
-    if (window.Vaadin && window.Vaadin.templateRendererCallback) {
-      window.Vaadin.templateRendererCallback(this);
-    }
   }
 
   /** @protected */

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.js
@@ -63,20 +63,7 @@ import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixi
  * in the next renderer call and will be provided with the `root` argument.
  * On first call it will be empty.
  *
- * ### Item Template
- *
- * Alternatively, the content of the `<vaadin-combo-box-item>` can be populated by using
- * custom item template provided in the light DOM:
- *
- * ```html
- * <vaadin-combo-box items='[{"label": "Hydrogen", "value": "H"}]'>
- *   <template>
- *     [[index]]: [[item.label]] <b>[[item.value]</b>
- *   </template>
- * </vaadin-combo-box>
- * ```
- *
- * The following properties are available for item template bindings:
+ * The following properties are available in the `model` argument:
  *
  * Property name | Type | Description
  * --------------|------|------------
@@ -389,6 +376,10 @@ class ComboBoxElement extends ElementMixin(
     this._nativeInput.setAttribute('role', 'combobox');
     this._nativeInput.setAttribute('aria-autocomplete', 'list');
     this._updateAriaExpanded();
+
+    if (window.Vaadin && window.Vaadin.templateRendererCallback) {
+      window.Vaadin.templateRendererCallback(this);
+    }
   }
 
   /** @protected */

--- a/packages/vaadin-combo-box/test/combo-box-light.test.js
+++ b/packages/vaadin-combo-box/test/combo-box-light.test.js
@@ -16,6 +16,7 @@ import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@polymer/iron-input/iron-input.js';
 import '@polymer/paper-input/paper-input.js';
 import '@vaadin/vaadin-text-field/vaadin-text-field.js';
+import '@vaadin/vaadin-template-renderer';
 import { createEventSpy, TOUCH_DEVICE } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box-light.js';

--- a/packages/vaadin-combo-box/test/dropdown.test.js
+++ b/packages/vaadin-combo-box/test/dropdown.test.js
@@ -6,11 +6,7 @@ describe('dropdown', () => {
   let dropdown, overlay;
 
   beforeEach(() => {
-    dropdown = fixtureSync(`
-      <vaadin-combo-box-dropdown>
-        <template></template>
-      </vaadin-combo-box-dropdown>
-    `);
+    dropdown = fixtureSync(`<vaadin-combo-box-dropdown></vaadin-combo-box-dropdown>`);
     overlay = dropdown.$.overlay;
   });
 

--- a/packages/vaadin-combo-box/test/fixtures/mock-combo-box-light-template-wrapper.js
+++ b/packages/vaadin-combo-box/test/fixtures/mock-combo-box-light-template-wrapper.js
@@ -1,0 +1,39 @@
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import '../../vaadin-combo-box-light.js';
+
+class MockComboBoxLightTemplateWrapper extends PolymerElement {
+  static get template() {
+    return html`
+      <vaadin-combo-box-light id="comboBox" items="[[items]]">
+        <vaadin-text-field></vaadin-text-field>
+
+        <template>
+          <div>index: [[index]]</div>
+          <div>item: [[item]]</div>
+          <div>selected: [[selected]]</div>
+          <div>focused: [[focused]]</div>
+          <div>parentProperty: [[parentProperty]]</div>
+          <div>parentProperty.foo: [[parentProperty.foo]]</div>
+          <div>parentMethod: [[parentMethod()]]</div>
+          <button on-click="parentEventHandler"></button>
+        </template>
+      </vaadin-combo-box-light>
+    `;
+  }
+
+  static get properties() {
+    return {
+      items: Array
+    };
+  }
+
+  parentMethod() {
+    return 'quux';
+  }
+
+  parentEventHandler() {
+    // do nothing
+  }
+}
+
+customElements.define('mock-combo-box-light-template-wrapper', MockComboBoxLightTemplateWrapper);

--- a/packages/vaadin-combo-box/test/fixtures/mock-combo-box-template-wrapper.js
+++ b/packages/vaadin-combo-box/test/fixtures/mock-combo-box-template-wrapper.js
@@ -1,0 +1,37 @@
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import '../../vaadin-combo-box.js';
+
+class MockComboBoxTemplateWrapper extends PolymerElement {
+  static get template() {
+    return html`
+      <vaadin-combo-box id="comboBox" items="[[items]]">
+        <template>
+          <div>index: [[index]]</div>
+          <div>item: [[item]]</div>
+          <div>selected: [[selected]]</div>
+          <div>focused: [[focused]]</div>
+          <div>parentProperty: [[parentProperty]]</div>
+          <div>parentProperty.foo: [[parentProperty.foo]]</div>
+          <div>parentMethod: [[parentMethod()]]</div>
+          <button on-click="parentEventHandler"></button>
+        </template>
+      </vaadin-combo-box>
+    `;
+  }
+
+  static get properties() {
+    return {
+      items: Array
+    };
+  }
+
+  parentMethod() {
+    return 'quux';
+  }
+
+  parentEventHandler() {
+    // do nothing
+  }
+}
+
+customElements.define('mock-combo-box-template-wrapper', MockComboBoxTemplateWrapper);

--- a/packages/vaadin-combo-box/test/item-renderer.test.js
+++ b/packages/vaadin-combo-box/test/item-renderer.test.js
@@ -1,100 +1,69 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-template-renderer';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
 describe('form field', () => {
   let comboBox;
 
-  describe('without template', () => {
-    let items;
+  let items;
 
-    beforeEach(() => {
-      comboBox = fixtureSync(`
-        <vaadin-combo-box
-          item-label-path="name"
-          item-value-path="symbol">
-        </vaadin-combo-box>
-      `);
-      items = ['foo', 'bar', 'baz'];
-      comboBox.items = items;
-    });
-
-    afterEach(() => {
-      comboBox.opened = false;
-    });
-
-    it('should use renderer when it is defined', () => {
-      comboBox.renderer = (root, comboBox, model) => {
-        const textNode = document.createTextNode(`${model.item} ${model.index}`);
-        root.appendChild(textNode);
-      };
-      comboBox.opened = true;
-
-      const item = comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
-      expect(item.$.content.textContent.trim()).to.equal('foo 0');
-    });
-
-    it('renderer should receive root, comboBox and model', (done) => {
-      let isDone = false;
-
-      comboBox.renderer = (root, comboBox, model) => {
-        expect(root.getAttribute('part')).to.equal('content');
-        expect(items.indexOf(model.item)).to.not.equal(-1);
-        expect(comboBox).to.eql(comboBox);
-
-        if (!isDone) {
-          isDone = true;
-          done();
-        }
-      };
-
-      comboBox.opened = true;
-    });
-
-    it('should throw an error and remove template when added after renderer', () => {
-      comboBox.renderer = () => {};
-      const template = document.createElement('template');
-      expect(() => {
-        comboBox.appendChild(template);
-        comboBox._observer.flush();
-      }).to.throw(Error);
-      expect(comboBox._itemTemplate).to.be.not.ok;
-    });
-
-    it('should be possible to manually invoke renderer', () => {
-      comboBox.renderer = sinon.spy();
-      comboBox.opened = true;
-
-      // Number of items rendered on opening
-      const renderedCount = comboBox.renderer.callCount;
-      comboBox.render();
-      expect(comboBox.renderer.callCount).to.be.equal(renderedCount * 2);
-    });
-
-    it('should not throw if render() called before opening', () => {
-      expect(() => comboBox.render()).not.to.throw(Error);
-    });
+  beforeEach(() => {
+    comboBox = fixtureSync(`
+      <vaadin-combo-box
+        item-label-path="name"
+        item-value-path="symbol">
+      </vaadin-combo-box>
+    `);
+    items = ['foo', 'bar', 'baz'];
+    comboBox.items = items;
   });
 
-  describe('with template', () => {
-    beforeEach(() => {
-      comboBox = fixtureSync(`
-        <vaadin-combo-box item-label-path="name" item-value-path="symbol">
-          <template>
-            <p>templatizer-content</p>
-          </template>
-        </vaadin-combo-box>
-      `);
+  afterEach(() => {
+    comboBox.opened = false;
+  });
 
-      comboBox.items = ['foo', 'bar', 'baz'];
-      comboBox._observer.flush();
-    });
+  it('should use renderer when it is defined', () => {
+    comboBox.renderer = (root, comboBox, model) => {
+      const textNode = document.createTextNode(`${model.item} ${model.index}`);
+      root.appendChild(textNode);
+    };
+    comboBox.opened = true;
 
-    it('should throw an error and remove renderer when added after template', () => {
-      expect(() => (comboBox.renderer = () => {})).to.throw(Error);
-      expect(comboBox.renderer).to.be.not.ok;
-    });
+    const item = comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
+    expect(item.$.content.textContent.trim()).to.equal('foo 0');
+  });
+
+  it('renderer should receive root, comboBox and model', (done) => {
+    let isDone = false;
+
+    comboBox.renderer = (root, comboBox, model) => {
+      expect(root.getAttribute('part')).to.equal('content');
+      expect(items.indexOf(model.item)).to.not.equal(-1);
+      expect(comboBox).to.eql(comboBox);
+
+      if (!isDone) {
+        isDone = true;
+        done();
+      }
+    };
+
+    comboBox.opened = true;
+  });
+
+  it('should be possible to manually invoke renderer', () => {
+    comboBox.renderer = sinon.spy();
+    comboBox.opened = true;
+
+    // Number of items rendered on opening
+    const renderedCount = comboBox.renderer.callCount;
+    comboBox.render();
+    expect(comboBox.renderer.callCount).to.be.equal(renderedCount * 2);
+  });
+
+  it('should not throw if render() called before opening', () => {
+    expect(() => comboBox.render()).not.to.throw(Error);
   });
 });

--- a/packages/vaadin-combo-box/test/item-renderer.test.js
+++ b/packages/vaadin-combo-box/test/item-renderer.test.js
@@ -5,10 +5,14 @@ import '@vaadin/vaadin-template-renderer';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
-describe('form field', () => {
+describe('item renderer', () => {
   let comboBox;
 
   let items;
+
+  function getFirstItem() {
+    return comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
+  }
 
   beforeEach(() => {
     comboBox = fixtureSync(`
@@ -32,8 +36,7 @@ describe('form field', () => {
     };
     comboBox.opened = true;
 
-    const item = comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
-    expect(item.$.content.textContent.trim()).to.equal('foo 0');
+    expect(getFirstItem().$.content.textContent.trim()).to.equal('foo 0');
   });
 
   it('renderer should receive root, comboBox and model', (done) => {
@@ -65,5 +68,18 @@ describe('form field', () => {
 
   it('should not throw if render() called before opening', () => {
     expect(() => comboBox.render()).not.to.throw(Error);
+  });
+
+  it('should render the item label when removing the renderer', () => {
+    comboBox.renderer = (root) => {
+      root.textContent = 'bar';
+    };
+    comboBox.opened = true;
+
+    expect(getFirstItem().$.content.textContent).to.equal('bar');
+
+    comboBox.renderer = null;
+
+    expect(getFirstItem().$.content.textContent).to.equal('foo');
   });
 });

--- a/packages/vaadin-combo-box/test/item-renderer.test.js
+++ b/packages/vaadin-combo-box/test/item-renderer.test.js
@@ -29,6 +29,42 @@ describe('item renderer', () => {
     comboBox.opened = false;
   });
 
+  describe('arguments', () => {
+    beforeEach(() => {
+      comboBox.renderer = sinon.spy();
+      comboBox.opened = true;
+    });
+
+    it(`should pass the 'root', 'owner', 'model' arguments to the renderer`, () => {
+      const [root, owner, model] = comboBox.renderer.args[0];
+
+      expect(root.getAttribute('part')).to.equal('content');
+      expect(owner).to.eql(comboBox);
+      expect(model).to.deep.equal({
+        item: 'foo',
+        index: 0,
+        focused: false,
+        selected: false
+      });
+    });
+
+    it(`should change the 'model.selected' property`, () => {
+      comboBox.value = 'foo';
+
+      const model = comboBox.renderer.lastCall.args[2];
+
+      expect(model.selected).to.be.true;
+    });
+
+    it(`should change the 'model.focused' property`, () => {
+      comboBox._focusedIndex = 0;
+
+      const model = comboBox.renderer.lastCall.args[2];
+
+      expect(model.focused).to.be.true;
+    });
+  });
+
   it('should use renderer when it is defined', () => {
     comboBox.renderer = (root, comboBox, model) => {
       const textNode = document.createTextNode(`${model.item} ${model.index}`);
@@ -37,23 +73,6 @@ describe('item renderer', () => {
     comboBox.opened = true;
 
     expect(getFirstItem().$.content.textContent.trim()).to.equal('foo 0');
-  });
-
-  it('renderer should receive root, comboBox and model', (done) => {
-    let isDone = false;
-
-    comboBox.renderer = (root, comboBox, model) => {
-      expect(root.getAttribute('part')).to.equal('content');
-      expect(items.indexOf(model.item)).to.not.equal(-1);
-      expect(comboBox).to.eql(comboBox);
-
-      if (!isDone) {
-        isDone = true;
-        done();
-      }
-    };
-
-    comboBox.opened = true;
   });
 
   it('should be possible to manually invoke renderer', () => {

--- a/packages/vaadin-combo-box/test/item-template.test.js
+++ b/packages/vaadin-combo-box/test/item-template.test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import '@vaadin/vaadin-template-renderer';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 

--- a/packages/vaadin-combo-box/test/item-template.test.js
+++ b/packages/vaadin-combo-box/test/item-template.test.js
@@ -1,116 +1,91 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import '@vaadin/vaadin-template-renderer';
 import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 
-class ComboBoxWrapper extends PolymerElement {
-  static get template() {
-    return html`
-      <vaadin-combo-box id="combobox" items="[[items]]">
-        <template>
-          index: [[index]] item: [[item]] selected: [[selected]] focused: [[focused]] parentProperty: [[parentProperty]]
-          parentProperty.foo: [[parentProperty.foo]] parentMethod: [[parentMethod()]]
-          <button on-click="parentEventHandler"></button>
-        </template>
-      </vaadin-combo-box>
-    `;
-  }
-
-  static get properties() {
-    return {
-      items: Array
-    };
-  }
-
-  parentMethod() {
-    return 'quux';
-  }
-
-  parentEventHandler() {
-    // do nothing
-  }
-}
-
-customElements.define('combo-box-wrapper', ComboBoxWrapper);
+import './fixtures/mock-combo-box-template-wrapper.js';
+import './fixtures/mock-combo-box-light-template-wrapper.js';
 
 describe('item template', () => {
-  let scope, combobox, firstItem;
+  let wrapper, comboBox, firstItem;
 
-  beforeEach(() => {
-    scope = fixtureSync('<combo-box-wrapper></combo-box-wrapper>');
-    combobox = scope.$.combobox;
-    combobox.items = ['foo', 'bar'];
-    combobox.open();
+  ['combo-box', 'combo-box-light'].forEach((name) => {
+    describe(name, () => {
+      beforeEach(() => {
+        wrapper = fixtureSync(`<mock-${name}-template-wrapper></mock-${name}-template-wrapper>`);
+        comboBox = wrapper.$.comboBox;
+        comboBox.items = ['foo', 'bar'];
+        comboBox.open();
 
-    flush();
-    firstItem = combobox.$.overlay._selector.querySelector('vaadin-combo-box-item');
-  });
+        flush();
+        firstItem = comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
+      });
 
-  it('should render items using template', () => {
-    expect(firstItem.shadowRoot.innerHTML).to.contain('item: foo');
-  });
+      it('should render items using template', () => {
+        expect(firstItem.shadowRoot.innerHTML).to.contain('item: foo');
+      });
 
-  it('should have index property', () => {
-    expect(firstItem.shadowRoot.innerHTML).to.contain('index: 0');
-  });
+      it('should have index property', () => {
+        expect(firstItem.shadowRoot.innerHTML).to.contain('index: 0');
+      });
 
-  it('should have selected property', () => {
-    expect(firstItem.shadowRoot.innerHTML).to.contain('selected: false');
-  });
+      it('should have selected property', () => {
+        expect(firstItem.shadowRoot.innerHTML).to.contain('selected: false');
+      });
 
-  it('should update selected property', () => {
-    combobox.value = 'foo';
-    expect(firstItem.shadowRoot.innerHTML).to.contain('selected: true');
-  });
+      it('should update selected property', () => {
+        comboBox.value = 'foo';
+        expect(firstItem.shadowRoot.innerHTML).to.contain('selected: true');
+      });
 
-  it('should have focused property', () => {
-    expect(firstItem.shadowRoot.innerHTML).to.contain('focused: false');
-  });
+      it('should have focused property', () => {
+        expect(firstItem.shadowRoot.innerHTML).to.contain('focused: false');
+      });
 
-  it('should update focused property', () => {
-    keyDownOn(combobox.inputElement, 40); // Press arrow down key
-    expect(firstItem.shadowRoot.innerHTML).to.contain('focused: true');
-  });
+      it('should update focused property', () => {
+        keyDownOn(comboBox.inputElement, 40); // Press arrow down key
+        expect(firstItem.shadowRoot.innerHTML).to.contain('focused: true');
+      });
 
-  it('should forward parent properties', () => {
-    scope.parentProperty = 'qux';
-    expect(firstItem.shadowRoot.innerHTML).to.contain('parentProperty: qux');
-  });
+      it('should forward parent properties', () => {
+        wrapper.parentProperty = 'qux';
+        expect(firstItem.shadowRoot.innerHTML).to.contain('parentProperty: qux');
+      });
 
-  it('should forward parent paths', () => {
-    scope.parentProperty = { foo: '' };
-    scope.set('parentProperty.foo', 'bar');
-    expect(firstItem.shadowRoot.innerHTML).to.contain('parentProperty.foo: bar');
-  });
+      it('should forward parent paths', () => {
+        wrapper.parentProperty = { foo: '' };
+        wrapper.set('parentProperty.foo', 'bar');
+        expect(firstItem.shadowRoot.innerHTML).to.contain('parentProperty.foo: bar');
+      });
 
-  it('should support computed bindings in parent scope', () => {
-    expect(firstItem.shadowRoot.innerHTML).to.contain('parentMethod: quux');
-  });
+      it('should support computed bindings in parent scope', () => {
+        expect(firstItem.shadowRoot.innerHTML).to.contain('parentMethod: quux');
+      });
 
-  it('should support event handlers in parent scope', () => {
-    const spy = sinon.spy(scope, 'parentEventHandler');
-    firstItem.shadowRoot.querySelector('button').click();
-    expect(spy.calledOnce).to.be.true;
-  });
+      it('should support event handlers in parent scope', () => {
+        const spy = sinon.spy(wrapper, 'parentEventHandler');
+        firstItem.shadowRoot.querySelector('button').click();
+        expect(spy.calledOnce).to.be.true;
+      });
 
-  it('should have content part wrapping template', () => {
-    const content = firstItem.shadowRoot.querySelector('[part="content"]');
-    expect(content.querySelector('button').parentElement).to.equal(content);
-  });
+      it('should have content part wrapping template', () => {
+        const content = firstItem.shadowRoot.querySelector('[part="content"]');
+        expect(content.querySelector('button').parentElement).to.equal(content);
+      });
 
-  it('should have block style for the content part', () => {
-    const content = firstItem.shadowRoot.querySelector('[part="content"]');
-    expect(getComputedStyle(content).display).to.equal('block');
-  });
+      it('should have block style for the content part', () => {
+        const content = firstItem.shadowRoot.querySelector('[part="content"]');
+        expect(getComputedStyle(content).display).to.equal('block');
+      });
 
-  it('should preserve and propagate dir to the items', () => {
-    combobox.close();
-    combobox.setAttribute('dir', 'ltr');
-    combobox.open();
-    expect(firstItem.getAttribute('dir')).to.eql('ltr');
+      it('should preserve and propagate dir to the items', () => {
+        comboBox.close();
+        comboBox.setAttribute('dir', 'ltr');
+        comboBox.open();
+        expect(firstItem.getAttribute('dir')).to.eql('ltr');
+      });
+    });
   });
 });

--- a/packages/vaadin-combo-box/test/toggling-dropdown.test.js
+++ b/packages/vaadin-combo-box/test/toggling-dropdown.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { aTimeout, click, fixtureSync, focusout } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-template-renderer';
 import { createEventSpy, fireDownUpClick, TOUCH_DEVICE } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';

--- a/packages/vaadin-template-renderer/src/vaadin-template-renderer-templatizer.js
+++ b/packages/vaadin-template-renderer/src/vaadin-template-renderer-templatizer.js
@@ -12,49 +12,48 @@ export class Templatizer extends PolymerElement {
     return 'vaadin-template-renderer-templatizer';
   }
 
-  static get properties() {
-    return {
-      __template: Object,
-      __TemplateClass: Object,
-      __templateInstance: Object
-    };
+  constructor() {
+    super();
+
+    this.__template = null;
+    this.__TemplateClass = null;
+    this.__templateInstances = new Set();
   }
 
-  /**
-   * @public
-   */
-  render(element) {
-    // TODO: Support creating multiple instances of the template
-    if (!this.__templateInstance) {
-      this.__createTemplateInstance();
-
-      element.__templateInstance = this.__templateInstance;
-      element.replaceChildren(this.__templateInstance.root);
-    }
-  }
-
-  /**
-   * @private
-   */
-  __createTemplateInstance() {
-    this.__createTemplateClass();
-
-    this.__templateInstance = new this.__TemplateClass();
-  }
-
-  /**
-   * @private
-   */
-  __createTemplateClass() {
-    if (this.__TemplateClass) {
+  render(element, properties) {
+    // If the template instance exists and has been instantiated by this templatizer,
+    // it only re-renders the instance with the new properties.
+    if (this.__templateInstances.has(element.__templateInstance)) {
+      element.__templateInstance.setProperties(properties);
       return;
     }
 
+    // Otherwise, it instantiates a new template instance
+    // with the given properties and then renders the result to the element
+    const templateInstance = this.__createTemplateInstance(properties);
+    element.innerHTML = '';
+    element.__templateInstance = templateInstance;
+    element.appendChild(templateInstance.root);
+  }
+
+  __createTemplateInstance(properties) {
+    this.__createTemplateClass();
+
+    const instance = new this.__TemplateClass(properties);
+    this.__templateInstances.add(instance);
+    return instance;
+  }
+
+  __createTemplateClass() {
+    if (this.__TemplateClass) return;
+
     this.__TemplateClass = templatize(this.__template, this, {
+      // When changing a property of the data host component, this callback forwards
+      // the changed property to the template instances so that cause their re-rendering.
       forwardHostProp(prop, value) {
-        if (this.__templateInstance) {
-          this.__templateInstance.forwardHostProp(prop, value);
-        }
+        this.__templateInstances.forEach((instance) => {
+          instance.forwardHostProp(prop, value);
+        });
       }
     });
   }

--- a/packages/vaadin-template-renderer/src/vaadin-template-renderer-templatizer.js
+++ b/packages/vaadin-template-renderer/src/vaadin-template-renderer-templatizer.js
@@ -20,7 +20,7 @@ export class Templatizer extends PolymerElement {
     this.__templateInstances = new Set();
   }
 
-  render(element, properties) {
+  render(element, properties = {}) {
     // If the template instance exists and has been instantiated by this templatizer,
     // it only re-renders the instance with the new properties.
     if (this.__templateInstances.has(element.__templateInstance)) {
@@ -37,17 +37,25 @@ export class Templatizer extends PolymerElement {
   }
 
   __createTemplateInstance(properties) {
-    this.__createTemplateClass();
+    this.__createTemplateClass(properties);
 
     const instance = new this.__TemplateClass(properties);
     this.__templateInstances.add(instance);
     return instance;
   }
 
-  __createTemplateClass() {
+  __createTemplateClass(properties) {
     if (this.__TemplateClass) return;
 
+    const instanceProps = Object.keys(properties).reduce((accum, key) => {
+      return { ...accum, [key]: true };
+    }, {});
+
     this.__TemplateClass = templatize(this.__template, this, {
+      // This property prevents the template instance properties
+      // from passing into the `forwardHostProp` callback
+      instanceProps,
+
       // When changing a property of the data host component, this callback forwards
       // the changed property to the template instances so that cause their re-rendering.
       forwardHostProp(prop, value) {

--- a/packages/vaadin-template-renderer/src/vaadin-template-renderer.js
+++ b/packages/vaadin-template-renderer/src/vaadin-template-renderer.js
@@ -4,9 +4,9 @@ import { Templatizer } from './vaadin-template-renderer-templatizer.js';
 function createRenderer(template) {
   const templatizer = Templatizer.create(template);
 
-  return (root) => {
+  return (root, _owner, model) => {
     template.__templatizer = templatizer;
-    template.__templatizer.render(root);
+    template.__templatizer.render(root, model);
   };
 }
 

--- a/packages/vaadin-template-renderer/test/list.test.js
+++ b/packages/vaadin-template-renderer/test/list.test.js
@@ -1,0 +1,75 @@
+import sinon from 'sinon';
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, fire, click } from '@vaadin/testing-helpers';
+
+import '../vaadin-template-renderer.js';
+
+import './x-list-host.js';
+import './x-list.js';
+
+describe('list', () => {
+  let host, list, template;
+
+  function getItemText(item) {
+    return item.querySelector('.item-text').textContent;
+  }
+
+  function getItemValueText(item) {
+    return item.querySelector('.value-text').textContent;
+  }
+
+  beforeEach(() => {
+    host = fixtureSync(`<x-list-host></x-list-host>`);
+    list = host.$.list;
+    template = host.$.list.querySelector('template');
+  });
+
+  it('should render the list', () => {
+    expect(list.$.items.children).to.have.lengthOf(2);
+    expect(getItemText(list.$.items.children[0])).to.equal('item1');
+    expect(getItemText(list.$.items.children[1])).to.equal('item2');
+  });
+
+  it('should handle events from the template instances', () => {
+    const spy = sinon.spy(host, 'onClick');
+
+    const button0 = list.$.items.children[0].querySelector('button');
+    const button1 = list.$.items.children[1].querySelector('button');
+
+    click(button0);
+    click(button1);
+
+    expect(spy.calledTwice).to.be.true;
+  });
+
+  it('should re-render the list when removing an item', () => {
+    host.items = ['item1'];
+
+    expect(list.$.items.children).to.have.lengthOf(1);
+    expect(getItemText(list.$.items.children[0])).to.equal('item1');
+  });
+
+  it('should create a template instance for each item', () => {
+    const templateInstance0 = list.$.items.children[0].__templateInstance;
+    const templateInstance1 = list.$.items.children[1].__templateInstance;
+
+    expect(template.__templatizer.__templateInstances).to.include(templateInstance0);
+    expect(template.__templatizer.__templateInstances).to.include(templateInstance1);
+  });
+
+  it('should support the 2-way property binding', () => {
+    const input = list.$.items.children[0].querySelector('input');
+
+    input.value = 'foobar';
+    fire(input, 'input');
+
+    expect(host.value).to.equal('foobar');
+  });
+
+  it('should re-render the template instances when changing a parent property', () => {
+    host.value = 'foobar';
+
+    expect(getItemValueText(list.$.items.children[0])).to.equal('foobar');
+    expect(getItemValueText(list.$.items.children[1])).to.equal('foobar');
+  });
+});

--- a/packages/vaadin-template-renderer/test/list.test.js
+++ b/packages/vaadin-template-renderer/test/list.test.js
@@ -72,4 +72,11 @@ describe('list', () => {
     expect(getItemValueText(list.$.items.children[0])).to.equal('foobar');
     expect(getItemValueText(list.$.items.children[1])).to.equal('foobar');
   });
+
+  it('should re-render the template instances when changing items', () => {
+    host.items = ['foo', 'bar'];
+
+    expect(getItemText(list.$.items.children[0])).to.equal('foo');
+    expect(getItemText(list.$.items.children[1])).to.equal('bar');
+  });
 });

--- a/packages/vaadin-template-renderer/test/x-component-host.js
+++ b/packages/vaadin-template-renderer/test/x-component-host.js
@@ -2,7 +2,7 @@ import { PolymerElement, html } from '@polymer/polymer';
 
 import './x-component.js';
 
-export class XPolymerHost extends PolymerElement {
+export class XComponentHost extends PolymerElement {
   static get template() {
     return html`
       <x-component id="component">
@@ -24,4 +24,4 @@ export class XPolymerHost extends PolymerElement {
   onClick() {}
 }
 
-customElements.define('x-polymer-host', XPolymerHost);
+customElements.define('x-component-host', XComponentHost);

--- a/packages/vaadin-template-renderer/test/x-component.js
+++ b/packages/vaadin-template-renderer/test/x-component.js
@@ -3,15 +3,16 @@ export class XComponent extends HTMLElement {
     super();
     this.attachShadow({ mode: 'open' });
     this.shadowRoot.innerHTML = `<div id="content"></div>`;
-    this.__content = this.shadowRoot.querySelector('#content');
   }
 
   connectedCallback() {
     window.Vaadin.templateRendererCallback?.(this);
   }
 
-  get content() {
-    return this.__content;
+  get $() {
+    return {
+      content: this.shadowRoot.querySelector('#content')
+    };
   }
 
   set renderer(renderer) {
@@ -20,7 +21,7 @@ export class XComponent extends HTMLElement {
   }
 
   render() {
-    this.__renderer?.(this.__content);
+    this.__renderer?.(this.$.content);
   }
 }
 

--- a/packages/vaadin-template-renderer/test/x-list-host.js
+++ b/packages/vaadin-template-renderer/test/x-list-host.js
@@ -1,0 +1,38 @@
+import { PolymerElement, html } from '@polymer/polymer';
+
+import './x-list.js';
+
+export class XListHost extends PolymerElement {
+  static get template() {
+    return html`
+      <x-list id="list" items="[[items]]">
+        <template>
+          <div class="item-text">[[item]]</div>
+
+          <div class="value-text">[[value]]</div>
+
+          <input value="{{value::input}}" />
+
+          <button on-click="onClick"></button>
+        </template>
+      </x-list>
+    `;
+  }
+
+  static get properties() {
+    return {
+      value: String,
+
+      items: {
+        type: Array,
+        value() {
+          return ['item1', 'item2'];
+        }
+      }
+    };
+  }
+
+  onClick() {}
+}
+
+customElements.define('x-list-host', XListHost);

--- a/packages/vaadin-template-renderer/test/x-list.js
+++ b/packages/vaadin-template-renderer/test/x-list.js
@@ -34,13 +34,15 @@ export class XList extends HTMLElement {
   render() {
     if (!this.__renderer) return;
 
-    this.$.items.innerHTML = '';
+    const children = this.items.map((item, index) => {
+      const root = this.$.items.children[index] ?? document.createElement('div');
 
-    this.items.forEach((item) => {
-      const root = document.createElement('div');
       this.__renderer(root, this, { item });
-      this.$.items.appendChild(root);
+
+      return root;
     });
+
+    this.$.items.replaceChildren(...children);
   }
 }
 

--- a/packages/vaadin-template-renderer/test/x-list.js
+++ b/packages/vaadin-template-renderer/test/x-list.js
@@ -1,0 +1,47 @@
+export class XList extends HTMLElement {
+  constructor() {
+    super();
+
+    this.__items = [];
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `<div id="items"></div>`;
+  }
+
+  connectedCallback() {
+    window.Vaadin.templateRendererCallback?.(this);
+  }
+
+  set renderer(renderer) {
+    this.__renderer = renderer;
+    this.render();
+  }
+
+  get items() {
+    return this.__items;
+  }
+
+  set items(items) {
+    this.__items = items;
+    this.render();
+  }
+
+  get $() {
+    return {
+      items: this.shadowRoot.querySelector('#items')
+    };
+  }
+
+  render() {
+    if (!this.__renderer) return;
+
+    this.$.items.innerHTML = '';
+
+    this.items.forEach((item) => {
+      const root = document.createElement('div');
+      this.__renderer(root, this, { item });
+      this.$.items.appendChild(root);
+    });
+  }
+}
+
+customElements.define('x-list', XList);


### PR DESCRIPTION
## Description

- [x] Supports creating multiple instances of the Polymer template for `vaadin-template-renderer`
- [x] Removes the Polymer Template API from `vaadin-combo-box`

Part of #256

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
