### PR TITLE
feat: allow passing specific item type to combo box types

### DIFF
--- a/packages/vaadin-combo-box/src/interfaces.d.ts
+++ b/packages/vaadin-combo-box/src/interfaces.d.ts
@@ -1,15 +1,19 @@
-import { ComboBoxElement } from '../src/vaadin-combo-box.js';
+import { ComboBoxElement } from './vaadin-combo-box';
 
-export type ComboBoxItem = unknown;
+export type ComboBoxDefaultItem = any;
 
-export interface ComboBoxItemModel {
+export interface ComboBoxItemModel<TItem> {
   index: number;
-  item: ComboBoxItem | string;
+  item: TItem;
 }
 
-export type ComboBoxRenderer = (root: HTMLElement, comboBox: ComboBoxElement, model: ComboBoxItemModel) => void;
+export type ComboBoxRenderer<TItem> = (
+  root: HTMLElement,
+  comboBox: ComboBoxElement<TItem>,
+  model: ComboBoxItemModel<TItem>
+) => void;
 
-export type ComboBoxDataProviderCallback = (items: Array<ComboBoxItem | string>, size: number) => void;
+export type ComboBoxDataProviderCallback<TItem> = (items: Array<TItem>, size: number) => void;
 
 export interface ComboBoxDataProviderParams {
   page: number;
@@ -17,7 +21,10 @@ export interface ComboBoxDataProviderParams {
   filter: string;
 }
 
-export type ComboBoxDataProvider = (params: ComboBoxDataProviderParams, callback: ComboBoxDataProviderCallback) => void;
+export type ComboBoxDataProvider<TItem> = (
+  params: ComboBoxDataProviderParams,
+  callback: ComboBoxDataProviderCallback<TItem>
+) => void;
 
 /**
  * Fired when the user sets a custom value.
@@ -47,9 +54,9 @@ export type ComboBoxFilterChangedEvent = CustomEvent<{ value: string }>;
 /**
  * Fired when the `selectedItem` property changes.
  */
-export type ComboBoxSelectedItemChangedEvent<T> = CustomEvent<{ value: T }>;
+export type ComboBoxSelectedItemChangedEvent<TItem> = CustomEvent<{ value: TItem }>;
 
-export interface ComboBoxElementEventMap {
+export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
   'custom-value-set': ComboBoxCustomValueSetEvent;
 
   'opened-changed': ComboBoxOpenedChangedEvent;
@@ -60,7 +67,5 @@ export interface ComboBoxElementEventMap {
 
   'value-changed': ComboBoxValueChangedEvent;
 
-  'selected-item-changed': ComboBoxSelectedItemChangedEvent<any>;
+  'selected-item-changed': ComboBoxSelectedItemChangedEvent<TItem>;
 }
-
-export interface ComboBoxEventMap extends HTMLElementEventMap, ComboBoxElementEventMap {}

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
@@ -1,14 +1,14 @@
 import { ComboBoxDataProvider } from './interfaces';
 
-declare function ComboBoxDataProviderMixin<T extends new (...args: any[]) => {}>(
+declare function ComboBoxDataProviderMixin<TItem, T extends new (...args: any[]) => {}>(
   base: T
-): T & ComboBoxDataProviderMixinConstructor;
+): T & ComboBoxDataProviderMixinConstructor<TItem>;
 
-interface ComboBoxDataProviderMixinConstructor {
-  new (...args: any[]): ComboBoxDataProviderMixin;
+interface ComboBoxDataProviderMixinConstructor<TItem> {
+  new (...args: any[]): ComboBoxDataProviderMixin<TItem>;
 }
 
-interface ComboBoxDataProviderMixin {
+interface ComboBoxDataProviderMixin<TItem> {
   /**
    * Number of items fetched at a time from the dataprovider.
    * @attr {number} page-size
@@ -33,7 +33,7 @@ interface ComboBoxDataProviderMixin {
    *   - `items` Current page of items
    *   - `size` Total number of items.
    */
-  dataProvider: ComboBoxDataProvider | null | undefined;
+  dataProvider: ComboBoxDataProvider<TItem> | null | undefined;
 
   /**
    * Clears the cached pages and reloads data from dataprovider when needed.

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-light.d.ts
@@ -1,10 +1,10 @@
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin';
 
-import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
+import { ComboBoxMixin } from './vaadin-combo-box-mixin';
 
-import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixin.js';
+import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixin';
 
-import { ComboBoxEventMap } from './interfaces';
+import { ComboBoxDefaultItem, ComboBoxEventMap } from './interfaces';
 
 /**
  * `<vaadin-combo-box-light>` is a customizable version of the `<vaadin-combo-box>` providing
@@ -57,7 +57,7 @@ import { ComboBoxEventMap } from './interfaces';
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class ComboBoxLightElement extends ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixin(HTMLElement))) {
+declare class ComboBoxLightElement<TItem = ComboBoxDefaultItem> extends HTMLElement {
   readonly _propertyForValue: string;
 
   _inputElementValue: string;
@@ -73,22 +73,27 @@ declare class ComboBoxLightElement extends ComboBoxDataProviderMixin(ComboBoxMix
 
   readonly inputElement: Element | undefined;
 
-  addEventListener<K extends keyof ComboBoxEventMap>(
+  addEventListener<K extends keyof ComboBoxEventMap<TItem>>(
     type: K,
-    listener: (this: ComboBoxLightElement, ev: ComboBoxEventMap[K]) => void,
+    listener: (this: ComboBoxLightElement<TItem>, ev: ComboBoxEventMap<TItem>[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
-  removeEventListener<K extends keyof ComboBoxEventMap>(
+  removeEventListener<K extends keyof ComboBoxEventMap<TItem>>(
     type: K,
-    listener: (this: ComboBoxLightElement, ev: ComboBoxEventMap[K]) => void,
+    listener: (this: ComboBoxLightElement<TItem>, ev: ComboBoxEventMap<TItem>[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
+interface ComboBoxLightElement<TItem = ComboBoxDefaultItem>
+  extends ComboBoxDataProviderMixin<TItem>,
+    ComboBoxMixin<TItem>,
+    ThemableMixin {}
+
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-combo-box-light': ComboBoxLightElement;
+    'vaadin-combo-box-light': ComboBoxLightElement<ComboBoxDefaultItem>;
   }
 }
 

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -1,12 +1,14 @@
-import { ComboBoxItem, ComboBoxRenderer } from './interfaces';
+import { ComboBoxRenderer } from './interfaces';
 
-declare function ComboBoxMixin<T extends new (...args: any[]) => {}>(base: T): T & ComboBoxMixinConstructor;
+declare function ComboBoxMixin<TItem, T extends new (...args: any[]) => {}>(
+  base: T
+): T & ComboBoxMixinConstructor<TItem>;
 
-interface ComboBoxMixinConstructor {
-  new (...args: any[]): ComboBoxMixin;
+interface ComboBoxMixinConstructor<TItem> {
+  new (...args: any[]): ComboBoxMixin<TItem>;
 }
 
-interface ComboBoxMixin {
+interface ComboBoxMixin<TItem> {
   readonly _propertyForValue: string;
 
   /**
@@ -41,13 +43,13 @@ interface ComboBoxMixin {
    *   - `model.index` The index of the rendered item.
    *   - `model.item` The item.
    */
-  renderer: ComboBoxRenderer | null | undefined;
+  renderer: ComboBoxRenderer<TItem> | null | undefined;
 
   /**
    * A full set of items to filter the visible options from.
    * The items can be of either `String` or `Object` type.
    */
-  items: Array<ComboBoxItem | string> | undefined;
+  items: Array<TItem> | undefined;
 
   /**
    * If `true`, the user can input a value that is not present in the items list.
@@ -63,7 +65,7 @@ interface ComboBoxMixin {
    * can be assigned directly to omit the internal filtering functionality.
    * The items can be of either `String` or `Object` type.
    */
-  filteredItems: Array<ComboBoxItem | string> | undefined;
+  filteredItems: Array<TItem> | undefined;
 
   /**
    * The `String` value for the selected item of the combo box.
@@ -90,7 +92,7 @@ interface ComboBoxMixin {
   /**
    * The selected item from the `items` array.
    */
-  selectedItem: ComboBoxItem | string | null | undefined;
+  selectedItem: TItem | null | undefined;
 
   /**
    * Path for label of the item. If `items` is an array of objects, the

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.d.ts
@@ -1,16 +1,16 @@
 import { TextFieldElement } from '@vaadin/vaadin-text-field/vaadin-text-field';
 
-import { ControlStateMixin } from '@vaadin/vaadin-control-state-mixin/vaadin-control-state-mixin.js';
+import { ControlStateMixin } from '@vaadin/vaadin-control-state-mixin/vaadin-control-state-mixin';
 
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin';
 
-import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
+import { ComboBoxMixin } from './vaadin-combo-box-mixin';
 
-import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixin.js';
+import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixin';
 
-import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
+import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin';
 
-import { ComboBoxEventMap } from './interfaces';
+import { ComboBoxDefaultItem, ComboBoxEventMap } from './interfaces';
 
 /**
  * `<vaadin-combo-box>` is a combo box element combining a dropdown list with an
@@ -156,9 +156,7 @@ import { ComboBoxEventMap } from './interfaces';
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class ComboBoxElement extends ElementMixin(
-  ControlStateMixin(ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixin(HTMLElement))))
-) {
+declare class ComboBoxElement<TItem = ComboBoxDefaultItem> extends HTMLElement {
   /**
    * Focusable element used by vaadin-control-state-mixin
    */
@@ -222,22 +220,29 @@ declare class ComboBoxElement extends ElementMixin(
    */
   clearButtonVisible: boolean;
 
-  addEventListener<K extends keyof ComboBoxEventMap>(
+  addEventListener<K extends keyof ComboBoxEventMap<TItem>>(
     type: K,
-    listener: (this: ComboBoxElement, ev: ComboBoxEventMap[K]) => void,
+    listener: (this: ComboBoxElement<TItem>, ev: ComboBoxEventMap<TItem>[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
-  removeEventListener<K extends keyof ComboBoxEventMap>(
+  removeEventListener<K extends keyof ComboBoxEventMap<TItem>>(
     type: K,
-    listener: (this: ComboBoxElement, ev: ComboBoxEventMap[K]) => void,
+    listener: (this: ComboBoxElement<TItem>, ev: ComboBoxEventMap<TItem>[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
+interface ComboBoxElement<TItem = ComboBoxDefaultItem>
+  extends ElementMixin,
+    ControlStateMixin,
+    ComboBoxDataProviderMixin<TItem>,
+    ComboBoxMixin<TItem>,
+    ThemableMixin {}
+
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-combo-box': ComboBoxElement;
+    'vaadin-combo-box': ComboBoxElement<ComboBoxDefaultItem>;
   }
 }
 

--- a/packages/vaadin-combo-box/test/typings/combo-box.types.ts
+++ b/packages/vaadin-combo-box/test/typings/combo-box.types.ts
@@ -1,81 +1,100 @@
-import '../../vaadin-combo-box.js';
+import { ControlStateMixin } from '@vaadin/vaadin-control-state-mixin';
+import { ElementMixin } from '@vaadin/vaadin-element-mixin';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
+import { ComboBoxDataProviderMixin } from '../../src/vaadin-combo-box-data-provider-mixin';
+import { ComboBoxMixin } from '../../src/vaadin-combo-box-mixin';
 import {
   ComboBoxFilterChangedEvent,
   ComboBoxInvalidChangedEvent,
   ComboBoxOpenedChangedEvent,
   ComboBoxValueChangedEvent,
   ComboBoxCustomValueSetEvent,
-  ComboBoxSelectedItemChangedEvent
-} from '../../vaadin-combo-box.js';
+  ComboBoxSelectedItemChangedEvent,
+  ComboBoxElement
+} from '../../vaadin-combo-box';
+import { ComboBoxLightElement } from '../../vaadin-combo-box-light';
 
-import '../../vaadin-combo-box-light.js';
+interface TestComboBoxItem {
+  testProperty: string;
+}
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-const comboBox = document.createElement('vaadin-combo-box');
+/* ComboBoxElement */
+const genericComboBox = document.createElement('vaadin-combo-box');
 
-comboBox.addEventListener('custom-value-set', (event) => {
+const narrowedComboBox = genericComboBox as ComboBoxElement<TestComboBoxItem>;
+assertType<ComboBoxElement>(narrowedComboBox);
+assertType<ElementMixin>(narrowedComboBox);
+assertType<ControlStateMixin>(narrowedComboBox);
+assertType<ComboBoxDataProviderMixin<TestComboBoxItem>>(narrowedComboBox);
+assertType<ThemableMixin>(narrowedComboBox);
+
+narrowedComboBox.addEventListener('custom-value-set', (event) => {
   assertType<ComboBoxCustomValueSetEvent>(event);
   assertType<string>(event.detail);
 });
 
-comboBox.addEventListener('opened-changed', (event) => {
+narrowedComboBox.addEventListener('opened-changed', (event) => {
   assertType<ComboBoxOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
-comboBox.addEventListener('invalid-changed', (event) => {
+narrowedComboBox.addEventListener('invalid-changed', (event) => {
   assertType<ComboBoxInvalidChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
-comboBox.addEventListener('value-changed', (event) => {
+narrowedComboBox.addEventListener('value-changed', (event) => {
   assertType<ComboBoxValueChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
 
-comboBox.addEventListener('filter-changed', (event) => {
+narrowedComboBox.addEventListener('filter-changed', (event) => {
   assertType<ComboBoxFilterChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
 
-comboBox.addEventListener(
-  'selected-item-changed',
-  (event: ComboBoxSelectedItemChangedEvent<{ label: string; value: string }>) => {
-    assertType<{ label: string; value: string }>(event.detail.value);
-  }
-);
+narrowedComboBox.addEventListener('selected-item-changed', (event) => {
+  assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
+  assertType<TestComboBoxItem>(event.detail.value);
+});
 
-const light = document.createElement('vaadin-combo-box-light');
+/* ComboBoxLightElement */
+const genericComboBoxLightElement = document.createElement('vaadin-combo-box-light');
+assertType<ComboBoxLightElement>(genericComboBoxLightElement);
 
-light.addEventListener('custom-value-set', (event) => {
+const narrowedComboBoxLightElement = genericComboBoxLightElement as ComboBoxLightElement<TestComboBoxItem>;
+assertType<ComboBoxDataProviderMixin<TestComboBoxItem>>(narrowedComboBoxLightElement);
+assertType<ComboBoxMixin<TestComboBoxItem>>(narrowedComboBoxLightElement);
+assertType<ThemableMixin>(narrowedComboBoxLightElement);
+
+narrowedComboBoxLightElement.addEventListener('custom-value-set', (event) => {
   assertType<ComboBoxCustomValueSetEvent>(event);
   assertType<string>(event.detail);
 });
 
-light.addEventListener('opened-changed', (event) => {
+narrowedComboBoxLightElement.addEventListener('opened-changed', (event) => {
   assertType<ComboBoxOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
-light.addEventListener('invalid-changed', (event) => {
+narrowedComboBoxLightElement.addEventListener('invalid-changed', (event) => {
   assertType<ComboBoxInvalidChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
-light.addEventListener('value-changed', (event) => {
+narrowedComboBoxLightElement.addEventListener('value-changed', (event) => {
   assertType<ComboBoxValueChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
 
-light.addEventListener('filter-changed', (event) => {
+narrowedComboBoxLightElement.addEventListener('filter-changed', (event) => {
   assertType<ComboBoxFilterChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
 
-light.addEventListener(
-  'selected-item-changed',
-  (event: ComboBoxSelectedItemChangedEvent<{ label: string; value: string }>) => {
-    assertType<{ label: string; value: string }>(event.detail.value);
-  }
-);
+narrowedComboBoxLightElement.addEventListener('selected-item-changed', (event) => {
+  assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
+  assertType<TestComboBoxItem>(event.detail.value);
+});


### PR DESCRIPTION
## Description

Made combo box types generic, similar to how it was done for grid.

Fixes #664

## Type of change

- [x] Feature

