### PR TITLE
fix: clear select content when removing renderer

### DIFF
--- a/packages/vaadin-select/src/vaadin-select.js
+++ b/packages/vaadin-select/src/vaadin-select.js
@@ -449,11 +449,16 @@ class SelectElement extends ElementMixin(
       throw new Error('You should only use either a renderer or a template for select content');
     }
 
+    const rendererChanged = this._oldRenderer !== renderer;
+
     this._oldTemplate = template;
     this._oldRenderer = renderer;
 
-    if (renderer) {
+    if (rendererChanged) {
       overlay.setProperties({ owner: this, renderer: renderer });
+    }
+
+    if (renderer) {
       this.render();
 
       if (overlay.content.firstChild) {

--- a/packages/vaadin-select/test/renderer.test.js
+++ b/packages/vaadin-select/test/renderer.test.js
@@ -87,6 +87,19 @@ describe('renderer', () => {
         document.body.removeChild(select);
       }).to.not.throw(Error);
     });
+
+    it('should clear the content when removing the renderer', () => {
+      select.renderer = (root) => {
+        root.innerHTML = 'foo';
+      };
+      select.opened = true;
+
+      expect(select._overlayElement.textContent).to.equal('foo');
+
+      select.renderer = null;
+
+      expect(select._overlayElement.textContent).to.equal('');
+    });
   });
 
   describe('with template', () => {


### PR DESCRIPTION
## Description

Currently, `vaadin-select` doesn't clear the content after removing the renderer function.

This PR aims to address this issue in the `20.0` branch.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
