### PR TITLE
feat: add mixins to handle focus and disabled state

### DIFF
--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -1,3 +1,4 @@
+export { DelegateFocusMixin } from './src/delegate-focus-mixin.js';
 export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';

--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -1,4 +1,5 @@
 export { FieldAriaMixin } from './src/field-aria-mixin.js';
+export { FocusMixin } from './src/focus-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';

--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -1,3 +1,4 @@
+export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -1,3 +1,4 @@
+export { DelegateFocusMixin } from './src/delegate-focus-mixin.js';
 export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -1,4 +1,5 @@
 export { FieldAriaMixin } from './src/field-aria-mixin.js';
+export { FocusMixin } from './src/focus-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -1,3 +1,4 @@
+export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';

--- a/packages/field-base/src/delegate-focus-mixin.d.ts
+++ b/packages/field-base/src/delegate-focus-mixin.d.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { FocusMixin } from './focus-mixin.js';
+import { DisabledMixin } from './disabled-mixin.js';
+
+/**
+ * A mixin to forward focus to an element in the light DOM.
+ */
+declare function DelegateFocusMixin<T extends new (...args: any[]) => {}>(base: T): T & DelegateFocusMixinConstructor;
+
+interface DelegateFocusMixinConstructor {
+  new (...args: any[]): DelegateFocusMixin;
+}
+
+interface DelegateFocusMixin extends DisabledMixin, FocusMixin {
+  /**
+   * Specify that this control should have input focus when the page loads.
+   */
+  autofocus: boolean;
+
+  /**
+   * Any element extending this mixin is required to implement this getter.
+   * It returns the actual focusable element in the component.
+   */
+  readonly focusElement: Element | null | undefined;
+}
+
+export { DelegateFocusMixinConstructor, DelegateFocusMixin };

--- a/packages/field-base/src/delegate-focus-mixin.js
+++ b/packages/field-base/src/delegate-focus-mixin.js
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { FocusMixin } from './focus-mixin.js';
+import { DisabledMixin } from './disabled-mixin.js';
+
+const DelegateFocusMixinImplementation = (superclass) =>
+  class DelegateFocusMixinClass extends FocusMixin(DisabledMixin(superclass)) {
+    static get properties() {
+      return {
+        /**
+         * Specify that this control should have input focus when the page loads.
+         */
+        autofocus: {
+          type: Boolean
+        }
+      };
+    }
+
+    /**
+     * Any element extending this mixin is required to implement this getter.
+     * It returns the actual focusable element in the component.
+     * @return {Element | null | undefined}
+     */
+    get focusElement() {
+      console.warn(`Please implement the 'focusElement' property in <${this.localName}>`);
+      return null;
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      if (this.autofocus && !this.disabled) {
+        requestAnimationFrame(() => {
+          this.focusElement.focus();
+          this._setFocused(true);
+          this.setAttribute('focus-ring', '');
+        });
+      }
+    }
+
+    focus() {
+      if (!this.focusElement || this.disabled) {
+        return;
+      }
+
+      this.focusElement.focus();
+      this._setFocused(true);
+    }
+
+    blur() {
+      if (!this.focusElement) {
+        return;
+      }
+      this.focusElement.blur();
+      this._setFocused(false);
+    }
+
+    click() {
+      if (this.focusElement && !this.disabled) {
+        this.focusElement.click();
+      }
+    }
+
+    /**
+     * @param {Event} event
+     * @return {boolean}
+     * @protected
+     */
+    _shouldSetFocus(event) {
+      return event.composedPath()[0] === this.focusElement;
+    }
+
+    /**
+     * @param {boolean} disabled
+     * @protected
+     */
+    _disabledChanged(disabled) {
+      super._disabledChanged(disabled);
+
+      if (this.focusElement) {
+        this.focusElement.disabled = disabled;
+      }
+
+      if (disabled) {
+        this.blur();
+      }
+    }
+  };
+
+/**
+ * A mixin to forward focus to an element in the light DOM.
+ */
+export const DelegateFocusMixin = dedupingMixin(DelegateFocusMixinImplementation);

--- a/packages/field-base/src/delegate-focus-mixin.js
+++ b/packages/field-base/src/delegate-focus-mixin.js
@@ -36,8 +36,7 @@ const DelegateFocusMixinImplementation = (superclass) =>
 
       if (this.autofocus && !this.disabled) {
         requestAnimationFrame(() => {
-          this.focusElement.focus();
-          this._setFocused(true);
+          this.focus();
           this.setAttribute('focus-ring', '');
         });
       }
@@ -72,7 +71,7 @@ const DelegateFocusMixinImplementation = (superclass) =>
      * @protected
      */
     _shouldSetFocus(event) {
-      return event.composedPath()[0] === this.focusElement;
+      return event.target === this.focusElement;
     }
 
     /**

--- a/packages/field-base/src/disabled-mixin.d.ts
+++ b/packages/field-base/src/disabled-mixin.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A mixin to provide disabled property for field components.
+ */
+declare function DisabledMixin<T extends new (...args: any[]) => {}>(base: T): T & DisabledMixinConstructor;
+
+interface DisabledMixinConstructor {
+  new (...args: any[]): DisabledMixin;
+}
+
+interface DisabledMixin {
+  /**
+   * If true, the user cannot interact with this element.
+   */
+  disabled: boolean;
+}
+
+export { DisabledMixinConstructor, DisabledMixin };

--- a/packages/field-base/src/disabled-mixin.js
+++ b/packages/field-base/src/disabled-mixin.js
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+
+const DisabledMixinImplementation = (superclass) =>
+  class DisabledMixinClass extends superclass {
+    static get properties() {
+      return {
+        /**
+         * If true, the user cannot interact with this element.
+         */
+        disabled: {
+          type: Boolean,
+          value: false,
+          observer: '_disabledChanged',
+          reflectToAttribute: true
+        }
+      };
+    }
+
+    /**
+     * @param {boolean} disabled
+     * @protected
+     */
+    _disabledChanged(disabled) {
+      this._setAriaDisabled(disabled);
+    }
+
+    /**
+     * @param {boolean} disabled
+     * @protected
+     */
+    _setAriaDisabled(disabled) {
+      if (disabled) {
+        this.setAttribute('aria-disabled', 'true');
+      } else {
+        this.removeAttribute('aria-disabled');
+      }
+    }
+  };
+
+/**
+ * A mixin to provide disabled property for field components.
+ */
+export const DisabledMixin = dedupingMixin(DisabledMixinImplementation);

--- a/packages/field-base/src/focus-mixin.d.ts
+++ b/packages/field-base/src/focus-mixin.d.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A mixin to handle `focused` and `focus-ring` attributes based on focus.
+ */
+declare function FocusMixin<T extends new (...args: any[]) => {}>(base: T): T & FocusMixinConstructor;
+
+interface FocusMixinConstructor {
+  new (...args: any[]): FocusMixin;
+}
+
+interface FocusMixin {
+  /**
+   * Override to change how focused and focus-ring attributes are set.
+   */
+  _setFocused(focused: boolean): void;
+
+  /**
+   * Override to define if the field receives focus based on the event.
+   */
+  _shouldSetFocus(event: FocusEvent): boolean;
+
+  /**
+   * Override to define if the field loses focus based on the event.
+   */
+  _shouldRemoveFocus(event: FocusEvent): boolean;
+}
+
+export { FocusMixinConstructor, FocusMixin };

--- a/packages/field-base/src/focus-mixin.js
+++ b/packages/field-base/src/focus-mixin.js
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+
+// We consider the keyboard to be active if the window has received a keydown
+// event since the last mousedown event.
+let keyboardActive = false;
+
+// Listen for top-level keydown and mousedown events.
+// Use capture phase so we detect events even if they're handled.
+window.addEventListener(
+  'keydown',
+  () => {
+    keyboardActive = true;
+  },
+  { capture: true }
+);
+
+window.addEventListener(
+  'mousedown',
+  () => {
+    keyboardActive = false;
+  },
+  { capture: true }
+);
+
+const FocusMixinImplementation = (superclass) =>
+  class FocusMixinClass extends superclass {
+    /** @protected */
+    ready() {
+      this.addEventListener('focusin', (e) => {
+        if (this._shouldSetFocus(e)) {
+          this._setFocused(true);
+        }
+      });
+
+      this.addEventListener('focusout', (e) => {
+        if (this._shouldRemoveFocus(e)) {
+          this._setFocused(false);
+        }
+      });
+
+      // In super.ready() other 'focusin' and 'focusout' listeners might be
+      // added, so we call it after our own ones to ensure they execute first.
+      // Issue to watch out: when incorrect, <vaadin-combo-box> refocuses the
+      // input field on iOS after “Done” is pressed.
+      super.ready();
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+
+      // in non-Chrome browsers, blur does not fire on the element when it is disconnected.
+      // reproducible in `<vaadin-date-picker>` when closing on `Cancel` or `Today` click.
+      if (this.hasAttribute('focused')) {
+        this._setFocused(false);
+      }
+    }
+
+    /**
+     * Override to change how focused and focus-ring attributes are set.
+     *
+     * @param {boolean} focused
+     * @protected
+     */
+    _setFocused(focused) {
+      if (focused) {
+        this.setAttribute('focused', '');
+      } else {
+        this.removeAttribute('focused');
+      }
+
+      // focus-ring is true when the element was focused from the keyboard.
+      // Focus Ring [A11ycasts]: https://youtu.be/ilj2P5-5CjI
+      if (focused && keyboardActive) {
+        this.setAttribute('focus-ring', '');
+      } else {
+        this.removeAttribute('focus-ring');
+      }
+    }
+
+    /**
+     * Override to define if the field receives focus based on the event.
+     *
+     * @param {FocusEvent} event
+     * @return {boolean}
+     * @protected
+     */
+    _shouldSetFocus(_event) {
+      return true;
+    }
+
+    /**
+     * Override to define if the field loses focus based on the event.
+     *
+     * @param {FocusEvent} event
+     * @return {boolean}
+     * @protected
+     */
+    _shouldRemoveFocus(_event) {
+      return true;
+    }
+  };
+
+/**
+ * A mixin to handle `focused` and `focus-ring` attributes based on focus.
+ */
+export const FocusMixin = dedupingMixin(FocusMixinImplementation);

--- a/packages/field-base/src/focus-mixin.js
+++ b/packages/field-base/src/focus-mixin.js
@@ -68,19 +68,11 @@ const FocusMixinImplementation = (superclass) =>
      * @protected
      */
     _setFocused(focused) {
-      if (focused) {
-        this.setAttribute('focused', '');
-      } else {
-        this.removeAttribute('focused');
-      }
+      this.toggleAttribute('focused', focused);
 
       // focus-ring is true when the element was focused from the keyboard.
       // Focus Ring [A11ycasts]: https://youtu.be/ilj2P5-5CjI
-      if (focused && keyboardActive) {
-        this.setAttribute('focus-ring', '');
-      } else {
-        this.removeAttribute('focus-ring');
-      }
+      this.toggleAttribute('focus-ring', focused && keyboardActive);
     }
 
     /**

--- a/packages/field-base/test/delegate-focus-mixin.test.js
+++ b/packages/field-base/test/delegate-focus-mixin.test.js
@@ -1,0 +1,139 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { DelegateFocusMixin } from '../src/delegate-focus-mixin.js';
+import { InputMixin } from '../src/input-mixin.js';
+
+customElements.define(
+  'delegate-focus-mixin-element',
+  class extends DelegateFocusMixin(InputMixin(PolymerElement)) {
+    static get template() {
+      return html`<slot name="input"></slot>`;
+    }
+
+    get focusElement() {
+      return this._inputNode;
+    }
+  }
+);
+
+describe('delegate-focus-mixin', () => {
+  let element, input;
+
+  describe('default', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<delegate-focus-mixin-element></delegate-focus-mixin-element>`);
+      input = element.querySelector('input');
+    });
+
+    it('should focus the input on focus call', () => {
+      const spy = sinon.spy(input, 'focus');
+      element.focus();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should set focused attribute on focus call', () => {
+      element.focus();
+      expect(element.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should blur the input on blur call', () => {
+      const spy = sinon.spy(input, 'blur');
+      element.focus();
+      element.blur();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should remove focused attribute on blur call', () => {
+      element.focus();
+      element.blur();
+      expect(element.hasAttribute('focused')).to.be.false;
+    });
+
+    it('should not focus the input on focus when disabled', () => {
+      const spy = sinon.spy(input, 'focus');
+      element.disabled = true;
+      element.focus();
+      expect(spy.calledOnce).to.be.false;
+    });
+
+    it('should not set focused attribute when disabled', () => {
+      element.disabled = true;
+      element.focus();
+      expect(element.hasAttribute('focused')).to.be.false;
+    });
+
+    it('should propagate disabled property to the input', () => {
+      element.disabled = true;
+      expect(input.disabled).to.be.true;
+
+      element.disabled = false;
+      expect(input.disabled).to.be.false;
+    });
+
+    it('should call blur when disabled is set to true', () => {
+      const spy = sinon.spy(element, 'blur');
+      element.disabled = true;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should click the input on click call', () => {
+      const spy = sinon.spy(input, 'click');
+      element.click();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should not click the input on click when disabled', () => {
+      const spy = sinon.spy(input, 'click');
+      element.disabled = true;
+      element.click();
+      expect(spy.calledOnce).to.be.false;
+    });
+  });
+
+  describe('autofocus', () => {
+    beforeEach(() => {
+      element = document.createElement('delegate-focus-mixin-element');
+      element.autofocus = true;
+    });
+
+    afterEach(() => {
+      document.body.removeChild(element);
+    });
+
+    it('should focus the input when autofocus is set', async () => {
+      document.body.appendChild(element);
+      const spy = sinon.spy(element._inputNode, 'focus');
+      await nextFrame();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should set focused attribute when autofocus is set', async () => {
+      document.body.appendChild(element);
+      await nextFrame();
+      expect(element.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should set focus-ring attribute when autofocus is set', async () => {
+      document.body.appendChild(element);
+      await nextFrame();
+      expect(element.hasAttribute('focus-ring')).to.be.true;
+    });
+
+    it('should not focus the input when disabled is set', async () => {
+      element.disabled = true;
+      document.body.appendChild(element);
+      const spy = sinon.spy(element.focusElement, 'focus');
+      await nextFrame();
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not set focused attribute when autofocus is set', async () => {
+      element.disabled = true;
+      document.body.appendChild(element);
+      await nextFrame();
+      expect(element.hasAttribute('focused')).to.be.false;
+    });
+  });
+});

--- a/packages/field-base/test/delegate-focus-mixin.test.js
+++ b/packages/field-base/test/delegate-focus-mixin.test.js
@@ -129,11 +129,18 @@ describe('delegate-focus-mixin', () => {
       expect(spy.called).to.be.false;
     });
 
-    it('should not set focused attribute when autofocus is set', async () => {
+    it('should not set focused attribute when disabled is set', async () => {
       element.disabled = true;
       document.body.appendChild(element);
       await nextFrame();
       expect(element.hasAttribute('focused')).to.be.false;
+    });
+
+    it('should not set focus-ring attribute when disabled is set', async () => {
+      element.disabled = true;
+      document.body.appendChild(element);
+      await nextFrame();
+      expect(element.hasAttribute('focus-ring')).to.be.false;
     });
   });
 });

--- a/packages/field-base/test/disabled-mixin.test.js
+++ b/packages/field-base/test/disabled-mixin.test.js
@@ -1,0 +1,41 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { DisabledMixin } from '../src/disabled-mixin.js';
+
+customElements.define(
+  'disabled-mixin-element',
+  class extends DisabledMixin(PolymerElement) {
+    static get template() {
+      return html`<slot></slot>`;
+    }
+  }
+);
+
+describe('disabled-mixin', () => {
+  let element;
+
+  beforeEach(() => {
+    element = fixtureSync(`<disabled-mixin-element></disabled-mixin-element>`);
+  });
+
+  it('should set disabled property to false by default', () => {
+    expect(element.disabled).to.be.false;
+  });
+
+  it('should reflect disabled property to attribute', () => {
+    element.disabled = true;
+    expect(element.hasAttribute('disabled')).to.be.true;
+
+    element.disabled = false;
+    expect(element.hasAttribute('disabled')).to.be.false;
+  });
+
+  it('should set the aria-disabled attribute when disabled', () => {
+    element.disabled = true;
+    expect(element.getAttribute('aria-disabled')).to.equal('true');
+
+    element.disabled = false;
+    expect(element.hasAttribute('aria-disabled')).to.be.false;
+  });
+});

--- a/packages/field-base/test/focus-mixin.test.js
+++ b/packages/field-base/test/focus-mixin.test.js
@@ -1,0 +1,54 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, focusin, focusout, keyDownOn } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { FocusMixin } from '../src/focus-mixin.js';
+
+customElements.define(
+  'focus-mixin-element',
+  class extends FocusMixin(PolymerElement) {
+    static get template() {
+      return html`<slot></slot>`;
+    }
+
+    ready() {
+      super.ready();
+      const input = document.createElement('input');
+      this.appendChild(input);
+    }
+  }
+);
+
+describe('focus-mixin', () => {
+  let element, input;
+
+  beforeEach(() => {
+    element = fixtureSync(`<focus-mixin-element></focus-mixin-element>`);
+    input = element.querySelector('input');
+  });
+
+  it('should set focused attribute on focusin event', () => {
+    focusin(input);
+    expect(element.hasAttribute('focused')).to.be.true;
+  });
+
+  it('should remove focused attribute on focusout event', () => {
+    focusin(input);
+    focusout(input);
+    expect(element.hasAttribute('focused')).to.be.false;
+  });
+
+  it('should set the focus-ring attribute on focusin after keydown', () => {
+    keyDownOn(document.body, 9);
+    focusin(input);
+    expect(element.hasAttribute('focus-ring')).to.be.true;
+
+    focusout(input);
+    expect(element.hasAttribute('focus-ring')).to.be.false;
+  });
+
+  it('should remove focused attribute when disconnected from the DOM', () => {
+    focusin(input);
+    element.parentNode.removeChild(element);
+    expect(element.hasAttribute('focused')).to.be.false;
+  });
+});

--- a/packages/field-base/test/focus-mixin.test.js
+++ b/packages/field-base/test/focus-mixin.test.js
@@ -52,7 +52,7 @@ describe('focus-mixin', () => {
     expect(element.hasAttribute('focused')).to.be.false;
   });
 
-  it('should not the focus-ring attribute on mousedown after keydown', () => {
+  it('should not set the focus-ring attribute on mousedown after keydown', () => {
     keyDownOn(document.body, 9);
     mousedown(input);
     focusin(input);

--- a/packages/field-base/test/focus-mixin.test.js
+++ b/packages/field-base/test/focus-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, focusin, focusout, keyDownOn } from '@vaadin/testing-helpers';
+import { fixtureSync, focusin, focusout, keyDownOn, mousedown } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { FocusMixin } from '../src/focus-mixin.js';
 
@@ -50,5 +50,12 @@ describe('focus-mixin', () => {
     focusin(input);
     element.parentNode.removeChild(element);
     expect(element.hasAttribute('focused')).to.be.false;
+  });
+
+  it('should not the focus-ring attribute on mousedown after keydown', () => {
+    keyDownOn(document.body, 9);
+    mousedown(input);
+    focusin(input);
+    expect(element.hasAttribute('focus-ring')).to.be.false;
   });
 });


### PR DESCRIPTION
## Description

This is a third batch of mixins that are needed to implement slotted `input` support in field components.

The code is mostly the same as in `ControlStateMixin`, but there are two important differences:
1. We expect the `focusElement` to be in light DOM so event listeners are updated accordingly,
2. We no longer set `tabindex` on the host element, and it is no longer focusable. So we don't handle `tabindex` and expect the user to set it directly on the slotted `<input>` if needed (although we should not encourage doing this).
 
Fixes #2186

## Type of change

- Internal feature