### PR TITLE
fix: clear the content when removing the renderer in vaadin-overlay

### DIFF
--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -902,17 +902,14 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
     const openedChanged = this._oldOpened !== opened;
     this._oldOpened = opened;
 
+    if (rendererChanged) {
+      this.content = this;
+      this.content.innerHTML = '';
+    }
+
     if (template && templateOrInstancePropsChanged) {
       this._stampOverlayTemplate(template, instanceProps);
     } else if (renderer && (rendererChanged || openedChanged || ownerOrModelChanged)) {
-      this.content = this;
-
-      if (rendererChanged) {
-        while (this.content.firstChild) {
-          this.content.removeChild(this.content.firstChild);
-        }
-      }
-
       if (opened) {
         this.render();
       }

--- a/packages/vaadin-overlay/test/renderer.test.js
+++ b/packages/vaadin-overlay/test/renderer.test.js
@@ -121,6 +121,19 @@ describe('renderer', () => {
       overlay.renderer = () => spy();
       expect(spy.called).to.be.false;
     });
+
+    it('should clear the content when removing the renderer', () => {
+      overlay.renderer = (root) => {
+        root.innerHTML = 'foo';
+      };
+      overlay.opened = true;
+
+      expect(overlay.textContent.trim()).to.equal('foo');
+
+      overlay.renderer = null;
+
+      expect(overlay.textContent.trim()).to.equal('');
+    });
   });
 
   describe('with template', () => {


### PR DESCRIPTION
## Description

While I was working on #353, I discovered that `vaadin-overlay` doesn't clear the content after removing the renderer function. 

This PR aims to address this issue in `20.0`.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
