### PR TITLE
feat: add API docs for grid cell focus event

### DIFF
--- a/packages/vaadin-grid/src/interfaces.d.ts
+++ b/packages/vaadin-grid/src/interfaces.d.ts
@@ -41,7 +41,7 @@ export interface GridFilter {
 }
 
 export interface GridEventContext<TItem> {
-  section: 'body' | 'header' | 'footer' | 'details';
+  section?: 'body' | 'header' | 'footer' | 'details';
   item?: TItem;
   column?: GridColumnElement<TItem>;
   index?: number;

--- a/packages/vaadin-grid/src/vaadin-grid-event-context-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-event-context-mixin.d.ts
@@ -27,7 +27,7 @@ interface EventContextMixin<TItem> {
    * This may be the case eg. if the event is fired on the `<vaadin-grid>` element and not any deeper in the DOM, or if
    * the event targets the empty part of the grid body.
    */
-  getEventContext(event: Event): GridEventContext<TItem> | object | null;
+  getEventContext(event: Event): GridEventContext<TItem>;
 }
 
 export { EventContextMixin, EventContextMixinConstructor };

--- a/packages/vaadin-grid/src/vaadin-grid-event-context-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-event-context-mixin.js
@@ -28,7 +28,7 @@ export const EventContextMixin = (superClass) =>
      * the event targets the empty part of the grid body.
      *
      * @param {!Event} event
-     * @return {GridEventContext | object}
+     * @return {GridEventContext}
      */
     getEventContext(event) {
       const context = {};

--- a/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -727,4 +727,12 @@ export const KeyboardNavigationMixin = (superClass) =>
       if (focusTargetCell === this._footerFocusable) return this.$.footer;
       return null;
     }
+
+    /**
+     * Fired when a cell is focused with click or keyboard navigation.
+     *
+     * Use {@see GridElement#getEventContext} to get detailed information about the event.
+     *
+     * @event cell-focus
+     */
   };

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -49,6 +49,11 @@ export type GridActiveItemChangedEvent<TItem> = CustomEvent<{ value: TItem }>;
 export type GridCellActivateEvent<TItem> = CustomEvent<{ model: GridItemModel<TItem> }>;
 
 /**
+ * Fired when a cell is focused with click or keyboard navigation.
+ */
+export type GridCellFocusEvent = CustomEvent;
+
+/**
  * Fired when the columns in the grid are reordered.
  */
 export type GridColumnReorderEvent<TItem> = CustomEvent<{ columns: GridColumnElement<TItem>[] }>;
@@ -95,6 +100,8 @@ export interface GridElementEventMap<TItem> {
   'active-item-changed': GridActiveItemChangedEvent<TItem>;
 
   'cell-activate': GridCellActivateEvent<TItem>;
+
+  'cell-focus': GridCellFocusEvent;
 
   'column-reorder': GridColumnReorderEvent<TItem>;
 
@@ -330,6 +337,7 @@ export interface GridEventMap<TItem> extends HTMLElementEventMap, GridElementEve
  *
  * @fires {CustomEvent} active-item-changed - Fired when the `activeItem` property changes.
  * @fires {CustomEvent} cell-activate - Fired when the cell is activated with click or keyboard.
+ * @fires {CustomEvent} cell-focus - Fired when a cell is focused with click or keyboard navigation.
  * @fires {CustomEvent} column-reorder - Fired when the columns in the grid are reordered.
  * @fires {CustomEvent} column-resize - Fired when the grid column resize is finished.
  * @fires {CustomEvent} expanded-items-changed - Fired when the `expandedItems` property changes.

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -253,6 +253,7 @@ const TOUCH_DEVICE = (() => {
  *
  * @fires {CustomEvent} active-item-changed - Fired when the `activeItem` property changes.
  * @fires {CustomEvent} cell-activate - Fired when the cell is activated with click or keyboard.
+ * @fires {CustomEvent} cell-focus - Fired when a cell is focused with click or keyboard navigation.
  * @fires {CustomEvent} column-reorder - Fired when the columns in the grid are reordered.
  * @fires {CustomEvent} column-resize - Fired when the grid column resize is finished.
  * @fires {CustomEvent} expanded-items-changed - Fired when the `expandedItems` property changes.

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -31,6 +31,7 @@ import {
   ColumnBaseMixin,
   GridActiveItemChangedEvent,
   GridCellActivateEvent,
+  GridCellFocusEvent,
   GridColumnElement,
   GridColumnReorderEvent,
   GridColumnResizeEvent,
@@ -83,6 +84,10 @@ narrowedGrid.addEventListener('active-item-changed', (event) => {
 narrowedGrid.addEventListener('cell-activate', (event) => {
   assertType<GridCellActivateEvent<TestGridItem>>(event);
   assertType<GridItemModel<TestGridItem>>(event.detail.model);
+});
+
+narrowedGrid.addEventListener('cell-focus', (event) => {
+  assertType<GridCellFocusEvent>(event);
 });
 
 narrowedGrid.addEventListener('column-reorder', (event) => {


### PR DESCRIPTION
## Description

Added API docs and type definitions for the cell-focus event. Also corrected type definitions for `EventContextMixin.getEventContext` to always return a `GridEventContext` with all props being optional.

Related to: #337

## Type of change

- [X] Feature
