### PR TITLE
feat: expose icon ids of iconsets for outside use

### DIFF
--- a/packages/vaadin-icon/src/vaadin-iconset.js
+++ b/packages/vaadin-icon/src/vaadin-iconset.js
@@ -79,27 +79,20 @@ class IconsetElement extends ElementMixin(PolymerElement) {
   }
 
   /**
+   * An array of icon ids defined in the iconset.
+   */
+  get icons() {
+    return Object.keys(this.__iconMap);
+  }
+
+  /**
    * Produce SVGTemplateResult for the element matching `name` in this
    * iconset, or `undefined` if there is no matching element.
    *
    * @param {string} name
    */
   applyIcon(name) {
-    // create the icon map on-demand, since the iconset itself has no discrete
-    // signal to know when it's children are fully parsed
-    this._icons = this._icons || this.__createIconMap();
-    return { svg: cloneSvgNode(this._icons[this.__getIconId(name)]), size: this.size };
-  }
-
-  /**
-   * Create a map of child SVG elements by id.
-   */
-  __createIconMap() {
-    const icons = {};
-    this.querySelectorAll('[id]').forEach((icon) => {
-      icons[this.__getIconId(icon.id)] = icon;
-    });
-    return icons;
+    return { svg: cloneSvgNode(this.__iconMap[this.__getIconId(name)]), size: this.size };
   }
 
   /** @private */
@@ -117,6 +110,32 @@ class IconsetElement extends ElementMixin(PolymerElement) {
       iconRegistry[name] = this;
       document.dispatchEvent(new CustomEvent('vaadin-iconset-registered', { detail: name }));
     }
+  }
+
+  /**
+   * Create a map of child SVG elements by id.
+   *
+   * @private
+   */
+  __createIconMap() {
+    const icons = {};
+    this.querySelectorAll('[id]').forEach((icon) => {
+      icons[this.__getIconId(icon.id)] = icon;
+    });
+    return icons;
+  }
+
+  /**
+   * The icon map created on-demand, since the iconset itself has no discrete
+   * signal to know when it's children are fully parsed.
+   * The getter caches the resulting map once it is created.
+   *
+   * @private
+   */
+  get __iconMap() {
+    this.__cachedIconMap = this.__cachedIconMap || this.__createIconMap();
+
+    return this.__cachedIconMap;
   }
 }
 

--- a/packages/vaadin-icon/test/iconset.test.js
+++ b/packages/vaadin-icon/test/iconset.test.js
@@ -19,6 +19,12 @@ describe('vaadin-iconset', () => {
     `);
   });
 
+  describe('icons', () => {
+    it('should return the array of icon ids', () => {
+      expect(iconset.icons).to.deep.equal(['caret-down', 'caret-up']);
+    });
+  });
+
   describe('applyIcon', () => {
     it('should return svg literal when called with correct id', () => {
       const { svg } = iconset.applyIcon('caret-down');


### PR DESCRIPTION
## Description

Currently, there is no way to get the list containing all the icon ids of an icon set when using `vaadin-iconset`. Previously, it was possible to get such a list using the `iron-meta` package.

This PR introduces the `icons` method that returns the list of icon ids to further use in the `docs` repo for [the icons preview page](https://github.com/vaadin/docs/blob/312acbc7aa4d07eb76aa3335fefaf2c04c708453/frontend/demo/foundation/icons-preview.ts). 

Part of #2112 (issue)

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
