### PR TITLE
fix: decrease complexity of CSS selectors

### DIFF
--- a/packages/vaadin-upload/src/vaadin-upload-file.js
+++ b/packages/vaadin-upload/src/vaadin-upload-file.js
@@ -56,7 +56,7 @@ class UploadFileElement extends ThemableMixin(PolymerElement) {
           display: none;
         }
 
-        li[part='row'] {
+        [part='row'] {
           list-style-type: none;
         }
 


### PR DESCRIPTION
## Description

> Whenever is possible, decrease the complexity of CSS selectors to facilitate their overriding for the user later on.

This PR is a follow-up for https://github.com/vaadin/web-components/pull/2316 and intends to decrease the complexity of a CSS selector applied for `vaadin-upload-file`.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
