### PR TITLE
fix: force model's item bindings to re-render in template renderer

### DIFF
--- a/packages/vaadin-template-renderer/src/vaadin-template-renderer-templatizer.js
+++ b/packages/vaadin-template-renderer/src/vaadin-template-renderer-templatizer.js
@@ -24,7 +24,7 @@ export class Templatizer extends PolymerElement {
     // If the template instance exists and has been instantiated by this templatizer,
     // it only re-renders the instance with the new properties.
     if (this.__templateInstances.has(element.__templateInstance)) {
-      element.__templateInstance.setProperties(properties);
+      this.__updateProperties(element.__templateInstance, properties);
       return;
     }
 
@@ -34,6 +34,18 @@ export class Templatizer extends PolymerElement {
     element.innerHTML = '';
     element.__templateInstance = templateInstance;
     element.appendChild(templateInstance.root);
+  }
+
+  __updateProperties(instance, properties) {
+    // The Polymer uses `===` to check whether a property is changed and should be re-rendered.
+    // This means, object properties won't be re-rendered when mutated inside.
+    // This workaround forces the `item` property to re-render even
+    // the new item is stricly equal to the old item.
+    if (instance.item === properties.item) {
+      instance._setPendingProperty('item');
+    }
+
+    instance.setProperties(properties);
   }
 
   __createTemplateInstance(properties) {

--- a/packages/vaadin-template-renderer/test/fixtures/mock-list-host.js
+++ b/packages/vaadin-template-renderer/test/fixtures/mock-list-host.js
@@ -7,10 +7,9 @@ export class MockListHost extends PolymerElement {
     return html`
       <mock-list id="list" items="[[items]]">
         <template>
-          <div class="item-text">[[item]]</div>
+          <div class="title">[[item.title]]</div>
 
-          <div class="value-text">[[value]]</div>
-
+          <div class="value">[[value]]</div>
           <input value="{{value::input}}" />
 
           <button on-click="onClick"></button>
@@ -26,7 +25,7 @@ export class MockListHost extends PolymerElement {
       items: {
         type: Array,
         value() {
-          return ['item1', 'item2'];
+          return [{ title: 'title0' }, { title: 'title1' }];
         }
       }
     };

--- a/packages/vaadin-template-renderer/test/list.test.js
+++ b/packages/vaadin-template-renderer/test/list.test.js
@@ -10,12 +10,12 @@ import './fixtures/mock-list.js';
 describe('list', () => {
   let host, list, template;
 
-  function getItemText(item) {
-    return item.querySelector('.item-text').textContent;
+  function getItemTitle(item) {
+    return item.querySelector('.title').textContent;
   }
 
-  function getItemValueText(item) {
-    return item.querySelector('.value-text').textContent;
+  function getItemValue(item) {
+    return item.querySelector('.value').textContent;
   }
 
   beforeEach(() => {
@@ -26,8 +26,8 @@ describe('list', () => {
 
   it('should render the list', () => {
     expect(list.$.items.children).to.have.lengthOf(2);
-    expect(getItemText(list.$.items.children[0])).to.equal('item1');
-    expect(getItemText(list.$.items.children[1])).to.equal('item2');
+    expect(getItemTitle(list.$.items.children[0])).to.equal('title0');
+    expect(getItemTitle(list.$.items.children[1])).to.equal('title1');
   });
 
   it('should handle events from the template instances', () => {
@@ -43,10 +43,10 @@ describe('list', () => {
   });
 
   it('should re-render the list when removing an item', () => {
-    host.items = ['item1'];
+    host.items = [{ title: 'new0' }];
 
     expect(list.$.items.children).to.have.lengthOf(1);
-    expect(getItemText(list.$.items.children[0])).to.equal('item1');
+    expect(getItemTitle(list.$.items.children[0])).to.equal('new0');
   });
 
   it('should create a template instance for each item', () => {
@@ -69,14 +69,22 @@ describe('list', () => {
   it('should re-render the template instances when changing a parent property', () => {
     host.value = 'foobar';
 
-    expect(getItemValueText(list.$.items.children[0])).to.equal('foobar');
-    expect(getItemValueText(list.$.items.children[1])).to.equal('foobar');
+    expect(getItemValue(list.$.items.children[0])).to.equal('foobar');
+    expect(getItemValue(list.$.items.children[1])).to.equal('foobar');
   });
 
   it('should re-render the template instances when changing items', () => {
-    host.items = ['foo', 'bar'];
+    host.items = [{ title: 'new0' }, { title: 'new1' }];
 
-    expect(getItemText(list.$.items.children[0])).to.equal('foo');
-    expect(getItemText(list.$.items.children[1])).to.equal('bar');
+    expect(getItemTitle(list.$.items.children[0])).to.equal('new0');
+    expect(getItemTitle(list.$.items.children[1])).to.equal('new1');
+  });
+
+  it('should re-render the template instances when mutating an item', () => {
+    host.items[0].title = 'new0';
+    list.render();
+
+    expect(getItemTitle(list.$.items.children[0])).to.equal('new0');
+    expect(getItemTitle(list.$.items.children[1])).to.equal('title1');
   });
 });


### PR DESCRIPTION
## Description

When calling `setProperties(...)` to re-render a Polymer template instance, it compares the new properties with old ones using the `===` operator to skip rendering not changed properties.

However, in case of an object property, the `===` operator can't determine whether the object has been mutated inside. Thus, the property won't be re-rendered when mutated. 

This issue appears in the template renderer when mutating the `model.item` object after it is bound to a template. 

This PR introduces a workaround that forces `model.item` template bindings to re-render even the new item is strictly equal to the old item.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
