### PR TITLE
feat!: remove polymer template api from vaadin-context-menu

### DIFF
--- a/packages/vaadin-context-menu/package.json
+++ b/packages/vaadin-context-menu/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
     "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/vaadin-template-renderer": "^21.0.0-alpha0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu-overlay.js
@@ -43,16 +43,6 @@ class ContextMenuOverlayElement extends OverlayElement {
 
   static get properties() {
     return {
-      instanceProps: {
-        type: Object,
-        value: () => {
-          return {
-            detail: true,
-            target: true
-          };
-        }
-      },
-
       /**
        * @protected
        */

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
@@ -9,9 +9,7 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
 import { ContextMenuEventMap, ContextMenuRenderer } from './interfaces';
 
 /**
- * `<vaadin-context-menu>` is a Web Component for creating context menus. The content of the
- * menu can be populated in three ways: imperatively by using the items API or a renderer callback function and
- * declaratively by using Polymer's Templates.
+ * `<vaadin-context-menu>` is a Web Component for creating context menus.
  *
  * ### Items
  *
@@ -46,9 +44,11 @@ import { ContextMenuEventMap, ContextMenuRenderer } from './interfaces';
  * });
  * ```
  *
- * **NOTE:** when the `items` array is defined, the renderer or a template cannot be used.
+ * **NOTE:** when the `items` array is defined, the renderer cannot be used.
  *
  * ### Rendering
+ *
+ * The content of the menu can be populated by using the renderer callback function.
  *
  * The renderer function provides `root`, `contextMenu`, `model` arguments when applicable.
  * Generate DOM content by using `model` object properties if needed, append it to the `root`
@@ -86,29 +86,10 @@ import { ContextMenuEventMap, ContextMenuRenderer } from './interfaces';
  * in the next renderer call and will be provided with the `root` argument.
  * On first call it will be empty.
  *
- * **NOTE:** when the `renderer` function is defined, the template content
- * is not in use.
- *
- * ### Polymer Templates
- *
- * Alternatively to using the `renderer`, you can populate
- * the menu content using Polymer's Templates:
- *
- * ```html
- * <vaadin-context-menu>
- *   <template>
- *     <vaadin-list-box>
- *       <vaadin-item>First menu item</vaadin-item>
- *       <vaadin-item>Second menu item</vaadin-item>
- *     </vaadin-list-box>
- *   </template>
- * </vaadin-context-menu>
- * ```
- *
  * ### “vaadin-contextmenu” Gesture Event
  *
  * `vaadin-contextmenu` is a gesture event (a custom event),
- * which is dispatched after either `contextmenu` and long touch events.
+ * which is dispatched after either `contextmenu` or long touch events.
  * This enables support for both mouse and touch environments in a uniform way.
  *
  * `<vaadin-context-menu>` opens the menu overlay on the `vaadin-contextmenu`
@@ -117,42 +98,18 @@ import { ContextMenuEventMap, ContextMenuRenderer } from './interfaces';
  * ### Menu Listener
  *
  * By default, the `<vaadin-context-menu>` element listens for the menu opening
- * event on itself. In order to have a context menu on your content, wrap
- * your content with the `<vaadin-context-menu>` element, and add a template
- * element with a menu. Example:
- *
- * ```html
- * <vaadin-context-menu>
- *   <template>
- *     <vaadin-list-box>
- *       <vaadin-item>First menu item</vaadin-item>
- *       <vaadin-item>Second menu item</vaadin-item>
- *     </vaadin-list-box>
- *   </template>
- *
- *   <p>This paragraph has the context menu provided in the above template.</p>
- *   <p>Another paragraph with the context menu.</p>
- * </vaadin-context-menu>
- * ```
- *
- * In case if you do not want to wrap the page content, you can listen for
+ * event on itself. In case if you do not want to wrap the target, you can listen for
  * events on an element outside the `<vaadin-context-menu>` by setting the
  * `listenOn` property:
  *
  * ```html
- * <vaadin-context-menu id="customListener">
- *   <template>
- *     <vaadin-list-box>
- *       ...
- *     </vaadin-list-box>
- *   </template>
- * </vaadin-context-menu>
+ * <vaadin-context-menu id="contextMenu"></vaadin-context-menu>
  *
- * <div id="menuListener">The element that listens for the context menu.</div>
+ * <div id="menuListener">The element that listens for the contextmenu event.</div>
  * ```
  * ```javascript
- *   const contextMenu = document.querySelector('vaadin-context-menu#customListener');
- *   contextMenu.listenOn = document.querySelector('#menuListener');
+ * const contextMenu = document.querySelector('#contextMenu');
+ * contextMenu.listenOn = document.querySelector('#menuListener');
  * ```
  *
  * ### Filtering Menu Targets
@@ -165,12 +122,6 @@ import { ContextMenuEventMap, ContextMenuRenderer } from './interfaces';
  *
  * ```html
  * <vaadin-context-menu selector=".has-menu">
- *   <template>
- *     <vaadin-list-box>
- *       ...
- *     </vaadin-list-box>
- *   </template>
- *
  *   <p class="has-menu">This paragraph opens the context menu</p>
  *   <p>This paragraph does not open the context menu</p>
  * </vaadin-context-menu>
@@ -178,7 +129,7 @@ import { ContextMenuEventMap, ContextMenuRenderer } from './interfaces';
  *
  * ### Menu Context
  *
- * You can bind to the following properties in the menu template:
+ * You can use the following properties in the renderer function:
  *
  * - `target` is the menu opening event target, which is the element that
  * the user has called the context menu for
@@ -188,19 +139,30 @@ import { ContextMenuEventMap, ContextMenuRenderer } from './interfaces';
  * of the element that opened the menu:
  *
  * ```html
- * <vaadin-context-menu selector="li">
- *   <template>
- *     <vaadin-list-box>
- *       <vaadin-item>The menu target: [[target.textContent]]</vaadin-item>
- *     </vaadin-list-box>
- *   </template>
- *
+ * <vaadin-context-menu selector="li" id="contextMenu">
  *   <ul>
  *     <li>Foo</li>
  *     <li>Bar</li>
  *     <li>Baz</li>
  *   </ul>
  * </vaadin-context-menu>
+ * ```
+ * ```js
+ * const contextMenu = document.querySelector('#contextMenu');
+ * contextMenu.renderer = (root, contextMenu, context) => {
+ *   let listBox = root.firstElementChild;
+ *   if (!listBox) {
+ *     listBox = document.createElement('vaadin-list-box');
+ *     root.appendChild(listBox);
+ *   }
+ *
+ *   let item = listBox.querySelector('vaadin-item');
+ *   if (!item) {
+ *     item = document.createElement('vaadin-item');
+ *     listBox.appendChild(item);
+ *   }
+ *   item.textContent = 'The menu target: ' + context.target.textContent;
+ * };
  * ```
  *
  * ### Styling

--- a/packages/vaadin-context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/vaadin-context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -41,7 +41,7 @@ interface ItemsMixin {
    * If a menu item has a non-empty `children` set, a sub-menu with the child items is opened
    * next to the parent menu on mouseover, tap or a right arrow keypress.
    *
-   * The items API can't be used together with a renderer or a template!
+   * The items API can't be used together with a renderer!
    *
    * #### Example
    *

--- a/packages/vaadin-context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/vaadin-context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -58,7 +58,7 @@ export const ItemsMixin = (superClass) =>
          * If a menu item has a non-empty `children` set, a sub-menu with the child items is opened
          * next to the parent menu on mouseover, tap or a right arrow keypress.
          *
-         * The items API can't be used together with a renderer or a template!
+         * The items API can't be used together with a renderer!
          *
          * #### Example
          *

--- a/packages/vaadin-context-menu/test/context.test.js
+++ b/packages/vaadin-context-menu/test/context.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { fixtureSync, fire } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import '@vaadin/vaadin-template-renderer';
 import '@vaadin/vaadin-list-box/vaadin-list-box.js';
 import '@vaadin/vaadin-item/vaadin-item.js';
 import './not-animated-styles.js';

--- a/packages/vaadin-context-menu/test/integration.test.js
+++ b/packages/vaadin-context-menu/test/integration.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, click, fixtureSync, isIOS, makeSoloTouchEvent } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import '@vaadin/vaadin-template-renderer';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 

--- a/packages/vaadin-context-menu/test/items.test.js
+++ b/packages/vaadin-context-menu/test/items.test.js
@@ -390,14 +390,6 @@ describe('items', () => {
       expect(() => (rootMenu.renderer = () => {})).to.throw(Error);
     });
 
-    it('should throw with template', () => {
-      const addTemplate = () => {
-        rootMenu.appendChild(document.createElement('template'));
-        rootMenu._observer.flush();
-      };
-      expect(addTemplate).to.throw(Error);
-    });
-
     it('should not remove the component attributes', () => {
       rootMenu.close();
       const button = document.createElement('button');

--- a/packages/vaadin-context-menu/test/overlay.test.js
+++ b/packages/vaadin-context-menu/test/overlay.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, isIOS, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-template-renderer';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 

--- a/packages/vaadin-context-menu/test/properties.test.js
+++ b/packages/vaadin-context-menu/test/properties.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-template-renderer';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 

--- a/packages/vaadin-context-menu/test/renderer.test.js
+++ b/packages/vaadin-context-menu/test/renderer.test.js
@@ -7,131 +7,102 @@ import '../vaadin-context-menu.js';
 describe('renderer', () => {
   let menu, target;
 
+  beforeEach(() => {
+    menu = fixtureSync(`
+      <vaadin-context-menu>
+        <div id="target"></div>
+      </vaadin-context-menu>
+    `);
+    menu.renderer = sinon.spy((root, _, context) => {
+      if (root.firstChild) {
+        return;
+      }
+      root.appendChild(
+        document.createTextNode(`Renderer ${context.detail && context.detail.foo} ${context.target.id}`)
+      );
+    });
+    target = menu.querySelector('#target');
+  });
+
   afterEach(() => {
     menu.close();
   });
 
-  describe('without template', () => {
-    beforeEach(() => {
-      menu = fixtureSync(`
-        <vaadin-context-menu>
-          <div id="target"></div>
-        </vaadin-context-menu>
-      `);
-      menu.renderer = sinon.spy((root, _, context) => {
-        if (root.firstChild) {
-          return;
-        }
-        root.appendChild(
-          document.createTextNode(`Renderer ${context.detail && context.detail.foo} ${context.target.id}`)
-        );
-      });
-      target = menu.querySelector('#target');
-    });
+  it('should render on open', () => {
+    expect(menu.renderer.callCount).to.equal(0);
 
-    it('should render on open', () => {
-      expect(menu.renderer.callCount).to.equal(0);
+    fire(target, 'vaadin-contextmenu');
 
-      fire(target, 'vaadin-contextmenu');
-
-      expect(menu.renderer.callCount).to.equal(1);
-      expect(menu.$.overlay.content.textContent).to.contain('Renderer');
-    });
-
-    it('should have target in context', () => {
-      fire(target, 'vaadin-contextmenu');
-
-      expect(menu.$.overlay.content.textContent).to.contain('target');
-    });
-
-    it('should have detail in context', () => {
-      fire(target, 'vaadin-contextmenu', { foo: 'bar' });
-
-      expect(menu.$.overlay.content.textContent).to.contain('bar');
-    });
-
-    it('should have contextMenu owner argument', () => {
-      fire(target, 'vaadin-contextmenu');
-
-      expect(menu.renderer.firstCall.args[1]).to.equal(menu);
-    });
-
-    it('should rerender on reopen', () => {
-      fire(target, 'vaadin-contextmenu');
-      menu.close();
-      fire(target, 'vaadin-contextmenu');
-
-      expect(menu.renderer.callCount).to.equal(2);
-      expect(menu.renderer.getCall(1).args).to.deep.equal(menu.renderer.getCall(0).args);
-    });
-
-    it('should rerender with new target on reopen', () => {
-      const otherTarget = document.createElement('div');
-      menu.appendChild(otherTarget);
-      fire(target, 'vaadin-contextmenu');
-      menu.close();
-      fire(otherTarget, 'vaadin-contextmenu');
-
-      expect(menu.renderer.callCount).to.equal(2);
-      expect(menu.renderer.getCall(0).args[2].target).to.equal(target);
-      expect(menu.renderer.getCall(1).args[2].target).to.equal(otherTarget);
-    });
-
-    it('should rerender with new detail on reopen', () => {
-      fire(target, 'vaadin-contextmenu', { foo: 'one' });
-      menu.close();
-      fire(target, 'vaadin-contextmenu', { foo: 'two' });
-
-      expect(menu.renderer.callCount).to.equal(2);
-      expect(menu.renderer.getCall(0).args[2].detail).to.deep.equal({ foo: 'one' });
-      expect(menu.renderer.getCall(1).args[2].detail).to.deep.equal({ foo: 'two' });
-    });
-
-    it('should remove template when added after renderer', () => {
-      menu.renderer = () => {};
-      const template = document.createElement('template');
-      expect(() => {
-        menu.appendChild(template);
-        menu._observer.flush();
-      }).to.throw(Error);
-      expect(menu._contentTemplate).to.be.not.ok;
-    });
-
-    it('should be possible to manually invoke renderer', () => {
-      fire(target, 'vaadin-contextmenu');
-      expect(menu.renderer.calledOnce).to.be.true;
-      menu.render();
-      expect(menu.renderer.calledTwice).to.be.true;
-    });
+    expect(menu.renderer.callCount).to.equal(1);
+    expect(menu.$.overlay.content.textContent).to.contain('Renderer');
   });
 
-  describe('with template', () => {
-    beforeEach(() => {
-      menu = fixtureSync(`
-        <vaadin-context-menu>
-          <template>Template [[detail.foo]] [[target.id]]</template>
-          <div id="target"></div>
-        </vaadin-context-menu>
-      `);
-      target = menu.querySelector('#target');
-    });
+  it('should have target in context', () => {
+    fire(target, 'vaadin-contextmenu');
 
-    it('should fallback to template if renderer is missing', () => {
-      fire(target, 'vaadin-contextmenu', { foo: 'bar' });
+    expect(menu.$.overlay.content.textContent).to.contain('target');
+  });
 
-      expect(menu.$.overlay.content.textContent).to.contain('Template bar target');
-      expect(menu.$.overlay.content.textContent).to.not.contain('Renderer');
-    });
+  it('should have detail in context', () => {
+    fire(target, 'vaadin-contextmenu', { foo: 'bar' });
 
-    it('should throw an error when setting a renderer if there is already a template', () => {
-      menu._observer.flush();
-      expect(() => (menu.renderer = () => {})).to.throw(Error);
-    });
+    expect(menu.$.overlay.content.textContent).to.contain('bar');
+  });
 
-    it('should remove renderer when added after template', () => {
-      menu._observer.flush();
-      expect(() => (menu.renderer = () => {})).to.throw(Error);
-      expect(menu.renderer).to.be.not.ok;
-    });
+  it('should have contextMenu owner argument', () => {
+    fire(target, 'vaadin-contextmenu');
+
+    expect(menu.renderer.firstCall.args[1]).to.equal(menu);
+  });
+
+  it('should rerender on reopen', () => {
+    fire(target, 'vaadin-contextmenu');
+    menu.close();
+    fire(target, 'vaadin-contextmenu');
+
+    expect(menu.renderer.callCount).to.equal(2);
+    expect(menu.renderer.getCall(1).args).to.deep.equal(menu.renderer.getCall(0).args);
+  });
+
+  it('should rerender with new target on reopen', () => {
+    const otherTarget = document.createElement('div');
+    menu.appendChild(otherTarget);
+    fire(target, 'vaadin-contextmenu');
+    menu.close();
+    fire(otherTarget, 'vaadin-contextmenu');
+
+    expect(menu.renderer.callCount).to.equal(2);
+    expect(menu.renderer.getCall(0).args[2].target).to.equal(target);
+    expect(menu.renderer.getCall(1).args[2].target).to.equal(otherTarget);
+  });
+
+  it('should rerender with new detail on reopen', () => {
+    fire(target, 'vaadin-contextmenu', { foo: 'one' });
+    menu.close();
+    fire(target, 'vaadin-contextmenu', { foo: 'two' });
+
+    expect(menu.renderer.callCount).to.equal(2);
+    expect(menu.renderer.getCall(0).args[2].detail).to.deep.equal({ foo: 'one' });
+    expect(menu.renderer.getCall(1).args[2].detail).to.deep.equal({ foo: 'two' });
+  });
+
+  it('should be possible to manually invoke renderer', () => {
+    fire(target, 'vaadin-contextmenu');
+    expect(menu.renderer.calledOnce).to.be.true;
+    menu.render();
+    expect(menu.renderer.calledTwice).to.be.true;
+  });
+
+  it('should clear the content when removing the renderer', () => {
+    menu.renderer = (root) => {
+      root.innerHTML = 'foo';
+    };
+    fire(target, 'vaadin-contextmenu');
+
+    expect(menu.$.overlay.content.textContent.trim()).to.equal('foo');
+
+    menu.renderer = null;
+
+    expect(menu.$.overlay.content.textContent.trim()).to.equal('');
   });
 });

--- a/packages/vaadin-context-menu/test/selection.test.js
+++ b/packages/vaadin-context-menu/test/selection.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { click, enter, fire, fixtureSync, isIOS, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-template-renderer';
 import '@vaadin/vaadin-list-box/vaadin-list-box.js';
 import '@vaadin/vaadin-item/vaadin-item.js';
 import './not-animated-styles.js';

--- a/packages/vaadin-context-menu/test/template.test.js
+++ b/packages/vaadin-context-menu/test/template.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-template-renderer';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 
@@ -17,8 +18,6 @@ describe('template', () => {
   });
 
   it('should stamp template on open', () => {
-    expect(menu.$.overlay.content).to.be.undefined;
-
     menu._setOpened(true);
 
     expect(menu.$.overlay.content.textContent).to.contain('FOOBAR');

--- a/packages/vaadin-context-menu/test/touch.test.js
+++ b/packages/vaadin-context-menu/test/touch.test.js
@@ -12,6 +12,7 @@ import {
 } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { gestures } from '@polymer/polymer/lib/utils/gestures.js';
+import '@vaadin/vaadin-template-renderer';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 

--- a/packages/vaadin-context-menu/test/visual/lumo/context-menu.test.js
+++ b/packages/vaadin-context-menu/test/visual/lumo/context-menu.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '@vaadin/vaadin-template-renderer';
 import { openSubMenus } from '../common.js';
 import '../../../theme/lumo/vaadin-context-menu.js';
 import '../../not-animated-styles.js';

--- a/packages/vaadin-context-menu/test/visual/material/context-menu.test.js
+++ b/packages/vaadin-context-menu/test/visual/material/context-menu.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '@vaadin/vaadin-template-renderer';
 import { openSubMenus } from '../common.js';
 import '../../../theme/material/vaadin-context-menu.js';
 import '../../not-animated-styles.js';


### PR DESCRIPTION
## Description

- [x] Removes the Polymer Template API from `vaadin-context-menu`.
- [x] Addresses the issue where `vaadin-context-menu` doesn't clear the content after removing the renderer. 

Fixes #325

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
