### PR TITLE
feat: throw when using both a template and a renderer

### DIFF
--- a/packages/vaadin-template-renderer/src/vaadin-template-renderer.js
+++ b/packages/vaadin-template-renderer/src/vaadin-template-renderer.js
@@ -14,34 +14,52 @@ function createRenderer(component, template, TemplatizerClass = Templatizer) {
   };
 
   template.__templatizer = templatizer;
+  renderer.__templatized = true;
 
   return renderer;
 }
 
+function assignRenderer(component, rendererName, renderer) {
+  const oldRenderer = component[rendererName];
+
+  if (oldRenderer && !oldRenderer.__templatized) {
+    const tag = component.localName;
+
+    throw new Error(`Cannot use both a template and a renderer for <${tag} />.`);
+  }
+
+  component[rendererName] = renderer;
+}
+
 function processGridTemplate(grid, template) {
   if (template.matches('.row-details')) {
-    grid.rowDetailsRenderer = createRenderer(grid, template, GridTemplatizer);
+    const renderer = createRenderer(grid, template, GridTemplatizer);
+    assignRenderer(grid, 'rowDetailsRenderer', renderer);
     return;
   }
 }
 
 function processGridColumnTemplate(column, template) {
   if (template.matches('.header')) {
-    column.headerRenderer = createRenderer(column, template);
+    const renderer = createRenderer(column, template);
+    assignRenderer(column, 'headerRenderer', renderer);
     return;
   }
 
   if (template.matches('.footer')) {
-    column.footerRenderer = createRenderer(column, template);
+    const renderer = createRenderer(column, template);
+    assignRenderer(column, 'footerRenderer', renderer);
     return;
   }
 
   if (template.matches('.editor')) {
-    column.editModeRenderer = createRenderer(column, template, GridTemplatizer);
+    const renderer = createRenderer(column, template, GridTemplatizer);
+    assignRenderer(column, 'editModeRenderer', renderer);
     return;
   }
 
-  column.renderer = createRenderer(column, template, GridTemplatizer);
+  const renderer = createRenderer(column, template, GridTemplatizer);
+  assignRenderer(column, 'renderer', renderer);
 }
 
 function processTemplate(component, template) {
@@ -55,7 +73,8 @@ function processTemplate(component, template) {
     return;
   }
 
-  component.renderer = createRenderer(component, template);
+  const renderer = createRenderer(component, template);
+  assignRenderer(component, 'renderer', renderer);
 }
 
 function processTemplates(component) {

--- a/packages/vaadin-template-renderer/test/fixtures/mock-component.js
+++ b/packages/vaadin-template-renderer/test/fixtures/mock-component.js
@@ -6,7 +6,9 @@ export class MockComponent extends HTMLElement {
   }
 
   connectedCallback() {
-    window.Vaadin.templateRendererCallback?.(this);
+    if (this.getAttribute('disable-template-renderer-callback') === null) {
+      window.Vaadin.templateRendererCallback(this);
+    }
   }
 
   get $() {
@@ -18,6 +20,10 @@ export class MockComponent extends HTMLElement {
   set renderer(renderer) {
     this.__renderer = renderer;
     this.render();
+  }
+
+  get renderer() {
+    return this.__renderer;
   }
 
   render() {

--- a/packages/vaadin-template-renderer/test/fixtures/mock-component.js
+++ b/packages/vaadin-template-renderer/test/fixtures/mock-component.js
@@ -6,9 +6,7 @@ export class MockComponent extends HTMLElement {
   }
 
   connectedCallback() {
-    if (this.getAttribute('disable-template-renderer-callback') === null) {
-      window.Vaadin.templateRendererCallback(this);
-    }
+    window.Vaadin.templateRendererCallback(this);
   }
 
   get $() {

--- a/packages/vaadin-template-renderer/test/fixtures/mock-grid-host.js
+++ b/packages/vaadin-template-renderer/test/fixtures/mock-grid-host.js
@@ -10,12 +10,6 @@ export class MockGridHost extends PolymerElement {
     return html`
       <vaadin-grid id="grid" items="[[items]]">
         <vaadin-grid-column>
-          <template class="header">header</template>
-          <template class="footer">footer</template>
-          <template class="body">[[item.title]]</template>
-        </vaadin-grid-column>
-
-        <vaadin-grid-column>
           <template>
             <input class="parent-property" value="{{parentProperty::input}}" />
             <input class="title" value="{{item.title::input}}" />
@@ -39,8 +33,6 @@ export class MockGridHost extends PolymerElement {
         <vaadin-grid-tree-column></vaadin-grid-tree-column>
 
         <template class="row-details">
-          row-details
-
           <div class="index">[[index]]</div>
           <input class="title" value="{{item.title::input}}" />
           <vaadin-checkbox class="selected" checked="{{selected}}" />
@@ -68,8 +60,6 @@ export class MockGridHost extends PolymerElement {
       }
     };
   }
-
-  onClick() {}
 }
 
 customElements.define('mock-grid-host', MockGridHost);

--- a/packages/vaadin-template-renderer/test/grid-body.test.js
+++ b/packages/vaadin-template-renderer/test/grid-body.test.js
@@ -1,10 +1,44 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-grid';
 import { GridTemplatizer } from '../src/vaadin-template-renderer-grid-templatizer.js';
 
 import '../vaadin-template-renderer.js';
 
 import './fixtures/mock-grid-host.js';
+
+describe('grid body template', () => {
+  function fixtureGrid() {
+    return fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column>
+          <template></template>
+        </vaadin-grid-column>
+      </vaadin-grid>
+    `);
+  }
+
+  it('should process the template', () => {
+    const grid = fixtureGrid();
+    const template = grid.querySelector('template');
+
+    expect(template.__templatizer).to.be.an.instanceof(GridTemplatizer);
+  });
+
+  it('should throw when using both a template and a renderer', () => {
+    const stub = sinon.stub(window.Vaadin, 'templateRendererCallback');
+    const grid = fixtureGrid();
+    const column = grid.firstElementChild;
+    stub.restore();
+
+    column.renderer = () => {};
+
+    expect(() => window.Vaadin.templateRendererCallback(column)).to.throw(
+      /^Cannot use both a template and a renderer for <vaadin-grid-column \/>\.$/
+    );
+  });
+});
 
 describe('grid body template', () => {
   let host, grid;
@@ -26,55 +60,49 @@ describe('grid body template', () => {
     await nextRender(grid);
   });
 
-  it('should process the template', () => {
-    const template = grid.querySelector('template.body');
-
-    expect(template.__templatizer).to.be.an.instanceof(GridTemplatizer);
-  });
-
   it('should render parentProperty', () => {
-    const parentProperty0 = queryCellContent({ row: 0, col: 2 }, 'div.parent-property');
-    const parentProperty1 = queryCellContent({ row: 1, col: 2 }, 'div.parent-property');
+    const parentProperty0 = queryCellContent({ row: 0, col: 1 }, 'div.parent-property');
+    const parentProperty1 = queryCellContent({ row: 1, col: 1 }, 'div.parent-property');
 
     expect(parentProperty0.textContent).to.equal('parentValue');
     expect(parentProperty1.textContent).to.equal('parentValue');
   });
 
   it('should render model.index', () => {
-    const index0 = queryCellContent({ row: 0, col: 2 }, 'div.index');
-    const index1 = queryCellContent({ row: 1, col: 2 }, 'div.index');
+    const index0 = queryCellContent({ row: 0, col: 1 }, 'div.index');
+    const index1 = queryCellContent({ row: 1, col: 1 }, 'div.index');
 
     expect(index0.textContent).to.equal('0');
     expect(index1.textContent).to.equal('1');
   });
 
   it('should render model.selected', () => {
-    const selected0 = queryCellContent({ row: 0, col: 2 }, 'div.selected');
-    const selected1 = queryCellContent({ row: 1, col: 2 }, 'div.selected');
+    const selected0 = queryCellContent({ row: 0, col: 1 }, 'div.selected');
+    const selected1 = queryCellContent({ row: 1, col: 1 }, 'div.selected');
 
     expect(selected0.textContent).to.equal('false');
     expect(selected1.textContent).to.equal('false');
   });
 
   it('should render model.expanded', () => {
-    const expanded0 = queryCellContent({ row: 0, col: 2 }, 'div.expanded');
-    const expanded1 = queryCellContent({ row: 1, col: 2 }, 'div.expanded');
+    const expanded0 = queryCellContent({ row: 0, col: 1 }, 'div.expanded');
+    const expanded1 = queryCellContent({ row: 1, col: 1 }, 'div.expanded');
 
     expect(expanded0.textContent).to.equal('false');
     expect(expanded1.textContent).to.equal('false');
   });
 
   it('should render model.detailsOpened', () => {
-    const detailsOpened0 = queryCellContent({ row: 0, col: 2 }, 'div.details-opened');
-    const detailsOpened1 = queryCellContent({ row: 1, col: 2 }, 'div.details-opened');
+    const detailsOpened0 = queryCellContent({ row: 0, col: 1 }, 'div.details-opened');
+    const detailsOpened1 = queryCellContent({ row: 1, col: 1 }, 'div.details-opened');
 
     expect(detailsOpened0.textContent).to.equal('false');
     expect(detailsOpened1.textContent).to.equal('false');
   });
 
   it('should render model.item.title', () => {
-    const title0 = queryCellContent({ row: 0, col: 2 }, 'div.title');
-    const title1 = queryCellContent({ row: 1, col: 2 }, 'div.title');
+    const title0 = queryCellContent({ row: 0, col: 1 }, 'div.title');
+    const title1 = queryCellContent({ row: 1, col: 1 }, 'div.title');
 
     expect(title0.textContent).to.equal('item0');
     expect(title1.textContent).to.equal('item1');
@@ -82,7 +110,7 @@ describe('grid body template', () => {
 
   describe('changing parentProperty', () => {
     beforeEach(() => {
-      const input = queryCellContent({ row: 0, col: 1 }, 'input.parent-property');
+      const input = queryCellContent({ row: 0, col: 0 }, 'input.parent-property');
 
       input.value = 'new';
       fire(input, 'input');
@@ -93,8 +121,8 @@ describe('grid body template', () => {
     });
 
     it('should re-render the property in other rows', () => {
-      const parentProperty0 = queryCellContent({ row: 0, col: 2 }, 'div.parent-property');
-      const parentProperty1 = queryCellContent({ row: 1, col: 2 }, 'div.parent-property');
+      const parentProperty0 = queryCellContent({ row: 0, col: 1 }, 'div.parent-property');
+      const parentProperty1 = queryCellContent({ row: 1, col: 1 }, 'div.parent-property');
 
       expect(parentProperty0.textContent).to.equal('new');
       expect(parentProperty1.textContent).to.equal('new');
@@ -103,7 +131,7 @@ describe('grid body template', () => {
 
   describe('changing model.item.title', () => {
     beforeEach(() => {
-      const input = queryCellContent({ row: 0, col: 1 }, 'input.title');
+      const input = queryCellContent({ row: 0, col: 0 }, 'input.title');
 
       input.value = 'new0';
       fire(input, 'input');
@@ -115,8 +143,8 @@ describe('grid body template', () => {
     });
 
     it('should re-render the row', () => {
-      const title0 = queryCellContent({ row: 0, col: 2 }, 'div.title');
-      const title1 = queryCellContent({ row: 1, col: 2 }, 'div.title');
+      const title0 = queryCellContent({ row: 0, col: 1 }, 'div.title');
+      const title1 = queryCellContent({ row: 1, col: 1 }, 'div.title');
 
       expect(title0.textContent).to.equal('new0');
       expect(title1.textContent).to.equal('item1');
@@ -137,9 +165,9 @@ describe('grid body template', () => {
         cb(items, 1);
       };
 
-      checkbox = getCell({ row: 0, col: 1 })._content.querySelector('vaadin-checkbox.expanded');
-      expanded0 = getCell({ row: 0, col: 2 })._content.querySelector('div.expanded');
-      expanded1 = getCell({ row: 1, col: 2 })._content.querySelector('div.expanded');
+      checkbox = getCell({ row: 0, col: 0 })._content.querySelector('vaadin-checkbox.expanded');
+      expanded0 = getCell({ row: 0, col: 1 })._content.querySelector('div.expanded');
+      expanded1 = getCell({ row: 1, col: 1 })._content.querySelector('div.expanded');
     });
 
     beforeEach(() => {
@@ -175,9 +203,9 @@ describe('grid body template', () => {
     let checkbox, selected0, selected1;
 
     beforeEach(() => {
-      checkbox = queryCellContent({ row: 0, col: 1 }, 'vaadin-checkbox.selected');
-      selected0 = queryCellContent({ row: 0, col: 2 }, 'div.selected');
-      selected1 = queryCellContent({ row: 1, col: 2 }, 'div.selected');
+      checkbox = queryCellContent({ row: 0, col: 0 }, 'vaadin-checkbox.selected');
+      selected0 = queryCellContent({ row: 0, col: 1 }, 'div.selected');
+      selected1 = queryCellContent({ row: 1, col: 1 }, 'div.selected');
     });
 
     beforeEach(() => {
@@ -213,9 +241,9 @@ describe('grid body template', () => {
     let checkbox, detailsOpened0, detailsOpened1;
 
     beforeEach(() => {
-      checkbox = queryCellContent({ row: 0, col: 1 }, 'vaadin-checkbox.details-opened');
-      detailsOpened0 = queryCellContent({ row: 0, col: 2 }, 'div.details-opened');
-      detailsOpened1 = queryCellContent({ row: 1, col: 2 }, 'div.details-opened');
+      checkbox = queryCellContent({ row: 0, col: 0 }, 'vaadin-checkbox.details-opened');
+      detailsOpened0 = queryCellContent({ row: 0, col: 1 }, 'div.details-opened');
+      detailsOpened1 = queryCellContent({ row: 1, col: 1 }, 'div.details-opened');
     });
 
     beforeEach(() => {

--- a/packages/vaadin-template-renderer/test/grid-editor.test.js
+++ b/packages/vaadin-template-renderer/test/grid-editor.test.js
@@ -1,5 +1,7 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, enter } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-grid-pro';
 import { GridTemplatizer } from '../src/vaadin-template-renderer-grid-templatizer.js';
 
 import '../vaadin-template-renderer.js';
@@ -7,7 +9,40 @@ import '../vaadin-template-renderer.js';
 import './fixtures/mock-grid-pro-host.js';
 
 describe('grid editor template', () => {
+  function fixtureGrid() {
+    return fixtureSync(`
+      <vaadin-grid-pro>
+        <vaadin-grid-pro-edit-column>
+          <template class="editor"></template>
+        </vaadin-grid-pro-edit-column>
+      </vaadin-grid-pro>
+    `);
+  }
+
+  it('should process the template', () => {
+    const grid = fixtureGrid();
+    const template = grid.querySelector('template.editor');
+
+    expect(template.__templatizer).to.be.an.instanceof(GridTemplatizer);
+  });
+
+  it('should throw when using both a template and a renderer', () => {
+    const stub = sinon.stub(window.Vaadin, 'templateRendererCallback');
+    const grid = fixtureGrid();
+    const column = grid.firstElementChild;
+    stub.restore();
+
+    column.editModeRenderer = () => {};
+
+    expect(() => window.Vaadin.templateRendererCallback(column)).to.throw(
+      /^Cannot use both a template and a renderer for <vaadin-grid-pro-edit-column \/>\.$/
+    );
+  });
+});
+
+describe('grid editor template', () => {
   let host, grid;
+  let cell0, cell1, input;
 
   function getCell({ row, col }) {
     const items = grid.$.items.children;
@@ -20,48 +55,36 @@ describe('grid editor template', () => {
     grid = host.$.grid;
 
     await nextRender(grid);
+
+    cell0 = getCell({ row: 0, col: 0 });
+    cell1 = getCell({ row: 1, col: 0 });
+
+    enter(cell0._content);
+
+    input = cell0._content.querySelector('input');
   });
 
-  it('should process the template', () => {
-    const template = grid.querySelector('template.editor');
-
-    expect(template.__templatizer).to.be.an.instanceof(GridTemplatizer);
+  it('should render the editor template', () => {
+    expect(cell0._content.children).to.have.lengthOf(1);
+    expect(cell0._content.children[0]).to.equal(input);
+    expect(cell1._content.textContent).to.equal('item1');
   });
 
-  describe('editing', () => {
-    let cell0, cell1, input;
+  it('should render the body template when finishing editing', () => {
+    enter(cell0._content);
 
-    beforeEach(() => {
-      cell0 = getCell({ row: 0, col: 0 });
-      cell1 = getCell({ row: 1, col: 0 });
+    expect(cell0._content.children[0]).not.to.equal(input);
+    expect(cell0._content.textContent).to.equal('item0');
+    expect(cell1._content.textContent).to.equal('item1');
+  });
 
-      enter(cell0._content);
+  it('should re-render the body template after changing the value', () => {
+    input.value = 'new0';
 
-      input = cell0._content.querySelector('input');
-    });
+    enter(cell0._content);
 
-    it('should render the editor template', () => {
-      expect(cell0._content.children).to.have.lengthOf(1);
-      expect(cell0._content.children[0]).to.equal(input);
-      expect(cell1._content.textContent).to.equal('item1');
-    });
-
-    it('should render the body template when finishing editing', () => {
-      enter(cell0._content);
-
-      expect(cell0._content.children[0]).not.to.equal(input);
-      expect(cell0._content.textContent).to.equal('item0');
-      expect(cell1._content.textContent).to.equal('item1');
-    });
-
-    it('should re-render the body template after changing the value', () => {
-      input.value = 'new0';
-
-      enter(cell0._content);
-
-      expect(cell0._content.children[0]).not.to.equal(input);
-      expect(cell0._content.textContent).to.equal('new0');
-      expect(cell1._content.textContent).to.equal('item1');
-    });
+    expect(cell0._content.children[0]).not.to.equal(input);
+    expect(cell0._content.textContent).to.equal('new0');
+    expect(cell1._content.textContent).to.equal('item1');
   });
 });

--- a/packages/vaadin-template-renderer/test/grid-footer.test.js
+++ b/packages/vaadin-template-renderer/test/grid-footer.test.js
@@ -1,5 +1,7 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-grid';
 import { Templatizer } from '../src/vaadin-template-renderer-templatizer.js';
 
 import '../vaadin-template-renderer.js';
@@ -7,30 +9,42 @@ import '../vaadin-template-renderer.js';
 import './fixtures/mock-grid-host.js';
 
 describe('grid footer template', () => {
-  let host, grid, footerCell;
-
-  function getFooterCell({ row, col }) {
-    const footer = grid.$.footer.children;
-
-    return footer[row].querySelectorAll('[part~="cell"]')[col];
+  function fixtureGrid() {
+    return fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column>
+          <template class="footer">footer</template>
+        </vaadin-grid-column>
+      </vaadin-grid>
+    `);
   }
 
-  beforeEach(async () => {
-    host = fixtureSync(`<mock-grid-host></mock-grid-host>`);
-    grid = host.$.grid;
-
-    await nextRender(grid);
-
-    footerCell = getFooterCell({ row: 0, col: 0 });
-  });
-
   it('should process the template', () => {
+    const grid = fixtureGrid();
     const template = grid.querySelector('template.footer');
 
     expect(template.__templatizer).to.be.an.instanceof(Templatizer);
   });
 
-  it('should render the template', () => {
-    expect(footerCell._content.textContent).to.equal('footer');
+  it('should render the template', async () => {
+    const grid = await fixtureGrid();
+    const column = grid.firstElementChild;
+
+    await nextRender(grid);
+
+    expect(column._footerCell._content.textContent).to.equal('footer');
+  });
+
+  it('should throw when using both a template and a renderer', () => {
+    const stub = sinon.stub(window.Vaadin, 'templateRendererCallback');
+    const grid = fixtureGrid();
+    const column = grid.firstElementChild;
+    stub.restore();
+
+    column.footerRenderer = () => {};
+
+    expect(() => window.Vaadin.templateRendererCallback(column)).to.throw(
+      /^Cannot use both a template and a renderer for <vaadin-grid-column \/>\.$/
+    );
   });
 });

--- a/packages/vaadin-template-renderer/test/grid-header.test.js
+++ b/packages/vaadin-template-renderer/test/grid-header.test.js
@@ -1,5 +1,7 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '@vaadin/vaadin-grid';
 import { Templatizer } from '../src/vaadin-template-renderer-templatizer.js';
 
 import '../vaadin-template-renderer.js';
@@ -7,30 +9,42 @@ import '../vaadin-template-renderer.js';
 import './fixtures/mock-grid-host.js';
 
 describe('grid header template', () => {
-  let host, grid, headerCell;
-
-  function getHeaderCell({ row, col }) {
-    const header = grid.$.header.children;
-
-    return header[row].querySelectorAll('[part~="cell"]')[col];
+  function fixtureGrid() {
+    return fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column>
+          <template class="header">header</template>
+        </vaadin-grid-column>
+      </vaadin-grid>
+    `);
   }
 
-  beforeEach(async () => {
-    host = fixtureSync(`<mock-grid-host></mock-grid-host>`);
-    grid = host.$.grid;
-
-    await nextRender(grid);
-
-    headerCell = getHeaderCell({ row: 0, col: 0 });
-  });
-
   it('should process the template', () => {
+    const grid = fixtureGrid();
     const template = grid.querySelector('template.header');
 
     expect(template.__templatizer).to.be.an.instanceof(Templatizer);
   });
 
-  it('should render the template', () => {
-    expect(headerCell._content.textContent).to.equal('header');
+  it('should render the template', async () => {
+    const grid = await fixtureGrid();
+    const column = grid.firstElementChild;
+
+    await nextRender(grid);
+
+    expect(column._headerCell._content.textContent).to.equal('header');
+  });
+
+  it('should throw when using both a template and a renderer', () => {
+    const stub = sinon.stub(window.Vaadin, 'templateRendererCallback');
+    const grid = fixtureGrid();
+    const column = grid.firstElementChild;
+    stub.restore();
+
+    column.headerRenderer = () => {};
+
+    expect(() => window.Vaadin.templateRendererCallback(column)).to.throw(
+      /^Cannot use both a template and a renderer for <vaadin-grid-column \/>\.$/
+    );
   });
 });

--- a/packages/vaadin-template-renderer/test/grid-row-details.test.js
+++ b/packages/vaadin-template-renderer/test/grid-row-details.test.js
@@ -1,10 +1,41 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
+import '@vaadin/vaadin-grid';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { GridTemplatizer } from '../src/vaadin-template-renderer-grid-templatizer.js';
 
 import '../vaadin-template-renderer.js';
 
 import './fixtures/mock-grid-host.js';
+
+describe('row details template', () => {
+  function fixtureGrid() {
+    return fixtureSync(`
+      <vaadin-grid>
+        <template class="row-details"></template>
+      </vaadin-grid>
+    `);
+  }
+
+  it('should process the template', () => {
+    const grid = fixtureGrid();
+    const template = grid.querySelector('template.row-details');
+
+    expect(template.__templatizer).to.be.an.instanceof(GridTemplatizer);
+  });
+
+  it('should throw when using both a template and a renderer', () => {
+    const stub = sinon.stub(window.Vaadin, 'templateRendererCallback');
+    const grid = fixtureGrid();
+    stub.restore();
+
+    grid.rowDetailsRenderer = () => {};
+
+    expect(() => window.Vaadin.templateRendererCallback(grid)).to.throw(
+      /^Cannot use both a template and a renderer for <vaadin-grid \/>\.$/
+    );
+  });
+});
 
 describe('row details template', () => {
   let host, grid;
@@ -16,7 +47,7 @@ describe('row details template', () => {
   }
 
   function queryDetailsCellContent(selector) {
-    return getCell({ row: 0, col: 4 })._content.querySelector(selector);
+    return getCell({ row: 0, col: 3 })._content.querySelector(selector);
   }
 
   beforeEach(async () => {
@@ -26,12 +57,6 @@ describe('row details template', () => {
     await nextRender(grid);
 
     grid.openItemDetails(grid.items[0]);
-  });
-
-  it('should process the template', () => {
-    const template = grid.querySelector('template.row-details');
-
-    expect(template.__templatizer).to.be.an.instanceof(GridTemplatizer);
   });
 
   it('should render model.index', () => {

--- a/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
+++ b/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
@@ -71,6 +71,20 @@ describe('vaadin-template-renderer', () => {
     });
   });
 
+  it('should throw when using both a template and a renderer', () => {
+    const component = fixtureSync(`
+      <mock-component disable-template-renderer-callback>
+        <template>foo</template>
+      </mock-component>
+    `);
+
+    component.renderer = () => {};
+
+    expect(() => window.Vaadin.templateRendererCallback(component)).to.throw(
+      /^Cannot use both a template and a renderer for <mock-component \/>\.$/
+    );
+  });
+
   it('should not process non-child templates', () => {
     const component = fixtureSync(`
       <mock-component>

--- a/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
+++ b/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
@@ -72,11 +72,13 @@ describe('vaadin-template-renderer', () => {
   });
 
   it('should throw when using both a template and a renderer', () => {
+    const stub = sinon.stub(window.Vaadin, 'templateRendererCallback');
     const component = fixtureSync(`
-      <mock-component disable-template-renderer-callback>
+      <mock-component>
         <template>foo</template>
       </mock-component>
     `);
+    stub.restore();
 
     component.renderer = () => {};
 


### PR DESCRIPTION
## Description

Previously, all the components which had the public support of the Polymer Template API used to throw an exception when using both a template and a renderer. So far as it was a part of the Template API and we no longer support this API, it was decided that the Template Renderer should throw such exceptions instead.

This PR has a purpose to support throwing such exceptions for the Template Renderer.

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
