### PR TITLE
fix: dispose of Lit parts after clearing innerHTML

### DIFF
--- a/packages/vaadin-grid-pro/package.json
+++ b/packages/vaadin-grid-pro/package.json
@@ -44,6 +44,7 @@
     "@vaadin/vaadin-date-picker": "21.0.0-alpha13",
     "@vaadin/vaadin-dialog": "21.0.0-alpha13",
     "@vaadin/vaadin-template-renderer": "21.0.0-alpha13",
+    "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro-edit-column.js
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro-edit-column.js
@@ -211,18 +211,20 @@ class GridProEditColumnElement extends GridColumnElement {
   /** @private */
   _renderEditor(cell, model) {
     cell.__savedRenderer = this._renderer || cell._renderer;
-    cell._content.innerHTML = '';
     cell._renderer = this.editModeRenderer || this.__editModeRenderer;
-    this.__runRenderer(cell._renderer, cell, model);
+
+    this._clearCellContent(cell);
+    this._runRenderer(cell._renderer, cell, model);
   }
 
   /** @private */
   _removeEditor(cell, _model) {
     if (!cell.__savedRenderer) return;
 
-    cell._content.innerHTML = '';
     cell._renderer = cell.__savedRenderer;
     cell.__savedRenderer = undefined;
+
+    this._clearCellContent(cell);
 
     const row = cell.parentElement;
     this._grid._updateItem(row, row._item);
@@ -251,7 +253,7 @@ class GridProEditColumnElement extends GridColumnElement {
    */
   _startCellEdit(cell, model) {
     this._renderEditor(cell, model);
-    this._grid.notifyResize();
+
     const editor = this._getEditorComponent(cell);
     editor.addEventListener('focusout', this._grid.__boundEditorFocusOut);
     editor.addEventListener('focusin', this._grid.__boundEditorFocusIn);
@@ -269,19 +271,9 @@ class GridProEditColumnElement extends GridColumnElement {
    * @protected
    */
   _stopCellEdit(cell, model) {
-    const editor = this._getEditorComponent(cell);
-    let shouldResize = true;
-    if (editor) {
-      editor.removeEventListener('focusout', this._grid.__boundEditorFocusOut);
-      editor.removeEventListener('focusin', this._grid.__boundEditorFocusIn);
-      editor.removeEventListener('internal-tab', this._grid.__boundCancelCellSwitch);
-    } else {
-      // avoid notify resize of editor removed due to scroll
-      shouldResize = false;
-    }
     document.body.removeEventListener('focusin', this._grid.__boundGlobalFocusIn);
+
     this._removeEditor(cell, model);
-    shouldResize && this._grid.notifyResize();
   }
 }
 

--- a/packages/vaadin-grid-pro/test/lit.test.js
+++ b/packages/vaadin-grid-pro/test/lit.test.js
@@ -1,0 +1,60 @@
+import { expect } from '@esm-bundle/chai';
+import { enter, fixtureSync } from '@vaadin/testing-helpers';
+import { html, render } from 'lit';
+
+import '../vaadin-grid-pro.js';
+import '../vaadin-grid-pro-edit-column.js';
+import { flushGrid } from './helpers.js';
+
+describe('lit', () => {
+  describe('edit column', () => {
+    describe('edit mode renderer', () => {
+      let grid, column, cell;
+
+      function getCell(container, { row, col }) {
+        return container.children[row].querySelectorAll('[part~="cell"]')[col];
+      }
+
+      beforeEach(() => {
+        grid = fixtureSync(`
+          <vaadin-grid-pro>
+            <vaadin-grid-pro-edit-column path="name"></vaadin-grid-pro-edit-column>
+          </vaadin-grid-pro>
+        `);
+        grid.items = [{ name: 'Item' }];
+
+        column = grid.firstElementChild;
+        column.renderer = (root) => {
+          render(html`Item`, root);
+        };
+        column.editModeRenderer = (root) => {
+          render(html`<input /> Edit Item`, root);
+        };
+
+        flushGrid(grid);
+
+        cell = getCell(grid.$.items, { row: 0, col: 0 });
+      });
+
+      it('should render the content', () => {
+        expect(cell._content.textContent).to.equal('Item');
+      });
+
+      describe('edit mode', () => {
+        beforeEach(() => {
+          enter(cell._content);
+        });
+
+        it('should enter the edit mode', () => {
+          expect(cell._content.textContent.trim()).to.equal('Edit Item');
+        });
+
+        it('should exit the edit mode', () => {
+          enter(cell._content);
+
+          expect(cell._content.textContent).to.equal('Item');
+        });
+      });
+    });
+  });
+});

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -449,8 +449,8 @@ export const ColumnBaseMixin = (superClass) =>
       this._previousHidden = hidden;
     }
 
-    /** @private */
-    __runRenderer(renderer, cell, model) {
+    /** @protected */
+    _runRenderer(renderer, cell, model) {
       const args = [cell._content, this];
       if (model && model.item) {
         args.push(model);
@@ -476,19 +476,28 @@ export const ColumnBaseMixin = (superClass) =>
         if (!renderer) return;
 
         if (cell._renderer !== renderer) {
-          cell._content.innerHTML = '';
-          // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
-          // When clearing the rendered content, this part needs to be manually disposed of.
-          // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
-          delete cell._content._$litPart$;
+          this._clearCellContent(cell);
         }
 
         cell._renderer = renderer;
 
         if (model.item || renderer === this._headerRenderer || renderer === this._footerRenderer) {
-          this.__runRenderer(renderer, cell, model);
+          this._runRenderer(renderer, cell, model);
         }
       });
+    }
+
+    /**
+     * Clears the content of a cell.
+     *
+     * @protected
+     */
+    _clearCellContent(cell) {
+      cell._content.innerHTML = '';
+      // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
+      // When clearing the rendered content, this part needs to be manually disposed of.
+      // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
+      delete cell._content._$litPart$;
     }
 
     /**

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -477,6 +477,10 @@ export const ColumnBaseMixin = (superClass) =>
 
         if (cell._renderer !== renderer) {
           cell._content.innerHTML = '';
+          // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
+          // When clearing the rendered content, this part needs to be manually disposed of.
+          // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
+          delete cell._content._$litPart$;
         }
 
         cell._renderer = renderer;

--- a/packages/vaadin-grid/test/lit-renderers.test.js
+++ b/packages/vaadin-grid/test/lit-renderers.test.js
@@ -106,7 +106,7 @@ describe('lit renderers', () => {
 
       grid.openItemDetails(grid.items[0]);
 
-      cell = getCell(grid.$.items, { row: 0, col: 1 });
+      cell = getCell(grid.$.items, { row: 0, col: 1 /* column count + 1 = the row details cell */ });
     });
 
     it('should render the content', () => {

--- a/packages/vaadin-grid/test/lit-renderers.test.js
+++ b/packages/vaadin-grid/test/lit-renderers.test.js
@@ -1,0 +1,124 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { render, html } from 'lit';
+import '../vaadin-grid.js';
+import '../vaadin-grid-column.js';
+import { flushGrid } from './helpers.js';
+
+describe('lit renderers', () => {
+  let grid, column;
+
+  function getCell(container, { row, col }) {
+    return container.children[row].querySelectorAll('[part~="cell"]')[col];
+  }
+
+  beforeEach(() => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    grid.items = ['item1'];
+    column = grid.firstElementChild;
+
+    flushGrid(grid);
+  });
+
+  describe('header renderer', () => {
+    let cell;
+
+    beforeEach(() => {
+      column.headerRenderer = (root) => {
+        render(html`Header`, root);
+      };
+
+      cell = getCell(grid.$.header, { row: 0, col: 0 });
+    });
+
+    it('should render the content', () => {
+      expect(cell._content.textContent).to.equal('Header');
+    });
+
+    it('should render new content after assigning a new renderer', () => {
+      column.headerRenderer = (root) => {
+        render(html`New Header`, root);
+      };
+
+      expect(cell._content.textContent).to.equal('New Header');
+    });
+  });
+
+  describe('footer renderer', () => {
+    let cell;
+
+    beforeEach(() => {
+      column.footerRenderer = (root) => {
+        render(html`Footer`, root);
+      };
+
+      cell = getCell(grid.$.footer, { row: 0, col: 0 });
+    });
+
+    it('should render the content', () => {
+      expect(cell._content.textContent).to.equal('Footer');
+    });
+
+    it('should render new content after assigning a new renderer', () => {
+      column.footerRenderer = (root) => {
+        render(html`New Footer`, root);
+      };
+
+      expect(cell._content.textContent).to.equal('New Footer');
+    });
+  });
+
+  describe('body renderer', () => {
+    let cell;
+
+    beforeEach(() => {
+      column.renderer = (root) => {
+        render(html`Item`, root);
+      };
+
+      cell = getCell(grid.$.items, { row: 0, col: 0 });
+    });
+
+    it('should render the content', () => {
+      expect(cell._content.textContent).to.equal('Item');
+    });
+
+    it('should render new content after assigning a new renderer', () => {
+      column.renderer = (root) => {
+        render(html`New Item`, root);
+      };
+
+      expect(cell._content.textContent).to.equal('New Item');
+    });
+  });
+
+  describe('row details renderer', () => {
+    let cell;
+
+    beforeEach(() => {
+      grid.rowDetailsRenderer = (root) => {
+        render(html`Row Details`, root);
+      };
+
+      grid.openItemDetails(grid.items[0]);
+
+      cell = getCell(grid.$.items, { row: 0, col: 1 });
+    });
+
+    it('should render the content', () => {
+      expect(cell._content.textContent).to.equal('Row Details');
+    });
+
+    it('should render new content after assigning a new renderer', () => {
+      grid.rowDetailsRenderer = (root) => {
+        render(html`New Row Details`, root);
+      };
+
+      expect(cell._content.textContent).to.equal('New Row Details');
+    });
+  });
+});

--- a/packages/vaadin-grid/test/lit.test.js
+++ b/packages/vaadin-grid/test/lit.test.js
@@ -4,14 +4,10 @@ import { render, html } from 'lit';
 import '../vaadin-grid.js';
 import { getPhysicalItems } from './helpers.js';
 
-describe('rendering with lit', () => {
-  let wrapper;
-
-  beforeEach(() => {
-    wrapper = fixtureSync(`<div></div>`);
-  });
-
+describe('lit', () => {
   it('should render items after dynamically adding more columns', async () => {
+    const wrapper = fixtureSync(`<div></div>`);
+
     function renderGrid(columnPaths, items) {
       render(
         html`

--- a/packages/vaadin-notification/package.json
+++ b/packages/vaadin-notification/package.json
@@ -32,6 +32,7 @@
     "@vaadin/vaadin-themable-mixin": "21.0.0-alpha13"
   },
   "devDependencies": {
+    "lit": "^2.0.0-rc.1",
     "@esm-bundle/chai": "^4.1.5",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-button": "21.0.0-alpha13",

--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -349,6 +349,10 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
 
     if (rendererChanged) {
       card.innerHTML = '';
+      // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
+      // When clearing the rendered content, this part needs to be manually disposed of.
+      // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
+      delete card._$litPart$;
     }
 
     if (opened) {

--- a/packages/vaadin-notification/test/lit.test.js
+++ b/packages/vaadin-notification/test/lit.test.js
@@ -1,0 +1,31 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { html, render } from 'lit';
+
+import '../vaadin-notification.js';
+
+describe('lit', () => {
+  describe('renderer', () => {
+    let notification;
+
+    beforeEach(() => {
+      notification = fixtureSync(`<vaadin-notification></vaadin-notification>`);
+      notification.open();
+      notification.renderer = (root) => {
+        render(html`Initial Content`, root);
+      };
+    });
+
+    it('should render the content', () => {
+      expect(notification._card.textContent).to.equal('Initial Content');
+    });
+
+    it('should render new content after assigning a new renderer', () => {
+      notification.renderer = (root) => {
+        render(html`New Content`, root);
+      };
+
+      expect(notification._card.textContent).to.equal('New Content');
+    });
+  });
+});

--- a/packages/vaadin-overlay/package.json
+++ b/packages/vaadin-overlay/package.json
@@ -33,6 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "21.0.0-alpha13"
   },
   "devDependencies": {
+    "lit": "^2.0.0-rc.1",
     "@esm-bundle/chai": "^4.1.5",
     "@polymer/iron-overlay-behavior": "^3.0.0",
     "@vaadin/testing-helpers": "^0.2.1",

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -919,6 +919,10 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
     if (rendererChanged) {
       this.content = this;
       this.content.innerHTML = '';
+      // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
+      // When clearing the rendered content, this part needs to be manually disposed of.
+      // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
+      delete this.content._$litPart$;
     }
 
     if (template && templateOrInstancePropsChanged) {

--- a/packages/vaadin-overlay/test/lit.test.js
+++ b/packages/vaadin-overlay/test/lit.test.js
@@ -1,0 +1,31 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { html, render } from 'lit';
+
+import '../vaadin-overlay.js';
+
+describe('lit', () => {
+  describe('renderer', () => {
+    let overlay;
+
+    beforeEach(() => {
+      overlay = fixtureSync(`<vaadin-overlay></vaadin-overlay>`);
+      overlay.opened = true;
+      overlay.renderer = (root) => {
+        render(html`Initial Content`, root);
+      };
+    });
+
+    it('should render the content', () => {
+      expect(overlay.textContent).to.equal('Initial Content');
+    });
+
+    it('should render new content after assigning a new renderer', () => {
+      overlay.renderer = (root) => {
+        render(html`New Content`, root);
+      };
+
+      expect(overlay.textContent).to.equal('New Content');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Disposes of Lit parts after clearing `innerHTML` to prevent throwing exceptions when running Lit-based renderers afterward.

Fixes #2161 (issue)

- [x] vaadin-notification
- [x] vaadin-overlay
- [x] vaadin-grid
- [x] vaadin-grid-pro

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
