### PR TITLE
fix: skip calculation when grid is hidden

### DIFF
--- a/packages/vaadin-grid/src/iron-list.js
+++ b/packages/vaadin-grid/src/iron-list.js
@@ -588,6 +588,15 @@ export const PolymerIronList = Class({
    * @param {!Array<number>=} itemSet
    */
   _updateMetrics: function (itemSet) {
+    // Sometimes the call for this method is schedule before Grid is hidden
+    // but it happens when Grid is already hidden.
+    // When this happens, there might be some issues as described
+    // here https://github.com/vaadin/web-components/issues/2127.
+    // Skipping any calculation for a hidden Grid.
+    if (this.hidden) {
+      return;
+    }
+
     // Make sure we distributed all the physical items
     // so we can measure them.
     flush();

--- a/packages/vaadin-grid/test/basic.test.js
+++ b/packages/vaadin-grid/test/basic.test.js
@@ -264,6 +264,18 @@ describe('basic features', () => {
     expect(parseInt(window.getComputedStyle(grid).getPropertyValue('flex-grow'))).to.equal(1);
     expect(window.getComputedStyle(grid).getPropertyValue('flex-basis')).to.equal('auto');
   });
+
+  it('should keep row position after hiding/unhiding Grid', () => {
+    grid._scrollToIndex(100);
+
+    grid.notifyResize();
+    grid.setAttribute('hidden', 'hidden');
+    flushGrid(grid);
+
+    grid.removeAttribute('hidden');
+    flushGrid(grid);
+    expect(grid.firstVisibleIndex).to.equal(100);
+  });
 });
 
 describe('flex child', () => {


### PR DESCRIPTION
If a resize or any event that triggers `iron-resize` happens as the Grid is about to hide, it may lead to some calculations to happen when the Grid is already hidden. That may lead to some misbehavior, like described on the linked issue.

This fix checks the visibility status of the Grid to skip metrics calculation in case the Grid is not visible.

Fixes https://github.com/vaadin/web-components/issues/2127

## Type of change

- [x] Bugfix
- [ ] Feature
