### PR TITLE
feat: support rendering slotted templates for template renderer

### DIFF
--- a/packages/vaadin-template-renderer/src/vaadin-template-renderer.js
+++ b/packages/vaadin-template-renderer/src/vaadin-template-renderer.js
@@ -1,3 +1,5 @@
+import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
+
 import './vaadin-template-renderer-templatizer.js';
 import { Templatizer } from './vaadin-template-renderer-templatizer.js';
 
@@ -15,7 +17,7 @@ function processTemplate(component, template) {
 }
 
 function processTemplates(component) {
-  [...component.children]
+  FlattenedNodesObserver.getFlattenedNodes(component)
     .filter((child) => {
       return child instanceof HTMLTemplateElement;
     })
@@ -29,16 +31,16 @@ function processTemplates(component) {
     });
 }
 
-const observer = new MutationObserver((mutations) => {
-  mutations.forEach(({ target }) => {
-    processTemplates(target);
+function observeTemplates(component) {
+  if (component.__templateObserver) return;
+
+  component.__templateObserver = new FlattenedNodesObserver(component, () => {
+    processTemplates(component);
   });
-});
+}
 
 window.Vaadin = window.Vaadin || {};
 window.Vaadin.templateRendererCallback = (component) => {
   processTemplates(component);
-
-  // The observer stops observing automatically as the component node is removed
-  observer.observe(component, { childList: true });
+  observeTemplates(component);
 };

--- a/packages/vaadin-template-renderer/test/fixtures/mock-component-host.js
+++ b/packages/vaadin-template-renderer/test/fixtures/mock-component-host.js
@@ -1,17 +1,17 @@
 import { PolymerElement, html } from '@polymer/polymer';
 
-import './x-component.js';
+import './mock-component.js';
 
-export class XComponentHost extends PolymerElement {
+export class MockComponentHost extends PolymerElement {
   static get template() {
     return html`
-      <x-component id="component">
+      <mock-component id="component">
         <template>
           [[value]]
           <input value="{{value::input}}" />
           <button on-click="onClick"></button>
         </template>
-      </x-component>
+      </mock-component>
     `;
   }
 
@@ -24,4 +24,4 @@ export class XComponentHost extends PolymerElement {
   onClick() {}
 }
 
-customElements.define('x-component-host', XComponentHost);
+customElements.define('mock-component-host', MockComponentHost);

--- a/packages/vaadin-template-renderer/test/fixtures/mock-component-slotted-host.js
+++ b/packages/vaadin-template-renderer/test/fixtures/mock-component-slotted-host.js
@@ -1,0 +1,17 @@
+import { PolymerElement, html } from '@polymer/polymer';
+
+import './mock-component.js';
+
+export class MockComponentSlottedHost extends PolymerElement {
+  static get template() {
+    return html`
+      <mock-component id="component">
+        <slot name="template">
+          <template>fallback</template>
+        </slot>
+      </mock-component>
+    `;
+  }
+}
+
+customElements.define('mock-component-slotted-host', MockComponentSlottedHost);

--- a/packages/vaadin-template-renderer/test/fixtures/mock-component.js
+++ b/packages/vaadin-template-renderer/test/fixtures/mock-component.js
@@ -1,4 +1,4 @@
-export class XComponent extends HTMLElement {
+export class MockComponent extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
@@ -25,4 +25,4 @@ export class XComponent extends HTMLElement {
   }
 }
 
-customElements.define('x-component', XComponent);
+customElements.define('mock-component', MockComponent);

--- a/packages/vaadin-template-renderer/test/fixtures/mock-list-host.js
+++ b/packages/vaadin-template-renderer/test/fixtures/mock-list-host.js
@@ -1,11 +1,11 @@
 import { PolymerElement, html } from '@polymer/polymer';
 
-import './x-list.js';
+import './mock-list.js';
 
-export class XListHost extends PolymerElement {
+export class MockListHost extends PolymerElement {
   static get template() {
     return html`
-      <x-list id="list" items="[[items]]">
+      <mock-list id="list" items="[[items]]">
         <template>
           <div class="item-text">[[item]]</div>
 
@@ -15,7 +15,7 @@ export class XListHost extends PolymerElement {
 
           <button on-click="onClick"></button>
         </template>
-      </x-list>
+      </mock-list>
     `;
   }
 
@@ -35,4 +35,4 @@ export class XListHost extends PolymerElement {
   onClick() {}
 }
 
-customElements.define('x-list-host', XListHost);
+customElements.define('mock-list-host', MockListHost);

--- a/packages/vaadin-template-renderer/test/fixtures/mock-list.js
+++ b/packages/vaadin-template-renderer/test/fixtures/mock-list.js
@@ -1,4 +1,4 @@
-export class XList extends HTMLElement {
+export class MockList extends HTMLElement {
   constructor() {
     super();
 
@@ -46,4 +46,4 @@ export class XList extends HTMLElement {
   }
 }
 
-customElements.define('x-list', XList);
+customElements.define('mock-list', MockList);

--- a/packages/vaadin-template-renderer/test/list.test.js
+++ b/packages/vaadin-template-renderer/test/list.test.js
@@ -4,8 +4,8 @@ import { fixtureSync, fire, click } from '@vaadin/testing-helpers';
 
 import '../vaadin-template-renderer.js';
 
-import './x-list-host.js';
-import './x-list.js';
+import './fixtures/mock-list-host.js';
+import './fixtures/mock-list.js';
 
 describe('list', () => {
   let host, list, template;
@@ -19,7 +19,7 @@ describe('list', () => {
   }
 
   beforeEach(() => {
-    host = fixtureSync(`<x-list-host></x-list-host>`);
+    host = fixtureSync(`<mock-list-host></mock-list-host>`);
     list = host.$.list;
     template = host.$.list.querySelector('template');
   });

--- a/packages/vaadin-template-renderer/test/observer.test.js
+++ b/packages/vaadin-template-renderer/test/observer.test.js
@@ -1,0 +1,119 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+
+import '../vaadin-template-renderer.js';
+
+import './fixtures/mock-component.js';
+import './fixtures/mock-component-slotted-host.js';
+
+describe('observer', () => {
+  it('should initialize the observer only once', () => {
+    const component = fixtureSync(`
+      <mock-component>
+        <template>foo</template>
+      </mock-component>
+    `);
+
+    const oldTemplateObserver = component.__templateObserver;
+
+    window.Vaadin.templateRendererCallback(component);
+
+    const newTemplateObserver = component.__templateObserver;
+
+    expect(newTemplateObserver).to.be.ok;
+    expect(newTemplateObserver).to.equal(oldTemplateObserver);
+  });
+
+  it('should observe adding templates', async () => {
+    const component = fixtureSync(`<mock-component></mock-component>`);
+    const template = fixtureSync(`<template>bar</template>`);
+
+    component.appendChild(template);
+    await nextFrame();
+
+    expect(component.$.content.textContent).to.equal('bar');
+  });
+
+  it('should observe replacing templates', async () => {
+    const component = fixtureSync(`
+      <mock-component>
+        <template>foo</template>
+      </mock-component>
+    `);
+    const template = fixtureSync(`<template>bar</template>`);
+
+    component.replaceChildren(template);
+    await nextFrame();
+
+    expect(component.$.content.textContent).to.equal('bar');
+  });
+
+  it('should not observe adding non-template elements', async () => {
+    const component = fixtureSync(`<mock-component></mock-component>`);
+    const element = fixtureSync('<div>bar</div>');
+
+    component.appendChild(element);
+    await nextFrame();
+
+    expect(component.$.content.textContent).to.equal('');
+  });
+
+  it('should not observe adding non-child templates', async () => {
+    const component = fixtureSync(`
+      <mock-component>
+        <div></div>
+      </mock-component>
+    `);
+    const template = fixtureSync(`<template>bar</template>`);
+
+    component.querySelector('div').appendChild(template);
+    await nextFrame();
+
+    expect(component.$.content.textContent).to.equal('');
+  });
+
+  describe('slotted templates', () => {
+    it('should observe adding slotted templates', async () => {
+      const host = fixtureSync(`
+        <mock-component-slotted-host></mock-component-slotted-host>
+      `);
+      const component = host.$.component;
+      const template = fixtureSync(`<template slot="template">added</template>`);
+
+      host.appendChild(template);
+      await nextFrame();
+
+      expect(component.$.content.textContent).to.equal('added');
+    });
+
+    it('should observe replacing slotted templates', async () => {
+      const host = fixtureSync(`
+        <mock-component-slotted-host>
+          <template slot="template">slotted</template>
+        </mock-component-slotted-host>
+      `);
+      const component = host.$.component;
+      const template = fixtureSync(`<template slot="template">replaced</template>`);
+
+      host.replaceChildren(template);
+      await nextFrame();
+
+      expect(component.$.content.textContent).to.equal('replaced');
+    });
+
+    it('should render the fallback template when removing the slotted template', async () => {
+      const host = fixtureSync(`
+        <mock-component-slotted-host>
+          <template slot="template">slotted</template>
+        </mock-component-slotted-host>
+      `);
+      const template = host.querySelector('template');
+      const component = host.$.component;
+
+      host.removeChild(template);
+      await nextFrame();
+
+      expect(component.$.content.textContent).to.equal('fallback');
+    });
+  });
+});

--- a/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
+++ b/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
@@ -5,8 +5,8 @@ import { click, fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-template-renderer.js';
 import { Templatizer } from '../src/vaadin-template-renderer-templatizer.js';
 
-import './x-component-host.js';
-import './x-component.js';
+import './fixtures/mock-component-host.js';
+import './fixtures/mock-component.js';
 
 describe('vaadin-template-renderer', () => {
   describe('basic', () => {
@@ -14,9 +14,9 @@ describe('vaadin-template-renderer', () => {
 
     beforeEach(() => {
       component = fixtureSync(`
-        <x-component>
+        <mock-component>
           <template>foo</template>
-        </x-component>
+        </mock-component>
       `);
 
       template = component.querySelector('template');
@@ -52,11 +52,11 @@ describe('vaadin-template-renderer', () => {
 
   it('should not process non-child templates', () => {
     const component = fixtureSync(`
-      <x-component>
+      <mock-component>
         <div>
           <template>foo</template>
         </div>
-      </x-component>
+      </mock-component>
     `);
 
     expect(component.$.content.textContent).to.equal('');
@@ -64,17 +64,17 @@ describe('vaadin-template-renderer', () => {
 
   it('should render the last child template in case of multiple templates', () => {
     const component = fixtureSync(`
-      <x-component>
+      <mock-component>
         <template>foo</template>
         <template>bar</template>
-      </x-component>
+      </mock-component>
     `);
 
     expect(component.$.content.textContent).to.equal('bar');
   });
 
   it('should handle events from the template instance', () => {
-    const host = fixtureSync(`<x-component-host></x-component-host>`);
+    const host = fixtureSync(`<mock-component-host></mock-component-host>`);
     const component = host.$.component;
     const button = component.$.content.querySelector('button');
     const spy = sinon.spy(host, 'onClick');
@@ -85,7 +85,7 @@ describe('vaadin-template-renderer', () => {
   });
 
   it('should re-render the template istance when changing a parent property', async () => {
-    const host = fixtureSync(`<x-component-host></x-component-host>`);
+    const host = fixtureSync(`<mock-component-host></mock-component-host>`);
     const component = host.$.component;
 
     host.value = 'foobar';
@@ -94,8 +94,8 @@ describe('vaadin-template-renderer', () => {
   });
 
   it('should re-render multiple template instances independently', async () => {
-    const host1 = fixtureSync(`<x-component-host></x-component-host>`);
-    const host2 = fixtureSync(`<x-component-host></x-component-host>`);
+    const host1 = fixtureSync(`<mock-component-host></mock-component-host>`);
+    const host2 = fixtureSync(`<mock-component-host></mock-component-host>`);
     const component1 = host1.$.component;
     const component2 = host2.$.component;
 
@@ -107,7 +107,7 @@ describe('vaadin-template-renderer', () => {
   });
 
   it('should support the 2-way property binding', () => {
-    const host = fixtureSync(`<x-component-host></x-component-host>`);
+    const host = fixtureSync(`<mock-component-host></mock-component-host>`);
     const component = host.$.component;
     const input = component.$.content.querySelector('input');
 
@@ -119,7 +119,7 @@ describe('vaadin-template-renderer', () => {
 
   describe('observer', () => {
     it('should observe adding a template', async () => {
-      const component = fixtureSync(`<x-component></x-component>`);
+      const component = fixtureSync(`<mock-component></mock-component>`);
       const template = fixtureSync(`<template>bar</template>`);
 
       component.appendChild(template);
@@ -130,9 +130,9 @@ describe('vaadin-template-renderer', () => {
 
     it('should observe replacing a template', async () => {
       const component = fixtureSync(`
-        <x-component>
+        <mock-component>
           <template>foo</template>
-        </x-component>
+        </mock-component>
       `);
       const template = fixtureSync(`<template>bar</template>`);
 
@@ -143,7 +143,7 @@ describe('vaadin-template-renderer', () => {
     });
 
     it('should not observe adding a non-template element', async () => {
-      const component = fixtureSync(`<x-component></x-component>`);
+      const component = fixtureSync(`<mock-component></mock-component>`);
       const element = fixtureSync('<div>bar</div>');
 
       component.appendChild(element);
@@ -154,9 +154,9 @@ describe('vaadin-template-renderer', () => {
 
     it('should not observe adding a non-child template', async () => {
       const component = fixtureSync(`
-        <x-component>
+        <mock-component>
           <div></div>
-        </x-component>
+        </mock-component>
       `);
       const template = fixtureSync(`<template>bar</template>`);
 

--- a/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
+++ b/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
@@ -1,12 +1,13 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { click, fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { click, fire, fixtureSync } from '@vaadin/testing-helpers';
 
 import '../vaadin-template-renderer.js';
 import { Templatizer } from '../src/vaadin-template-renderer-templatizer.js';
 
-import './fixtures/mock-component-host.js';
 import './fixtures/mock-component.js';
+import './fixtures/mock-component-host.js';
+import './fixtures/mock-component-slotted-host.js';
 
 describe('vaadin-template-renderer', () => {
   describe('basic', () => {
@@ -117,53 +118,25 @@ describe('vaadin-template-renderer', () => {
     expect(host.value).to.equal('foobar');
   });
 
-  describe('observer', () => {
-    it('should observe adding a template', async () => {
-      const component = fixtureSync(`<mock-component></mock-component>`);
-      const template = fixtureSync(`<template>bar</template>`);
-
-      component.appendChild(template);
-      await nextFrame();
-
-      expect(component.$.content.textContent).to.equal('bar');
-    });
-
-    it('should observe replacing a template', async () => {
-      const component = fixtureSync(`
-        <mock-component>
-          <template>foo</template>
-        </mock-component>
+  describe('slotted templates', () => {
+    it('should render the fallback template', () => {
+      const host = fixtureSync(`
+        <mock-component-slotted-host></mock-component-slotted-host>
       `);
-      const template = fixtureSync(`<template>bar</template>`);
+      const component = host.$.component;
 
-      component.replaceChildren(template);
-      await nextFrame();
-
-      expect(component.$.content.textContent).to.equal('bar');
+      expect(component.$.content.textContent).to.equal('fallback');
     });
 
-    it('should not observe adding a non-template element', async () => {
-      const component = fixtureSync(`<mock-component></mock-component>`);
-      const element = fixtureSync('<div>bar</div>');
-
-      component.appendChild(element);
-      await nextFrame();
-
-      expect(component.$.content.textContent).to.equal('');
-    });
-
-    it('should not observe adding a non-child template', async () => {
-      const component = fixtureSync(`
-        <mock-component>
-          <div></div>
-        </mock-component>
+    it('should render the slotted template', () => {
+      const host = fixtureSync(`
+        <mock-component-slotted-host>
+          <template slot="template">slotted</template>
+        </mock-component-slotted-host>
       `);
-      const template = fixtureSync(`<template>bar</template>`);
+      const component = host.$.component;
 
-      component.querySelector('div').appendChild(template);
-      await nextFrame();
-
-      expect(component.$.content.textContent).to.equal('');
+      expect(component.$.content.textContent).to.equal('slotted');
     });
   });
 });


### PR DESCRIPTION
## Description

Currently, `vaadin-template-renderer` can process and observe only children templates which are not inside a slot. 

The support of slotted templates is a necessary step towards removing the Polymer Template API from `vaadin-grid`. It actively uses slotted templates in the tests.

This PR aims to support processing and observing slotted templates for `vaadin-template-renderer`.

Part of #326.

**Note:** I preferred using the Polymer Flattened Observer instead of creating an own implementation as far as it supports observing slotted nodes out of the box, and we already have the `@polymer/polymer` dependency.

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
