### PR TITLE
chore: node12 compat fix for the transferIssues script [skip ci]

### DIFF
--- a/scripts/transferIssues.js
+++ b/scripts/transferIssues.js
@@ -1,4 +1,4 @@
-const fs = require('fs/promises');
+const fs = require('fs').promises;
 const dotenv = require('dotenv');
 const { Octokit } = require('octokit');
 const axios = require('axios');


### PR DESCRIPTION
## Description

`require('fs/promises')` is supported from node 14 onwards. The Node version on the Bender CI server is below that.

Related to https://github.com/vaadin/components-team-tasks/issues/580

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.