### PR TITLE
fix: clear dialog content when removing renderer

### DIFF
--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -348,10 +348,12 @@ class DialogElement extends ThemePropertyMixin(
       throw new Error('You should only use either a renderer or a template for dialog content');
     }
 
+    const rendererChanged = this._oldRenderer !== renderer;
+
     this._oldTemplate = template;
     this._oldRenderer = renderer;
 
-    if (renderer) {
+    if (rendererChanged) {
       this.$.overlay.setProperties({ owner: this, renderer: renderer });
     }
   }

--- a/packages/vaadin-dialog/test/renderer.test.js
+++ b/packages/vaadin-dialog/test/renderer.test.js
@@ -40,6 +40,19 @@ describe('vaadin-dialog renderer', () => {
       dialog.render();
       expect(dialog.renderer.calledTwice).to.be.true;
     });
+
+    it('should clear the content when removing the renderer', () => {
+      dialog.renderer = (root) => {
+        root.innerHTML = 'foo';
+      };
+      dialog.opened = true;
+
+      expect(overlay.textContent).to.equal('foo');
+
+      dialog.renderer = null;
+
+      expect(overlay.textContent).to.equal('');
+    });
   });
 
   describe('with template', () => {


### PR DESCRIPTION
## Description

Currently, `vaadin-context-menu` doesn't clear the content after removing the renderer function. 

This PR aims to address this issue in the `20.0` branch.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
