### PR TITLE
fix: use more strict types for grid properties

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.d.ts
@@ -12,7 +12,7 @@ interface RowDetailsMixin<TItem> {
   /**
    * An array containing references to items with open row details.
    */
-  detailsOpenedItems: Array<TItem | null> | null | undefined;
+  detailsOpenedItems: Array<TItem>;
 
   /**
    * Custom function for rendering the content of the row details.

--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
@@ -13,7 +13,7 @@ export const RowDetailsMixin = (superClass) =>
       return {
         /**
          * An array containing references to items with open row details.
-         * @type {Array<GridItem> | null | undefined}
+         * @type {!Array<!GridItem>}
          */
         detailsOpenedItems: {
           type: Array,

--- a/packages/vaadin-grid/src/vaadin-grid-selection-mixin.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-mixin.d.ts
@@ -10,7 +10,7 @@ interface SelectionMixin<TItem> {
   /**
    * An array that contains the selected items.
    */
-  selectedItems: Array<TItem | null> | null;
+  selectedItems: Array<TItem>;
 
   _isSelected(item: TItem): boolean;
 

--- a/packages/vaadin-grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-mixin.js
@@ -13,7 +13,7 @@ export const SelectionMixin = (superClass) =>
       return {
         /**
          * An array that contains the selected items.
-         * @type {Array<GridItem>}
+         * @type {!Array<!GridItem>}
          */
         selectedItems: {
           type: Object,

--- a/packages/vaadin-grid/test/typings/grid.types.ts
+++ b/packages/vaadin-grid/test/typings/grid.types.ts
@@ -128,6 +128,9 @@ narrowedGrid.addEventListener('grid-drop', (event) => {
   assertType<GridDropLocation>(event.detail.dropLocation);
 });
 
+assertType<TestGridItem[]>(narrowedGrid.selectedItems);
+assertType<TestGridItem[]>(narrowedGrid.detailsOpenedItems);
+
 /* GridColumnElement */
 const genericColumn = document.createElement('vaadin-grid-column');
 assertType<GridColumnElement>(genericColumn);


### PR DESCRIPTION
## Description

The properties `selectedItems` and `detailsOpenedItems` which expected to always contain an array of items.
Both have a default value which is an empty array, so we should disallow setting them to `null` or `undefined`.

Fixes #2296

## Type of change

- Bugfix