### PR TITLE
fix: include vaadin-iconset.js in the package

### DIFF
--- a/packages/vaadin-icons/package.json
+++ b/packages/vaadin-icons/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://vaadin.com/icons",
   "files": [
     "iconset.js",
-    "vaadin-icons.js"
+    "vaadin-icons.js",
+    "vaadin-iconset.js"
   ],
   "scripts": {
     "icons": "gulp icons"


### PR DESCRIPTION
The new `vaadin-iconset.js` file should be included in the package