### PR TITLE
chore: use actions/setup-node built-in cache

### DIFF
--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -14,14 +14,8 @@ jobs:
       - name: Setup Node 14.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          node-version: '14'
+          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -14,18 +14,8 @@ jobs:
       - name: Setup Node 14.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
-
-      - name: Set environment variables
-        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.playwright" >> $GITHUB_ENV
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-            ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          node-version: '14'
+          cache: 'yarn'
 
       - uses: microsoft/playwright-github-action@v1
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,8 @@ jobs:
       - name: Setup Node 14.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          node-version: '14'
+          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/lumo.yml
+++ b/.github/workflows/lumo.yml
@@ -16,14 +16,8 @@ jobs:
       - name: Setup Node 14.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          node-version: '14'
+          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/material.yml
+++ b/.github/workflows/material.yml
@@ -16,14 +16,8 @@ jobs:
       - name: Setup Node 14.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          node-version: '14'
+          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/webkit.yml
+++ b/.github/workflows/webkit.yml
@@ -14,18 +14,8 @@ jobs:
       - name: Setup Node 14.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
-
-      - name: Set environment variables
-        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.playwright" >> $GITHUB_ENV
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-            ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          node-version: '14'
+          cache: 'yarn'
 
       - uses: microsoft/playwright-github-action@v1
 


### PR DESCRIPTION
## Description

Updated GitHub Actions config to use the built-in caching, see https://github.com/actions/setup-node/pull/272

## Type of change

- Internal change