### PR TITLE
docs: fix API docs for crud slots [skip ci]

### DIFF
--- a/packages/vaadin-crud/src/vaadin-crud.d.ts
+++ b/packages/vaadin-crud/src/vaadin-crud.d.ts
@@ -49,26 +49,28 @@ import { CrudDataProvider, CrudEditorPosition, CrudEventMap, CrudI18n } from './
  * `toolbar` | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
  *
  * #### Example:
+ *
  * ```html
  * <vaadin-crud
  *   id="crud"
  *   items='[{"name": "John", "surname": "Lennon", "role": "singer"},
  *           {"name": "Ringo", "surname": "Starr", "role": "drums"}]'
  * >
- *  <vaadin-grid slot="grid">
- *   <vaadin-crud-edit-column></vaadin-crud-edit-column>
- *   <vaadin-grid-column id="column1"></vaadin-grid-column>
- *   <vaadin-grid-column id="column2"></vaadin-grid-column>
- *  </vaadin-grid>
+ *   <vaadin-grid slot="grid">
+ *     <vaadin-crud-edit-column></vaadin-crud-edit-column>
+ *     <vaadin-grid-column id="column1"></vaadin-grid-column>
+ *     <vaadin-grid-column id="column2"></vaadin-grid-column>
+ *   </vaadin-grid>
  *
- *  <vaadin-form-layout slot="form">
- *   <vaadin-text-field label="First" path="name"></vaadin-text-field>
- *   <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
- *  </vaadin-form-layout>
+ *   <vaadin-form-layout slot="form">
+ *     <vaadin-text-field label="First" path="name"></vaadin-text-field>
+ *     <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
+ *   </vaadin-form-layout>
  *
- *  <div slot="footer">Total singers: [[size]]</div>
- *
- *  <button slot="new">New singer</button>
+ *   <div slot="toolbar">
+ *     Total singers: [[size]]
+ *     <button new-button>New singer</button>
+ *   </div>
  * </vaadin-crud>
  * ```
  * ```js

--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -62,26 +62,28 @@ import './vaadin-crud-form.js';
  * `toolbar` | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
  *
  * #### Example:
+ *
  * ```html
  * <vaadin-crud
  *   id="crud"
  *   items='[{"name": "John", "surname": "Lennon", "role": "singer"},
  *           {"name": "Ringo", "surname": "Starr", "role": "drums"}]'
  * >
- *  <vaadin-grid slot="grid">
- *   <vaadin-crud-edit-column></vaadin-crud-edit-column>
- *   <vaadin-grid-column id="column1"></vaadin-grid-column>
- *   <vaadin-grid-column id="column2"></vaadin-grid-column>
- *  </vaadin-grid>
+ *   <vaadin-grid slot="grid">
+ *     <vaadin-crud-edit-column></vaadin-crud-edit-column>
+ *     <vaadin-grid-column id="column1"></vaadin-grid-column>
+ *     <vaadin-grid-column id="column2"></vaadin-grid-column>
+ *   </vaadin-grid>
  *
- *  <vaadin-form-layout slot="form">
- *   <vaadin-text-field label="First" path="name"></vaadin-text-field>
- *   <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
- *  </vaadin-form-layout>
+ *   <vaadin-form-layout slot="form">
+ *     <vaadin-text-field label="First" path="name"></vaadin-text-field>
+ *     <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
+ *   </vaadin-form-layout>
  *
- *  <div slot="footer">Total singers: [[size]]</div>
- *
- *  <button slot="new">New singer</button>
+ *   <div slot="toolbar">
+ *     Total singers: [[size]]
+ *     <button new-button>New singer</button>
+ *   </div>
  * </vaadin-crud>
  * ```
  * ```js
@@ -102,6 +104,7 @@ import './vaadin-crud-form.js';
  * column2.renderer = (root, column, model) => {
  *   root.textContent = model.item.surname;
  * };
+ * ```
  *
  * ### Helpers
  *


### PR DESCRIPTION
## Description

1. Updated API docs to mention `slot="toolbar"` instead of no longer existing `new` and `footer` slots,
2. Fixed the code snippet in API docs that was broken when adding JS snippet for column renderers.

## Type of change

- Documentation