### PR TITLE
ref: use default renderer for crud edit column

### DIFF
--- a/packages/vaadin-crud/src/vaadin-crud-edit-column.js
+++ b/packages/vaadin-crud/src/vaadin-crud-edit-column.js
@@ -4,7 +4,6 @@
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { GridColumnElement } from '@vaadin/vaadin-grid/src/vaadin-grid-column.js';
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import './vaadin-crud-edit.js';
 
 /**
@@ -25,15 +24,6 @@ import './vaadin-crud-edit.js';
  * @extends GridColumnElement
  */
 class CrudEditColumnElement extends GridColumnElement {
-  static get template() {
-    return html`
-      <template class="header" id="defaultHeaderTemplate" aria-label="Edit"> </template>
-      <template id="defaultBodyTemplate">
-        <div id="edit">Edit</div>
-      </template>
-    `;
-  }
-
   static get is() {
     return 'vaadin-crud-edit-column';
   }
@@ -63,17 +53,30 @@ class CrudEditColumnElement extends GridColumnElement {
     };
   }
 
-  /** @private */
-  ready() {
-    super.ready();
-    this.renderer = (root) => {
-      if (!root.firstElementChild) {
-        const elm = document.createElement('vaadin-crud-edit');
-        this.hasAttribute('theme') && elm.setAttribute('theme', this.getAttribute('theme'));
-        this.editLabel && elm.setAttribute('aria-label', this.ariaLabel);
-        root.appendChild(elm);
+  static get observers() {
+    return ['_onBodyTemplateOrRendererOrBindingChanged(_bodyTemplate, _renderer, _cells, _cells.*, path, ariaLabel)'];
+  }
+
+  /**
+   * Renders the crud edit element to the body cell.
+   *
+   * @override
+   */
+  _defaultRenderer(root, _column) {
+    let edit = root.firstElementChild;
+    if (!edit) {
+      edit = document.createElement('vaadin-crud-edit');
+      if (this.hasAttribute('theme')) {
+        edit.setAttribute('theme', this.getAttribute('theme'));
       }
-    };
+      root.appendChild(edit);
+    }
+
+    if (this.ariaLabel) {
+      edit.setAttribute('aria-label', this.ariaLabel);
+    } else {
+      edit.removeAttribute('aria-label');
+    }
   }
 }
 

--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -534,14 +534,15 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   __onI18Change(i18n, grid) {
-    if (grid) {
-      afterNextRender(grid, () => {
-        Array.from(grid.querySelectorAll('vaadin-crud-edit-column')).forEach((e) => (e.ariaLabel = i18n.editLabel));
-        Array.from(grid.querySelectorAll('vaadin-crud-edit')).forEach((e) =>
-          e.setAttribute('aria-label', i18n.editLabel)
-        );
-      });
+    if (!grid) {
+      return;
     }
+
+    afterNextRender(grid, () => {
+      Array.from(grid.querySelectorAll('vaadin-crud-edit-column')).forEach((column) => {
+        column.ariaLabel = i18n.editLabel;
+      });
+    });
   }
 
   /** @private */


### PR DESCRIPTION
## Description

A small refactoring that makes `vaadin-crud-edit-column` use the default renderer instead of defining a custom renderer in the constructor.

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
