### PR TITLE
feat: deprecate render() for menu-bar

### DIFF
--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -136,11 +136,18 @@ export const ButtonsMixin = (superClass) =>
     /**
      * Call this method after updating menu bar `items` dynamically, including changing
      * any property on the item object corresponding to one of the menu bar buttons.
+     *
+     * @deprecated Since Vaadin 21, `render()` is deprecated. The `items` value is immutable. Please replace it with a new value instead of mutating in place.
      */
     render() {
+      console.warn(
+        'WARNING: Since Vaadin 21, render() is deprecated. The items value is immutable. Please replace it with a new value instead of mutating in place.'
+      );
+
       if (!this.shadowRoot) {
         return;
       }
+
       this.__renderButtons(this.items);
     }
 

--- a/packages/vaadin-menu-bar/test/menu-bar.test.js
+++ b/packages/vaadin-menu-bar/test/menu-bar.test.js
@@ -80,6 +80,25 @@ describe('root menu layout', () => {
     expect(() => document.createElement('vaadin-menu-bar').render()).to.not.throw(Error);
   });
 
+  it('should render buttons when calling deprecated render()', () => {
+    const stub = sinon.stub(menu, '__renderButtons');
+    menu.render();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+  });
+
+  it('should warn when calling deprecated render()', () => {
+    const stub = sinon.stub(console, 'warn');
+    menu.render();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.args[0][0]).to.equal(
+      'WARNING: Since Vaadin 21, render() is deprecated. The items value is immutable. Please replace it with a new value instead of mutating in place.'
+    );
+  });
+
   describe('keyboard navigation', () => {
     describe('default mode', () => {
       it('should move focus to next button on "arrow-right" keydown', () => {
@@ -107,8 +126,8 @@ describe('root menu layout', () => {
       });
 
       it('should move focus to second button if first is disabled on "home" keydown', () => {
-        menu.set('items.0.disabled', true);
-        menu.render();
+        menu.items[0].disabled = true;
+        menu.items = [...menu.items];
         buttons = menu._buttons;
         buttons[3].focus();
         const spy = sinon.spy(buttons[1], 'focus');
@@ -126,8 +145,8 @@ describe('root menu layout', () => {
       });
 
       it('should move focus to the closest enabled button if last is disabled on "end" keydown', () => {
-        menu.set('items.3.disabled', true);
-        menu.render();
+        menu.items[3].disabled = true;
+        menu.items = [...menu.items];
         buttons = menu._buttons;
         buttons[0].focus();
         const spy = sinon.spy(buttons[1], 'focus');

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -8,6 +8,7 @@ const HIDDEN_WARNINGS = [
   'The <vaadin-grid> needs the total number of items in order to display rows. Set the total number of items to the `size` property, or provide the total number of items in the second argument of the `dataProvider`’s `callback` call.',
   'PositionMixin is not considered stable and might change any time',
   'WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.',
+  'WARNING: Since Vaadin 21, render() is deprecated. The items value is immutable. Please replace it with a new value instead of mutating in place.',
   /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/
 ];
 


### PR DESCRIPTION
## Description

LitElement reserves the `render()` method to return TemplateResult so we cannot use it for re-rendering `vaadin-menu-bar` anymore.

This PR deprecates `render()` for `vaadin-menu-bar` and supposes it to be removed later.

Part of #73

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
