### PR TITLE
fix: make sure rows are generated to an empty grid with heightByRows

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-styles.js
+++ b/packages/vaadin-grid/src/vaadin-grid-styles.js
@@ -52,6 +52,10 @@ registerStyles(
       position: relative;
     }
 
+    :host([height-by-rows]) #items:empty {
+      height: 1px;
+    }
+
     #table {
       display: flex;
       flex-direction: column;

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -964,8 +964,8 @@ class GridElement extends ElementMixin(
   }
 
   /** @protected */
-  __updateVisibleRows() {
-    this.__virtualizer && this.__virtualizer.update();
+  __updateVisibleRows(start, end) {
+    this.__virtualizer && this.__virtualizer.update(start, end);
   }
 
   /**

--- a/packages/vaadin-grid/test/resizing.test.js
+++ b/packages/vaadin-grid/test/resizing.test.js
@@ -9,7 +9,8 @@ import {
   getRowCells,
   infiniteDataProvider,
   scrollToEnd,
-  nextResize
+  nextResize,
+  getPhysicalItems
 } from './helpers.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
@@ -105,6 +106,18 @@ describe('resizing', () => {
     const bodyHeight = grid.$.items.clientHeight;
     const footerHeight = grid.$.footer.clientHeight;
     expect(grid.clientHeight).to.equal(headerHeight + bodyHeight + footerHeight);
+  });
+
+  it('should have body rows if header is not visible', async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="value"></vaadin-grid-column>
+      </vaadin-grid>`);
+    grid.firstElementChild.header = null;
+    grid.heightByRows = true;
+    grid.items = [{ value: 1 }];
+    flushGrid(grid);
+    expect(getPhysicalItems(grid).length).to.be.above(0);
   });
 
   // NOTE: This issue only manifests with scrollbars that affect the layout


### PR DESCRIPTION
These changes are required to make https://github.com/vaadin/flow-components/pull/978 pass

1. A grid with `heightByRows` and an invisible header should be able to generate row elements. If the scroll target's height is 0, the virtualizer doesn't try to create any elements even if the grid has items. So we force a 1px default height to the grid's scroll target that would otherwise have a height of 0,  if `heightByRows` is in use. [Link to the failing test case.](https://github.com/vaadin/flow-components/blob/4a61d259fd6b32020243f6f690d7566fd4f97a2a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/RecalculateColumnWidthsIT.java#L31)
2. The grid [connector used index arguments](https://github.com/vaadin/flow-components/blob/4a61d259fd6b32020243f6f690d7566fd4f97a2a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js#L601) with the `_assignModels()` -function. Need to enable the arguments in `__updateVisibleRows` to support that use-case. [Link to the failing test case](https://github.com/vaadin/flow-components/blob/4a61d259fd6b32020243f6f690d7566fd4f97a2a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridItemRefreshPageIT.java#L67).