### PR TITLE
fix: temporarily disable new text-field styles

### DIFF
--- a/packages/email-field/theme/lumo/vaadin-email-field-styles.js
+++ b/packages/email-field/theme/lumo/vaadin-email-field-styles.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '@vaadin/text-field/theme/lumo/vaadin-input-field-shared-styles.js';
 
 registerStyles(
   'vaadin-email-field',
@@ -16,5 +17,5 @@ registerStyles(
       --_lumo-text-field-overflow-mask-image: none;
     }
   `,
-  { moduleId: 'lumo-email-field' }
+  { moduleId: 'lumo-email-field', include: ['lumo-input-field-shared-styles'] }
 );

--- a/packages/email-field/theme/material/vaadin-email-field-styles.js
+++ b/packages/email-field/theme/material/vaadin-email-field-styles.js
@@ -3,13 +3,10 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-
-/* TODO: uncomment in https://github.com/vaadin/web-components/issues/2220
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-import './vaadin-input-field-shared-styles.js';
+import '@vaadin/text-field/theme/material/vaadin-input-field-shared-styles.js';
 
-registerStyles('vaadin-text-field', css``, {
-  moduleId: 'material-text-field-styles',
+registerStyles('vaadin-email-field', css``, {
+  moduleId: 'material-email-field',
   include: ['material-input-field-shared-styles']
 });
-*/

--- a/packages/email-field/theme/material/vaadin-email-field.js
+++ b/packages/email-field/theme/material/vaadin-email-field.js
@@ -4,4 +4,5 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/text-field/theme/material/vaadin-text-field.js';
+import './vaadin-email-field-styles.js';
 import '../../src/vaadin-email-field.js';

--- a/packages/password-field/theme/lumo/vaadin-password-field-styles.js
+++ b/packages/password-field/theme/lumo/vaadin-password-field-styles.js
@@ -6,6 +6,7 @@
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
+import '@vaadin/text-field/theme/lumo/vaadin-input-field-shared-styles.js';
 
 registerStyles(
   'vaadin-password-field',
@@ -39,5 +40,5 @@ registerStyles(
       border: none;
     }
   `,
-  { moduleId: 'lumo-password-field' }
+  { moduleId: 'lumo-password-field', include: ['lumo-input-field-shared-styles'] }
 );

--- a/packages/password-field/theme/material/vaadin-password-field-styles.js
+++ b/packages/password-field/theme/material/vaadin-password-field-styles.js
@@ -5,6 +5,7 @@
  */
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
+import '@vaadin/text-field/theme/material/vaadin-input-field-shared-styles.js';
 
 registerStyles(
   'vaadin-password-field',
@@ -46,5 +47,5 @@ registerStyles(
       border: none;
     }
   `,
-  { moduleId: 'material-password-field' }
+  { moduleId: 'material-password-field', include: ['material-input-field-shared-styles'] }
 );

--- a/packages/text-field/test/visual/lumo/text-field.test.js
+++ b/packages/text-field/test/visual/lumo/text-field.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../../theme/lumo/vaadin-text-field.js';
+// TODO: remove in https://github.com/vaadin/web-components/issues/2220
+import './vaadin-text-field.js';
 import { TextField } from '../../../src/vaadin-text-field.js';
 
 customElements.define('vaadin-text-field', TextField);

--- a/packages/text-field/test/visual/lumo/vaadin-text-field.js
+++ b/packages/text-field/test/visual/lumo/vaadin-text-field.js
@@ -1,3 +1,4 @@
+// TODO: remove this file in https://github.com/vaadin/web-components/issues/2220
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '../../../theme/lumo/vaadin-text-field.js';
 import '../../../theme/lumo/vaadin-input-field-shared-styles.js';

--- a/packages/text-field/test/visual/lumo/vaadin-text-field.js
+++ b/packages/text-field/test/visual/lumo/vaadin-text-field.js
@@ -1,0 +1,8 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '../../../theme/lumo/vaadin-text-field.js';
+import '../../../theme/lumo/vaadin-input-field-shared-styles.js';
+
+registerStyles('vaadin-text-field', css``, {
+  moduleId: 'lumo-text-field-styles',
+  include: ['lumo-input-field-shared-styles']
+});

--- a/packages/text-field/test/visual/material/text-field.test.js
+++ b/packages/text-field/test/visual/material/text-field.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../../theme/material/vaadin-text-field.js';
+// TODO: remove in https://github.com/vaadin/web-components/issues/2220
+import './vaadin-text-field.js';
 import { TextField } from '../../../src/vaadin-text-field.js';
 
 customElements.define('vaadin-text-field', TextField);

--- a/packages/text-field/test/visual/material/vaadin-text-field.js
+++ b/packages/text-field/test/visual/material/vaadin-text-field.js
@@ -1,3 +1,4 @@
+// TODO: remove this file in https://github.com/vaadin/web-components/issues/2220
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '../../../theme/material/vaadin-text-field.js';
 import '../../../theme/material/vaadin-input-field-shared-styles.js';

--- a/packages/text-field/test/visual/material/vaadin-text-field.js
+++ b/packages/text-field/test/visual/material/vaadin-text-field.js
@@ -1,0 +1,8 @@
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import '../../../theme/material/vaadin-text-field.js';
+import '../../../theme/material/vaadin-input-field-shared-styles.js';
+
+registerStyles('vaadin-text-field', css``, {
+  moduleId: 'material-text-field-styles',
+  include: ['material-input-field-shared-styles']
+});

--- a/packages/text-field/theme/lumo/vaadin-text-field-styles.js
+++ b/packages/text-field/theme/lumo/vaadin-text-field-styles.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+
+/* TODO: uncomment in https://github.com/vaadin/web-components/issues/2220
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import './vaadin-input-field-shared-styles.js';
 
@@ -10,3 +12,4 @@ registerStyles('vaadin-text-field', css``, {
   moduleId: 'lumo-text-field-styles',
   include: ['lumo-input-field-shared-styles']
 });
+*/


### PR DESCRIPTION
## Description

This is a follow-up from #2323 tackling the same problem but in a better way.

1. Commented out the new theme module that applies to `vaadin-text-field` component, 
2. Updated `@vaadin/password-field` and `@vaadin/email-field` to import the new module,
3. Updated the visual tests in the `@vaadin/text-field` to keep visual tests working.

This fixes visual tests in the following PRs: #2319 , #2320 

## Type of change

- Bugfix