### PR TITLE
feat!: remove polymer template api from vaadin-select

### DIFF
--- a/packages/vaadin-custom-field/package.json
+++ b/packages/vaadin-custom-field/package.json
@@ -40,6 +40,7 @@
     "@vaadin/vaadin-select": "^21.0.0-alpha0",
     "@vaadin/vaadin-text-field": "^21.0.0-alpha0",
     "@vaadin/vaadin-time-picker": "^21.0.0-alpha0",
+    "@vaadin/vaadin-template-renderer": "^21.0.0-alpha0",
     "sinon": "^9.2.0"
   },
   "publishConfig": {

--- a/packages/vaadin-custom-field/test/visual/lumo/custom-field.test.js
+++ b/packages/vaadin-custom-field/test/visual/lumo/custom-field.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '@vaadin/vaadin-template-renderer';
 import '@vaadin/vaadin-combo-box/theme/lumo/vaadin-combo-box.js';
 import '@vaadin/vaadin-date-picker/theme/lumo/vaadin-date-picker.js';
 import '@vaadin/vaadin-item/theme/lumo/vaadin-item.js';

--- a/packages/vaadin-custom-field/test/visual/material/custom-field.test.js
+++ b/packages/vaadin-custom-field/test/visual/material/custom-field.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '@vaadin/vaadin-template-renderer';
 import '@vaadin/vaadin-combo-box/theme/material/vaadin-combo-box.js';
 import '@vaadin/vaadin-date-picker/theme/material/vaadin-date-picker.js';
 import '@vaadin/vaadin-item/theme/material/vaadin-item.js';

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -902,17 +902,14 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
     const openedChanged = this._oldOpened !== opened;
     this._oldOpened = opened;
 
+    if (rendererChanged) {
+      this.content = this;
+      this.content.innerHTML = '';
+    }
+
     if (template && templateOrInstancePropsChanged) {
       this._stampOverlayTemplate(template, instanceProps);
     } else if (renderer && (rendererChanged || openedChanged || ownerOrModelChanged)) {
-      this.content = this;
-
-      if (rendererChanged) {
-        while (this.content.firstChild) {
-          this.content.removeChild(this.content.firstChild);
-        }
-      }
-
       if (opened) {
         this.render();
       }

--- a/packages/vaadin-overlay/test/renderer.test.js
+++ b/packages/vaadin-overlay/test/renderer.test.js
@@ -121,6 +121,19 @@ describe('renderer', () => {
       overlay.renderer = () => spy();
       expect(spy.called).to.be.false;
     });
+
+    it('should clear the content when removing the renderer', () => {
+      overlay.renderer = (root) => {
+        root.innerHTML = 'foo';
+      };
+      overlay.opened = true;
+
+      expect(overlay.textContent.trim()).to.equal('foo');
+
+      overlay.renderer = null;
+
+      expect(overlay.textContent.trim()).to.equal('');
+    });
   });
 
   describe('with template', () => {

--- a/packages/vaadin-select/package.json
+++ b/packages/vaadin-select/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
     "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/vaadin-template-renderer": "^21.0.0-alpha0",
     "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.0"
   },

--- a/packages/vaadin-select/src/vaadin-select.d.ts
+++ b/packages/vaadin-select/src/vaadin-select.d.ts
@@ -7,13 +7,11 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
 import { SelectEventMap, SelectRenderer } from './interfaces';
 
 /**
- * `<vaadin-select>` is a Web Component for selecting values from a list of items. The content of the
- * the select can be populated in two ways: imperatively by using renderer callback function and
- * declaratively by using Polymer's Templates.
+ * `<vaadin-select>` is a Web Component for selecting values from a list of items.
  *
  * ### Rendering
  *
- * By default, the select uses the content provided by using the renderer callback function.
+ * The content of the select can be populated by using the renderer callback function.
  *
  * The renderer function provides `root`, `select` arguments.
  * Generate DOM content, append it to the `root` element and control the state
@@ -30,6 +28,7 @@ import { SelectEventMap, SelectRenderer } from './interfaces';
  *   ['Jose', 'Manolo', 'Pedro'].forEach(function(name) {
  *     const item = document.createElement('vaadin-item');
  *     item.textContent = name;
+ *     item.setAttribute('label', name)
  *     listBox.appendChild(item);
  *   });
  *
@@ -43,25 +42,7 @@ import { SelectEventMap, SelectRenderer } from './interfaces';
  * in the next renderer call and will be provided with the `root` argument.
  * On first call it will be empty.
  *
- * ### Polymer Templates
- *
- * Alternatively, the content can be provided with Polymer's Template.
- * Select finds the first child template and uses that in case renderer callback function
- * is not provided. You can also set a custom template using the `template` property.
- *
- * ```
- * <vaadin-select>
- *   <template>
- *     <vaadin-list-box>
- *       <vaadin-item label="foo">Foo</vaadin-item>
- *       <vaadin-item>Bar</vaadin-item>
- *       <vaadin-item>Baz</vaadin-item>
- *     </vaadin-list-box>
- *   </template>
- * </vaadin-select>
- * ```
- *
- * Hint: By setting the `label` property of inner vaadin-items you will
+ * * Hint: By setting the `label` property of inner vaadin-items you will
  * be able to change the visual representation of the selected value in the input part.
  *
  * ### Styling

--- a/packages/vaadin-select/test/renderer.test.js
+++ b/packages/vaadin-select/test/renderer.test.js
@@ -7,6 +7,7 @@ import '../vaadin-select.js';
 
 describe('renderer', () => {
   let select;
+  let overlay;
   let rendererContent;
 
   function generateRendererWithItems(items) {
@@ -28,91 +29,74 @@ describe('renderer', () => {
     };
   }
 
-  describe('without template', () => {
-    beforeEach(() => {
-      select = fixtureSync(`<vaadin-select></vaadin-select>`);
-      rendererContent = document.createElement('vaadin-list-box');
-      const rendererItem = document.createElement('vaadin-item');
-      rendererItem.textContent = 'renderer item';
-      rendererContent.appendChild(rendererItem);
-    });
-
-    it('should use renderer when it is defined', () => {
-      select.renderer = (root) => root.appendChild(rendererContent);
-      expect(select.shadowRoot.querySelector('vaadin-list-box vaadin-item').textContent.trim()).to.equal(
-        'renderer item'
-      );
-    });
-
-    it('should pass vaadin-select as owner to vaadin-overlay', () => {
-      select.renderer = (root, owner) => {
-        expect(owner).to.eql(select);
-      };
-    });
-
-    it('should be possible to manually invoke renderer', () => {
-      const spy = (select.renderer = sinon.spy());
-      select.opened = true;
-      spy.resetHistory();
-      select.render();
-      expect(spy.callCount).to.equal(1);
-    });
-
-    it('should update selected value after renderer is called', async () => {
-      select.renderer = generateRendererWithItems(['foo', 'bar']);
-      await nextFrame();
-      select.value = 'bar';
-      select.__testVar = 'baz';
-      select.render();
-      await nextFrame();
-      expect(select._menuElement.selected).to.be.equal(1);
-      expect(select._valueElement.textContent.trim()).to.be.equal('barbaz');
-    });
-
-    it('should update selected value after renderer is reassigned based on the value', async () => {
-      select.renderer = generateRendererWithItems(['foo', 'bar']);
-      await nextFrame();
-      select.value = 'bar';
-      select.renderer = generateRendererWithItems(['bar', 'foo']);
-      await nextFrame();
-      expect(select.value).to.equal('bar');
-      expect(select._menuElement.selected).to.equal(0);
-    });
-
-    it('should not throw when setting renderer before overlay is ready', () => {
-      expect(() => {
-        const select = document.createElement('vaadin-select');
-        select.renderer = () => {};
-        document.body.appendChild(select);
-        document.body.removeChild(select);
-      }).to.not.throw(Error);
-    });
+  beforeEach(() => {
+    select = fixtureSync(`<vaadin-select></vaadin-select>`);
+    overlay = select.shadowRoot.querySelector('vaadin-select-overlay');
+    rendererContent = document.createElement('vaadin-list-box');
+    const rendererItem = document.createElement('vaadin-item');
+    rendererItem.textContent = 'renderer item';
+    rendererContent.appendChild(rendererItem);
   });
 
-  describe('with template', () => {
-    beforeEach(() => {
-      select = fixtureSync(`
-        <vaadin-select>
-          <template>
-            <vaadin-list-box>
-              <vaadin-item>templatizer item</vaadin-item>
-            </vaadin-list-box>
-          </template>
-        </vaadin-select>
-      `);
-    });
+  it('should use renderer when it is defined', () => {
+    select.renderer = (root) => root.appendChild(rendererContent);
+    expect(select.shadowRoot.querySelector('vaadin-list-box vaadin-item').textContent.trim()).to.equal('renderer item');
+  });
 
-    it('should fallback to render content with Templatizer when renderer is not defined', () => {
-      expect(select.shadowRoot.querySelector('vaadin-item').textContent.trim()).to.equal('templatizer item');
-    });
+  it('should pass vaadin-select as owner to vaadin-overlay', () => {
+    select.renderer = (root, owner) => {
+      expect(owner).to.eql(select);
+    };
+  });
 
-    it('should throw an error when setting a renderer if there is already a template', () => {
-      expect(() => (select.renderer = () => {})).to.throw(Error);
-    });
+  it('should be possible to manually invoke renderer', () => {
+    const spy = (select.renderer = sinon.spy());
+    select.opened = true;
+    spy.resetHistory();
+    select.render();
+    expect(spy.callCount).to.equal(1);
+  });
 
-    it('should remove renderer when added after template', () => {
-      expect(() => (select.renderer = () => {})).to.throw(Error);
-      expect(select.renderer).to.be.not.ok;
-    });
+  it('should update selected value after renderer is called', async () => {
+    select.renderer = generateRendererWithItems(['foo', 'bar']);
+    await nextFrame();
+    select.value = 'bar';
+    select.__testVar = 'baz';
+    select.render();
+    await nextFrame();
+    expect(select._menuElement.selected).to.be.equal(1);
+    expect(select._valueElement.textContent.trim()).to.be.equal('barbaz');
+  });
+
+  it('should update selected value after renderer is reassigned based on the value', async () => {
+    select.renderer = generateRendererWithItems(['foo', 'bar']);
+    await nextFrame();
+    select.value = 'bar';
+    select.renderer = generateRendererWithItems(['bar', 'foo']);
+    await nextFrame();
+    expect(select.value).to.equal('bar');
+    expect(select._menuElement.selected).to.equal(0);
+  });
+
+  it('should not throw when setting renderer before overlay is ready', () => {
+    expect(() => {
+      const select = document.createElement('vaadin-select');
+      select.renderer = () => {};
+      document.body.appendChild(select);
+      document.body.removeChild(select);
+    }).to.not.throw(Error);
+  });
+
+  it('should clear the select content when removing the renderer', () => {
+    select.renderer = (root) => {
+      root.innerHTML = 'foo';
+    };
+    select.opened = true;
+
+    expect(overlay.content.textContent).to.equal('foo');
+
+    select.renderer = null;
+
+    expect(overlay.content.textContent).to.equal('');
   });
 });

--- a/packages/vaadin-select/test/template.test.js
+++ b/packages/vaadin-select/test/template.test.js
@@ -1,0 +1,31 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-item';
+import '@vaadin/vaadin-list-box';
+import '@vaadin/vaadin-template-renderer';
+import '../vaadin-select.js';
+
+describe('template', () => {
+  let select, overlay, listBox;
+
+  beforeEach(() => {
+    select = fixtureSync(`
+      <vaadin-select>
+        <template>
+          <vaadin-list-box>
+            <vaadin-item>item</vaadin-item>
+          </vaadin-list-box>
+        </template>
+      </vaadin-select>
+    `);
+
+    overlay = select.shadowRoot.querySelector('vaadin-select-overlay');
+    listBox = overlay.querySelector('vaadin-list-box');
+
+    select.opened = true;
+  });
+
+  it('should render the template', () => {
+    expect(listBox.textContent.trim()).to.equal('item');
+  });
+});


### PR DESCRIPTION
## Description

- [x] Removes the Polymer Template API from `vaadin-select`.
- [x] Addresses the issue where `vaadin-overlay` doesn't clear the content after removing the renderer.

Fixes #324

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
