### PR TITLE
fix: don't throw when renderer is set before adding to DOM

### DIFF
--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -302,7 +302,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   }
 
   static get observers() {
-    return ['_durationChanged(duration, opened)', '_rendererChanged(renderer, opened)'];
+    return ['_durationChanged(duration, opened)', '_rendererChanged(renderer, opened, _card)'];
   }
 
   /** @protected */
@@ -326,12 +326,16 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   }
 
   /** @private */
-  _rendererChanged(renderer, opened) {
+  _rendererChanged(renderer, opened, card) {
+    if (!card) {
+      return;
+    }
+
     const rendererChanged = this._oldRenderer !== renderer;
     this._oldRenderer = renderer;
 
     if (rendererChanged) {
-      this._card.innerHTML = '';
+      card.innerHTML = '';
     }
 
     if (opened) {

--- a/packages/vaadin-notification/test/renderer.test.js
+++ b/packages/vaadin-notification/test/renderer.test.js
@@ -4,107 +4,132 @@ import sinon from 'sinon';
 import '@vaadin/vaadin-template-renderer';
 import '../vaadin-notification.js';
 
-describe('vaadin-notification', () => {
-  let notification;
-  let rendererContent;
+describe('renderer', () => {
+  describe('basic', () => {
+    let notification;
+    let rendererContent;
 
-  beforeEach(() => {
-    rendererContent = document.createElement('p');
-    rendererContent.textContent = 'renderer-content';
+    beforeEach(() => {
+      rendererContent = document.createElement('p');
+      rendererContent.textContent = 'renderer-content';
 
-    notification = fixtureSync('<vaadin-notification></vaadin-notification>');
+      notification = fixtureSync('<vaadin-notification></vaadin-notification>');
 
-    // Force sync card attaching and removal instead of waiting for the animation
-    sinon.stub(notification, '_animatedAppendNotificationCard').callsFake(() => notification._appendNotificationCard());
-    sinon.stub(notification, '_animatedRemoveNotificationCard').callsFake(() => notification._removeNotificationCard());
+      // Force sync card attaching and removal instead of waiting for the animation
+      sinon
+        .stub(notification, '_animatedAppendNotificationCard')
+        .callsFake(() => notification._appendNotificationCard());
+      sinon
+        .stub(notification, '_animatedRemoveNotificationCard')
+        .callsFake(() => notification._removeNotificationCard());
 
-    notification.open();
-  });
+      notification.open();
+    });
 
-  afterEach(() => {
-    // Close to stop all pending timers.
-    notification.close();
-    // delete singleton reference, so as it's created in next test
-    delete notification.constructor._container;
-  });
+    afterEach(() => {
+      // Close to stop all pending timers.
+      notification.close();
+      // delete singleton reference, so as it's created in next test
+      delete notification.constructor._container;
+    });
 
-  it('should use renderer when it is defined', () => {
-    notification.renderer = (root) => {
-      root.appendChild(rendererContent);
-    };
-    notification.opened = true;
-    expect(notification._card.textContent.trim()).to.equal('renderer-content');
-  });
-
-  it('renderer should receive notification when defined', () => {
-    notification.renderer = (root, notification) => {
-      expect(notification).to.eql(notification);
-    };
-  });
-
-  it('should remove template when added after renderer', () => {
-    notification.renderer = () => {};
-    const template = document.createElement('template');
-    expect(() => {
-      notification.appendChild(template);
-      notification._observer.flush();
-    }).to.throw(Error);
-    expect(notification._notificationTemplate).to.be.not.ok;
-  });
-
-  it('should be possible to manually invoke renderer', () => {
-    notification.renderer = sinon.spy();
-    notification.opened = true;
-    expect(notification.renderer.calledOnce).to.be.true;
-    notification.render();
-    expect(notification.renderer.calledTwice).to.be.true;
-  });
-
-  it('should provide root from the previous renderer call', () => {
-    notification.renderer = (root) => {
-      const generatedContent = document.createTextNode('rendered');
-      root.appendChild(generatedContent);
-    };
-    notification.opened = true;
-    notification.opened = false;
-    notification.opened = true;
-    expect(notification._card.textContent.trim()).to.equal('renderedrendered');
-  });
-
-  it('should clear the root when renderer changed', () => {
-    for (let i = 0; i < 2; i++) {
+    it('should use renderer when it is defined', () => {
       notification.renderer = (root) => {
-        const generatedContent = document.createTextNode('rendered-' + i);
+        root.appendChild(rendererContent);
+      };
+      notification.opened = true;
+      expect(notification._card.textContent.trim()).to.equal('renderer-content');
+    });
+
+    it('renderer should receive notification when defined', () => {
+      notification.renderer = (root, notification) => {
+        expect(notification).to.eql(notification);
+      };
+    });
+
+    it('should remove template when added after renderer', () => {
+      notification.renderer = () => {};
+      const template = document.createElement('template');
+      expect(() => {
+        notification.appendChild(template);
+        notification._observer.flush();
+      }).to.throw(Error);
+      expect(notification._notificationTemplate).to.be.not.ok;
+    });
+
+    it('should be possible to manually invoke renderer', () => {
+      notification.renderer = sinon.spy();
+      notification.opened = true;
+      expect(notification.renderer.calledOnce).to.be.true;
+      notification.render();
+      expect(notification.renderer.calledTwice).to.be.true;
+    });
+
+    it('should provide root from the previous renderer call', () => {
+      notification.renderer = (root) => {
+        const generatedContent = document.createTextNode('rendered');
         root.appendChild(generatedContent);
       };
       notification.opened = true;
-      expect(notification._card.textContent.trim()).to.equal('rendered-' + i);
-    }
+      notification.opened = false;
+      notification.opened = true;
+      expect(notification._card.textContent.trim()).to.equal('renderedrendered');
+    });
+
+    it('should clear the root when renderer changed', () => {
+      for (let i = 0; i < 2; i++) {
+        notification.renderer = (root) => {
+          const generatedContent = document.createTextNode('rendered-' + i);
+          root.appendChild(generatedContent);
+        };
+        notification.opened = true;
+        expect(notification._card.textContent.trim()).to.equal('rendered-' + i);
+      }
+    });
+
+    it('should open notification when renderer is defined after notification opened', () => {
+      notification.opened = true;
+      notification.renderer = (root) => {
+        root.appendChild(rendererContent);
+      };
+      const clientRect = notification._card.getBoundingClientRect();
+      expect(clientRect.x).to.not.equal(0);
+      expect(clientRect.y).to.not.equal(0);
+      expect(clientRect.width).to.not.equal(0);
+      expect(clientRect.height).to.not.equal(0);
+      expect(clientRect.top).to.not.equal(0);
+    });
+
+    it('should clear the notification card when removing the renderer', () => {
+      notification.opened = true;
+      notification.renderer = (root) => {
+        root.innerHTML = 'foo';
+      };
+
+      expect(notification._card.textContent).to.equal('foo');
+
+      notification.renderer = null;
+
+      expect(notification._card.textContent).to.equal('');
+    });
   });
 
-  it('should open notification when renderer is defined after notification opened', () => {
-    notification.opened = true;
-    notification.renderer = (root) => {
-      root.appendChild(rendererContent);
-    };
-    const clientRect = notification._card.getBoundingClientRect();
-    expect(clientRect.x).to.not.equal(0);
-    expect(clientRect.y).to.not.equal(0);
-    expect(clientRect.width).to.not.equal(0);
-    expect(clientRect.height).to.not.equal(0);
-    expect(clientRect.top).to.not.equal(0);
-  });
+  describe('set before connected', () => {
+    let notification;
 
-  it('should clear the notification card when removing the renderer', () => {
-    notification.opened = true;
-    notification.renderer = (root) => {
-      root.innerHTML = 'foo';
-    };
+    beforeEach(() => {
+      notification = document.createElement('vaadin-notification');
+    });
 
-    expect(notification._card.textContent).to.equal('foo');
+    afterEach(() => {
+      document.body.removeChild(notification);
+    });
 
-    notification.renderer = null;
-
-    expect(notification._card.textContent).to.equal('');
+    it('should not throw when the renderer is set before adding to DOM', () => {
+      expect(() => {
+        notification.renderer = () => {};
+        document.body.appendChild(notification);
+      }).to.not.throw(Error);
+    });
   });
 });


### PR DESCRIPTION
## Description

Currently, `vaadin-notification` throws an exception if you set the renderer before the notification is added to DOM. 

This PR aims to address this issue.

Fixes #375

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
