### PR TITLE
feat: add indicator part to new fields

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -53,6 +53,7 @@ class CustomField extends FieldAriaMixin(LabelMixin(FocusMixin(ThemableMixin(Ele
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
+          <span part="indicator" aria-hidden="true"></span>
         </div>
 
         <div class="inputs-wrapper" on-change="__onInputChange">

--- a/packages/custom-field/theme/lumo/vaadin-custom-field-styles.js
+++ b/packages/custom-field/theme/lumo/vaadin-custom-field-styles.js
@@ -34,6 +34,11 @@ registerStyles(
       align-items: center;
     }
 
+    /* TODO: remove when all components use new indicator */
+    [part='label']::after {
+      display: none;
+    }
+
     /* align with text-field label */
     :host([has-label]) [part='label'] {
       padding-bottom: calc(0.5em - var(--lumo-space-xs));

--- a/packages/custom-field/theme/lumo/vaadin-custom-field-styles.js
+++ b/packages/custom-field/theme/lumo/vaadin-custom-field-styles.js
@@ -34,7 +34,8 @@ registerStyles(
       align-items: center;
     }
 
-    /* TODO: remove when all components use new indicator */
+    /* TODO: remove when the following components are updated to use new indicator:
+      combo-box, date-picker, time-picker, date-time-picker, select. */
     [part='label']::after {
       display: none;
     }

--- a/packages/custom-field/theme/material/vaadin-custom-field-styles.js
+++ b/packages/custom-field/theme/material/vaadin-custom-field-styles.js
@@ -24,6 +24,11 @@ registerStyles(
       -moz-osx-font-smoothing: grayscale;
     }
 
+    /* TODO: remove when all components use new indicator */
+    [part='label']::after {
+      display: none;
+    }
+
     /* align with text-field label */
     :host([has-label]) {
       padding-top: 16px;

--- a/packages/custom-field/theme/material/vaadin-custom-field-styles.js
+++ b/packages/custom-field/theme/material/vaadin-custom-field-styles.js
@@ -24,7 +24,8 @@ registerStyles(
       -moz-osx-font-smoothing: grayscale;
     }
 
-    /* TODO: remove when all components use new indicator */
+    /* TODO: remove when the following components are updated to use new indicator:
+      combo-box, date-picker, time-picker, date-time-picker, select. */
     [part='label']::after {
       display: none;
     }

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -58,6 +58,7 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
+          <span part="indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -102,6 +102,7 @@ export class TextArea extends TextFieldMixin(ThemableMixin(ElementMixin(PolymerE
       <div part="container">
         <div part="label">
           <slot name="label"></slot>
+          <span part="indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -30,6 +30,7 @@ export class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(Polymer
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
+          <span part="indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/text-field/theme/lumo/vaadin-input-field-shared-styles.js
+++ b/packages/text-field/theme/lumo/vaadin-input-field-shared-styles.js
@@ -38,6 +38,11 @@ registerStyles(
       color: var(--lumo-primary-text-color);
     }
 
+    /* TODO: remove when all components use new indicator */
+    [part='label']::after {
+      display: none;
+    }
+
     :host([has-helper]) [part='helper-text']::before {
       content: '';
       display: block;

--- a/packages/text-field/theme/lumo/vaadin-input-field-shared-styles.js
+++ b/packages/text-field/theme/lumo/vaadin-input-field-shared-styles.js
@@ -38,7 +38,8 @@ registerStyles(
       color: var(--lumo-primary-text-color);
     }
 
-    /* TODO: remove when all components use new indicator */
+    /* TODO: remove when the following components are updated to use new indicator:
+      combo-box, date-picker, time-picker, date-time-picker, select. */
     [part='label']::after {
       display: none;
     }

--- a/packages/text-field/theme/material/vaadin-input-field-shared-styles.js
+++ b/packages/text-field/theme/material/vaadin-input-field-shared-styles.js
@@ -31,7 +31,8 @@ registerStyles(
       line-height: 32px;
     }
 
-    /* TODO: remove when all components use new indicator */
+    /* TODO: remove when the following components are updated to use new indicator:
+      combo-box, date-picker, time-picker, date-time-picker, select. */
     [part='label']::after {
       display: none;
     }

--- a/packages/text-field/theme/material/vaadin-input-field-shared-styles.js
+++ b/packages/text-field/theme/material/vaadin-input-field-shared-styles.js
@@ -31,6 +31,11 @@ registerStyles(
       line-height: 32px;
     }
 
+    /* TODO: remove when all components use new indicator */
+    [part='label']::after {
+      display: none;
+    }
+
     /* Strange gymnastics to make fields vertically align nicely in most cases
          (no label, with label, without prefix, with prefix, etc.) */
 

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -18,6 +18,7 @@ const requiredField = css`
     margin-left: calc(var(--lumo-border-radius-m) / 4);
     transition: color 0.2s;
     line-height: 1;
+    padding-right: 1em;
     padding-bottom: 0.5em;
     overflow: hidden;
     white-space: nowrap;
@@ -35,11 +36,9 @@ const requiredField = css`
     padding-top: var(--lumo-space-m);
   }
 
-  :host([required]) [part='label'] {
-    padding-right: 1em;
-  }
-
-  [part='label']::after {
+  /* TODO: remove old required indicator pseudo element */
+  [part='label']::after,
+  [part='indicator']::after {
     content: var(--lumo-required-field-indicator, '•');
     transition: opacity 0.2s;
     opacity: 0;
@@ -50,11 +49,13 @@ const requiredField = css`
     text-align: center;
   }
 
-  :host([required]:not([has-value])) [part='label']::after {
+  :host([required]:not([has-value])) [part='label']::after,
+  :host([required]:not([has-value])) [part='indicator']::after {
     opacity: 1;
   }
 
-  :host([invalid]) [part='label']::after {
+  :host([invalid]) [part='label']::after,
+  :host([invalid]) [part='indicator']::after {
     color: var(--lumo-error-text-color);
   }
 
@@ -88,12 +89,13 @@ const requiredField = css`
     margin-right: calc(var(--lumo-border-radius-m) / 4);
   }
 
-  :host([required][dir='rtl']) [part='label'] {
+  :host([dir='rtl']) [part='label'] {
     padding-left: 1em;
     padding-right: 0;
   }
 
-  :host([dir='rtl']) [part='label']::after {
+  :host([dir='rtl']) [part='label']::after,
+  :host([dir='rtl']) [part='indicator']::after {
     right: auto;
     left: 0;
   }

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -36,7 +36,8 @@ const requiredField = css`
     padding-top: var(--lumo-space-m);
   }
 
-  /* TODO: remove old required indicator pseudo element */
+  /* TODO: remove old pseudo element when the following components are updated to use new indicator:
+    combo-box, date-picker, time-picker, date-time-picker, select. */
   [part='label']::after,
   [part='indicator']::after {
     content: var(--lumo-required-field-indicator, '•');

--- a/packages/vaadin-material-styles/mixins/required-field.js
+++ b/packages/vaadin-material-styles/mixins/required-field.js
@@ -23,7 +23,8 @@ const requiredField = css`
     transform: scale(0.75);
   }
 
-  :host([required]) [part='label']::after {
+  :host([required]) [part='label']::after,
+  :host([required]) [part='indicator']::after {
     content: ' *';
     color: inherit;
   }

--- a/packages/vaadin-material-styles/mixins/required-field.js
+++ b/packages/vaadin-material-styles/mixins/required-field.js
@@ -23,6 +23,8 @@ const requiredField = css`
     transform: scale(0.75);
   }
 
+  /* TODO: remove old pseudo element when the following components are updated to use new indicator:
+    combo-box, date-picker, time-picker, date-time-picker, select. */
   :host([required]) [part='label']::after,
   :host([required]) [part='indicator']::after {
     content: ' *';


### PR DESCRIPTION
## Description

1. Updated the required indicator to use a dedicated HTML element with `indicator` part
2. Changed the new fields to use the new indicator (the old ones are still using pseudo element)
3. Updated Lumo to include fix for incorrect animation by always using `padding` on the label part.
  See https://github.com/vaadin/vaadin-lumo-styles/pull/92

Fixes #2301
Fixes #1634

## Type of change

- Feature