### PR TITLE
test: cleanup helper text unit tests

### DIFF
--- a/packages/vaadin-text-field/test/text-area.test.js
+++ b/packages/vaadin-text-field/test/text-area.test.js
@@ -374,7 +374,7 @@ describe('helper text', () => {
         </vaadin-text-area>
       `);
 
-      helper = field.root.querySelector('[part="helper-text"]');
+      helper = field.shadowRoot.querySelector('[part="helper-text"]');
     });
 
     it('should not get focus when helper text is clicked', () => {

--- a/packages/vaadin-text-field/test/text-field.test.js
+++ b/packages/vaadin-text-field/test/text-field.test.js
@@ -305,17 +305,8 @@ customElements.define('field-wrapper', FieldWrapper);
       describe(`label ${condition}`, () => {
         it('should not update focused property on click if disabled', () => {
           textField.disabled = true;
-          const label = textField.root.querySelector('[part="label"]');
+          const label = textField.shadowRoot.querySelector('[part="label"]');
           label.click();
-          expect(textField.getAttribute('focused')).to.be.null;
-        });
-      });
-
-      describe(`helper ${condition}`, () => {
-        it('should not update focused property on click if disabled', () => {
-          textField.disabled = true;
-          const helper = textField.root.querySelector('[part="helper-text"]');
-          helper.click();
           expect(textField.getAttribute('focused')).to.be.null;
         });
       });
@@ -654,7 +645,7 @@ describe('helper slot', () => {
         </vaadin-text-field>
       `);
 
-      helper = field.root.querySelector('[part="helper-text"]');
+      helper = field.shadowRoot.querySelector('[part="helper-text"]');
     });
 
     it('should not get focus when helper text is only text', () => {


### PR DESCRIPTION
## Description

This is a follow-up from #2232 

1. Updated the tests to use `shadowRoot` and not `root`
2. Removed an old test which does not make sense anymore

## Type of change

- [x] Tests