### PR TITLE
chore: add version to release notes [skip ci]

### DIFF
--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -235,6 +235,7 @@ function logCommitsByType(commits) {
 
 // Output the release notes for the set of commits
 function generateReleaseNotes(commits) {
+  console.log(`${to}\n`);
   console.log(`[API Documentation →](https://cdn.vaadin.com/vaadin-web-components/${version}/)\n`);
   if (commits.length) {
     console.log(`### Changes Since [${from}](https://github.com/vaadin/vaadin-web-components/releases/tag/${from})`);


### PR DESCRIPTION
## Description

Current script lacks the title for the release which has to be the [text up to the first blank line](https://github.com/github/hub/blob/c8e68d548a39ec0fab6f674a669c21b54d4eec61/commands/release.go#L80):

```
The text up to the first blank line in <MESSAGE> is treated as the release
title, and the rest is used as release description in Markdown format.
```

## Type of change

- [x] Internal change