### PR TITLE
refactor: remove iron resizable behaviour from dialog

### DIFF
--- a/packages/vaadin-dialog/package.json
+++ b/packages/vaadin-dialog/package.json
@@ -25,7 +25,6 @@
     "theme"
   ],
   "dependencies": {
-    "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-element-mixin": "^21.0.0-alpha9",
     "@vaadin/vaadin-lumo-styles": "^21.0.0-alpha9",

--- a/packages/vaadin-dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog-resizable-mixin.js
@@ -213,8 +213,6 @@ export const DialogResizableMixin = (superClass) =>
             }
           }
         });
-
-        this.$.overlay.notifyResize();
       }
     }
 

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -4,8 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { OverlayElement } from '@vaadin/vaadin-overlay/src/vaadin-overlay.js';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import { processTemplates } from '@vaadin/vaadin-element-mixin/templates.js';
@@ -40,7 +38,7 @@ let memoizedTemplate;
  * @extends OverlayElement
  * @private
  */
-class DialogOverlayElement extends mixinBehaviors(IronResizableBehavior, OverlayElement) {
+class DialogOverlayElement extends OverlayElement {
   static get is() {
     return 'vaadin-dialog-overlay';
   }


### PR DESCRIPTION
## Description

It appears that `IronResizableBehaviour` is not actually used in `vaadin-dialog` and can be removed.

Part of #331 (issue)

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
