### PR TITLE
fix: allow null and undefined in selected-item-changed event

### DIFF
--- a/packages/vaadin-combo-box/src/interfaces.d.ts
+++ b/packages/vaadin-combo-box/src/interfaces.d.ts
@@ -1,5 +1,4 @@
 import { ComboBoxElement } from './vaadin-combo-box';
-import { ComboBoxSelectedItem } from './vaadin-combo-box-mixin';
 
 export type ComboBoxDefaultItem = any;
 
@@ -55,7 +54,7 @@ export type ComboBoxFilterChangedEvent = CustomEvent<{ value: string }>;
 /**
  * Fired when the `selectedItem` property changes.
  */
-export type ComboBoxSelectedItemChangedEvent<TItem> = CustomEvent<{ value: ComboBoxSelectedItem<TItem> }>;
+export type ComboBoxSelectedItemChangedEvent<TItem> = CustomEvent<{ value: TItem | null | undefined }>;
 
 export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
   'custom-value-set': ComboBoxCustomValueSetEvent;

--- a/packages/vaadin-combo-box/src/interfaces.d.ts
+++ b/packages/vaadin-combo-box/src/interfaces.d.ts
@@ -1,4 +1,5 @@
 import { ComboBoxElement } from './vaadin-combo-box';
+import { ComboBoxSelectedItem } from './vaadin-combo-box-mixin';
 
 export type ComboBoxDefaultItem = any;
 
@@ -54,7 +55,7 @@ export type ComboBoxFilterChangedEvent = CustomEvent<{ value: string }>;
 /**
  * Fired when the `selectedItem` property changes.
  */
-export type ComboBoxSelectedItemChangedEvent<TItem> = CustomEvent<{ value: TItem }>;
+export type ComboBoxSelectedItemChangedEvent<TItem> = CustomEvent<{ value: ComboBoxSelectedItem<TItem> }>;
 
 export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
   'custom-value-set': ComboBoxCustomValueSetEvent;

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -8,8 +8,6 @@ interface ComboBoxMixinConstructor<TItem> {
   new (...args: any[]): ComboBoxMixin<TItem>;
 }
 
-type ComboBoxSelectedItem<TItem> = TItem | null | undefined;
-
 interface ComboBoxMixin<TItem> {
   readonly _propertyForValue: string;
 
@@ -94,7 +92,7 @@ interface ComboBoxMixin<TItem> {
   /**
    * The selected item from the `items` array.
    */
-  selectedItem: ComboBoxSelectedItem<TItem>;
+  selectedItem: TItem | null | undefined;
 
   /**
    * Path for label of the item. If `items` is an array of objects, the
@@ -208,4 +206,4 @@ interface ComboBoxMixin<TItem> {
   _stopPropagation(e: Event): void;
 }
 
-export { ComboBoxMixin, ComboBoxMixinConstructor, ComboBoxSelectedItem };
+export { ComboBoxMixin, ComboBoxMixinConstructor };

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -8,6 +8,8 @@ interface ComboBoxMixinConstructor<TItem> {
   new (...args: any[]): ComboBoxMixin<TItem>;
 }
 
+type ComboBoxSelectedItem<TItem> = TItem | null | undefined;
+
 interface ComboBoxMixin<TItem> {
   readonly _propertyForValue: string;
 
@@ -92,7 +94,7 @@ interface ComboBoxMixin<TItem> {
   /**
    * The selected item from the `items` array.
    */
-  selectedItem: TItem | null | undefined;
+  selectedItem: ComboBoxSelectedItem<TItem>;
 
   /**
    * Path for label of the item. If `items` is an array of objects, the
@@ -206,4 +208,4 @@ interface ComboBoxMixin<TItem> {
   _stopPropagation(e: Event): void;
 }
 
-export { ComboBoxMixin, ComboBoxMixinConstructor };
+export { ComboBoxMixin, ComboBoxMixinConstructor, ComboBoxSelectedItem };

--- a/packages/vaadin-combo-box/test/typings/combo-box.types.ts
+++ b/packages/vaadin-combo-box/test/typings/combo-box.types.ts
@@ -2,7 +2,7 @@ import { ControlStateMixin } from '@vaadin/vaadin-control-state-mixin';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
 import { ComboBoxDataProviderMixin } from '../../src/vaadin-combo-box-data-provider-mixin';
-import { ComboBoxMixin } from '../../src/vaadin-combo-box-mixin';
+import { ComboBoxMixin, ComboBoxSelectedItem } from '../../src/vaadin-combo-box-mixin';
 import {
   ComboBoxFilterChangedEvent,
   ComboBoxInvalidChangedEvent,
@@ -57,7 +57,9 @@ narrowedComboBox.addEventListener('filter-changed', (event) => {
 
 narrowedComboBox.addEventListener('selected-item-changed', (event) => {
   assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
-  assertType<TestComboBoxItem>(event.detail.value);
+  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(event.detail.value);
+  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(null);
+  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(undefined);
 });
 
 /* ComboBoxLightElement */
@@ -96,5 +98,7 @@ narrowedComboBoxLightElement.addEventListener('filter-changed', (event) => {
 
 narrowedComboBoxLightElement.addEventListener('selected-item-changed', (event) => {
   assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
-  assertType<TestComboBoxItem>(event.detail.value);
+  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(event.detail.value);
+  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(null);
+  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(undefined);
 });

--- a/packages/vaadin-combo-box/test/typings/combo-box.types.ts
+++ b/packages/vaadin-combo-box/test/typings/combo-box.types.ts
@@ -20,11 +20,6 @@ interface TestComboBoxItem {
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-const selectItemChangeEventListenerTypeAssertion = (event: ComboBoxSelectedItemChangedEvent<TestComboBoxItem>) => {
-  assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
-  assertType<TestComboBoxItem | null | undefined>(event.detail.value);
-};
-
 /* ComboBoxElement */
 const genericComboBox = document.createElement('vaadin-combo-box');
 
@@ -61,7 +56,8 @@ narrowedComboBox.addEventListener('filter-changed', (event) => {
 });
 
 narrowedComboBox.addEventListener('selected-item-changed', (event) => {
-  selectItemChangeEventListenerTypeAssertion(event);
+  assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
+  assertType<TestComboBoxItem | null | undefined>(event.detail.value);
 });
 
 /* ComboBoxLightElement */
@@ -99,5 +95,6 @@ narrowedComboBoxLightElement.addEventListener('filter-changed', (event) => {
 });
 
 narrowedComboBoxLightElement.addEventListener('selected-item-changed', (event) => {
-  selectItemChangeEventListenerTypeAssertion(event);
+  assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
+  assertType<TestComboBoxItem | null | undefined>(event.detail.value);
 });

--- a/packages/vaadin-combo-box/test/typings/combo-box.types.ts
+++ b/packages/vaadin-combo-box/test/typings/combo-box.types.ts
@@ -20,6 +20,13 @@ interface TestComboBoxItem {
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
+const selectItemChangeEventListenerTypeAssertion = (event: ComboBoxSelectedItemChangedEvent<TestComboBoxItem>) => {
+  assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
+  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(event.detail.value);
+  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(null);
+  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(undefined);
+};
+
 /* ComboBoxElement */
 const genericComboBox = document.createElement('vaadin-combo-box');
 
@@ -56,10 +63,7 @@ narrowedComboBox.addEventListener('filter-changed', (event) => {
 });
 
 narrowedComboBox.addEventListener('selected-item-changed', (event) => {
-  assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
-  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(event.detail.value);
-  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(null);
-  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(undefined);
+  selectItemChangeEventListenerTypeAssertion(event);
 });
 
 /* ComboBoxLightElement */
@@ -97,8 +101,5 @@ narrowedComboBoxLightElement.addEventListener('filter-changed', (event) => {
 });
 
 narrowedComboBoxLightElement.addEventListener('selected-item-changed', (event) => {
-  assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
-  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(event.detail.value);
-  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(null);
-  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(undefined);
+  selectItemChangeEventListenerTypeAssertion(event);
 });

--- a/packages/vaadin-combo-box/test/typings/combo-box.types.ts
+++ b/packages/vaadin-combo-box/test/typings/combo-box.types.ts
@@ -2,7 +2,7 @@ import { ControlStateMixin } from '@vaadin/vaadin-control-state-mixin';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
 import { ComboBoxDataProviderMixin } from '../../src/vaadin-combo-box-data-provider-mixin';
-import { ComboBoxMixin, ComboBoxSelectedItem } from '../../src/vaadin-combo-box-mixin';
+import { ComboBoxMixin } from '../../src/vaadin-combo-box-mixin';
 import {
   ComboBoxFilterChangedEvent,
   ComboBoxInvalidChangedEvent,
@@ -22,9 +22,7 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 
 const selectItemChangeEventListenerTypeAssertion = (event: ComboBoxSelectedItemChangedEvent<TestComboBoxItem>) => {
   assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
-  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(event.detail.value);
-  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(null);
-  assertType<ComboBoxSelectedItem<TestComboBoxItem>>(undefined);
+  assertType<TestComboBoxItem | null | undefined>(event.detail.value);
 };
 
 /* ComboBoxElement */


### PR DESCRIPTION
## Description

This PR fixes the inconsistency between `selectedItem` type in combo box mixin definition and interfaces that we have defined for events.

Fixes #2214

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
