### PR TITLE
fix: correct setting order of columns when we have more than 10 columns

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-column-group.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column-group.js
@@ -7,7 +7,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { microTask } from '@polymer/polymer/lib/utils/async.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { ColumnBaseMixin } from './vaadin-grid-column.js';
-import { updateColumnOrders } from './vaadin-grid-helper.js';
+import { updateColumnOrders } from './vaadin-grid-helpers.js';
 
 /**
  * A `<vaadin-grid-column-group>` is used to make groups of columns in `<vaadin-grid>` and

--- a/packages/vaadin-grid/src/vaadin-grid-column-group.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column-group.js
@@ -7,6 +7,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { microTask } from '@polymer/polymer/lib/utils/async.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { ColumnBaseMixin } from './vaadin-grid-column.js';
+import { updateColumnOrders } from './vaadin-grid-helper.js';
 
 /**
  * A `<vaadin-grid-column-group>` is used to make groups of columns in `<vaadin-grid>` and
@@ -166,18 +167,7 @@ class GridColumnGroupElement extends ColumnBaseMixin(PolymerElement) {
       if (_rootColumns[0] && _rootColumns[0]._order) {
         _rootColumns.sort((a, b) => a._order - b._order);
       }
-
-      let c = 0;
-      _rootColumns.forEach((column, _) => {
-        // avoid multiples of 10 because they introduce and extra zero and
-        // causes the underlying calculations for child order goes wrong
-
-        if (c !== 0 && c % 9 === 0) {
-          c++;
-        }
-        column._order = order + (c + 1) * scope;
-        c++;
-      });
+      updateColumnOrders(_rootColumns, scope, order);
     }
   }
 

--- a/packages/vaadin-grid/src/vaadin-grid-column-group.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column-group.js
@@ -156,7 +156,9 @@ class GridColumnGroupElement extends ColumnBaseMixin(PolymerElement) {
 
       // In an unlikely situation where a group has more than 9 child columns,
       // the child scope must have 1 digit less...
-      const childCountDigits = ~~(Math.log(rootColumns.length) / Math.log(Math.LN10)) + 1;
+      // Log^a_b = Ln(a)/Ln(b)
+      // Number of digits of a number is equal to floor(Log(number)_10) + 1
+      const childCountDigits = ~~(Math.log(rootColumns.length) / Math.LN10) + 1;
 
       // Final scope for the child columns needs to mind both factors.
       const scope = Math.pow(10, trailingZeros - childCountDigits);
@@ -165,7 +167,17 @@ class GridColumnGroupElement extends ColumnBaseMixin(PolymerElement) {
         _rootColumns.sort((a, b) => a._order - b._order);
       }
 
-      _rootColumns.forEach((column, index) => (column._order = order + (index + 1) * scope));
+      let c = 0;
+      _rootColumns.forEach((column, _) => {
+        // avoid multiples of 10 because they introduce and extra zero and
+        // causes the underlying calculations for child order goes wrong
+
+        if (c !== 0 && c % 9 === 0) {
+          c++;
+        }
+        column._order = order + (c + 1) * scope;
+        c++;
+      });
     }
   }
 

--- a/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
@@ -5,6 +5,7 @@
  */
 import { GestureEventListeners } from '@polymer/polymer/lib/mixins/gesture-event-listeners.js';
 import { addListener } from '@polymer/polymer/lib/utils/gestures.js';
+import { updateColumnOrders } from './vaadin-grid-helper';
 
 /**
  * @polymerMixin
@@ -275,17 +276,7 @@ export const ColumnReorderingMixin = (superClass) =>
       // Reset all column orders
       columnTree[0].forEach((column) => (column._order = 0));
       // Set order numbers to top-level columns
-      let c = 0;
-      columnTree[0].forEach((column, _) => {
-        // avoid multiples of 10 because they introduce and extra zero and
-        // causes the underlying calculations for child order goes wrong
-
-        if (c > 0 && c % 9 === 0) {
-          c++;
-        }
-        column._order = (c + 1) * this._orderBaseScope;
-        c++;
-      });
+      updateColumnOrders(columnTree[0], this._orderBaseScope, 0);
     }
 
     /**

--- a/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
@@ -5,7 +5,7 @@
  */
 import { GestureEventListeners } from '@polymer/polymer/lib/mixins/gesture-event-listeners.js';
 import { addListener } from '@polymer/polymer/lib/utils/gestures.js';
-import { updateColumnOrders } from './vaadin-grid-helper';
+import { updateColumnOrders } from './vaadin-grid-helper.js';
 
 /**
  * @polymerMixin

--- a/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
@@ -275,7 +275,17 @@ export const ColumnReorderingMixin = (superClass) =>
       // Reset all column orders
       columnTree[0].forEach((column) => (column._order = 0));
       // Set order numbers to top-level columns
-      columnTree[0].forEach((column, index) => (column._order = (index + 1) * this._orderBaseScope));
+      let c = 0;
+      columnTree[0].forEach((column, _) => {
+        // avoid multiples of 10 because they introduce and extra zero and
+        // causes the underlying calculations for child order goes wrong
+
+        if (c > 0 && c % 9 === 0) {
+          c++;
+        }
+        column._order = (c + 1) * this._orderBaseScope;
+        c++;
+      });
     }
 
     /**

--- a/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
@@ -5,7 +5,7 @@
  */
 import { GestureEventListeners } from '@polymer/polymer/lib/mixins/gesture-event-listeners.js';
 import { addListener } from '@polymer/polymer/lib/utils/gestures.js';
-import { updateColumnOrders } from './vaadin-grid-helper.js';
+import { updateColumnOrders } from './vaadin-grid-helpers.js';
 
 /**
  * @polymerMixin

--- a/packages/vaadin-grid/src/vaadin-grid-helper.js
+++ b/packages/vaadin-grid/src/vaadin-grid-helper.js
@@ -1,0 +1,12 @@
+export function updateColumnOrders(columns, scope, order) {
+  let c = 0;
+  columns.forEach((column, _) => {
+    // avoid multiples of 10 because they introduce and extra zero and
+    // causes the underlying calculations for child order goes wrong
+    if (c !== 0 && c % 9 === 0) {
+      c++;
+    }
+    column._order = order + (c + 1) * scope;
+    c++;
+  });
+}

--- a/packages/vaadin-grid/src/vaadin-grid-helper.js
+++ b/packages/vaadin-grid/src/vaadin-grid-helper.js
@@ -1,4 +1,15 @@
-export function updateColumnOrders(columns, scope, order) {
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * @param {Array<Object>} columns array of columns to be modified
+ * @param {number} scope multiplier added to base order for each column
+ * @param {number} baseOrder base number used for order
+ */
+export function updateColumnOrders(columns, scope, baseOrder) {
   let c = 0;
   columns.forEach((column, _) => {
     // avoid multiples of 10 because they introduce and extra zero and
@@ -6,7 +17,7 @@ export function updateColumnOrders(columns, scope, order) {
     if (c !== 0 && c % 9 === 0) {
       c++;
     }
-    column._order = order + (c + 1) * scope;
+    column._order = baseOrder + (c + 1) * scope;
     c++;
   });
 }

--- a/packages/vaadin-grid/src/vaadin-grid-helper.js
+++ b/packages/vaadin-grid/src/vaadin-grid-helper.js
@@ -10,14 +10,14 @@
  * @param {number} baseOrder base number used for order
  */
 export function updateColumnOrders(columns, scope, baseOrder) {
-  let c = 0;
+  let c = 1;
   columns.forEach((column, _) => {
     // avoid multiples of 10 because they introduce and extra zero and
     // causes the underlying calculations for child order goes wrong
-    if (c !== 0 && c % 9 === 0) {
+    if (c % 10 === 0) {
       c++;
     }
-    column._order = baseOrder + (c + 1) * scope;
+    column._order = baseOrder + c * scope;
     c++;
   });
 }

--- a/packages/vaadin-grid/src/vaadin-grid-helpers.js
+++ b/packages/vaadin-grid/src/vaadin-grid-helpers.js
@@ -11,7 +11,7 @@
  */
 export function updateColumnOrders(columns, scope, baseOrder) {
   let c = 1;
-  columns.forEach((column, _) => {
+  columns.forEach((column) => {
     // avoid multiples of 10 because they introduce and extra zero and
     // causes the underlying calculations for child order goes wrong
     if (c % 10 === 0) {

--- a/packages/vaadin-grid/test/column-groups.test.js
+++ b/packages/vaadin-grid/test/column-groups.test.js
@@ -446,22 +446,22 @@ describe('column groups', () => {
 
     beforeEach(() => {
       grid = fixtureSync(`
-      <vaadin-grid>
-        <vaadin-grid-column-group header="groupA">
-          ${Array.from(Array(13).keys())
-            .slice(1)
-            .map((group) => {
-              const col = (group - 1) * 2;
-              return `
-                <vaadin-grid-column-group header="group${group - 1}">
-                  <vaadin-grid-column id="col${col}" header="Col ${col}"></vaadin-grid-column>
-                  <vaadin-grid-column id="col${col + 1}" header="Col ${col + 1}"></vaadin-grid-column>
-                </vaadin-grid-column-group>
-              `;
-            })
-            .join('')}
-        </vaadin-grid-column-group>
-      </vaadin-grid>
+        <vaadin-grid>
+          <vaadin-grid-column-group header="groupA">
+            ${Array.from(Array(13).keys())
+              .slice(1)
+              .map((group) => {
+                const col = (group - 1) * 2;
+                return `
+                  <vaadin-grid-column-group header="group${group - 1}">
+                    <vaadin-grid-column id="col${col}" header="Col ${col}"></vaadin-grid-column>
+                    <vaadin-grid-column id="col${col + 1}" header="Col ${col + 1}"></vaadin-grid-column>
+                  </vaadin-grid-column-group>
+                `;
+              })
+              .join('')}
+          </vaadin-grid-column-group>
+        </vaadin-grid>
       `);
     });
 
@@ -478,17 +478,17 @@ describe('column groups', () => {
 
     beforeEach(() => {
       grid = fixtureSync(`
-      <vaadin-grid>
-        ${Array.from(Array(101).keys())
-          .map(
-            (col) => `
-            <vaadin-grid-column-group>
-              <vaadin-grid-column id="col${col}" header="Col ${col}"></vaadin-grid-column>
-            </vaadin-grid-column-group>
-            `
-          )
-          .join('')}
-      </vaadin-grid>
+        <vaadin-grid>
+          ${Array.from(Array(101).keys())
+            .map(
+              (col) => `
+              <vaadin-grid-column-group>
+                <vaadin-grid-column id="col${col}" header="Col ${col}"></vaadin-grid-column>
+              </vaadin-grid-column-group>
+              `
+            )
+            .join('')}
+        </vaadin-grid>
       `);
     });
 

--- a/packages/vaadin-grid/test/column-groups.test.js
+++ b/packages/vaadin-grid/test/column-groups.test.js
@@ -448,54 +448,18 @@ describe('column groups', () => {
       grid = fixtureSync(`
       <vaadin-grid>
         <vaadin-grid-column-group header="groupA">
-          <vaadin-grid-column-group header="group1">
-            <vaadin-grid-column header="Col 0"></vaadin-grid-column>
-            <vaadin-grid-column header="Col 1"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group2">
-            <vaadin-grid-column header="Col 2"></vaadin-grid-column>
-            <vaadin-grid-column header="Col 3"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group3">
-            <vaadin-grid-column header="Col 4"></vaadin-grid-column>
-            <vaadin-grid-column header="Col 5"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group4">
-            <vaadin-grid-column header="Col 6"></vaadin-grid-column>
-            <vaadin-grid-column header="Col 7"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group5">
-            <vaadin-grid-column header="Col 8"></vaadin-grid-column>
-            <vaadin-grid-column header="Col 9"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group6">
-            <vaadin-grid-column header="Col 10"></vaadin-grid-column>
-            <vaadin-grid-column header="Col 11"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group7">
-            <vaadin-grid-column header="Col 12"></vaadin-grid-column>
-            <vaadin-grid-column header="Col 13"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group8">
-            <vaadin-grid-column header="Col 14"></vaadin-grid-column>
-            <vaadin-grid-column header="Col 15"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group9">
-            <vaadin-grid-column header="Col 16"></vaadin-grid-column>
-            <vaadin-grid-column header="Col 17"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group10">
-            <vaadin-grid-column header="Col 18"></vaadin-grid-column>
-            <vaadin-grid-column id="col19" header="Col 19"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group11">
-            <vaadin-grid-column id="col20" header="Col 20"></vaadin-grid-column>
-            <vaadin-grid-column id="col21" header="Col 21"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-          <vaadin-grid-column-group header="group12">
-            <vaadin-grid-column id="col22" header="Col 22"></vaadin-grid-column>
-            <vaadin-grid-column id="col23" header="Col 23"></vaadin-grid-column>
-          </vaadin-grid-column-group>
+          ${Array.from(Array(13).keys())
+            .slice(1)
+            .map((group) => {
+              const col = (group - 1) * 2;
+              return `
+                <vaadin-grid-column-group header="group${group - 1}">
+                  <vaadin-grid-column id="col${col}" header="Col ${col}"></vaadin-grid-column>
+                  <vaadin-grid-column id="col${col + 1}" header="Col ${col + 1}"></vaadin-grid-column>
+                </vaadin-grid-column-group>
+              `;
+            })
+            .join('')}
         </vaadin-grid-column-group>
       </vaadin-grid>
       `);
@@ -507,315 +471,28 @@ describe('column groups', () => {
       await nextFrame();
       expect(col19._order).to.be.lessThan(col20._order);
     });
+  });
 
-    it('should correctly set column order when we have more than 100 columns', async () => {
-      let grid = fixtureSync(`
+  describe('More than 100 columns', () => {
+    let grid;
+
+    beforeEach(() => {
+      grid = fixtureSync(`
       <vaadin-grid>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 0"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 1"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 2"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 3"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 4"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 5"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 6"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 7"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 8"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 9"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 10"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 11"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 12"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 13"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 14"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 15"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 16"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 17"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 18"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 19"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 20"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column header="Col 21"></vaadin-grid-column>
-          </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 22"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 23"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 24"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 25"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 26"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 27"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 28"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 29"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 30"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 31"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 32"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 33"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 34"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 35"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 36"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 37"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 38"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 39"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 40"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 41"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 42"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 43"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 44"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 45"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 46"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 47"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 48"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 49"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 50"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 51"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 52"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 53"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 54"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 55"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 56"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 57"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 58"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 59"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 60"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 61"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 62"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 63"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 64"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 65"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 66"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 67"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 68"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 69"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 70"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 71"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 72"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 73"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 74"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 75"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 76"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 77"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 78"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 79"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 80"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 81"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 82"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 83"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 84"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 85"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 86"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 87"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 88"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 89"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 90"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 91"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 92"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 93"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 94"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 95"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 96"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 97"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 98"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column id="col99" header="Col 99"></vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <vaadin-grid-column id="col100" header="Col 100"></vaadin-grid-column>
-        </vaadin-grid-column-group>        
-        <vaadin-grid-column-group>
-          <vaadin-grid-column header="Col 101"></vaadin-grid-column>
-        </vaadin-grid-column-group>
+        ${Array.from(Array(101).keys())
+          .map(
+            (col) => `
+            <vaadin-grid-column-group>
+              <vaadin-grid-column id="col${col}" header="Col ${col}"></vaadin-grid-column>
+            </vaadin-grid-column-group>
+            `
+          )
+          .join('')}
       </vaadin-grid>
       `);
+    });
 
+    it('should correctly set column order when we have more than 100 columns', async () => {
       let col99 = grid.querySelector('#col99');
       let col100 = grid.querySelector('#col100');
       await nextFrame();

--- a/packages/vaadin-grid/test/column-groups.test.js
+++ b/packages/vaadin-grid/test/column-groups.test.js
@@ -440,4 +440,76 @@ describe('column groups', () => {
       expect(columns[1].hidden).not.to.be.true;
     });
   });
+
+  describe('Large nested groups', () => {
+    let grid;
+    beforeEach(() => {
+      grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column-group header="groupA">
+          <vaadin-grid-column-group header="group1">
+            <vaadin-grid-column><template class="header">Col 0</template></vaadin-grid-column>
+            <vaadin-grid-column><template class="header">Col 1</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+          <vaadin-grid-column-group header="group2">
+            <vaadin-grid-column><template class="header">Col 2</template></vaadin-grid-column>
+            <vaadin-grid-column><template class="header">Col 3</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+    
+          <vaadin-grid-column-group header="group3">
+            <vaadin-grid-column><template class="header">Col 4</template></vaadin-grid-column>
+            <vaadin-grid-column><template class="header">Col 5</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+          <vaadin-grid-column-group header="group4">
+            <vaadin-grid-column><template class="header">Col 6</template></vaadin-grid-column>
+            <vaadin-grid-column><template class="header">Col 7</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+    
+          <vaadin-grid-column-group header="group5">
+            <vaadin-grid-column><template class="header">Col 8</template></vaadin-grid-column>
+            <vaadin-grid-column><template class="header">Col 9</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+          <vaadin-grid-column-group header="group6">
+            <vaadin-grid-column><template class="header">Col 10</template></vaadin-grid-column>
+            <vaadin-grid-column><template class="header">Col 11</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+    
+          <vaadin-grid-column-group header="group7">
+            <vaadin-grid-column><template class="header">Col 12</template></vaadin-grid-column>
+            <vaadin-grid-column><template class="header">Col 13</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+          <vaadin-grid-column-group header="group8">
+            <vaadin-grid-column><template class="header">Col 14</template></vaadin-grid-column>
+            <vaadin-grid-column><template class="header">Col 15</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+    
+          <vaadin-grid-column-group header="group9">
+            <vaadin-grid-column><template class="header">Col 16</template></vaadin-grid-column>
+            <vaadin-grid-column><template class="header">Col 17</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+          <vaadin-grid-column-group header="group10">
+            <vaadin-grid-column><template class="header">Col 18</template></vaadin-grid-column>
+            <vaadin-grid-column id="col19"><template class="header">Col 19</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+    
+          <vaadin-grid-column-group header="group11">
+            <vaadin-grid-column id="col20"><template class="header">Col 20</template></vaadin-grid-column>
+            <vaadin-grid-column id="col21"><template class="header">Col 21</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+          <vaadin-grid-column-group header="group12">
+            <vaadin-grid-column id="col22"><template class="header">Col 22</template></vaadin-grid-column>
+            <vaadin-grid-column id="col23"><template class="header">Col 23</template></vaadin-grid-column>
+          </vaadin-grid-column-group>
+        </vaadin-grid-column-group>
+      </vaadin-grid>
+      `);
+    });
+
+    it('should correctley set column order', async () => {
+      let col19 = grid.querySelector('#col19');
+      let col20 = grid.querySelector('#col20');
+      await nextFrame();
+      expect(col19._order).to.be.lessThan(col20._order);
+    });
+  });
 });

--- a/packages/vaadin-grid/test/column-groups.test.js
+++ b/packages/vaadin-grid/test/column-groups.test.js
@@ -507,5 +507,319 @@ describe('column groups', () => {
       await nextFrame();
       expect(col19._order).to.be.lessThan(col20._order);
     });
+
+    it('should correctly set column order when we have more than 100 columns', async () => {
+      let grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 0"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 1"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 2"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 3"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 4"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 5"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 6"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 7"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 8"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 9"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 10"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 11"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 12"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 13"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 14"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 15"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 16"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 17"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 18"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 19"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 20"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column header="Col 21"></vaadin-grid-column>
+          </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 22"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 23"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 24"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 25"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 26"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 27"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 28"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 29"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 30"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 31"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 32"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 33"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 34"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 35"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 36"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 37"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 38"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 39"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 40"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 41"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 42"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 43"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 44"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 45"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 46"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 47"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 48"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 49"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 50"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 51"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 52"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 53"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 54"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 55"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 56"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 57"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 58"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 59"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 60"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 61"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 62"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 63"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 64"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 65"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 66"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 67"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 68"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 69"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 70"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 71"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 72"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 73"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 74"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 75"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 76"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 77"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 78"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 79"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 80"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 81"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 82"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 83"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 84"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 85"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 86"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 87"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 88"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 89"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 90"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 91"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 92"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 93"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 94"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 95"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 96"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 97"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 98"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column id="col99" header="Col 99"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column-group>
+          <vaadin-grid-column id="col100" header="Col 100"></vaadin-grid-column>
+        </vaadin-grid-column-group>        
+        <vaadin-grid-column-group>
+          <vaadin-grid-column header="Col 101"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+      </vaadin-grid>
+      `);
+
+      let col99 = grid.querySelector('#col99');
+      let col100 = grid.querySelector('#col100');
+      await nextFrame();
+      expect(col99._order).to.be.lessThan(col100._order);
+    });
   });
 });

--- a/packages/vaadin-grid/test/column-groups.test.js
+++ b/packages/vaadin-grid/test/column-groups.test.js
@@ -443,69 +443,65 @@ describe('column groups', () => {
 
   describe('Large nested groups', () => {
     let grid;
+
     beforeEach(() => {
       grid = fixtureSync(`
       <vaadin-grid>
         <vaadin-grid-column-group header="groupA">
           <vaadin-grid-column-group header="group1">
-            <vaadin-grid-column><template class="header">Col 0</template></vaadin-grid-column>
-            <vaadin-grid-column><template class="header">Col 1</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 0"></vaadin-grid-column>
+            <vaadin-grid-column header="Col 1"></vaadin-grid-column>
           </vaadin-grid-column-group>
           <vaadin-grid-column-group header="group2">
-            <vaadin-grid-column><template class="header">Col 2</template></vaadin-grid-column>
-            <vaadin-grid-column><template class="header">Col 3</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 2"></vaadin-grid-column>
+            <vaadin-grid-column header="Col 3"></vaadin-grid-column>
           </vaadin-grid-column-group>
-    
           <vaadin-grid-column-group header="group3">
-            <vaadin-grid-column><template class="header">Col 4</template></vaadin-grid-column>
-            <vaadin-grid-column><template class="header">Col 5</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 4"></vaadin-grid-column>
+            <vaadin-grid-column header="Col 5"></vaadin-grid-column>
           </vaadin-grid-column-group>
           <vaadin-grid-column-group header="group4">
-            <vaadin-grid-column><template class="header">Col 6</template></vaadin-grid-column>
-            <vaadin-grid-column><template class="header">Col 7</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 6"></vaadin-grid-column>
+            <vaadin-grid-column header="Col 7"></vaadin-grid-column>
           </vaadin-grid-column-group>
-    
           <vaadin-grid-column-group header="group5">
-            <vaadin-grid-column><template class="header">Col 8</template></vaadin-grid-column>
-            <vaadin-grid-column><template class="header">Col 9</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 8"></vaadin-grid-column>
+            <vaadin-grid-column header="Col 9"></vaadin-grid-column>
           </vaadin-grid-column-group>
           <vaadin-grid-column-group header="group6">
-            <vaadin-grid-column><template class="header">Col 10</template></vaadin-grid-column>
-            <vaadin-grid-column><template class="header">Col 11</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 10"></vaadin-grid-column>
+            <vaadin-grid-column header="Col 11"></vaadin-grid-column>
           </vaadin-grid-column-group>
-    
           <vaadin-grid-column-group header="group7">
-            <vaadin-grid-column><template class="header">Col 12</template></vaadin-grid-column>
-            <vaadin-grid-column><template class="header">Col 13</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 12"></vaadin-grid-column>
+            <vaadin-grid-column header="Col 13"></vaadin-grid-column>
           </vaadin-grid-column-group>
           <vaadin-grid-column-group header="group8">
-            <vaadin-grid-column><template class="header">Col 14</template></vaadin-grid-column>
-            <vaadin-grid-column><template class="header">Col 15</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 14"></vaadin-grid-column>
+            <vaadin-grid-column header="Col 15"></vaadin-grid-column>
           </vaadin-grid-column-group>
-    
           <vaadin-grid-column-group header="group9">
-            <vaadin-grid-column><template class="header">Col 16</template></vaadin-grid-column>
-            <vaadin-grid-column><template class="header">Col 17</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 16"></vaadin-grid-column>
+            <vaadin-grid-column header="Col 17"></vaadin-grid-column>
           </vaadin-grid-column-group>
           <vaadin-grid-column-group header="group10">
-            <vaadin-grid-column><template class="header">Col 18</template></vaadin-grid-column>
-            <vaadin-grid-column id="col19"><template class="header">Col 19</template></vaadin-grid-column>
+            <vaadin-grid-column header="Col 18"></vaadin-grid-column>
+            <vaadin-grid-column id="col19" header="Col 19"></vaadin-grid-column>
           </vaadin-grid-column-group>
-    
           <vaadin-grid-column-group header="group11">
-            <vaadin-grid-column id="col20"><template class="header">Col 20</template></vaadin-grid-column>
-            <vaadin-grid-column id="col21"><template class="header">Col 21</template></vaadin-grid-column>
+            <vaadin-grid-column id="col20" header="Col 20"></vaadin-grid-column>
+            <vaadin-grid-column id="col21" header="Col 21"></vaadin-grid-column>
           </vaadin-grid-column-group>
           <vaadin-grid-column-group header="group12">
-            <vaadin-grid-column id="col22"><template class="header">Col 22</template></vaadin-grid-column>
-            <vaadin-grid-column id="col23"><template class="header">Col 23</template></vaadin-grid-column>
+            <vaadin-grid-column id="col22" header="Col 22"></vaadin-grid-column>
+            <vaadin-grid-column id="col23" header="Col 23"></vaadin-grid-column>
           </vaadin-grid-column-group>
         </vaadin-grid-column-group>
       </vaadin-grid>
       `);
     });
 
-    it('should correctley set column order', async () => {
+    it('should correctly set column order', async () => {
       let col19 = grid.querySelector('#col19');
       let col20 = grid.querySelector('#col20');
       await nextFrame();


### PR DESCRIPTION
## Description
This PR fixes the issue with setting `order` of header columns, the current approach uses bases of 10 to assign order correctly to columns and their children.

The current approach assignes multiple of `_orderBaseScope` (equal to 10000000) to root columns and children order are calculated based on these base numbers. For example if we have 100 children for our group, because number of digits of child count is 3, we can uniquely assign each child an order from numbers in this range 1xxx0000. (or by adding multiples of 10000 to base order). When doing so, multiples of 10, introduce and extra zero to our newly order and this extra zero, causes the calculations to go wrong in some nodes.

This PR solves this issue by avoiding multiples of 10 when forming new order value for child columns or base columns.

Fixes https://github.com/vaadin/web-components/issues/1343
## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
