### PR TITLE
chore: do not disable repo isses by the transfer script [skip ci]

### DIFF
--- a/scripts/transferIssues.js
+++ b/scripts/transferIssues.js
@@ -416,27 +416,6 @@ async function main() {
 
       console.log(`total issues in the ${repo.name} repo: ${issueCount}`);
       totalIssueCount += issueCount;
-
-      const {
-        data: { open_issues_count }
-      } = await octokit.rest.repos.get({
-        owner: repo.owner.login,
-        repo: repo.name
-      });
-
-      if (open_issues_count === 0) {
-        // disable issues on the repo
-        await octokit.rest.repos.update({
-          owner: repo.owner.login,
-          repo: repo.name,
-          has_issues: false
-        });
-        console.log(`issues on the ${repo.name} repo are disabled`);
-      } else {
-        console.log(
-          `issues on the ${repo.name} repo are NOT disabled because it has ${open_issues_count} open issue(s)`
-        );
-      }
     })
   );
 


### PR DESCRIPTION
## Description

When running on the CI the API call to disable repo issues consistently fails (even though is runs OK when running locally using an API token with fewer scopes).

Related https://github.com/vaadin/components-team-tasks/issues/580

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.