### PR TITLE
fix: skip virtualizer flush if scrollTarget is hidden

### DIFF
--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -107,7 +107,7 @@ export class IronListAdapter {
     if (this.scrollTarget.offsetHeight === 0) {
       return;
     }
-    
+
     this._resizeHandler();
     flush();
     this._scrollHandler();

--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -103,13 +103,16 @@ export class IronListAdapter {
   }
 
   flush() {
-    if (this.scrollTarget.offsetHeight) {
-      this._resizeHandler();
-      flush();
-      this._scrollHandler();
-      this.__scrollReorderDebouncer && this.__scrollReorderDebouncer.flush();
-      this.__debouncerWheelAnimationFrame && this.__debouncerWheelAnimationFrame.flush();
+    // The scroll target is hidden.
+    if (this.scrollTarget.offsetHeight === 0) {
+      return;
     }
+    
+    this._resizeHandler();
+    flush();
+    this._scrollHandler();
+    this.__scrollReorderDebouncer && this.__scrollReorderDebouncer.flush();
+    this.__debouncerWheelAnimationFrame && this.__debouncerWheelAnimationFrame.flush();
   }
 
   update(startIndex = 0, endIndex = this.size - 1) {

--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -103,11 +103,13 @@ export class IronListAdapter {
   }
 
   flush() {
-    this._resizeHandler();
-    flush();
-    this._scrollHandler();
-    this.__scrollReorderDebouncer && this.__scrollReorderDebouncer.flush();
-    this.__debouncerWheelAnimationFrame && this.__debouncerWheelAnimationFrame.flush();
+    if (this.scrollTarget.offsetHeight) {
+      this._resizeHandler();
+      flush();
+      this._scrollHandler();
+      this.__scrollReorderDebouncer && this.__scrollReorderDebouncer.flush();
+      this.__debouncerWheelAnimationFrame && this.__debouncerWheelAnimationFrame.flush();
+    }
   }
 
   update(startIndex = 0, endIndex = this.size - 1) {

--- a/packages/vaadin-virtual-list/test/virtualizer.test.js
+++ b/packages/vaadin-virtual-list/test/virtualizer.test.js
@@ -90,6 +90,15 @@ describe('virtualizer', () => {
     expect(item.getBoundingClientRect().top).to.equal(scrollTarget.getBoundingClientRect().top);
   });
 
+  it('should not flush when hidden', () => {
+    virtualizer.scrollToIndex(50);
+    scrollTarget.hidden = true;
+    virtualizer.flush();
+    scrollTarget.hidden = false;
+    const item = elementsContainer.querySelector('#item-50');
+    expect(item).to.be.ok;
+  });
+
   it('should scroll to start with an index smaller than the first index', () => {
     virtualizer.scrollToIndex(50);
     virtualizer.scrollToIndex(-1);


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/2164