### PR TITLE
fix: keep the invalid indicating background on hover

### DIFF
--- a/packages/vaadin-text-field/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/vaadin-text-field/theme/lumo/vaadin-text-area-styles.js
@@ -30,12 +30,12 @@ registerStyles(
       border: none;
     }
 
-    :host(:hover:not([readonly]):not([focused])) [part='input-field'] {
+    :host(:hover:not([readonly]):not([focused]):not([invalid])) [part='input-field'] {
       background-color: var(--lumo-contrast-20pct);
     }
 
     @media (pointer: coarse) {
-      :host(:hover:not([readonly]):not([focused])) [part='input-field'] {
+      :host(:hover:not([readonly]):not([focused]):not([invalid])) [part='input-field'] {
         background-color: var(--lumo-contrast-10pct);
       }
 


### PR DESCRIPTION
## Description

Fixes #1149

When you hover over an invalid `vaadin-text-area` it should keep the background as is.
Fixes the problem by excluding `[invalid]` state when applying `:hover` styles.


## Type of change

- [X] Bugfix

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.