### PR TITLE
docs: clarify date picker i18n usage

### DIFF
--- a/packages/vaadin-date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -75,7 +75,15 @@ interface DatePickerMixin {
   /**
    * The object used to localize this component.
    * To change the default localization, replace the entire
-   * _i18n_ object or just the property you want to modify.
+   * `i18n` object with a custom one.
+   *
+   * To update individual properties, extend the existing i18n object like so:
+   * ```
+   * datePicker.i18n = { ...datePicker.i18n, {
+   *   formatDate: date => { ... },
+   *   parseDate: value => { ... },
+   * }};
+   * ```
    *
    * The object has the following JSON structure and default values:
    *

--- a/packages/vaadin-date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker-mixin.js
@@ -129,7 +129,15 @@ export const DatePickerMixin = (subclass) =>
         /**
          * The object used to localize this component.
          * To change the default localization, replace the entire
-         * _i18n_ object or just the property you want to modify.
+         * `i18n` object with a custom one.
+         *
+         * To update individual properties, extend the existing i18n object like so:
+         * ```
+         * datePicker.i18n = { ...datePicker.i18n, {
+         *   formatDate: date => { ... },
+         *   parseDate: value => { ... },
+         * }};
+         * ```
          *
          * The object has the following JSON structure and default values:
          *


### PR DESCRIPTION
## Description

Corrected date picker docs to state that the whole i18n object must be replaced to trigger data-binding, and provided example on how to extend the existing i18n object with just a few specific properties.

No related issue.

## Type of change

- [x] Docs
