### PR TITLE
fix: virtual list styles

### DIFF
--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -37,10 +37,16 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           display: block;
           height: 200px;
           overflow: auto;
+          flex: auto;
+          align-self: stretch;
         }
 
         :host([hidden]) {
           display: none !important;
+        }
+
+        :host(:not([grid])) #items > ::slotted(*) {
+          width: 100%;
         }
       </style>
 

--- a/packages/vaadin-virtual-list/test/virtual-list.test.js
+++ b/packages/vaadin-virtual-list/test/virtual-list.test.js
@@ -28,6 +28,15 @@ describe('virtual-list', () => {
     expect(list.children.length).to.equal(0);
   });
 
+  it('should not collapse inside a flexbox', () => {
+    const flexBox = fixtureSync(`
+      <div style="display:flex">
+        <vaadin-virtual-list></vaadin-virtual-list>
+      </div>`);
+
+    expect(flexBox.firstElementChild.offsetWidth).to.equal(flexBox.offsetWidth);
+  });
+
   describe('with items', () => {
     beforeEach(() => {
       const size = 100;
@@ -74,6 +83,10 @@ describe('virtual-list', () => {
       const listRect = list.getBoundingClientRect();
       const firstVisibleElement = list.getRootNode().elementFromPoint(listRect.left, listRect.top);
       expect(firstVisibleElement.textContent.trim()).to.equal('value-50');
+    });
+
+    it('should have full width items', () => {
+      expect(list.firstElementChild.offsetWidth).to.equal(list.offsetWidth);
     });
   });
 });


### PR DESCRIPTION
Fixes to default styles:
- Make the child elements 100% wide by default
- Make the component not collapse inside a flex box
