### PR TITLE
fix: avoid having selectAll default value clear pre-selections

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.js
@@ -174,6 +174,12 @@ class GridSelectionColumnElement extends GridColumnElement {
       return;
     }
 
+    if (!this.__selectAllInitialized) {
+      // The initial value for selectAll property was applied, avoid clearing pre-selected items
+      this.__selectAllInitialized = true;
+      return;
+    }
+
     if (this._selectAllChangeLock) {
       return;
     }

--- a/packages/vaadin-grid/test/selection.test.js
+++ b/packages/vaadin-grid/test/selection.test.js
@@ -392,6 +392,16 @@ describe('multi selection column', () => {
     expect(selectionColumn.selectAll).to.be.false;
   });
 
+  it('should not clear pre-selected items', () => {
+    const grid = fixtureSync(`
+      <vaadin-grid selected-items='[{"value": "foo"}]'>
+        <vaadin-grid-selection-column></vaadin-grid-selection-column>
+        <vaadin-grid-column path="value"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    expect(grid.selectedItems).to.eql([{ value: 'foo' }]);
+  });
+
   it('should have selectAll after selecting all manually', () => {
     selectAllCheckbox.click();
     firstBodyCheckbox.checked = true;

--- a/packages/vaadin-grid/test/selection.test.js
+++ b/packages/vaadin-grid/test/selection.test.js
@@ -399,7 +399,7 @@ describe('multi selection column', () => {
         <vaadin-grid-column path="value"></vaadin-grid-column>
       </vaadin-grid>
     `);
-    expect(grid.selectedItems).to.eql([{ value: 'foo' }]);
+    expect(grid.selectedItems).to.have.length(1);
   });
 
   it('should have selectAll after selecting all manually', () => {


### PR DESCRIPTION
Seems that the `<vaadin-grid-selection-column>`'s default value for the `selectAll` property causes pre-selection to get cleared.