### PR TITLE
fix: issue with grid when grid table body is clicked and enter key is hit

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -346,9 +346,9 @@ export const KeyboardNavigationMixin = (superClass) =>
     _parseEventPath(path) {
       const tableIndex = path.indexOf(this.$.table);
       return {
-        rowGroup: path[tableIndex - 1],
-        row: path[tableIndex - 2],
-        cell: path[tableIndex - 3]
+        rowGroup: tableIndex >= 3 ? path[tableIndex - 1] : null,
+        row: tableIndex >= 3 ? path[tableIndex - 2] : null,
+        cell: tableIndex >= 3 ? path[tableIndex - 3] : null
       };
     }
 
@@ -374,7 +374,7 @@ export const KeyboardNavigationMixin = (superClass) =>
 
       const { cell } = this._parseEventPath(e.composedPath());
 
-      if (this.interacting !== wantInteracting) {
+      if (this.interacting !== wantInteracting && cell !== null) {
         if (wantInteracting) {
           const focusTarget = cell._content.querySelector('[focus-target]') || cell._content.firstElementChild;
           if (focusTarget) {

--- a/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -345,10 +345,12 @@ export const KeyboardNavigationMixin = (superClass) =>
     /** @private */
     _parseEventPath(path) {
       const tableIndex = path.indexOf(this.$.table);
+      const inRange = tableIndex >= 3;
+
       return {
-        rowGroup: tableIndex >= 3 ? path[tableIndex - 1] : null,
-        row: tableIndex >= 3 ? path[tableIndex - 2] : null,
-        cell: tableIndex >= 3 ? path[tableIndex - 3] : null
+        rowGroup: inRange ? path[tableIndex - 1] : null,
+        row: inRange ? path[tableIndex - 2] : null,
+        cell: inRange ? path[tableIndex - 3] : null
       };
     }
 

--- a/packages/vaadin-grid/test/keyboard-navigation.test.js
+++ b/packages/vaadin-grid/test/keyboard-navigation.test.js
@@ -1882,6 +1882,13 @@ describe('keyboard navigation', () => {
 
       expect(grid.hasAttribute('interacting')).to.be.true;
     });
+
+    it('should not throw error when hit enter after focus on table body', () => {
+      expect(() => {
+        grid.$.items.focus();
+        enter(grid);
+      }).not.to.throw(Error);
+    });
   });
 
   describe('focus events on cell content', () => {


### PR DESCRIPTION
This PR solves the issue with the grid when the table body of the grid is clicked and enter key is hit, the error shows when no row of the table is selected, Or as in the mentioned in the issue when a row is clicked and empty area of the table is selected and enter key is hit.

Fixes: https://github.com/vaadin/flow-components/issues/1011

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
