### PR TITLE
fix: make sure rows are generated to an emptied grid with heightByRows

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-styles.js
+++ b/packages/vaadin-grid/src/vaadin-grid-styles.js
@@ -52,8 +52,8 @@ registerStyles(
       position: relative;
     }
 
-    :host([height-by-rows]) #items:empty {
-      height: 1px;
+    :host([height-by-rows]) #items {
+      min-height: 1px;
     }
 
     #table {

--- a/packages/vaadin-grid/test/resizing.test.js
+++ b/packages/vaadin-grid/test/resizing.test.js
@@ -120,6 +120,22 @@ describe('resizing', () => {
     expect(getPhysicalItems(grid).length).to.be.above(0);
   });
 
+  it('should have body rows after items reset and repopulated', async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="value"></vaadin-grid-column>
+      </vaadin-grid>`);
+    grid.firstElementChild.header = null;
+    grid.heightByRows = true;
+    grid.items = [{ value: 1 }];
+    flushGrid(grid);
+    grid.items = [];
+    flushGrid(grid);
+    grid.items = [{ value: 1 }];
+    flushGrid(grid);
+    expect(getPhysicalItems(grid).length).to.be.above(0);
+  });
+
   // NOTE: This issue only manifests with scrollbars that affect the layout
   // (On mac: Show scroll bars: Always) and Chrome / Safari browser
   it('should have correct layout after column width change', async () => {

--- a/packages/vaadin-grid/test/resizing.test.js
+++ b/packages/vaadin-grid/test/resizing.test.js
@@ -108,34 +108,6 @@ describe('resizing', () => {
     expect(grid.clientHeight).to.equal(headerHeight + bodyHeight + footerHeight);
   });
 
-  it('should have body rows if header is not visible', async () => {
-    grid = fixtureSync(`
-      <vaadin-grid>
-        <vaadin-grid-column path="value"></vaadin-grid-column>
-      </vaadin-grid>`);
-    grid.firstElementChild.header = null;
-    grid.heightByRows = true;
-    grid.items = [{ value: 1 }];
-    flushGrid(grid);
-    expect(getPhysicalItems(grid).length).to.be.above(0);
-  });
-
-  it('should have body rows after items reset and repopulated', async () => {
-    grid = fixtureSync(`
-      <vaadin-grid>
-        <vaadin-grid-column path="value"></vaadin-grid-column>
-      </vaadin-grid>`);
-    grid.firstElementChild.header = null;
-    grid.heightByRows = true;
-    grid.items = [{ value: 1 }];
-    flushGrid(grid);
-    grid.items = [];
-    flushGrid(grid);
-    grid.items = [{ value: 1 }];
-    flushGrid(grid);
-    expect(getPhysicalItems(grid).length).to.be.above(0);
-  });
-
   // NOTE: This issue only manifests with scrollbars that affect the layout
   // (On mac: Show scroll bars: Always) and Chrome / Safari browser
   it('should have correct layout after column width change', async () => {
@@ -186,7 +158,7 @@ describe('resizing', () => {
 describe('height by rows', () => {
   let grid;
 
-  beforeEach(() => {
+  it('should align height with number of rows after first render', () => {
     grid = fixtureSync(`
       <vaadin-grid>
         <vaadin-grid-column>
@@ -194,9 +166,6 @@ describe('height by rows', () => {
         </vaadin-grid-column>
       </vaadin-grid>
     `);
-  });
-
-  it('should align height with number of rows after first render', () => {
     const rows = 100;
     grid.items = grid.items = Array(...new Array(rows)).map(() => {});
     flushGrid(grid);
@@ -205,5 +174,33 @@ describe('height by rows', () => {
     flushGrid(grid);
 
     expect(grid.$.items.children.length).to.equal(rows);
+  });
+
+  it('should have body rows if header is not visible', () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="value"></vaadin-grid-column>
+      </vaadin-grid>`);
+    grid.firstElementChild.header = null;
+    grid.heightByRows = true;
+    grid.items = [{ value: 1 }];
+    flushGrid(grid);
+    expect(getPhysicalItems(grid).length).to.be.above(0);
+  });
+
+  it('should have body rows after items reset and repopulated', () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="value"></vaadin-grid-column>
+      </vaadin-grid>`);
+    grid.firstElementChild.header = null;
+    grid.heightByRows = true;
+    grid.items = [{ value: 1 }];
+    flushGrid(grid);
+    grid.items = [];
+    flushGrid(grid);
+    grid.items = [{ value: 1 }];
+    flushGrid(grid);
+    expect(getPhysicalItems(grid).length).to.be.above(0);
   });
 });


### PR DESCRIPTION
Related to https://github.com/vaadin/start/issues/1249

Follow-up for https://github.com/vaadin/web-components/pull/387

The previous selector with `items:empty` doesn't apply when there are `hidden` rows in the DOM. This PR makes the `items` container always have a min-height of 1px when `heightByRows` is used. This is to make sure the virtualizer generates rows even when there are non-visible rows in the DOM.