### PR TITLE
feat: add first/last visible index APIs to virtual list

### DIFF
--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.d.ts
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.d.ts
@@ -59,6 +59,16 @@ declare class VirtualListElement extends ElementMixin(ThemableMixin(HTMLElement)
    * Scroll to a specific index in the virtual list.
    */
   scrollToIndex(index: number): void;
+
+  /**
+   * Gets the index of the first visible item in the viewport.
+   */
+  firstVisibleIndex: number;
+
+  /**
+   * Gets the index of the last visible item in the viewport.
+   */
+  lastVisibleIndex: number;
 }
 
 declare global {

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.d.ts
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.d.ts
@@ -68,7 +68,7 @@ declare class VirtualListElement extends ElementMixin(ThemableMixin(HTMLElement)
   /**
    * Gets the index of the last visible item in the viewport.
    */
-  lastVisibleIndex: number;
+  readonly lastVisibleIndex: number;
 }
 
 declare global {

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.d.ts
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.d.ts
@@ -63,7 +63,7 @@ declare class VirtualListElement extends ElementMixin(ThemableMixin(HTMLElement)
   /**
    * Gets the index of the first visible item in the viewport.
    */
-  firstVisibleIndex: number;
+  readonly firstVisibleIndex: number;
 
   /**
    * Gets the index of the last visible item in the viewport.

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -143,6 +143,24 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       }
     }
   }
+
+  /**
+   * Gets the index of the first visible item in the viewport.
+   *
+   * @type {number}
+   */
+  get firstVisibleIndex() {
+    return this.__virtualizer.firstVisibleIndex;
+  }
+
+  /**
+   * Gets the index of the last visible item in the viewport.
+   *
+   * @type {number}
+   */
+  get lastVisibleIndex() {
+    return this.__virtualizer.lastVisibleIndex;
+  }
 }
 
 customElements.define(VirtualListElement.is, VirtualListElement);

--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -60,6 +60,14 @@ export class IronListAdapter {
     return 0;
   }
 
+  get adjustedFirstVisibleIndex() {
+    return this.firstVisibleIndex + this._vidxOffset;
+  }
+
+  get adjustedLastVisibleIndex() {
+    return this.lastVisibleIndex + this._vidxOffset;
+  }
+
   scrollToIndex(index) {
     if (typeof index !== 'number' || isNaN(index) || this.size === 0 || !this.scrollTarget.offsetHeight) {
       return;

--- a/packages/vaadin-virtual-list/src/virtualizer.js
+++ b/packages/vaadin-virtual-list/src/virtualizer.js
@@ -62,4 +62,22 @@ export class Virtualizer {
   flush() {
     this.__adapter.flush();
   }
+
+  /**
+   * Gets the index of the first visible item in the viewport.
+   *
+   * @type {number}
+   */
+  get firstVisibleIndex() {
+    return this.__adapter.adjustedFirstVisibleIndex;
+  }
+
+  /**
+   * Gets the index of the last visible item in the viewport.
+   *
+   * @type {number}
+   */
+  get lastVisibleIndex() {
+    return this.__adapter.adjustedLastVisibleIndex;
+  }
 }

--- a/packages/vaadin-virtual-list/test/typings/virtual-list.types.ts
+++ b/packages/vaadin-virtual-list/test/typings/virtual-list.types.ts
@@ -25,3 +25,6 @@ virtualList.renderer = (root, virtualList, model) => {
 assertType<VirtualListRenderer>(virtualList.renderer);
 
 assertType<void>(virtualList.scrollToIndex(3));
+
+assertType<number>(virtualList.firstVisibleIndex);
+assertType<number>(virtualList.lastVisibleIndex);

--- a/packages/vaadin-virtual-list/test/unlimited-size.test.js
+++ b/packages/vaadin-virtual-list/test/unlimited-size.test.js
@@ -168,4 +168,32 @@ describe('unlimited size', () => {
     const item = elementsContainer.querySelector(`#item-${virtualizer.size - 1}`);
     expect(item.getBoundingClientRect().bottom).to.be.closeTo(scrollTarget.getBoundingClientRect().bottom, 1);
   });
+
+  it('should have a first visible index at start', () => {
+    const item = elementsContainer.querySelector(`#item-${virtualizer.firstVisibleIndex}`);
+    const itemRect = item.getBoundingClientRect();
+    expect(scrollTarget.getBoundingClientRect().top).to.be.within(itemRect.top, itemRect.bottom);
+  });
+
+  it('should have a last visible index at start', () => {
+    const item = elementsContainer.querySelector(`#item-${virtualizer.lastVisibleIndex}`);
+    const itemRect = item.getBoundingClientRect();
+    expect(scrollTarget.getBoundingClientRect().bottom).to.be.within(itemRect.top, itemRect.bottom);
+  });
+
+  it('should have a first visible index at end', () => {
+    virtualizer.scrollToIndex(virtualizer.size - 1);
+
+    const item = elementsContainer.querySelector(`#item-${virtualizer.firstVisibleIndex}`);
+    const itemRect = item.getBoundingClientRect();
+    expect(scrollTarget.getBoundingClientRect().top).to.be.within(itemRect.top, itemRect.bottom);
+  });
+
+  it('should have a last visible index at end', () => {
+    virtualizer.scrollToIndex(virtualizer.size - 1);
+
+    const item = elementsContainer.querySelector(`#item-${virtualizer.lastVisibleIndex}`);
+    const itemRect = item.getBoundingClientRect();
+    expect(scrollTarget.getBoundingClientRect().bottom).to.be.within(itemRect.top, itemRect.bottom);
+  });
 });

--- a/packages/vaadin-virtual-list/test/virtual-list.test.js
+++ b/packages/vaadin-virtual-list/test/virtual-list.test.js
@@ -88,5 +88,17 @@ describe('virtual-list', () => {
     it('should have full width items', () => {
       expect(list.firstElementChild.offsetWidth).to.equal(list.offsetWidth);
     });
+
+    it('should have a first visible index', () => {
+      const item = [...list.children].find((el) => el.textContent === `value-${list.firstVisibleIndex}`);
+      const itemRect = item.getBoundingClientRect();
+      expect(list.getBoundingClientRect().top).to.be.within(itemRect.top, itemRect.bottom);
+    });
+
+    it('should have a last visible index', () => {
+      const item = [...list.children].find((el) => el.textContent === `value-${list.lastVisibleIndex}`);
+      const itemRect = item.getBoundingClientRect();
+      expect(list.getBoundingClientRect().bottom).to.be.within(itemRect.top, itemRect.bottom);
+    });
   });
 });


### PR DESCRIPTION
Related to https://github.com/vaadin/flow-components/issues/853

The `IronList` Flow component's TestBench element has [APIs for getting the first and last visible item indexes](https://github.com/vaadin/flow-components/blob/20.0/vaadin-iron-list-flow-parent/vaadin-iron-list-testbench/src/main/java/com/vaadin/flow/component/ironlist/testbench/IronListElement.java#L37-L53).

In order to have the same APIs in VirtualList's TestBench element, the `<vaadin-virtual-list>` Web Component needs to expose `firstVisibleIndex` and `lastVisibleIndex` properties.