### PR TITLE
fix: Correct material theme imports of `vaadin-date-picker-light`

### DIFF
--- a/packages/vaadin-date-picker/theme/material/vaadin-date-picker-light.js
+++ b/packages/vaadin-date-picker/theme/material/vaadin-date-picker-light.js
@@ -1,4 +1,4 @@
-import './vaadin-date-picker-overlay.js';
-import './vaadin-date-picker-overlay-content.js';
-import './vaadin-month-calendar.js';
+import './vaadin-date-picker-overlay-styles.js';
+import './vaadin-date-picker-overlay-content-styles.js';
+import './vaadin-month-calendar-styles.js';
 import '../../src/vaadin-date-picker-light.js';


### PR DESCRIPTION
## Description

The style import of the `material` theme for `vaadin-date-picker-light` where pointing at the wrong files.

This PR corrects them.

Fixes # (issue)

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
