### PR TITLE
chore: bump highcharts to latest minor

### DIFF
--- a/packages/vaadin-charts/package.json
+++ b/packages/vaadin-charts/package.json
@@ -29,7 +29,7 @@
     "@vaadin/vaadin-element-mixin": "^21.0.0-alpha5",
     "@vaadin/vaadin-license-checker": "^2.1.0",
     "@vaadin/vaadin-themable-mixin": "^21.0.0-alpha5",
-    "highcharts": "8.1.2"
+    "highcharts": "8.2.2"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",


### PR DESCRIPTION
Bump highcharts to latest minor, this is just a transfer of this [PR](https://github.com/vaadin/vaadin-charts/pull/568) from the legacy charts repo.

Fixes: https://github.com/vaadin/flow-components/issues/1730
