### PR TITLE
feat: close sub menu on mouseleave when openOnHover mode

### DIFF
--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -49,7 +49,7 @@ export const InteractionsMixin = (superClass) =>
       container.addEventListener('mouseover', (e) => this._onMouseOver(e));
 
       if (this.openOnHover){
-          container.addEventListener('mouseleave', e => this._requestClose(e));
+          container.addEventListener('mouseleave', () => this._requestClose());
       }
     }
 
@@ -287,16 +287,11 @@ export const InteractionsMixin = (superClass) =>
     }
 
     /** @private */
-    _requestClose(e) {
+    _requestClose() {
       this.preventClose = false;
       // wait if something has to prevent the close event
       setTimeout(() => {
-        let toElement = e.toElement;
-        if (!toElement){
-          return;
-        }
-        let id = toElement.id;
-        if (id !== 'overlay' && !this.preventClose) {
+        if (!this.preventClose) {
           this._close(false);
         }
       }, 300);
@@ -306,7 +301,7 @@ export const InteractionsMixin = (superClass) =>
     _addHoverListener(subMenu) {
       let menuOverlay = subMenu.$.overlay.$.overlay;
 
-      menuOverlay.addEventListener('mouseleave', e => this._requestClose(e));
+      menuOverlay.addEventListener('mouseleave', () => this._requestClose());
       // when hovering between sub menus the subMenu will close if we don't prevent it
       menuOverlay.addEventListener('mouseenter', () => this.preventClose = true);
     }

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -237,7 +237,7 @@ export const InteractionsMixin = (superClass) =>
      * @protected
      */
     _onMouseOver(e) {
-      this.preventClose = true
+      this.preventClose = true;
       const button = this._getButtonFromEvent(e);
       if (button && button !== this._expandedButton) {
         const isOpened = this._subMenu.opened;
@@ -321,7 +321,7 @@ export const InteractionsMixin = (superClass) =>
         let menu = e.detail.subMenuElement;
         this._addHoverListener(menu);
         this._addSubMenuOpenListener(menu);
-      })
+      });
     }
 
     /** @private */

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -237,7 +237,9 @@ export const InteractionsMixin = (superClass) =>
      * @protected
      */
     _onMouseOver(e) {
-      this.preventClose = true;
+      if (this.openOnHover) {
+        this.preventClose = true;
+      }
       const button = this._getButtonFromEvent(e);
       if (button && button !== this._expandedButton) {
         const isOpened = this._subMenu.opened;

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -47,6 +47,10 @@ export const InteractionsMixin = (superClass) =>
       const container = this._container;
       container.addEventListener('click', this.__onButtonClick.bind(this));
       container.addEventListener('mouseover', (e) => this._onMouseOver(e));
+
+      if (this.openOnHover){
+          container.addEventListener('mouseleave', e => this._requestClose(e));
+      }
     }
 
     /** @private */
@@ -233,6 +237,7 @@ export const InteractionsMixin = (superClass) =>
      * @protected
      */
     _onMouseOver(e) {
+      this.preventClose = true
       const button = this._getButtonFromEvent(e);
       if (button && button !== this._expandedButton) {
         const isOpened = this._subMenu.opened;
@@ -280,9 +285,54 @@ export const InteractionsMixin = (superClass) =>
     }
 
     /** @private */
+    _requestClose(e) {
+      this.preventClose = false;
+      // wait if something has to prevent the close event
+      setTimeout(() => {
+        let toElement = e.toElement;
+        if (!toElement){
+          return;
+        }
+        let id = toElement.id;
+        if (id !== 'overlay' && !this.preventClose) {
+          this._close(false);
+        }
+      }, 300);
+    }
+
+    /** @private */
+    _addHoverListener(subMenu) {
+      let menuOverlay = subMenu.$.overlay.$.overlay;
+
+      menuOverlay.addEventListener('mouseleave', e => this._requestClose(e));
+      // when hovering between sub menus the subMenu will close if we don't prevent it
+      menuOverlay.addEventListener('mouseenter', () => this.preventClose = true);
+    }
+
+    /**
+     * Recursive method, adding an event listener for opening a sub menu.
+     * It adds also hover listeners to the sub menus, whenever they are opened.
+     * Only used in 'openOnHover' mode.
+     * @param subMenu - the menu to listen to open events
+     * @private
+     */
+    _addSubMenuOpenListener(subMenu) {
+      subMenu.addEventListener('sub-menu-opened', e => {
+        let menu = e.detail.subMenuElement;
+        this._addHoverListener(menu);
+        this._addSubMenuOpenListener(menu);
+      })
+    }
+
+    /** @private */
     __openSubMenu(button, event, options = {}) {
       const subMenu = this._subMenu;
       const item = button.item;
+
+      if (this.openOnHover) {
+        this._addHoverListener(subMenu);
+        this._addSubMenuOpenListener(subMenu);
+      }
 
       if (subMenu.opened) {
         this._close();

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-submenu.js
@@ -40,6 +40,22 @@ class MenuBarSubmenuElement extends ContextMenuElement {
       this.getRootNode().host._close();
     }
   }
+
+  /**
+   * Overriding the open method to fire an event when a sub menu is opened.
+   * @private
+   */
+  __openSubMenu(subMenu, itemElement) {
+    super.__openSubMenu(subMenu, itemElement);
+
+    this.dispatchEvent(
+        new CustomEvent('sub-menu-opened', {
+          detail: {
+            subMenuElement: subMenu
+          }
+        })
+    );
+  }
 }
 
 customElements.define(MenuBarSubmenuElement.is, MenuBarSubmenuElement);


### PR DESCRIPTION
## Description

Enhances the 'openOnHover' behavior of vaadin-menu-bar by addin close functionality on mouseleave.

Fixes #589

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
