### PR TITLE
fix: make registerStyles work with Lit 2

### DIFF
--- a/packages/vaadin-themable-mixin/register-styles.d.ts
+++ b/packages/vaadin-themable-mixin/register-styles.d.ts
@@ -6,6 +6,6 @@ export { css, unsafeCSS } from 'lit';
  * Registers CSS styles for a component type. Make sure to register the styles before
  * the first instance of a component of the type is attached to DOM.
  */
-declare function registerStyles(themeFor: String | null, styles: CSSResultGroup, options?: object | null): void;
+declare function registerStyles(themeFor: string | null, styles: CSSResultGroup, options?: object | null): void;
 
 export { registerStyles };

--- a/packages/vaadin-themable-mixin/register-styles.d.ts
+++ b/packages/vaadin-themable-mixin/register-styles.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit';
+import { CSSResultGroup } from 'lit';
 
 export { css, unsafeCSS } from 'lit';
 
@@ -6,10 +6,6 @@ export { css, unsafeCSS } from 'lit';
  * Registers CSS styles for a component type. Make sure to register the styles before
  * the first instance of a component of the type is attached to DOM.
  */
-declare function registerStyles(
-  themeFor: String | null,
-  styles: CSSResult | Array<CSSResult | null> | null,
-  options?: object | null
-): void;
+declare function registerStyles(themeFor: String | null, styles: CSSResultGroup, options?: object | null): void;
 
 export { registerStyles };

--- a/packages/vaadin-themable-mixin/register-styles.js
+++ b/packages/vaadin-themable-mixin/register-styles.js
@@ -11,7 +11,7 @@ const styleMap = {};
  * the first instance of a component of the type is attached to DOM.
  *
  * @param {String} themeFor The local/tag name of the component type to register the styles for
- * @param {CSSResult | CSSResult[]} styles The CSS style rules to be registered for the component type
+ * @param {CSSResultGroup} styles The CSS style rules to be registered for the component type
  * matching themeFor and included in the local scope of each component instance
  * @param {Object=} options Additional options
  * @return {void}

--- a/packages/vaadin-themable-mixin/test/typings/register-styles.types.ts
+++ b/packages/vaadin-themable-mixin/test/typings/register-styles.types.ts
@@ -1,0 +1,11 @@
+import { registerStyles, css } from '../../register-styles.js';
+
+registerStyles(
+  'vaadin-grid',
+  css`
+    [part~='cell'].dark {
+      color: var(--lumo-contrast-color);
+      background-color: var(--lumo-base-color);
+    }
+  `
+);


### PR DESCRIPTION
## Description

There is a breaking change and Lit 2 which means we should make `registerStyles` respect new types.

Fixes #359

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.