### PR TITLE
fix: clear context menu content when removing renderer

### DIFF
--- a/packages/vaadin-context-menu/src/vaadin-context-menu.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.js
@@ -544,9 +544,6 @@ class ContextMenuElement extends ElementMixin(ThemePropertyMixin(ItemsMixin(Gest
       throw new Error('You should only use either a renderer or a template for context-menu content');
     }
 
-    this._oldTemplate = template;
-    this._oldRenderer = renderer;
-
     if (items) {
       if (template || renderer) {
         throw new Error('The items API cannot be used together with a template/renderer');
@@ -557,7 +554,13 @@ class ContextMenuElement extends ElementMixin(ThemePropertyMixin(ItemsMixin(Gest
 
       renderer = this.__itemsRenderer;
     }
-    if (renderer && context) {
+
+    const rendererChanged = this._oldRenderer !== renderer;
+
+    this._oldTemplate = template;
+    this._oldRenderer = renderer;
+
+    if (rendererChanged) {
       this.$.overlay.setProperties({ owner: this, renderer: renderer });
     }
   }

--- a/packages/vaadin-context-menu/test/renderer.test.js
+++ b/packages/vaadin-context-menu/test/renderer.test.js
@@ -103,6 +103,19 @@ describe('renderer', () => {
       menu.render();
       expect(menu.renderer.calledTwice).to.be.true;
     });
+
+    it('should clear the content when removing the renderer', () => {
+      menu.renderer = (root) => {
+        root.innerHTML = 'foo';
+      };
+      fire(target, 'vaadin-contextmenu');
+
+      expect(menu.$.overlay.content.textContent.trim()).to.equal('foo');
+
+      menu.renderer = null;
+
+      expect(menu.$.overlay.content.textContent.trim()).to.equal('');
+    });
   });
 
   describe('with template', () => {


### PR DESCRIPTION
## Description

While I was working on #364, I discovered that `vaadin-context-menu` doesn't clear the content after removing the renderer function. 

This PR aims to address this issue in `20.0`.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
