### PR TITLE
fix: remove ID attribute from notification card

### DIFF
--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -242,7 +242,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
           display: none;
         }
       </style>
-      <vaadin-notification-card id="vaadin-notification-card" theme$="[[theme]]"> </vaadin-notification-card>
+      <vaadin-notification-card theme$="[[theme]]"> </vaadin-notification-card>
     `;
   }
 
@@ -309,7 +309,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   ready() {
     super.ready();
 
-    this._card = this.$['vaadin-notification-card'];
+    this._card = this.shadowRoot.querySelector('vaadin-notification-card');
 
     if (window.Vaadin && window.Vaadin.templateRendererCallback) {
       window.Vaadin.templateRendererCallback(this);

--- a/packages/vaadin-notification/test/notification.test.js
+++ b/packages/vaadin-notification/test/notification.test.js
@@ -30,6 +30,10 @@ describe('vaadin-notification', () => {
     delete notification.constructor._container;
   });
 
+  it('should not set an ID attribute for the card', () => {
+    expect(notification._card.getAttribute('id')).to.be.null;
+  });
+
   describe('vaadin-notification-container', () => {
     it('should be in the body when notification opens', () => {
       expect(document.body.querySelectorAll('vaadin-notification-container').length).to.be.equal(1);


### PR DESCRIPTION
## Description

Currently, `vaadin-notification-card` has the ID attribute. As soon as you open multiple notifications simultaneously, all the notifications end up in the Shadow DOM of `vaadin-notification-container` that leads to duplicating IDs.

![image](https://user-images.githubusercontent.com/5039436/117945652-33d2ba00-b317-11eb-8960-48f27720ee90.png)

Fixes #378

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
