### PR TITLE
fix: remove overflow: hidden from RTE

### DIFF
--- a/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
@@ -126,7 +126,6 @@ class RichTextEditorElement extends ElementMixin(ThemableMixin(PolymerElement)) 
           display: flex;
           flex-direction: column;
           box-sizing: border-box;
-          overflow: hidden;
         }
 
         :host([hidden]) {


### PR DESCRIPTION
## Description

`overflow: hidden` breaks the field highlight of Collaboration Engine. To me this property seems redundant, because `overflow: hidden` is also defined on the content part of RTE, and at least I couldn't find out a way to break anything with this change. Let me know if I've overlooked something.

More details in comment: https://github.com/vaadin/collaboration-engine/issues/29#issuecomment-845123081

Fixes https://github.com/vaadin/collaboration-engine/issues/29

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
