### PR TITLE
fix!: re-render row when toggling details

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-a11y-mixin.js
@@ -91,13 +91,13 @@ export const A11yMixin = (superClass) =>
      * @protected
      */
     _a11yUpdateRowDetailsOpened(row, detailsOpened) {
+      const detailsCell = row.querySelector('[part~=details-cell]');
+
       Array.from(row.children).forEach((cell) => {
-        if (typeof detailsOpened === 'boolean') {
+        if (detailsCell) {
           cell.setAttribute('aria-expanded', detailsOpened);
         } else {
-          if (cell.hasAttribute('aria-expanded')) {
-            cell.removeAttribute('aria-expanded');
-          }
+          cell.removeAttribute('aria-expanded');
         }
       });
     }

--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { Templatizer } from './vaadin-grid-templatizer.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 
 /**
  * @polymerMixin
@@ -68,7 +67,7 @@ export const RowDetailsMixin = (superClass) =>
 
       this._detailsCellResizeObserver = new ResizeObserver((entries) => {
         entries.forEach(({ target: cell }) => {
-          cell.parentElement.style.setProperty('padding-bottom', `${cell.offsetHeight}px`);
+          this._updateDetailsCellHeight(cell.parentElement);
         });
 
         // This workaround is needed until Safari also supports
@@ -102,23 +101,28 @@ export const RowDetailsMixin = (superClass) =>
             delete row.querySelector('[part~=details-cell]')._instance;
           });
         }
-
-        if (this.detailsOpenedItems.length) {
-          Array.from(this.$.items.children).forEach(this._toggleDetailsCell, this);
-        }
       }
     }
 
     /** @private */
-    _detailsOpenedItemsChanged(changeRecord) {
+    _detailsOpenedItemsChanged(changeRecord, _rowDetailsTemplate, _rowDetailsRenderer) {
+      // Skip to avoid duplicate work of both “.splices” and “.length” updates
       if (changeRecord.path === 'detailsOpenedItems.length' || !changeRecord.value) {
-        // Let’s avoid duplicate work of both “.splices” and “.length” updates.
         return;
       }
-      Array.from(this.$.items.children).forEach((row) => {
-        this._toggleDetailsCell(row, row._item);
-        this._a11yUpdateRowDetailsOpened(row, this._isDetailsOpened(row._item));
-        this._toggleAttribute('details-opened', this._isDetailsOpened(row._item), row);
+
+      [...this.$.items.children].forEach((row) => {
+        // Re-renders the row to possibly close the previously opened details
+        if (row.hasAttribute('details-opened')) {
+          this._updateItem(row, row._item);
+          return;
+        }
+
+        // Re-renders the row to open the details when either a renderer or a template is provided
+        if ((_rowDetailsTemplate || _rowDetailsRenderer) && this._isDetailsOpened(row._item)) {
+          this._updateItem(row, row._item);
+          return;
+        }
       });
     }
 
@@ -140,34 +144,42 @@ export const RowDetailsMixin = (superClass) =>
      * @param {!GridItem} item
      * @protected
      */
-    _toggleDetailsCell(row, item) {
+    _toggleDetailsCell(row, detailsOpened) {
       const cell = row.querySelector('[part~="details-cell"]');
       if (!cell) {
         return;
       }
-      const detailsHidden = !this._isDetailsOpened(item);
 
-      if ((!cell._instance && !cell._renderer) || cell.hidden !== detailsHidden) {
-        cell.hidden = detailsHidden;
-        if (detailsHidden) {
-          row.style.removeProperty('padding-bottom');
-        } else {
-          if (this.rowDetailsRenderer) {
-            cell._renderer = this.rowDetailsRenderer;
-            cell._renderer.call(this, cell._content, this, { index: row.index, item: item });
-          } else if (this._rowDetailsTemplate && !cell._instance) {
-            // Stamp the template
-            cell._instance = this._rowDetailsTemplate.templatizer.createInstance();
-            cell._content.innerHTML = '';
-            cell._content.appendChild(cell._instance.root);
-            this._updateItem(row, item);
-          }
+      cell.hidden = !detailsOpened;
 
-          flush();
-          row.style.setProperty('padding-bottom', `${cell.offsetHeight}px`);
+      if (cell.hidden) {
+        return;
+      }
 
-          requestAnimationFrame(() => this.notifyResize());
-        }
+      // Assign either a renderer...
+      if (this.rowDetailsRenderer) {
+        cell._renderer = this.rowDetailsRenderer;
+      }
+
+      // ...or a template.
+      if (this._rowDetailsTemplate && !cell._instance) {
+        cell._instance = this._rowDetailsTemplate.templatizer.createInstance();
+        cell._content.innerHTML = '';
+        cell._content.appendChild(cell._instance.root);
+      }
+    }
+
+    /** @protected */
+    _updateDetailsCellHeight(row) {
+      const cell = row.querySelector('[part~="details-cell"]');
+      if (!cell) {
+        return;
+      }
+
+      if (cell.hidden) {
+        row.style.removeProperty('padding-bottom');
+      } else {
+        row.style.setProperty('padding-bottom', `${cell.offsetHeight}px`);
       }
     }
 

--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
@@ -105,7 +105,7 @@ export const RowDetailsMixin = (superClass) =>
     }
 
     /** @private */
-    _detailsOpenedItemsChanged(changeRecord, _rowDetailsTemplate, _rowDetailsRenderer) {
+    _detailsOpenedItemsChanged(changeRecord, rowDetailsTemplate, rowDetailsRenderer) {
       // Skip to avoid duplicate work of both “.splices” and “.length” updates.
       if (changeRecord.path === 'detailsOpenedItems.length' || !changeRecord.value) {
         return;
@@ -119,7 +119,7 @@ export const RowDetailsMixin = (superClass) =>
         }
 
         // Re-renders the row to open the details when either a renderer or a template is provided.
-        if ((_rowDetailsTemplate || _rowDetailsRenderer) && this._isDetailsOpened(row._item)) {
+        if ((rowDetailsTemplate || rowDetailsRenderer) && this._isDetailsOpened(row._item)) {
           this._updateItem(row, row._item);
           return;
         }

--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
@@ -156,13 +156,11 @@ export const RowDetailsMixin = (superClass) =>
         return;
       }
 
-      // Assign either a renderer...
+      // Assigns either a renderer or a template when the details cell is opened.
+      // The content of the details cell is rendered later in the `_updateItem` method.
       if (this.rowDetailsRenderer) {
         cell._renderer = this.rowDetailsRenderer;
-      }
-
-      // ...or a template.
-      if (this._rowDetailsTemplate && !cell._instance) {
+      } else if (this._rowDetailsTemplate && !cell._instance) {
         cell._instance = this._rowDetailsTemplate.templatizer.createInstance();
         cell._content.innerHTML = '';
         cell._content.appendChild(cell._instance.root);

--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
@@ -183,8 +183,8 @@ export const RowDetailsMixin = (superClass) =>
 
     /** @protected */
     _updateDetailsCellHeights() {
-      Array.from(this.$.items.querySelectorAll('[part~="details-cell"]:not([hidden])')).forEach((cell) => {
-        cell.parentElement.style.setProperty('padding-bottom', `${cell.offsetHeight}px`);
+      [...this.$.items.children].forEach((row) => {
+        this._updateDetailsCellHeight(row);
       });
     }
 

--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
@@ -106,19 +106,19 @@ export const RowDetailsMixin = (superClass) =>
 
     /** @private */
     _detailsOpenedItemsChanged(changeRecord, _rowDetailsTemplate, _rowDetailsRenderer) {
-      // Skip to avoid duplicate work of both “.splices” and “.length” updates
+      // Skip to avoid duplicate work of both “.splices” and “.length” updates.
       if (changeRecord.path === 'detailsOpenedItems.length' || !changeRecord.value) {
         return;
       }
 
       [...this.$.items.children].forEach((row) => {
-        // Re-renders the row to possibly close the previously opened details
+        // Re-renders the row to possibly close the previously opened details.
         if (row.hasAttribute('details-opened')) {
           this._updateItem(row, row._item);
           return;
         }
 
-        // Re-renders the row to open the details when either a renderer or a template is provided
+        // Re-renders the row to open the details when either a renderer or a template is provided.
         if ((_rowDetailsTemplate || _rowDetailsRenderer) && this._isDetailsOpened(row._item)) {
           this._updateItem(row, row._item);
           return;

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -896,14 +896,16 @@ class GridElement extends ElementMixin(
     row._item = item;
     const model = this.__getRowModel(row);
 
-    this._toggleAttribute('selected', model.selected, row);
-    this._a11yUpdateRowSelected(row, model.selected);
+    this._toggleDetailsCell(row, model.detailsOpened);
+
     this._a11yUpdateRowLevel(row, model.level);
+    this._a11yUpdateRowSelected(row, model.selected);
+    this._a11yUpdateRowDetailsOpened(row, model.detailsOpened);
+
     this._toggleAttribute('expanded', model.expanded, row);
-    this._toggleAttribute('details-opened', this._isDetailsOpened(item), row);
-    if (this._rowDetailsTemplate || this.rowDetailsRenderer) {
-      this._toggleDetailsCell(row, item);
-    }
+    this._toggleAttribute('selected', model.selected, row);
+    this._toggleAttribute('details-opened', model.detailsOpened, row);
+
     this._generateCellClassNames(row, model);
     this._filterDragAndDrop(row, model);
 
@@ -919,6 +921,10 @@ class GridElement extends ElementMixin(
         cell._instance.setProperties(model);
       }
     });
+
+    this._updateDetailsCellHeight(row);
+
+    requestAnimationFrame(() => this.notifyResize());
   }
 
   /** @private */

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -923,8 +923,6 @@ class GridElement extends ElementMixin(
     });
 
     this._updateDetailsCellHeight(row);
-
-    requestAnimationFrame(() => this.notifyResize());
   }
 
   /** @private */

--- a/packages/vaadin-grid/test/renderers.test.js
+++ b/packages/vaadin-grid/test/renderers.test.js
@@ -99,12 +99,24 @@ describe('renderers', () => {
         expect(getContainerCell(grid.$.items, 1, 1).hidden).to.be.false;
       });
 
-      it('should pass column as `owner` and `this` to the renderer', () => {
-        grid.rowDetailsRenderer = function (root, owner) {
-          expect(this).to.eql(owner);
-          expect(owner.localName).to.eql('vaadin-grid');
-        };
-        grid.detailsOpenedItems = grid.items;
+      it('should pass the `root`, `owner`, `model` arguments to the renderer', () => {
+        const detailsCell = getBodyCellContent(grid, 0, 1);
+
+        grid.rowDetailsRenderer = sinon.spy();
+        grid.detailsOpenedItems = [grid.items[0]];
+
+        expect(grid.rowDetailsRenderer.calledOnce).to.be.true;
+        expect(grid.rowDetailsRenderer.thisValues[0]).to.equal(grid);
+        expect(grid.rowDetailsRenderer.args[0][0]).to.equal(detailsCell);
+        expect(grid.rowDetailsRenderer.args[0][1]).to.equal(grid);
+        expect(grid.rowDetailsRenderer.args[0][2]).to.deep.equal({
+          index: 0,
+          level: 0,
+          expanded: false,
+          selected: false,
+          detailsOpened: true,
+          item: grid.items[0]
+        });
       });
 
       it('should allow to change the renderer', () => {

--- a/packages/vaadin-grid/test/row-details.test.js
+++ b/packages/vaadin-grid/test/row-details.test.js
@@ -146,7 +146,7 @@ describe('row details', () => {
       expect(bounds.height).to.be.above(10);
     };
 
-    it('should have correct bounds', () => {
+    it('should have correct bounds', async () => {
       openRowDetails(1);
       assertDetailsBounds();
     });
@@ -278,7 +278,7 @@ describe('row details', () => {
       `);
     });
 
-    it('should have correct height', () => {
+    it('should have correct height', async () => {
       grid.openItemDetails(items[0]);
 
       grid.dataProvider = (params, callback) => callback(items);

--- a/packages/vaadin-grid/test/row-details.test.js
+++ b/packages/vaadin-grid/test/row-details.test.js
@@ -146,7 +146,7 @@ describe('row details', () => {
       expect(bounds.height).to.be.above(10);
     };
 
-    it('should have correct bounds', async () => {
+    it('should have correct bounds', () => {
       openRowDetails(1);
       assertDetailsBounds();
     });
@@ -193,6 +193,34 @@ describe('row details', () => {
       expect(cells[1].hidden).to.be.false;
       grid.closeItemDetails({ value: 'foo0' });
       expect(cells[1].hidden).to.be.true;
+    });
+
+    it('should invoke the body renderer when opening details', () => {
+      grid.renderer = sinon.spy();
+
+      openRowDetails(0);
+
+      grid.renderer.args.forEach(([_root, _owner, model], index) => {
+        if (index === 0) {
+          expect(model.detailsOpened).to.be.true;
+        } else {
+          expect(model.detailsOpened).to.be.false;
+        }
+      });
+    });
+
+    it('should invoke the body renderer when closing details', () => {
+      grid.renderer = sinon.spy();
+
+      openRowDetails(0);
+
+      grid.renderer.resetHistory();
+
+      closeRowDetails(0);
+
+      grid.renderer.args.forEach(([_root, _owner, model]) => {
+        expect(model.detailsOpened).to.be.false;
+      });
     });
   });
 
@@ -278,7 +306,7 @@ describe('row details', () => {
       `);
     });
 
-    it('should have correct height', async () => {
+    it('should have correct height', () => {
       grid.openItemDetails(items[0]);
 
       grid.dataProvider = (params, callback) => callback(items);


### PR DESCRIPTION
## Description

### The row cells are not re-rendered after opening details when using renderers

`bodyRenderer` is invoked with the `model.detailsOpened` property that means the renderer's result can depend on this property. 

The correct behavior would be to re-call the body renderer once opening details, that unfortunately doesn't happen now.

### Mismatch of rowDetailsRenderer’s model and templateInstance’s model

[According to the code](https://github.com/vaadin/web-components/blob/master/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js#L157), `rowDetailsRenderer` is invoked with only: `model.item` and `model.index`.

As for template instances, it seems they are invoked with the “standard” row model including `item`, `index`, `level`, `expanded` and so on. (look at [here](https://github.com/vaadin/web-components/blob/master/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js#L163) and [here](https://github.com/vaadin/web-components/blob/ca052d47831e2e76d6137c89f8343ceb416c6f2f/packages/vaadin-grid/src/vaadin-grid.js#L914-L920)). 

---

This PR aims to address both issues. 

There was also removed the legacy `notifyResize` call from `_toggleDetailsCell` wherefore the PR was marked with `!`.

Related to #410.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
