### PR TITLE
fix: workaround a Safari sticky positioning issue

### DIFF
--- a/packages/vaadin-grid/test/basic.test.js
+++ b/packages/vaadin-grid/test/basic.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import {
   flushGrid,
   getBodyCellContent,
@@ -297,6 +297,10 @@ describe('flex child', () => {
       await aTimeout(0);
       flushGrid(grid);
       const { left, top } = grid.getBoundingClientRect();
+
+      oneEvent(grid.$.table, 'scroll');
+      flushGrid(grid);
+
       const cell = grid._cellFromPoint(left + 1, top + 1);
       expect(grid.$.header.contains(cell)).to.be.true;
     });

--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -18,6 +18,8 @@ export class IronListAdapter {
     this.elementsContainer = elementsContainer || scrollContainer;
     this.reorderElements = reorderElements;
 
+    this.__safari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
     this.timeouts = {
       SCROLL_REORDER: 500,
       IGNORE_WHEEL: 500
@@ -421,9 +423,11 @@ export class IronListAdapter {
     // Due to a rendering bug, reordering the rows can make parts of the scroll target disappear
     // on Safari when using sticky positioning in case the scroll target is inside a flexbox.
     // This issue manifests with grid (the header can disappear if grid is used inside a flexbox)
-    const { transform } = this.scrollTarget.style;
-    this.scrollTarget.style.transform = 'translateZ(0)';
-    setTimeout(() => (this.scrollTarget.style.transform = transform));
+    if (this.__safari) {
+      const { transform } = this.scrollTarget.style;
+      this.scrollTarget.style.transform = 'translateZ(0)';
+      setTimeout(() => (this.scrollTarget.style.transform = transform));
+    }
   }
 
   /** @private */

--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -417,6 +417,13 @@ export class IronListAdapter {
         this.elementsContainer.insertBefore(visibleElements[i], visibleElements[0]);
       }
     }
+
+    // Due to a rendering bug, reordering the rows can make parts of the scroll target disappear
+    // on Safari when using sticky positioning in case the scroll target is inside a flexbox.
+    // This issue manifests with grid (the header can disappear if grid is used inside a flexbox)
+    const { transform } = this.scrollTarget.style;
+    this.scrollTarget.style.transform = 'translateZ(0)';
+    setTimeout(() => (this.scrollTarget.style.transform = transform));
   }
 
   /** @private */


### PR DESCRIPTION
This fixes a regression from https://github.com/vaadin/web-components/pull/321

Open https://vaadin.com/docs/latest/ds/components/grid Scroll any of the grids on Safari and the header disappears once the scrolling stops (as the DOM rows get reordered)

![Kapture 2021-05-31 at 12 01 30](https://user-images.githubusercontent.com/1222264/120169355-87467280-c208-11eb-87f6-5c2eb5bd739c.gif)

The [original fix to the issue was removed](https://github.com/vaadin/web-components/pull/321/files#diff-087afca125e21a05da8e5d0dd9093fbd66f748f1fa124c4076fd2c4b28fac8d0L317-L323) because it wasn't caught by any of the tests with the new architecture. Turns out the issue was still there but the test just needed a change in timing. This PR restores the [original fix](https://github.com/vaadin/vaadin-grid/pull/1799).