### PR TITLE
feat: warn if suppress-template-warning attribute is not defined

### DIFF
--- a/packages/vaadin-template-renderer/src/vaadin-template-renderer.js
+++ b/packages/vaadin-template-renderer/src/vaadin-template-renderer.js
@@ -31,6 +31,22 @@ function assignRenderer(component, rendererName, renderer) {
   component[rendererName] = renderer;
 }
 
+function showTemplateWarning(component) {
+  if (component.__suppressTemplateWarning) {
+    return;
+  }
+
+  if (component.hasAttribute('suppress-template-warning')) {
+    return;
+  }
+
+  console.warn(
+    `WARNING: <template> inside <${component.localName}> is deprecated. Use a renderer function instead (see https://vaad.in/template-renderer)`
+  );
+
+  component.__suppressTemplateWarning = true;
+}
+
 function processGridTemplate(grid, template) {
   if (template.matches('.row-details')) {
     const renderer = createRenderer(grid, template, GridTemplatizer);
@@ -63,6 +79,8 @@ function processGridColumnTemplate(column, template) {
 }
 
 function processTemplate(component, template) {
+  showTemplateWarning(component);
+
   if (component.__gridElement) {
     processGridTemplate(component, template);
     return;
@@ -87,6 +105,7 @@ function processTemplates(component) {
       if (template.__templatizer) {
         return;
       }
+
       processTemplate(component, template);
     });
 }
@@ -99,6 +118,9 @@ function observeTemplates(component) {
   });
 }
 
+/**
+ * Public API
+ */
 window.Vaadin = window.Vaadin || {};
 window.Vaadin.templateRendererCallback = (component) => {
   processTemplates(component);

--- a/packages/vaadin-template-renderer/test/warning.test.js
+++ b/packages/vaadin-template-renderer/test/warning.test.js
@@ -1,0 +1,53 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { fixtureSync } from '@vaadin/testing-helpers';
+
+import '../vaadin-template-renderer.js';
+
+import './fixtures/mock-component.js';
+
+describe('warning', () => {
+  let stub;
+
+  beforeEach(() => {
+    stub = sinon.stub(console, 'warn');
+  });
+
+  afterEach(() => {
+    stub.restore();
+  });
+
+  it('should show the warning', () => {
+    fixtureSync(`
+      <mock-component>
+        <template></template>
+      </mock-component>
+    `);
+
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.args[0][0]).to.equal(
+      'WARNING: <template> inside <mock-component> is deprecated. Use a renderer function instead (see https://vaad.in/template-renderer)'
+    );
+  });
+
+  it('should show the warning only once per component', () => {
+    fixtureSync(`
+      <mock-component>
+        <template></template>
+        <template></template>
+      </mock-component>
+    `);
+
+    expect(stub.calledOnce).to.be.true;
+  });
+
+  it('should suppress the warning for an individual component', () => {
+    fixtureSync(`
+      <mock-component suppress-template-warning>
+        <template></template>
+      </mock-component>
+    `);
+
+    expect(stub.called).to.be.false;
+  });
+});

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -3,13 +3,30 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
-const ALLOWED_WARNINGS = [
+const HIDDEN_WARNINGS = [
   '<vaadin-crud> Unable to autoconfigure form because the data structure is unknown. Either specify `include` or ensure at least one item is available beforehand.',
   'The <vaadin-grid> needs the total number of items in order to display rows. Set the total number of items to the `size` property, or provide the total number of items in the second argument of the `dataProvider`’s `callback` call.',
-  'PositionMixin is not considered stable and might change any time'
+  'PositionMixin is not considered stable and might change any time',
+  /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/
 ];
 
-const filterBrowserLogs = (log) => ALLOWED_WARNINGS.includes(log.args[0]) === false;
+const filterBrowserLogs = (log) => {
+  const message = log.args[0];
+
+  const isHidden = HIDDEN_WARNINGS.some((warning) => {
+    if (warning instanceof RegExp && warning.test(message)) {
+      return true;
+    }
+
+    if (warning === message) {
+      return true;
+    }
+
+    return false;
+  });
+
+  return !isHidden;
+};
 
 const group = process.argv.indexOf('--group') !== -1;
 


### PR DESCRIPTION
## Description

Since [the previous PR](https://github.com/vaadin/web-components/pull/2101), we have started showing a warning when the user attempts to use legacy Template API without importing the template renderer. 

But even when the user has imported the template renderer, we want to show another warning once per component to encourage using renderer functions instead of templates, e.g:

```
WARNING: <template> inside <vaadin-combo-box> is deprecated. Use a renderer function instead (see https://vaad.in/template-renderer)
```

This warning can be manually suppressed by adding the `suppress-template-warning` attribute to a component that the user wants to use templates with:

```html
<vaadin-combo-box suppress-template-warning>
  <template>
    ...
  </template>
</vaadin-combo-box>
```

Closes #313 

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
