### PR TITLE
feat: deprecate update() in favor of updateConfiguration()

### DIFF
--- a/packages/vaadin-charts/src/interfaces.d.ts
+++ b/packages/vaadin-charts/src/interfaces.d.ts
@@ -168,7 +168,7 @@ export type ChartPointSelectEvent = CustomEvent<{ point: Point; originalEvent: C
 export type ChartPointUnselectEvent = CustomEvent<{ point: Point; originalEvent: ChartPointEvent }>;
 
 /**
- * Fired when the point is updated programmatically through `.update()` method.
+ * Fired when the point is updated programmatically through `.updateConfiguration()` method.
  */
 export type ChartPointUpdateEvent = CustomEvent<{ point: Point; originalEvent: ChartPointEvent }>;
 

--- a/packages/vaadin-charts/src/vaadin-chart.d.ts
+++ b/packages/vaadin-charts/src/vaadin-chart.d.ts
@@ -174,7 +174,7 @@ import { ChartCategories, ChartCategoryPosition, ChartEventMap, ChartStacking } 
  * @fires {CustomEvent} point-remove - Fired when the point is removed from the series.
  * @fires {CustomEvent} point-select -Fired when the point is selected either programmatically or by clicking on the point.
  * @fires {CustomEvent} point-unselect - Fired when the point is unselected either programmatically or by clicking on the point.
- * @fires {CustomEvent} point-update - Fired when the point is updated programmatically through `.update()` method.
+ * @fires {CustomEvent} point-update - Fired when the point is updated programmatically through `.updateConfiguration()` method.
  * @fires {CustomEvent} xaxes-extremes-set - Fired when when the minimum and maximum is set for the X axis.
  * @fires {CustomEvent} yaxes-extremes-set - Fired when when the minimum and maximum is set for the Y axis.
  */
@@ -331,7 +331,7 @@ declare class ChartElement extends ThemableMixin(ElementMixin(HTMLElement)) {
    * Styling properties specified in this configuration will be ignored. To learn about chart styling
    * please see the CSS Styling section above.
    *
-   * @param jsonConfiguration Object chart configuration. Most important properties are:
+   * @param {!Options} jsonConfiguration Object chart configuration. Most important properties are:
    *
    * - chart `Object` with options regarding the chart area and plot area as well as general chart options.
    *    Detailed API for chart object is available in [API Site](http://api.highcharts.com/highcharts/chart)
@@ -355,8 +355,48 @@ declare class ChartElement extends ThemableMixin(ElementMixin(HTMLElement)) {
    *    Detailed API for yAxis object is available in [API Site](http://api.highcharts.com/highcharts/yAxis)
    * - zAxis `Object[]` The Z axis or depth axis for 3D plots.
    *    Detailed API for zAxis object is available in [API Site](http://api.highcharts.com/highcharts/zAxis)
-   * @param resetConfiguration Optional boolean that should be set to true if no other chart configuration was set before or
+   *
+   * @param {boolean=} resetConfiguration Optional boolean that should be set to true if no other chart configuration was set before or
    *    if existing configuration should be discarded.
+   */
+  updateConfiguration(jsonConfiguration: Options, resetConfiguration?: boolean): void;
+
+  /**
+   * Update the chart configuration.
+   * This JSON API provides a simple single-argument alternative to the configuration property.
+   *
+   * Styling properties specified in this configuration will be ignored. To learn about chart styling
+   * please see the CSS Styling section above.
+   *
+   * @param {!Options} jsonConfiguration Object chart configuration. Most important properties are:
+   *
+   * - chart `Object` with options regarding the chart area and plot area as well as general chart options.
+   *    Detailed API for chart object is available in [API Site](http://api.highcharts.com/highcharts/chart)
+   * - credits `Object` with options regarding the chart area and plot area as well as general chart options.
+   *    Detailed API for credits object is available in [API Site](http://api.highcharts.com/highcharts/credits)
+   * - labels `Object[]` with HTML labels that can be positioned anywhere in the chart area
+   *    Detailed API for labels object is available in [API Site](http://api.highcharts.com/highcharts/labels)
+   * - plotOptions `Object` wrapper for config objects for each series type.
+   *    Detailed API for plotOptions object is available in [API Site](http://api.highcharts.com/highcharts/plotOptions)
+   * - series `Object[]` the actual series to append to the chart.
+   *    Detailed API for series object is available in [API Site](http://api.highcharts.com/highcharts/series)
+   * - subtitle `Object` the chart's subtitle.
+   *    Detailed API for subtitle object is available in [API Site](http://api.highcharts.com/highcharts/subtitle)
+   * - title `Object` the chart's main title.
+   *    Detailed API for title object is available in [API Site](http://api.highcharts.com/highcharts/title)
+   * - tooltip `Object` Options for the tooltip that appears when the user hovers over a series or point.
+   *    Detailed API for tooltip object is available in [API Site](http://api.highcharts.com/highcharts/tooltip)
+   * - xAxis `Object[]` The X axis or category axis. Normally this is the horizontal axis.
+   *    Detailed API for xAxis object is available in [API Site](http://api.highcharts.com/highcharts/xAxis)
+   * - yAxis `Object[]` The Y axis or value axis. Normally this is the vertical axis.
+   *    Detailed API for yAxis object is available in [API Site](http://api.highcharts.com/highcharts/yAxis)
+   * - zAxis `Object[]` The Z axis or depth axis for 3D plots.
+   *    Detailed API for zAxis object is available in [API Site](http://api.highcharts.com/highcharts/zAxis)
+   *
+   * @param {boolean=} resetConfiguration Optional boolean that should be set to true if no other chart configuration was set before or
+   *    if existing configuration should be discarded.
+   *
+   * @deprecated Since Vaadin 21, `update()` is deprecated. Please use `updateConfiguration()` instead.
    */
   update(jsonConfiguration: Options, resetConfiguration?: boolean): void;
 

--- a/packages/vaadin-charts/src/vaadin-chart.d.ts
+++ b/packages/vaadin-charts/src/vaadin-chart.d.ts
@@ -68,10 +68,10 @@ import { ChartCategories, ChartCategoryPosition, ChartEventMap, ChartStacking } 
  * ```html
  *     <vaadin-chart id="mychart"></vaadin-chart>
  * ```
- * 1. Add a function that uses `update` method (JS JSON Api) to set chart title, categories and data
+ * 1. Add a function that uses `updateConfiguration` method (JS JSON Api) to set chart title, categories and data
  * ```js
  * initChartWithJSJSONApi() {
- *     this.$.mychart.update({
+ *     this.$.mychart.updateConfiguration({
  *       title: {
  *         text: 'The chart title'
  *       },

--- a/packages/vaadin-charts/src/vaadin-chart.js
+++ b/packages/vaadin-charts/src/vaadin-chart.js
@@ -120,10 +120,10 @@ export const deepMerge = function deepMerge(target, source) {
  * ```html
  *     <vaadin-chart id="mychart"></vaadin-chart>
  * ```
- * 1. Add a function that uses `update` method (JS JSON Api) to set chart title, categories and data
+ * 1. Add a function that uses `updateConfiguration` method (JS JSON Api) to set chart title, categories and data
  * ```js
  * initChartWithJSJSONApi() {
- *     this.$.mychart.update({
+ *     this.$.mychart.updateConfiguration({
  *       title: {
  *         text: 'The chart title'
  *       },

--- a/packages/vaadin-charts/src/vaadin-chart.js
+++ b/packages/vaadin-charts/src/vaadin-chart.js
@@ -226,7 +226,7 @@ export const deepMerge = function deepMerge(target, source) {
  * @fires {CustomEvent} point-remove - Fired when the point is removed from the series.
  * @fires {CustomEvent} point-select -Fired when the point is selected either programmatically or by clicking on the point.
  * @fires {CustomEvent} point-unselect - Fired when the point is unselected either programmatically or by clicking on the point.
- * @fires {CustomEvent} point-update - Fired when the point is updated programmatically through `.update()` method.
+ * @fires {CustomEvent} point-update - Fired when the point is updated programmatically through `.updateConfiguration()` method.
  * @fires {CustomEvent} xaxes-extremes-set - Fired when when the minimum and maximum is set for the X axis.
  * @fires {CustomEvent} yaxes-extremes-set - Fired when when the minimum and maximum is set for the Y axis.
  *
@@ -885,7 +885,7 @@ class ChartElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       unselect: 'point-unselect',
 
       /**
-       * Fired when the point is updated programmatically through `.update()` method.
+       * Fired when the point is updated programmatically through `.updateConfiguration()` method.
        * @event point-update
        * @param {Object} detail.originalEvent object with details about the event sent
        * @param {Object} point Point object where the event was sent from
@@ -1133,7 +1133,7 @@ class ChartElement extends ElementMixin(ThemableMixin(PolymerElement)) {
    * @param {boolean=} resetConfiguration Optional boolean that should be set to true if no other chart configuration was set before or
    *    if existing configuration should be discarded.
    */
-  update(jsonConfiguration, resetConfiguration) {
+  updateConfiguration(jsonConfiguration, resetConfiguration) {
     if (resetConfiguration || !this._jsonConfigurationBuffer) {
       this._jsonConfigurationBuffer = {};
     }
@@ -1171,6 +1171,49 @@ class ChartElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       }
       this._jsonConfigurationBuffer = null;
     });
+  }
+
+  /**
+   * Update the chart configuration.
+   * This JSON API provides a simple single-argument alternative to the configuration property.
+   *
+   * Styling properties specified in this configuration will be ignored. To learn about chart styling
+   * please see the CSS Styling section above.
+   *
+   * @param {!Options} jsonConfiguration Object chart configuration. Most important properties are:
+   *
+   * - chart `Object` with options regarding the chart area and plot area as well as general chart options.
+   *    Detailed API for chart object is available in [API Site](http://api.highcharts.com/highcharts/chart)
+   * - credits `Object` with options regarding the chart area and plot area as well as general chart options.
+   *    Detailed API for credits object is available in [API Site](http://api.highcharts.com/highcharts/credits)
+   * - labels `Object[]` with HTML labels that can be positioned anywhere in the chart area
+   *    Detailed API for labels object is available in [API Site](http://api.highcharts.com/highcharts/labels)
+   * - plotOptions `Object` wrapper for config objects for each series type.
+   *    Detailed API for plotOptions object is available in [API Site](http://api.highcharts.com/highcharts/plotOptions)
+   * - series `Object[]` the actual series to append to the chart.
+   *    Detailed API for series object is available in [API Site](http://api.highcharts.com/highcharts/series)
+   * - subtitle `Object` the chart's subtitle.
+   *    Detailed API for subtitle object is available in [API Site](http://api.highcharts.com/highcharts/subtitle)
+   * - title `Object` the chart's main title.
+   *    Detailed API for title object is available in [API Site](http://api.highcharts.com/highcharts/title)
+   * - tooltip `Object` Options for the tooltip that appears when the user hovers over a series or point.
+   *    Detailed API for tooltip object is available in [API Site](http://api.highcharts.com/highcharts/tooltip)
+   * - xAxis `Object[]` The X axis or category axis. Normally this is the horizontal axis.
+   *    Detailed API for xAxis object is available in [API Site](http://api.highcharts.com/highcharts/xAxis)
+   * - yAxis `Object[]` The Y axis or value axis. Normally this is the vertical axis.
+   *    Detailed API for yAxis object is available in [API Site](http://api.highcharts.com/highcharts/yAxis)
+   * - zAxis `Object[]` The Z axis or depth axis for 3D plots.
+   *    Detailed API for zAxis object is available in [API Site](http://api.highcharts.com/highcharts/zAxis)
+   *
+   * @param {boolean=} resetConfiguration Optional boolean that should be set to true if no other chart configuration was set before or
+   *    if existing configuration should be discarded.
+   *
+   * @deprecated Since Vaadin 21, `update()` is deprecated. Please use `updateConfiguration()` instead.
+   */
+  update(jsonConfiguration, resetConfiguration) {
+    console.warn('WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.');
+
+    this.updateConfiguration(jsonConfiguration, resetConfiguration);
   }
 
   /** @private */
@@ -1568,7 +1611,7 @@ class ChartElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   /** @private */
   __updateAdditionalOptions(options) {
     if (this.configuration && options.base) {
-      this.update(options.base);
+      this.updateConfiguration(options.base);
     }
   }
 

--- a/packages/vaadin-charts/test/chart-element.test.js
+++ b/packages/vaadin-charts/test/chart-element.test.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
@@ -53,7 +54,7 @@ describe('vaadin-chart', () => {
     });
 
     it('should set a chart title using update', async () => {
-      chart.update({ title: { text: 'Awesome chart' } });
+      chart.updateConfiguration({ title: { text: 'Awesome chart' } });
       document.body.appendChild(chart);
       await oneEvent(chart, 'chart-load');
       expect(chart.$.chart.querySelector('.highcharts-title > tspan').textContent).to.equal('Awesome chart');
@@ -120,7 +121,7 @@ describe('vaadin-chart', () => {
     });
 
     it('should set chart title using update', async () => {
-      chart.update({ title: { text: 'Custom title' } });
+      chart.updateConfiguration({ title: { text: 'Custom title' } });
       await oneEvent(chart, 'chart-redraw');
       const title = chart.$.chart.querySelector('.highcharts-title > tspan');
       expect(title).to.be.ok;
@@ -128,7 +129,7 @@ describe('vaadin-chart', () => {
     });
 
     it('should create chart series using update', async () => {
-      chart.update({
+      chart.updateConfiguration({
         series: [
           {
             type: 'column',
@@ -144,7 +145,7 @@ describe('vaadin-chart', () => {
     });
 
     it('should set chart categories using update', async () => {
-      chart.update({
+      chart.updateConfiguration({
         xAxis: {
           categories: MONTHS
         },
@@ -162,12 +163,33 @@ describe('vaadin-chart', () => {
     });
 
     it('should clear chart title using reset flag', async () => {
-      chart.update({ title: { text: 'Custom title' } });
-      chart.update({}, true);
+      chart.updateConfiguration({ title: { text: 'Custom title' } });
+      chart.updateConfiguration({}, true);
       await oneEvent(chart, 'chart-redraw');
       const title = chart.$.chart.querySelector('.highcharts-title');
       expect(title).to.be.ok;
       expect(title.textContent).to.be.empty;
+    });
+
+    it('should call updateConfiguration() when calling deprecated update()', () => {
+      const stub = sinon.stub(chart, 'updateConfiguration');
+      chart.update({}, true);
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.args[0][0]).to.be.an('object');
+      expect(stub.args[0][1]).to.be.true;
+    });
+
+    it('should warn when calling deprecated update()', () => {
+      const stub = sinon.stub(console, 'warn');
+      chart.update({}, true);
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.args[0][0]).to.equal(
+        'WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.'
+      );
     });
   });
 
@@ -200,7 +222,7 @@ describe('vaadin-chart', () => {
     });
 
     it('should apply options passed using update', async () => {
-      chart.update({
+      chart.updateConfiguration({
         series: [
           {
             name: 'series-name'
@@ -213,14 +235,14 @@ describe('vaadin-chart', () => {
     });
 
     it('should preserve configuration on multiple update calls', async () => {
-      chart.update({
+      chart.updateConfiguration({
         series: [
           {
             innerSize: 40
           }
         ]
       });
-      chart.update({
+      chart.updateConfiguration({
         series: [
           {
             name: 'name of the series',
@@ -236,10 +258,10 @@ describe('vaadin-chart', () => {
     });
 
     it('should handle merging multiple series', async () => {
-      chart.update({
+      chart.updateConfiguration({
         series: [{ name: 'series 1' }, { name: 'series 2' }]
       });
-      chart.update({
+      chart.updateConfiguration({
         series: [null, { innerSize: 100 }]
       });
       await oneEvent(chart, 'chart-redraw');
@@ -332,13 +354,13 @@ describe('vaadin-chart', () => {
     });
 
     it('should apply configuration update when attached to a new parent', async () => {
-      chart.update({ title: { text: 'Awesome title' }, credits: { enabled: false } });
+      chart.updateConfiguration({ title: { text: 'Awesome title' }, credits: { enabled: false } });
       await oneEvent(chart, 'chart-redraw');
       expect(chart.$.chart.querySelector('.highcharts-title > tspan').textContent).to.equal('Awesome title');
       expect(chart.$.chart.querySelector('.highcharts-credits')).to.be.null;
 
       wrapper.removeChild(chart);
-      chart.update({ subtitle: { text: 'Awesome subtitle' }, credits: { enabled: true, text: 'Vaadin' } });
+      chart.updateConfiguration({ subtitle: { text: 'Awesome subtitle' }, credits: { enabled: true, text: 'Vaadin' } });
 
       inner.appendChild(chart);
       await oneEvent(chart, 'chart-redraw');

--- a/packages/vaadin-charts/test/chart-properties.test.js
+++ b/packages/vaadin-charts/test/chart-properties.test.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
@@ -261,6 +262,15 @@ describe('vaadin-chart properties', () => {
       chart.addEventListener('xaxes-extremes-set', extremesListener);
       chart.setAttribute('category-min', newCategoryMin);
     });
+
+    it('should warn when setting a not valid minimum value', () => {
+      const stub = sinon.stub(console, 'warn');
+      chart.categoryMin = 'invalid';
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.args[0][0]).to.equal('<vaadin-chart> Acceptable value for "category-min" are Numbers or null');
+    });
   });
 
   describe('category-max', () => {
@@ -289,6 +299,15 @@ describe('vaadin-chart properties', () => {
       }
       chart.addEventListener('xaxes-extremes-set', extremesListener);
       chart.setAttribute('category-max', newCategoryMax);
+    });
+
+    it('should warn when setting a not valid maximum value', () => {
+      const stub = sinon.stub(console, 'warn');
+      chart.categoryMax = 'invalid';
+      stub.restore();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.args[0][0]).to.equal('<vaadin-chart> Acceptable value for "category-max" are Numbers or null');
     });
   });
 

--- a/packages/vaadin-charts/test/chart-properties.test.js
+++ b/packages/vaadin-charts/test/chart-properties.test.js
@@ -21,7 +21,7 @@ describe('vaadin-chart properties', () => {
     });
 
     it('should not reset subtitle on update', async () => {
-      chart.update({ title: { text: 'Awesome chart' } });
+      chart.updateConfiguration({ title: { text: 'Awesome chart' } });
       await oneEvent(chart, 'chart-redraw');
       expect(chartContainer.querySelector('.highcharts-title > tspan').textContent).to.equal('Awesome chart');
       expect(chartContainer.querySelector('.highcharts-subtitle > tspan').textContent).to.equal('My subtitle');
@@ -195,7 +195,7 @@ describe('vaadin-chart properties', () => {
     });
 
     it('should have tooltips when tooltip is set using update', async () => {
-      chart.update({ tooltip: { enabled: true, pointFormat: 'custom' } });
+      chart.updateConfiguration({ tooltip: { enabled: true, pointFormat: 'custom' } });
       await aTimeout(50);
       expect(chart.configuration.tooltip.options.enabled).to.be.true;
     });
@@ -364,7 +364,7 @@ describe('vaadin-chart properties', () => {
       });
 
       it('should react to category position changes with multiple x-axes', async () => {
-        chart.update({
+        chart.updateConfiguration({
           xAxis: [
             {
               name: 'First',

--- a/packages/vaadin-charts/test/events.test.js
+++ b/packages/vaadin-charts/test/events.test.js
@@ -26,7 +26,7 @@ describe('vaadin-chart events', () => {
     it('should trigger chart-redraw event on update', async () => {
       const spy = sinon.spy();
       chart.addEventListener('chart-redraw', spy);
-      chart.update({
+      chart.updateConfiguration({
         chart: {
           type: 'column'
         }

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -7,6 +7,7 @@ const HIDDEN_WARNINGS = [
   '<vaadin-crud> Unable to autoconfigure form because the data structure is unknown. Either specify `include` or ensure at least one item is available beforehand.',
   'The <vaadin-grid> needs the total number of items in order to display rows. Set the total number of items to the `size` property, or provide the total number of items in the second argument of the `dataProvider`’s `callback` call.',
   'PositionMixin is not considered stable and might change any time',
+  'WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.',
   /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/
 ];
 


### PR DESCRIPTION
## Description

LitElement reserves the `update()` method so that we cannot use it to update chart configuration anymore.

This PR deprecates `update()` and introduces `updateConfiguration()` instead. Though calling `update()` still updates chart configuration, now it shows a deprecation warning as well.

Part of #73 (issue)

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
