### PR TITLE
fix: fix icon when it's defined before iconset

### DIFF
--- a/packages/vaadin-icon/src/vaadin-icon.js
+++ b/packages/vaadin-icon/src/vaadin-icon.js
@@ -110,8 +110,7 @@ class IconElement extends ThemableMixin(ElementMixin(PolymerElement)) {
        * See also [`name`](#/elements/vaadin-iconset#property-name) property of `vaadin-iconset`.
        */
       icon: {
-        type: String,
-        observer: '__iconChanged'
+        type: String
       },
 
       /**
@@ -130,18 +129,26 @@ class IconElement extends ThemableMixin(ElementMixin(PolymerElement)) {
       },
 
       /** @private */
-      __svgElement: Object
+      __svgElement: Object,
+
+      /** @private */
+      __vaadinIconsetDefined: {
+        value: false
+      }
     };
   }
 
   static get observers() {
-    return ['__svgChanged(svg, __svgElement)'];
+    return ['__svgChanged(svg, __svgElement)', '__iconChanged(icon, __vaadinIconsetDefined)'];
   }
 
   /** @protected */
   ready() {
     super.ready();
     this.__svgElement = this.shadowRoot.querySelector('svg');
+    customElements.whenDefined('vaadin-iconset').then(() => {
+      this.__vaadinIconsetDefined = true;
+    });
   }
 
   /** @private */


### PR DESCRIPTION
The following HTML page doesn't currently display the icon due to the order in which `<vaadin-icon>` and `<vaadin-iconset>` get defined (the import order doesn't matter):

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <meta http-equiv="X-UA-Compatible" content="IE=edge">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Document</title>

  <script type="module">
    import '@vaadin/vaadin-icons/vaadin-iconset.js';
    import '@vaadin/vaadin-icon/vaadin-icon.js';
  </script>
</head>
<body>
  <vaadin-icon icon="vaadin:phone"></vaadin-icon>
</body>
</html>
```

This PR fixes the issue by adding an observer in `<vaadin-icon>` that will re-apply the `icon` property once `<vaadin-iconset>` gets defined.

This can't be tested with a unit test.