### PR TITLE
feat: add mixins for input properties and clear button

### DIFF
--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -5,6 +5,7 @@ export { FocusMixin } from './src/focus-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
+export { InputPropsMixin } from './src/input-props-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
 export { ValidateMixin } from './src/validate-mixin.js';

--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -1,3 +1,4 @@
+export { ClearButtonMixin } from './src/clear-button-mixin.js';
 export { DelegateFocusMixin } from './src/delegate-focus-mixin.js';
 export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaMixin } from './src/field-aria-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -5,6 +5,7 @@ export { FocusMixin } from './src/focus-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
+export { InputPropsMixin } from './src/input-props-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
 export { ValidateMixin } from './src/validate-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -1,3 +1,4 @@
+export { ClearButtonMixin } from './src/clear-button-mixin.js';
 export { DelegateFocusMixin } from './src/delegate-focus-mixin.js';
 export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaMixin } from './src/field-aria-mixin.js';

--- a/packages/field-base/src/clear-button-mixin.d.ts
+++ b/packages/field-base/src/clear-button-mixin.d.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { InputMixin } from './input-mixin.js';
+
+/**
+ * A mixin to add clear button support to field components.
+ */
+declare function ClearButtonMixin<T extends new (...args: any[]) => {}>(base: T): T & ClearButtonMixinConstructor;
+
+interface ClearButtonMixinConstructor {
+  new (...args: any[]): ClearButtonMixin;
+}
+
+interface ClearButtonMixin extends InputMixin {
+  /**
+   * Set to true to display the clear icon which clears the input.
+   * @attr {boolean} clear-button-visible
+   */
+  clearButtonVisible: boolean;
+
+  /**
+   * Clear the value of this field.
+   */
+  clear(): void;
+
+  readonly _clearOnEsc: boolean;
+}
+
+export { ClearButtonMixin, ClearButtonMixinConstructor };

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { InputMixin } from './input-mixin.js';
+
+const ClearButtonMixinImplementation = (superclass) =>
+  class ClearButtonMixinClass extends InputMixin(superclass) {
+    static get properties() {
+      return {
+        /**
+         * Set to true to display the clear icon which clears the input.
+         * @attr {boolean} clear-button-visible
+         */
+        clearButtonVisible: {
+          type: Boolean,
+          reflectToAttribute: true,
+          value: false
+        }
+      };
+    }
+
+    /** @protected */
+    get _clearOnEsc() {
+      return true;
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.addEventListener('keydown', (e) => this._handleKeyDown(e));
+
+      this._clearElement = this.$.clearButton;
+      this._clearElement.addEventListener('click', this._onClearButtonClick.bind(this));
+    }
+
+    /**
+     * Clear the value of this field.
+     */
+    clear() {
+      this.value = this._inputNode.value = '';
+    }
+
+    /** @private */
+    _onClearButtonClick(e) {
+      e.preventDefault();
+      this._inputNode.focus();
+      this.clear();
+      const inputEvent = new Event('input', { bubbles: true, composed: true });
+      inputEvent.__fromClearButton = true;
+
+      const changeEvent = new Event('change', { bubbles: true });
+      changeEvent.__fromClearButton = true;
+
+      this._inputNode.dispatchEvent(inputEvent);
+      this._inputNode.dispatchEvent(changeEvent);
+    }
+
+    /**
+     * @param {Event} event
+     * @protected
+     */
+    _handleKeyDown(event) {
+      if (event.key === 'Escape' && this.clearButtonVisible && this._clearOnEsc) {
+        const dispatchChange = !!this.value;
+        this.clear();
+        dispatchChange && this._inputNode.dispatchEvent(new Event('change'));
+      }
+    }
+  };
+
+/**
+ * A mixin to add clear button support to field components.
+ */
+export const ClearButtonMixin = dedupingMixin(ClearButtonMixinImplementation);

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -22,6 +22,17 @@ const ClearButtonMixinImplementation = (superclass) =>
       };
     }
 
+    /**
+     * Any element extending this mixin is required to implement this getter.
+     * It returns the reference to the clear button element.
+     * @protected
+     * @return {Element | null | undefined}
+     */
+    get clearElement() {
+      console.warn(`Please implement the 'clearElement' property in <${this.localName}>`);
+      return null;
+    }
+
     /** @protected */
     get _clearOnEsc() {
       return true;
@@ -33,8 +44,9 @@ const ClearButtonMixinImplementation = (superclass) =>
 
       this.addEventListener('keydown', (e) => this._onKeyDown(e));
 
-      this._clearElement = this.$.clearButton;
-      this._clearElement.addEventListener('click', this._onClearButtonClick.bind(this));
+      if (this.clearElement) {
+        this.clearElement.addEventListener('click', this._onClearButtonClick.bind(this));
+      }
     }
 
     /**

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -56,7 +56,10 @@ const ClearButtonMixinImplementation = (superclass) =>
       this.value = this._inputNode.value = '';
     }
 
-    /** @private */
+    /**
+     * @param {Event} event
+     * @protected
+     */
     _onClearButtonClick(event) {
       event.preventDefault();
       this._inputNode.focus();

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -64,10 +64,8 @@ const ClearButtonMixinImplementation = (superclass) =>
       event.preventDefault();
       this._inputNode.focus();
       this.clear();
-      const inputEvent = new Event('input', { bubbles: true, composed: true });
-      const changeEvent = new Event('change', { bubbles: true });
-      this._inputNode.dispatchEvent(inputEvent);
-      this._inputNode.dispatchEvent(changeEvent);
+      this._inputNode.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+      this._inputNode.dispatchEvent(new Event('change', { bubbles: true }));
     }
 
     /**

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -31,7 +31,7 @@ const ClearButtonMixinImplementation = (superclass) =>
     ready() {
       super.ready();
 
-      this.addEventListener('keydown', (e) => this._handleKeyDown(e));
+      this.addEventListener('keydown', (e) => this._onKeyDown(e));
 
       this._clearElement = this.$.clearButton;
       this._clearElement.addEventListener('click', this._onClearButtonClick.bind(this));
@@ -45,16 +45,12 @@ const ClearButtonMixinImplementation = (superclass) =>
     }
 
     /** @private */
-    _onClearButtonClick(e) {
-      e.preventDefault();
+    _onClearButtonClick(event) {
+      event.preventDefault();
       this._inputNode.focus();
       this.clear();
       const inputEvent = new Event('input', { bubbles: true, composed: true });
-      inputEvent.__fromClearButton = true;
-
       const changeEvent = new Event('change', { bubbles: true });
-      changeEvent.__fromClearButton = true;
-
       this._inputNode.dispatchEvent(inputEvent);
       this._inputNode.dispatchEvent(changeEvent);
     }
@@ -63,11 +59,11 @@ const ClearButtonMixinImplementation = (superclass) =>
      * @param {Event} event
      * @protected
      */
-    _handleKeyDown(event) {
+    _onKeyDown(event) {
       if (event.key === 'Escape' && this.clearButtonVisible && this._clearOnEsc) {
         const dispatchChange = !!this.value;
         this.clear();
-        dispatchChange && this._inputNode.dispatchEvent(new Event('change'));
+        dispatchChange && this._inputNode.dispatchEvent(new Event('change', { bubbles: true }));
       }
     }
   };

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -45,7 +45,7 @@ const ClearButtonMixinImplementation = (superclass) =>
       this.addEventListener('keydown', (e) => this._onKeyDown(e));
 
       if (this.clearElement) {
-        this.clearElement.addEventListener('click', this._onClearButtonClick.bind(this));
+        this.clearElement.addEventListener('click', (e) => this._onClearButtonClick(e));
       }
     }
 

--- a/packages/field-base/src/input-props-mixin.d.ts
+++ b/packages/field-base/src/input-props-mixin.d.ts
@@ -7,7 +7,7 @@ import { InputAriaMixin } from './input-aria-mixin.js';
 import { ValidateMixin } from './validate-mixin.js';
 
 /**
- * A mixin to add `<input>` element to the corresponding named slot.
+ * A mixin to forward properties to the native <input> element.
  */
 declare function InputPropsMixin<T extends new (...args: any[]) => {}>(base: T): T & InputPropsMixinConstructor;
 

--- a/packages/field-base/src/input-props-mixin.d.ts
+++ b/packages/field-base/src/input-props-mixin.d.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { InputAriaMixin } from './input-aria-mixin.js';
+import { ValidateMixin } from './validate-mixin.js';
+
+/**
+ * A mixin to add `<input>` element to the corresponding named slot.
+ */
+declare function InputPropsMixin<T extends new (...args: any[]) => {}>(base: T): T & InputPropsMixinConstructor;
+
+interface InputPropsMixinConstructor {
+  new (...args: any[]): InputPropsMixin;
+}
+
+interface InputPropsMixin extends InputAriaMixin, ValidateMixin {
+  /**
+   * The name of this field.
+   */
+  name: string;
+
+  /**
+   * A hint to the user of what can be entered in the field.
+   */
+  placeholder: string;
+
+  /**
+   * When present, it specifies that the field is read-only.
+   */
+  readonly: boolean;
+
+  /**
+   * The text usually displayed in a tooltip popup when the mouse is over the field.
+   */
+  title: string;
+}
+
+export { InputPropsMixinConstructor, InputPropsMixin };

--- a/packages/field-base/src/input-props-mixin.js
+++ b/packages/field-base/src/input-props-mixin.js
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { InputAriaMixin } from './input-aria-mixin.js';
+import { ValidateMixin } from './validate-mixin.js';
+
+const InputPropsMixinImplementation = (superclass) =>
+  class InputPropsMixinClass extends ValidateMixin(InputAriaMixin(superclass)) {
+    static get properties() {
+      return {
+        /**
+         * The name of this field.
+         */
+        name: {
+          type: String
+        },
+
+        /**
+         * A hint to the user of what can be entered in the field.
+         */
+        placeholder: {
+          type: String
+        },
+
+        /**
+         * When present, it specifies that the field is read-only.
+         */
+        readonly: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true
+        },
+
+        /**
+         * The text usually displayed in a tooltip popup when the mouse is over the field.
+         */
+        title: {
+          type: String
+        }
+      };
+    }
+
+    static get hostProps() {
+      return ['name', 'type', 'placeholder', 'readonly', 'required', 'invalid', 'title'];
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      if (this._inputNode) {
+        // Propagate initially defined properties to the slotted input
+        this._propagateHostAttributes(this.constructor.hostProps.map((attr) => this[attr] || this.getAttribute(attr)));
+      }
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      // create observer dynamically to allow subclasses to override hostProps
+      this._createMethodObserver(`_hostPropsChanged(${this.constructor.hostProps.join(', ')})`);
+    }
+
+    /** @private */
+    _hostPropsChanged(...attributesValues) {
+      this._propagateHostAttributes(attributesValues);
+    }
+
+    /** @private */
+    _propagateHostAttributes(attributesValues) {
+      const input = this._inputNode;
+      const attributeNames = this.constructor.hostProps;
+
+      attributeNames.forEach((attr, index) => {
+        if (attr === 'invalid') {
+          this._setOrToggleAttribute('aria-invalid', this.invalid ? 'true' : false, input);
+        } else {
+          this._setOrToggleAttribute(attr, attributesValues[index], input);
+        }
+      });
+    }
+
+    /** @protected */
+    _setOrToggleAttribute(name, value, node) {
+      if (!name || !node) {
+        return;
+      }
+
+      if (value) {
+        node.setAttribute(name, typeof value === 'boolean' ? '' : value);
+      } else {
+        node.removeAttribute(name);
+      }
+    }
+  };
+
+export const InputPropsMixin = dedupingMixin(InputPropsMixinImplementation);

--- a/packages/field-base/src/input-props-mixin.js
+++ b/packages/field-base/src/input-props-mixin.js
@@ -76,10 +76,12 @@ const InputPropsMixinImplementation = (superclass) =>
       const attributeNames = this.constructor.hostProps;
 
       attributeNames.forEach((attr, index) => {
+        const value = attributesValues[index];
         if (attr === 'invalid') {
-          this._setOrToggleAttribute('aria-invalid', this.invalid ? 'true' : false, input);
+          this._setOrToggleAttribute(attr, value, input);
+          this._setOrToggleAttribute('aria-invalid', value ? 'true' : false, input);
         } else {
-          this._setOrToggleAttribute(attr, attributesValues[index], input);
+          this._setOrToggleAttribute(attr, value, input);
         }
       });
     }

--- a/packages/field-base/src/input-props-mixin.js
+++ b/packages/field-base/src/input-props-mixin.js
@@ -100,4 +100,7 @@ const InputPropsMixinImplementation = (superclass) =>
     }
   };
 
+/**
+ * A mixin to forward properties to the native <input> element.
+ */
 export const InputPropsMixin = dedupingMixin(InputPropsMixinImplementation);

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -1,0 +1,106 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { fixtureSync, escKeyDown } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { ClearButtonMixin } from '../src/clear-button-mixin.js';
+
+customElements.define(
+  'clear-button-mixin-element',
+  class extends ClearButtonMixin(PolymerElement) {
+    static get template() {
+      return html`
+        <slot name="input"></slot>
+        <button id="clearButton">Clear</button>
+      `;
+    }
+
+    static get properties() {
+      return {
+        value: String
+      };
+    }
+  }
+);
+
+describe('clear-button-mixin', () => {
+  let element, input, button;
+
+  beforeEach(() => {
+    element = fixtureSync('<clear-button-mixin-element value="foo"></clear-button-mixin-element>');
+    input = element.querySelector('[slot=input]');
+    button = element.$.clearButton;
+  });
+
+  it('should clear the field value on clear method call', () => {
+    element.clear();
+    expect(element.value).to.equal('');
+  });
+
+  it('should clear the input value on clear method call', () => {
+    element.clear();
+    expect(input.value).to.equal('');
+  });
+
+  it('should clear the field value on clear button click', () => {
+    button.click();
+    expect(element.value).to.equal('');
+  });
+
+  it('should clear the input value on clear button click', () => {
+    button.click();
+    expect(input.value).to.equal('');
+  });
+
+  it('should focus the input on clear button click', () => {
+    const spy = sinon.spy(input, 'focus');
+    button.click();
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should dispatch input event on clear button click', () => {
+    const spy = sinon.spy();
+    input.addEventListener('input', spy);
+    button.click();
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should dispatch change event on clear button click', () => {
+    const spy = sinon.spy();
+    element.addEventListener('change', spy);
+    button.click();
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should call preventDefault on the button click event', () => {
+    const event = new CustomEvent('click', { cancelable: true });
+    button.dispatchEvent(event);
+    expect(event.defaultPrevented).to.be.true;
+  });
+
+  it('should reflect clearButtonVisible property to attribute', () => {
+    element.clearButtonVisible = true;
+    expect(element.hasAttribute('clear-button-visible')).to.be.true;
+
+    element.clearButtonVisible = false;
+    expect(element.hasAttribute('clear-button-visible')).to.be.false;
+  });
+
+  it('should clear value on Esc when clearButtonVisible is true', () => {
+    element.clearButtonVisible = true;
+    escKeyDown(button);
+    expect(input.value).to.equal('');
+  });
+
+  it('should not clear value on Esc when clearButtonVisible is false', () => {
+    escKeyDown(button);
+    expect(input.value).to.equal('foo');
+  });
+
+  it('should dispatch change event when clearing value on Esc', () => {
+    const spy = sinon.spy();
+    input.addEventListener('change', spy);
+    element.clearButtonVisible = true;
+    escKeyDown(button);
+    expect(spy.calledOnce).to.be.true;
+  });
+});

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -62,6 +62,9 @@ describe('clear-button-mixin', () => {
     input.addEventListener('input', spy);
     button.click();
     expect(spy.calledOnce).to.be.true;
+    const event = spy.firstCall.args[0];
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.true;
   });
 
   it('should dispatch change event on clear button click', () => {
@@ -69,6 +72,9 @@ describe('clear-button-mixin', () => {
     element.addEventListener('change', spy);
     button.click();
     expect(spy.calledOnce).to.be.true;
+    const event = spy.firstCall.args[0];
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.false;
   });
 
   it('should call preventDefault on the button click event', () => {
@@ -102,5 +108,8 @@ describe('clear-button-mixin', () => {
     element.clearButtonVisible = true;
     escKeyDown(button);
     expect(spy.calledOnce).to.be.true;
+    const event = spy.firstCall.args[0];
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.false;
   });
 });

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -19,6 +19,10 @@ customElements.define(
         value: String
       };
     }
+
+    get clearElement() {
+      return this.$.clearButton;
+    }
   }
 );
 

--- a/packages/field-base/test/input-props-mixin.test.js
+++ b/packages/field-base/test/input-props-mixin.test.js
@@ -1,0 +1,113 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { InputPropsMixin } from '../src/input-props-mixin.js';
+
+customElements.define(
+  'input-props-mixin-element',
+  class extends InputPropsMixin(PolymerElement) {
+    static get template() {
+      return html`<slot name="input"></slot>`;
+    }
+  }
+);
+
+describe('input-props-mixin', () => {
+  let element, input;
+
+  describe('name', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-props-mixin-element name="foo"></input-props-mixin-element>');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should propagate name attribute to the input', () => {
+      expect(input.name).to.equal('foo');
+    });
+
+    it('should propagate name property to the input', () => {
+      element.name = 'bar';
+      expect(input.name).to.equal('bar');
+    });
+  });
+
+  describe('title', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-props-mixin-element title="foo"></input-props-mixin-element>');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should propagate title attribute to the input', () => {
+      expect(input.title).to.equal('foo');
+    });
+
+    it('should propagate title property to the input', () => {
+      element.title = 'bar';
+      expect(input.title).to.equal('bar');
+    });
+  });
+
+  describe('placeholder', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-props-mixin-element placeholder="foo"></input-props-mixin-element>');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should propagate placeholder attribute to the input', () => {
+      expect(input.placeholder).to.equal('foo');
+    });
+
+    it('should propagate placeholder property to the input', () => {
+      element.placeholder = 'bar';
+      expect(input.placeholder).to.equal('bar');
+    });
+  });
+
+  describe('readonly', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-props-mixin-element readonly></input-props-mixin-element>');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should propagate readonly attribute to the input', () => {
+      expect(input.readOnly).to.be.true;
+    });
+
+    it('should propagate readonly property to the input', () => {
+      element.readonly = false;
+      expect(input.readOnly).to.be.false;
+    });
+  });
+
+  describe('required', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-props-mixin-element required></input-props-mixin-element>');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should propagate required attribute to the input', () => {
+      expect(input.required).to.be.true;
+    });
+
+    it('should propagate required property to the input', () => {
+      element.required = false;
+      expect(input.required).to.be.false;
+    });
+  });
+
+  describe('invalid', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-props-mixin-element invalid></input-props-mixin-element>');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should set aria-invalid attribute on the input', () => {
+      expect(input.getAttribute('aria-invalid')).to.equal('true');
+    });
+
+    it('should remove aria-invalid attribute when valid', () => {
+      element.invalid = false;
+      expect(input.hasAttribute('aria-invalid')).to.be.false;
+    });
+  });
+});

--- a/packages/field-base/test/input-props-mixin.test.js
+++ b/packages/field-base/test/input-props-mixin.test.js
@@ -101,8 +101,17 @@ describe('input-props-mixin', () => {
       input = element.querySelector('[slot=input]');
     });
 
+    it('should set invalid attribute on the input', () => {
+      expect(input.hasAttribute('invalid')).to.be.true;
+    });
+
     it('should set aria-invalid attribute on the input', () => {
       expect(input.getAttribute('aria-invalid')).to.equal('true');
+    });
+
+    it('should remove invalid attribute when valid', () => {
+      element.invalid = false;
+      expect(input.hasAttribute('invalid')).to.be.false;
     });
 
     it('should remove aria-invalid attribute when valid', () => {


### PR DESCRIPTION
## Description

This is a PR to add two mixins:

1. `InputPropsMixin` used to propagate some properties to the slotted `input`.
2. `ClearButtonMixin` used to handle a clear button in field components.

Fixes #2187 

## Type of change

- Internal feature