### PR TITLE
fix: dispose of Lit parts after changing a renderer [combo-box, virtual-list]

### DIFF
--- a/packages/vaadin-combo-box/package.json
+++ b/packages/vaadin-combo-box/package.json
@@ -38,6 +38,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
+    "lit": "^2.0.0-rc.1",
     "@esm-bundle/chai": "4.3.0",
     "@polymer/iron-input": "^3.0.1",
     "@polymer/paper-input": "^3.0.0",

--- a/packages/vaadin-combo-box/package.json
+++ b/packages/vaadin-combo-box/package.json
@@ -38,13 +38,13 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "lit": "^2.0.0-rc.1",
     "@esm-bundle/chai": "4.3.0",
     "@polymer/iron-input": "^3.0.1",
     "@polymer/paper-input": "^3.0.0",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-dialog": "^22.0.0-alpha1",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha1",
+    "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.0"
   },
   "publishConfig": {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
@@ -145,6 +145,10 @@ class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
 
     if (this._oldRenderer !== renderer) {
       this.$.content.innerHTML = '';
+      // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
+      // When clearing the rendered content, this part needs to be manually disposed of.
+      // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
+      delete this.$.content._$litPart$;
     }
 
     if (renderer) {

--- a/packages/vaadin-combo-box/test/item-renderer.test.js
+++ b/packages/vaadin-combo-box/test/item-renderer.test.js
@@ -123,4 +123,10 @@ describe('item renderer', () => {
 
     expect(getFirstItem().$.content.textContent).to.equal('foo');
   });
+
+  it('should clear the old content after assigning a new renderer', () => {
+    comboBox.opened = true;
+    comboBox.renderer = () => {};
+    expect(getFirstItem().$.content.textContent).to.equal('');
+  });
 });

--- a/packages/vaadin-combo-box/test/lit.test.js
+++ b/packages/vaadin-combo-box/test/lit.test.js
@@ -1,0 +1,41 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { html, render } from 'lit';
+import '../vaadin-combo-box.js';
+
+describe('lit', () => {
+  describe('renderer', () => {
+    let comboBox;
+
+    function getFirstItem() {
+      return comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
+    }
+
+    beforeEach(() => {
+      comboBox = fixtureSync(`<vaadin-combo-box></vaadin-combo-box>`);
+
+      const size = 100;
+
+      comboBox.items = new Array(size).fill().map((e, i) => {
+        return { value: `value-${i}` };
+      });
+
+      comboBox.renderer = (root, _, { index }) => {
+        render(html`value-${index}`, root);
+      };
+    });
+
+    it('should render the content', () => {
+      comboBox.opened = true;
+      expect(getFirstItem().$.content.textContent).to.equal('value-0');
+    });
+
+    it('should render new content after assigning a new renderer', () => {
+      comboBox.opened = true;
+      comboBox.renderer = (root, _, { index }) => {
+        render(html`new-${index}`, root);
+      };
+      expect(getFirstItem().$.content.textContent).to.equal('new-0');
+    });
+  });
+});

--- a/packages/vaadin-virtual-list/package.json
+++ b/packages/vaadin-virtual-list/package.json
@@ -32,9 +32,9 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "lit": "^2.0.0-rc.1",
     "@esm-bundle/chai": "^4.1.5",
     "@vaadin/testing-helpers": "^0.2.1",
+    "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-virtual-list/package.json
+++ b/packages/vaadin-virtual-list/package.json
@@ -32,6 +32,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
+    "lit": "^2.0.0-rc.1",
     "@esm-bundle/chai": "^4.1.5",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.4"

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -128,8 +128,24 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   /** @private */
   __updateElement(el, index) {
     if (this.renderer) {
+      if (el.__currentRenderer !== this.renderer) {
+        this._clearRenderTargetContent(el);
+        el.__currentRenderer = this.renderer;
+      }
+
       this.renderer(el, this, { item: this.items[index], index });
     }
+  }
+
+  /**
+   * Clears the content of a render target.
+   */
+  _clearRenderTargetContent(element) {
+    element.innerHTML = '';
+    // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
+    // When clearing the rendered content, this part needs to be manually disposed of.
+    // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
+    delete element._$litPart$;
   }
 
   /** @private */

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -128,9 +128,9 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   /** @private */
   __updateElement(el, index) {
     if (this.renderer) {
-      if (el.__currentRenderer !== this.renderer) {
-        this._clearRenderTargetContent(el);
-        el.__currentRenderer = this.renderer;
+      if (el.__renderer !== this.renderer) {
+        el.__renderer = this.renderer;
+        this.__clearRenderTargetContent(el);
       }
 
       this.renderer(el, this, { item: this.items[index], index });
@@ -139,8 +139,9 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /**
    * Clears the content of a render target.
+   * @private
    */
-  _clearRenderTargetContent(element) {
+  __clearRenderTargetContent(element) {
     element.innerHTML = '';
     // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
     // When clearing the rendered content, this part needs to be manually disposed of.

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -127,12 +127,12 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   __updateElement(el, index) {
-    if (this.renderer) {
-      if (el.__renderer !== this.renderer) {
-        el.__renderer = this.renderer;
-        this.__clearRenderTargetContent(el);
-      }
+    if (el.__renderer !== this.renderer) {
+      el.__renderer = this.renderer;
+      this.__clearRenderTargetContent(el);
+    }
 
+    if (this.renderer) {
       this.renderer(el, this, { item: this.items[index], index });
     }
   }
@@ -151,7 +151,8 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   __itemsOrRendererChanged(items = [], renderer, virtualizer) {
-    if (renderer && virtualizer) {
+    const hasRenderedItems = this.childElementCount > 0;
+    if ((renderer || hasRenderedItems) && virtualizer) {
       if (items.length === virtualizer.size) {
         virtualizer.update();
       } else {

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -151,7 +151,11 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   __itemsOrRendererChanged(items = [], renderer, virtualizer) {
+    // If the renderer is removed but there are elements created by
+    // a previous renderer, we need to request an update from the virtualizer
+    // to get the already existing elements properly cleared.
     const hasRenderedItems = this.childElementCount > 0;
+
     if ((renderer || hasRenderedItems) && virtualizer) {
       if (items.length === virtualizer.size) {
         virtualizer.update();

--- a/packages/vaadin-virtual-list/test/lit.test.js
+++ b/packages/vaadin-virtual-list/test/lit.test.js
@@ -1,0 +1,36 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { html, render } from 'lit';
+import '../vaadin-virtual-list.js';
+
+describe('lit', () => {
+  describe('renderer', () => {
+    let list;
+
+    beforeEach(() => {
+      list = fixtureSync(`<vaadin-virtual-list></vaadin-virtual-list>`);
+
+      const size = 100;
+
+      list.items = new Array(size).fill().map((e, i) => {
+        return { value: `value-${i}` };
+      });
+
+      list.renderer = (root, _, { index }) => {
+        render(html`value-${index}`, root);
+      };
+    });
+
+    it('should render the content', () => {
+      expect(list.children[0].textContent.trim()).to.equal('value-0');
+    });
+
+    it('should render new content after assigning a new renderer', () => {
+      list.renderer = (root, _, { index }) => {
+        render(html`new-${index}`, root);
+      };
+
+      expect(list.children[0].textContent.trim()).to.equal('new-0');
+    });
+  });
+});

--- a/packages/vaadin-virtual-list/test/virtual-list.test.js
+++ b/packages/vaadin-virtual-list/test/virtual-list.test.js
@@ -105,5 +105,10 @@ describe('virtual-list', () => {
       list.renderer = () => {};
       expect(list.children[0].textContent.trim()).to.equal('');
     });
+
+    it('should clear the old content after removing the renderer', () => {
+      list.renderer = null;
+      expect(list.children[0].textContent.trim()).to.equal('');
+    });
   });
 });

--- a/packages/vaadin-virtual-list/test/virtual-list.test.js
+++ b/packages/vaadin-virtual-list/test/virtual-list.test.js
@@ -100,5 +100,10 @@ describe('virtual-list', () => {
       const itemRect = item.getBoundingClientRect();
       expect(list.getBoundingClientRect().bottom).to.be.within(itemRect.top, itemRect.bottom);
     });
+
+    it('should clear the old content after assigning a new renderer', () => {
+      list.renderer = () => {};
+      expect(list.children[0].textContent.trim()).to.equal('');
+    });
   });
 });


### PR DESCRIPTION
Fixes #2235

This is a follow-up for https://github.com/vaadin/web-components/pull/2172 and addresses the same issues in `<vaadin-combo-box>` and `<vaadin-virtual-list>`.