### PR TITLE
feat: add context to event data and update relevant types.

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -519,8 +519,11 @@ export const KeyboardNavigationMixin = (superClass) =>
         // Inform cell content of the focus (used in <vaadin-grid-sorter>)
         cell._content.dispatchEvent(new CustomEvent('cell-focusin', { bubbles: false }));
 
-        // Fire a public event for cell focus.
-        cell.dispatchEvent(new CustomEvent('cell-focus', { bubbles: true, composed: true }));
+        const context = this.getEventContext(e);
+        // Fire a public event for cell.
+        cell.dispatchEvent(
+          new CustomEvent('cell-focus', { bubbles: true, composed: true, detail: { context: context } })
+        );
       }
 
       this._detectFocusedItemIndex(e);
@@ -719,7 +722,7 @@ export const KeyboardNavigationMixin = (superClass) =>
     /**
      * Fired when a cell is focused with click or keyboard navigation.
      *
-     * Use {@see GridElement#getEventContext} to get detailed information about the event.
+     * Use context property of @type {GridCellFocusEvent} to get detail information about the event.
      *
      * @event cell-focus
      */

--- a/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -519,8 +519,8 @@ export const KeyboardNavigationMixin = (superClass) =>
         // Inform cell content of the focus (used in <vaadin-grid-sorter>)
         cell._content.dispatchEvent(new CustomEvent('cell-focusin', { bubbles: false }));
 
-        const context = this.getEventContext(e);
         // Fire a public event for cell.
+        const context = this.getEventContext(e);
         cell.dispatchEvent(
           new CustomEvent('cell-focus', { bubbles: true, composed: true, detail: { context: context } })
         );
@@ -722,7 +722,7 @@ export const KeyboardNavigationMixin = (superClass) =>
     /**
      * Fired when a cell is focused with click or keyboard navigation.
      *
-     * Use context property of @type {GridCellFocusEvent} to get detail information about the event.
+     * Use context property of @see {@link GridCellFocusEvent} to get detail information about the event.
      *
      * @event cell-focus
      */

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -2,7 +2,7 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
 
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-import { GridDefaultItem, GridDropLocation, GridItemModel } from './interfaces';
+import { GridDefaultItem, GridDropLocation, GridEventContext, GridItemModel } from './interfaces';
 
 import { A11yMixin } from './vaadin-grid-a11y-mixin.js';
 
@@ -51,7 +51,7 @@ export type GridCellActivateEvent<TItem> = CustomEvent<{ model: GridItemModel<TI
 /**
  * Fired when a cell is focused with click or keyboard navigation.
  */
-export type GridCellFocusEvent = CustomEvent;
+export type GridCellFocusEvent<TItem> = CustomEvent<{ context: GridEventContext<TItem> }>;
 
 /**
  * Fired when the columns in the grid are reordered.
@@ -101,7 +101,7 @@ export interface GridElementEventMap<TItem> {
 
   'cell-activate': GridCellActivateEvent<TItem>;
 
-  'cell-focus': GridCellFocusEvent;
+  'cell-focus': GridCellFocusEvent<TItem>;
 
   'column-reorder': GridColumnReorderEvent<TItem>;
 

--- a/packages/vaadin-grid/test/keyboard-navigation.test.js
+++ b/packages/vaadin-grid/test/keyboard-navigation.test.js
@@ -1976,20 +1976,28 @@ describe('keyboard navigation', () => {
       tabToBody();
       right();
 
-      const spy = sinon.spy();
-
+      let detail = null;
       const eventHandler = (e) => {
-        spy();
+        detail = e.detail;
 
-        expect(e.detail).not.to.be.empty;
+        expect(e.detail.context).not.to.be.undefined;
+        expect(e.detail.context).to.be.deep.equal({
+          column: grid.querySelector('vaadin-grid-column'),
+          detailsOpened: false,
+          expanded: false,
+          index: 0,
+          item: 'foo',
+          level: 0,
+          section: 'body',
+          selected: false
+        });
         done();
       };
-
       grid.addEventListener('cell-focus', eventHandler);
 
       left();
 
-      expect(spy.calledOnce).to.be.true;
+      expect(detail).not.to.be.null;
 
       grid.removeEventListener('cell-focus', eventHandler);
     });

--- a/packages/vaadin-grid/test/keyboard-navigation.test.js
+++ b/packages/vaadin-grid/test/keyboard-navigation.test.js
@@ -1984,6 +1984,7 @@ describe('keyboard navigation', () => {
 
       const e = spy.firstCall.args[0];
 
+      expect(spy.calledOnce).to.be.true;
       expect(e.detail.context).to.be.deep.equal({
         column: grid.querySelector('vaadin-grid-column'),
         detailsOpened: false,
@@ -1994,7 +1995,6 @@ describe('keyboard navigation', () => {
         section: 'body',
         selected: false
       });
-      expect(spy.callCount).to.be.equal(1);
 
       grid.removeEventListener('cell-focus', spy);
     });

--- a/packages/vaadin-grid/test/keyboard-navigation.test.js
+++ b/packages/vaadin-grid/test/keyboard-navigation.test.js
@@ -1939,7 +1939,7 @@ describe('keyboard navigation', () => {
       expect(spy.callCount).to.equal(1);
     });
 
-    it('should dispatch cell-focus on keyboard navigation', (done) => {
+    it('should dispatch cell-focus on keyboard navigation', () => {
       const expectedContext = {
         column: grid.querySelector('vaadin-grid-column'),
         detailsOpened: false,
@@ -1956,45 +1956,15 @@ describe('keyboard navigation', () => {
 
       const spy = sinon.spy();
 
-      const eventHandler = (e) => {
-        spy();
-
-        const context = e.target.getEventContext(e);
-        expect(context).to.deep.equal(expectedContext);
-        done();
-      };
-
-      grid.addEventListener('cell-focus', eventHandler);
-
-      left();
-
-      expect(spy.calledOnce).to.be.true;
-      grid.removeEventListener('cell-focus', eventHandler);
-    });
-
-    it('should contain event context in event detail', () => {
-      tabToBody();
-      right();
-
-      const spy = sinon.spy();
-
       grid.addEventListener('cell-focus', spy);
 
       left();
 
+      expect(spy.calledOnce).to.be.true;
+
       const e = spy.firstCall.args[0];
 
-      expect(spy.calledOnce).to.be.true;
-      expect(e.detail.context).to.be.deep.equal({
-        column: grid.querySelector('vaadin-grid-column'),
-        detailsOpened: false,
-        expanded: false,
-        index: 0,
-        item: 'foo',
-        level: 0,
-        section: 'body',
-        selected: false
-      });
+      expect(e.detail.context).to.be.deep.equal(expectedContext);
 
       grid.removeEventListener('cell-focus', spy);
     });

--- a/packages/vaadin-grid/test/keyboard-navigation.test.js
+++ b/packages/vaadin-grid/test/keyboard-navigation.test.js
@@ -1972,34 +1972,31 @@ describe('keyboard navigation', () => {
       grid.removeEventListener('cell-focus', eventHandler);
     });
 
-    it('should contain event context in event detail', (done) => {
+    it('should contain event context in event detail', () => {
       tabToBody();
       right();
 
-      let detail = null;
-      const eventHandler = (e) => {
-        detail = e.detail;
+      const spy = sinon.spy();
 
-        expect(e.detail.context).not.to.be.undefined;
-        expect(e.detail.context).to.be.deep.equal({
-          column: grid.querySelector('vaadin-grid-column'),
-          detailsOpened: false,
-          expanded: false,
-          index: 0,
-          item: 'foo',
-          level: 0,
-          section: 'body',
-          selected: false
-        });
-        done();
-      };
-      grid.addEventListener('cell-focus', eventHandler);
+      grid.addEventListener('cell-focus', spy);
 
       left();
 
-      expect(detail).not.to.be.null;
+      const e = spy.firstCall.args[0];
 
-      grid.removeEventListener('cell-focus', eventHandler);
+      expect(e.detail.context).to.be.deep.equal({
+        column: grid.querySelector('vaadin-grid-column'),
+        detailsOpened: false,
+        expanded: false,
+        index: 0,
+        item: 'foo',
+        level: 0,
+        section: 'body',
+        selected: false
+      });
+      expect(spy.callCount).to.be.equal(1);
+
+      grid.removeEventListener('cell-focus', spy);
     });
   });
 });

--- a/packages/vaadin-grid/test/keyboard-navigation.test.js
+++ b/packages/vaadin-grid/test/keyboard-navigation.test.js
@@ -1956,17 +1956,42 @@ describe('keyboard navigation', () => {
 
       const spy = sinon.spy();
 
-      grid.addEventListener('cell-focus', (e) => {
+      const eventHandler = (e) => {
         spy();
 
         const context = e.target.getEventContext(e);
         expect(context).to.deep.equal(expectedContext);
         done();
-      });
+      };
+
+      grid.addEventListener('cell-focus', eventHandler);
 
       left();
 
       expect(spy.calledOnce).to.be.true;
+      grid.removeEventListener('cell-focus', eventHandler);
+    });
+
+    it('should contain event context in event detail', (done) => {
+      tabToBody();
+      right();
+
+      const spy = sinon.spy();
+
+      const eventHandler = (e) => {
+        spy();
+
+        expect(e.detail).not.to.be.empty;
+        done();
+      };
+
+      grid.addEventListener('cell-focus', eventHandler);
+
+      left();
+
+      expect(spy.calledOnce).to.be.true;
+
+      grid.removeEventListener('cell-focus', eventHandler);
     });
   });
 });

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -1,6 +1,6 @@
 import { ElementMixin } from '@vaadin/vaadin-element-mixin';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
-import { GridBodyRenderer } from '../../src/interfaces';
+import { GridBodyRenderer, GridEventContext } from '../../src/interfaces';
 import { A11yMixin } from '../../src/vaadin-grid-a11y-mixin';
 import { ActiveItemMixin } from '../../src/vaadin-grid-active-item-mixin';
 import { ArrayDataProviderMixin } from '../../src/vaadin-grid-array-data-provider-mixin';
@@ -89,6 +89,7 @@ narrowedGrid.addEventListener('cell-activate', (event) => {
 
 narrowedGrid.addEventListener('cell-focus', (event) => {
   assertType<GridCellFocusEvent<TestGridItem>>(event);
+  assertType<GridEventContext<TestGridItem>>(event.detail.context);
 });
 
 narrowedGrid.addEventListener('column-reorder', (event) => {

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -88,7 +88,7 @@ narrowedGrid.addEventListener('cell-activate', (event) => {
 });
 
 narrowedGrid.addEventListener('cell-focus', (event) => {
-  assertType<GridCellFocusEvent>(event);
+  assertType<GridCellFocusEvent<TestGridItem>>(event);
 });
 
 narrowedGrid.addEventListener('column-reorder', (event) => {


### PR DESCRIPTION

## Description

This change adds event context for grid cells into the event object itself and removes an excess call to another method for getting the context that the event happened. It also modifies some type to reflect newly added fields into the propagated event.

It also adds required test cases and also modifies another test so that newly added tests run correctly.

Fixes #2130 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
