### PR TITLE
chore: update change detection branch to 21.0

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -55,7 +55,7 @@ const isLockfileChanged = () => {
  * Get packages changed since master.
  */
 const getChangedPackages = () => {
-  const output = execSync('./node_modules/.bin/lerna ls --since origin/master --json --loglevel silent');
+  const output = execSync('./node_modules/.bin/lerna ls --since origin/21.0 --json --loglevel silent');
   return JSON.parse(output.toString()).map((project) => project.name.replace('@vaadin/', ''));
 };
 


### PR DESCRIPTION
## Description

Update the web test runner change detection script to use 21.0 as a base branch for Vaadin 21.

## Type of change

- [x] Internal change
