### PR TITLE
fix: clear notification card when removing renderer

### DIFF
--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -337,6 +337,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   ready() {
     super.ready();
 
+    this._card = this.$['vaadin-notification-card'];
     this._observer = new FlattenedNodesObserver(this, (info) => {
       this._setTemplateFromNodes(info.addedNodes);
     });
@@ -382,15 +383,11 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
     const rendererChanged = this._oldRenderer !== renderer;
     this._oldRenderer = renderer;
 
+    if (rendererChanged) {
+      this._card.innerHTML = '';
+    }
+
     if (renderer) {
-      this._card = this.$['vaadin-notification-card'];
-
-      if (rendererChanged) {
-        while (this._card.firstChild) {
-          this._card.removeChild(this._card.firstChild);
-        }
-      }
-
       if (opened) {
         if (!this._didAnimateNotificationAppend) {
           this._animatedAppendNotificationCard();

--- a/packages/vaadin-notification/test/renderer.test.js
+++ b/packages/vaadin-notification/test/renderer.test.js
@@ -101,6 +101,19 @@ describe('vaadin-notification', () => {
       expect(clientRect.height).to.not.equal(0);
       expect(clientRect.top).to.not.equal(0);
     });
+
+    it('should clear the notification card when removing the renderer', () => {
+      notification.opened = true;
+      notification.renderer = (root) => {
+        root.innerHTML = 'foo';
+      };
+
+      expect(notification._card.textContent).to.equal('foo');
+
+      notification.renderer = null;
+
+      expect(notification._card.textContent).to.equal('');
+    });
   });
 
   describe('with template', () => {


### PR DESCRIPTION
## Description

While I was working on #345, I discovered that the notification card isn't cleared after removing the renderer function.

This PR aims to address this issue for `20.0` branch.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
