### PR TITLE
test: cleanup and fix helper focus tests

### DIFF
--- a/packages/vaadin-checkbox/test/checkbox-group.test.js
+++ b/packages/vaadin-checkbox/test/checkbox-group.test.js
@@ -508,13 +508,12 @@ describe('slot focus', () => {
       </vaadin-checkbox-group>
     `);
     group._observer.flush();
-    group.focus();
     helper = group.querySelector('[slot="helper"]');
   });
 
   it('should not get focus after click', () => {
+    const spy = sinon.spy(group, 'focus');
     helper.click();
-
-    expect(group.hasAttribute('focused')).to.be.false;
+    expect(spy.called).to.be.false;
   });
 });

--- a/packages/vaadin-custom-field/test/helper.test.js
+++ b/packages/vaadin-custom-field/test/helper.test.js
@@ -110,19 +110,16 @@ describe('helper text', () => {
     beforeEach(() => {
       field = fixtureSync(`
         <vaadin-custom-field>
-            <input type="text" />
-
-            <input type="text" slot="helper" />
+          <input type="text" />
+          <input type="text" slot="helper" />
         </vaadin-custom-field>
       `);
       helper = field.querySelector('[slot="helper"]');
-      field.focus();
     });
 
     it('should not focus the field on helper click', () => {
       const spy = sinon.spy(field, 'focus');
       helper.click();
-
       expect(spy.called).to.be.false;
     });
   });

--- a/packages/vaadin-text-field/test/text-area.test.js
+++ b/packages/vaadin-text-field/test/text-area.test.js
@@ -348,18 +348,14 @@ describe('helper text', () => {
     beforeEach(() => {
       field = fixtureSync(`
         <vaadin-text-area label="outer">
-          <vaadin-text-area label="inner" slot="helper">
-            <vaadin-text-area label="inner" slot="helper"></vaadin-text-area>
-          </vaadin-text-area>
+          <vaadin-text-area label="inner" slot="helper"></vaadin-text-area>
         </vaadin-text-area>
       `);
       helper = field.querySelector('[slot="helper"]');
-      field.focus();
     });
 
     it('helper should get focus when clicked', () => {
       const spy = sinon.spy(field, 'focus');
-
       helper.click();
       expect(spy.called).to.be.false;
     });
@@ -369,17 +365,14 @@ describe('helper text', () => {
     let field, helper;
 
     beforeEach(() => {
-      field = fixtureSync(`
-        <vaadin-text-area label='text-field' helper-text='helper-text'>
-        </vaadin-text-area>
-      `);
-
+      field = fixtureSync('<vaadin-text-area helper-text="helper-text"></vaadin-text-area>');
       helper = field.shadowRoot.querySelector('[part="helper-text"]');
     });
 
     it('should not get focus when helper text is clicked', () => {
+      const spy = sinon.spy(field, 'focus');
       helper.click();
-      expect(field.hasAttribute('focused')).to.be.false;
+      expect(spy.called).to.be.false;
     });
   });
 });

--- a/packages/vaadin-text-field/test/text-field.test.js
+++ b/packages/vaadin-text-field/test/text-field.test.js
@@ -614,15 +614,13 @@ describe('helper slot', () => {
     });
   });
 
-  describe('nested helper', () => {
+  describe('slotted helper', () => {
     let field, helper;
 
     beforeEach(() => {
       field = fixtureSync(`
         <vaadin-text-field label="outer">
-          <vaadin-text-field label="inner" slot="helper">
-            <vaadin-text-field label="inner" slot="helper"></vaadin-text-field>
-          </vaadin-text-field>
+          <vaadin-text-field label="inner" slot="helper"></vaadin-text-field>
         </vaadin-text-field>
       `);
       helper = field.querySelector('[slot="helper"]');
@@ -631,7 +629,6 @@ describe('helper slot', () => {
     it('helper should get focus when clicked', () => {
       const spy = sinon.spy(field, 'focus');
       helper.click();
-
       expect(spy.called).to.be.false;
     });
   });
@@ -640,18 +637,13 @@ describe('helper slot', () => {
     let field, helper;
 
     beforeEach(() => {
-      field = fixtureSync(`
-        <vaadin-text-field label='text-field' helper-text='helper-text'>
-        </vaadin-text-field>
-      `);
-
+      field = fixtureSync('<vaadin-text-field helper-text="helper-text"></vaadin-text-field>');
       helper = field.shadowRoot.querySelector('[part="helper-text"]');
     });
 
     it('should not get focus when helper text is only text', () => {
       const spy = sinon.spy(field, 'focus');
       helper.click();
-
       expect(spy.called).to.be.false;
     });
   });


### PR DESCRIPTION
## Description

1. Updated all the tests for helper focus removal to use spy and avoid relying on `focused` attribute.
2. Minor cleanup: removed nested components in slotted helper tests, removed empty newlines.

See #2255 