### PR TITLE
test: add missing test for vaadin-dialog

### DIFF
--- a/packages/vaadin-dialog/test/renderer.test.js
+++ b/packages/vaadin-dialog/test/renderer.test.js
@@ -31,6 +31,19 @@ describe('vaadin-dialog renderer', () => {
       dialog.render();
       expect(dialog.renderer.calledTwice).to.be.true;
     });
+
+    it('should clear the content when removing the renderer', () => {
+      dialog.renderer = (root) => {
+        root.innerHTML = 'foo';
+      };
+      dialog.opened = true;
+
+      expect(overlay.textContent).to.equal('foo');
+
+      dialog.renderer = null;
+
+      expect(overlay.textContent).to.equal('');
+    });
   });
 
   describe('with template', () => {
@@ -39,17 +52,15 @@ describe('vaadin-dialog renderer', () => {
     beforeEach(() => {
       dialog = fixtureSync(`
         <vaadin-dialog>
-          <template>
-            <div>Template content</div>
-          </template>
+          <template>foo</template>
         </vaadin-dialog>
       `);
       overlay = dialog.$.overlay;
     });
 
-    it('should default to template if renderer function not provided', () => {
+    it('should render the template', () => {
       dialog.opened = true;
-      expect(overlay.textContent).to.include('Template content');
+      expect(overlay.textContent).to.equal('foo');
     });
   });
 });


### PR DESCRIPTION
## Description

This PR adds a missing test for `vaadin-dialog` that checks if the dialog content is cleared after removing the renderer function.

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
