### PR TITLE
fix: don't use optional chaining operator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 2020
+    "ecmaVersion": 2019
   },
   "plugins": [
     "prettier",

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.js
@@ -57,7 +57,7 @@ class GridFilterColumnElement extends GridColumnElement {
    */
   _defaultHeaderRenderer(root, _column) {
     let filter = root.firstElementChild;
-    let textField = filter?.firstElementChild;
+    let textField = filter ? filter.firstElementChild : undefined;
 
     if (!filter) {
       filter = document.createElement('vaadin-grid-filter');


### PR DESCRIPTION
## Description

As long as the Vaadin Platform targets ES2019 we can't use the optional chaining operator (`?.`) in the mono-repo.

This PR removes any uses of the optional chaining operator in the mono-repo and fixes the ECMA version for the ESLint parser to align it with the Platform's version (`2019`).

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
