### PR TITLE
chore: use playwright-cli to install deps

### DIFF
--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -27,10 +27,11 @@ jobs:
             ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - uses: microsoft/playwright-github-action@v1
-
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
+
+      - name: Install Playwright
+        run: npx playwright install-deps firefox
 
       - name: Test
         run: yarn test:firefox

--- a/.github/workflows/webkit.yml
+++ b/.github/workflows/webkit.yml
@@ -27,10 +27,11 @@ jobs:
             ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
-      - uses: microsoft/playwright-github-action@v1
-
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
+
+      - name: Install Playwright
+        run: npx playwright install-deps webkit
 
       - name: Test
         run: yarn test:webkit


### PR DESCRIPTION
## Description

The GitHub Action is deprecated (see its [README](https://github.com/microsoft/playwright-github-action)) and it is recommended to use Playwright CLI, starting with Playwright 1.8.0.

## Type of change

- Internal change