### PR TITLE
docs: deprecate the `iron-resize` event [skip ci]

### DIFF
--- a/packages/vaadin-split-layout/src/vaadin-split-layout.js
+++ b/packages/vaadin-split-layout/src/vaadin-split-layout.js
@@ -348,6 +348,7 @@ class SplitLayoutElement extends ElementMixin(
    * Fired when the splitter is dragged. Non-bubbling. Fired for the splitter
    * element and any nested elements with `IronResizableBehavior`.
    *
+   * DEPRECATED: This event will be dropped in one of the future Vaadin versions. Use a ResizeObserver instead.
    * @event iron-resize
    */
 

--- a/packages/vaadin-text-field/src/vaadin-text-area.js
+++ b/packages/vaadin-text-field/src/vaadin-text-area.js
@@ -219,6 +219,7 @@ class TextAreaElement extends ElementMixin(TextFieldMixin(ControlStateMixin(Them
   /**
    * Fired when the text-area height changes.
    *
+   * DEPRECATED: This event will be dropped in one of the future Vaadin versions. Use a ResizeObserver instead.
    * @event iron-resize
    */
 }

--- a/packages/vaadin-text-field/src/vaadin-text-field-mixin.js
+++ b/packages/vaadin-text-field/src/vaadin-text-field-mixin.js
@@ -869,6 +869,7 @@ export const TextFieldMixin = (subclass) =>
     /**
      * Fired when the size of the element changes.
      *
+     * DEPRECATED: This event will be dropped in one of the future Vaadin versions. Use a ResizeObserver instead.
      * @event iron-resize
      */
   };


### PR DESCRIPTION
## Description

The `iron-resize` event is an internal implementation detail, yet it's currently documented as a part of the public API of:
 - vaadin-text-field
 - vaadin-number-field
 - vaadin-email-field
 - vaadin-password-field
 - vaadin-text-area
 - vaadin-split-layout

This commit adda a depracation note for this event in  the API docs. The intention is to drop this even in the future when the implementat will change from IronResizableBehavior to ResizeObserver.

Fixes #2167

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Documentation

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.