### PR TITLE
[WIP] feat!: place CRUD editor in the light DOM

### DIFF
--- a/packages/vaadin-crud/src/vaadin-crud-dialog.js
+++ b/packages/vaadin-crud/src/vaadin-crud-dialog.js
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2021 Vaadin Ltd.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
+ */
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { DialogElement } from '@vaadin/vaadin-dialog/src/vaadin-dialog.js';
+
+registerStyles(
+  'vaadin-dialog-overlay',
+  css`
+    [part='scroller'] {
+      display: flex;
+      flex-direction: column;
+      overflow: auto;
+      -webkit-overflow-scrolling: touch;
+      flex: auto;
+    }
+
+    [part='footer'] {
+      display: flex;
+      flex: none;
+      flex-direction: row-reverse;
+    }
+  `,
+  { moduleId: 'vaadin-crud-dialog-overlay-styles' }
+);
+
+const editorTemplate = html`
+  <div part="scroller" role="group" aria-labelledby="header">
+    <div part="header" id="header">
+      <slot name="header"></slot>
+    </div>
+    <slot name="form"></slot>
+  </div>
+
+  <div part="footer" role="toolbar">
+    <slot name="save"></slot>
+    <slot name="cancel"></slot>
+    <slot name="delete"></slot>
+  </div>
+`;
+
+class CrudDialogElement extends DialogElement {
+  ready() {
+    super.ready();
+
+    this.renderer = (root) => {
+      if (!root.__dialogInitialized) {
+        root.__dialogInitialized = true;
+        root.$.content.appendChild(editorTemplate.content.cloneNode(true));
+      }
+    };
+  }
+}
+
+customElements.define('vaadin-crud-dialog', CrudDialogElement);

--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -222,7 +222,7 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
           theme="crud"
         >
           <h3 slot="header">[[__computeEditorHeader(__isNew, i18n.newItem, i18n.editItem)]]</h3>
-          <div id="editor">
+          <div id="editor" slot="form">
             <slot name="form">
               <vaadin-crud-form
                 theme$="[[theme]]"
@@ -233,12 +233,11 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
             </slot>
           </div>
 
-          <vaadin-button slot="footer" on-click="__save" theme="primary" disabled="[[!__isDirty]]"
+          <vaadin-button slot="save" on-click="__save" theme="primary" disabled="[[!__isDirty]]"
             >[[i18n.saveItem]]</vaadin-button
           >
-          <vaadin-button slot="footer" on-click="__cancel" theme="tertiary">[[i18n.cancel]]</vaadin-button>
-          <div slot="footer" style="flex: auto;"></div>
-          <vaadin-button slot="footer" on-click="__delete" theme="tertiary error" hidden="[[__isNew]]"
+          <vaadin-button slot="cancel" on-click="__cancel" theme="tertiary">[[i18n.cancel]]</vaadin-button>
+          <vaadin-button slot="delete" on-click="__delete" theme="tertiary error" hidden="[[__isNew]]"
             >[[i18n.deleteItem]]</vaadin-button
           >
         </vaadin-dialog-layout>

--- a/packages/vaadin-crud/test/crud-editor.test.js
+++ b/packages/vaadin-crud/test/crud-editor.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { flushGrid } from './helpers.js';
-import '@vaadin/vaadin-template-renderer';
-import '../vaadin-crud.js';
+import '../src/vaadin-crud.js';
 
 describe('vaadin-crud editor', () => {
   ['default', 'custom'].forEach((type) => {
@@ -16,10 +15,7 @@ describe('vaadin-crud editor', () => {
       </vaadin-crud>`;
 
     describe(`${type} form`, () => {
-      let crud, dialogLayout, dialog, form;
-
-      const buttons = () => form.parentElement.querySelectorAll('vaadin-button');
-      const btnCancel = () => buttons()[1];
+      let crud, dialog, form, overlay;
 
       beforeEach(async () => {
         crud = fixtureSync(tpl);
@@ -29,37 +25,38 @@ describe('vaadin-crud editor', () => {
         flushGrid(crud._grid);
 
         crud.set('items', [{ foo: 'bar' }, { foo: 'baz' }]);
-        dialogLayout = crud.$.dialog;
-        form = dialogLayout.form;
-        dialog = dialogLayout.$.dialog;
+        form = crud.$.dialog.form;
+        dialog = crud.$.dialog.$.dialog;
+        overlay = dialog.$.overlay;
       });
 
       it(`should move ${type} form to dialog content with default editorPosition`, () => {
         crud._grid.activeItem = crud.items[0];
-        expect(form.parentElement).to.equal(dialog.$.overlay.$.content);
+        expect(form.parentElement).to.equal(overlay);
       });
 
       it(`should move ${type} form to layout when editorPosition set to bottom`, () => {
         crud.editorPosition = 'bottom';
         crud._grid.activeItem = crud.items[0];
-        expect(form.parentElement).to.equal(dialogLayout);
+        expect(form.parentElement).to.equal(crud);
       });
 
       it(`should move ${type} form to layout when editorPosition set to aside`, () => {
         crud.editorPosition = 'aside';
         crud._grid.activeItem = crud.items[0];
-        expect(form.parentElement).to.equal(dialogLayout);
+        expect(form.parentElement).to.equal(crud);
       });
 
       it(`should move ${type} form when editorPosition changes from default to bottom`, async () => {
         crud._grid.activeItem = crud.items[0];
-        btnCancel().click();
+        const cancel = overlay.querySelector('[slot=cancel]');
+        cancel.click();
 
         crud.editorPosition = 'bottom';
         await nextRender(crud);
 
         crud._grid.activeItem = crud.items[1];
-        expect(form.parentElement).to.equal(dialogLayout);
+        expect(form.parentElement).to.equal(crud);
       });
 
       it(`should move ${type} form when editorPosition changes from bottom to default`, async () => {
@@ -67,13 +64,14 @@ describe('vaadin-crud editor', () => {
         await nextRender(crud);
 
         crud._grid.activeItem = crud.items[0];
-        btnCancel().click();
+        const cancel = crud.$.dialog.querySelector('[slot=cancel]');
+        cancel.click();
 
         crud.editorPosition = '';
         await nextRender(crud);
 
         crud._grid.activeItem = crud.items[1];
-        expect(form.parentElement).to.equal(dialog.$.overlay.$.content);
+        expect(form.parentElement).to.equal(overlay);
       });
     });
   });

--- a/packages/vaadin-crud/test/crud.test.js
+++ b/packages/vaadin-crud/test/crud.test.js
@@ -6,16 +6,12 @@ import { flushGrid, getBodyCellContent } from './helpers.js';
 import '../src/vaadin-crud.js';
 
 describe('crud', () => {
-  let crud;
+  let crud, buttons;
 
   // Buttons in the editor dialog
   const change = () => crud._form.dispatchEvent(new Event('change', { bubbles: true }));
-  const buttons = () => crud.$.dialog.$.dialog.$.overlay.shadowRoot.querySelectorAll('vaadin-button');
-  const btnSave = () => buttons()[0];
-  const btnCancel = () => buttons()[1];
-  const btnDelete = () => buttons()[2];
 
-  const editorHeader = () => crud.$.dialog.$.dialog.$.overlay.shadowRoot.querySelector('[slot=header]');
+  const editorHeader = () => crud.$.dialog.$.dialog.$.overlay.querySelector('[slot=header]');
 
   // Buttons in confirm dialogs
   const btnConfDialog = (confirm, id) =>
@@ -99,6 +95,7 @@ describe('crud', () => {
       crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
       crud.include = 'foo';
       await nextRender(crud);
+      buttons = crud.$.dialog.querySelectorAll('vaadin-button');
     });
 
     it('should save a new item when list is empty but `include` is set', (done) => {
@@ -110,7 +107,7 @@ describe('crud', () => {
       crud.$.new.click();
       crud._form._fields[0].value = 'baz';
       change();
-      btnSave().click();
+      buttons[0].click();
     });
   });
 
@@ -137,6 +134,7 @@ describe('crud', () => {
   describe('items', () => {
     beforeEach(async () => {
       crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
+      buttons = crud.$.dialog.querySelectorAll('vaadin-button');
       crud.items = [{ foo: 'bar' }];
       await nextRender(crud._grid);
     });
@@ -165,7 +163,7 @@ describe('crud', () => {
         edit(crud.items[0]);
         crud._form._fields[0].value = 'baz';
         change();
-        btnSave().click();
+        buttons[0].click();
         expect(crud.items[0].foo).to.be.equal('baz');
       });
 
@@ -173,13 +171,13 @@ describe('crud', () => {
         crud.$.new.click();
         crud._form._fields[0].value = 'baz';
         change();
-        btnSave().click();
+        buttons[0].click();
         expect(crud.items[1].foo).to.be.equal('baz');
       });
 
       it('should delete a item', () => {
         edit(crud.items[0]);
-        btnDelete().click();
+        buttons[2].click();
         btnConfDialog(crud.$.confirmDelete, 'confirm').click();
         expect(crud.items.length).to.be.equal(0);
       });
@@ -204,13 +202,13 @@ describe('crud', () => {
         crud.editedItem = { foo: 'baz' };
         crud._form._fields[0].value = 'baz';
         change();
-        btnSave().click();
+        buttons[0].click();
         expect(crud.items[1].foo).to.be.equal('baz');
       });
 
       it('should not delete any item if item was not in items array', () => {
         crud.editedItem = { foo: 'baz' };
-        btnDelete().click();
+        buttons[2].click();
         btnConfDialog(crud.$.confirmDelete, 'confirm').click();
         expect(crud.items.length).to.be.equal(1);
       });
@@ -236,7 +234,7 @@ describe('crud', () => {
       describe('cancel', () => {
         it('should not ask for confirmation on cancel when not modified', () => {
           edit(crud.items[0]);
-          btnCancel().click();
+          buttons[1].click();
           expect(crud.$.confirmCancel.opened).not.to.be.ok;
         });
 
@@ -255,7 +253,7 @@ describe('crud', () => {
         it('should ask for confirmation on cancel when modified', () => {
           edit(crud.items[0]);
           change();
-          btnCancel().click();
+          buttons[1].click();
           expect(crud.$.confirmCancel.opened).to.be.true;
         });
 
@@ -276,7 +274,7 @@ describe('crud', () => {
         it('should continue editing when closing confirmation with confirm', () => {
           edit(crud.items[0]);
           change();
-          btnCancel().click();
+          buttons[1].click();
           btnConfDialog(crud.$.confirmCancel, 'cancel').click();
           expect(crud.$.confirmCancel.opened).not.to.be.ok;
           expect(crud.$.dialog.opened).to.be.true;
@@ -285,7 +283,7 @@ describe('crud', () => {
         it('should cancel editing when closing confirmation with reject', () => {
           edit(crud.items[0]);
           change();
-          btnCancel().click();
+          buttons[1].click();
           btnConfDialog(crud.$.confirmCancel, 'confirm').click();
           expect(crud.$.confirmCancel.opened).not.to.be.ok;
           expect(crud.$.dialog.opened).not.to.be.ok;
@@ -298,7 +296,7 @@ describe('crud', () => {
           crud.addEventListener('cancel', cancelSpyListener);
 
           crud._grid.activeItem = crud.items[0];
-          btnCancel().click();
+          buttons[1].click();
           await aTimeout(0);
           expect(cancelSpyListener.calledOnce).to.be.ok;
         });
@@ -343,7 +341,7 @@ describe('crud', () => {
           crud._grid.activeItem = crud.items[0];
           edit(crud.items[0]);
           change();
-          btnSave().click();
+          buttons[0].click();
           await aTimeout(0);
           expect(cancelSpyListener.notCalled).to.be.ok;
         });
@@ -352,13 +350,13 @@ describe('crud', () => {
       describe('delete', () => {
         it('should ask for confirmation on delete', () => {
           edit(crud.items[0]);
-          btnDelete().click();
+          buttons[2].click();
           expect(crud.$.confirmDelete.opened).to.be.true;
         });
 
         it('should continue editing when closing confirmation with cancel', () => {
           edit(crud.items[0]);
-          btnDelete().click();
+          buttons[2].click();
           btnConfDialog(crud.$.confirmDelete, 'cancel').click();
           expect(crud.$.confirmDelete.opened).not.to.be.ok;
           expect(crud.$.dialog.opened).to.be.true;
@@ -366,7 +364,7 @@ describe('crud', () => {
 
         it('should delete when closing confirmation with confirm', () => {
           edit(crud.items[0]);
-          btnDelete().click();
+          buttons[2].click();
           btnConfDialog(crud.$.confirmDelete, 'confirm').click();
           expect(crud.$.confirmDelete.opened).not.to.be.ok;
           expect(crud.$.dialog.opened).not.to.be.ok;
@@ -394,7 +392,7 @@ describe('crud', () => {
 
       it('should configure new flag when editedItem changed', async () => {
         crud.editedItem = crud.items[0];
-        btnCancel().click();
+        buttons[1].click();
         await nextRender(crud);
         expect(crud.__isNew).not.to.be.true;
       });
@@ -408,14 +406,14 @@ describe('crud', () => {
       it('should hide delete button on new', async () => {
         crud.$.new.click();
         await nextRender(crud.$.dialog.$.overlay);
-        expect(btnDelete().hasAttribute('hidden')).to.be.true;
+        expect(buttons[2].hasAttribute('hidden')).to.be.true;
       });
 
       it('should show delete button and disable save button on edit', async () => {
         edit(crud.items[0]);
         await nextRender(crud.$.dialog.$.overlay);
-        expect(btnSave().hasAttribute('disabled')).to.be.true;
-        expect(btnDelete().hasAttribute('hidden')).not.to.be.true;
+        expect(buttons[0].hasAttribute('disabled')).to.be.true;
+        expect(buttons[2].hasAttribute('hidden')).not.to.be.true;
       });
 
       ['change', 'input'].forEach((type) => {
@@ -423,7 +421,7 @@ describe('crud', () => {
           edit(crud.items[0]);
           await nextRender(crud.$.dialog.$.overlay);
           crud._form.dispatchEvent(new Event(type, { bubbles: true }));
-          expect(btnSave().hasAttribute('disabled')).not.to.be.true;
+          expect(buttons[0].hasAttribute('disabled')).not.to.be.true;
         });
       });
 
@@ -546,20 +544,20 @@ describe('crud', () => {
           });
           edit(crud.items[0]);
           change();
-          btnSave().click();
+          buttons[0].click();
         });
 
         it('on save should close dialog if not default prevented', () => {
           edit(crud.items[0]);
           change();
-          btnSave().click();
+          buttons[0].click();
           expect(crud.$.dialog.opened).not.to.be.ok;
         });
 
         it('on save should keep opened dialog if default prevented', () => {
           listenOnce(crud, 'save', (e) => e.preventDefault());
           edit(crud.items[0]);
-          btnSave().click();
+          buttons[0].click();
           expect(crud.$.dialog.opened).to.be.true;
         });
 
@@ -570,7 +568,7 @@ describe('crud', () => {
           edit(crud.items[0]);
           crud._fields[0].value = 'Modified';
           change();
-          btnSave().click();
+          buttons[0].click();
 
           expect(crud.items[0]).to.be.deep.equal(originalItem);
         });
@@ -580,7 +578,7 @@ describe('crud', () => {
           edit(crud.items[0]);
           crud._fields[0].value = 'Modified';
           change();
-          btnSave().click();
+          buttons[0].click();
 
           expect(crud.items[0]).to.not.be.deep.equal(originalItem);
         });
@@ -593,12 +591,12 @@ describe('crud', () => {
             done();
           });
           edit(crud.items[0]);
-          btnCancel().click();
+          buttons[1].click();
         });
 
         it('on cancel should close dialog if not default prevented', () => {
           edit(crud.items[0]);
-          btnCancel().click();
+          buttons[1].click();
           expect(crud.$.dialog.opened).not.to.be.ok;
           expect(crud.editorOpened).not.to.be.ok;
         });
@@ -606,7 +604,7 @@ describe('crud', () => {
         it('on cancel should keep opened dialog if default prevented', () => {
           listenOnce(crud, 'cancel', (e) => e.preventDefault());
           edit(crud.items[0]);
-          btnCancel().click();
+          buttons[1].click();
           expect(crud.$.dialog.opened).to.be.true;
         });
       });
@@ -618,13 +616,13 @@ describe('crud', () => {
             done();
           });
           edit(crud.items[0]);
-          btnDelete().click();
+          buttons[2].click();
           btnConfDialog(crud.$.confirmDelete, 'confirm').click();
         });
 
         it('on delete should close dialog if not default prevented', () => {
           edit(crud.items[0]);
-          btnDelete().click();
+          buttons[2].click();
           btnConfDialog(crud.$.confirmDelete, 'confirm').click();
           expect(crud.$.dialog.opened).not.to.be.ok;
         });
@@ -632,7 +630,7 @@ describe('crud', () => {
         it('on delete should keep opened dialog if default prevented', () => {
           listenOnce(crud, 'delete', (e) => e.preventDefault());
           edit(crud.items[0]);
-          btnDelete().click();
+          buttons[2].click();
           btnConfDialog(crud.$.confirmDelete, 'confirm').click();
           expect(crud.$.dialog.opened).to.be.true;
         });

--- a/packages/vaadin-crud/theme/lumo/vaadin-crud-styles.js
+++ b/packages/vaadin-crud/theme/lumo/vaadin-crud-styles.js
@@ -139,3 +139,32 @@ registerStyles(
   `,
   { moduleId: 'lumo-dialog-layout' }
 );
+
+registerStyles(
+  'vaadin-dialog-overlay',
+  css`
+    [part='header'] ::slotted(*) {
+      margin-top: var(--lumo-space-s);
+      margin-bottom: var(--lumo-space-s);
+    }
+
+    [part='scroller'] {
+      padding: var(--lumo-space-l);
+    }
+
+    [part='footer'] {
+      background-color: var(--lumo-contrast-5pct);
+      padding: var(--lumo-space-s) var(--lumo-space-s);
+    }
+
+    [part='footer'] ::slotted(*) {
+      margin-left: var(--lumo-space-s);
+      margin-right: var(--lumo-space-s);
+    }
+
+    [part='footer'] ::slotted([slot='delete']) {
+      margin-right: auto;
+    }
+  `,
+  { moduleId: 'lumo-dialog-layout-overlay' }
+);


### PR DESCRIPTION
DO NOT MERGE. This is a proof of concept that needs some more thinking.

## Description

This is a breaking change to make the CRUD editor form (with all the fields) easily stylable by moving them to light DOM.

Fixes #1212

## Type of change

- [x] Feature

## Notable changes

1. From now on, `vaadin-crud-form` is always placed in the light DOM of `vaadin-crud` when `editorPosition` is set to `bottom` or `aside`. This also applies to the default form (created as a slot fallback and then moved to slot manually).
2. Updated the dialog to use `renderer` and avoid adding shadow DOM to the overlay content. Also, the `form` slot is aligned with the one provided by `vaadin-crud` so that `::slotted([slot="form"])` applies to `vaadin-dialog-overlay` as well.
3. Added individual slots for `cancel`, `delete` and `save` buttons in the dialog overlay and the internal dialog layout.
4. Removed `<div slot="footer">` used for styling, and changed to use CSS `margin-right: auto` on the button instead.

## DOM example

```html
<vaadin-crud>
  <!-- Both default and custom form stay in light DOM -->
  <vaadin-crud-form slot="form"><vaadin-crud-form>
</vaadin-crud>
```

```html
<vaadin-dialog-overlay theme="crud layout">
  <h3 slot="header">Edit item</h3>
  <vaadin-crud-form slot="form"><vaadin-crud-form> 
  <vaadin-button slot="save">Save</vaadin-button>
  <vaadin-button slot="cancel">Cancel</vaadin-button>
  <vaadin-button slot="delete">Delete...</vaadin-button>
</vaadin-dialog-overlay>
```

## Open questions

1. Should we expose slots for header (e.g. `editor-header`) and buttons (`cancel`, `delete` and `save`) on the `vaadin-crud` itself? This would place them all in the light DOM and make all the light DOM children aligned in CRUD / dialog overlay.
2. If the answer to the first question is "yes", then do we want to have an option to make custom dialog editor footer fully configurable? IMO the slots for buttons are enough, and that's aligned with `vaadin-confirm-dialog` to some extent.
3. Related to the above: should we cover #503 at the same time, to provide more consistent DX for both components?