### PR TITLE
fix: compute final renderers even dependencies are undefined

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -119,8 +119,10 @@ export const ColumnBaseMixin = (superClass) =>
         _grid: Object,
 
         /**
-         * An internal property that can be used to force initial invoke of a Polymer observer
-         * even the other dependencies in the observer are `undefined`.
+         * By default, the Polymer doesn't invoke the observer
+         * during initialization if all of its dependencies are `undefined`.
+         * This internal property can be used to force initial invocation of an observer
+         * even the other dependencies of the observer are `undefined`.
          *
          * @private
          */

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -119,6 +119,17 @@ export const ColumnBaseMixin = (superClass) =>
         _grid: Object,
 
         /**
+         * An internal property that can be used to force initial invoke of a Polymer observer
+         * even the other dependencies in the observer are `undefined`.
+         *
+         * @private
+         */
+        __initialized: {
+          type: Boolean,
+          value: true
+        },
+
+        /**
          * Custom function for rendering the header content.
          * Receives two arguments:
          *
@@ -138,7 +149,7 @@ export const ColumnBaseMixin = (superClass) =>
          */
         _headerRenderer: {
           type: Function,
-          computed: '_computeHeaderRenderer(headerRenderer, _headerTemplate, header)'
+          computed: '_computeHeaderRenderer(headerRenderer, _headerTemplate, header, __initialized)'
         },
 
         /**
@@ -161,7 +172,7 @@ export const ColumnBaseMixin = (superClass) =>
          */
         _footerRenderer: {
           type: Function,
-          computed: '_computeFooterRenderer(footerRenderer, _footerTemplate)'
+          computed: '_computeFooterRenderer(footerRenderer, _footerTemplate, __initialized)'
         }
       };
     }
@@ -804,7 +815,7 @@ class GridColumnElement extends ColumnBaseMixin(DirMixin(PolymerElement)) {
        */
       _renderer: {
         type: Function,
-        computed: '_computeRenderer(renderer, _bodyTemplate)'
+        computed: '_computeRenderer(renderer, _bodyTemplate, __initialized)'
       },
 
       /**


### PR DESCRIPTION
## Description

After closing #1967, I rebased [the branch](https://github.com/vaadin/web-components/pull/2052) about removing Grid Template API. Surprisingly, default renderers didn't work when [the template logic](https://github.com/vaadin/web-components/pull/2052/files#diff-37fc749a7a99c4f9c6690e4879c4657c493c59e185d41c3abdff95d08963c76dR276-R280) is removed. 

According to [the Polymer documentation](https://polymer-library.polymer-project.org/3.0/docs/devguide/observers#define-a-computed-property), it doesn’t invoke a computed function until at least one of its dependencies gets defined (`!== undefined`). 

It turns out that after removing the template properties from the dependency list, all the remaining properties were `undefined`, so the final renderer wasn't computed.

This PR introduces a private property (`__initialized`) that is supposed to be added in a dependency list of an observer to force its initial invocation:

```js
_footerRenderer: {
  type: Function,
  computed: '_computeFooterRenderer(footerRenderer, _footerTemplate, __initialized /* <----- */)'
}
```

Related to #1967

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
