### PR TITLE
docs:  fix time-picker `step` property API docs [skip ci]

### DIFF
--- a/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.js
@@ -278,8 +278,8 @@ class DateTimePickerElement extends ElementMixin(ThemableMixin(PolymerElement)) 
       },
 
       /**
-       * Specifies the number of valid intervals in a day used for
-       * configuring the items displayed in the time selection box.
+       * Defines the time interval (in seconds) between the items displayed
+       * in the time selection box. The default is 1 hour (i.e. `3600`).
        *
        * It also configures the precision of the time part of the value string. By default
        * the component formats time values as `hh:mm` but setting a step value

--- a/packages/vaadin-time-picker/src/vaadin-time-picker.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker.js
@@ -280,8 +280,8 @@ class TimePickerElement extends ElementMixin(ControlStateMixin(ThemableMixin(Pol
       },
 
       /**
-       * Specifies the number of valid intervals in a day used for
-       * configuring the items displayed in the selection box.
+       * Defines the time interval (in seconds) between the items displayed
+       * in the time selection box. The default is 1 hour (i.e. `3600`).
        *
        * It also configures the precision of the value string. By default
        * the component formats values as `hh:mm` but setting a step value


### PR DESCRIPTION
## Description

Clarifies the description of the `step` property in vaadin-date-time-picker and vaadin-time-picker components to make it clear that it's a number of seconds between steps, not the number of steps in a day.

Fixes #254

Related PR to update the docs: https://github.com/vaadin/docs/pull/424

## Type of change

- [x] Bugfix
- [ ] Feature