### PR TITLE
feat: improve error messages of upload

### DIFF
--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -408,16 +408,9 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
                 unknown: 'unknown remaining time'
               },
               error: {
-                serverError: {
-                  internalServerError: "File couldn't be uploaded becase there is an issue with server.",
-                  serviceNotAvailable: "File couldn't be uploaded becase service is not availble."
-                },
-                clientError: {
-                  unauthorized: 'You are not authorized to upload file',
-                  forbidden: "You don't have sufficient right to upload file",
-                  badRequest: "Server couldn't not process your request"
-                },
-                networkError: "File couldn't be uploaded, please try again later"
+                serverUnavailable: 'Server Unavailable',
+                unexpectedServerError: 'Unexpected Server Error',
+                forbidden: 'Forbidden'
               }
             },
             units: {
@@ -646,23 +639,12 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         if (!evt) {
           return;
         }
-
         if (xhr.status === 0) {
-          file.error = this.i18n.uploading.error.networkError;
+          file.error = this.i18n.uploading.error.serverUnavailable;
         } else if (xhr.status >= 500) {
-          if (xhr.status === 503) {
-            file.error = this.i18n.uploading.error.serverError.serviceNotAvailable;
-          } else {
-            file.error = this.i18n.uploading.error.serverError.internalServerError;
-          }
+          file.error = this.i18n.uploading.error.unexpectedServerError;
         } else if (xhr.status >= 400) {
-          if (xhr.status === 401) {
-            file.error = this.i18n.uploading.error.clientError.unauthorized;
-          } else if (xhr.status === 403) {
-            file.error = this.i18n.uploading.error.clientError.forbidden;
-          } else {
-            file.error = this.i18n.uploading.error.clientError.badRequest;
-          }
+          file.error = this.i18n.uploading.error.forbidden;
         }
 
         file.complete = !file.error;

--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -408,9 +408,9 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
                 unknown: 'unknown remaining time'
               },
               error: {
-                serverUnavailable: 'Server Unavailable',
-                unexpectedServerError: 'Unexpected Server Error',
-                forbidden: 'Forbidden'
+                serverUnavailable: 'Upload failed, please try again later',
+                unexpectedServerError: 'Upload failed due to server error',
+                forbidden: 'Upload forbidden'
               }
             },
             units: {

--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -408,9 +408,16 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
                 unknown: 'unknown remaining time'
               },
               error: {
-                serverUnavailable: 'Server Unavailable',
-                unexpectedServerError: 'Unexpected Server Error',
-                forbidden: 'Forbidden'
+                serverError: {
+                  internalServerError: "File couldn't be uploaded becase there is an issue with server.",
+                  serviceNotAvailable: "File couldn't be uploaded becase service is not availble."
+                },
+                clientError: {
+                  unauthorized: 'You are not authorized to upload file',
+                  forbidden: "You don't have sufficient right to upload file",
+                  badRequest: "Server couldn't not process your request"
+                },
+                networkError: "File couldn't be uploaded, please try again later"
               }
             },
             units: {
@@ -639,12 +646,23 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         if (!evt) {
           return;
         }
+
         if (xhr.status === 0) {
-          file.error = this.i18n.uploading.error.serverUnavailable;
+          file.error = this.i18n.uploading.error.networkError;
         } else if (xhr.status >= 500) {
-          file.error = this.i18n.uploading.error.unexpectedServerError;
+          if (xhr.status === 503) {
+            file.error = this.i18n.uploading.error.serverError.serviceNotAvailable;
+          } else {
+            file.error = this.i18n.uploading.error.serverError.internalServerError;
+          }
         } else if (xhr.status >= 400) {
-          file.error = this.i18n.uploading.error.forbidden;
+          if (xhr.status === 401) {
+            file.error = this.i18n.uploading.error.clientError.unauthorized;
+          } else if (xhr.status === 403) {
+            file.error = this.i18n.uploading.error.clientError.forbidden;
+          } else {
+            file.error = this.i18n.uploading.error.clientError.badRequest;
+          }
         }
 
         file.complete = !file.error;

--- a/packages/vaadin-upload/test/upload.test.js
+++ b/packages/vaadin-upload/test/upload.test.js
@@ -119,7 +119,7 @@ describe('upload', () => {
         const errorEvt = errorSpy.firstCall.args[0];
 
         expect(errorEvt.detail.file.uploading).not.to.be.ok;
-        expect(errorEvt.detail.file.error).to.be.equal('Server Unavailable');
+        expect(errorEvt.detail.file.error).to.be.equal("File couldn't be uploaded, please try again later");
         expect(errorEvt.detail.xhr.status).not.to.be.equal(200);
       });
 
@@ -307,16 +307,28 @@ describe('upload', () => {
         expect(e.detail.file.error).to.be.equal(error);
       }
 
-      [400, 401, 403, 404, 451].forEach((status) => {
-        it('should fail with forbidden error for status code ' + status, async () => {
-          await expectResponseErrorForStatus(upload.i18n.uploading.error.forbidden, status);
+      [400, 404, 451].forEach((status) => {
+        it('should fail with bad request error for status code ' + status, async () => {
+          await expectResponseErrorForStatus(upload.i18n.uploading.error.clientError.badRequest, status);
         });
       });
 
-      [500, 501, 502, 503, 504].forEach((status) => {
-        it('should fail with unexpected error for status code ' + status, async () => {
-          await expectResponseErrorForStatus(upload.i18n.uploading.error.unexpectedServerError, status);
+      it('should fail with unauthorized message for status code 401', async () => {
+        await expectResponseErrorForStatus(upload.i18n.uploading.error.clientError.unauthorized, 401);
+      });
+
+      it('should fail with forbidden message for status code 403', async () => {
+        await expectResponseErrorForStatus(upload.i18n.uploading.error.clientError.forbidden, 403);
+      });
+
+      [500, 501, 502, 504].forEach((status) => {
+        it('should fail with internal server error for status code ' + status, async () => {
+          await expectResponseErrorForStatus(upload.i18n.uploading.error.serverError.internalServerError, status);
         });
+      });
+
+      it('should fail with service unavailble mesage for status code 503', async () => {
+        await expectResponseErrorForStatus(upload.i18n.uploading.error.serverError.serviceNotAvailable, 503);
       });
     });
   });

--- a/packages/vaadin-upload/test/upload.test.js
+++ b/packages/vaadin-upload/test/upload.test.js
@@ -119,7 +119,7 @@ describe('upload', () => {
         const errorEvt = errorSpy.firstCall.args[0];
 
         expect(errorEvt.detail.file.uploading).not.to.be.ok;
-        expect(errorEvt.detail.file.error).to.be.equal('Server Unavailable');
+        expect(errorEvt.detail.file.error).to.be.equal('Upload failed, please try again later');
         expect(errorEvt.detail.xhr.status).not.to.be.equal(200);
       });
 

--- a/packages/vaadin-upload/test/upload.test.js
+++ b/packages/vaadin-upload/test/upload.test.js
@@ -119,7 +119,7 @@ describe('upload', () => {
         const errorEvt = errorSpy.firstCall.args[0];
 
         expect(errorEvt.detail.file.uploading).not.to.be.ok;
-        expect(errorEvt.detail.file.error).to.be.equal("File couldn't be uploaded, please try again later");
+        expect(errorEvt.detail.file.error).to.be.equal('Server Unavailable');
         expect(errorEvt.detail.xhr.status).not.to.be.equal(200);
       });
 
@@ -307,28 +307,16 @@ describe('upload', () => {
         expect(e.detail.file.error).to.be.equal(error);
       }
 
-      [400, 404, 451].forEach((status) => {
-        it('should fail with bad request error for status code ' + status, async () => {
-          await expectResponseErrorForStatus(upload.i18n.uploading.error.clientError.badRequest, status);
+      [400, 401, 403, 404, 451].forEach((status) => {
+        it('should fail with forbidden error for status code ' + status, async () => {
+          await expectResponseErrorForStatus(upload.i18n.uploading.error.forbidden, status);
         });
       });
 
-      it('should fail with unauthorized message for status code 401', async () => {
-        await expectResponseErrorForStatus(upload.i18n.uploading.error.clientError.unauthorized, 401);
-      });
-
-      it('should fail with forbidden message for status code 403', async () => {
-        await expectResponseErrorForStatus(upload.i18n.uploading.error.clientError.forbidden, 403);
-      });
-
-      [500, 501, 502, 504].forEach((status) => {
-        it('should fail with internal server error for status code ' + status, async () => {
-          await expectResponseErrorForStatus(upload.i18n.uploading.error.serverError.internalServerError, status);
+      [500, 501, 502, 503, 504].forEach((status) => {
+        it('should fail with unexpected error for status code ' + status, async () => {
+          await expectResponseErrorForStatus(upload.i18n.uploading.error.unexpectedServerError, status);
         });
-      });
-
-      it('should fail with service unavailble mesage for status code 503', async () => {
-        await expectResponseErrorForStatus(upload.i18n.uploading.error.serverError.serviceNotAvailable, 503);
       });
     });
   });


### PR DESCRIPTION
## Description

This change separates error messages of `vaadin-upload` component based on their origin. Those that are client error, specifically 401 and 403 errors which are related to authentication and authorization, and the one that has 0 as status code which generally means browser wasn't able to make the request (timeout, ...)

This change also has changed the structure of `i18n` file to better reflect these errors on translation keys.

Fixes #425