### PR TITLE
fix: make grid renderer arguments required

### DIFF
--- a/packages/vaadin-grid/src/interfaces.d.ts
+++ b/packages/vaadin-grid/src/interfaces.d.ts
@@ -3,8 +3,8 @@ import { GridElement } from './vaadin-grid.js';
 
 export type GridBodyRenderer<TItem> = (
   root: HTMLElement,
-  column?: GridColumnElement<TItem>,
-  model?: GridItemModel<TItem>
+  column: GridColumnElement<TItem>,
+  model: GridItemModel<TItem>
 ) => void;
 
 export type GridCellClassNameGenerator<TItem> = (
@@ -51,7 +51,7 @@ export interface GridEventContext<TItem> {
   level?: number;
 }
 
-export type GridHeaderFooterRenderer<TItem> = (root: HTMLElement, column?: GridColumnElement<TItem>) => void;
+export type GridHeaderFooterRenderer<TItem> = (root: HTMLElement, column: GridColumnElement<TItem>) => void;
 
 export type GridDefaultItem = any;
 

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -1,5 +1,6 @@
 import { ElementMixin } from '@vaadin/vaadin-element-mixin';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
+import { GridBodyRenderer } from '../../src/interfaces';
 import { A11yMixin } from '../../src/vaadin-grid-a11y-mixin';
 import { ActiveItemMixin } from '../../src/vaadin-grid-active-item-mixin';
 import { ArrayDataProviderMixin } from '../../src/vaadin-grid-array-data-provider-mixin';
@@ -129,6 +130,18 @@ narrowedGrid.addEventListener('grid-drop', (event) => {
 /* GridColumnElement */
 const genericColumn = document.createElement('vaadin-grid-column');
 assertType<GridColumnElement>(genericColumn);
+
+const bodyRenderer: GridBodyRenderer<TestGridItem> = (root, column, model) => {
+  assertType<HTMLElement>(root);
+  assertType<GridColumnElement>(column);
+  assertType<TestGridItem>(model.item);
+};
+genericColumn.renderer = bodyRenderer;
+
+genericColumn.headerRenderer = (root, column) => {
+  assertType<HTMLElement>(root);
+  assertType<GridColumnElement>(column);
+};
 
 const narrowedColumn = genericColumn as GridColumnElement<TestGridItem>;
 assertType<HTMLElement>(narrowedColumn);


### PR DESCRIPTION
It shouldn't be possible for the grid body renderer not to have a defined `model`. The current typings require you to either check for the `model`:
```ts
private renderer: GridBodyRenderer<Person> = (root, _column, model) => {
  root.textContent = model ? model.item.lastName : '';
};
```

or use non-null assertion:

```ts
private renderer: GridBodyRenderer<Person> = (root, _column, model) => {
  root.textContent = model!.item.lastName;
};
```