### PR TITLE
ref!: convert internal grid templates to renderers

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column.d.ts
@@ -80,23 +80,9 @@ interface ColumnBaseMixin<TItem> {
 
   _prepareTemplatizer(template: HTMLTemplateElement | null, instanceProps: object | null): HTMLTemplateElement | null;
 
-  _renderHeaderAndFooter(): void;
-
   _selectFirstTemplate(header?: boolean, footer?: boolean): HTMLTemplateElement | null;
 
   _findTemplate(header: boolean, footer: boolean): HTMLTemplateElement | null;
-
-  _pathOrHeaderChanged(
-    path: string | undefined,
-    header: string | undefined,
-    headerCell: HTMLTableCellElement | undefined,
-    footerCell: HTMLTableCellElement | undefined,
-    cells: object | undefined,
-    renderer: GridBodyRenderer<TItem> | null | undefined,
-    headerRenderer: GridHeaderFooterRenderer<TItem> | null | undefined,
-    bodyTemplate: HTMLTemplateElement | null | undefined,
-    headerTemplate: HTMLTemplateElement | null | undefined
-  ): void;
 
   _generateHeader(path: string): string;
 

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -129,6 +129,15 @@ export const ColumnBaseMixin = (superClass) =>
          */
         headerRenderer: Function,
 
+        /** @private */
+        __defaultHeaderRenderer: Function,
+
+        /** @private */
+        __headerRenderer: {
+          type: Function,
+          computed: '__computeHeaderRenderer(headerRenderer, __defaultHeaderRenderer, _headerTemplate)'
+        },
+
         /**
          * Custom function for rendering the footer content.
          * Receives two arguments:
@@ -138,7 +147,16 @@ export const ColumnBaseMixin = (superClass) =>
          *
          * @type {GridHeaderFooterRenderer | null | undefined}
          */
-        footerRenderer: Function
+        footerRenderer: Function,
+
+        /** @private */
+        __defaultFooterRenderer: Function,
+
+        /** @private */
+        __footerRenderer: {
+          type: Function,
+          computed: '__computeFooterRenderer(footerRenderer, __defaultFooterRenderer, _footerTemplate)'
+        }
       };
     }
 
@@ -151,9 +169,9 @@ export const ColumnBaseMixin = (superClass) =>
         '_textAlignChanged(textAlign, _cells.*, _headerCell, _footerCell)',
         '_orderChanged(_order, _headerCell, _footerCell, _cells.*)',
         '_lastFrozenChanged(_lastFrozen)',
-        '_setBodyTemplateOrRenderer(_bodyTemplate, renderer, _cells, _cells.*)',
-        '_setHeaderTemplateOrRenderer(_headerTemplate, headerRenderer, _headerCell)',
-        '_setFooterTemplateOrRenderer(_footerTemplate, footerRenderer, _footerCell)',
+        '_setBodyTemplateOrRenderer(_bodyTemplate, __renderer, _cells, _cells.*)',
+        '_setHeaderTemplateOrRenderer(_headerTemplate, __headerRenderer, _headerCell)',
+        '_setFooterTemplateOrRenderer(_footerTemplate, __footerRenderer, _footerCell)',
         '_resizableChanged(resizable, _headerCell)',
         '_reorderStatusChanged(_reorderStatus, _headerCell, _footerCell, _cells.*)',
         '_hiddenChanged(hidden, _headerCell, _footerCell, _cells.*)'
@@ -293,11 +311,11 @@ export const ColumnBaseMixin = (superClass) =>
 
     /** @protected */
     _renderHeaderAndFooter() {
-      if (this.headerRenderer && this._headerCell) {
-        this.__runRenderer(this.headerRenderer, this._headerCell);
+      if (this.__headerRenderer && this._headerCell) {
+        this.__runRenderer(this.__headerRenderer, this._headerCell);
       }
-      if (this.footerRenderer && this._footerCell) {
-        this.__runRenderer(this.footerRenderer, this._footerCell);
+      if (this.__footerRenderer && this._footerCell) {
+        this.__runRenderer(this.__footerRenderer, this._footerCell);
       }
     }
 
@@ -327,7 +345,7 @@ export const ColumnBaseMixin = (superClass) =>
         if (renderer) {
           cell._renderer = renderer;
 
-          if (model.item || renderer === this.headerRenderer || renderer === this.footerRenderer) {
+          if (model.item || renderer === this.__headerRenderer || renderer === this.__footerRenderer) {
             this.__runRenderer(renderer, cell, model);
           }
         } else if (cell._template !== template) {
@@ -471,7 +489,7 @@ export const ColumnBaseMixin = (superClass) =>
       bodyTemplate,
       headerTemplate
     ) {
-      const hasHeaderText = header !== undefined;
+      const hasHeaderText = header !== undefined && header !== null;
       if (!headerRenderer && !headerTemplate && hasHeaderText && headerCell) {
         this.__setTextContent(headerCell._content, header);
       }
@@ -482,7 +500,7 @@ export const ColumnBaseMixin = (superClass) =>
           this.__setColumnTemplateOrRenderer(undefined, pathRenderer, cells.value);
         }
 
-        if (!headerRenderer && !headerTemplate && !hasHeaderText && headerCell && header !== null) {
+        if (!headerRenderer && !headerTemplate && !hasHeaderText && headerCell) {
           this.__setTextContent(headerCell._content, this._generateHeader(path));
         }
       }
@@ -619,6 +637,32 @@ export const ColumnBaseMixin = (superClass) =>
       }
       this._previousHidden = hidden;
     }
+
+    /** @private */
+    __computeHeaderRenderer(headerRenderer, defaultHeaderRenderer, headerTemplate) {
+      if (headerRenderer) {
+        return headerRenderer;
+      }
+
+      if (headerTemplate) {
+        return;
+      }
+
+      return defaultHeaderRenderer;
+    }
+
+    /** @private */
+    __computeFooterRenderer(footerRenderer, defaultFooterRenderer, footerTemplate) {
+      if (footerRenderer) {
+        return footerRenderer;
+      }
+
+      if (footerTemplate) {
+        return;
+      }
+
+      return defaultFooterRenderer;
+    }
   };
 
 /**
@@ -674,6 +718,15 @@ class GridColumnElement extends ColumnBaseMixin(DirMixin(PolymerElement)) {
        */
       renderer: Function,
 
+      /** @private */
+      __defaultRenderer: Function,
+
+      /** @private */
+      __renderer: {
+        type: Function,
+        computed: '__computeRenderer(renderer, __defaultRenderer, _bodyTemplate)'
+      },
+
       /**
        * Path to an item sub-property whose value gets displayed in the column body cells.
        * The property name is also shown in the column header if an explicit header or renderer isn't defined.
@@ -718,6 +771,19 @@ class GridColumnElement extends ColumnBaseMixin(DirMixin(PolymerElement)) {
        */
       _cells: Array
     };
+  }
+
+  /** @private */
+  __computeRenderer(renderer, defaultRenderer, template) {
+    if (renderer) {
+      return renderer;
+    }
+
+    if (template) {
+      return;
+    }
+
+    return defaultRenderer;
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -137,7 +137,7 @@ export const ColumnBaseMixin = (superClass) =>
          */
         __headerRenderer: {
           type: Function,
-          computed: '__computeHeaderRenderer(headerRenderer, _headerTemplate, header, path, _cells.*)'
+          computed: '__computeHeaderRenderer(headerRenderer, _headerTemplate, header)'
         },
 
         /**
@@ -172,9 +172,9 @@ export const ColumnBaseMixin = (superClass) =>
         '_textAlignChanged(textAlign, _cells.*, _headerCell, _footerCell)',
         '_orderChanged(_order, _headerCell, _footerCell, _cells.*)',
         '_lastFrozenChanged(_lastFrozen)',
-        '_setBodyTemplateOrRenderer(_bodyTemplate, __renderer, _cells, _cells.*, path)',
-        '_setHeaderTemplateOrRenderer(_headerTemplate, __headerRenderer, _headerCell, path, header)',
-        '_setFooterTemplateOrRenderer(_footerTemplate, __footerRenderer, _footerCell)',
+        '__setBodyTemplateOrRenderer(_bodyTemplate, __renderer, _cells, _cells.*, path)',
+        '__setHeaderTemplateOrRenderer(_headerTemplate, __headerRenderer, _headerCell, path, header)',
+        '__setFooterTemplateOrRenderer(_footerTemplate, __footerRenderer, _footerCell)',
         '_resizableChanged(resizable, _headerCell)',
         '_reorderStatusChanged(_reorderStatus, _headerCell, _footerCell, _cells.*)',
         '_hiddenChanged(hidden, _headerCell, _footerCell, _cells.*)'
@@ -368,14 +368,14 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /** @private */
-    _setBodyTemplateOrRenderer(template, renderer, cells) {
+    __setBodyTemplateOrRenderer(template, renderer, cells) {
       if ((template || renderer) && cells) {
         this.__setColumnTemplateOrRenderer(template, renderer, cells);
       }
     }
 
     /** @private */
-    _setHeaderTemplateOrRenderer(headerTemplate, headerRenderer, headerCell, _path, _header) {
+    __setHeaderTemplateOrRenderer(headerTemplate, headerRenderer, headerCell, _path, _header) {
       if ((headerTemplate || headerRenderer) && headerCell) {
         this.__setColumnTemplateOrRenderer(headerTemplate, headerRenderer, [headerCell]);
         this._grid.__updateHeaderFooterRowVisibility(headerCell.parentElement);
@@ -383,7 +383,7 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /** @private */
-    _setFooterTemplateOrRenderer(footerTemplate, footerRenderer, footerCell) {
+    __setFooterTemplateOrRenderer(footerTemplate, footerRenderer, footerCell) {
       if ((footerTemplate || footerRenderer) && footerCell) {
         this.__setColumnTemplateOrRenderer(footerTemplate, footerRenderer, [footerCell]);
         this._grid.__updateHeaderFooterRowVisibility(footerCell.parentElement);
@@ -600,7 +600,7 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /**
-     * Renders the header cell content based on the `header` property
+     * Renders a custom text header to the header cell.
      *
      * @private
      */
@@ -609,30 +609,43 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /**
-     * Renders the header cell content based on the `path` property
+     * Computes the property name based on the path and renders it to the header cell.
+     * If the path is not defined, then nothing is rendered.
      *
      * @private
      */
-    __pathHeaderRenderer() {
+    __defaultHeaderRenderer() {
+      if (!this.path) return;
+
       this.__setTextContent(this._headerCell._content, this._generateHeader(this.path));
     }
 
     /**
-     * Renders the body cell content based on the `path` property
+     * Computes the item property value based on the path and renders it to the body cell.
+     * If the path is not defined, then nothing is rendered.
      *
      * @private
      */
-    __pathRenderer(root, _owner, { item }) {
+    __defaultRenderer(root, _owner, { item }) {
+      if (!this.path) return;
+
       this.__setTextContent(root, this.get(this.path, item));
     }
 
     /**
-     * Computes the final header renderer that is intended
-     * for internal use when rendering the header content.
+     * By default, nothing is rendered to the footer cell.
      *
      * @private
      */
-    __computeHeaderRenderer(headerRenderer, headerTemplate, header, path, cells) {
+    __defaultFooterRenderer() {}
+
+    /**
+     * Computes the final header renderer that is intended
+     * for internal use when rendering the header cell content.
+     *
+     * @private
+     */
+    __computeHeaderRenderer(headerRenderer, headerTemplate, header) {
       if (headerRenderer) {
         return headerRenderer;
       }
@@ -641,10 +654,6 @@ export const ColumnBaseMixin = (superClass) =>
 
       if (header !== undefined && header !== null) {
         return this.__textHeaderRenderer;
-      }
-
-      if (path && cells.value) {
-        return this.__pathHeaderRenderer;
       }
 
       return this.__defaultHeaderRenderer;
@@ -656,23 +665,19 @@ export const ColumnBaseMixin = (superClass) =>
      *
      * @private
      */
-    __computeRenderer(renderer, template, path, cells) {
+    __computeRenderer(renderer, template) {
       if (renderer) {
         return renderer;
       }
 
       if (template) return;
 
-      if (path && cells.value) {
-        return this.__pathRenderer;
-      }
-
       return this.__defaultRenderer;
     }
 
     /**
      * Computes the final footer renderer that is intended
-     * for internal use when rendering the footer content.
+     * for internal use when rendering the footer cell content.
      *
      * @private
      */
@@ -748,7 +753,7 @@ class GridColumnElement extends ColumnBaseMixin(DirMixin(PolymerElement)) {
        */
       __renderer: {
         type: Function,
-        computed: '__computeRenderer(renderer, _bodyTemplate, path, _cells.*)'
+        computed: '__computeRenderer(renderer, _bodyTemplate)'
       },
 
       /**

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -130,8 +130,8 @@ export const ColumnBaseMixin = (superClass) =>
         headerRenderer: Function,
 
         /**
-         * Represents the final header renderer computed on the dependencies,
-         * intended to use internally when rendering the header content.
+         * Represents the final header renderer computed according to the dependencies,
+         * supposed to use internally when rendering the header cell content.
          *
          * @private
          */
@@ -152,8 +152,8 @@ export const ColumnBaseMixin = (superClass) =>
         footerRenderer: Function,
 
         /**
-         * Represents the final footer renderer computed on the dependencies,
-         * intended to use internally when rendering the footer content.
+         * Represents the final footer renderer computed according to the dependencies,
+         * supposed to use internally when rendering the footer cell content.
          *
          * @private
          */
@@ -600,7 +600,7 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /**
-     * Renders a custom text header to the header cell.
+     * Renders the text header to the header cell.
      *
      * @private
      */
@@ -640,8 +640,8 @@ export const ColumnBaseMixin = (superClass) =>
     __defaultFooterRenderer() {}
 
     /**
-     * Computes the final header renderer that is intended
-     * for internal use when rendering the header cell content.
+     * Computes the final header renderer that is supposed
+     * to use internally when rendering the header cell content.
      *
      * @private
      */
@@ -660,8 +660,8 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /**
-     * Computes the final renderer that is intended
-     * for internal use when rendering the content of a body cell.
+     * Computes the final renderer that is supposed
+     * to use internally when rendering the content of a body cell.
      *
      * @private
      */
@@ -676,8 +676,8 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /**
-     * Computes the final footer renderer that is intended
-     * for internal use when rendering the footer cell content.
+     * Computes the final footer renderer that is supposed
+     * to use internally when rendering the footer cell content.
      *
      * @private
      */
@@ -746,8 +746,8 @@ class GridColumnElement extends ColumnBaseMixin(DirMixin(PolymerElement)) {
       renderer: Function,
 
       /**
-       * Represents the final renderer computed on the dependencies,
-       * intended to use internally when rendering the content of a body cell.
+       * Represents the final renderer computed according to the dependencies,
+       * supposed to use internally when rendering the content of a body cell.
        *
        * @private
        */

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -131,9 +131,10 @@ export const ColumnBaseMixin = (superClass) =>
 
         /**
          * Represents the final header renderer computed on the set of observable arguments.
-         * It supposed to be used internally when rendering the header cell content.
+         * It is supposed to be used internally when rendering the header cell content.
          *
          * @private
+         * @type {GridHeaderFooterRenderer | undefined}
          */
         __headerRenderer: {
           type: Function,
@@ -153,9 +154,10 @@ export const ColumnBaseMixin = (superClass) =>
 
         /**
          * Represents the final footer renderer computed on the set of observable arguments.
-         * It supposed to be used internally when rendering the footer cell content.
+         * It is supposed to be used internally when rendering the footer cell content.
          *
          * @private
+         * @type {GridHeaderFooterRenderer | undefined}
          */
         __footerRenderer: {
           type: Function,
@@ -546,6 +548,10 @@ export const ColumnBaseMixin = (superClass) =>
         const model = this._grid.__getRowModel(cell.parentElement);
 
         if (renderer) {
+          if (cell._renderer !== renderer) {
+            cell._content.innerHTML = '';
+          }
+
           cell._renderer = renderer;
 
           if (model.item || renderer === this.__headerRenderer || renderer === this.__footerRenderer) {
@@ -572,26 +578,10 @@ export const ColumnBaseMixin = (superClass) =>
      * @private
      */
     __renderBodyCellsContent() {
-      if (!this._bodyTemplate && !this.__renderer) return;
       if (!this._cells) return;
+      if (!this._bodyTemplate && !this.__renderer) return;
 
       this.__renderCellsContent(this._bodyTemplate, this.__renderer, this._cells);
-    }
-
-    /**
-     * Renders the footer cell content using either a template or a renderer
-     * and then updates the visibility of the parent row depending on
-     * whether all its children cells are empty or not.
-     *
-     * @private
-     */
-    __renderHeaderCellContent() {
-      if (!this._headerTemplate && !this.__headerRenderer) return;
-      if (!this._headerCell) return;
-
-      this.__renderCellsContent(this._headerTemplate, this.__headerRenderer, [this._headerCell]);
-
-      this._grid.__updateHeaderFooterRowVisibility(this._headerCell.parentElement);
     }
 
     /**
@@ -601,9 +591,25 @@ export const ColumnBaseMixin = (superClass) =>
      *
      * @private
      */
+    __renderHeaderCellContent() {
+      if (!this._headerCell) return;
+      if (!this._headerTemplate && !this.__headerRenderer) return;
+
+      this.__renderCellsContent(this._headerTemplate, this.__headerRenderer, [this._headerCell]);
+
+      this._grid.__updateHeaderFooterRowVisibility(this._headerCell.parentElement);
+    }
+
+    /**
+     * Renders the footer cell content using either a template or a renderer
+     * and then updates the visibility of the parent row depending on
+     * whether all its children cells are empty or not.
+     *
+     * @private
+     */
     __renderFooterCellContent() {
-      if (!this._footerTemplate && !this.__footerRenderer) return;
       if (!this._footerCell) return;
+      if (!this._footerTemplate && !this.__footerRenderer) return;
 
       this.__renderCellsContent(this._footerTemplate, this.__footerRenderer, [this._footerCell]);
 
@@ -661,6 +667,7 @@ export const ColumnBaseMixin = (superClass) =>
      * once an argument is changed to update the property value.
      *
      * @private
+     * @return {GridHeaderFooterRenderer | undefined}
      */
     __computeHeaderRenderer(headerRenderer, headerTemplate, header) {
       if (headerRenderer) {
@@ -682,6 +689,7 @@ export const ColumnBaseMixin = (superClass) =>
      * once an argument is changed to update the property value.
      *
      * @private
+     * @return {GridBodyRenderer | undefined}
      */
     __computeRenderer(renderer, template) {
       if (renderer) {
@@ -699,6 +707,7 @@ export const ColumnBaseMixin = (superClass) =>
      * once an argument is changed to update the property value.
      *
      * @private
+     * @return {GridHeaderFooterRenderer | undefined}
      */
     __computeFooterRenderer(footerRenderer, footerTemplate) {
       if (footerRenderer) {
@@ -766,9 +775,10 @@ class GridColumnElement extends ColumnBaseMixin(DirMixin(PolymerElement)) {
 
       /**
        * Represents the final renderer computed on the set of observable arguments.
-       * It supposed to be used internally when rendering the content of a body cell.
+       * It is supposed to be used internally when rendering the content of a body cell.
        *
        * @private
+       * @type {GridBodyRenderer | undefined}
        */
       __renderer: {
         type: Function,

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -130,8 +130,8 @@ export const ColumnBaseMixin = (superClass) =>
         headerRenderer: Function,
 
         /**
-         * Represents the final header renderer computed according to the dependencies,
-         * supposed to use internally when rendering the header cell content.
+         * Represents the final header renderer computed on the set of observable arguments.
+         * It supposed to be used internally when rendering the header cell content.
          *
          * @private
          */
@@ -152,8 +152,8 @@ export const ColumnBaseMixin = (superClass) =>
         footerRenderer: Function,
 
         /**
-         * Represents the final footer renderer computed according to the dependencies,
-         * supposed to use internally when rendering the footer cell content.
+         * Represents the final footer renderer computed on the set of observable arguments.
+         * It supposed to be used internally when rendering the footer cell content.
          *
          * @private
          */
@@ -640,8 +640,9 @@ export const ColumnBaseMixin = (superClass) =>
     __defaultFooterRenderer() {}
 
     /**
-     * Computes the final header renderer that is supposed
-     * to use internally when rendering the header cell content.
+     * Computes the final header renderer for the `__headerRenderer` computed property.
+     * All the arguments are observable by the Polymer, it re-calls the method
+     * once an argument is changed to update the property value.
      *
      * @private
      */
@@ -660,8 +661,9 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /**
-     * Computes the final renderer that is supposed
-     * to use internally when rendering the content of a body cell.
+     * Computes the final renderer for the `__renderer` property.
+     * All the arguments are observable by the Polymer, it re-calls the method
+     * once an argument is changed to update the property value.
      *
      * @private
      */
@@ -676,8 +678,9 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /**
-     * Computes the final footer renderer that is supposed
-     * to use internally when rendering the footer cell content.
+     * Computes the final footer renderer for the `__footerRenderer` property.
+     * All the arguments are observable by the Polymer, it re-calls the method
+     * once an argument is changed to update the property value.
      *
      * @private
      */
@@ -746,8 +749,8 @@ class GridColumnElement extends ColumnBaseMixin(DirMixin(PolymerElement)) {
       renderer: Function,
 
       /**
-       * Represents the final renderer computed according to the dependencies,
-       * supposed to use internally when rendering the content of a body cell.
+       * Represents the final renderer computed on the set of observable arguments.
+       * It supposed to be used internally when rendering the content of a body cell.
        *
        * @private
        */

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
@@ -3,7 +3,7 @@ import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**
  * `<vaadin-grid-filter-column>` is a helper element for the `<vaadin-grid>`
- * that provides default header template and functionality for filtering.
+ * that provides default header renderer and functionality for filtering.
  *
  * #### Example:
  * ```html

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.js
@@ -74,7 +74,7 @@ class GridFilterColumnElement extends GridColumnElement {
 
     textField.__rendererValue = this._filterValue;
     textField.value = this._filterValue;
-    textField.label = this.__getFilterTextFieldLabel();
+    textField.label = this.__getHeader();
   }
 
   /**
@@ -95,24 +95,13 @@ class GridFilterColumnElement extends GridColumnElement {
   }
 
   /**
-   * The filter column is only intended to work with the default header renderer
-   * and doesn't allow using custom renderers.
+   * The filter column is supposed to use with no other renderers
+   * except the default header renderer
    *
    * @private
    */
   __computeHeaderRenderer() {
     return this.__defaultHeaderRenderer;
-  }
-
-  /** @private */
-  __getFilterTextFieldLabel() {
-    if (this.header) {
-      return this.header;
-    }
-
-    if (this.path) {
-      return this._generateHeader(this.path);
-    }
   }
 
   /**
@@ -127,6 +116,17 @@ class GridFilterColumnElement extends GridColumnElement {
     }
 
     this._filterValue = e.detail.value;
+  }
+
+  /** @private */
+  __getHeader() {
+    if (this.header) {
+      return this.header;
+    }
+
+    if (this.path) {
+      return this._generateHeader(this.path);
+    }
   }
 }
 

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.js
@@ -78,7 +78,8 @@ class GridFilterColumnElement extends GridColumnElement {
   }
 
   /**
-   * Re-runs the header renderer when a column instance property used in the renderer is changed
+   * Re-runs the header default renderer once a column instance property
+   * used in the renderer is changed.
    *
    * @private
    */
@@ -95,7 +96,7 @@ class GridFilterColumnElement extends GridColumnElement {
   }
 
   /**
-   * The filter column is supposed to use with no other renderers
+   * The filter column is not supposed to be used with other renderers
    * except the default header renderer
    *
    * @private
@@ -105,12 +106,13 @@ class GridFilterColumnElement extends GridColumnElement {
   }
 
   /**
-   * Updates the `_filterValue` property after the value of the filter text field is changed.
+   * Updates the `_filterValue` property once the filter text field is changed.
    * The listener handles only user-fired events.
    *
    * @private
    */
   __onFilterValueChanged(e) {
+    // Skip if the value is changed by the renderer.
     if (e.detail.value === e.target.__rendererValue) {
       return;
     }

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.js
@@ -39,7 +39,7 @@ class GridFilterColumnElement extends GridColumnElement {
   }
 
   static get observers() {
-    return ['__onDefaultHeaderRendererBindingChanged(_filterValue, path, header)'];
+    return ['__renderHeaderCellContent(_filterValue, path, header)'];
   }
 
   constructor() {
@@ -49,7 +49,7 @@ class GridFilterColumnElement extends GridColumnElement {
   }
 
   /**
-   * Renders `vaadin-grid-filter` with the custom text field to the header cell
+   * Renders the grid filter with the custom text field to the header cell.
    *
    * @private
    */
@@ -74,30 +74,13 @@ class GridFilterColumnElement extends GridColumnElement {
 
     textField.__rendererValue = this._filterValue;
     textField.value = this._filterValue;
-    textField.label = this.__getHeader();
+    textField.label = this.__getHeader(this.header, this.path);
   }
 
   /**
-   * Re-runs the header default renderer once a column instance property
-   * used in the renderer is changed.
-   *
-   * @private
-   */
-  __onDefaultHeaderRendererBindingChanged() {
-    if (this.__headerRenderer !== this.__defaultHeaderRenderer) {
-      return;
-    }
-
-    if (!this._headerCell) {
-      return;
-    }
-
-    this.__runRenderer(this.__headerRenderer, this._headerCell);
-  }
-
-  /**
-   * The filter column is not supposed to be used with other renderers
-   * except the default header renderer
+   * The filter column doesn't allow to use a custom header renderer
+   * to override the header cell content.
+   * It always renders the grid filter to the header cell.
    *
    * @private
    */
@@ -106,7 +89,7 @@ class GridFilterColumnElement extends GridColumnElement {
   }
 
   /**
-   * Updates the `_filterValue` property once the filter text field is changed.
+   * Updates the internal filter value once the filter text field is changed.
    * The listener handles only user-fired events.
    *
    * @private
@@ -121,13 +104,13 @@ class GridFilterColumnElement extends GridColumnElement {
   }
 
   /** @private */
-  __getHeader() {
-    if (this.header) {
-      return this.header;
+  __getHeader(header, path) {
+    if (header) {
+      return header;
     }
 
-    if (this.path) {
-      return this._generateHeader(this.path);
+    if (path) {
+      return this._generateHeader(path);
     }
   }
 }

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.js
@@ -8,7 +8,7 @@ import './vaadin-grid-filter.js';
 
 /**
  * `<vaadin-grid-filter-column>` is a helper element for the `<vaadin-grid>`
- * that provides default header template and functionality for filtering.
+ * that provides default header renderer and functionality for filtering.
  *
  * #### Example:
  * ```html

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.js
@@ -39,7 +39,9 @@ class GridFilterColumnElement extends GridColumnElement {
   }
 
   static get observers() {
-    return ['__renderHeaderCellContent(_filterValue, path, header)'];
+    return [
+      '_onHeaderTemplateOrRendererOrBindingChanged(_headerTemplate, _headerRenderer, _headerCell, path, header, _filterValue)'
+    ];
   }
 
   constructor() {
@@ -51,9 +53,9 @@ class GridFilterColumnElement extends GridColumnElement {
   /**
    * Renders the grid filter with the custom text field to the header cell.
    *
-   * @private
+   * @override
    */
-  __defaultHeaderRenderer(root, _column) {
+  _defaultHeaderRenderer(root, _column) {
     let filter = root.firstElementChild;
     let textField = filter?.firstElementChild;
 
@@ -82,10 +84,10 @@ class GridFilterColumnElement extends GridColumnElement {
    * to override the header cell content.
    * It always renders the grid filter to the header cell.
    *
-   * @private
+   * @override
    */
-  __computeHeaderRenderer() {
-    return this.__defaultHeaderRenderer;
+  _computeHeaderRenderer() {
+    return this._defaultHeaderRenderer;
   }
 
   /**

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
@@ -14,7 +14,7 @@ export interface GridSelectionColumnEventMap extends HTMLElementEventMap, GridSe
 
 /**
  * `<vaadin-grid-selection-column>` is a helper element for the `<vaadin-grid>`
- * that provides default templates and functionality for item selection.
+ * that provides default renderers and functionality for item selection.
  *
  * #### Example:
  * ```html

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.js
@@ -128,17 +128,7 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Overrides the path header renderer to render the Select All checkbox
-   * in the header cell even the path property has been defined.
-   *
-   * @private
-   */
-  __pathHeaderRenderer(...args) {
-    return this.__defaultHeaderRenderer(...args);
-  }
-
-  /**
-   * Renders the Select All checkbox in the header cell
+   * Renders the Select All checkbox to the header cell
    *
    * @private
    */
@@ -165,7 +155,7 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Renders the Select Row checkbox in a body cell
+   * Renders the Select Row checkbox to a body cell
    *
    * @private
    */
@@ -183,7 +173,11 @@ class GridSelectionColumnElement extends GridColumnElement {
     checkbox.checked = selected;
   }
 
-  /** @private */
+  /**
+   * Re-runs the header renderer when a column instance property used in the renderer is changed
+   *
+   * @private
+   */
   __onDefaultHeaderRendererBindingChanged() {
     if (!this._headerCell) {
       return;

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.js
@@ -145,13 +145,8 @@ class GridSelectionColumnElement extends GridColumnElement {
     const checked = this.__isChecked(this.selectAll, this.__indeterminate);
     checkbox.__rendererChecked = checked;
     checkbox.checked = checked;
+    checkbox.hidden = this.__selectAllHidden;
     checkbox.indeterminate = this.__indeterminate;
-
-    if (this.__selectAllHidden) {
-      checkbox.setAttribute('hidden', 'hidden');
-    } else {
-      checkbox.removeAttribute('hidden');
-    }
   }
 
   /**

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.js
@@ -8,7 +8,7 @@ import '@vaadin/vaadin-checkbox/src/vaadin-checkbox.js';
 
 /**
  * `<vaadin-grid-selection-column>` is a helper element for the `<vaadin-grid>`
- * that provides default templates and functionality for item selection.
+ * that provides default renderers and functionality for item selection.
  *
  * #### Example:
  * ```html
@@ -169,9 +169,8 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * When the default header renderer is a current renderer, it re-renders
-   * the header cell content once an instance property of the column
-   * used in the default header renderer is changed.
+   * Re-renders the header cell content once a column property
+   * bound in the default header renderer is changed.
    *
    * @private
    */
@@ -207,7 +206,7 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Updates the select all state of the grid once the Select All checkbox is switched.
+   * Enables or disables the Select All mode once the Select All checkbox is switched.
    * The listener handles only user-fired events.
    *
    * @private

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.js
@@ -128,7 +128,7 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Renders the Select All checkbox to the header cell
+   * Renders the Select All checkbox to the header cell.
    *
    * @private
    */
@@ -150,7 +150,7 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Renders the Select Row checkbox to a body cell
+   * Renders the Select Row checkbox to the body cell.
    *
    * @private
    */
@@ -169,8 +169,9 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Re-runs the header default renderer once a column instance property
-   * used in the renderer is changed.
+   * When the default header renderer is a current renderer, it re-renders
+   * the header cell content once an instance property of the column
+   * used in the default header renderer is changed.
    *
    * @private
    */
@@ -179,11 +180,7 @@ class GridSelectionColumnElement extends GridColumnElement {
       return;
     }
 
-    if (!this._headerCell) {
-      return;
-    }
-
-    this.__runRenderer(this.__headerRenderer, this._headerCell);
+    this.__renderHeaderCellContent();
   }
 
   /** @private */
@@ -210,13 +207,13 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Updates the `selectAll` property once the Select All checkbox is switched.
+   * Updates the select all state of the grid once the Select All checkbox is switched.
    * The listener handles only user-fired events.
    *
    * @private
    */
   __onSelectAllCheckedChanged(e) {
-    // Skip if the `checked` state is changed by the renderer.
+    // Skip if the state is changed by the renderer.
     if (e.target.checked === e.target.__rendererChecked) {
       return;
     }
@@ -231,7 +228,7 @@ class GridSelectionColumnElement extends GridColumnElement {
    * @private
    */
   __onSelectRowCheckedChanged(e) {
-    // Skip if the `checked` state is changed by the renderer.
+    // Skip if the state is changed by the renderer.
     if (e.target.checked === e.target.__rendererChecked) {
       return;
     }

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.js
@@ -94,7 +94,7 @@ class GridSelectionColumnElement extends GridColumnElement {
   static get observers() {
     return [
       '__onSelectAllChanged(selectAll)',
-      '__onDefaultHeaderRendererBindingChanged(__indeterminate, __selectAllHidden, selectAll)'
+      '_onHeaderTemplateOrRendererOrBindingChanged(_headerTemplate, _headerRenderer, _headerCell, path, header, selectAll, __indeterminate, __selectAllHidden)'
     ];
   }
 
@@ -130,9 +130,9 @@ class GridSelectionColumnElement extends GridColumnElement {
   /**
    * Renders the Select All checkbox to the header cell.
    *
-   * @private
+   * @override
    */
-  __defaultHeaderRenderer(root, _column) {
+  _defaultHeaderRenderer(root, _column) {
     let checkbox = root.firstElementChild;
     if (!checkbox) {
       checkbox = document.createElement('vaadin-checkbox');
@@ -152,9 +152,9 @@ class GridSelectionColumnElement extends GridColumnElement {
   /**
    * Renders the Select Row checkbox to the body cell.
    *
-   * @private
+   * @override
    */
-  __defaultRenderer(root, _column, { item, selected }) {
+  _defaultRenderer(root, _column, { item, selected }) {
     let checkbox = root.firstElementChild;
     if (!checkbox) {
       checkbox = document.createElement('vaadin-checkbox');
@@ -166,20 +166,6 @@ class GridSelectionColumnElement extends GridColumnElement {
     checkbox.__item = item;
     checkbox.__rendererChecked = selected;
     checkbox.checked = selected;
-  }
-
-  /**
-   * Re-renders the header cell content once a column property
-   * bound in the default header renderer is changed.
-   *
-   * @private
-   */
-  __onDefaultHeaderRendererBindingChanged() {
-    if (this.__headerRenderer !== this.__defaultHeaderRenderer) {
-      return;
-    }
-
-    this.__renderHeaderCellContent();
   }
 
   /** @private */

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.js
@@ -179,11 +179,11 @@ class GridSelectionColumnElement extends GridColumnElement {
    * @private
    */
   __onDefaultHeaderRendererBindingChanged() {
-    if (!this._headerCell) {
+    if (this.__headerRenderer !== this.__defaultHeaderRenderer) {
       return;
     }
 
-    if (this.__headerRenderer !== this.__defaultHeaderRenderer) {
+    if (!this._headerCell) {
       return;
     }
 

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.js
@@ -169,7 +169,8 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Re-runs the header renderer when a column instance property used in the renderer is changed
+   * Re-runs the header default renderer once a column instance property
+   * used in the renderer is changed.
    *
    * @private
    */
@@ -209,13 +210,13 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Updates the `selectAll` property after the Select All checkbox is switched.
+   * Updates the `selectAll` property once the Select All checkbox is switched.
    * The listener handles only user-fired events.
    *
    * @private
    */
   __onSelectAllCheckedChanged(e) {
-    // Skip if the listener is called after `checked` is set by the renderer.
+    // Skip if the `checked` state is changed by the renderer.
     if (e.target.checked === e.target.__rendererChecked) {
       return;
     }
@@ -224,13 +225,13 @@ class GridSelectionColumnElement extends GridColumnElement {
   }
 
   /**
-   * Selects or deselects the row after the Select Row checkbox is switched.
+   * Selects or deselects the row once the Select Row checkbox is switched.
    * The listener handles only user-fired events.
    *
    * @private
    */
   __onSelectRowCheckedChanged(e) {
-    // Skip if the listener is called after `checked` is set by the renderer
+    // Skip if the `checked` state is changed by the renderer.
     if (e.target.checked === e.target.__rendererChecked) {
       return;
     }

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
@@ -15,7 +15,7 @@ export interface GridSortColumnEventMap extends HTMLElementEventMap, GridSortCol
 
 /**
  * `<vaadin-grid-sort-column>` is a helper element for the `<vaadin-grid>`
- * that provides default header template and functionality for sorting.
+ * that provides default header renderer and functionality for sorting.
  *
  * #### Example:
  * ```html

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.js
@@ -47,7 +47,7 @@ class GridSortColumnElement extends GridColumnElement {
   }
 
   static get observers() {
-    return ['__onDefaultHeaderRendererBindingChanged(direction, path, header)'];
+    return ['__renderHeaderCellContent(direction, path, header)'];
   }
 
   constructor() {
@@ -57,7 +57,7 @@ class GridSortColumnElement extends GridColumnElement {
   }
 
   /**
-   * Renders `vaadin-grid-sorter` to the header cell
+   * Renders the grid sorter to the header cell.
    *
    * @private
    */
@@ -76,26 +76,9 @@ class GridSortColumnElement extends GridColumnElement {
   }
 
   /**
-   * Re-runs the header default renderer once a column instance property
-   * used in the renderer is changed.
-   *
-   * @private
-   */
-  __onDefaultHeaderRendererBindingChanged() {
-    if (this.__headerRenderer !== this.__defaultHeaderRenderer) {
-      return;
-    }
-
-    if (!this._headerCell) {
-      return;
-    }
-
-    this.__runRenderer(this.__headerRenderer, this._headerCell);
-  }
-
-  /**
-   * The sort column is not supposed to be used with other renderers
-   * except the default header renderer.
+   * The sort column doesn't allow to use a custom header renderer
+   * to override the header cell content.
+   * It always renders the grid sorter to the header cell.
    *
    * @private
    */
@@ -104,7 +87,7 @@ class GridSortColumnElement extends GridColumnElement {
   }
 
   /**
-   * Updates the `direction` property once the direction of `vaadin-grid-sorter` is changed.
+   * Updates the sorting direction once the grid sorter's direction is changed.
    * The listener handles only user-fired events.
    *
    * @private
@@ -119,13 +102,13 @@ class GridSortColumnElement extends GridColumnElement {
   }
 
   /** @private */
-  __getHeader() {
-    if (this.header) {
-      return this.header;
+  __getHeader(header, path) {
+    if (header) {
+      return header;
     }
 
-    if (this.path) {
-      return this._generateHeader(this.path);
+    if (path) {
+      return this._generateHeader(path);
     }
   }
 }

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.js
@@ -8,7 +8,7 @@ import './vaadin-grid-sorter.js';
 
 /**
  * `<vaadin-grid-sort-column>` is a helper element for the `<vaadin-grid>`
- * that provides default header template and functionality for sorting.
+ * that provides default header renderer and functionality for sorting.
  *
  * #### Example:
  * ```html

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.js
@@ -47,7 +47,9 @@ class GridSortColumnElement extends GridColumnElement {
   }
 
   static get observers() {
-    return ['__renderHeaderCellContent(direction, path, header)'];
+    return [
+      '_onHeaderTemplateOrRendererOrBindingChanged(_headerTemplate, _headerRenderer, _headerCell, path, header, direction)'
+    ];
   }
 
   constructor() {
@@ -59,9 +61,9 @@ class GridSortColumnElement extends GridColumnElement {
   /**
    * Renders the grid sorter to the header cell.
    *
-   * @private
+   * @override
    */
-  __defaultHeaderRenderer(root, _column) {
+  _defaultHeaderRenderer(root, _column) {
     let sorter = root.firstElementChild;
     if (!sorter) {
       sorter = document.createElement('vaadin-grid-sorter');
@@ -80,10 +82,10 @@ class GridSortColumnElement extends GridColumnElement {
    * to override the header cell content.
    * It always renders the grid sorter to the header cell.
    *
-   * @private
+   * @override
    */
-  __computeHeaderRenderer() {
-    return this.__defaultHeaderRenderer;
+  _computeHeaderRenderer() {
+    return this._defaultHeaderRenderer;
   }
 
   /**

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.js
@@ -76,7 +76,8 @@ class GridSortColumnElement extends GridColumnElement {
   }
 
   /**
-   * Re-runs the header renderer when a column instance property used in the renderer is changed
+   * Re-runs the header default renderer once a column instance property
+   * used in the renderer is changed.
    *
    * @private
    */
@@ -93,8 +94,8 @@ class GridSortColumnElement extends GridColumnElement {
   }
 
   /**
-   * The sort column is supposed to use with no other renderers
-   * except the default header renderer
+   * The sort column is not supposed to be used with other renderers
+   * except the default header renderer.
    *
    * @private
    */
@@ -103,12 +104,13 @@ class GridSortColumnElement extends GridColumnElement {
   }
 
   /**
-   * Updates the `direction` property after the direction of `vaadin-grid-sorter` is changed.
+   * Updates the `direction` property once the direction of `vaadin-grid-sorter` is changed.
    * The listener handles only user-fired events.
    *
    * @private
    */
   __onDirectionChanged(e) {
+    // Skip if the direction is changed by the renderer.
     if (e.detail.value === e.target.__rendererDirection) {
       return;
     }

--- a/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
@@ -3,7 +3,7 @@ import { GridColumnElement } from './vaadin-grid-column.js';
 
 /**
  * `<vaadin-grid-tree-column>` is a helper element for the `<vaadin-grid>`
- * that provides default template and functionality for toggling tree/hierarchical items.
+ * that provides default renderer and functionality for toggling tree/hierarchical items.
  *
  * #### Example:
  * ```html

--- a/packages/vaadin-grid/src/vaadin-grid-tree-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-column.js
@@ -43,7 +43,9 @@ class GridTreeColumnElement extends GridColumnElement {
   }
 
   static get observers() {
-    return ['__renderBodyCellsContent(itemHasChildrenPath, path)'];
+    return [
+      '_onBodyTemplateOrRendererOrBindingChanged(_bodyTemplate, _renderer, _cells, _cells.*, path, itemHasChildrenPath)'
+    ];
   }
 
   constructor() {
@@ -77,9 +79,9 @@ class GridTreeColumnElement extends GridColumnElement {
    * to override the content of body cells.
    * It always renders the grid tree toggle to body cells.
    *
-   * @private
+   * @override
    */
-  __computeRenderer() {
+  _computeRenderer() {
     return this.__defaultRenderer;
   }
 

--- a/packages/vaadin-grid/src/vaadin-grid-tree-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-column.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { GridColumnElement } from './vaadin-grid-column.js';
 import './vaadin-grid-tree-toggle.js';
 
@@ -21,20 +20,6 @@ import './vaadin-grid-tree-toggle.js';
  * ```
  */
 class GridTreeColumnElement extends GridColumnElement {
-  static get template() {
-    return html`
-      <template id="template">
-        <vaadin-grid-tree-toggle
-          leaf="[[__isLeafItem(item, itemHasChildrenPath)]]"
-          expanded="{{expanded}}"
-          level="[[level]]"
-        >
-          [[__getToggleContent(path, item)]]
-        </vaadin-grid-tree-toggle>
-      </template>
-    `;
-  }
-
   static get is() {
     return 'vaadin-grid-tree-column';
   }
@@ -57,18 +42,72 @@ class GridTreeColumnElement extends GridColumnElement {
     };
   }
 
+  static get observers() {
+    return ['__renderBodyCellsContent(itemHasChildrenPath, path)'];
+  }
+
+  constructor() {
+    super();
+
+    this.__boundOnExpandedChanged = this.__onExpandedChanged.bind(this);
+  }
+
+  /**
+   * Renders the grid tree toggle to the body cell
+   *
+   * @private
+   */
+  __defaultRenderer(root, _column, { item, expanded }) {
+    let toggle = root.firstElementChild;
+    if (!toggle) {
+      toggle = document.createElement('vaadin-grid-tree-toggle');
+      toggle.addEventListener('expanded-changed', this.__boundOnExpandedChanged);
+      root.appendChild(toggle);
+    }
+
+    toggle.__item = item;
+    toggle.__rendererExpanded = expanded;
+    toggle.expanded = expanded;
+    toggle.leaf = this.__isLeafItem(item, this.itemHasChildrenPath);
+    toggle.textContent = this.__getToggleContent(this.path, item);
+  }
+
+  /**
+   * The tree column doesn't allow to use a custom renderer
+   * to override the content of body cells.
+   * It always renders the grid tree toggle to body cells.
+   *
+   * @private
+   */
+  __computeRenderer() {
+    return this.__defaultRenderer;
+  }
+
+  /**
+   * Expands or collapses the row once the tree toggle is switched.
+   * The listener handles only user-fired events.
+   *
+   * @private
+   */
+  __onExpandedChanged(e) {
+    // Skip if the state is changed by the renderer.
+    if (e.detail.value === e.target.__rendererExpanded) {
+      return;
+    }
+
+    if (e.detail.value) {
+      this._grid.expandItem(e.target.__item);
+    } else {
+      this._grid.collapseItem(e.target.__item);
+    }
+  }
+
   /** @private */
-  _prepareBodyTemplate() {
-    const template = this._prepareTemplatizer(this.$.template);
-    // needed to override the dataHost correctly in case internal template is used.
-    template.templatizer.dataHost = this;
-    return template;
-  }
-
   __isLeafItem(item, itemHasChildrenPath) {
-    return !(item && item[itemHasChildrenPath]);
+    return !item || !item[itemHasChildrenPath];
   }
 
+  /** @private */
   __getToggleContent(path, item) {
     return path && this.get(path, item);
   }

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -979,7 +979,10 @@ class GridElement extends ElementMixin(
     if (this._columnTree) {
       // header and footer renderers
       this._columnTree.forEach((level) => {
-        level.forEach((column) => column._renderHeaderAndFooter());
+        level.forEach((column) => {
+          column.__renderHeaderCellContent();
+          column.__renderFooterCellContent();
+        });
       });
 
       // body and row details renderers

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -980,8 +980,7 @@ class GridElement extends ElementMixin(
       // header and footer renderers
       this._columnTree.forEach((level) => {
         level.forEach((column) => {
-          column.__renderHeaderCellContent();
-          column.__renderFooterCellContent();
+          column._renderHeaderAndFooter();
         });
       });
 

--- a/packages/vaadin-grid/test/filtering.test.js
+++ b/packages/vaadin-grid/test/filtering.test.js
@@ -170,12 +170,13 @@ describe('filtering', () => {
   });
 
   describe('filter-column', () => {
-    let filterColumn, filter, filterTextField;
+    let filterColumn, filterCellContent, filter, filterTextField;
 
     beforeEach(() => {
       filterColumn = grid.querySelector('vaadin-grid-filter-column');
-      const content = getHeaderCellContent(grid, 0, 2);
-      filter = content.querySelector('vaadin-grid-filter');
+      filterCellContent = getHeaderCellContent(grid, 0, 2);
+
+      filter = filterCellContent.querySelector('vaadin-grid-filter');
       filterTextField = filter.firstElementChild;
     });
 
@@ -197,6 +198,14 @@ describe('filtering', () => {
     it('should apply the input fields value to the filter', () => {
       filterTextField.value = 'foo';
       expect(filter.value).to.equal('foo');
+    });
+
+    it('should ignore a custom header renderer', () => {
+      filterColumn.headerRenderer = (root) => {
+        root.innerHTML = 'header';
+      };
+
+      expect(filterCellContent.firstElementChild).to.equal(filter);
     });
   });
 });

--- a/packages/vaadin-grid/test/renderers.test.js
+++ b/packages/vaadin-grid/test/renderers.test.js
@@ -62,6 +62,13 @@ describe('renderers', () => {
       expect(getCell(grid, 1)._content.innerHTML).to.eql('1 test');
     });
 
+    it('should clear the content when changing the renderer', () => {
+      column.renderer = (_root, _column, _model) => {};
+
+      expect(getCell(grid, 0)._content.textContent).to.be.empty;
+      expect(getCell(grid, 1)._content.textContent).to.be.empty;
+    });
+
     it('should throw an error when setting a template if there is already a renderer', () => {
       expect(() => (column._bodyTemplate = {})).to.throw(Error);
     });
@@ -175,16 +182,20 @@ describe('renderers', () => {
   });
 
   describe('header cell', () => {
+    let headerCell;
+
     beforeEach(() => {
       column.headerRenderer = (root) => {
-        root.innerHTML = 'RDR header';
+        root.textContent = 'header';
       };
 
       flushGrid(grid);
+
+      headerCell = getHeaderCell(grid);
     });
 
     it('should have valid content when renderer is set', () => {
-      expect(getHeaderCell(grid)._content.innerHTML).to.eql('RDR header');
+      expect(headerCell._content.textContent).to.eql('header');
     });
 
     it('should throw an error when setting a template if there is already a renderer', () => {
@@ -212,23 +223,39 @@ describe('renderers', () => {
       flushGrid(grid);
       expect(grid.$.header.firstElementChild.hidden).to.be.false;
     });
+
+    it('should clear the content when changing the renderer', () => {
+      column.headerRenderer = (_root, _column) => {};
+
+      expect(headerCell._content.textContent).to.be.empty;
+    });
   });
 
   describe('footer cell', () => {
+    let footerCell;
+
     beforeEach(() => {
       column.footerRenderer = (root) => {
-        root.innerHTML = 'RDR footer';
+        root.textContent = 'footer';
       };
 
       flushGrid(grid);
+
+      footerCell = getFooterCell(grid);
     });
 
     it('should have valid content when renderer is set', () => {
-      expect(getFooterCell(grid)._content.innerHTML).to.eql('RDR footer');
+      expect(footerCell._content.textContent).to.eql('footer');
     });
 
     it('should throw an error when setting a template if there is already a renderer', () => {
       expect(() => (column._footerTemplate = {})).to.throw(Error);
+    });
+
+    it('should clear the content when changing the renderer', () => {
+      column.footerRenderer = (_root, _column) => {};
+
+      expect(footerCell._content.textContent).to.be.empty;
     });
   });
 

--- a/packages/vaadin-grid/test/selection.test.js
+++ b/packages/vaadin-grid/test/selection.test.js
@@ -448,18 +448,23 @@ describe('multi selection column', () => {
     expect(() => checkbox.click()).not.to.throw(Error);
   });
 
-  it('should override the header content with header text', () => {
+  it('should override the header content with a header text', () => {
     selectionColumn.header = 'foo';
 
     expect(firstHeaderCellContent.textContent).to.equal('foo');
     expect(firstBodyCellContent.firstElementChild).to.equal(firstBodyCheckbox);
   });
 
-  it('should not override the content of cells when defining a path', () => {
+  it('should not override the header content with a path', () => {
+    selectionColumn.path = 'length';
+
+    expect(firstHeaderCellContent.firstElementChild).to.equal(selectAllCheckbox);
+  });
+
+  it('should not override the body content with a path', () => {
     selectionColumn.path = 'length';
 
     expect(firstBodyCellContent.firstElementChild).to.equal(firstBodyCheckbox);
-    expect(firstHeaderCellContent.firstElementChild).to.equal(selectAllCheckbox);
   });
 
   it('should override the header content with a header renderer', () => {

--- a/packages/vaadin-grid/test/selection.test.js
+++ b/packages/vaadin-grid/test/selection.test.js
@@ -450,24 +450,32 @@ describe('multi selection column', () => {
 
   it('should override the header content with header text', () => {
     selectionColumn.header = 'foo';
+
     expect(firstHeaderCellContent.textContent).to.equal('foo');
     expect(firstBodyCellContent.firstElementChild).to.equal(firstBodyCheckbox);
   });
 
-  it('should override the header content with a header renderer', () => {
-    selectionColumn.headerRenderer = (root) => (root.textContent = 'foo');
-    expect(firstHeaderCellContent.textContent).to.equal('foo');
-    expect(firstBodyCellContent.firstElementChild).to.equal(firstBodyCheckbox);
-  });
-
-  it('should override the body content with path', () => {
+  it('should not override the content of cells when defining a path', () => {
     selectionColumn.path = 'length';
-    expect(firstBodyCellContent.textContent).to.equal('3');
+
+    expect(firstBodyCellContent.firstElementChild).to.equal(firstBodyCheckbox);
     expect(firstHeaderCellContent.firstElementChild).to.equal(selectAllCheckbox);
   });
 
+  it('should override the header content with a header renderer', () => {
+    selectionColumn.headerRenderer = (root) => {
+      root.textContent = 'foo';
+    };
+
+    expect(firstHeaderCellContent.textContent).to.equal('foo');
+    expect(firstBodyCellContent.firstElementChild).to.equal(firstBodyCheckbox);
+  });
+
   it('should override the body content with a renderer', () => {
-    selectionColumn.renderer = (root) => (root.textContent = 'foo');
+    selectionColumn.renderer = (root) => {
+      root.textContent = 'foo';
+    };
+
     expect(firstBodyCellContent.textContent).to.equal('foo');
     expect(firstHeaderCellContent.firstElementChild).to.equal(selectAllCheckbox);
   });

--- a/packages/vaadin-grid/test/sorting.test.js
+++ b/packages/vaadin-grid/test/sorting.test.js
@@ -409,24 +409,25 @@ describe('sorting', () => {
     });
 
     describe('sort-column', () => {
-      let sortColumn, sorter;
+      let sortColumn, sortCellContent, sorter;
 
       beforeEach(() => {
         sortColumn = grid.querySelector('vaadin-grid-sort-column');
-        sorter = getHeaderCellContent(grid, 0, 2).querySelector('vaadin-grid-sorter');
+        sortCellContent = getHeaderCellContent(grid, 0, 2);
+        sorter = sortCellContent.querySelector('vaadin-grid-sorter');
       });
 
-      it('should propagate path property to the internal vaadin-grid-sorter', () => {
+      it('should propagate path property to the internal grid sorter', () => {
         sortColumn.path = 'last';
         expect(sorter.path).to.equal('last');
       });
 
-      it('should propagate direction property to the internal vaadin-grid-sorter', () => {
+      it('should propagate direction property to the internal grid sorter', () => {
         sortColumn.direction = 'asc';
         expect(sorter.direction).to.equal('asc');
       });
 
-      it('should notify direction property change from the internal vaadin-grid-sorter', () => {
+      it('should fire direction-changed when changing the internal grid sorter direction', () => {
         const spy = sinon.spy();
         sortColumn.addEventListener('direction-changed', spy);
 
@@ -445,6 +446,14 @@ describe('sorting', () => {
       it('should generate the text content based on path property, if header is not defined', () => {
         sortColumn.path = 'last';
         expect(sorter.textContent).to.equal('Last');
+      });
+
+      it('should ignore a custom header renderer', () => {
+        sortColumn.headerRenderer = (root) => {
+          root.innerHTML = 'header';
+        };
+
+        expect(sortCellContent.firstElementChild).to.equal(sorter);
       });
     });
   });

--- a/packages/vaadin-grid/test/sorting.test.js
+++ b/packages/vaadin-grid/test/sorting.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { click, fixtureSync, listenOnce, nextFrame } from '@vaadin/testing-helpers';
+import { click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { buildDataSet, flushGrid, getBodyCellContent, getHeaderCellContent, getRows, getRowCells } from './helpers.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-sorter.js';
@@ -39,9 +39,13 @@ describe('sorting', () => {
       expect(sorter.direction).to.equal(null);
     });
 
-    it('should fire a sorter-changed event', (done) => {
-      listenOnce(sorter, 'sorter-changed', () => done());
+    it('should fire a sorter-changed event', () => {
+      const spy = sinon.spy();
+      sorter.addEventListener('sorter-changed', spy);
+
       sorter.direction = 'asc';
+
+      expect(spy.calledOnce).to.be.true;
     });
 
     it('should show order indicator', () => {
@@ -422,12 +426,15 @@ describe('sorting', () => {
         expect(sorter.direction).to.equal('asc');
       });
 
-      it('should notify direction property change from the internal vaadin-grid-sorter', (done) => {
-        listenOnce(sortColumn, 'direction-changed', (e) => {
-          expect(e.detail.value).to.equal('desc');
-          done();
-        });
+      it('should notify direction property change from the internal vaadin-grid-sorter', () => {
+        const spy = sinon.spy();
+        sortColumn.addEventListener('direction-changed', spy);
+
         sorter.direction = 'desc';
+
+        const event = spy.args[0][0];
+        expect(spy.calledOnce).to.be.true;
+        expect(event.detail.value).to.be.equal('desc');
       });
 
       it('should use header property to determine the text that gets slotted inside the sorter', () => {

--- a/packages/vaadin-grid/test/tree-toggle.test.js
+++ b/packages/vaadin-grid/test/tree-toggle.test.js
@@ -143,5 +143,13 @@ describe('tree toggle', () => {
       column.itemHasChildrenPath = 'hasChildren';
       expect(toggle.leaf).to.be.false;
     });
+
+    it('should ignore a custom renderer', () => {
+      column.renderer = (root) => {
+        root.innerHTML = 'cell';
+      };
+
+      expect(getBodyCellContent(grid, 0, 0).firstElementChild).to.equal(toggle);
+    });
   });
 });


### PR DESCRIPTION
## Description

Previously, some internal grid components used Polymer templates to render a pre-defined cell content. 

The PR introduces the concept of default renders and converts all the internal grid templates to default renderers.

- [x] ref!: `vaadin-grid-selection-column` (see breaking change below)
- [x] ref: `vaadin-grid-filter-column`
- [x] ref: `vaadin-grid-sort-column`
- [x] ref: `vaadin-grid-tree-column`

Fixes #1963

Related to #326 (removing the Polymer Template API from grids)

### Computed renderers

I found the logic of computing a final renderer to render is quite messy and not obvious to work with. The renderers used to be re-assigned in different observers, so that made it hard to know which renderer is being used at the moment. 

After a refactoring, all such the logic has been moved to computed properties, e.g:
- [`__computeHeaderRenderer`](https://github.com/vaadin/web-components/pull/1967/files#diff-37fc749a7a99c4f9c6690e4879c4657c493c59e185d41c3abdff95d08963c76dR694)
- [`__computeRenderer`](https://github.com/vaadin/web-components/pull/1967/files#diff-37fc749a7a99c4f9c6690e4879c4657c493c59e185d41c3abdff95d08963c76dR716)
- [`__computeFooterRenderer`](https://github.com/vaadin/web-components/pull/1967/files#diff-37fc749a7a99c4f9c6690e4879c4657c493c59e185d41c3abdff95d08963c76dR716)


### Breaking change in the Selection Column

Setting the `path` property for the selection column is no longer supported.

**Before**:

```js
const column = document.createElement('vaadin-grid-selection-column');

column.header = 'custom header text'; // Overrides the header cell content

column.path = 'property.0.title'; // Overrides the body cells content
```

**After**:

```js
const column = document.createElement('vaadin-grid-selection-column');

column.header = 'custom header text'; // Overrides the header cell content

column.path = 'property.0.title'; // Doesn't affect the column anymore!
```

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
