### PR TITLE
fix: publish vaadin-template-renderer src folder

### DIFF
--- a/packages/vaadin-template-renderer/package.json
+++ b/packages/vaadin-template-renderer/package.json
@@ -17,7 +17,8 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
-    "vaadin-*.js"
+    "vaadin-*.js",
+    "src"
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0"


### PR DESCRIPTION
## Description

The actual implementation was not published to npm because of incorrect `files` field.

We need to think about how to avoid this in future.