### PR TITLE
chore: increase the virtual-list default height

### DIFF
--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -35,7 +35,7 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       <style>
         :host {
           display: block;
-          height: 200px;
+          height: 400px;
           overflow: auto;
           flex: auto;
           align-self: stretch;

--- a/packages/vaadin-virtual-list/test/virtual-list.test.js
+++ b/packages/vaadin-virtual-list/test/virtual-list.test.js
@@ -10,7 +10,7 @@ describe('virtual-list', () => {
   });
 
   it('should have a default height', () => {
-    expect(list.offsetHeight).to.equal(200);
+    expect(list.offsetHeight).to.equal(400);
   });
 
   it('should override default height', () => {


### PR DESCRIPTION
Align the default height of `<vaadin-virtual-list>` with that of `<vaadin-grid>` as suggested [here](https://github.com/vaadin/flow-components/issues/179#issuecomment-411301614)