### PR TITLE
feat: deprecate render() in favor of requestContentUpdate()

### DIFF
--- a/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
@@ -117,7 +117,7 @@ class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the item.
    */
   runRenderers() {
     if (!this.renderer) {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
@@ -117,9 +117,12 @@ class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the item.
+   * Requests an update for the content of the item.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers() {
+  requestContentUpdate() {
     if (!this.renderer) {
       return;
     }
@@ -146,7 +149,7 @@ class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
 
     if (renderer) {
       this._oldRenderer = renderer;
-      this.runRenderers();
+      this.requestContentUpdate();
     }
   }
 

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
@@ -99,7 +99,7 @@ class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   static get observers() {
-    return ['_rendererOrItemChanged(renderer, index, item.*, selected, focused)', '_updateLabel(label, renderer)'];
+    return ['__rendererOrItemChanged(renderer, index, item.*, selected, focused)', '__updateLabel(label, renderer)'];
   }
 
   connectedCallback() {
@@ -116,7 +116,10 @@ class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
     }
   }
 
-  _render() {
+  /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers() {
     if (!this.renderer) {
       return;
     }
@@ -131,7 +134,8 @@ class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
     this.renderer(this.$.content, this._comboBox, model);
   }
 
-  _rendererOrItemChanged(renderer, index, item, _selected, _focused) {
+  /** @private */
+  __rendererOrItemChanged(renderer, index, item, _selected, _focused) {
     if (item === undefined || index === undefined) {
       return;
     }
@@ -142,11 +146,12 @@ class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
 
     if (renderer) {
       this._oldRenderer = renderer;
-      this._render();
+      this.runRenderers();
     }
   }
 
-  _updateLabel(label, renderer) {
+  /** @private */
+  __updateLabel(label, renderer) {
     if (renderer) return;
 
     if (this.$.content) {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -142,14 +142,17 @@ interface ComboBoxMixin<TItem> {
   _inputElementValue: string | null | undefined;
 
   /**
-   * Runs the renderer passed in the `renderer` property for each item to update its content.
+   * Requests an update for the content of items.
+   * While performing the update, it invokes the renderer (passed in the `renderer` property) once an item.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers(): void;
+  requestContentUpdate(): void;
 
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -142,7 +142,7 @@ interface ComboBoxMixin<TItem> {
   _inputElementValue: string | null | undefined;
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property for each item to update its content.
    */
   runRenderers(): void;
 

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -142,7 +142,14 @@ interface ComboBoxMixin<TItem> {
   _inputElementValue: string | null | undefined;
 
   /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers(): void;
+
+  /**
    * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -305,7 +305,7 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /**
-     * Runs all the renderers to possibly update the content.
+     * Runs the renderer passed in the `renderer` property for each item to update its content.
      */
     runRenderers() {
       if (!this.$.overlay._selector) {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -305,12 +305,27 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /**
+     * Runs all the renderers to possibly update the content.
+     */
+    runRenderers() {
+      if (!this.$.overlay._selector) {
+        return;
+      }
+
+      this.$.overlay._selector.querySelectorAll('vaadin-combo-box-item').forEach((item) => {
+        item.runRenderers();
+      });
+    }
+
+    /**
      * Manually invoke existing renderer.
+     *
+     * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
      */
     render() {
-      if (this.$.overlay._selector) {
-        this.$.overlay._selector.querySelectorAll('vaadin-combo-box-item').forEach((item) => item._render());
-      }
+      console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+
+      this.runRenderers();
     }
 
     /**

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -305,27 +305,30 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /**
-     * Runs the renderer passed in the `renderer` property for each item to update its content.
+     * Requests an update for the content of items.
+     * While performing the update, it invokes the renderer (passed in the `renderer` property) once an item.
+     *
+     * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
      */
-    runRenderers() {
+    requestContentUpdate() {
       if (!this.$.overlay._selector) {
         return;
       }
 
       this.$.overlay._selector.querySelectorAll('vaadin-combo-box-item').forEach((item) => {
-        item.runRenderers();
+        item.requestContentUpdate();
       });
     }
 
     /**
      * Manually invoke existing renderer.
      *
-     * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+     * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
      */
     render() {
-      console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+      console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.');
 
-      this.runRenderers();
+      this.requestContentUpdate();
     }
 
     /**

--- a/packages/vaadin-combo-box/test/item-renderer.test.js
+++ b/packages/vaadin-combo-box/test/item-renderer.test.js
@@ -75,18 +75,40 @@ describe('item renderer', () => {
     expect(getFirstItem().$.content.textContent.trim()).to.equal('foo 0');
   });
 
-  it('should be possible to manually invoke renderer', () => {
+  it('should run renderers manually', () => {
     comboBox.renderer = sinon.spy();
     comboBox.opened = true;
 
-    // Number of items rendered on opening
-    const renderedCount = comboBox.renderer.callCount;
+    expect(comboBox.renderer.callCount).to.be.equal(comboBox.items.length);
+
+    comboBox.runRenderers();
+
+    expect(comboBox.renderer.callCount).to.be.equal(comboBox.items.length * 2);
+  });
+
+  it('should run renderers when calling deprecated render()', () => {
+    const stub = sinon.stub(comboBox, 'runRenderers');
+    comboBox.opened = true;
     comboBox.render();
-    expect(comboBox.renderer.callCount).to.be.equal(renderedCount * 2);
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+  });
+
+  it('should warn when calling deprecated render()', () => {
+    const stub = sinon.stub(console, 'warn');
+    comboBox.opened = true;
+    comboBox.render();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.args[0][0]).to.equal(
+      'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+    );
   });
 
   it('should not throw if render() called before opening', () => {
-    expect(() => comboBox.render()).not.to.throw(Error);
+    expect(() => comboBox.runRenderers()).not.to.throw(Error);
   });
 
   it('should render the item label when removing the renderer', () => {

--- a/packages/vaadin-combo-box/test/item-renderer.test.js
+++ b/packages/vaadin-combo-box/test/item-renderer.test.js
@@ -75,19 +75,19 @@ describe('item renderer', () => {
     expect(getFirstItem().$.content.textContent.trim()).to.equal('foo 0');
   });
 
-  it('should run renderers manually', () => {
+  it('should run renderers when requesting content update', () => {
     comboBox.renderer = sinon.spy();
     comboBox.opened = true;
 
     expect(comboBox.renderer.callCount).to.be.equal(comboBox.items.length);
 
-    comboBox.runRenderers();
+    comboBox.requestContentUpdate();
 
     expect(comboBox.renderer.callCount).to.be.equal(comboBox.items.length * 2);
   });
 
-  it('should run renderers when calling deprecated render()', () => {
-    const stub = sinon.stub(comboBox, 'runRenderers');
+  it('should request content update when calling deprecated render()', () => {
+    const stub = sinon.stub(comboBox, 'requestContentUpdate');
     comboBox.opened = true;
     comboBox.render();
     stub.restore();
@@ -103,12 +103,12 @@ describe('item renderer', () => {
 
     expect(stub.calledOnce).to.be.true;
     expect(stub.args[0][0]).to.equal(
-      'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+      'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.'
     );
   });
 
-  it('should not throw if render() called before opening', () => {
-    expect(() => comboBox.runRenderers()).not.to.throw(Error);
+  it('should not throw if requestContentUpdate() called before opening', () => {
+    expect(() => comboBox.requestContentUpdate()).not.to.throw(Error);
   });
 
   it('should render the item label when removing the renderer', () => {

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
@@ -235,14 +235,17 @@ declare class ContextMenuElement extends ElementMixin(
   renderer: ContextMenuRenderer | null | undefined;
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the menu overlay.
+   * Requests an update for the content of the menu overlay.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers(): void;
+  requestContentUpdate(): void;
 
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
@@ -235,7 +235,14 @@ declare class ContextMenuElement extends ElementMixin(
   renderer: ContextMenuRenderer | null | undefined;
 
   /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers(): void;
+
+  /**
    * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
@@ -235,7 +235,7 @@ declare class ContextMenuElement extends ElementMixin(
   renderer: ContextMenuRenderer | null | undefined;
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the menu overlay.
    */
   runRenderers(): void;
 

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.js
@@ -452,10 +452,21 @@ class ContextMenuElement extends ElementMixin(ThemePropertyMixin(ItemsMixin(Gest
   }
 
   /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers() {
+    this.$.overlay.runRenderers();
+  }
+
+  /**
    * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
    */
   render() {
-    this.$.overlay.runRenderers();
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+
+    this.runRenderers();
   }
 
   /** @private */

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.js
@@ -452,21 +452,24 @@ class ContextMenuElement extends ElementMixin(ThemePropertyMixin(ItemsMixin(Gest
   }
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the menu overlay.
+   * Requests an update for the content of the menu overlay.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers() {
-    this.$.overlay.runRenderers();
+  requestContentUpdate() {
+    this.$.overlay.requestContentUpdate();
   }
 
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render() {
-    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.');
 
-    this.runRenderers();
+    this.requestContentUpdate();
   }
 
   /** @private */

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.js
@@ -452,7 +452,7 @@ class ContextMenuElement extends ElementMixin(ThemePropertyMixin(ItemsMixin(Gest
   }
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the menu overlay.
    */
   runRenderers() {
     this.$.overlay.runRenderers();

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.js
@@ -455,7 +455,7 @@ class ContextMenuElement extends ElementMixin(ThemePropertyMixin(ItemsMixin(Gest
    * Manually invoke existing renderer.
    */
   render() {
-    this.$.overlay.render();
+    this.$.overlay.runRenderers();
   }
 
   /** @private */

--- a/packages/vaadin-context-menu/test/renderer.test.js
+++ b/packages/vaadin-context-menu/test/renderer.test.js
@@ -86,11 +86,35 @@ describe('renderer', () => {
     expect(menu.renderer.getCall(1).args[2].detail).to.deep.equal({ foo: 'two' });
   });
 
-  it('should be possible to manually invoke renderer', () => {
+  it('should run renderers when calling runRenderers()', () => {
     fire(target, 'vaadin-contextmenu');
+
     expect(menu.renderer.calledOnce).to.be.true;
-    menu.render();
+
+    menu.runRenderers();
+
     expect(menu.renderer.calledTwice).to.be.true;
+  });
+
+  it('should run renderers when calling deprecated render()', () => {
+    const stub = sinon.stub(menu, 'runRenderers');
+    fire(target, 'vaadin-contextmenu');
+    menu.render();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+  });
+
+  it('should warn when calling deprecated render()', () => {
+    const stub = sinon.stub(console, 'warn');
+    fire(target, 'vaadin-contextmenu');
+    menu.render();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.args[0][0]).to.equal(
+      'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+    );
   });
 
   it('should clear the content when removing the renderer', () => {

--- a/packages/vaadin-context-menu/test/renderer.test.js
+++ b/packages/vaadin-context-menu/test/renderer.test.js
@@ -86,18 +86,18 @@ describe('renderer', () => {
     expect(menu.renderer.getCall(1).args[2].detail).to.deep.equal({ foo: 'two' });
   });
 
-  it('should run renderers manually', () => {
+  it('should run renderers when requesting content update', () => {
     fire(target, 'vaadin-contextmenu');
 
     expect(menu.renderer.calledOnce).to.be.true;
 
-    menu.runRenderers();
+    menu.requestContentUpdate();
 
     expect(menu.renderer.calledTwice).to.be.true;
   });
 
-  it('should run renderers when calling deprecated render()', () => {
-    const stub = sinon.stub(menu, 'runRenderers');
+  it('should request content update when calling deprecated render()', () => {
+    const stub = sinon.stub(menu, 'requestContentUpdate');
     fire(target, 'vaadin-contextmenu');
     menu.render();
     stub.restore();
@@ -113,7 +113,7 @@ describe('renderer', () => {
 
     expect(stub.calledOnce).to.be.true;
     expect(stub.args[0][0]).to.equal(
-      'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+      'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.'
     );
   });
 

--- a/packages/vaadin-context-menu/test/renderer.test.js
+++ b/packages/vaadin-context-menu/test/renderer.test.js
@@ -86,7 +86,7 @@ describe('renderer', () => {
     expect(menu.renderer.getCall(1).args[2].detail).to.deep.equal({ foo: 'two' });
   });
 
-  it('should run renderers when calling runRenderers()', () => {
+  it('should run renderers manually', () => {
     fire(target, 'vaadin-contextmenu');
 
     expect(menu.renderer.calledOnce).to.be.true;

--- a/packages/vaadin-dialog/src/vaadin-dialog.d.ts
+++ b/packages/vaadin-dialog/src/vaadin-dialog.d.ts
@@ -94,14 +94,17 @@ declare class DialogElement extends ThemePropertyMixin(
   modeless: boolean;
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the dialog.
+   * Requests an update for the content of the dialog.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers(): void;
+  requestContentUpdate(): void;
 
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-dialog/src/vaadin-dialog.d.ts
+++ b/packages/vaadin-dialog/src/vaadin-dialog.d.ts
@@ -94,7 +94,14 @@ declare class DialogElement extends ThemePropertyMixin(
   modeless: boolean;
 
   /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers(): void;
+
+  /**
    * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-dialog/src/vaadin-dialog.d.ts
+++ b/packages/vaadin-dialog/src/vaadin-dialog.d.ts
@@ -94,7 +94,7 @@ declare class DialogElement extends ThemePropertyMixin(
   modeless: boolean;
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the dialog.
    */
   runRenderers(): void;
 

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -283,10 +283,21 @@ class DialogElement extends ThemePropertyMixin(
   }
 
   /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers() {
+    this.$.overlay.runRenderers();
+  }
+
+  /**
    * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
    */
   render() {
-    this.$.overlay.runRenderers();
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+
+    this.runRenderers();
   }
 
   /** @private */

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -286,7 +286,7 @@ class DialogElement extends ThemePropertyMixin(
    * Manually invoke existing renderer.
    */
   render() {
-    this.$.overlay.render();
+    this.$.overlay.runRenderers();
   }
 
   /** @private */

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -283,21 +283,24 @@ class DialogElement extends ThemePropertyMixin(
   }
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the dialog.
+   * Requests an update for the content of the dialog.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers() {
-    this.$.overlay.runRenderers();
+  requestContentUpdate() {
+    this.$.overlay.requestContentUpdate();
   }
 
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render() {
-    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.');
 
-    this.runRenderers();
+    this.requestContentUpdate();
   }
 
   /** @private */

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -283,7 +283,7 @@ class DialogElement extends ThemePropertyMixin(
   }
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the dialog.
    */
   runRenderers() {
     this.$.overlay.runRenderers();

--- a/packages/vaadin-dialog/test/renderer.test.js
+++ b/packages/vaadin-dialog/test/renderer.test.js
@@ -24,12 +24,34 @@ describe('vaadin-dialog renderer', () => {
       expect(overlay.textContent).to.include('The content of the dialog');
     });
 
-    it('should be possible to manually invoke renderer', () => {
+    it('should run renderers when calling runRenderers()', () => {
       dialog.renderer = sinon.spy();
       dialog.opened = true;
+
       expect(dialog.renderer.calledOnce).to.be.true;
-      dialog.render();
+
+      dialog.runRenderers();
+
       expect(dialog.renderer.calledTwice).to.be.true;
+    });
+
+    it('should run renderers when calling deprecated render()', () => {
+      const stub = sinon.stub(dialog, 'runRenderers');
+      dialog.render();
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+    });
+
+    it('should warn when calling deprecated render()', () => {
+      const stub = sinon.stub(console, 'warn');
+      dialog.render();
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.args[0][0]).to.equal(
+        'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+      );
     });
 
     it('should clear the content when removing the renderer', () => {

--- a/packages/vaadin-dialog/test/renderer.test.js
+++ b/packages/vaadin-dialog/test/renderer.test.js
@@ -24,19 +24,19 @@ describe('vaadin-dialog renderer', () => {
       expect(overlay.textContent).to.include('The content of the dialog');
     });
 
-    it('should run renderers manually', () => {
+    it('should run renderers when requesting content update', () => {
       dialog.renderer = sinon.spy();
       dialog.opened = true;
 
       expect(dialog.renderer.calledOnce).to.be.true;
 
-      dialog.runRenderers();
+      dialog.requestContentUpdate();
 
       expect(dialog.renderer.calledTwice).to.be.true;
     });
 
-    it('should run renderers when calling deprecated render()', () => {
-      const stub = sinon.stub(dialog, 'runRenderers');
+    it('should request content update when calling deprecated render()', () => {
+      const stub = sinon.stub(dialog, 'requestContentUpdate');
       dialog.render();
       stub.restore();
 
@@ -50,7 +50,7 @@ describe('vaadin-dialog renderer', () => {
 
       expect(stub.calledOnce).to.be.true;
       expect(stub.args[0][0]).to.equal(
-        'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+        'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.'
       );
     });
 

--- a/packages/vaadin-dialog/test/renderer.test.js
+++ b/packages/vaadin-dialog/test/renderer.test.js
@@ -24,7 +24,7 @@ describe('vaadin-dialog renderer', () => {
       expect(overlay.textContent).to.include('The content of the dialog');
     });
 
-    it('should run renderers when calling runRenderers()', () => {
+    it('should run renderers manually', () => {
       dialog.renderer = sinon.spy();
       dialog.opened = true;
 

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -359,8 +359,21 @@ declare class GridElement<TItem = GridDefaultItem> extends HTMLElement {
   __getRowModel(row: HTMLTableRowElement): GridItemModel<TItem>;
 
   /**
+   * Runs all the renderers to update the content of the cells.
+   *
+   * This method invokes the following renderers:
+   * - `GridElement.rowDetailsRenderer`
+   * - `GridColumnElement.renderer`
+   * - `GridColumnElement.headerRenderer`
+   * - `GridColumnElement.footerRenderer`
+   */
+  runRenderers(): void;
+
+  /**
    * Manually invoke existing renderers for all the columns
    * (header, footer and body cells) and opened row details.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -359,21 +359,23 @@ declare class GridElement<TItem = GridDefaultItem> extends HTMLElement {
   __getRowModel(row: HTMLTableRowElement): GridItemModel<TItem>;
 
   /**
-   * Runs all the renderers to update the content of the cells.
+   * Requests an update for the content of cells.
    *
-   * This method invokes the following renderers:
+   * While performing the update, the following renderers are invoked:
    * - `GridElement.rowDetailsRenderer`
    * - `GridColumnElement.renderer`
    * - `GridColumnElement.headerRenderer`
    * - `GridColumnElement.footerRenderer`
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers(): void;
+  requestContentUpdate(): void;
 
   /**
    * Manually invoke existing renderers for all the columns
    * (header, footer and body cells) and opened row details.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -965,15 +965,17 @@ class GridElement extends ElementMixin(
   }
 
   /**
-   * Runs all the renderers to update the content of the cells.
+   * Requests an update for the content of cells.
    *
-   * This method invokes the following renderers:
+   * While performing the update, the following renderers are invoked:
    * - `GridElement.rowDetailsRenderer`
    * - `GridColumnElement.renderer`
    * - `GridColumnElement.headerRenderer`
    * - `GridColumnElement.footerRenderer`
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers() {
+  requestContentUpdate() {
     if (this._columnTree) {
       // header and footer renderers
       this._columnTree.forEach((level) => {
@@ -991,12 +993,12 @@ class GridElement extends ElementMixin(
    * Manually invoke existing renderers for all the columns
    * (header, footer and body cells) and opened row details.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render() {
-    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.');
 
-    this.runRenderers();
+    this.requestContentUpdate();
   }
 
   /** @protected */

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -965,13 +965,13 @@ class GridElement extends ElementMixin(
   }
 
   /**
-   * Runs all the columns' renderers to possibly update the content of the cells.
+   * Runs all the renderers to update the content of the cells.
    *
-   * The following column renderers are invoked:
-   * - `renderer`
-   * - `headerRenderer`
-   * - `footerRenderer`
-   * - `rowDetailsRenderer`
+   * This method invokes the following renderers:
+   * - `GridElement.rowDetailsRenderer`
+   * - `GridColumnElement.renderer`
+   * - `GridColumnElement.headerRenderer`
+   * - `GridColumnElement.footerRenderer`
    */
   runRenderers() {
     if (this._columnTree) {

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -965,10 +965,15 @@ class GridElement extends ElementMixin(
   }
 
   /**
-   * Manually invoke existing renderers for all the columns
-   * (header, footer and body cells) and opened row details.
+   * Runs all the columns' renderers to possibly update the content of the cells.
+   *
+   * The following column renderers are invoked:
+   * - `renderer`
+   * - `headerRenderer`
+   * - `footerRenderer`
+   * - `rowDetailsRenderer`
    */
-  render() {
+  runRenderers() {
     if (this._columnTree) {
       // header and footer renderers
       this._columnTree.forEach((level) => {
@@ -980,6 +985,18 @@ class GridElement extends ElementMixin(
       // body and row details renderers
       this.__updateVisibleRows();
     }
+  }
+
+  /**
+   * Manually invoke existing renderers for all the columns
+   * (header, footer and body cells) and opened row details.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   */
+  render() {
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+
+    this.runRenderers();
   }
 
   /** @protected */

--- a/packages/vaadin-grid/test/class-name-generator.test.js
+++ b/packages/vaadin-grid/test/class-name-generator.test.js
@@ -90,7 +90,7 @@ describe('class name generator', () => {
     assertClassList(firstCell, []);
   });
 
-  ['generateCellClassNames', 'clearCache', 'runRenderers'].forEach((funcName) => {
+  ['generateCellClassNames', 'clearCache', 'requestContentUpdate'].forEach((funcName) => {
     it(`should update classes on ${funcName}`, () => {
       let condition = false;
       grid.cellClassNameGenerator = () => condition && 'foo';

--- a/packages/vaadin-grid/test/class-name-generator.test.js
+++ b/packages/vaadin-grid/test/class-name-generator.test.js
@@ -90,7 +90,7 @@ describe('class name generator', () => {
     assertClassList(firstCell, []);
   });
 
-  ['generateCellClassNames', 'clearCache', 'render'].forEach((funcName) => {
+  ['generateCellClassNames', 'clearCache', 'runRenderers'].forEach((funcName) => {
     it(`should update classes on ${funcName}`, () => {
       let condition = false;
       grid.cellClassNameGenerator = () => condition && 'foo';

--- a/packages/vaadin-grid/test/column.test.js
+++ b/packages/vaadin-grid/test/column.test.js
@@ -202,7 +202,7 @@ describe('column', () => {
         newColumn.footerRenderer = () => {};
         grid.appendChild(newColumn);
         flushGrid(grid);
-        expect(() => grid.render()).not.to.throw(Error);
+        expect(() => grid.runRenderers()).not.to.throw(Error);
       });
 
       it('should not remove details row when a column is hidden', () => {

--- a/packages/vaadin-grid/test/column.test.js
+++ b/packages/vaadin-grid/test/column.test.js
@@ -202,7 +202,7 @@ describe('column', () => {
         newColumn.footerRenderer = () => {};
         grid.appendChild(newColumn);
         flushGrid(grid);
-        expect(() => grid.runRenderers()).not.to.throw(Error);
+        expect(() => grid.requestContentUpdate()).not.to.throw(Error);
       });
 
       it('should not remove details row when a column is hidden', () => {

--- a/packages/vaadin-grid/test/data-provider.test.js
+++ b/packages/vaadin-grid/test/data-provider.test.js
@@ -332,7 +332,7 @@ describe('data provider', () => {
         expandIndex(grid, 0);
         expect(isIndexExpanded(grid, 0)).to.be.true;
         grid.itemIdPath = 'id';
-        grid.runRenderers();
+        grid.requestContentUpdate();
         expect(isIndexExpanded(grid, 0)).to.be.true;
       });
 

--- a/packages/vaadin-grid/test/data-provider.test.js
+++ b/packages/vaadin-grid/test/data-provider.test.js
@@ -332,7 +332,7 @@ describe('data provider', () => {
         expandIndex(grid, 0);
         expect(isIndexExpanded(grid, 0)).to.be.true;
         grid.itemIdPath = 'id';
-        grid.render();
+        grid.runRenderers();
         expect(isIndexExpanded(grid, 0)).to.be.true;
       });
 

--- a/packages/vaadin-grid/test/renderers.test.js
+++ b/packages/vaadin-grid/test/renderers.test.js
@@ -255,7 +255,7 @@ describe('renderers', () => {
     });
   });
 
-  it('should run renderers manually', () => {
+  it('should run renderers when requesting content update', () => {
     column.renderer = sinon.spy();
     column.headerRenderer = sinon.spy();
     column.footerRenderer = sinon.spy();
@@ -265,15 +265,15 @@ describe('renderers', () => {
     flushGrid(grid);
 
     renderers.forEach((renderer) => renderer.resetHistory());
-    grid.runRenderers();
+    grid.requestContentUpdate();
 
     renderers.forEach((renderer) => {
       expect(renderer.called).to.be.true;
     });
   });
 
-  it('should run renderers when calling deprecated render()', () => {
-    const stub = sinon.stub(grid, 'runRenderers');
+  it('should request content update when calling deprecated render()', () => {
+    const stub = sinon.stub(grid, 'requestContentUpdate');
     grid.render();
     stub.restore();
 
@@ -287,7 +287,7 @@ describe('renderers', () => {
 
     expect(stub.calledOnce).to.be.true;
     expect(stub.args[0][0]).to.equal(
-      'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+      'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.'
     );
   });
 });

--- a/packages/vaadin-grid/test/renderers.test.js
+++ b/packages/vaadin-grid/test/renderers.test.js
@@ -255,20 +255,39 @@ describe('renderers', () => {
     });
   });
 
-  describe('manual invocation', () => {
-    it('should support `render()` method to invoke all the renderers', () => {
-      column.renderer = sinon.spy();
-      column.headerRenderer = sinon.spy();
-      column.footerRenderer = sinon.spy();
-      grid.rowDetailsRenderer = sinon.spy();
-      grid.detailsOpenedItems = grid.items;
-      const renderers = [column.renderer, column.headerRenderer, column.footerRenderer, grid.rowDetailsRenderer];
-      flushGrid(grid);
-      renderers.forEach((renderer) => renderer.resetHistory());
-      grid.render();
-      renderers.forEach((renderer) => {
-        expect(renderer.called).to.be.true;
-      });
+  it('should run renderers manually', () => {
+    column.renderer = sinon.spy();
+    column.headerRenderer = sinon.spy();
+    column.footerRenderer = sinon.spy();
+    grid.rowDetailsRenderer = sinon.spy();
+    grid.detailsOpenedItems = grid.items;
+    const renderers = [column.renderer, column.headerRenderer, column.footerRenderer, grid.rowDetailsRenderer];
+    flushGrid(grid);
+
+    renderers.forEach((renderer) => renderer.resetHistory());
+    grid.runRenderers();
+
+    renderers.forEach((renderer) => {
+      expect(renderer.called).to.be.true;
     });
+  });
+
+  it('should run renderers when calling deprecated render()', () => {
+    const stub = sinon.stub(grid, 'runRenderers');
+    grid.render();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+  });
+
+  it('should warn when calling deprecated render()', () => {
+    const stub = sinon.stub(console, 'warn');
+    grid.render();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.args[0][0]).to.equal(
+      'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+    );
   });
 });

--- a/packages/vaadin-notification/src/vaadin-notification.d.ts
+++ b/packages/vaadin-notification/src/vaadin-notification.d.ts
@@ -96,7 +96,14 @@ declare class NotificationElement extends ThemePropertyMixin(ElementMixin(HTMLEl
   renderer: NotificationRenderer | undefined;
 
   /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers(): void;
+
+  /**
    * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-notification/src/vaadin-notification.d.ts
+++ b/packages/vaadin-notification/src/vaadin-notification.d.ts
@@ -96,14 +96,17 @@ declare class NotificationElement extends ThemePropertyMixin(ElementMixin(HTMLEl
   renderer: NotificationRenderer | undefined;
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the notification.
+   * Requests an update for the content of the notification.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers(): void;
+  requestContentUpdate(): void;
 
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-notification/src/vaadin-notification.d.ts
+++ b/packages/vaadin-notification/src/vaadin-notification.d.ts
@@ -96,7 +96,7 @@ declare class NotificationElement extends ThemePropertyMixin(ElementMixin(HTMLEl
   renderer: NotificationRenderer | undefined;
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the notification.
    */
   runRenderers(): void;
 

--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -316,12 +316,23 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   }
 
   /**
-   * Manually invoke existing renderer.
+   * Runs all the renderers to possibly update the content.
    */
-  render() {
+  runRenderers() {
     if (!this.renderer) return;
 
     this.renderer(this._card, this);
+  }
+
+  /**
+   * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   */
+  render() {
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+
+    this.runRenderers();
   }
 
   /** @private */
@@ -341,7 +352,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
       if (!this._didAnimateNotificationAppend) {
         this._animatedAppendNotificationCard();
       }
-      this.render();
+      this.runRenderers();
     }
   }
 

--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -316,7 +316,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   }
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the notification.
    */
   runRenderers() {
     if (!this.renderer) return;

--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -316,9 +316,12 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   }
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the notification.
+   * Requests an update for the content of the notification.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers() {
+  requestContentUpdate() {
     if (!this.renderer) return;
 
     this.renderer(this._card, this);
@@ -327,12 +330,12 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render() {
-    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.');
 
-    this.runRenderers();
+    this.requestContentUpdate();
   }
 
   /** @private */
@@ -352,7 +355,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
       if (!this._didAnimateNotificationAppend) {
         this._animatedAppendNotificationCard();
       }
-      this.runRenderers();
+      this.requestContentUpdate();
     }
   }
 

--- a/packages/vaadin-notification/test/renderer.test.js
+++ b/packages/vaadin-notification/test/renderer.test.js
@@ -47,7 +47,7 @@ describe('renderer', () => {
       };
     });
 
-    it('should run renderers when calling runRenderers()', () => {
+    it('should run renderers manually', () => {
       notification.renderer = sinon.spy();
       notification.opened = true;
 

--- a/packages/vaadin-notification/test/renderer.test.js
+++ b/packages/vaadin-notification/test/renderer.test.js
@@ -47,19 +47,19 @@ describe('renderer', () => {
       };
     });
 
-    it('should run renderers manually', () => {
+    it('should run renderers when requesting content update', () => {
       notification.renderer = sinon.spy();
       notification.opened = true;
 
       expect(notification.renderer.calledOnce).to.be.true;
 
-      notification.runRenderers();
+      notification.requestContentUpdate();
 
       expect(notification.renderer.calledTwice).to.be.true;
     });
 
-    it('should run renderers when calling deprecated render()', () => {
-      const stub = sinon.stub(notification, 'runRenderers');
+    it('should request content update when calling deprecated render()', () => {
+      const stub = sinon.stub(notification, 'requestContentUpdate');
       notification.opened = true;
       notification.render();
       stub.restore();
@@ -75,7 +75,7 @@ describe('renderer', () => {
 
       expect(stub.calledOnce).to.be.true;
       expect(stub.args[0][0]).to.equal(
-        'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+        'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.'
       );
     });
 

--- a/packages/vaadin-notification/test/renderer.test.js
+++ b/packages/vaadin-notification/test/renderer.test.js
@@ -47,12 +47,36 @@ describe('renderer', () => {
       };
     });
 
-    it('should be possible to manually invoke renderer', () => {
+    it('should run renderers when calling runRenderers()', () => {
       notification.renderer = sinon.spy();
       notification.opened = true;
+
       expect(notification.renderer.calledOnce).to.be.true;
-      notification.render();
+
+      notification.runRenderers();
+
       expect(notification.renderer.calledTwice).to.be.true;
+    });
+
+    it('should run renderers when calling deprecated render()', () => {
+      const stub = sinon.stub(notification, 'runRenderers');
+      notification.opened = true;
+      notification.render();
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+    });
+
+    it('should warn when calling deprecated render()', () => {
+      const stub = sinon.stub(console, 'warn');
+      notification.opened = true;
+      notification.render();
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.args[0][0]).to.equal(
+        'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+      );
     });
 
     it('should provide root from the previous renderer call', () => {

--- a/packages/vaadin-overlay/src/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay.d.ts
@@ -202,7 +202,7 @@ declare class OverlayElement extends ThemableMixin(DirMixin(HTMLElement)) {
   _stampOverlayTemplate(template: HTMLTemplateElement, instanceProps: object | null): void;
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the overlay.
    */
   runRenderers(): void;
 

--- a/packages/vaadin-overlay/src/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay.d.ts
@@ -202,14 +202,17 @@ declare class OverlayElement extends ThemableMixin(DirMixin(HTMLElement)) {
   _stampOverlayTemplate(template: HTMLTemplateElement, instanceProps: object | null): void;
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the overlay.
+   * Requests an update for the content of the overlay.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers(): void;
+  requestContentUpdate(): void;
 
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-overlay/src/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay.d.ts
@@ -202,7 +202,14 @@ declare class OverlayElement extends ThemableMixin(DirMixin(HTMLElement)) {
   _stampOverlayTemplate(template: HTMLTemplateElement, instanceProps: object | null): void;
 
   /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers(): void;
+
+  /**
    * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -445,6 +445,26 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
     }
   }
 
+  /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers() {
+    if (this.renderer) {
+      this.renderer.call(this.owner, this.content, this.owner, this.model);
+    }
+  }
+
+  /**
+   * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   */
+  render() {
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+
+    this.runRenderers();
+  }
+
   /** @private */
   _ironOverlayCanceled(event) {
     event.preventDefault();
@@ -872,15 +892,6 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
     }
   }
 
-  /**
-   * Manually invoke existing renderer.
-   */
-  render() {
-    if (this.renderer) {
-      this.renderer.call(this.owner, this.content, this.owner, this.model);
-    }
-  }
-
   /** @private */
   _templateOrRendererChanged(template, renderer, owner, model, instanceProps, opened) {
     if (template && renderer) {
@@ -911,7 +922,7 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
       this._stampOverlayTemplate(template, instanceProps);
     } else if (renderer && (rendererChanged || openedChanged || ownerOrModelChanged)) {
       if (opened) {
-        this.render();
+        this.runRenderers();
       }
     }
   }

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -446,7 +446,7 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the overlay.
    */
   runRenderers() {
     if (this.renderer) {

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -446,9 +446,12 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the overlay.
+   * Requests an update for the content of the overlay.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers() {
+  requestContentUpdate() {
     if (this.renderer) {
       this.renderer.call(this.owner, this.content, this.owner, this.model);
     }
@@ -457,12 +460,12 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render() {
-    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.');
 
-    this.runRenderers();
+    this.requestContentUpdate();
   }
 
   /** @private */
@@ -922,7 +925,7 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
       this._stampOverlayTemplate(template, instanceProps);
     } else if (renderer && (rendererChanged || openedChanged || ownerOrModelChanged)) {
       if (opened) {
-        this.runRenderers();
+        this.requestContentUpdate();
       }
     }
   }

--- a/packages/vaadin-overlay/test/renderer.test.js
+++ b/packages/vaadin-overlay/test/renderer.test.js
@@ -110,15 +110,15 @@ describe('renderer', () => {
       expect(overlay.template).to.be.not.ok;
     });
 
-    it('should run renderers manually', () => {
+    it('should run renderers when requesting content update', () => {
       overlay.renderer = sinon.spy();
-      overlay.runRenderers();
+      overlay.requestContentUpdate();
 
       expect(overlay.renderer.calledOnce).to.be.true;
     });
 
-    it('should run renderers when calling deprecated render()', () => {
-      const stub = sinon.stub(overlay, 'runRenderers');
+    it('should request content update when calling deprecated render()', () => {
+      const stub = sinon.stub(overlay, 'requestContentUpdate');
       overlay.render();
       stub.restore();
 
@@ -132,7 +132,7 @@ describe('renderer', () => {
 
       expect(stub.calledOnce).to.be.true;
       expect(stub.args[0][0]).to.equal(
-        'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+        'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.'
       );
     });
 

--- a/packages/vaadin-overlay/test/renderer.test.js
+++ b/packages/vaadin-overlay/test/renderer.test.js
@@ -110,10 +110,30 @@ describe('renderer', () => {
       expect(overlay.template).to.be.not.ok;
     });
 
-    it('should be possible to manually invoke renderer', () => {
+    it('should run renderers when calling runRenderers()', () => {
       overlay.renderer = sinon.spy();
-      overlay.render();
+      overlay.runRenderers();
+
       expect(overlay.renderer.calledOnce).to.be.true;
+    });
+
+    it('should run renderers when calling deprecated render()', () => {
+      const stub = sinon.stub(overlay, 'runRenderers');
+      overlay.render();
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+    });
+
+    it('should warn when calling deprecated render()', () => {
+      const stub = sinon.stub(console, 'warn');
+      overlay.render();
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.args[0][0]).to.equal(
+        'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+      );
     });
 
     it('should not render if overlay is not open', () => {

--- a/packages/vaadin-overlay/test/renderer.test.js
+++ b/packages/vaadin-overlay/test/renderer.test.js
@@ -110,7 +110,7 @@ describe('renderer', () => {
       expect(overlay.template).to.be.not.ok;
     });
 
-    it('should run renderers when calling runRenderers()', () => {
+    it('should run renderers manually', () => {
       overlay.renderer = sinon.spy();
       overlay.runRenderers();
 

--- a/packages/vaadin-select/src/vaadin-select.d.ts
+++ b/packages/vaadin-select/src/vaadin-select.d.ts
@@ -169,7 +169,7 @@ declare class SelectElement extends ElementMixin(ControlStateMixin(ThemableMixin
   ready(): void;
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the select.
    */
   runRenderers(): void;
 

--- a/packages/vaadin-select/src/vaadin-select.d.ts
+++ b/packages/vaadin-select/src/vaadin-select.d.ts
@@ -169,7 +169,14 @@ declare class SelectElement extends ElementMixin(ControlStateMixin(ThemableMixin
   ready(): void;
 
   /**
+   * Runs all the renderers to possibly update the content.
+   */
+  runRenderers(): void;
+
+  /**
    * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-select/src/vaadin-select.d.ts
+++ b/packages/vaadin-select/src/vaadin-select.d.ts
@@ -169,14 +169,17 @@ declare class SelectElement extends ElementMixin(ControlStateMixin(ThemableMixin
   ready(): void;
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the select.
+   * Requests an update for the content of the select.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers(): void;
+  requestContentUpdate(): void;
 
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render(): void;
 

--- a/packages/vaadin-select/src/vaadin-select.js
+++ b/packages/vaadin-select/src/vaadin-select.js
@@ -365,7 +365,7 @@ class SelectElement extends ElementMixin(
   }
 
   /**
-   * Runs all the renderers to possibly update the content.
+   * Runs the renderer passed in the `renderer` property to update the content of the select.
    */
   runRenderers() {
     this._overlayElement.runRenderers();

--- a/packages/vaadin-select/src/vaadin-select.js
+++ b/packages/vaadin-select/src/vaadin-select.js
@@ -365,13 +365,25 @@ class SelectElement extends ElementMixin(
   }
 
   /**
-   * Manually invoke existing renderer.
+   * Runs all the renderers to possibly update the content.
    */
-  render() {
+  runRenderers() {
     this._overlayElement.runRenderers();
+
     if (this._menuElement && this._menuElement.items) {
       this._updateSelectedItem(this.value, this._menuElement.items);
     }
+  }
+
+  /**
+   * Manually invoke existing renderer.
+   *
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   */
+  render() {
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+
+    this.runRenderers();
   }
 
   /** @private */
@@ -382,7 +394,7 @@ class SelectElement extends ElementMixin(
 
     overlay.setProperties({ owner: this, renderer });
 
-    this.render();
+    this.runRenderers();
 
     if (renderer) {
       this._assignMenuElement();

--- a/packages/vaadin-select/src/vaadin-select.js
+++ b/packages/vaadin-select/src/vaadin-select.js
@@ -368,7 +368,7 @@ class SelectElement extends ElementMixin(
    * Manually invoke existing renderer.
    */
   render() {
-    this._overlayElement.render();
+    this._overlayElement.runRenderers();
     if (this._menuElement && this._menuElement.items) {
       this._updateSelectedItem(this.value, this._menuElement.items);
     }

--- a/packages/vaadin-select/src/vaadin-select.js
+++ b/packages/vaadin-select/src/vaadin-select.js
@@ -365,10 +365,13 @@ class SelectElement extends ElementMixin(
   }
 
   /**
-   * Runs the renderer passed in the `renderer` property to update the content of the select.
+   * Requests an update for the content of the select.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
-  runRenderers() {
-    this._overlayElement.runRenderers();
+  requestContentUpdate() {
+    this._overlayElement.requestContentUpdate();
 
     if (this._menuElement && this._menuElement.items) {
       this._updateSelectedItem(this.value, this._menuElement.items);
@@ -378,12 +381,12 @@ class SelectElement extends ElementMixin(
   /**
    * Manually invoke existing renderer.
    *
-   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `runRenderers()` instead.
+   * @deprecated Since Vaadin 21, `render()` is deprecated. Please use `requestContentUpdate()` instead.
    */
   render() {
-    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.');
+    console.warn('WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.');
 
-    this.runRenderers();
+    this.requestContentUpdate();
   }
 
   /** @private */
@@ -394,7 +397,7 @@ class SelectElement extends ElementMixin(
 
     overlay.setProperties({ owner: this, renderer });
 
-    this.runRenderers();
+    this.requestContentUpdate();
 
     if (renderer) {
       this._assignMenuElement();

--- a/packages/vaadin-select/test/renderer.test.js
+++ b/packages/vaadin-select/test/renderer.test.js
@@ -54,7 +54,6 @@ describe('renderer', () => {
     select.opened = true;
 
     select.renderer.resetHistory();
-
     select.runRenderers();
 
     expect(select.renderer.calledOnce).to.be.true;

--- a/packages/vaadin-select/test/renderer.test.js
+++ b/packages/vaadin-select/test/renderer.test.js
@@ -49,7 +49,7 @@ describe('renderer', () => {
     };
   });
 
-  it('should run renderers when calling runRenderers()', () => {
+  it('should run renderers manually', () => {
     select.renderer = sinon.spy();
     select.opened = true;
 

--- a/packages/vaadin-select/test/renderer.test.js
+++ b/packages/vaadin-select/test/renderer.test.js
@@ -49,18 +49,18 @@ describe('renderer', () => {
     };
   });
 
-  it('should run renderers manually', () => {
+  it('should run renderers when requesting content update', () => {
     select.renderer = sinon.spy();
     select.opened = true;
 
     select.renderer.resetHistory();
-    select.runRenderers();
+    select.requestContentUpdate();
 
     expect(select.renderer.calledOnce).to.be.true;
   });
 
-  it('should run renderers when calling deprecated render()', () => {
-    const stub = sinon.stub(select, 'runRenderers');
+  it('should request content update when calling deprecated render()', () => {
+    const stub = sinon.stub(select, 'requestContentUpdate');
     select.opened = true;
     select.render();
     stub.restore();
@@ -76,7 +76,7 @@ describe('renderer', () => {
 
     expect(stub.calledOnce).to.be.true;
     expect(stub.args[0][0]).to.equal(
-      'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+      'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.'
     );
   });
 
@@ -85,7 +85,7 @@ describe('renderer', () => {
     await nextFrame();
     select.value = 'bar';
     select.__testVar = 'baz';
-    select.runRenderers();
+    select.requestContentUpdate();
     await nextFrame();
     expect(select._menuElement.selected).to.be.equal(1);
     expect(select._valueElement.textContent.trim()).to.be.equal('barbaz');

--- a/packages/vaadin-select/test/renderer.test.js
+++ b/packages/vaadin-select/test/renderer.test.js
@@ -49,12 +49,36 @@ describe('renderer', () => {
     };
   });
 
-  it('should be possible to manually invoke renderer', () => {
-    const spy = (select.renderer = sinon.spy());
+  it('should run renderers when calling runRenderers()', () => {
+    select.renderer = sinon.spy();
     select.opened = true;
-    spy.resetHistory();
+
+    select.renderer.resetHistory();
+
+    select.runRenderers();
+
+    expect(select.renderer.calledOnce).to.be.true;
+  });
+
+  it('should run renderers when calling deprecated render()', () => {
+    const stub = sinon.stub(select, 'runRenderers');
+    select.opened = true;
     select.render();
-    expect(spy.callCount).to.equal(1);
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+  });
+
+  it('should warn when calling deprecated render()', () => {
+    const stub = sinon.stub(console, 'warn');
+    select.opened = true;
+    select.render();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.args[0][0]).to.equal(
+      'WARNING: Since Vaadin 21, render() is deprecated. Please use runRenderers() instead.'
+    );
   });
 
   it('should update selected value after renderer is called', async () => {
@@ -62,7 +86,7 @@ describe('renderer', () => {
     await nextFrame();
     select.value = 'bar';
     select.__testVar = 'baz';
-    select.render();
+    select.runRenderers();
     await nextFrame();
     expect(select._menuElement.selected).to.be.equal(1);
     expect(select._valueElement.textContent.trim()).to.be.equal('barbaz');

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -9,6 +9,7 @@ const HIDDEN_WARNINGS = [
   'PositionMixin is not considered stable and might change any time',
   'WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.',
   'WARNING: Since Vaadin 21, render() is deprecated. The items value is immutable. Please replace it with a new value instead of mutating in place.',
+  'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.',
   /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/
 ];
 


### PR DESCRIPTION
## Description

LitElement reserves the `render()` method to return `TemplateResult` so we cannot use it to run renderers anymore.

This PR deprecates `render()` and introduces `requestContentUpdate()` instead. 

**Difference:**
- `render()` **did** guarantee that rendering happens immediately after the method is called.
- `requestContentUpdate()` **does not** guarantee that rendering happens immediately (synchronously) after the method is called.

**Components:**
- [x] `vaadin-overlay`
- [x] `vaadin-dialog`
- [x] `vaadin-context-menu`
- [x] `vaadin-select`
- [x] `vaadin-notification`
- [x] `vaadin-combo-box`

Fixes #73.

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
