### PR TITLE
chore: add utility classes to package.json files

### DIFF
--- a/packages/vaadin-lumo-styles/package.json
+++ b/packages/vaadin-lumo-styles/package.json
@@ -24,7 +24,8 @@
     "*.d.ts",
     "mixins/*.js",
     "mixins/*.d.ts",
-    "presets/*.js"
+    "presets/*.js",
+    "utilities/*.js"
   ],
   "scripts": {
     "icons": "gulp icons"


### PR DESCRIPTION
Individual files containing utility classes were not added to package.json, which means they would not be released.

Fixes #2147
