### PR TITLE
feat: Indicate editable and read-only cells visually

### DIFF
--- a/packages/vaadin-grid-pro/theme/lumo/vaadin-grid-pro-styles.js
+++ b/packages/vaadin-grid-pro/theme/lumo/vaadin-grid-pro-styles.js
@@ -14,6 +14,36 @@ registerStyles(
       pointer-events: none;
       box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
     }
+
+    [part~='editable-cell']:hover,
+    [part~='editable-cell']:focus {
+      background-color: var(--lumo-contrast-5pct);
+      background-clip: padding-box;
+    }
+
+    /* Indicate editable cells */
+
+    :host([theme~='highlight-editable-cells']) [part~='editable-cell'] {
+      background-color: var(--lumo-contrast-5pct);
+      background-clip: border-box;
+    }
+
+    :host([theme~='highlight-editable-cells']) [part~='editable-cell']:hover,
+    :host([theme~='highlight-editable-cells']) [part~='editable-cell']:focus {
+      background-color: var(--lumo-contrast-10pct);
+    }
+
+    /* Indicate read-only cells */
+
+    :host([theme~='highlight-read-only-cells']) [part~='body-cell']:not([part~='editable-cell']) {
+      background-image: repeating-linear-gradient(
+        135deg,
+        transparent,
+        transparent 6px,
+        var(--lumo-contrast-5pct) 6px,
+        var(--lumo-contrast-5pct) 14px
+      );
+    }
   `,
   { moduleId: 'lumo-grid-pro' }
 );


### PR DESCRIPTION
Add a default hover style for editable cells, and opt-in theme variants for indicating editable or read-only cells.

Fixes #723 

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
