### PR TITLE
fix: do not reset initial invalid state

### DIFF
--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -115,7 +115,6 @@ const InputFieldMixinImplementation = (superclass) =>
 
         if (this.value) {
           this._inputNode.value = this.value;
-          this.validate();
         }
       }
     }

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -220,4 +220,14 @@ describe('input-field-mixin', () => {
       expect(console.warn.called).to.be.true;
     });
   });
+
+  describe('invalid', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-field-mixin-element value="foo" invalid></input-field-mixin-element>');
+    });
+
+    it('should not reset invalid state set with attribute', () => {
+      expect(element.invalid).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Description

This is a small fix to align the new implementation of the text field components with the old one.

Fixes #2317

## Type of change

- Bugfix