### PR TITLE
fix: use isVisible on iron-list to check Grid's visibility

### DIFF
--- a/packages/vaadin-grid/src/iron-list.js
+++ b/packages/vaadin-grid/src/iron-list.js
@@ -593,7 +593,7 @@ export const PolymerIronList = Class({
     // When this happens, there might be some issues as described
     // here https://github.com/vaadin/web-components/issues/2127.
     // Skipping any calculation for a hidden Grid.
-    if (this.hidden) {
+    if (!this._isVisible) {
       return;
     }
 

--- a/packages/vaadin-grid/test/basic.test.js
+++ b/packages/vaadin-grid/test/basic.test.js
@@ -276,6 +276,18 @@ describe('basic features', () => {
     flushGrid(grid);
     expect(grid.firstVisibleIndex).to.equal(100);
   });
+
+  it('should keep row position after hiding/unhiding a parent of Grid', () => {
+    grid._scrollToIndex(100);
+
+    grid.notifyResize();
+    grid.parentNode.setAttribute('hidden', 'hidden');
+    flushGrid(grid);
+
+    grid.parentNode.removeAttribute('hidden');
+    flushGrid(grid);
+    expect(grid.firstVisibleIndex).to.equal(100);
+  });
 });
 
 describe('flex child', () => {


### PR DESCRIPTION
This is a complementary fix of #2244.
The original fix works when Grid is directly set to hidden, but fails for other cases, eg. when a Grid's parent get hidden instead.

This change uses `iron-list`s `_isVisible` to check Grid's visibility to determine whether any further calculation should be skipped or not.

Related to #2127