### PR TITLE
docs: fix API docs for crud slots [skip ci]

### DIFF
--- a/packages/vaadin-crud/src/vaadin-crud.d.ts
+++ b/packages/vaadin-crud/src/vaadin-crud.d.ts
@@ -49,28 +49,34 @@ import { CrudDataProvider, CrudEditorPosition, CrudEventMap, CrudI18n } from './
  * `toolbar` | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
  *
  * #### Example:
+ *
  * ```html
- * <vaadin-crud items='[{"name": "John", "surname": "Lennon", "role": "singer"},
- *                      {"name": "Ringo", "surname": "Starr", "role": "drums"}]'>
+ * <vaadin-crud
+ *   id="crud"
+ *   items='[{"name": "John", "surname": "Lennon", "role": "singer"},
+ *           {"name": "Ringo", "surname": "Starr", "role": "drums"}]'
+ * >
+ *   <vaadin-grid slot="grid">
+ *     <vaadin-crud-edit-column></vaadin-crud-edit-column>
+ *     <vaadin-grid-column>
+ *       <template class="header">Name</template>
+ *       <template>[[item.name]]</template>
+ *     </vaadin-grid-column>
+ *     <vaadin-grid-column>
+ *       <template class="header">Surname</template>
+ *       <template>[[item.surname]]</template>
+ *     </vaadin-grid-column>
+ *   </vaadin-grid>
  *
- *  <vaadin-grid slot="grid">
- *   <vaadin-crud-edit-column></vaadin-crud-edit-column>
- *   <vaadin-grid-column>
- *    <template class="header">Name</template><template>[[item.name]]</template>
- *   </vaadin-grid-column>
- *   <vaadin-grid-column>
- *    <template class="header">Surname</template><template>[[item.surname]]</template>
- *   </vaadin-grid-column>
- *  </vaadin-grid>
+ *   <vaadin-form-layout slot="form">
+ *     <vaadin-text-field label="First" path="name"></vaadin-text-field>
+ *     <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
+ *   </vaadin-form-layout>
  *
- *  <vaadin-form-layout slot="form">
- *   <vaadin-text-field label="First" path="name"></vaadin-text-field>
- *   <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
- *  </vaadin-form-layout>
- *
- *  <div slot="footer">Total singers: [[size]]</div>
- *
- *  <button slot="new">New singer</button>
+ *   <div slot="toolbar">
+ *     Total singers: [[size]]
+ *     <button new-button>New singer</button>
+ *   </div>
  * </vaadin-crud>
  * ```
  *

--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -62,28 +62,34 @@ import './vaadin-crud-form.js';
  * `toolbar` | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
  *
  * #### Example:
+ *
  * ```html
- * <vaadin-crud items='[{"name": "John", "surname": "Lennon", "role": "singer"},
- *                      {"name": "Ringo", "surname": "Starr", "role": "drums"}]'>
+ * <vaadin-crud
+ *   id="crud"
+ *   items='[{"name": "John", "surname": "Lennon", "role": "singer"},
+ *           {"name": "Ringo", "surname": "Starr", "role": "drums"}]'
+ * >
+ *   <vaadin-grid slot="grid">
+ *     <vaadin-crud-edit-column></vaadin-crud-edit-column>
+ *     <vaadin-grid-column>
+ *       <template class="header">Name</template>
+ *       <template>[[item.name]]</template>
+ *     </vaadin-grid-column>
+ *     <vaadin-grid-column>
+ *       <template class="header">Surname</template>
+ *       <template>[[item.surname]]</template>
+ *     </vaadin-grid-column>
+ *   </vaadin-grid>
  *
- *  <vaadin-grid slot="grid">
- *   <vaadin-crud-edit-column></vaadin-crud-edit-column>
- *   <vaadin-grid-column>
- *    <template class="header">Name</template><template>[[item.name]]</template>
- *   </vaadin-grid-column>
- *   <vaadin-grid-column>
- *    <template class="header">Surname</template><template>[[item.surname]]</template>
- *   </vaadin-grid-column>
- *  </vaadin-grid>
+ *   <vaadin-form-layout slot="form">
+ *     <vaadin-text-field label="First" path="name"></vaadin-text-field>
+ *     <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
+ *   </vaadin-form-layout>
  *
- *  <vaadin-form-layout slot="form">
- *   <vaadin-text-field label="First" path="name"></vaadin-text-field>
- *   <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
- *  </vaadin-form-layout>
- *
- *  <div slot="footer">Total singers: [[size]]</div>
- *
- *  <button slot="new">New singer</button>
+ *   <div slot="toolbar">
+ *     Total singers: [[size]]
+ *     <button new-button>New singer</button>
+ *   </div>
  * </vaadin-crud>
  * ```
  *


### PR DESCRIPTION
## Description

Cherry-pick of #2260 for `20.0` branch, done manually because of API docs conflicting with V21 due to renderers usage.