### PR TITLE
fix: handle leading hidden body rows

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -282,7 +282,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       // For body rows, use index property to find destination row, otherwise use DOM child index
       const dstRow =
         activeRowGroup === this.$.items
-          ? Array.from(activeRowGroup.children).filter((el) => el.index === dstRowIndex)[0]
+          ? Array.from(activeRowGroup.children).filter((el) => !el.hidden && el.index === dstRowIndex)[0]
           : activeRowGroup.children[dstRowIndex];
       if (!dstRow) {
         return;

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -501,9 +501,33 @@ class GridElement extends ElementMixin(
   }
 
   /** @private */
+  __getBodyCellCoordinates(cell) {
+    if (this.$.items.contains(cell) && cell.localName === 'td') {
+      return {
+        item: cell.parentElement._item,
+        column: cell._column
+      };
+    }
+  }
+
+  /** @private */
+  __focusBodyCell({ item, column }) {
+    const row = this._getVisibleRows().find((row) => row._item === item);
+    const cell = row && [...row.children].find((cell) => cell._column === column);
+    cell && cell.focus();
+  }
+
+  /** @private */
   _effectiveSizeChanged(effectiveSize, virtualizer, hasData, columnTree) {
     if (virtualizer && hasData && columnTree) {
+      // Changing the virtualizer size may result in the row with focus getting hidden
+      const cell = this.shadowRoot.activeElement;
+      const cellCoordinates = this.__getBodyCellCoordinates(cell);
+
       virtualizer.size = effectiveSize;
+
+      // If the focused cell's parent row got hidden by the size change, focus the corresponding new cell
+      cellCoordinates && cell.parentElement.hidden && this.__focusBodyCell(cellCoordinates);
     }
   }
 


### PR DESCRIPTION
Can't come up with a local test case. This is needed to fix [this test](https://github.com/vaadin/flow-components/blob/4a61d259fd6b32020243f6f690d7566fd4f97a2a/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/treegrid/it/TreeGridHugeTreeNavigationIT.java#L41) in https://github.com/vaadin/flow-components/pull/978