### PR TITLE
fix: update typing of virtual-list first/lastVisibleIndex getters

### DIFF
--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -146,7 +146,7 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   /**
    * Gets the index of the first visible item in the viewport.
    *
-   * @type {number}
+   * @return {number}
    */
   get firstVisibleIndex() {
     return this.__virtualizer.firstVisibleIndex;
@@ -155,7 +155,7 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   /**
    * Gets the index of the last visible item in the viewport.
    *
-   * @type {number}
+   * @return {number}
    */
   get lastVisibleIndex() {
     return this.__virtualizer.lastVisibleIndex;

--- a/packages/vaadin-virtual-list/src/virtualizer.js
+++ b/packages/vaadin-virtual-list/src/virtualizer.js
@@ -66,7 +66,7 @@ export class Virtualizer {
   /**
    * Gets the index of the first visible item in the viewport.
    *
-   * @type {number}
+   * @return {number}
    */
   get firstVisibleIndex() {
     return this.__adapter.adjustedFirstVisibleIndex;
@@ -75,7 +75,7 @@ export class Virtualizer {
   /**
    * Gets the index of the last visible item in the viewport.
    *
-   * @type {number}
+   * @return {number}
    */
   get lastVisibleIndex() {
     return this.__adapter.adjustedLastVisibleIndex;


### PR DESCRIPTION
The type of `firstVisibleIndex` and `lastVisibleIndex` currently documents as `?` in https://cdn.vaadin.com/vaadin-web-components/21.0.0-alpha8/#/elements/VirtualListElement#property-firstVisibleIndex. This PR fixes the getter return types.