### PR TITLE
fix: don't throw when renderer is set before adding to DOM (#379) (CP: 20.0)

### DIFF
--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -329,7 +329,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   static get observers() {
     return [
       '_durationChanged(duration, opened)',
-      '_templateOrRendererChanged(_notificationTemplate, renderer, opened)'
+      '_templateOrRendererChanged(_notificationTemplate, renderer, opened, _card)'
     ];
   }
 
@@ -372,7 +372,11 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   }
 
   /** @private */
-  _templateOrRendererChanged(template, renderer, opened) {
+  _templateOrRendererChanged(template, renderer, opened, card) {
+    if (!card) {
+      return;
+    }
+
     if (template && renderer) {
       this._removeNewRendererOrTemplate(template, this._oldTemplate, renderer, this._oldRenderer);
       throw new Error('You should only use either a renderer or a template for notification content');
@@ -384,7 +388,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
     this._oldRenderer = renderer;
 
     if (rendererChanged) {
-      this._card.innerHTML = '';
+      card.innerHTML = '';
     }
 
     if (renderer) {

--- a/packages/vaadin-notification/test/renderer.test.js
+++ b/packages/vaadin-notification/test/renderer.test.js
@@ -160,4 +160,23 @@ describe('vaadin-notification', () => {
       expect(notification.renderer).to.be.not.ok;
     });
   });
+
+  describe('set before connected', () => {
+    let notification;
+
+    beforeEach(() => {
+      notification = document.createElement('vaadin-notification');
+    });
+
+    afterEach(() => {
+      document.body.removeChild(notification);
+    });
+
+    it('should not throw when the renderer is set before adding to DOM', () => {
+      expect(() => {
+        notification.renderer = () => {};
+        document.body.appendChild(notification);
+      }).to.not.throw(Error);
+    });
+  });
 });


### PR DESCRIPTION
## Description

This PR aims to address #379 in the `20.0` branch.

Fixes #379

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
