### PR TITLE
test: fix version regex to allow RC

### DIFF
--- a/packages/vaadin-accordion/test/accordion.test.js
+++ b/packages/vaadin-accordion/test/accordion.test.js
@@ -45,7 +45,7 @@ describe('vaadin-accordion', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(accordion.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(accordion.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 

--- a/packages/vaadin-app-layout/test/app-layout.test.js
+++ b/packages/vaadin-app-layout/test/app-layout.test.js
@@ -27,7 +27,7 @@ describe('vaadin-app-layout', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 

--- a/packages/vaadin-avatar/test/avatar-group.test.js
+++ b/packages/vaadin-avatar/test/avatar-group.test.js
@@ -22,7 +22,7 @@ describe('avatar-group', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(group.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(group.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 

--- a/packages/vaadin-avatar/test/avatar.test.js
+++ b/packages/vaadin-avatar/test/avatar.test.js
@@ -24,7 +24,7 @@ describe('vaadin-avatar', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(avatar.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(avatar.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 

--- a/packages/vaadin-board/test/basic.test.js
+++ b/packages/vaadin-board/test/basic.test.js
@@ -18,6 +18,6 @@ describe('vaadin-details', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(board.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(board.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 });

--- a/packages/vaadin-button/test/button.test.js
+++ b/packages/vaadin-button/test/button.test.js
@@ -26,7 +26,7 @@ describe('vaadin-button', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(vaadinButton.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(vaadinButton.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 
   it('should define button label using light DOM', () => {

--- a/packages/vaadin-charts/test/chart-element.test.js
+++ b/packages/vaadin-charts/test/chart-element.test.js
@@ -20,7 +20,7 @@ describe('vaadin-chart', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(chart.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(chart.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 

--- a/packages/vaadin-confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/vaadin-confirm-dialog/test/confirm-dialog.test.js
@@ -18,7 +18,7 @@ describe('vaadin-confirm-dialog', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(confirm.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(confirm.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 

--- a/packages/vaadin-cookie-consent/test/cookie-consent.test.js
+++ b/packages/vaadin-cookie-consent/test/cookie-consent.test.js
@@ -15,7 +15,7 @@ describe('vaadin-cookie-consent', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(consent.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(consent.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 

--- a/packages/vaadin-date-time-picker/test/basic.test.js
+++ b/packages/vaadin-date-time-picker/test/basic.test.js
@@ -49,7 +49,7 @@ describe('Basic features', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(dateTimePicker.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(dateTimePicker.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 
   it('should have default value', () => {

--- a/packages/vaadin-details/test/details.test.js
+++ b/packages/vaadin-details/test/details.test.js
@@ -23,7 +23,7 @@ describe('vaadin-details', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(details.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(details.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 

--- a/packages/vaadin-dialog/test/dialog.test.js
+++ b/packages/vaadin-dialog/test/dialog.test.js
@@ -44,7 +44,7 @@ describe('vaadin-dialog', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(dialog.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(dialog.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
 
     describe('attributes', () => {

--- a/packages/vaadin-icon/test/icon.test.js
+++ b/packages/vaadin-icon/test/icon.test.js
@@ -24,7 +24,7 @@ describe('vaadin-icon', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(icon.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(icon.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 

--- a/packages/vaadin-item/test/item.test.js
+++ b/packages/vaadin-item/test/item.test.js
@@ -10,7 +10,7 @@ describe('vaadin-item', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(item.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(item.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 
   it('should extend item-mixin', () => {

--- a/packages/vaadin-login/test/login-form.test.js
+++ b/packages/vaadin-login/test/login-form.test.js
@@ -69,7 +69,7 @@ describe('login form', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(login.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(login.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 
   it('should display default strings', () => {

--- a/packages/vaadin-menu-bar/test/menu-bar.test.js
+++ b/packages/vaadin-menu-bar/test/menu-bar.test.js
@@ -34,7 +34,7 @@ describe('custom element definition', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(menu.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(menu.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 });
 

--- a/packages/vaadin-messages/test/message-input.test.js
+++ b/packages/vaadin-messages/test/message-input.test.js
@@ -13,7 +13,7 @@ describe('message-input', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(messageInput.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(messageInput.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 
   it('message should be initialized', () => {

--- a/packages/vaadin-messages/test/message-list.test.js
+++ b/packages/vaadin-messages/test/message-list.test.js
@@ -52,7 +52,7 @@ describe('message-list', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(messageList.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(messageList.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 
   it('message list should be initially empty', () => {

--- a/packages/vaadin-messages/test/message.test.js
+++ b/packages/vaadin-messages/test/message.test.js
@@ -17,7 +17,7 @@ describe('message', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(message.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(message.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 
   it('avatar should be initially visible but without data', () => {

--- a/packages/vaadin-ordered-layout/test/horizontal-layout.js
+++ b/packages/vaadin-ordered-layout/test/horizontal-layout.js
@@ -21,7 +21,7 @@ describe('vaadin-horizontal-layout', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
 
     it('should have a box-sizing set to border-box', () => {

--- a/packages/vaadin-ordered-layout/test/scroller.test.js
+++ b/packages/vaadin-ordered-layout/test/scroller.test.js
@@ -25,7 +25,7 @@ describe('vaadin-scroller', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
 
     it('should extend ThemableMixin', () => {

--- a/packages/vaadin-ordered-layout/test/vertical-layout.test.js
+++ b/packages/vaadin-ordered-layout/test/vertical-layout.test.js
@@ -21,7 +21,7 @@ describe('vaadin-vertical-layout', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
 
     it('should have a box-sizing set to border-box', () => {

--- a/packages/vaadin-progress-bar/test/progress-bar.test.js
+++ b/packages/vaadin-progress-bar/test/progress-bar.test.js
@@ -11,7 +11,7 @@ describe('progress bar', () => {
   });
 
   it('should have a valid version number', () => {
-    expect(progress.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+    expect(progress.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 
   it('should have proper scale', () => {

--- a/packages/vaadin-tabs/test/tabs.test.js
+++ b/packages/vaadin-tabs/test/tabs.test.js
@@ -37,7 +37,7 @@ describe('tabs', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
+      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 


### PR DESCRIPTION
## Description

We have a bunch of tests checking the `version` getters in components and they fail for `20.0.0-rc1`:

```
 ❌ tabs > custom element definition > should have a valid version number
      AssertionError: expected '20.0.0-rc1' to match /^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/
        at o.<anonymous> (packages/vaadin-tabs/test/tabs.test.js:40:54)
```

## Type of change

- [x] Internal change