### PR TITLE
fix: don't hide rows in the grid logic

### DIFF
--- a/packages/vaadin-grid/package.json
+++ b/packages/vaadin-grid/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
     "@vaadin/testing-helpers": "^0.2.1",
+    "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.0"
   },
   "publishConfig": {

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -694,9 +694,7 @@ class GridElement extends ElementMixin(
 
     Array.from(row.children).forEach((cell) => (cell._vacant = true));
     row.innerHTML = '';
-    if (row.id !== 'sizer') {
-      row.hidden = true;
-    }
+
     columns
       .filter((column) => !column.hidden)
       .forEach((column, index, cols) => {

--- a/packages/vaadin-grid/test/lit.test.js
+++ b/packages/vaadin-grid/test/lit.test.js
@@ -4,7 +4,7 @@ import { render, html } from 'lit';
 import '../vaadin-grid.js';
 import { getPhysicalItems } from './helpers.js';
 
-describe('renderig with lit', () => {
+describe('rendering with lit', () => {
   let wrapper;
 
   beforeEach(() => {

--- a/packages/vaadin-grid/test/lit.test.js
+++ b/packages/vaadin-grid/test/lit.test.js
@@ -1,0 +1,39 @@
+import { expect } from '@esm-bundle/chai';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { render, html } from 'lit';
+import '../vaadin-grid.js';
+import { getPhysicalItems } from './helpers.js';
+
+describe('renderig with lit', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = fixtureSync(`<div></div>`);
+  });
+
+  it('should render items after dynamically adding more columns', async () => {
+    function renderGrid(columnPaths, items) {
+      render(
+        html`
+          <vaadin-grid .items=${items}>
+            ${columnPaths.map((columnPath) => {
+              return html`<vaadin-grid-column path=${columnPath}></vaadin-grid-column>`;
+            })}
+          </vaadin-grid>
+        `,
+        wrapper
+      );
+    }
+
+    // First render with just one column and 0 items
+    renderGrid(['first'], []);
+
+    await aTimeout(0);
+    // Then render with more than one column and more than 0 items
+    renderGrid(['first', 'second'], [{ first: 'foo', second: 'bar' }]);
+
+    await aTimeout(0);
+    const grid = wrapper.firstElementChild;
+    expect(getPhysicalItems(grid).length).to.equal(1);
+  });
+});


### PR DESCRIPTION
This fixes a regression from #321

Seems that with very specific timing, it's possible to end up with a grid that has non-empty `items` but no visible rows. The bug was reported as part of a Lit project and I couldn't find a way to reproduce it without using Lit in the test as well.

The offending line [was added a long time ago](https://github.com/vaadin/vaadin-grid/commit/7957099c02e1636adcaf7fa83770976058c4a2f8#) and doesn't seem to be relevant anymore. Only the virtualizer should be in charge of hiding/unhiding the body row elements.