### PR TITLE
docs: align Styling Components links [skip ci]

### DIFF
--- a/packages/vaadin-accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/vaadin-accordion/src/vaadin-accordion-panel.d.ts
@@ -23,7 +23,7 @@ import { DetailsElement } from '@vaadin/vaadin-details/src/vaadin-details.js';
  * `focus-ring` | Set when the element is focused using the keyboard.
  * `focused`    | Set when the element is focused.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */

--- a/packages/vaadin-accordion/src/vaadin-accordion-panel.js
+++ b/packages/vaadin-accordion/src/vaadin-accordion-panel.js
@@ -28,7 +28,7 @@ import { DetailsElement } from '@vaadin/vaadin-details/src/vaadin-details.js';
  * `focus-ring` | Set when the element is focused using the keyboard.
  * `focused`    | Set when the element is focused.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */

--- a/packages/vaadin-accordion/src/vaadin-accordion.d.ts
+++ b/packages/vaadin-accordion/src/vaadin-accordion.d.ts
@@ -61,7 +61,7 @@ export type AccordionEventMap = HTMLElementEventMap & AccordionElementEventMap;
  * }
  * ```
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.

--- a/packages/vaadin-accordion/src/vaadin-accordion.js
+++ b/packages/vaadin-accordion/src/vaadin-accordion.js
@@ -48,7 +48,7 @@ import { AccordionPanelElement } from './vaadin-accordion-panel.js';
  * }
  * ```
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.

--- a/packages/vaadin-app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/vaadin-app-layout/src/vaadin-app-layout.d.ts
@@ -70,7 +70,7 @@ export type AppLayoutEventMap = HTMLElementEventMap & AppLayoutElementEventMap;
  * `drawer`      | Container for the drawer area
  * `content`     | Container for page content.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Component's slots
  *

--- a/packages/vaadin-app-layout/src/vaadin-app-layout.js
+++ b/packages/vaadin-app-layout/src/vaadin-app-layout.js
@@ -56,7 +56,7 @@ import './detect-ios-navbar.js';
  * `drawer`      | Container for the drawer area
  * `content`     | Container for page content.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Component's slots
  *

--- a/packages/vaadin-avatar/src/vaadin-avatar-group.d.ts
+++ b/packages/vaadin-avatar/src/vaadin-avatar-group.d.ts
@@ -31,7 +31,7 @@ import { AvatarGroupItem, AvatarGroupI18n } from './interfaces';
  * `container` | The container element
  * `avatar`    | Individual avatars
  *
- * See [Styling Components](https://vaadin.com/docs/v14/themes/styling-components.html) documentation.
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-avatar/src/vaadin-avatar-group.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar-group.js
@@ -47,7 +47,7 @@ const MINIMUM_DISPLAYED_AVATARS = 2;
  * `container` | The container element
  * `avatar`    | Individual avatars
  *
- * See [Styling Components](https://vaadin.com/docs/v14/themes/styling-components.html) documentation.
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-avatar/src/vaadin-avatar.d.ts
+++ b/packages/vaadin-avatar/src/vaadin-avatar.d.ts
@@ -26,7 +26,7 @@ import { AvatarI18n } from './interfaces';
  * --------- | -----------
  * `has-color-index` | Set when the avatar has `colorIndex` and the corresponding custom CSS property exists.
  *
- * See [Styling Components](https://vaadin.com/docs/v14/themes/styling-components.html) documentation.
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  */
 declare class AvatarElement extends ElementMixin(ThemableMixin(HTMLElement)) {
   /**

--- a/packages/vaadin-avatar/src/vaadin-avatar.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar.js
@@ -52,7 +52,7 @@ window.addEventListener(
  * --------- | -----------
  * `has-color-index` | Set when the avatar has `colorIndex` and the corresponding custom CSS property exists.
  *
- * See [Styling Components](https://vaadin.com/docs/v14/themes/styling-components.html) documentation.
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/vaadin-button/src/vaadin-button.d.ts
+++ b/packages/vaadin-button/src/vaadin-button.d.ts
@@ -38,7 +38,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `focus-ring` | Set when the button is focused using the keyboard.
  * `focused` | Set when the button is focused.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  */
 declare class ButtonElement extends ElementMixin(ControlStateMixin(ThemableMixin(GestureEventListeners(HTMLElement)))) {
   readonly focusElement: Element | null;

--- a/packages/vaadin-button/src/vaadin-button.js
+++ b/packages/vaadin-button/src/vaadin-button.js
@@ -42,7 +42,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `focus-ring` | Set when the button is focused using the keyboard.
  * `focused` | Set when the button is focused.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/vaadin-checkbox/src/vaadin-checkbox-group.d.ts
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox-group.d.ts
@@ -56,7 +56,7 @@ export interface CheckboxGroupEventMap extends HTMLElementEventMap, CheckboxGrou
  * `required` | Set when the element is required | :host
  * `invalid` | Set when the element is invalid | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.

--- a/packages/vaadin-checkbox/src/vaadin-checkbox-group.js
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox-group.js
@@ -43,7 +43,7 @@ import { CheckboxElement } from './vaadin-checkbox.js';
  * `required` | Set when the element is required | :host
  * `invalid` | Set when the element is invalid | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.

--- a/packages/vaadin-checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox.d.ts
@@ -54,7 +54,7 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxElementEv
  * `checked` | Set when the checkbox is checked. | `:host`
  * `empty` | Set when there is no label provided. | `label`
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.

--- a/packages/vaadin-checkbox/src/vaadin-checkbox.js
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox.js
@@ -39,7 +39,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `checked` | Set when the checkbox is checked. | `:host`
  * `empty` | Set when there is no label provided. | `label`
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
@@ -25,7 +25,7 @@ import { DirMixin } from '@vaadin/vaadin-element-mixin/vaadin-dir-mixin.js';
  * `selected` | Set when the item is selected | :host
  * `focused` | Set when the item is focused | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @mixes ThemableMixin
  * @private

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.d.ts
@@ -159,7 +159,7 @@ import { ComboBoxEventMap } from './interfaces';
  * Note: the `theme` attribute value set on `<vaadin-combo-box>` is
  * propagated to the internal components listed above.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} custom-value-set - Fired when the user sets a custom value.

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.js
@@ -159,7 +159,7 @@ import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixi
  * Note: the `theme` attribute value set on `<vaadin-combo-box>` is
  * propagated to the internal components listed above.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} custom-value-set - Fired when the user sets a custom value.

--- a/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -38,7 +38,7 @@ export type ConfirmDialogEventMap = HTMLElementEventMap & ConfirmDialogElementEv
  * `message`  | Container for the message of the dialog
  * `footer`   | Container for the buttons
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Custom content
  *

--- a/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js
@@ -29,7 +29,7 @@ import '@vaadin/vaadin-dialog/src/vaadin-dialog.js';
  * `message`  | Container for the message of the dialog
  * `footer`   | Container for the buttons
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Custom content
  *

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
@@ -211,7 +211,7 @@ import { ContextMenuEventMap, ContextMenuRenderer } from './interfaces';
  * See [`<vaadin-overlay>`](#/elements/vaadin-overlay)
  * documentation for `<vaadin-context-menu-overlay>` stylable parts.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.js
@@ -218,7 +218,7 @@ import './vaadin-context-menu-overlay.js';
  * See [`<vaadin-overlay>`](#/elements/vaadin-overlay)
  * documentation for `<vaadin-context-menu-overlay>` stylable parts.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-crud/src/vaadin-crud.d.ts
+++ b/packages/vaadin-crud/src/vaadin-crud.d.ts
@@ -96,7 +96,7 @@ import { CrudDataProvider, CrudEditorPosition, CrudEventMap, CrudI18n } from './
  * --vaadin-crud-editor-max-height | max height of editor when opened on the bottom | 40%
  * --vaadin-crud-editor-max-width | max width of editor when opened on the side | 40%
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} editor-opened-changed - Fired when the `editorOpened` property changes.
  * @fires {CustomEvent} edited-item-changed - Fired when `editedItem` property changes.

--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -109,7 +109,7 @@ import './vaadin-crud-form.js';
  * --vaadin-crud-editor-max-height | max height of editor when opened on the bottom | 40%
  * --vaadin-crud-editor-max-width | max width of editor when opened on the side | 40%
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} editor-opened-changed - Fired when the `editorOpened` property changes.
  * @fires {CustomEvent} edited-item-changed - Fired when `editedItem` property changes.

--- a/packages/vaadin-custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/vaadin-custom-field/src/vaadin-custom-field.d.ts
@@ -38,7 +38,7 @@ import { CustomFieldEventMap } from './interfaces';
  * `invalid`    | Set when the field is invalid | :host
  * `focused`    | Set when the field contains focus | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change for any of the internal inputs.
  * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.

--- a/packages/vaadin-custom-field/src/vaadin-custom-field.js
+++ b/packages/vaadin-custom-field/src/vaadin-custom-field.js
@@ -40,7 +40,7 @@ import { CustomFieldMixin } from './vaadin-custom-field-mixin.js';
  * `invalid`    | Set when the field is invalid | :host
  * `focused`    | Set when the field contains focus | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change for any of the internal inputs.
  * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.

--- a/packages/vaadin-date-picker/src/vaadin-date-picker-light.d.ts
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker-light.d.ts
@@ -27,7 +27,7 @@ import { DatePickerEventMap } from './interfaces';
  * ----------------|----------------|----------------
  * `overlay-content` | The overlay element | vaadin-date-picker-light
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * In addition to `<vaadin-date-picker-light>` itself, the following
  * internal components are themable:

--- a/packages/vaadin-date-picker/src/vaadin-date-picker-light.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker-light.js
@@ -34,7 +34,7 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * ----------------|----------------|----------------
  * `overlay-content` | The overlay element | vaadin-date-picker-light
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * In addition to `<vaadin-date-picker-light>` itself, the following
  * internal components are themable:

--- a/packages/vaadin-date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker.d.ts
@@ -52,7 +52,7 @@ import { DatePickerEventMap } from './interfaces';
  * `week-number` | Week number element | vaadin-month-calendar
  * `date` | Date element | vaadin-month-calendar
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * The following state attributes are available for styling:
  *

--- a/packages/vaadin-date-picker/src/vaadin-date-picker.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker.js
@@ -57,7 +57,7 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
  * `week-number` | Week number element | vaadin-month-calendar
  * `date` | Date element | vaadin-month-calendar
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * The following state attributes are available for styling:
  *

--- a/packages/vaadin-details/src/vaadin-details.d.ts
+++ b/packages/vaadin-details/src/vaadin-details.d.ts
@@ -46,7 +46,7 @@ export type DetailsEventMap = HTMLElementEventMap & DetailsElementEventMap;
  * `focus-ring` | Set when the element is focused using the keyboard.
  * `focused`    | Set when the element is focused.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */

--- a/packages/vaadin-details/src/vaadin-details.js
+++ b/packages/vaadin-details/src/vaadin-details.js
@@ -39,7 +39,7 @@ import { ControlStateMixin } from '@vaadin/vaadin-control-state-mixin/vaadin-con
  * `focus-ring` | Set when the element is focused using the keyboard.
  * `focused`    | Set when the element is focused.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  *

--- a/packages/vaadin-dialog/src/vaadin-dialog.d.ts
+++ b/packages/vaadin-dialog/src/vaadin-dialog.d.ts
@@ -46,7 +46,7 @@ import { DialogEventMap, DialogRenderer } from './interfaces';
  * Note: the `theme` attribute value set on `<vaadin-dialog>` is
  * propagated to the internal `<vaadin-dialog-overlay>` component.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -160,7 +160,7 @@ customElements.define(DialogOverlayElement.is, DialogOverlayElement);
  * Note: the `theme` attribute value set on `<vaadin-dialog>` is
  * propagated to the internal `<vaadin-dialog-overlay>` component.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.

--- a/packages/vaadin-form-layout/src/vaadin-form-item.d.ts
+++ b/packages/vaadin-form-layout/src/vaadin-form-item.d.ts
@@ -90,7 +90,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `--vaadin-form-item-label-spacing` | Spacing between the label column and the input column when the labels are aside | `1em`
  * `--vaadin-form-item-row-spacing` | Height of the spacing between the form item elements | `1em`
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  */
 declare class FormItemElement extends ThemableMixin(HTMLElement) {}
 

--- a/packages/vaadin-form-layout/src/vaadin-form-item.js
+++ b/packages/vaadin-form-layout/src/vaadin-form-item.js
@@ -96,7 +96,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `--vaadin-form-item-label-spacing` | Spacing between the label column and the input column when the labels are aside | `1em`
  * `--vaadin-form-item-row-spacing` | Height of the spacing between the form item elements | `1em`
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @extends HTMLElement
  * @mixes ThemableMixin

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -328,7 +328,7 @@ export interface GridEventMap<TItem> extends HTMLElementEventMap, GridElementEve
  * `drag-disabled` | Set to a row that isn't available for dragging | row
  * `drop-disabled` | Set to a row that can't be dropped on top of | row
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} active-item-changed - Fired when the `activeItem` property changes.
  * @fires {CustomEvent} cell-activate - Fired when the cell is activated with click or keyboard.

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -249,7 +249,7 @@ const TOUCH_DEVICE = (() => {
  * `drag-disabled` | Set to a row that isn't available for dragging | row
  * `drop-disabled` | Set to a row that can't be dropped on top of | row
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} active-item-changed - Fired when the `activeItem` property changes.
  * @fires {CustomEvent} cell-activate - Fired when the cell is activated with click or keyboard.

--- a/packages/vaadin-list-box/src/vaadin-list-box.d.ts
+++ b/packages/vaadin-list-box/src/vaadin-list-box.d.ts
@@ -49,7 +49,7 @@ export interface ListBoxEventMap extends HTMLElementEventMap, ListBoxElementEven
  * ------------------|------------------------
  * `items`           | The items container
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.

--- a/packages/vaadin-list-box/src/vaadin-list-box.js
+++ b/packages/vaadin-list-box/src/vaadin-list-box.js
@@ -28,7 +28,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * ------------------|------------------------
  * `items`           | The items container
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.

--- a/packages/vaadin-login/src/vaadin-login-form.d.ts
+++ b/packages/vaadin-login/src/vaadin-login-form.d.ts
@@ -34,7 +34,7 @@ import { LoginEventMap } from './interfaces';
  * `error-message-description` | Container for error message description
  * `footer`  | Container additional information text from `i18n` object
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.

--- a/packages/vaadin-login/src/vaadin-login-form.js
+++ b/packages/vaadin-login/src/vaadin-login-form.js
@@ -40,7 +40,7 @@ import './vaadin-login-form-wrapper.js';
  * `error-message-description` | Container for error message description
  * `footer`  | Container additional information text from `i18n` object
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.

--- a/packages/vaadin-login/src/vaadin-login-overlay.d.ts
+++ b/packages/vaadin-login/src/vaadin-login-overlay.d.ts
@@ -28,7 +28,7 @@ import { LoginEventMap } from './interfaces';
  * `brand`         | Container for application title and description
  * `form`          | Container for the `<vaadin-login-form>` component
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * See [`<vaadin-login-form>`](#/elements/vaadin-login-form)
  * documentation for  `<vaadin-login-form-wrapper>` stylable parts.

--- a/packages/vaadin-login/src/vaadin-login-overlay.js
+++ b/packages/vaadin-login/src/vaadin-login-overlay.js
@@ -33,7 +33,7 @@ import './vaadin-login-overlay-wrapper.js';
  * `brand`         | Container for application title and description
  * `form`          | Container for the `<vaadin-login-form>` component
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * See [`<vaadin-login-form>`](#/elements/vaadin-login-form)
  * documentation for  `<vaadin-login-form-wrapper>` stylable parts.

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar.d.ts
@@ -35,7 +35,7 @@ import { MenuBarEventMap, MenuBarItem } from './interfaces';
  * `menu-bar-button` | The menu bar button.
  * `overflow-button` | The "overflow" button appearing when menu bar width is not enough to fit all the buttons.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
@@ -38,7 +38,7 @@ import './vaadin-menu-bar-button.js';
  * `menu-bar-button` | The menu bar button.
  * `overflow-button` | The "overflow" button appearing when menu bar width is not enough to fit all the buttons.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-messages/src/vaadin-message-list.d.ts
+++ b/packages/vaadin-messages/src/vaadin-message-list.d.ts
@@ -36,7 +36,7 @@ export interface MessageListItem {
  * ----------|----------------
  * `list`    | The container wrapping messages.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  */
 declare class MessageListElement extends ThemableMixin(ElementMixin(HTMLElement)) {
   /**

--- a/packages/vaadin-messages/src/vaadin-message-list.js
+++ b/packages/vaadin-messages/src/vaadin-message-list.js
@@ -34,7 +34,7 @@ import './vaadin-message.js';
  * ----------|----------------
  * `list`    | The container wrapping messages.
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @extends HTMLElement
  * @mixes ThemableMixin

--- a/packages/vaadin-messages/src/vaadin-message.d.ts
+++ b/packages/vaadin-messages/src/vaadin-message.d.ts
@@ -23,7 +23,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `time`    | When the message was posted
  * `content` | The message itself as a slotted content
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-messages/src/vaadin-message.js
+++ b/packages/vaadin-messages/src/vaadin-message.js
@@ -28,7 +28,7 @@ import './vaadin-message-avatar.js';
  * `time`    | When the message was posted
  * `content` | The message itself as a slotted content
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-notification/src/vaadin-notification.d.ts
+++ b/packages/vaadin-notification/src/vaadin-notification.d.ts
@@ -76,7 +76,7 @@ declare class NotificationCard extends ThemableMixin(HTMLElement) {}
  * `overlay` | The notification container
  * `content` | The content of the notification
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * Note: the `theme` attribute value set on `<vaadin-notification>` is
  * propagated to the internal `<vaadin-notification-card>`.

--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -241,7 +241,7 @@ class NotificationCard extends ThemableMixin(PolymerElement) {
  * `overlay` | The notification container
  * `content` | The content of the notification
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * Note: the `theme` attribute value set on `<vaadin-notification>` is
  * propagated to the internal `<vaadin-notification-card>`.

--- a/packages/vaadin-overlay/src/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay.d.ts
@@ -91,7 +91,7 @@ import { OverlayEventMap, OverlayRenderer } from './interfaces';
  * ---|---|---
  * `--vaadin-overlay-viewport-bottom` | Bottom offset of the visible viewport area | `0` or detected offset
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -99,7 +99,7 @@ import { FocusablesHelper } from './vaadin-focusables-helper.js';
  * ---|---|---
  * `--vaadin-overlay-viewport-bottom` | Bottom offset of the visible viewport area | `0` or detected offset
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  *

--- a/packages/vaadin-progress-bar/src/vaadin-progress-bar.d.ts
+++ b/packages/vaadin-progress-bar/src/vaadin-progress-bar.d.ts
@@ -21,7 +21,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `bar` | Progress-bar's background
  * `value` | Progress-bar's foreground
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * The following custom properties are available:
  *

--- a/packages/vaadin-progress-bar/src/vaadin-progress-bar.js
+++ b/packages/vaadin-progress-bar/src/vaadin-progress-bar.js
@@ -25,7 +25,7 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  * `bar` | Progress-bar's background
  * `value` | Progress-bar's foreground
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * The following custom properties are available:
  *

--- a/packages/vaadin-radio-button/src/vaadin-radio-button.d.ts
+++ b/packages/vaadin-radio-button/src/vaadin-radio-button.d.ts
@@ -43,7 +43,7 @@ export interface RadioButtonEventMap extends HTMLElementEventMap, RadioButtonEle
  * `checked`    | Set when the radio button is checked. | :host
  * `empty`      | Set when there is no label provided. | label
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.

--- a/packages/vaadin-radio-button/src/vaadin-radio-button.js
+++ b/packages/vaadin-radio-button/src/vaadin-radio-button.js
@@ -35,7 +35,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `checked`    | Set when the radio button is checked. | :host
  * `empty`      | Set when there is no label provided. | label
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.

--- a/packages/vaadin-radio-button/src/vaadin-radio-group.d.ts
+++ b/packages/vaadin-radio-button/src/vaadin-radio-group.d.ts
@@ -55,7 +55,7 @@ export interface RadioGroupEventMap extends HTMLElementEventMap, RadioGroupEleme
  * `has-error-message` | Set when the element has an error message, regardless if the field is valid or not | :host
  * `focused` | Set when the element contains focus | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.

--- a/packages/vaadin-radio-button/src/vaadin-radio-group.js
+++ b/packages/vaadin-radio-button/src/vaadin-radio-group.js
@@ -42,7 +42,7 @@ import { RadioButtonElement } from './vaadin-radio-button.js';
  * `has-error-message` | Set when the element has an error message, regardless if the field is valid or not | :host
  * `focused` | Set when the element contains focus | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.

--- a/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.d.ts
+++ b/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.d.ts
@@ -66,7 +66,7 @@ import { RichTextEditorEventMap, RichTextEditorI18n } from './interfaces';
  * `toolbar-button-code-block`          | The "code block" button
  * `toolbar-button-clean`               | The "clean formatting" button
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} html-value-changed - Fired when the `htmlValue` property changes.

--- a/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
@@ -108,7 +108,7 @@ const TAB_KEY = 9;
  * `toolbar-button-code-block`          | The "code block" button
  * `toolbar-button-clean`               | The "clean formatting" button
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} html-value-changed - Fired when the `htmlValue` property changes.

--- a/packages/vaadin-select/src/vaadin-select.d.ts
+++ b/packages/vaadin-select/src/vaadin-select.d.ts
@@ -88,7 +88,7 @@ import { SelectEventMap, SelectRenderer } from './interfaces';
  * --- | --- | ---
  * `--vaadin-select-text-field-width` | Width of the select text field | `vaadin-select-overlay`
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-select/src/vaadin-select.js
+++ b/packages/vaadin-select/src/vaadin-select.js
@@ -110,7 +110,7 @@ document.head.appendChild($_documentContainer.content);
  * --- | --- | ---
  * `--vaadin-select-text-field-width` | Width of the select text field | `vaadin-select-overlay`
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
  *

--- a/packages/vaadin-split-layout/src/vaadin-split-layout.d.ts
+++ b/packages/vaadin-split-layout/src/vaadin-split-layout.d.ts
@@ -151,7 +151,7 @@ export interface SplitLayoutEventMap extends HTMLElementEventMap, SplitLayoutEle
  * `splitter` | Split element | vaadin-split-layout
  * `handle` | The handle of the splitter | vaadin-split-layout
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} splitter-dragend - Fired after dragging the splitter have ended.
  */

--- a/packages/vaadin-split-layout/src/vaadin-split-layout.js
+++ b/packages/vaadin-split-layout/src/vaadin-split-layout.js
@@ -145,7 +145,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `splitter` | Split element | vaadin-split-layout
  * `handle` | The handle of the splitter | vaadin-split-layout
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} splitter-dragend - Fired after dragging the splitter have ended.
  *

--- a/packages/vaadin-tabs/src/vaadin-tab.d.ts
+++ b/packages/vaadin-tabs/src/vaadin-tab.d.ts
@@ -24,7 +24,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `active` | Set when mousedown or enter/spacebar pressed | :host
  * `orientation` | Set to `horizontal` or `vertical` depending on the direction of items  | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  */
 declare class TabElement extends ElementMixin(ThemableMixin(ItemMixin(HTMLElement))) {
   _onKeyup(event: KeyboardEvent): void;

--- a/packages/vaadin-tabs/src/vaadin-tab.js
+++ b/packages/vaadin-tabs/src/vaadin-tab.js
@@ -28,7 +28,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `active` | Set when mousedown or enter/spacebar pressed | :host
  * `orientation` | Set to `horizontal` or `vertical` depending on the direction of items  | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/vaadin-tabs/src/vaadin-tabs.d.ts
+++ b/packages/vaadin-tabs/src/vaadin-tabs.d.ts
@@ -53,7 +53,7 @@ export interface TabsEventMap extends HTMLElementEventMap, TabsElementEventMap {
  * `orientation` | Tabs disposition, valid values are `horizontal` and `vertical`. | :host
  * `overflow` | It's set to `start`, `end`, none or both. | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.

--- a/packages/vaadin-tabs/src/vaadin-tabs.js
+++ b/packages/vaadin-tabs/src/vaadin-tabs.js
@@ -41,7 +41,7 @@ import './vaadin-tab.js';
  * `orientation` | Tabs disposition, valid values are `horizontal` and `vertical`. | :host
  * `overflow` | It's set to `start`, `end`, none or both. | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.

--- a/packages/vaadin-text-field/src/vaadin-email-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-email-field.d.ts
@@ -12,7 +12,7 @@ import { TextFieldElement } from './vaadin-text-field.js';
  *
  * See vaadin-text-field.html for the styling documentation
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/vaadin-text-field/src/vaadin-email-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-email-field.d.ts
@@ -10,7 +10,7 @@ import { TextFieldElement } from './vaadin-text-field.js';
  *
  * ### Styling
  *
- * See vaadin-text-field.html for the styling documentation
+ * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *

--- a/packages/vaadin-text-field/src/vaadin-email-field.js
+++ b/packages/vaadin-text-field/src/vaadin-email-field.js
@@ -36,7 +36,7 @@ registerStyles(
  *
  * ### Styling
  *
- * See vaadin-text-field.html for the styling documentation
+ * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *

--- a/packages/vaadin-text-field/src/vaadin-email-field.js
+++ b/packages/vaadin-text-field/src/vaadin-email-field.js
@@ -38,7 +38,7 @@ registerStyles(
  *
  * See vaadin-text-field.html for the styling documentation
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/vaadin-text-field/src/vaadin-password-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-password-field.d.ts
@@ -10,7 +10,7 @@ import { TextFieldElement } from './vaadin-text-field.js';
  *
  * ### Styling
  *
- * See vaadin-text-field.html for the styling documentation
+ * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
  *
  * In addition to vaadin-text-field parts, here's the list of vaadin-password-field specific parts
  *

--- a/packages/vaadin-text-field/src/vaadin-password-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-password-field.d.ts
@@ -24,7 +24,7 @@ import { TextFieldElement } from './vaadin-text-field.js';
  * -------------|-------------|------------
  * `password-visible` | Set when the password is visible | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/vaadin-text-field/src/vaadin-password-field.js
+++ b/packages/vaadin-text-field/src/vaadin-password-field.js
@@ -47,7 +47,7 @@ let memoizedTemplate;
  *
  * ### Styling
  *
- * See vaadin-text-field.html for the styling documentation
+ * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
  *
  * In addition to vaadin-text-field parts, here's the list of vaadin-password-field specific parts
  *

--- a/packages/vaadin-text-field/src/vaadin-password-field.js
+++ b/packages/vaadin-text-field/src/vaadin-password-field.js
@@ -61,7 +61,7 @@ let memoizedTemplate;
  * -------------|-------------|------------
  * `password-visible` | Set when the password is visible | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/vaadin-text-field/src/vaadin-text-area.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-text-area.d.ts
@@ -55,7 +55,7 @@ import { TextFieldEventMap } from './interfaces';
  * `focus-ring` | Set when the element is keyboard focused | :host
  * `readonly` | Set to a readonly text field | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/vaadin-text-field/src/vaadin-text-area.js
+++ b/packages/vaadin-text-field/src/vaadin-text-area.js
@@ -56,7 +56,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `focus-ring` | Set when the element is keyboard focused | :host
  * `readonly` | Set to a readonly text field | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/vaadin-text-field/src/vaadin-text-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-text-field.d.ts
@@ -62,7 +62,7 @@ import { TextFieldEventMap } from './interfaces';
  * `focus-ring` | Set when the element is keyboard focused | :host
  * `readonly` | Set to a readonly text field | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/vaadin-text-field/src/vaadin-text-field.js
+++ b/packages/vaadin-text-field/src/vaadin-text-field.js
@@ -63,7 +63,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  * `focus-ring` | Set when the element is keyboard focused | :host
  * `readonly` | Set to a readonly text field | :host
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/vaadin-time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker.d.ts
@@ -26,7 +26,7 @@ import { TimePickerEventMap, TimePickerI18n, TimePickerTime } from './interfaces
  * ----------------|----------------
  * `toggle-button` | The toggle button
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * The following state attributes are available for styling:
  *

--- a/packages/vaadin-time-picker/src/vaadin-time-picker.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker.js
@@ -30,7 +30,7 @@ import './vaadin-time-picker-text-field.js';
  * ----------------|----------------
  * `toggle-button` | The toggle button
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * The following state attributes are available for styling:
  *

--- a/packages/vaadin-upload/src/vaadin-upload-file.js
+++ b/packages/vaadin-upload/src/vaadin-upload-file.js
@@ -40,7 +40,7 @@ import './vaadin-upload-icons.js';
  * `uploading` | Uploading is in progress | `:host`
  * `complete` | Uploading has finished successfully | `:host`
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @mixes ThemableMixin
  */

--- a/packages/vaadin-upload/src/vaadin-upload.d.ts
+++ b/packages/vaadin-upload/src/vaadin-upload.d.ts
@@ -33,7 +33,7 @@ import { UploadEventMap, UploadFile, UploadI18n, UploadMethod } from './interfac
  * `dragover` | A file is being dragged over the element | `:host`
  * `dragover-valid` | A dragged file is valid with `maxFiles` and `accept` criteria | `:host`
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} file-reject - Fired when a file cannot be added to the queue due to a constrain.
  * @fires {CustomEvent} files-changed - Fired when the `files` property changes.

--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -41,7 +41,7 @@ import './vaadin-upload-file.js';
  * `dragover` | A file is being dragged over the element | `:host`
  * `dragover-valid` | A dragged file is valid with `maxFiles` and `accept` criteria | `:host`
  *
- * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {CustomEvent} file-reject - Fired when a file cannot be added to the queue due to a constrain.
  * @fires {CustomEvent} files-changed - Fired when the `files` property changes.


### PR DESCRIPTION
## Description

The styling documentation links were not up to date, let's fix that.

Fixes #72

## Type of change

- [x] Internal change