### PR TITLE
fix: update the structure of hidden rows

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -831,9 +831,9 @@ class GridElement extends ElementMixin(
    * @protected
    */
   _renderColumnTree(columnTree) {
-    Array.from(this.$.items.children)
-      .filter((row) => !row.hidden)
-      .forEach((row) => this._updateRow(row, columnTree[columnTree.length - 1], null, false, true));
+    Array.from(this.$.items.children).forEach((row) =>
+      this._updateRow(row, columnTree[columnTree.length - 1], null, false, true)
+    );
 
     while (this.$.header.children.length < columnTree.length) {
       const headerRow = document.createElement('tr');

--- a/packages/vaadin-grid/test/column.test.js
+++ b/packages/vaadin-grid/test/column.test.js
@@ -10,6 +10,7 @@ import {
   getContainerCell,
   getContainerCellContent,
   getHeaderCellContent,
+  getPhysicalItems,
   infiniteDataProvider
 } from './helpers.js';
 import '../vaadin-grid.js';
@@ -169,8 +170,8 @@ describe('column', () => {
       });
 
       it('should update the structure of hidden rows', async () => {
-        // Redice the size so we end up with hidden rows
-        grid.size = 0;
+        // Reduce the size so we end up with hidden rows
+        grid.size = 1;
 
         // Detach grid from its parent
         const parentNode = grid.parentNode;
@@ -180,15 +181,18 @@ describe('column', () => {
         column.parentNode.removeChild(column);
 
         // Increase the size so one of the hidden rows becomes visible again
-        grid.size = 1;
+        grid.size = 2;
         flushGrid(grid);
 
         // Re-attach the grid
         parentNode.appendChild(grid);
 
         await nextFrame();
+        flushGrid(grid);
 
-        expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('cell');
+        // Expect the two rows (the second one was hidden) to have the same amount of cells
+        const rows = getPhysicalItems(grid);
+        expect(rows[1].childElementCount).to.equal(rows[0].childElementCount);
       });
 
       it('should not throw on render with initially hidden columns with header/footerRenderer', () => {

--- a/packages/vaadin-grid/test/column.test.js
+++ b/packages/vaadin-grid/test/column.test.js
@@ -168,6 +168,29 @@ describe('column', () => {
         expect(childCountAfter).to.be.below(childCountBefore);
       });
 
+      it('should update the structure of hidden rows', async () => {
+        // Redice the size so we end up with hidden rows
+        grid.size = 0;
+
+        // Detach grid from its parent
+        const parentNode = grid.parentNode;
+        parentNode.removeChild(grid);
+
+        // Remove a column
+        column.parentNode.removeChild(column);
+
+        // Increase the size so one of the hidden rows becomes visible again
+        grid.size = 1;
+        flushGrid(grid);
+
+        // Re-attach the grid
+        parentNode.appendChild(grid);
+
+        await nextFrame();
+
+        expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('cell');
+      });
+
       it('should not throw on render with initially hidden columns with header/footerRenderer', () => {
         const newColumn = document.createElement('vaadin-grid-column');
         newColumn.hidden = true;


### PR DESCRIPTION
Make sure that the cell structure of hidden rows gets updated when the column structure of a hidden grid changes

Fixes a regression from [this change](https://github.com/vaadin/web-components/pull/321/files#diff-f55be1687931f6b0777e240bb62e036552dd9f76d85bc316689f8b1258d7a79bL734-R812)