### PR TITLE
feat: add mixins for text-field and related components

### DIFF
--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -5,6 +5,7 @@ export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
+export { InputFieldMixin } from './src/input-field-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
 export { InputPropsMixin } from './src/input-props-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';

--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -10,4 +10,5 @@ export { InputMixin } from './src/input-mixin.js';
 export { InputPropsMixin } from './src/input-props-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
+export { TextFieldMixin } from './src/text-field-mixin.js';
 export { ValidateMixin } from './src/validate-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -5,6 +5,7 @@ export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputAriaMixin } from './src/input-aria-mixin.js';
+export { InputFieldMixin } from './src/input-field-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
 export { InputPropsMixin } from './src/input-props-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -10,4 +10,5 @@ export { InputMixin } from './src/input-mixin.js';
 export { InputPropsMixin } from './src/input-props-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
+export { TextFieldMixin } from './src/text-field-mixin.js';
 export { ValidateMixin } from './src/validate-mixin.js';

--- a/packages/field-base/src/input-field-mixin.d.ts
+++ b/packages/field-base/src/input-field-mixin.d.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ClearButtonMixin } from './clear-button-mixin.js';
+import { DelegateFocusMixin } from './delegate-focus-mixin.js';
+import { FieldAriaMixin } from './field-aria-mixin.js';
+import { InputPropsMixin } from './input-props-mixin.js';
+
+/**
+ * A mixin to provide logic for vaadin-text-field and related components.
+ */
+declare function InputFieldMixin<T extends new (...args: any[]) => {}>(base: T): T & InputFieldMixinConstructor;
+
+interface InputFieldMixinConstructor {
+  new (...args: any[]): InputFieldMixin;
+}
+
+interface InputFieldMixin extends ClearButtonMixin, DelegateFocusMixin, FieldAriaMixin, InputPropsMixin {
+  readonly inputElement: HTMLElement | undefined;
+
+  /**
+   * Whether the value of the control can be automatically completed by the browser.
+   * List of available options at:
+   * https://developer.mozilla.org/en/docs/Web/HTML/Element/input#attr-autocomplete
+   */
+  autocomplete: string | undefined;
+
+  /**
+   * This is a property supported by Safari that is used to control whether
+   * autocorrection should be enabled when the user is entering/editing the text.
+   * Possible values are:
+   * on: Enable autocorrection.
+   * off: Disable autocorrection.
+   */
+  autocorrect: 'on' | 'off' | undefined;
+
+  /**
+   * This is a property supported by Safari and Chrome that is used to control whether
+   * autocapitalization should be enabled when the user is entering/editing the text.
+   * Possible values are:
+   * characters: Characters capitalization.
+   * words: Words capitalization.
+   * sentences: Sentences capitalization.
+   * none: No capitalization.
+   */
+  autocapitalize: 'on' | 'off' | 'none' | 'characters' | 'words' | 'sentences' | undefined;
+
+  /**
+   * Specify that the value should be automatically selected when the field gains focus.
+   */
+  autoselect: boolean;
+
+  /**
+   * The value of the field.
+   */
+  value: string;
+
+  /**
+   * Returns true if the current input value satisfies all constraints (if any).
+   */
+  checkValidity(): boolean;
+}
+
+export { InputFieldMixin, InputFieldMixinConstructor };

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -1,0 +1,268 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
+import { animationFrame } from '@polymer/polymer/lib/utils/async.js';
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { ClearButtonMixin } from './clear-button-mixin.js';
+import { DelegateFocusMixin } from './delegate-focus-mixin.js';
+import { FieldAriaMixin } from './field-aria-mixin.js';
+import { InputPropsMixin } from './input-props-mixin.js';
+
+const InputFieldMixinImplementation = (superclass) =>
+  class InputFieldMixinClass extends ClearButtonMixin(FieldAriaMixin(InputPropsMixin(DelegateFocusMixin(superclass)))) {
+    static get properties() {
+      return {
+        /**
+         * Whether the value of the control can be automatically completed by the browser.
+         * List of available options at:
+         * https://developer.mozilla.org/en/docs/Web/HTML/Element/input#attr-autocomplete
+         */
+        autocomplete: {
+          type: String
+        },
+
+        /**
+         * This is a property supported by Safari that is used to control whether
+         * autocorrection should be enabled when the user is entering/editing the text.
+         * Possible values are:
+         * on: Enable autocorrection.
+         * off: Disable autocorrection.
+         */
+        autocorrect: {
+          type: String
+        },
+
+        /**
+         * This is a property supported by Safari and Chrome that is used to control whether
+         * autocapitalization should be enabled when the user is entering/editing the text.
+         * Possible values are:
+         * characters: Characters capitalization.
+         * words: Words capitalization.
+         * sentences: Sentences capitalization.
+         * none: No capitalization.
+         */
+        autocapitalize: {
+          type: String
+        },
+
+        /**
+         * Specify that the value should be automatically selected when the field gains focus.
+         */
+        autoselect: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * The value of the field.
+         */
+        value: {
+          type: String,
+          value: '',
+          observer: '_valueChanged',
+          notify: true
+        }
+      };
+    }
+
+    static get hostProps() {
+      return [...super.hostProps, 'autocapitalize', 'autocomplete', 'autocorrect'];
+    }
+
+    static get observers() {
+      return ['__observeOffsetHeight(errorMessage, invalid, label, helperText)'];
+    }
+
+    /** @protected */
+    get _ariaTarget() {
+      return this._inputNode;
+    }
+
+    /**
+     * @return {HTMLElement | undefined}}
+     * @protected
+     */
+    get inputElement() {
+      return this._inputNode;
+    }
+
+    get focusElement() {
+      return this._inputNode;
+    }
+
+    constructor() {
+      super();
+
+      this._boundOnInput = this._onInput.bind(this);
+      this._boundOnBlur = this._onBlur.bind(this);
+      this._boundOnFocus = this._onFocus.bind(this);
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      if (this._inputNode) {
+        this._addInputListeners(this._inputNode);
+        this._validateInputValue(this._inputNode);
+
+        if (this.value) {
+          this._inputNode.value = this.value;
+          this.validate();
+        }
+      }
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+
+      if (this._inputNode) {
+        this._removeInputListeners(this._inputNode);
+      }
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      // Lumo theme defines a max-height transition for the "error-message"
+      // part on invalid state change.
+      this.shadowRoot.querySelector('[part="error-message"]').addEventListener('transitionend', () => {
+        this.__observeOffsetHeight();
+      });
+    }
+
+    /**
+     * Returns true if the current input value satisfies all constraints (if any).
+     * @return {boolean}
+     */
+    checkValidity() {
+      if (this.required) {
+        return this.inputElement.checkValidity();
+      } else {
+        return !this.invalid;
+      }
+    }
+
+    // Workaround for https://github.com/Polymer/polymer/issues/5259
+    get __data() {
+      return this.__dataValue || {};
+    }
+
+    set __data(value) {
+      this.__dataValue = value;
+    }
+
+    /**
+     * @param {HTMLElement} node
+     * @protected
+     */
+    _addInputListeners(node) {
+      node.addEventListener('input', this._boundOnInput);
+      node.addEventListener('blur', this._boundOnBlur);
+      node.addEventListener('focus', this._boundOnFocus);
+    }
+
+    /**
+     * @param {HTMLElement} node
+     * @protected
+     */
+    _removeInputListeners(node) {
+      node.removeEventListener('input', this._boundOnInput);
+      node.removeEventListener('blur', this._boundOnBlur);
+      node.removeEventListener('focus', this._boundOnFocus);
+    }
+
+    /** @private */
+    _onFocus() {
+      if (this.autoselect) {
+        this._inputNode.select();
+      }
+    }
+
+    /** @private */
+    _onBlur() {
+      this.validate();
+    }
+
+    /**
+     * @param {Event} e
+     * @protected
+     */
+    _onInput(e) {
+      if (!e.__fromClearButton) {
+        this.__userInput = true;
+      }
+
+      this.value = e.target.value;
+      this.__userInput = false;
+    }
+
+    /** @private */
+    __dispatchIronResizeEventIfNeeded(prop, value) {
+      const oldSize = '__previous' + prop;
+      if (this[oldSize] !== undefined && this[oldSize] !== value) {
+        this.dispatchEvent(new CustomEvent('iron-resize', { bubbles: true, composed: true }));
+      }
+
+      this[oldSize] = value;
+    }
+
+    /** @private */
+    __observeOffsetHeight() {
+      this.__observeOffsetHeightDebouncer = Debouncer.debounce(
+        this.__observeOffsetHeightDebouncer,
+        animationFrame,
+        () => {
+          this.__dispatchIronResizeEventIfNeeded('Height', this.offsetHeight);
+        }
+      );
+    }
+
+    /** @private */
+    _validateInputValue(input) {
+      if (input.value !== this.value) {
+        console.warn(`Please define value on the <${this.localName}> component!`);
+        input.value = '';
+      }
+    }
+
+    /**
+     * @param {unknown} newVal
+     * @param {unknown} oldVal
+     * @protected
+     */
+    _valueChanged(newVal, oldVal) {
+      // setting initial value to empty string, skip validation
+      if (newVal === '' && oldVal === undefined) {
+        return;
+      }
+
+      if (newVal !== '' && newVal != null) {
+        this.setAttribute('has-value', '');
+      } else {
+        this.removeAttribute('has-value');
+      }
+
+      if (this.__userInput || !this.inputElement) {
+        return;
+      } else if (newVal != undefined) {
+        this.inputElement.value = newVal;
+      } else {
+        this.value = this.inputElement.value = '';
+      }
+
+      if (this.invalid) {
+        this.validate();
+      }
+    }
+  };
+
+/**
+ * A mixin to provide logic for vaadin-text-field and related components.
+ */
+export const InputFieldMixin = dedupingMixin(InputFieldMixinImplementation);

--- a/packages/field-base/src/text-field-mixin.d.ts
+++ b/packages/field-base/src/text-field-mixin.d.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { InputFieldMixin } from './input-field-mixin.js';
+
+/**
+ * A mixin to provide validation constraints for vaadin-text-field and related components.
+ */
+declare function TextFieldMixin<T extends new (...args: any[]) => {}>(base: T): T & TextFieldMixinConstructor;
+
+interface TextFieldMixinConstructor {
+  new (...args: any[]): TextFieldMixin;
+}
+
+interface TextFieldMixin extends InputFieldMixin {
+  /**
+   * Maximum number of characters (in Unicode code points) that the user can enter.
+   */
+  maxlength: number | null | undefined;
+
+  /**
+   * Minimum number of characters (in Unicode code points) that the user can enter.
+   */
+  minlength: number | null | undefined;
+
+  /**
+   * A regular expression that the value is checked against.
+   * The pattern must match the entire value, not just some subset.
+   */
+  pattern: string | null | undefined;
+
+  /**
+   * When set to true, user is prevented from typing a value that
+   * conflicts with the given `pattern`.
+   * @attr {boolean} prevent-invalid-input
+   */
+  preventInvalidInput: boolean | null | undefined;
+
+  /**
+   * Returns true if the current input value satisfies all constraints (if any).
+   */
+  checkValidity(): boolean;
+}
+
+export { TextFieldMixin, TextFieldMixinConstructor };

--- a/packages/field-base/src/text-field-mixin.js
+++ b/packages/field-base/src/text-field-mixin.js
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
+import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { InputFieldMixin } from './input-field-mixin.js';
+
+const TextFieldMixinImplementation = (superclass) =>
+  class TextFieldMixinClass extends InputFieldMixin(superclass) {
+    static get properties() {
+      return {
+        /**
+         * Maximum number of characters (in Unicode code points) that the user can enter.
+         */
+        maxlength: {
+          type: Number
+        },
+
+        /**
+         * Minimum number of characters (in Unicode code points) that the user can enter.
+         */
+        minlength: {
+          type: Number
+        },
+
+        /**
+         * A regular expression that the value is checked against.
+         * The pattern must match the entire value, not just some subset.
+         */
+        pattern: {
+          type: String
+        },
+
+        /**
+         * When set to true, user is prevented from typing a value that
+         * conflicts with the given `pattern`.
+         * @attr {boolean} prevent-invalid-input
+         */
+        preventInvalidInput: {
+          type: Boolean
+        }
+      };
+    }
+
+    static get hostProps() {
+      return [...super.hostProps, 'pattern', 'maxlength', 'minlength'];
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this._createConstraintsObserver();
+    }
+
+    /** @protected */
+    _createConstraintsObserver() {
+      // This complex observer needs to be added dynamically here (instead of defining it above in the `get observers()`)
+      // so that it runs after complex observers of inheriting classes. Otherwise e.g. `_stepOrMinChanged()` observer of
+      // vaadin-number-field would run after this and the `min` and `step` properties would not yet be propagated to
+      // the `inputElement` when this runs.
+      this._createMethodObserver('_constraintsChanged(required, minlength, maxlength, pattern)');
+    }
+
+    /**
+     * @param {boolean | undefined} required
+     * @param {number | undefined} minlength
+     * @param {number | undefined} maxlength
+     * @param {string | undefined} maxlength
+     * @protected
+     */
+    _constraintsChanged(required, minlength, maxlength, pattern) {
+      if (!this.invalid) {
+        return;
+      }
+
+      if (!required && !minlength && !maxlength && !pattern) {
+        this.invalid = false;
+      } else {
+        this.validate();
+      }
+    }
+
+    /**
+     * @param {Event} e
+     * @protected
+     */
+    _onInput(e) {
+      if (this.preventInvalidInput) {
+        const input = this.inputElement;
+        if (input.value.length > 0 && !this.checkValidity()) {
+          input.value = this.value || '';
+          // add input-prevented attribute for 200ms
+          this.setAttribute('input-prevented', '');
+          this._inputDebouncer = Debouncer.debounce(this._inputDebouncer, timeOut.after(200), () => {
+            this.removeAttribute('input-prevented');
+          });
+          return;
+        }
+      }
+
+      super._onInput(e);
+    }
+
+    /**
+     * Returns true if the current input value satisfies all constraints (if any)
+     * @return {boolean}
+     */
+    checkValidity() {
+      if (this.required || this.pattern || this.maxlength || this.minlength) {
+        return this.inputElement.checkValidity();
+      } else {
+        return !this.invalid;
+      }
+    }
+  };
+
+/**
+ * A mixin to provide validation constraints for vaadin-text-field and related components.
+ */
+export const TextFieldMixin = dedupingMixin(TextFieldMixinImplementation);

--- a/packages/field-base/src/text-field-mixin.js
+++ b/packages/field-base/src/text-field-mixin.js
@@ -58,10 +58,9 @@ const TextFieldMixinImplementation = (superclass) =>
 
     /** @protected */
     _createConstraintsObserver() {
-      // This complex observer needs to be added dynamically here (instead of defining it above in the `get observers()`)
-      // so that it runs after complex observers of inheriting classes. Otherwise e.g. `_stepOrMinChanged()` observer of
-      // vaadin-number-field would run after this and the `min` and `step` properties would not yet be propagated to
-      // the `inputElement` when this runs.
+      // This complex observer needs to be added dynamically instead of using `static get observers()`
+      // to make it possible to tweak this behavior in classes that apply this mixin.
+      // An example is `vaadin-email-field` where the pattern is set before defining the observer.
       this._createMethodObserver('_constraintsChanged(required, minlength, maxlength, pattern)');
     }
 
@@ -90,8 +89,8 @@ const TextFieldMixinImplementation = (superclass) =>
      */
     _onInput(e) {
       if (this.preventInvalidInput) {
-        const input = this.inputElement;
-        if (input.value.length > 0 && !this.checkValidity()) {
+        const input = this._inputNode;
+        if (input && input.value.length > 0 && !this.checkValidity()) {
           input.value = this.value || '';
           // add input-prevented attribute for 200ms
           this.setAttribute('input-prevented', '');
@@ -111,7 +110,7 @@ const TextFieldMixinImplementation = (superclass) =>
      */
     checkValidity() {
       if (this.required || this.pattern || this.maxlength || this.minlength) {
-        return this.inputElement.checkValidity();
+        return this._inputNode ? this._inputNode.checkValidity() : undefined;
       } else {
         return !this.invalid;
       }

--- a/packages/field-base/src/text-field-mixin.js
+++ b/packages/field-base/src/text-field-mixin.js
@@ -72,10 +72,6 @@ const TextFieldMixinImplementation = (superclass) =>
      * @protected
      */
     _constraintsChanged(required, minlength, maxlength, pattern) {
-      if (!this.invalid) {
-        return;
-      }
-
       if (!required && !minlength && !maxlength && !pattern) {
         this.invalid = false;
       } else {

--- a/packages/field-base/src/text-field-mixin.js
+++ b/packages/field-base/src/text-field-mixin.js
@@ -72,6 +72,12 @@ const TextFieldMixinImplementation = (superclass) =>
      * @protected
      */
     _constraintsChanged(required, minlength, maxlength, pattern) {
+      // Prevent marking field as invalid when setting required state
+      // or any other constraint before a user has entered the value.
+      if (!this.invalid) {
+        return;
+      }
+
       if (!required && !minlength && !maxlength && !pattern) {
         this.invalid = false;
       } else {

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -1,0 +1,223 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { InputFieldMixin } from '../src/input-field-mixin.js';
+
+customElements.define(
+  'input-field-mixin-element',
+  class extends InputFieldMixin(PolymerElement) {
+    static get template() {
+      return html`
+        <style>
+          :host {
+            display: block;
+          }
+
+          /* Mimic Lumo styles to test resize */
+          [part='error-message'] {
+            max-height: 5em;
+          }
+
+          :host(:not([invalid])) [part='error-message'] {
+            max-height: 0;
+            overflow: hidden;
+          }
+        </style>
+        <div part="label">
+          <slot name="label"></slot>
+        </div>
+        <slot name="input"></slot>
+        <button id="clearButton">Clear</button>
+        <div part="error-message">
+          <slot name="error-message"></slot>
+        </div>
+        <slot name="helper"></slot>
+      `;
+    }
+
+    get clearElement() {
+      return this.$.clearButton;
+    }
+  }
+);
+
+describe('input-field-mixin', () => {
+  let element, input;
+
+  describe('properties', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-field-mixin-element></input-field-mixin-element>');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should propagate autocomplete property to the input', () => {
+      element.autocomplete = 'on';
+      expect(input.autocomplete).to.equal('on');
+    });
+
+    it('should propagate autocorrect property to the input', () => {
+      element.autocorrect = 'on';
+      expect(input.getAttribute('autocorrect')).to.equal('on');
+    });
+
+    it('should propagate autocapitalize property to the input', () => {
+      element.autocapitalize = 'none';
+      expect(input.getAttribute('autocapitalize')).to.equal('none');
+    });
+
+    it('should select the input content when autoselect is set', () => {
+      const spy = sinon.spy(input, 'select');
+      element.autoselect = true;
+      input.focus();
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('value', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-field-mixin-element></input-field-mixin-element>');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should propagate value to the input element', () => {
+      element.value = 'foo';
+      expect(input.value).to.equal('foo');
+    });
+
+    it('should clear input value when value is set to null', () => {
+      element.value = null;
+      expect(input.value).to.equal('');
+    });
+
+    it('should update field value on the input event', () => {
+      input.value = 'foo';
+      input.dispatchEvent(new Event('input'));
+      expect(element.value).to.equal('foo');
+    });
+
+    it('should clear input value when value is set to undefined', () => {
+      element.value = undefined;
+      expect(input.value).to.equal('');
+    });
+
+    it('should set has-value attribute when value is set', () => {
+      element.value = 'foo';
+      expect(element.hasAttribute('has-value')).to.be.true;
+    });
+
+    it('should remove has-value attribute when value is removed', () => {
+      element.value = 'foo';
+      element.value = '';
+      expect(element.hasAttribute('has-value')).to.be.false;
+    });
+  });
+
+  describe('validation', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-field-mixin-element></input-field-mixin-element>');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should validate on input blur', () => {
+      const spy = sinon.spy(element, 'validate');
+      input.dispatchEvent(new Event('blur'));
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate on value change when field is invalid', () => {
+      const spy = sinon.spy(element, 'validate');
+      element.invalid = true;
+      element.value = 'foo';
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should call checkValidity on the input when required', () => {
+      const spy = sinon.spy(input, 'checkValidity');
+      element.required = true;
+      element.checkValidity();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should not call checkValidity on the input when not required', () => {
+      const spy = sinon.spy(input, 'checkValidity');
+      element.checkValidity();
+      expect(spy.calledOnce).to.be.false;
+    });
+  });
+
+  describe('iron-resize', () => {
+    let spy;
+
+    function flushTextField(textField) {
+      textField.__observeOffsetHeightDebouncer.flush();
+    }
+
+    beforeEach(() => {
+      element = fixtureSync('<input-field-mixin-element></input-field-mixin-element>');
+      spy = sinon.spy();
+      element.addEventListener('iron-resize', spy);
+    });
+
+    it('should not dispatch `iron-resize` event on init', () => {
+      expect(spy.called).to.be.false;
+    });
+
+    it('should dispatch `iron-resize` event on invalid height change', () => {
+      element.errorMessage = 'Error';
+      flushTextField(element);
+      element.invalid = true;
+      flushTextField(element);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should be a composed event', () => {
+      element.errorMessage = 'Error';
+      flushTextField(element);
+      element.invalid = true;
+      flushTextField(element);
+      const event = spy.lastCall.lastArg;
+      expect(event.composed).to.be.true;
+    });
+
+    it('should dispatch `iron-resize` event on error message height change', () => {
+      element.errorMessage = 'Error';
+      flushTextField(element);
+      element.invalid = true;
+      flushTextField(element);
+      spy.resetHistory();
+
+      // Long message that spans on multiple lines
+      element.errorMessage = [...new Array(42)].map(() => 'bla').join(' ');
+      flushTextField(element);
+
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should dispatch `iron-resize` event on label height change', () => {
+      flushTextField(element);
+      element.label = 'Label';
+      flushTextField(element);
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('slotted input value', () => {
+    beforeEach(() => {
+      sinon.stub(console, 'warn');
+    });
+
+    afterEach(() => {
+      console.warn.restore();
+    });
+
+    it('should warn when value is set on the slotted input', () => {
+      element = fixtureSync(`
+        <input-field-mixin-element>
+          <input slot="input" value="foo">
+        </input-field-mixin-element>
+      `);
+      expect(console.warn.called).to.be.true;
+    });
+  });
+});

--- a/packages/field-base/test/text-field-mixin.test.js
+++ b/packages/field-base/test/text-field-mixin.test.js
@@ -59,6 +59,11 @@ describe('text-field-mixin', () => {
       expect(element.invalid).to.be.true;
     });
 
+    it('should not validate the field when required is set', () => {
+      element.required = true;
+      expect(element.invalid).to.be.false;
+    });
+
     it('should validate the field when invalid and required is set', () => {
       element.invalid = true;
       const spy = sinon.spy(element, 'validate');

--- a/packages/field-base/test/text-field-mixin.test.js
+++ b/packages/field-base/test/text-field-mixin.test.js
@@ -64,6 +64,21 @@ describe('text-field-mixin', () => {
       expect(element.invalid).to.be.false;
     });
 
+    it('should not validate the field when minlength is set', () => {
+      element.minlength = 2;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should not validate the field when maxlength is set', () => {
+      element.maxlength = 6;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should not validate the field when pattern is set', () => {
+      element.pattern = '[-+\\d]';
+      expect(element.invalid).to.be.false;
+    });
+
     it('should validate the field when invalid and required is set', () => {
       element.invalid = true;
       const spy = sinon.spy(element, 'validate');

--- a/packages/field-base/test/text-field-mixin.test.js
+++ b/packages/field-base/test/text-field-mixin.test.js
@@ -1,0 +1,201 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { TextFieldMixin } from '../src/text-field-mixin.js';
+
+customElements.define(
+  'text-field-mixin-element',
+  class extends TextFieldMixin(PolymerElement) {
+    static get template() {
+      return html`
+        <slot name="label"></slot>
+        <slot name="input"></slot>
+        <button id="clearButton">Clear</button>
+        <div part="error-message">
+          <slot name="error-message"></slot>
+        </div>
+        <slot name="helper"></slot>
+      `;
+    }
+
+    get clearElement() {
+      return this.$.clearButton;
+    }
+  }
+);
+
+describe('text-field-mixin', () => {
+  let element, input;
+
+  beforeEach(() => {
+    element = fixtureSync('<text-field-mixin-element></text-field-mixin-element>');
+    input = element.querySelector('[slot=input]');
+  });
+
+  describe('properties', () => {
+    it('should propagate pattern property to the input', () => {
+      element.pattern = '[-+\\d]';
+      expect(input.pattern).to.equal('[-+\\d]');
+    });
+
+    it('should propagate maxlength property to the input', () => {
+      element.maxlength = 8;
+      expect(input.maxLength).to.equal(8);
+    });
+
+    it('should propagate minlength property to the input', () => {
+      element.minlength = 8;
+      expect(input.minLength).to.equal(8);
+    });
+  });
+
+  describe('validation', () => {
+    it('should not change invalid property if no constraints are set', () => {
+      element.validate();
+      expect(element.invalid).to.be.false;
+      element.invalid = true;
+      element.validate();
+      expect(element.invalid).to.be.true;
+    });
+
+    it('should validate the field when invalid and required is set', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.required = true;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate the field when invalid after minlength is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.minlength = 2;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate the field when invalid after maxlength is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.maxlength = 6;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate the field when invalid after pattern is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.pattern = '[-+\\d]';
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should override explicitly set invalid if constraints are set', () => {
+      element.invalid = true;
+      element.value = 'foo';
+      element.required = true;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should update invalid state when required is removed', () => {
+      element.required = true;
+      element.validate();
+      expect(element.invalid).to.be.true;
+
+      element.required = false;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should update invalid state when pattern is removed', () => {
+      element.value = '123foo';
+      element.pattern = '\\d+';
+      element.validate();
+      expect(element.invalid).to.be.true;
+
+      element.pattern = '';
+      expect(element.invalid).to.be.false;
+    });
+  });
+
+  describe('prevent invalid input', () => {
+    beforeEach(() => {
+      element.preventInvalidInput = true;
+      element.value = '1';
+    });
+
+    describe('user action', () => {
+      function inputText(value) {
+        input.value = value;
+        input.dispatchEvent(new CustomEvent('input'));
+      }
+
+      it('should prevent invalid pattern', () => {
+        element.pattern = '[0-9]*';
+        inputText('f');
+        expect(element.value).to.equal('1');
+      });
+
+      it('should temporarily set input-prevented attribute on invalid input', () => {
+        element.pattern = '[0-9]*';
+        inputText('f');
+        expect(element.hasAttribute('input-prevented')).to.be.true;
+      });
+
+      it('should not set input-prevented attribute on valid input', () => {
+        element.pattern = '[0-9]*';
+        inputText('1');
+        expect(element.hasAttribute('input-prevented')).to.be.false;
+      });
+
+      it('should have empty value', () => {
+        element.value = undefined;
+        element.pattern = '[0-9]*';
+        inputText('f');
+        expect(element.value).to.equal('');
+      });
+
+      it('should not fire value change', () => {
+        const spy = sinon.spy();
+        element.addEventListener('value-changed', spy);
+        element.pattern = '[0-9]*';
+        inputText('f');
+        expect(spy.called).to.be.false;
+      });
+
+      it('should not prevent valid pattern', () => {
+        element.pattern = '[0-9]*';
+        inputText('2');
+        expect(element.value).to.equal('2');
+      });
+
+      it('should not prevent too short value', () => {
+        element.minlength = 1;
+        inputText('');
+        expect(element.value).to.equal('');
+      });
+
+      it('should not prevent empty value for required field', () => {
+        element.required = true;
+        inputText('');
+        expect(element.value).to.equal('');
+      });
+    });
+
+    describe('programmatic', () => {
+      it('should not prevent invalid pattern', () => {
+        element.pattern = '[0-9]*';
+        element.value = 'foo';
+        expect(element.value).to.equal('foo');
+      });
+
+      it('should not prevent too short value', () => {
+        element.minlength = 1;
+        element.value = '';
+        expect(element.value).to.equal('');
+      });
+
+      it('should not prevent empty value for required field', () => {
+        element.required = true;
+        element.value = '';
+        expect(element.value).to.equal('');
+      });
+    });
+  });
+});

--- a/packages/field-base/test/text-field-mixin.test.js
+++ b/packages/field-base/test/text-field-mixin.test.js
@@ -144,6 +144,15 @@ describe('text-field-mixin', () => {
         expect(element.hasAttribute('input-prevented')).to.be.false;
       });
 
+      it('should remove input-prevented attribute after 200ms timeout', () => {
+        const clock = sinon.useFakeTimers();
+        element.pattern = '[0-9]*';
+        inputText('f');
+        clock.tick(200);
+        expect(element.hasAttribute('input-prevented')).to.be.false;
+        clock.restore();
+      });
+
       it('should have empty value', () => {
         element.value = undefined;
         element.pattern = '[0-9]*';


### PR DESCRIPTION
## Description

This is a PR to add two mixins:

1. `InputFieldMixin` used to implement hanling `value` and a few other properties,
2. `TextFieldMixin` used to add validation constraints such as `pattern`, `maxlength` and `minlength`.

Fixes #2188 

## Type of change

- Internal feature