### PR TITLE
fix: pass type argument to drag filters

### DIFF
--- a/packages/vaadin-grid/src/interfaces.d.ts
+++ b/packages/vaadin-grid/src/interfaces.d.ts
@@ -29,7 +29,7 @@ export type GridDataProvider = <TItem>(
   callback: GridDataProviderCallback<TItem>
 ) => void;
 
-export type GridDragAndDropFilter = <TItem>(model: GridItemModel<TItem>) => boolean;
+export type GridDragAndDropFilter<TItem> = (model: GridItemModel<TItem>) => boolean;
 
 export type GridDropLocation = 'above' | 'on-top' | 'below' | 'empty';
 

--- a/packages/vaadin-grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
@@ -40,7 +40,7 @@ interface DragAndDropMixin<TItem> {
    *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
    *   - `model.selected` Selected state.
    */
-  dragFilter: GridDragAndDropFilter | null | undefined;
+  dragFilter: GridDragAndDropFilter<TItem> | null | undefined;
 
   /**
    * A function that filters dropping on specific grid rows. The return value should be false
@@ -55,7 +55,7 @@ interface DragAndDropMixin<TItem> {
    *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
    *   - `model.selected` Selected state.
    */
-  dropFilter: GridDragAndDropFilter | null | undefined;
+  dropFilter: GridDragAndDropFilter<TItem> | null | undefined;
 
   _clearDragStyles(): void;
 


### PR DESCRIPTION
## Description

Updated the `GridDragAndDropFilter` type parameter placement to align with `GridCellClassNameGenerator` etc.

This should fix the issue reported by @Haprog - see https://github.com/runem/lit-analyzer/issues/163#issuecomment-844719009

## Type of change

- [x] Bugfix