### PR TITLE
fix: re-create template instance after detaching instance's root

### DIFF
--- a/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
+++ b/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
@@ -46,8 +46,28 @@ describe('vaadin-template-renderer', () => {
       const newTemplateInstance = component.$.content.__templateInstance;
 
       expect(template.__templatizer.__templateInstances).to.have.lengthOf(1);
-      expect(template.__templatizer.__templateInstances).to.include(newTemplateInstance);
       expect(template.__templatizer.__templateInstances).to.include(oldTemplateInstance);
+      expect(template.__templatizer.__templateInstances).to.include(newTemplateInstance);
+    });
+
+    it('should create a new template instance after clearing the content', () => {
+      const oldTemplateInstance = component.$.content.__templateInstance;
+
+      component.$.content.innerHTML = '';
+      component.render();
+
+      const newTemplateInstance = component.$.content.__templateInstance;
+
+      expect(template.__templatizer.__templateInstances).to.have.lengthOf(1);
+      expect(template.__templatizer.__templateInstances).not.to.include(oldTemplateInstance);
+      expect(template.__templatizer.__templateInstances).to.include(newTemplateInstance);
+    });
+
+    it('should render the template after clearing the content', () => {
+      component.$.content.innerHTML = '';
+      component.render();
+
+      expect(component.$.content.textContent).to.equal('foo');
     });
   });
 


### PR DESCRIPTION
## Description

Currently, the template renderer doesn't re-render the template instance after the instance's root has been detached from DOM (by the user, for example).

This issue came up while removing Polymer Template API from `vaadin-grid-pro`. There is `editModeRenderer` that replaces the content rendered by `renderer` with an input when editing a column. Once you finish editing, it calls `renderer` to return the original content to the column, but at that time the template instance' root turns disconnected with DOM and nothing is rendered.

This PR aims to address this issue. From now on, the template renderer creates a new template instance if for some reasons the instance's root is detached from DOM.

Related to #410.

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
