### PR TITLE
chore: skip open PRs in `transferIssues` script [skip ci]

### DIFF
--- a/scripts/transferIssues.js
+++ b/scripts/transferIssues.js
@@ -316,6 +316,11 @@ async function main() {
       for await (const { data: issues } of iterator) {
         // iterate through each issue in a page
         for (const issue of issues) {
+          // do not transfer open PRs
+          if (issue.html_url.indexOf('/pull/') > -1) {
+            continue;
+          }
+
           if (shouldExcludeIssue(issue)) {
             console.log(`Skipping ${repo.name}#${issue.number} because the shouldExcludeIssue() filter returned true`);
             continue;


### PR DESCRIPTION
## Description

Skip open PRs in the `transferIssues` script. The GitHub API to iterate over open issues sometimes returns PRs as well. This commit adds the logic to skip them in the transfer.

Related https://github.com/vaadin/components-team-tasks/issues/580

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.