### PR TITLE
feat: add mixins to handle slotted helper and error message

### DIFF
--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -1,3 +1,4 @@
+export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';

--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -1,3 +1,4 @@
+export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';

--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -3,3 +3,4 @@ export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
+export { ValidateMixin } from './src/validate-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -1,3 +1,4 @@
+export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -1,3 +1,4 @@
+export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -3,3 +3,4 @@ export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
+export { ValidateMixin } from './src/validate-mixin.js';

--- a/packages/field-base/src/field-aria-mixin.d.ts
+++ b/packages/field-base/src/field-aria-mixin.d.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { HelperTextMixin } from './helper-text-mixin.js';
+import { ValidateMixin } from './validate-mixin.js';
+
+/**
+ * A mixin to handle field ARIA attributes based on the label, error message and helper text.
+ */
+declare function FieldAriaMixin<T extends new (...args: any[]) => {}>(base: T): T & FieldAriaMixinConstructor;
+
+interface FieldAriaMixinConstructor {
+  new (...args: any[]): FieldAriaMixin;
+}
+
+interface FieldAriaMixin extends HelperTextMixin, ValidateMixin {
+  readonly _ariaTarget: HTMLElement;
+
+  readonly _ariaAttr: string;
+}
+
+export { FieldAriaMixin, FieldAriaMixinConstructor };

--- a/packages/field-base/src/field-aria-mixin.js
+++ b/packages/field-base/src/field-aria-mixin.js
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { HelperTextMixin } from './helper-text-mixin.js';
+import { ValidateMixin } from './validate-mixin.js';
+
+const FieldAriaMixinImplementation = (superclass) =>
+  class FieldAriaMixinClass extends HelperTextMixin(ValidateMixin(superclass)) {
+    /** @protected */
+    get _ariaTarget() {
+      return this;
+    }
+
+    /** @protected */
+    get _ariaAttr() {
+      return 'aria-describedby';
+    }
+
+    static get observers() {
+      return ['_invalidChanged(invalid)'];
+    }
+
+    /** @protected */
+    _updateAriaAttribute(invalid) {
+      const attr = this._ariaAttr;
+
+      if (this._ariaTarget && attr) {
+        // For groups, add all IDs to aria-labelledby rather than aria-describedby -
+        // that should guarantee that it's announced when the group is entered.
+        const ariaIds = attr === 'aria-describedby' ? [this._helperId] : [this._labelId, this._helperId];
+
+        // Error message ID needs to be dynamically added / removed based on the validity
+        // Otherwise assistive technologies would announce the error, even if we hide it.
+        if (invalid) {
+          ariaIds.push(this._errorId);
+        }
+
+        this._ariaTarget.setAttribute(attr, ariaIds.join(' '));
+      }
+    }
+
+    /** @protected */
+    _invalidChanged(invalid) {
+      this._updateAriaAttribute(invalid);
+    }
+  };
+
+/**
+ * A mixin to handle field ARIA attributes based on the label, error message and helper text.
+ */
+export const FieldAriaMixin = dedupingMixin(FieldAriaMixinImplementation);

--- a/packages/field-base/src/field-aria-mixin.js
+++ b/packages/field-base/src/field-aria-mixin.js
@@ -24,6 +24,13 @@ const FieldAriaMixinImplementation = (superclass) =>
     }
 
     /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      this._updateAriaAttribute(this.invalid);
+    }
+
+    /** @protected */
     _updateAriaAttribute(invalid) {
       const attr = this._ariaAttr;
 

--- a/packages/field-base/src/helper-text-mixin.d.ts
+++ b/packages/field-base/src/helper-text-mixin.d.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotMixin } from './slot-mixin.js';
+
+/**
+ * A mixin to provide helper text via corresponding property or named slot.
+ */
+declare function HelperTextMixin<T extends new (...args: any[]) => {}>(base: T): T & HelperTextMixinConstructor;
+
+interface HelperTextMixinConstructor {
+  new (...args: any[]): HelperTextMixin;
+}
+
+interface HelperTextMixin extends SlotMixin {
+  /**
+   * String used for the helper text.
+   */
+  helperText: string;
+}
+
+export { HelperTextMixinConstructor, HelperTextMixin };

--- a/packages/field-base/src/helper-text-mixin.js
+++ b/packages/field-base/src/helper-text-mixin.js
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { SlotMixin } from './slot-mixin.js';
+
+const HelperTextMixinImplementation = (superclass) =>
+  class HelperTextMixinClass extends SlotMixin(superclass) {
+    static get properties() {
+      return {
+        /**
+         * String used for the helper text.
+         * @attr {string} helper-text
+         */
+        helperText: {
+          type: String,
+          observer: '_helperTextChanged'
+        }
+      };
+    }
+
+    get slots() {
+      return {
+        ...super.slots,
+        helper: () => {
+          const helper = document.createElement('div');
+          helper.textContent = this.helperText;
+          return helper;
+        }
+      };
+    }
+
+    /** @protected */
+    get _helperNode() {
+      return this._getDirectSlotChild('helper');
+    }
+
+    constructor() {
+      super();
+
+      // Ensure every instance has unique ID
+      const uniqueId = (HelperTextMixinClass._uniqueId = 1 + HelperTextMixinClass._uniqueId || 0);
+      this._helperId = `helper-${this.localName}-${uniqueId}`;
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      if (this._helperNode) {
+        this._helperNode.id = this._helperId;
+
+        this._applyCustomHelper();
+      }
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.__helperSlot = this.shadowRoot.querySelector('[name="helper"]');
+      this.__helperSlot.addEventListener('slotchange', this._onHelperSlotChange.bind(this));
+    }
+
+    /** @private */
+    _onHelperSlotChange() {
+      // Check fot slotted element node that is not the one created by this mixin.
+      const helperNodes = this.__helperSlot
+        .assignedNodes({ flatten: true })
+        .filter((node) => node.nodeType === Node.ELEMENT_NODE);
+
+      const customHelper = helperNodes.find((node) => node !== this._helperNode);
+      if (customHelper) {
+        customHelper.id = this._helperId;
+        this._helperNode.remove();
+        this._applyCustomHelper();
+      }
+    }
+
+    /** @protected */
+    _applyCustomHelper() {
+      const helper = this._helperNode.textContent;
+      if (helper !== this.helperText) {
+        this.helperText = helper;
+      }
+    }
+
+    /** @protected */
+    _helperTextChanged(helper) {
+      if (this._helperNode) {
+        this._helperNode.textContent = helper;
+      }
+
+      this.toggleAttribute('has-helper', Boolean(helper));
+    }
+  };
+
+/**
+ * A mixin to provide helper text via corresponding property or named slot.
+ */
+export const HelperTextMixin = dedupingMixin(HelperTextMixinImplementation);

--- a/packages/field-base/src/helper-text-mixin.js
+++ b/packages/field-base/src/helper-text-mixin.js
@@ -74,11 +74,12 @@ const HelperTextMixinImplementation = (superclass) =>
 
       if (customHelper) {
         customHelper.id = this._helperId;
-        this._applyCustomHelper();
 
         if (this._currentHelper.isConnected) {
           this._currentHelper.remove();
         }
+
+        this._applyCustomHelper();
 
         this._currentHelper = customHelper;
       }

--- a/packages/field-base/src/helper-text-mixin.js
+++ b/packages/field-base/src/helper-text-mixin.js
@@ -50,7 +50,7 @@ const HelperTextMixinImplementation = (superclass) =>
       super.connectedCallback();
 
       if (this._helperNode) {
-        this._initialHelper = this._helperNode;
+        this._currentHelper = this._helperNode;
         this._helperNode.id = this._helperId;
 
         this._applyCustomHelper();
@@ -62,25 +62,25 @@ const HelperTextMixinImplementation = (superclass) =>
       super.ready();
 
       this.__helperSlot = this.shadowRoot.querySelector('[name="helper"]');
-      this.__helperSlot.addEventListener('slotchange', this._onHelperSlotChange.bind(this));
+      this.__helperSlot.addEventListener('slotchange', this.__onHelperSlotChange.bind(this));
     }
 
     /** @private */
-    _onHelperSlotChange() {
+    __onHelperSlotChange() {
       // Check fot slotted element node that is not the one created by this mixin.
-      const helperNodes = this.__helperSlot
-        .assignedNodes({ flatten: true })
-        .filter((node) => node.nodeType === Node.ELEMENT_NODE);
-
-      const customHelper = helperNodes.find((node) => node !== this._initialHelper);
+      const customHelper = this.__helperSlot
+        .assignedElements({ flatten: true })
+        .find((node) => node !== this._currentHelper);
 
       if (customHelper) {
         customHelper.id = this._helperId;
         this._applyCustomHelper();
 
-        if (this._initialHelper.isConnected) {
-          this._initialHelper.remove();
+        if (this._currentHelper.isConnected) {
+          this._currentHelper.remove();
         }
+
+        this._currentHelper = customHelper;
       }
     }
 

--- a/packages/field-base/src/helper-text-mixin.js
+++ b/packages/field-base/src/helper-text-mixin.js
@@ -50,6 +50,7 @@ const HelperTextMixinImplementation = (superclass) =>
       super.connectedCallback();
 
       if (this._helperNode) {
+        this._initialHelper = this._helperNode;
         this._helperNode.id = this._helperId;
 
         this._applyCustomHelper();
@@ -71,11 +72,15 @@ const HelperTextMixinImplementation = (superclass) =>
         .assignedNodes({ flatten: true })
         .filter((node) => node.nodeType === Node.ELEMENT_NODE);
 
-      const customHelper = helperNodes.find((node) => node !== this._helperNode);
+      const customHelper = helperNodes.find((node) => node !== this._initialHelper);
+
       if (customHelper) {
         customHelper.id = this._helperId;
-        this._helperNode.remove();
         this._applyCustomHelper();
+
+        if (this._initialHelper.isConnected) {
+          this._initialHelper.remove();
+        }
       }
     }
 

--- a/packages/field-base/src/validate-mixin.d.ts
+++ b/packages/field-base/src/validate-mixin.d.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotMixin } from './slot-mixin.js';
+
+/**
+ * A mixin to provide required state and validation logic.
+ */
+declare function ValidateMixin<T extends new (...args: any[]) => {}>(base: T): T & ValidateMixinConstructor;
+
+interface ValidateMixinConstructor {
+  new (...args: any[]): ValidateMixin;
+}
+
+interface ValidateMixin extends SlotMixin {
+  /**
+   * Set to true when the field is invalid.
+   */
+  invalid: boolean;
+
+  /**
+   * Specifies that the user must fill in a value.
+   */
+  required: boolean;
+
+  /**
+   * Error to show when the field is invalid.
+   *
+   * @attr {string} error-message
+   */
+  errorMessage: string;
+
+  /**
+   * Returns true if field is valid, and sets `invalid` to true otherwise.
+   */
+  validate(): boolean;
+
+  /**
+   * Returns true if the field value satisfies all constraints (if any).
+   */
+  checkValidity(): boolean;
+}
+
+export { ValidateMixinConstructor, ValidateMixin };

--- a/packages/field-base/src/validate-mixin.d.ts
+++ b/packages/field-base/src/validate-mixin.d.ts
@@ -33,7 +33,7 @@ interface ValidateMixin extends SlotMixin {
   errorMessage: string;
 
   /**
-   * Returns true if field is valid, and sets `invalid` to true otherwise.
+   * Returns true if field is valid, and sets `invalid` based on the field validity.
    */
   validate(): boolean;
 

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { SlotMixin } from './slot-mixin.js';
+
+const ValidateMixinImplementation = (superclass) =>
+  class ValidateMixinClass extends SlotMixin(superclass) {
+    static get properties() {
+      return {
+        /**
+         * Set to true when the field is invalid.
+         */
+        invalid: {
+          type: Boolean,
+          reflectToAttribute: true,
+          notify: true,
+          value: false
+        },
+
+        /**
+         * Specifies that the user must fill in a value.
+         */
+        required: {
+          type: Boolean,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Error to show when the field is invalid.
+         *
+         * @attr {string} error-message
+         */
+        errorMessage: {
+          type: String
+        }
+      };
+    }
+
+    get slots() {
+      return {
+        ...super.slots,
+        'error-message': () => {
+          const error = document.createElement('div');
+          error.textContent = this.errorMessage;
+          error.setAttribute('aria-live', 'assertive');
+          return error;
+        }
+      };
+    }
+
+    static get observers() {
+      return ['_updateErrorMessage(invalid, errorMessage)'];
+    }
+
+    /** @protected */
+    get _errorNode() {
+      return this._getDirectSlotChild('error-message');
+    }
+
+    constructor() {
+      super();
+
+      // Ensure every instance has unique ID
+      const uniqueId = (ValidateMixinClass._uniqueId = 1 + ValidateMixinClass._uniqueId || 0);
+      this._errorId = `error-${this.localName}-${uniqueId}`;
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      if (this._errorNode) {
+        this._errorNode.id = this._errorId;
+
+        this._applyCustomError();
+      }
+    }
+
+    /**
+     * Returns true if field is valid, and sets `invalid` to true otherwise.
+     *
+     * @return {boolean} True if the value is valid.
+     */
+    validate() {
+      return !(this.invalid = !this.checkValidity());
+    }
+
+    /**
+     * Returns true if the field value satisfies all constraints (if any).
+     *
+     * @return {boolean}
+     */
+    checkValidity() {
+      return !this.required || !!this.value;
+    }
+
+    /** @protected */
+    _applyCustomError() {
+      const error = this.__errorMessage;
+      if (error && error !== this.errorMessage) {
+        this.errorMessage = error;
+        delete this.__errorMessage;
+      }
+    }
+
+    /**
+     * @param {boolean} invalid
+     * @protected
+     */
+    _updateErrorMessage(invalid, errorMessage) {
+      if (this._errorNode) {
+        // save the custom error message content
+        if (this._errorNode.textContent && !errorMessage) {
+          this.__errorMessage = this._errorNode.textContent.trim();
+        }
+        const hasError = Boolean(invalid && errorMessage);
+        this._errorNode.textContent = hasError ? errorMessage : '';
+        this.toggleAttribute('has-error-message', hasError);
+      }
+    }
+  };
+
+/**
+ * A mixin to provide required state and validation logic.
+ */
+export const ValidateMixin = dedupingMixin(ValidateMixinImplementation);

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -80,7 +80,7 @@ const ValidateMixinImplementation = (superclass) =>
     }
 
     /**
-     * Returns true if field is valid, and sets `invalid` to true otherwise.
+     * Returns true if field is valid, and sets `invalid` based on the field validity.
      *
      * @return {boolean} True if the value is valid.
      */
@@ -111,15 +111,17 @@ const ValidateMixinImplementation = (superclass) =>
      * @protected
      */
     _updateErrorMessage(invalid, errorMessage) {
-      if (this._errorNode) {
-        // save the custom error message content
-        if (this._errorNode.textContent && !errorMessage) {
-          this.__errorMessage = this._errorNode.textContent.trim();
-        }
-        const hasError = Boolean(invalid && errorMessage);
-        this._errorNode.textContent = hasError ? errorMessage : '';
-        this.toggleAttribute('has-error-message', hasError);
+      if (!this._errorNode) {
+        return;
       }
+
+      // save the custom error message content
+      if (this._errorNode.textContent && !errorMessage) {
+        this.__errorMessage = this._errorNode.textContent.trim();
+      }
+      const hasError = Boolean(invalid && errorMessage);
+      this._errorNode.textContent = hasError ? errorMessage : '';
+      this.toggleAttribute('has-error-message', hasError);
     }
   };
 

--- a/packages/field-base/test/field-aria-mixin.test.js
+++ b/packages/field-base/test/field-aria-mixin.test.js
@@ -1,0 +1,87 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { FieldAriaMixin } from '../src/field-aria-mixin.js';
+import { LabelMixin } from '../src/label-mixin.js';
+
+customElements.define(
+  'field-aria-mixin-element',
+  class extends FieldAriaMixin(LabelMixin(PolymerElement)) {
+    static get template() {
+      return html`
+        <slot name="label"></slot>
+        <slot name="error-message"></slot>
+        <slot name="helper"></slot>
+      `;
+    }
+  }
+);
+
+customElements.define(
+  'field-aria-mixin-group-element',
+  class extends FieldAriaMixin(LabelMixin(PolymerElement)) {
+    static get template() {
+      return html`
+        <slot name="label"></slot>
+        <slot name="error-message"></slot>
+        <slot name="helper"></slot>
+      `;
+    }
+
+    get _ariaAttr() {
+      return 'aria-labelledby';
+    }
+  }
+);
+
+describe('field-aria-mixin', () => {
+  let element, label, error, helper;
+
+  describe('aria-describedby', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<field-aria-mixin-element></field-aria-mixin-element>`);
+      label = element.querySelector('[slot=label]');
+      error = element.querySelector('[slot=error-message]');
+      helper = element.querySelector('[slot=helper]');
+    });
+
+    it('should only add helper text to aria-describedby when field is valid', () => {
+      const aria = element.getAttribute('aria-describedby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.not.include(error.id);
+      expect(aria).to.not.include(label.id);
+    });
+
+    it('should add error message to aria-describedby when field is invalid', () => {
+      element.invalid = true;
+      const aria = element.getAttribute('aria-describedby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.include(error.id);
+      expect(aria).to.not.include(label.id);
+    });
+  });
+
+  describe('aria-labelledby', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<field-aria-mixin-group-element></field-aria-mixin-group-element>`);
+      label = element.querySelector('[slot=label]');
+      error = element.querySelector('[slot=error-message]');
+      helper = element.querySelector('[slot=helper]');
+    });
+
+    it('should add label and helper text to aria-labelledby when field is valid', () => {
+      const aria = element.getAttribute('aria-labelledby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.not.include(error.id);
+      expect(aria).to.include(label.id);
+    });
+
+    it('should add error message to aria-labelledby when field is invalid', () => {
+      element.invalid = true;
+      const aria = element.getAttribute('aria-labelledby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.include(error.id);
+      expect(aria).to.include(label.id);
+    });
+  });
+});

--- a/packages/field-base/test/field-aria-mixin.test.js
+++ b/packages/field-base/test/field-aria-mixin.test.js
@@ -3,16 +3,22 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { FieldAriaMixin } from '../src/field-aria-mixin.js';
 import { LabelMixin } from '../src/label-mixin.js';
+import { InputMixin } from '../src/input-mixin.js';
 
 customElements.define(
   'field-aria-mixin-element',
-  class extends FieldAriaMixin(LabelMixin(PolymerElement)) {
+  class extends FieldAriaMixin(LabelMixin(InputMixin(PolymerElement))) {
     static get template() {
       return html`
         <slot name="label"></slot>
+        <slot name="input"></slot>
         <slot name="error-message"></slot>
         <slot name="helper"></slot>
       `;
+    }
+
+    get _ariaTarget() {
+      return this._inputNode;
     }
   }
 );
@@ -35,7 +41,7 @@ customElements.define(
 );
 
 describe('field-aria-mixin', () => {
-  let element, label, error, helper;
+  let element, label, error, helper, input;
 
   describe('aria-describedby', () => {
     beforeEach(() => {
@@ -43,10 +49,11 @@ describe('field-aria-mixin', () => {
       label = element.querySelector('[slot=label]');
       error = element.querySelector('[slot=error-message]');
       helper = element.querySelector('[slot=helper]');
+      input = element.querySelector('[slot=input]');
     });
 
     it('should only add helper text to aria-describedby when field is valid', () => {
-      const aria = element.getAttribute('aria-describedby');
+      const aria = input.getAttribute('aria-describedby');
       expect(aria).to.include(helper.id);
       expect(aria).to.not.include(error.id);
       expect(aria).to.not.include(label.id);
@@ -54,7 +61,7 @@ describe('field-aria-mixin', () => {
 
     it('should add error message to aria-describedby when field is invalid', () => {
       element.invalid = true;
-      const aria = element.getAttribute('aria-describedby');
+      const aria = input.getAttribute('aria-describedby');
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);
       expect(aria).to.not.include(label.id);

--- a/packages/field-base/test/helper-text-mixin.test.js
+++ b/packages/field-base/test/helper-text-mixin.test.js
@@ -1,0 +1,138 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { HelperTextMixin } from '../src/helper-text-mixin.js';
+
+customElements.define(
+  'helper-text-mixin-element',
+  class extends HelperTextMixin(PolymerElement) {
+    static get template() {
+      return html`<slot name="helper"></slot>`;
+    }
+  }
+);
+
+describe('helper-text-mixin', () => {
+  let element, helper;
+
+  describe('default', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<helper-text-mixin-element></helper-text-mixin-element>`);
+      helper = element.querySelector('[slot=helper]');
+    });
+
+    it('should create a helper element', () => {
+      expect(helper instanceof HTMLDivElement).to.be.true;
+    });
+
+    it('should set slot on the helper', () => {
+      expect(helper.getAttribute('slot')).to.equal('helper');
+    });
+
+    it('should set id on the helper element', () => {
+      const idRegex = /^helper-helper-text-mixin-element-\d+$/;
+      expect(idRegex.test(helper.getAttribute('id'))).to.be.true;
+    });
+
+    it('should update helper content on attribute change', () => {
+      element.setAttribute('helper-text', '3 digits');
+      expect(helper.textContent).to.equal('3 digits');
+    });
+
+    it('should update helper content on property change', () => {
+      element.helperText = '3 digits';
+      expect(helper.textContent).to.equal('3 digits');
+    });
+
+    it('should not set has-helper attribute with no helper', () => {
+      expect(element.hasAttribute('has-helper')).to.be.false;
+    });
+
+    it('should set has-helper attribute when attribute is set', () => {
+      element.setAttribute('helper-text', '3 digits');
+      expect(element.hasAttribute('has-helper')).to.be.true;
+    });
+
+    it('should set has-helper attribute when property is set', () => {
+      element.helperText = '3 digits';
+      expect(element.hasAttribute('has-helper')).to.be.true;
+    });
+  });
+
+  describe('attribute', () => {
+    beforeEach(() => {
+      element = fixtureSync(`
+        <helper-text-mixin-element
+          helper-text="3 digits"
+        ></helper-text-mixin-element>
+      `);
+      helper = element.querySelector('[slot=helper]');
+    });
+
+    it('should set helper text content from attribute', () => {
+      expect(helper.textContent).to.equal('3 digits');
+    });
+  });
+
+  describe('slotted', () => {
+    beforeEach(() => {
+      element = fixtureSync(`
+        <helper-text-mixin-element>
+          <div slot="helper">Custom</div>
+        </helper-text-mixin-element>
+      `);
+      helper = element.querySelector('[slot=helper]');
+    });
+
+    it('should return slotted helper content as a helperText', () => {
+      expect(element.helperText).to.equal('Custom');
+    });
+
+    it('should set id on the slotted helper element', () => {
+      const idRegex = /^helper-helper-text-mixin-element-\d+$/;
+      expect(idRegex.test(helper.getAttribute('id'))).to.be.true;
+    });
+
+    it('should set has-helper attribute with slotted helper', () => {
+      expect(element.hasAttribute('has-helper')).to.be.true;
+    });
+
+    it('should update slotted helper content on property change', () => {
+      element.helperText = '3 digits';
+      expect(helper.textContent).to.equal('3 digits');
+    });
+  });
+
+  describe('lazy', () => {
+    beforeEach(async () => {
+      element = fixtureSync('<helper-text-mixin-element></helper-text-mixin-element>');
+      await nextFrame();
+      helper = document.createElement('div');
+      helper.setAttribute('slot', 'helper');
+      helper.textContent = 'Lazy';
+      element.appendChild(helper);
+    });
+
+    it('should return lazy helper content as a helperText', () => {
+      expect(element.helperText).to.equal('Lazy');
+    });
+
+    it('should store a reference to the lazily added helper', () => {
+      expect(element._helperNode).to.equal(helper);
+    });
+
+    it('should set id on the lazily added helper element', () => {
+      const idRegex = /^helper-helper-text-mixin-element-\d+$/;
+      expect(idRegex.test(helper.getAttribute('id'))).to.be.true;
+    });
+
+    it('should set has-helper attribute with lazy helper', () => {
+      expect(element.hasAttribute('has-helper')).to.be.true;
+    });
+
+    it('should update lazy helper content on property change', () => {
+      element.helperText = '3 digits';
+      expect(helper.textContent).to.equal('3 digits');
+    });
+  });
+});

--- a/packages/field-base/test/helper-text-mixin.test.js
+++ b/packages/field-base/test/helper-text-mixin.test.js
@@ -110,7 +110,7 @@ describe('helper-text-mixin', () => {
       helper = document.createElement('div');
       helper.setAttribute('slot', 'helper');
       helper.textContent = 'Lazy';
-      element.appendChild(helper);
+      element.replaceChild(helper, element._helperNode);
     });
 
     it('should return lazy helper content as a helperText', () => {

--- a/packages/field-base/test/helper-text-mixin.test.js
+++ b/packages/field-base/test/helper-text-mixin.test.js
@@ -22,7 +22,7 @@ describe('helper-text-mixin', () => {
     });
 
     it('should create a helper element', () => {
-      expect(helper instanceof HTMLDivElement).to.be.true;
+      expect(helper).to.be.an.instanceof(HTMLDivElement);
     });
 
     it('should set slot on the helper', () => {
@@ -31,7 +31,7 @@ describe('helper-text-mixin', () => {
 
     it('should set id on the helper element', () => {
       const idRegex = /^helper-helper-text-mixin-element-\d+$/;
-      expect(idRegex.test(helper.getAttribute('id'))).to.be.true;
+      expect(helper.getAttribute('id')).to.match(idRegex);
     });
 
     it('should update helper content on attribute change', () => {
@@ -90,7 +90,7 @@ describe('helper-text-mixin', () => {
 
     it('should set id on the slotted helper element', () => {
       const idRegex = /^helper-helper-text-mixin-element-\d+$/;
-      expect(idRegex.test(helper.getAttribute('id'))).to.be.true;
+      expect(helper.getAttribute('id')).to.match(idRegex);
     });
 
     it('should set has-helper attribute with slotted helper', () => {
@@ -104,13 +104,16 @@ describe('helper-text-mixin', () => {
   });
 
   describe('lazy', () => {
+    let defaultHelper;
+
     beforeEach(async () => {
       element = fixtureSync('<helper-text-mixin-element></helper-text-mixin-element>');
       await nextFrame();
       helper = document.createElement('div');
       helper.setAttribute('slot', 'helper');
       helper.textContent = 'Lazy';
-      element.replaceChild(helper, element._helperNode);
+      defaultHelper = element._helperNode;
+      element.insertBefore(helper, defaultHelper);
     });
 
     it('should return lazy helper content as a helperText', () => {
@@ -121,9 +124,13 @@ describe('helper-text-mixin', () => {
       expect(element._helperNode).to.equal(helper);
     });
 
+    it('should remove the default helper from the element', () => {
+      expect(defaultHelper.parentNode).to.be.null;
+    });
+
     it('should set id on the lazily added helper element', () => {
       const idRegex = /^helper-helper-text-mixin-element-\d+$/;
-      expect(idRegex.test(helper.getAttribute('id'))).to.be.true;
+      expect(helper.getAttribute('id')).to.match(idRegex);
     });
 
     it('should set has-helper attribute with lazy helper', () => {
@@ -133,6 +140,15 @@ describe('helper-text-mixin', () => {
     it('should update lazy helper content on property change', () => {
       element.helperText = '3 digits';
       expect(helper.textContent).to.equal('3 digits');
+    });
+
+    it('should support replacing lazy helper with a new one', async () => {
+      const div = document.createElement('div');
+      div.setAttribute('slot', 'helper');
+      div.textContent = 'New';
+      element.replaceChild(div, helper);
+      await nextFrame();
+      expect(element.helperText).to.equal('New');
     });
   });
 });

--- a/packages/field-base/test/helper-text-mixin.test.js
+++ b/packages/field-base/test/helper-text-mixin.test.js
@@ -104,51 +104,113 @@ describe('helper-text-mixin', () => {
   });
 
   describe('lazy', () => {
-    let defaultHelper;
+    describe('DOM manipulations', () => {
+      let defaultHelper;
 
-    beforeEach(async () => {
-      element = fixtureSync('<helper-text-mixin-element></helper-text-mixin-element>');
-      await nextFrame();
-      helper = document.createElement('div');
-      helper.setAttribute('slot', 'helper');
-      helper.textContent = 'Lazy';
-      defaultHelper = element._helperNode;
-      element.insertBefore(helper, defaultHelper);
+      beforeEach(async () => {
+        element = fixtureSync('<helper-text-mixin-element></helper-text-mixin-element>');
+        await nextFrame();
+        defaultHelper = element._helperNode;
+        helper = document.createElement('div');
+        helper.setAttribute('slot', 'helper');
+        helper.textContent = 'Lazy';
+      });
+
+      it('should return lazy helper content as a helperText using appendChild', async () => {
+        element.appendChild(helper);
+        await nextFrame();
+        expect(element.helperText).to.equal('Lazy');
+      });
+
+      it('should return lazy helper content as a helperText using insertBefore', async () => {
+        element.insertBefore(helper, defaultHelper);
+        await nextFrame();
+        expect(element.helperText).to.equal('Lazy');
+      });
+
+      it('should return lazy helper content as a helperText using replaceChild', async () => {
+        element.replaceChild(helper, defaultHelper);
+        await nextFrame();
+        expect(element.helperText).to.equal('Lazy');
+      });
+
+      it('should remove the default helper from the element when using appendChild', async () => {
+        element.appendChild(helper);
+        await nextFrame();
+        expect(defaultHelper.parentNode).to.be.null;
+      });
+
+      it('should remove the default helper from the element when using insertBefore', async () => {
+        element.insertBefore(helper, defaultHelper);
+        await nextFrame();
+        expect(defaultHelper.parentNode).to.be.null;
+      });
+
+      it('should support replacing lazy helper with a new one using appendChild', async () => {
+        element.appendChild(helper);
+        await nextFrame();
+
+        const div = document.createElement('div');
+        div.setAttribute('slot', 'helper');
+        div.textContent = 'New';
+        element.appendChild(div);
+        await nextFrame();
+        expect(element.helperText).to.equal('New');
+      });
+
+      it('should support replacing lazy helper with a new one using insertBefore', async () => {
+        element.appendChild(helper);
+        await nextFrame();
+
+        const div = document.createElement('div');
+        div.setAttribute('slot', 'helper');
+        div.textContent = 'New';
+        element.insertBefore(div, helper);
+        await nextFrame();
+        expect(element.helperText).to.equal('New');
+      });
+
+      it('should support replacing lazy helper with a new one using replaceChild', async () => {
+        element.appendChild(helper);
+        await nextFrame();
+
+        const div = document.createElement('div');
+        div.setAttribute('slot', 'helper');
+        div.textContent = 'New';
+        element.replaceChild(div, helper);
+        await nextFrame();
+        expect(element.helperText).to.equal('New');
+      });
     });
 
-    it('should return lazy helper content as a helperText', () => {
-      expect(element.helperText).to.equal('Lazy');
-    });
+    describe('attributes', () => {
+      beforeEach(async () => {
+        element = fixtureSync('<helper-text-mixin-element></helper-text-mixin-element>');
+        await nextFrame();
+        helper = document.createElement('div');
+        helper.setAttribute('slot', 'helper');
+        helper.textContent = 'Lazy';
+        element.appendChild(helper);
+        await nextFrame();
+      });
 
-    it('should store a reference to the lazily added helper', () => {
-      expect(element._helperNode).to.equal(helper);
-    });
+      it('should store a reference to the lazily added helper', () => {
+        expect(element._helperNode).to.equal(helper);
+      });
 
-    it('should remove the default helper from the element', () => {
-      expect(defaultHelper.parentNode).to.be.null;
-    });
+      it('should set id on the lazily added helper element', () => {
+        const idRegex = /^helper-helper-text-mixin-element-\d+$/;
+        expect(helper.getAttribute('id')).to.match(idRegex);
+      });
 
-    it('should set id on the lazily added helper element', () => {
-      const idRegex = /^helper-helper-text-mixin-element-\d+$/;
-      expect(helper.getAttribute('id')).to.match(idRegex);
-    });
+      it('should set has-helper attribute with lazy helper', () => {
+        expect(element.hasAttribute('has-helper')).to.be.true;
+      });
 
-    it('should set has-helper attribute with lazy helper', () => {
-      expect(element.hasAttribute('has-helper')).to.be.true;
-    });
-
-    it('should update lazy helper content on property change', () => {
-      element.helperText = '3 digits';
-      expect(helper.textContent).to.equal('3 digits');
-    });
-
-    it('should support replacing lazy helper with a new one', async () => {
-      const div = document.createElement('div');
-      div.setAttribute('slot', 'helper');
-      div.textContent = 'New';
-      element.replaceChild(div, helper);
-      await nextFrame();
-      expect(element.helperText).to.equal('New');
+      it('should update lazy helper content on property change', () => {
+        element.helperText = '3 digits';
+        expect(helper.textContent).to.equal('3 digits');
+      });
     });
   });
 });

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -1,0 +1,189 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { ValidateMixin } from '../src/validate-mixin.js';
+
+customElements.define(
+  'validate-mixin-element',
+  class extends ValidateMixin(PolymerElement) {
+    static get template() {
+      return html`<slot name="error-message"></slot>`;
+    }
+  }
+);
+
+describe('validate-mixin', () => {
+  let element, error;
+
+  describe('default', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<validate-mixin-element></validate-mixin-element>`);
+      error = element.querySelector('[slot=error-message]');
+      element.invalid = true;
+    });
+
+    it('should create an error message element', () => {
+      expect(error instanceof HTMLDivElement).to.be.true;
+    });
+
+    it('should set aria-live attribute on the error message', () => {
+      expect(error.getAttribute('aria-live')).to.equal('assertive');
+    });
+
+    it('should set id on the error message element', () => {
+      const idRegex = /^error-validate-mixin-element-\d+$/;
+      expect(idRegex.test(error.getAttribute('id'))).to.be.true;
+    });
+
+    it('should update error message content on attribute change', () => {
+      element.setAttribute('error-message', 'This field is required');
+      expect(error.textContent).to.equal('This field is required');
+    });
+
+    it('should update error message content on property change', () => {
+      element.errorMessage = 'This field is required';
+      expect(error.textContent).to.equal('This field is required');
+    });
+
+    it('should clear error message content when field is valid', () => {
+      element.errorMessage = 'This field is required';
+      element.invalid = false;
+      expect(error.textContent).to.equal('');
+    });
+
+    it('should not set has-error-message attribute with no error', () => {
+      expect(element.hasAttribute('has-error-message')).to.be.false;
+    });
+
+    it('should set has-error-message attribute when attribute is set', () => {
+      element.setAttribute('error-message', 'This field is required');
+      expect(element.hasAttribute('has-error-message')).to.be.true;
+    });
+
+    it('should set has-error-message attribute when property is set', () => {
+      element.errorMessage = 'This field is required';
+      expect(element.hasAttribute('has-error-message')).to.be.true;
+    });
+
+    it('should remove has-error-message attribute when field is valid', () => {
+      element.errorMessage = 'This field is required';
+      element.invalid = false;
+      expect(element.hasAttribute('has-error-message')).to.be.false;
+    });
+  });
+
+  describe('attribute', () => {
+    beforeEach(() => {
+      element = fixtureSync(`
+        <validate-mixin-element
+          error-message="This field is required"
+        ></validate-mixin-element>
+      `);
+      error = element.querySelector('[slot=error-message]');
+      element.invalid = true;
+    });
+
+    it('should set error-message text content from attribute', () => {
+      expect(error.textContent).to.equal('This field is required');
+    });
+  });
+
+  describe('slotted', () => {
+    beforeEach(() => {
+      element = fixtureSync(`
+        <validate-mixin-element>
+          <div slot="error-message">Required field</div>
+        </validate-mixin-element>
+      `);
+      error = element.querySelector('[slot=error-message]');
+      element.invalid = true;
+    });
+
+    it('should return slotted message content as an errorMessage', () => {
+      expect(element.errorMessage).to.equal('Required field');
+    });
+
+    it('should set id on the slotted error message element', () => {
+      const idRegex = /^error-validate-mixin-element-\d+$/;
+      expect(idRegex.test(error.getAttribute('id'))).to.be.true;
+    });
+
+    it('should set has-error-message attribute with slotted error message', () => {
+      expect(element.hasAttribute('has-error-message')).to.be.true;
+    });
+
+    it('should update slotted error message content on property change', () => {
+      element.errorMessage = 'This field is required';
+      expect(error.textContent).to.equal('This field is required');
+    });
+  });
+
+  describe('checkValidity', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<validate-mixin-element></validate-mixin-element>`);
+    });
+
+    it('should return true when element is not required', () => {
+      expect(element.checkValidity()).to.be.true;
+    });
+
+    it('should return false when element is required and value is not set', () => {
+      element.required = true;
+      expect(element.checkValidity()).to.be.false;
+    });
+
+    it('should return true when element is required and value is set', () => {
+      element.required = true;
+      element.value = 'value';
+      expect(element.checkValidity()).to.be.true;
+    });
+  });
+
+  describe('validate', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<validate-mixin-element></validate-mixin-element>`);
+    });
+
+    it('should return true when element is not required', () => {
+      expect(element.validate()).to.be.true;
+    });
+
+    it('should return false when element is required and value is not set', () => {
+      element.required = true;
+      expect(element.validate()).to.be.false;
+    });
+
+    it('should return true when element is required and value is set', () => {
+      element.required = true;
+      element.value = 'value';
+      expect(element.validate()).to.be.true;
+    });
+
+    it('should not set invalid to true when element is not required', () => {
+      element.validate();
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should set invalid when element is required and value is not set', () => {
+      element.required = true;
+      element.validate();
+      expect(element.invalid).to.be.true;
+    });
+
+    it('should not set invalid to true when element is required and value is set', () => {
+      element.required = true;
+      element.value = 'value';
+      element.validate();
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should set invalid back to false after value is set on the element', () => {
+      element.required = true;
+      element.validate();
+
+      element.value = 'value';
+      element.validate();
+      expect(element.invalid).to.be.false;
+    });
+  });
+});

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -23,7 +23,7 @@ describe('validate-mixin', () => {
     });
 
     it('should create an error message element', () => {
-      expect(error instanceof HTMLDivElement).to.be.true;
+      expect(error).to.be.an.instanceof(HTMLDivElement);
     });
 
     it('should set aria-live attribute on the error message', () => {
@@ -32,7 +32,7 @@ describe('validate-mixin', () => {
 
     it('should set id on the error message element', () => {
       const idRegex = /^error-validate-mixin-element-\d+$/;
-      expect(idRegex.test(error.getAttribute('id'))).to.be.true;
+      expect(error.getAttribute('id')).to.match(idRegex);
     });
 
     it('should update error message content on attribute change', () => {
@@ -105,7 +105,7 @@ describe('validate-mixin', () => {
 
     it('should set id on the slotted error message element', () => {
       const idRegex = /^error-validate-mixin-element-\d+$/;
-      expect(idRegex.test(error.getAttribute('id'))).to.be.true;
+      expect(error.getAttribute('id')).to.match(idRegex);
     });
 
     it('should set has-error-message attribute with slotted error message', () => {


### PR DESCRIPTION
## Description

This is a second batch of mixins that are needed to implement slotted `input` support in field components.

Fixes #2183

## Type of change

- Internal feature