### PR TITLE
fix: exclude non-visible body cells from grid column auto width calc

### DIFF
--- a/packages/vaadin-grid/test/column-auto-width.test.js
+++ b/packages/vaadin-grid/test/column-auto-width.test.js
@@ -113,6 +113,16 @@ describe('column auto-width', function () {
     await recalculateWidths();
     expectColumnWidthsToBeOk(columns, [42, 62, 84, 107]);
   });
+
+  it('should exclude non-visible body cells from grid column auto width calc', async () => {
+    // Assign more items to the grid. The last one with the long content, while in the DOM,
+    // will end up outside the visible viewport and therefor should not affect the
+    // calculated column auto-width
+    grid.items = [...testItems, { a: 'a' }, { a: 'aaaaaaaaaaaaaaaaaaaaa' }];
+
+    await recalculateWidths();
+    expectColumnWidthsToBeOk(columns);
+  });
 });
 
 describe('async recalculateWidth columns', () => {


### PR DESCRIPTION
This fixes a regression from #321 and slightly changes the behavior of `column.autoWidth`

After #321, the number of DOM elements representing the items (`<tr>`) is no longer deterministic. This had a direct impact on the resulting column widths when using `column.autoWidth` (making the resulting column auto width also non-deterministic).

This PR changes the behavior so that samples for the auto width calculation are only taken from the body cells, whose parent rows are included in the _visible viewport_. Any rows outside the viewport, even if in the DOM, are excluded from the calculation.

