### PR TITLE
chore: add a `transferIssues` script [skip ci]

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -5,5 +5,6 @@
 SAUCE_USERNAME=
 SAUCE_ACCESS_KEY=
 
-# GitHub credentials for the transferIssues script
+# GitHub and ZenHub credentials for the transferIssues script
 GITHUB_API_TOKEN=
+ZENHUB_API_TOKEN=

--- a/.env.dist
+++ b/.env.dist
@@ -4,3 +4,6 @@
 # Credentials for Sauce Labs (required to run visual tests)
 SAUCE_USERNAME=
 SAUCE_ACCESS_KEY=
+
+# GitHub credentials for the transferIssues script
+GITHUB_API_TOKEN=

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lerna": "^4.0.0",
     "lint-staged": "^10.5.4",
     "npm-run-all": "^4.1.5",
+    "octokit": "^1.0.4",
     "playwright": "1.9.2",
     "prettier": "^2.2.1",
     "replace-in-file": "^6.2.0",

--- a/scripts/transferIssues.js
+++ b/scripts/transferIssues.js
@@ -1,10 +1,55 @@
 const fs = require('fs/promises');
+const dotenv = require('dotenv');
+const { Octokit } = require('octokit');
+
+dotenv.config();
 
 async function main() {
+  const octokit = new Octokit({ auth: process.env.GITHUB_API_TOKEN });
+
+  const {
+    data: { login }
+  } = await octokit.rest.users.getAuthenticated();
+  console.log(`Logged-in to GitHub as ${login}`);
+
+  let totalIssueCount = 0;
+  console.time('issues');
   const packages = await fs.readdir('packages');
-  packages.forEach((package) => {
-    console.log(`Transferring issues for the package ${package}...`);
-  });
+  await Promise.all(
+    packages.map((package) =>
+      (async () => {
+        console.log(`Transferring issues for the package ${package}...`);
+
+        let issueCount = 0;
+        try {
+          const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
+            owner: 'vaadin',
+            repo: package,
+            per_page: 100
+          });
+
+          // iterate through each response
+          for await (const { data: issues } of iterator) {
+            for (const issue of issues) {
+              issueCount += 1;
+              console.log('%s#%d: %s', package, issue.number, issue.title);
+            }
+          }
+        } catch (e) {
+          if (!!e.constructor && e.constructor.name === 'RequestError' && e.status === 404) {
+            console.log(`Skipped the package ${package} as it has no separate repo`);
+          } else {
+            throw e;
+          }
+        }
+
+        console.log(`total issues in the ${package} repo: ${issueCount}`);
+        totalIssueCount += issueCount;
+      })(package)
+    )
+  );
+  console.log(`total issues in all repos combined: ${totalIssueCount}`);
+  console.timeEnd(`issues`);
 }
 
 main();

--- a/scripts/transferIssues.js
+++ b/scripts/transferIssues.js
@@ -1,0 +1,10 @@
+const fs = require('fs/promises');
+
+async function main() {
+  const packages = await fs.readdir('packages');
+  packages.forEach((package) => {
+    console.log(`Transferring issues for the package ${package}...`);
+  });
+}
+
+main();

--- a/scripts/transferIssues.js
+++ b/scripts/transferIssues.js
@@ -28,11 +28,24 @@ async function main() {
             per_page: 100
           });
 
-          // iterate through each response
+          // iterate through each page of issues
           for await (const { data: issues } of iterator) {
+            // iterate through each issue in a page
             for (const issue of issues) {
-              issueCount += 1;
+              const [{ data: labels }] = await Promise.all([
+                octokit.rest.issues.listLabelsOnIssue({
+                  owner: 'vaadin',
+                  repo: package,
+                  issue_number: issue.number
+                })
+              ]);
+
               console.log('%s#%d: %s', package, issue.number, issue.title);
+
+              if (labels.length > 0) {
+                console.log(`\t[${labels.map((label) => label.name).join(', ')}]`);
+              }
+              issueCount += 1;
             }
           }
         } catch (e) {
@@ -52,4 +65,4 @@ async function main() {
   console.timeEnd(`issues`);
 }
 
-main();
+main().catch(console.log);

--- a/scripts/transferIssues.js
+++ b/scripts/transferIssues.js
@@ -416,6 +416,27 @@ async function main() {
 
       console.log(`total issues in the ${repo.name} repo: ${issueCount}`);
       totalIssueCount += issueCount;
+
+      const {
+        data: { open_issues_count }
+      } = await octokit.rest.repos.get({
+        owner: repo.owner.login,
+        repo: repo.name
+      });
+
+      if (open_issues_count === 0) {
+        // disable issues on the repo
+        await octokit.rest.repos.update({
+          owner: repo.owner.login,
+          repo: repo.name,
+          has_issues: false
+        });
+        console.log(`issues on the ${repo.name} repo are disabled`);
+      } else {
+        console.log(
+          `issues on the ${repo.name} repo are NOT disabled because it has ${open_issues_count} open issue(s)`
+        );
+      }
     })
   );
 

--- a/scripts/transferIssues.js
+++ b/scripts/transferIssues.js
@@ -8,22 +8,86 @@ dotenv.config();
 // if DRY_RUN then no actual changes are made
 const DRY_RUN = process.env.PRODUCTION_RUN !== true;
 
+// GitHub API client (both REST and GraphQL)
+const octokit = new Octokit({ auth: process.env.GITHUB_API_TOKEN });
+
+// ZenHub API client
+const zhApi = axios.create({
+  baseURL: 'https://api.zenhub.com/',
+  headers: {
+    'X-Authentication-Token': process.env.ZENHUB_API_TOKEN
+  },
+  adapter: zhRateLimitingAdapter(axios.defaults.adapter)
+});
+
 // The packages listed here will be skipped by this script.
 // All issues opened in that repos will remain untouched.
 const EXCLUDED_PACKAGES = [
   'vaadin-messages' // managed by the CE team
 ];
 
-const zhApi = axios.create({
-  baseURL: 'https://api.zenhub.com/',
-  headers: {
-    'X-Authentication-Token': process.env.ZENHUB_API_TOKEN
+// All open issues from the source repos will be transferred to _this_ repo:
+const TARGET_REPO = {
+  name: 'web-components',
+  owner: 'vaadin'
+};
+
+async function getSourceReposList() {
+  const packages = await fs.readdir('packages');
+
+  const repos = await Promise.all(
+    packages
+      .filter((package) => {
+        const skip = EXCLUDED_PACKAGES.indexOf(package) > -1;
+        if (skip) {
+          console.log(`Skipped the package ${package} as it's in the skip list`);
+        }
+        return !skip;
+      })
+      .map(async (package) => {
+        try {
+          const { data: repo } = await octokit.rest.repos.get({
+            owner: 'vaadin',
+            repo: package
+          });
+          return repo;
+        } catch (e) {
+          if (!!e.constructor && e.constructor.name === 'RequestError' && e.status === 404) {
+            console.log(`Skipped the package ${package} as it has no separate repo`);
+            return;
+          } else {
+            throw e;
+          }
+        }
+      })
+  );
+
+  return repos.filter((repo) => !!repo); // remove skipped packages from the list
+}
+
+const zhWorkspaceNameById = new Map();
+async function getZenHubWorkspaceName(workspace_id, repo_id) {
+  if (!zhWorkspaceNameById.has(workspace_id)) {
+    zhWorkspaceNameById.set(
+      workspace_id,
+      (async (workspace_id, repo_id) => {
+        const { data: workspaces } = await zhApi.get(`/p2/repositories/${repo_id}/workspaces`);
+        const idx = workspaces.findIndex((workspace) => workspace.id === workspace_id);
+        if (idx > -1) {
+          return workspaces[idx].name;
+        } else {
+          throw new Error(`Cannot find ZenHub workspace with ID ${workspace_id} for the repo with ID ${repo_id}`);
+        }
+      })(workspace_id, repo_id)
+    );
   }
-});
+
+  return zhWorkspaceNameById.get(workspace_id);
+}
 
 // Special handling for ZenHub REST API rate limiting
 // (see https://github.com/ZenHubIO/API#api-rate-limit)
-function rateLimitingAdapter(adapter) {
+function zhRateLimitingAdapter(adapter) {
   return async (config) => {
     let response;
     let status = 403;
@@ -47,203 +111,171 @@ function rateLimitingAdapter(adapter) {
     return response;
   };
 }
-zhApi.defaults.adapter = rateLimitingAdapter(zhApi.defaults.adapter);
 
-const zhWorkspaceNameById = new Map();
-async function getZenHubWorkspaceName(workspace_id, repo_id) {
-  if (!zhWorkspaceNameById.has(workspace_id)) {
-    zhWorkspaceNameById.set(
-      workspace_id,
-      (async (workspace_id, repo_id) => {
-        const { data: workspaces } = await zhApi.get(`/p2/repositories/${repo_id}/workspaces`);
-        const idx = workspaces.findIndex((workspace) => workspace.id === workspace_id);
-        if (idx > -1) {
-          return workspaces[idx].name;
-        } else {
-          throw new Error(`Cannot find ZenHub workspace with ID ${workspace_id} for the repo with ID ${repo_id}`);
-        }
-      })(workspace_id, repo_id)
-    );
+async function transferLabel(label, repo) {
+  let newLabel;
+  if (DRY_RUN) {
+    newLabel = await Promise.resolve(label);
+  } else {
+    const { data } = await octokit.rest.issues.createLabel({
+      owner: repo.owner.login,
+      repo: repo.name,
+      name: label.name,
+      description: label.description,
+      color: label.color
+    });
+    newLabel = data;
   }
 
-  return zhWorkspaceNameById.get(workspace_id);
+  return {
+    ...newLabel,
+    transferred: true
+  };
+}
+
+async function makeRepoLabelsMap(repo) {
+  const map = new Map();
+  const repoLabels = {
+    get: (labelName) => map.get(labelName.toLowerCase()),
+    set: (labelName, label) => map.set(labelName.toLowerCase(), label),
+    has: (labelName) => map.has(labelName.toLowerCase()),
+    values: () => map.values(),
+    ensure: async (label) => {
+      if (!repoLabels.has(label.name)) {
+        // First store a promise to remember that a transfer of _this_ label has
+        // been scheduled to avoid transferring the same label several times.
+        const promise = transferLabel(label, repo);
+        repoLabels.set(label.name, promise);
+
+        // Eventually, store the transferred label itself
+        console.log(`creating a label '${label.name}' in the ${repo.full_name} repo`);
+        repoLabels.set(label.name, await promise);
+      } else if ('then' in repoLabels.get(label.name)) {
+        console.log(`waiting until the label '${label.name}' is created in the ${repo.full_name} repo`);
+        await repoLabels.get(label.name);
+      }
+    }
+  };
+
+  // fetch the list of all existing labels on the target repo
+  const iterator = octokit.paginate.iterator(octokit.rest.issues.listLabelsForRepo, {
+    owner: repo.owner.login,
+    repo: repo.name,
+    per_page: 100
+  });
+
+  for await (const { data: labels } of iterator) {
+    for (const label of labels) {
+      repoLabels.set(label.name, { ...label, transferred: false });
+    }
+  }
+
+  return repoLabels;
 }
 
 async function main() {
-  const octokit = new Octokit({ auth: process.env.GITHUB_API_TOKEN });
-
   const {
     data: { login }
   } = await octokit.rest.users.getAuthenticated();
   console.log(`Logged-in to GitHub as ${login}`);
 
-  // fetch the list of all existing labels on the '@vaadin/web-components' repo
-  const iterator = octokit.paginate.iterator(octokit.rest.issues.listLabelsForRepo, {
-    owner: 'vaadin',
-    repo: 'web-components',
-    per_page: 100
+  const { data: targetRepo } = await octokit.rest.repos.get({
+    owner: TARGET_REPO.owner,
+    repo: TARGET_REPO.name
   });
+  console.log(`Transferring issues to the ${targetRepo.full_name} repo (GraphQL Node ID: ${targetRepo.node_id})`);
 
-  const webComponentsRepoLabels = (() => {
-    // the webComponentsRepoLabels Map is private to ensure it's only accessed
-    // using the functions below that make the key case-insensitive
-    const map = new Map();
-
-    return {
-      get: (labelName) => map.get(labelName.toLowerCase()),
-      set: (labelName, label) => map.set(labelName.toLowerCase(), label),
-      has: (labelName) => map.has(labelName.toLowerCase())
-    };
-  })();
-
-  console.log(`Labels on the @vaadin/web-components repo:`);
-  for await (const { data: labels } of iterator) {
-    for (const label of labels) {
-      webComponentsRepoLabels.set(label.name, { ...label, transferred: false });
-      console.log(`\t${JSON.stringify(webComponentsRepoLabels.get(label.name))}`);
-    }
+  const targetRepoLabels = await makeRepoLabelsMap(targetRepo);
+  console.log(`Existing labels in the ${targetRepo.full_name} repo:`);
+  for (const { name, color, description } of targetRepoLabels.values()) {
+    console.log(`\t${JSON.stringify({ name, color, description })}`);
   }
 
-  async function ensureWebComponentsRepoLabelExists(label) {
-    if (!webComponentsRepoLabels.has(label.name)) {
-      webComponentsRepoLabels.set(
-        label.name,
-        (async () => {
-          console.log(`creating a label '${label.name}' in the web-components repo`);
-          let newLabel;
-          if (DRY_RUN) {
-            newLabel = await Promise.resolve(label);
-          } else {
-            const { data } = await octokit.rest.issues.createLabel({
-              owner: 'vaadin',
-              repo: 'web-components',
-              name: label.name,
-              description: label.description,
-              color: label.color
-            });
-            newLabel = data;
-          }
-          webComponentsRepoLabels.set(label.name, {
-            ...newLabel,
-            transferred: true
-          });
-          return newLabel;
-        })()
-      );
-    } else if ('then' in webComponentsRepoLabels.get(label.name)) {
-      console.log(`waiting until the label '${label.name}' is created in the web-components repo`);
-      await webComponentsRepoLabels.get(label.name);
-    }
-  }
-
+  console.time('issues');
   let totalIssueCount = 0;
   let totalZhEpics = 0;
   let totalIssuesWithZhEstimate = 0;
-  console.time('issues');
-  const packages = await fs.readdir('packages');
+
+  const repos = await getSourceReposList();
   await Promise.all(
-    packages
-      .filter((package) => {
-        const skip = EXCLUDED_PACKAGES.indexOf(package) > -1;
-        if (skip) {
-          console.log(`Skipped the package ${package} as it's in the skip list`);
-        }
-        return !skip;
-      })
-      .map((package) =>
-        (async () => {
-          let repo;
-          try {
-            const response = await octokit.rest.repos.get({
-              owner: 'vaadin',
-              repo: package
-            });
-            repo = response.data;
-          } catch (e) {
-            if (!!e.constructor && e.constructor.name === 'RequestError' && e.status === 404) {
-              console.log(`Skipped the package ${package} as it has no separate repo`);
-              return;
-            } else {
-              throw e;
-            }
-          }
+    repos.map(async (repo) => {
+      let issueCount = 0;
+      console.log(`Transferring issues from the repo ${repo.full_name}...`);
 
-          let issueCount = 0;
-          console.log(`Transferring issues for the package ${package}...`);
+      const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
+        owner: repo.owner.login,
+        repo: repo.name,
+        per_page: 100
+      });
 
-          const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
-            owner: 'vaadin',
-            repo: package,
-            per_page: 100
-          });
-
-          // iterate through each page of issues
-          for await (const { data: issues } of iterator) {
-            // iterate through each issue in a page
-            for (const issue of issues) {
-              const [{ data: labels }, zhIssue] = await Promise.all([
-                // fetch all labels on the issue
-                // (no need for pagination as there is never too many)
-                octokit.rest.issues.listLabelsOnIssue({
-                  owner: 'vaadin',
-                  repo: package,
-                  issue_number: issue.number
-                }),
-                // AND at the same time fetch ZenHub pipelines for the issue
-                zhApi.get(`/p1/repositories/${repo.id}/issues/${issue.number}`).then(async (response) => ({
-                  ...response.data,
-                  // enrich the returned pipelines list with the ZenHub workspace name for each pipeline
-                  pipelines: await Promise.all(
-                    response.data.pipelines.map(async (pipeline) => ({
-                      ...pipeline,
-                      workspace: await getZenHubWorkspaceName(pipeline.workspace_id, repo.id)
-                    }))
-                  )
+      // iterate through each page of issues
+      for await (const { data: issues } of iterator) {
+        // iterate through each issue in a page
+        for (const issue of issues) {
+          const [{ data: labels }, zhIssue] = await Promise.all([
+            // fetch all labels on the issue
+            // (no need for pagination as there is never too many)
+            octokit.rest.issues.listLabelsOnIssue({
+              owner: repo.owner.login,
+              repo: repo.name,
+              issue_number: issue.number
+            }),
+            // AND at the same time fetch ZenHub pipelines for the issue
+            (async () => {
+              const { data: zhIssue } = await zhApi.get(`/p1/repositories/${repo.id}/issues/${issue.number}`);
+              const pipelinesWithWorkspaceName = await Promise.all(
+                zhIssue.pipelines.map(async (pipeline) => ({
+                  ...pipeline,
+                  workspace: await getZenHubWorkspaceName(pipeline.workspace_id, repo.id)
                 }))
-              ]);
+              );
+              return { ...zhIssue, pipelines: pipelinesWithWorkspaceName };
+            })()
+          ]);
 
-              if (zhIssue.is_epic) {
-                console.log(`Skipping ${package}#${issue.number} because it's a ZH Epic`);
-                totalZhEpics += 1;
-                continue;
-              }
-
-              if (zhIssue.estimate) {
-                console.log(`${package}#${issue.number} has a ZH estimate of ${zhIssue.estimate.value}`);
-                totalIssuesWithZhEstimate += 1;
-              }
-
-              if (labels.length > 0) {
-                await Promise.all(labels.map(ensureWebComponentsRepoLabelExists));
-              }
-
-              console.log('%s#%d: %s', package, issue.number, issue.title);
-              if (labels.length > 0) {
-                console.log(
-                  `\tlabels: [${labels
-                    .map(
-                      (label) =>
-                        label.name + (webComponentsRepoLabels.get(label.name).transferred ? ' [TRANSFERRED]' : '')
-                    )
-                    .join(', ')}]`
-                );
-              }
-              if (zhIssue.pipelines.length > 0) {
-                console.log(
-                  `\tpipelines: [${zhIssue.pipelines
-                    .map((pipeline) => `${pipeline.name} in ${pipeline.workspace}`)
-                    .join(', ')}]`
-                );
-              }
-              issueCount += 1;
-            }
+          if (zhIssue.is_epic) {
+            console.log(`Skipping ${repo.name}#${issue.number} because it's a ZH Epic`);
+            totalZhEpics += 1;
+            continue;
           }
 
-          console.log(`total issues in the ${package} repo: ${issueCount}`);
-          totalIssueCount += issueCount;
-        })(package)
-      )
+          if (zhIssue.estimate) {
+            console.log(
+              `${repo.name}#${issue.number} has a ZH estimate of ${zhIssue.estimate.value}. ` +
+                `The estimate won't be transferred automatically, please do it manually.`
+            );
+            totalIssuesWithZhEstimate += 1;
+          }
+
+          if (labels.length > 0) {
+            await Promise.all(labels.map(targetRepoLabels.ensure));
+          }
+
+          console.log('%s#%d: %s', repo.name, issue.number, issue.title);
+
+          if (labels.length > 0) {
+            console.log(
+              `\tlabels: [${labels
+                .map((label) => label.name + (targetRepoLabels.get(label.name).transferred ? ' [TRANSFERRED]' : ''))
+                .join(', ')}]`
+            );
+          }
+          if (zhIssue.pipelines.length > 0) {
+            console.log(
+              `\tpipelines: [${zhIssue.pipelines
+                .map((pipeline) => `${pipeline.name} in ${pipeline.workspace}`)
+                .join(', ')}]`
+            );
+          }
+          issueCount += 1;
+        }
+      }
+
+      console.log(`total issues in the ${repo.name} repo: ${issueCount}`);
+      totalIssueCount += issueCount;
+    })
   );
+
   console.log(`total issues in all repos combined: ${totalIssueCount}`);
   console.log(`total ZenHub Epics skipped in all repos combined: ${totalZhEpics}`);
   console.log(`total issues with ZenHub estimates in all repos combined: ${totalIssuesWithZhEstimate}`);

--- a/scripts/transferIssues.js
+++ b/scripts/transferIssues.js
@@ -1,8 +1,36 @@
 const fs = require('fs/promises');
 const dotenv = require('dotenv');
 const { Octokit } = require('octokit');
+const axios = require('axios');
 
 dotenv.config();
+
+const zhApi = axios.create({
+  baseURL: 'https://api.zenhub.com/',
+  headers: {
+    'X-Authentication-Token': process.env.ZENHUB_API_TOKEN
+  }
+});
+
+const zhWorkspaceNameById = new Map();
+async function getZenHubWorkspaceName(workspace_id, repo_id) {
+  if (!zhWorkspaceNameById.has(workspace_id)) {
+    zhWorkspaceNameById.set(
+      workspace_id,
+      (async (workspace_id, repo_id) => {
+        const { data: workspaces } = await zhApi.get(`/p2/repositories/${repo_id}/workspaces`);
+        const idx = workspaces.findIndex((workspace) => workspace.id === workspace_id);
+        if (idx > -1) {
+          return workspaces[idx].name;
+        } else {
+          throw new Error(`Cannot find ZenHub workspace with ID ${workspace_id} for the repo with ID ${repo_id}`);
+        }
+      })(workspace_id, repo_id)
+    );
+  }
+
+  return zhWorkspaceNameById.get(workspace_id);
+}
 
 async function main() {
   const octokit = new Octokit({ auth: process.env.GITHUB_API_TOKEN });
@@ -18,41 +46,65 @@ async function main() {
   await Promise.all(
     packages.map((package) =>
       (async () => {
-        console.log(`Transferring issues for the package ${package}...`);
-
-        let issueCount = 0;
+        let repo;
         try {
-          const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
+          const response = await octokit.rest.repos.get({
             owner: 'vaadin',
-            repo: package,
-            per_page: 100
+            repo: package
           });
-
-          // iterate through each page of issues
-          for await (const { data: issues } of iterator) {
-            // iterate through each issue in a page
-            for (const issue of issues) {
-              const [{ data: labels }] = await Promise.all([
-                octokit.rest.issues.listLabelsOnIssue({
-                  owner: 'vaadin',
-                  repo: package,
-                  issue_number: issue.number
-                })
-              ]);
-
-              console.log('%s#%d: %s', package, issue.number, issue.title);
-
-              if (labels.length > 0) {
-                console.log(`\t[${labels.map((label) => label.name).join(', ')}]`);
-              }
-              issueCount += 1;
-            }
-          }
+          repo = response.data;
         } catch (e) {
           if (!!e.constructor && e.constructor.name === 'RequestError' && e.status === 404) {
             console.log(`Skipped the package ${package} as it has no separate repo`);
+            return;
           } else {
             throw e;
+          }
+        }
+
+        let issueCount = 0;
+        console.log(`Transferring issues for the package ${package}...`);
+
+        const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
+          owner: 'vaadin',
+          repo: package,
+          per_page: 100
+        });
+
+        // iterate through each page of issues
+        for await (const { data: issues } of iterator) {
+          // iterate through each issue in a page
+          for (const issue of issues) {
+            const [{ data: labels }, pipelines] = await Promise.all([
+              // fetch all labels on the issue
+              // (no need for pagination as there is never too many)
+              octokit.rest.issues.listLabelsOnIssue({
+                owner: 'vaadin',
+                repo: package,
+                issue_number: issue.number
+              }),
+              // AND at the same time fetch ZenHub pipelines for the issue
+              zhApi.get(`/p1/repositories/${repo.id}/issues/${issue.number}`).then(({ data: { pipelines } }) =>
+                // enrich the returned pipelines list with the ZenHub workspace name for each pipeline
+                Promise.all(
+                  pipelines.map(async (pipeline) => ({
+                    ...pipeline,
+                    workspace: await getZenHubWorkspaceName(pipeline.workspace_id, repo.id)
+                  }))
+                )
+              )
+            ]);
+
+            console.log('%s#%d: %s', package, issue.number, issue.title);
+            if (labels.length > 0) {
+              console.log(`\tlabels: [${labels.map((label) => label.name).join(', ')}]`);
+            }
+            if (pipelines.length > 0) {
+              console.log(
+                `\tpipelines: [${pipelines.map((pipeline) => `${pipeline.name} in ${pipeline.workspace}`).join(', ')}]`
+              );
+            }
+            issueCount += 1;
           }
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,6 +1019,70 @@
     node-gyp "^7.1.0"
     read-package-json-fast "^2.0.1"
 
+"@octokit/app@^12.0.0":
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/app/-/app-12.0.2.tgz#1232d1760c2495a2d1b5e655b423757e544e0d5c"
+  integrity sha512-yQNnVR7ZvElQHmuEfcI/fg3Z3waRCNV9TC1FLaO0e6AT4SEJPUrymRKWhG9ts7kUCWseVSHlxR+r/zsbIPd+9w==
+  dependencies:
+    "@octokit/auth-app" "^3.3.0"
+    "@octokit/auth-unauthenticated" "^2.0.4"
+    "@octokit/core" "^3.4.0"
+    "@octokit/oauth-app" "^3.3.2"
+    "@octokit/plugin-paginate-rest" "^2.13.3"
+    "@octokit/types" "^6.13.0"
+    "@octokit/webhooks" "^9.0.1"
+
+"@octokit/auth-app@^3.3.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-app/-/auth-app-3.4.0.tgz#af9f68512e7b8dd071b49e1470a1ddf88ff6a3a3"
+  integrity sha512-zBVgTnLJb0uoNMGCpcDkkAbPeavHX7oAjJkaDv2nqMmsXSsCw4AbUhjl99EtJQG/JqFY/kLFHM9330Wn0k70+g==
+  dependencies:
+    "@octokit/auth-oauth-app" "^4.1.0"
+    "@octokit/auth-oauth-user" "^1.2.3"
+    "@octokit/request" "^5.4.11"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^6.0.3"
+    "@types/lru-cache" "^5.1.0"
+    deprecation "^2.3.1"
+    lru-cache "^6.0.0"
+    universal-github-app-jwt "^1.0.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-oauth-app@^4.0.0", "@octokit/auth-oauth-app@^4.1.0":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-app/-/auth-oauth-app-4.1.2.tgz#bf3ff30c260e6e9f10b950386f279befb8fe907d"
+  integrity sha512-bdNGNRmuDJjKoHla3mUGtkk/xcxKngnQfBEnyk+7VwMqrABKvQB1wQRSrwSWkPPUX7Lcj2ttkPAPG7+iBkMRnw==
+  dependencies:
+    "@octokit/auth-oauth-device" "^3.1.1"
+    "@octokit/auth-oauth-user" "^1.2.1"
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^6.0.3"
+    "@types/btoa-lite" "^1.0.0"
+    btoa-lite "^1.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-oauth-device@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-device/-/auth-oauth-device-3.1.1.tgz#380499f9a850425e2c7bdeb62afc070181c536a9"
+  integrity sha512-ykDZROilszXZJ6pYdl6SZ15UZniCs0zDcKgwOZpMz3U0QDHPUhFGXjHToBCAIHwbncMu+jLt4/Nw4lq3FwAw/w==
+  dependencies:
+    "@octokit/oauth-methods" "^1.1.0"
+    "@octokit/request" "^5.4.14"
+    "@octokit/types" "^6.10.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-oauth-user@^1.2.1", "@octokit/auth-oauth-user@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-user/-/auth-oauth-user-1.2.4.tgz#3594eb7d40cb462240e7e90849781dfa0045aed5"
+  integrity sha512-efOajupCZBP1veqx5w59Qey0lIud1rDUgxTRjjkQDU3eOBmkAasY1pXemDsQwW0I85jb1P/gn2dMejedVxf9kw==
+  dependencies:
+    "@octokit/auth-oauth-device" "^3.1.1"
+    "@octokit/oauth-methods" "^1.1.0"
+    "@octokit/request" "^5.4.14"
+    "@octokit/types" "^6.12.2"
+    btoa-lite "^1.0.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/auth-token@^2.4.4":
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
@@ -1026,7 +1090,15 @@
   dependencies:
     "@octokit/types" "^6.0.3"
 
-"@octokit/core@^3.2.3":
+"@octokit/auth-unauthenticated@^2.0.0", "@octokit/auth-unauthenticated@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-unauthenticated/-/auth-unauthenticated-2.0.4.tgz#c84f98e0ca4b20e0f950eef5cc61d83384509c2c"
+  integrity sha512-jZMwIz2PfQuLcOQRRELY6zb/jIyWQKlPxVV1oEG4sxJNmnANz3Skvnz4kVNvfs1r2jhgKAx9Pb6f+3vXeyh7yg==
+  dependencies:
+    "@octokit/request-error" "^2.0.2"
+    "@octokit/types" "^6.0.3"
+
+"@octokit/core@^3.2.3", "@octokit/core@^3.3.1", "@octokit/core@^3.3.2", "@octokit/core@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.4.0.tgz#b48aa27d755b339fe7550548b340dcc2b513b742"
   integrity sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==
@@ -1057,17 +1129,52 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
+"@octokit/oauth-app@^3.3.0", "@octokit/oauth-app@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@octokit/oauth-app/-/oauth-app-3.3.2.tgz#f8c2687afee6b6657095d1db7f5e194e4d75751d"
+  integrity sha512-vZPleCS65Sq2fXQYWt1JmTqrNUdsmdvmgr4rmZhxKaX/Fc6xExtNCBmksAbSMY9q3uFBv76BuvNWGKFNpXy5Tw==
+  dependencies:
+    "@octokit/auth-oauth-app" "^4.0.0"
+    "@octokit/auth-oauth-user" "^1.2.3"
+    "@octokit/auth-unauthenticated" "^2.0.0"
+    "@octokit/core" "^3.3.2"
+    "@octokit/oauth-authorization-url" "^4.2.1"
+    "@octokit/oauth-methods" "^1.2.2"
+    fromentries "^1.3.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/oauth-authorization-url@^4.2.1", "@octokit/oauth-authorization-url@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@octokit/oauth-authorization-url/-/oauth-authorization-url-4.3.1.tgz#008d09bf427a7f61c70b5283040d60a456011a51"
+  integrity sha512-sI/SOEAvzRhqdzj+kJl+2ifblRve2XU6ZB36Lq25Su8R31zE3GoKToSLh64nWFnKePNi2RrdcMm94UEIQZslOw==
+
+"@octokit/oauth-methods@^1.1.0", "@octokit/oauth-methods@^1.2.2":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@octokit/oauth-methods/-/oauth-methods-1.2.3.tgz#0b332422ad3ea63e0011a7b4fb912cff5327c8e7"
+  integrity sha512-Lyta6i7vK9SrzE+Dybw465pSZPe9+vAh3fPA5BvXq+aVEY6wOd0Skczwz/bcPn8TEXzY6A3Tgywr2myLOW5muA==
+  dependencies:
+    "@octokit/oauth-authorization-url" "^4.3.1"
+    "@octokit/request" "^5.4.14"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.12.2"
+    btoa-lite "^1.0.0"
+
 "@octokit/openapi-types@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-6.0.0.tgz#7da8d7d5a72d3282c1a3ff9f951c8133a707480d"
   integrity sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ==
+
+"@octokit/openapi-types@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-7.0.0.tgz#0f6992db9854af15eca77d71ab0ec7fad2f20411"
+  integrity sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw==
 
 "@octokit/plugin-enterprise-rest@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-6.0.1.tgz#e07896739618dab8da7d4077c658003775f95437"
   integrity sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw==
 
-"@octokit/plugin-paginate-rest@^2.6.2":
+"@octokit/plugin-paginate-rest@^2.13.3", "@octokit/plugin-paginate-rest@^2.6.2":
   version "2.13.3"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz#f0f1792230805108762d87906fb02d573b9e070a"
   integrity sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==
@@ -1087,7 +1194,31 @@
     "@octokit/types" "^6.13.0"
     deprecation "^2.3.1"
 
-"@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.5":
+"@octokit/plugin-rest-endpoint-methods@^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.1.1.tgz#1720de3511944ebcca5c391ea82605e13e8f95eb"
+  integrity sha512-u4zy0rVA8darm/AYsIeWkRalhQR99qPL1D/EXHejV2yaECMdHfxXiTXtba8NMBSajOJe8+C9g+EqMKSvysx0dg==
+  dependencies:
+    "@octokit/types" "^6.14.1"
+    deprecation "^2.3.1"
+
+"@octokit/plugin-retry@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.7.tgz#174516f2b80b7140aee71ebc2b506db2c5c1d3d6"
+  integrity sha512-n08BPfVeKj5wnyH7IaOWnuKbx+e9rSJkhDHMJWXLPv61625uWjsN8G7sAW3zWm9n9vnS4friE7LL/XLcyGeG8Q==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    bottleneck "^2.15.3"
+
+"@octokit/plugin-throttling@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-3.4.1.tgz#586aaa01ea653019380b137872c6256b0e2f2e5d"
+  integrity sha512-qCQ+Z4AnL9OrXvV59EH3GzPxsB+WyqufoCjiCJXJxTbnt3W+leXbXw5vHrMp4NG9ltw00McFWIxIxNQAzLNoTA==
+  dependencies:
+    "@octokit/types" "^6.0.1"
+    bottleneck "^2.15.3"
+
+"@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.2", "@octokit/request-error@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.5.tgz#72cc91edc870281ad583a42619256b380c600143"
   integrity sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==
@@ -1096,7 +1227,7 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.11", "@octokit/request@^5.4.12", "@octokit/request@^5.4.14":
   version "5.4.15"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.15.tgz#829da413dc7dd3aa5e2cdbb1c7d0ebe1f146a128"
   integrity sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==
@@ -1118,12 +1249,39 @@
     "@octokit/plugin-request-log" "^1.0.2"
     "@octokit/plugin-rest-endpoint-methods" "5.0.0"
 
+"@octokit/types@^6.0.1", "@octokit/types@^6.10.0", "@octokit/types@^6.12.2", "@octokit/types@^6.14.1":
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.14.2.tgz#64c9457f38fb8522bdbba3c8cc814590a2d61bf5"
+  integrity sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==
+  dependencies:
+    "@octokit/openapi-types" "^7.0.0"
+
 "@octokit/types@^6.0.3", "@octokit/types@^6.11.0", "@octokit/types@^6.13.0", "@octokit/types@^6.7.1":
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.13.0.tgz#779e5b7566c8dde68f2f6273861dd2f0409480d0"
   integrity sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==
   dependencies:
     "@octokit/openapi-types" "^6.0.0"
+
+"@octokit/webhooks-methods@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-methods/-/webhooks-methods-1.0.0.tgz#274799138725c89a3466e3af2026afe755f28c4b"
+  integrity sha512-pVceMQcj9SZ5p2RkemL0TuuPdGULNQj9F3Pq1cNM1xH+Kst1VNt0dj3PEGZRZV473njrDnYdi/OG4wWY9TLbbA==
+
+"@octokit/webhooks-types@3.74.0":
+  version "3.74.0"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-3.74.0.tgz#f28db8331f1c4460111e8533419d1e8b06edb3a7"
+  integrity sha512-yRVaBKRNt22HXwmJ5GpOfXRf98Dsz30Hm+sWoW3tCYl29RWPQMu5q2R5BE10sSqyRzIS2nBteNyHxyzcF+GWew==
+
+"@octokit/webhooks@^9.0.1":
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-9.6.0.tgz#5a193f12e057fcff67524268c38d888e06304c60"
+  integrity sha512-/nfOuyyYihEf+1TjEQbqLXmMRHfT9P7WkzSjfLHmA06YhGXd6zfct+0wXw9k2FyAGjGnFBuVLA7sSM29TfwiKw==
+  dependencies:
+    "@octokit/request-error" "^2.0.2"
+    "@octokit/webhooks-methods" "^1.0.0"
+    "@octokit/webhooks-types" "3.74.0"
+    aggregate-error "^3.1.0"
 
 "@open-wc/building-utils@^2.18.3":
   version "2.18.4"
@@ -1314,7 +1472,7 @@
     "@polymer/iron-validatable-behavior" "^3.0.0-pre.26"
     "@polymer/polymer" "^3.0.0"
 
-"@polymer/iron-list@^3.0.0", "@polymer/iron-list@^3.1.0":
+"@polymer/iron-list@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@polymer/iron-list/-/iron-list-3.1.0.tgz#9b525249a90a53b6ae249330640b54b12141202a"
   integrity sha512-Eiv6xd3h3oPmn8SXFntXVfC3ZnegH+KHAxiKLKcOASFSRY3mHnr2AdcnExUJ9ItoCMA5UzKaM/0U22eWzGERtA==
@@ -1566,6 +1724,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/btoa-lite@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/btoa-lite/-/btoa-lite-1.0.0.tgz#e190a5a548e0b348adb0df9ac7fa5f1151c7cca4"
+  integrity sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg==
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
@@ -1706,6 +1869,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/jsonwebtoken@^8.3.3":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#56958cb2d80f6d74352bd2e501a018e2506a8a84"
+  integrity sha512-rNAPdomlIUX0i0cg2+I+Q1wOUr531zHBQ+cV/28PJ39bSPKjahatZZ2LMuhiguETkCgLVzfruw/ZvNMNkKoSzw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/keygrip@*":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.2.tgz#513abfd256d7ad0bf1ee1873606317b33b1b2a72"
@@ -1738,6 +1908,11 @@
     "@types/keygrip" "*"
     "@types/koa-compose" "*"
     "@types/node" "*"
+
+"@types/lru-cache@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
+  integrity sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==
 
 "@types/mdast@^3.0.0":
   version "3.0.3"
@@ -2318,7 +2493,7 @@ agentkeepalive@^4.1.3:
     depd "^1.1.2"
     humanize-ms "^1.2.1"
 
-aggregate-error@^3.0.0:
+aggregate-error@^3.0.0, aggregate-error@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
   integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
@@ -2893,6 +3068,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bottleneck@^2.15.3:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2935,6 +3115,11 @@ browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.0:
     escalade "^3.1.1"
     node-releases "^1.1.71"
 
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
+  integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
+
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
@@ -2952,6 +3137,11 @@ buffer-crc32@^0.2.1, buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer-equal@^1.0.0:
   version "1.0.0"
@@ -4468,6 +4658,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 edge-paths@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/edge-paths/-/edge-paths-2.2.1.tgz#d2d91513225c06514aeac9843bfce546abbf4391"
@@ -5294,6 +5491,11 @@ from2@^2.1.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fromentries@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
+  integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -6980,6 +7182,22 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -6999,6 +7217,23 @@ just-extend@^4.0.2:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 keygrip@~1.1.0:
   version "1.1.0"
@@ -7427,6 +7662,11 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -7437,10 +7677,25 @@ lodash.isarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
 
 lodash.isobject@^3.0.2:
   version "3.0.2"
@@ -7451,6 +7706,11 @@ lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -7465,6 +7725,11 @@ lodash.merge@^4.6.1:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.restparam@^3.0.0:
   version "3.6.1"
@@ -8543,6 +8808,20 @@ object.values@^1.1.0:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.2"
     has "^1.0.3"
+
+octokit@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/octokit/-/octokit-1.0.4.tgz#f594d26a62e140698202787e5e5183bf54c79d2b"
+  integrity sha512-/Esx6IDSMccmho9lbUoBJIrr0ZBGV41V9Xe/ZyFRDJNzUR9GZ0RrjogTJPWnYb5NiBfjjDy3L27mbJN+mYSXQQ==
+  dependencies:
+    "@octokit/app" "^12.0.0"
+    "@octokit/core" "^3.3.1"
+    "@octokit/oauth-app" "^3.3.0"
+    "@octokit/plugin-paginate-rest" "^2.13.3"
+    "@octokit/plugin-rest-endpoint-methods" "^5.0.0"
+    "@octokit/plugin-retry" "^3.0.7"
+    "@octokit/plugin-throttling" "^3.4.1"
+    "@octokit/types" "^6.13.0"
 
 on-finished@^2.3.0:
   version "2.3.0"
@@ -11466,6 +11745,14 @@ unist-util-stringify-position@^2.0.0:
   integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
   dependencies:
     "@types/unist" "^2.0.2"
+
+universal-github-app-jwt@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz#0abaa876101cdf1d3e4c546be2768841c0c1b514"
+  integrity sha512-3b+ocAjjz4JTyqaOT+NNBd5BtTuvJTxWElIoeHSVelUV9J3Jp7avmQTdLKCaoqi/5Ox2o/q+VK19TJ233rVXVQ==
+  dependencies:
+    "@types/jsonwebtoken" "^8.3.3"
+    jsonwebtoken "^8.5.1"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## Description

Intended usage: `node scripts/transferIssues.js` to transfer all open issues from individual web component repos into the web-components monorepo for each of the web components in the `./packages` folder of this monorepo.

Labels on the transferred issues are transferred as well. The transferred issues remain in the same pipelines (columns) on all ZenHub boards (if both the web-components monorepo and the original issue's repo are present on the board).

If a label was missing in the web-components repo, it will be created (with the same color as in the original repo).

Fixes https://github.com/vaadin/components-team-tasks/issues/580

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.