### PR TITLE
refactor: replace iron-list with virtualizer in combo-box

### DIFF
--- a/packages/vaadin-combo-box/package.json
+++ b/packages/vaadin-combo-box/package.json
@@ -25,7 +25,6 @@
   ],
   "dependencies": {
     "@polymer/iron-a11y-announcer": "^3.0.0",
-    "@polymer/iron-list": "^3.0.0",
     "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-control-state-mixin": "^22.0.0-alpha4",
@@ -35,7 +34,8 @@
     "@vaadin/vaadin-material-styles": "^22.0.0-alpha4",
     "@vaadin/vaadin-overlay": "^22.0.0-alpha4",
     "@vaadin/vaadin-text-field": "^22.0.0-alpha4",
-    "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha4"
+    "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha4",
+    "@vaadin/vaadin-virtual-list": "^22.0.0-alpha4"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -198,10 +198,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
             if (Object.keys(this._pendingRequests).length === 0) {
               this.loading = false;
             }
-            if (page === 0 && this.__repositionOverlayDebouncer && items.length > (this.__maxRenderedItems || 0)) {
-              setTimeout(() => this.__repositionOverlayDebouncer.flush());
-              this.__maxRenderedItems = items.length;
-            }
           }
         };
 

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
@@ -102,26 +102,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
        */
       theme: String,
 
-      /**
-       * Used to recognize if the filter changed, so to skip the
-       * scrolling restore. If true, then scroll to 0 position. Restore
-       * the previous position otherwise.
-       */
-      // filterChanged: {
-      //   type: Boolean,
-      //   value: false
-      // },
-
-      /**
-       * Used to recognize scroller reset after new items have been set
-       * to iron-list and to ignore unwanted pages load. If 'true', then
-       * skip loading of the pages until it becomes 'false'.
-       */
-      // _resetScrolling: {
-      //   type: Boolean,
-      //   value: false
-      // },
-
       _selectedItem: {
         type: Object
       },
@@ -154,15 +134,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
       _selector: Object,
 
       _itemIdPath: String,
-
-      /**
-       * Stores the scroller position before updating the 'items', in
-       * order to restore it immediately after 'items' have been updated
-       */
-      // _oldScrollerPosition: {
-      //   type: Number,
-      //   value: 0
-      // },
 
       __effectiveItems: {
         computed: '_getItems(opened, _items)',
@@ -204,7 +175,7 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
     el.setProperties({
       item: this.__effectiveItems[index],
       index: this.__requestItemByIndex(item, index),
-      label: this.getItemLabel(item, this._itemLabelPath),
+      label: this.getItemLabel(item, this._itemLabelPath), // TODO: _itemLabelPath should also invoke rerender
       selected: this._isItemSelected(item, this._selectedItem, this._itemIdPath), // TODO: _itemIdPath should also invoke rerender
       renderer: this.renderer,
       focused: this._isItemFocused(this._focusedIndex, index)
@@ -225,36 +196,10 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
 
   _getItems(opened, items) {
     if (opened) {
-      // if (this._isNotEmpty(items) && this._selector && !this.filterChanged) {
-      // iron-list triggers the scroller's reset after items update, and
-      // this is not appropriate for undefined size lazy loading.
-      // see https://github.com/vaadin/vaadin-combo-box-flow/issues/386
-      // We store iron-list scrolling position in order to restore
-      // it later on after the items have been updated.
-      // const currentScrollerPosition = this._selector.firstVisibleIndex;
-      // if (currentScrollerPosition !== 0) {
-      //   this._oldScrollerPosition = currentScrollerPosition;
-      //   this._resetScrolling = true;
-      // }
-      // }
-      // Let the position to be restored in the future calls unless it's not
-      // caused by filtering
-      // this.filterChanged = false;
       return items;
     }
     return [];
   }
-
-  // _restoreScrollerPosition(items) {
-  //   if (this._isNotEmpty(items) && this._selector && this._oldScrollerPosition !== 0) {
-  //     // new items size might be less than old scrolling position
-  //     this._scrollIntoView(Math.min(items.length - 1, this._oldScrollerPosition));
-  //     // this._resetScrolling = false;
-  //     // reset position to 0 again in order to properly handle the filter
-  //     // cases (scroll to 0 after typing the filter)
-  //     this._oldScrollerPosition = 0;
-  //   }
-  // }
 
   _isNotEmpty(items) {
     return !this._isEmpty(items);
@@ -330,11 +275,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
 
     // overlay max height is restrained by the #scroller max height which is set to 65vh in CSS.
     this.$.dropdown.$.overlay.style.maxHeight = maxHeight;
-
-    // we need to set height for iron-list to make its `firstVisibleIndex` work correctly.
-    // this._selector.style.maxHeight = maxHeight;
-
-    // this.updateViewportBoundaries();
   }
 
   _maxOverlayHeight(targetRect) {
@@ -450,19 +390,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
       targetIndex = this.__virtualizer.firstVisibleIndex;
     }
     this.__virtualizer.scrollToIndex(Math.max(0, targetIndex));
-
-    // Sometimes the item is partly below the bottom edge, detect and adjust.
-    // const pidx = this._selector._getPhysicalIndex(index),
-    //   physicalItem = this._selector._physicalItems[pidx];
-    // if (!physicalItem) {
-    //   return;
-    // }
-    // const physicalItemRect = physicalItem.getBoundingClientRect(),
-    //   scrollerRect = this._scroller.getBoundingClientRect(),
-    //   scrollTopAdjust = physicalItemRect.bottom - scrollerRect.bottom + this._viewportTotalPaddingBottom;
-    // if (scrollTopAdjust > 0) {
-    //   this._scroller.scrollTop += scrollTopAdjust;
-    // }
   }
 
   __updateAllItems() {
@@ -500,11 +427,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
     //   }
     // });
   }
-
-  // updateViewportBoundaries() {
-  //   this._cachedViewportTotalPaddingBottom = undefined;
-  //   this._selector.updateViewportBoundaries();
-  // }
 
   get _viewportTotalPaddingBottom() {
     if (this._cachedViewportTotalPaddingBottom === undefined) {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
@@ -415,17 +415,16 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
    * scrolling the parent similarly to touch scrolling.
    */
   _patchWheelOverScrolling() {
-    // const selector = this._selector;
-    // selector.addEventListener('wheel', (e) => {
-    //   const scroller = selector._scroller || selector.scrollTarget;
-    //   const scrolledToTop = scroller.scrollTop === 0;
-    //   const scrolledToBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <= 1;
-    //   if (scrolledToTop && e.deltaY < 0) {
-    //     e.preventDefault();
-    //   } else if (scrolledToBottom && e.deltaY > 0) {
-    //     e.preventDefault();
-    //   }
-    // });
+    this._selector.addEventListener('wheel', (e) => {
+      const scroller = this._scroller;
+      const scrolledToTop = scroller.scrollTop === 0;
+      const scrolledToBottom = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <= 1;
+      if (scrolledToTop && e.deltaY < 0) {
+        e.preventDefault();
+      } else if (scrolledToBottom && e.deltaY > 0) {
+        e.preventDefault();
+      }
+    });
   }
 
   get _viewportTotalPaddingBottom() {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
@@ -265,7 +265,7 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   }
 
   _setOverlayHeight() {
-    if (!this.opened || !this.positionTarget) {
+    if (!this.__virtualizer || !this.opened || !this.positionTarget) {
       return;
     }
 
@@ -374,7 +374,7 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   }
 
   _scrollIntoView(index) {
-    if (!(this.opened && index >= 0)) {
+    if (!this.__virtualizer || !(this.opened && index >= 0)) {
       return;
     }
     const visibleItemsCount = this._visibleItemsCount();

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
@@ -176,7 +176,7 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
     const item = this.__effectiveItems[index];
 
     el.setProperties({
-      item: this.__effectiveItems[index],
+      item,
       index: this.__requestItemByIndex(item, index),
       label: this.getItemLabel(item, this._itemLabelPath),
       selected: this._isItemSelected(item, this._selectedItem, this._itemIdPath),

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
@@ -257,10 +257,10 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
       return;
     }
 
-    if (loading) {
-      this.$.dropdown.$.overlay.setAttribute('loading', '');
-    } else {
-      this.$.dropdown.$.overlay.removeAttribute('loading');
+    this.$.dropdown.$.overlay.toggleAttribute('loading', loading);
+
+    if (!loading && this.__virtualizer) {
+      setTimeout(() => this.__virtualizer.update());
     }
   }
 

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
@@ -168,8 +168,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   }
 
   __updateElement(el, index) {
-    // TODO: This is called too many times for a single item initially
-
     const item = this.__effectiveItems[index];
 
     el.setProperties({
@@ -396,10 +394,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
     if (this.__virtualizer) {
       this.__virtualizer.update();
     }
-  }
-
-  ensureItemsRendered() {
-    this.__updateAllItems();
   }
 
   adjustScrollPosition() {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
@@ -152,10 +152,8 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
 
   __effectiveItemsChanged(effectiveItems) {
     if (this.__virtualizer && effectiveItems) {
-      // requestAnimationFrame(() => {
       this.__virtualizer.size = effectiveItems.length;
       this.__virtualizer.flush();
-      // });
     }
   }
 
@@ -170,13 +168,15 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   }
 
   __updateElement(el, index) {
+    // TODO: This is called too many times for a single item initially
+
     const item = this.__effectiveItems[index];
 
     el.setProperties({
       item: this.__effectiveItems[index],
       index: this.__requestItemByIndex(item, index),
-      label: this.getItemLabel(item, this._itemLabelPath), // TODO: _itemLabelPath should also invoke rerender
-      selected: this._isItemSelected(item, this._selectedItem, this._itemIdPath), // TODO: _itemIdPath should also invoke rerender
+      label: this.getItemLabel(item, this._itemLabelPath),
+      selected: this._isItemSelected(item, this._selectedItem, this._itemIdPath),
       renderer: this.renderer,
       focused: this._isItemFocused(this._focusedIndex, index)
     });
@@ -394,7 +394,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
 
   __updateAllItems() {
     if (this.__virtualizer) {
-      // TODO: Check if this causes excess renderer invocations
       this.__virtualizer.update();
     }
   }

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
@@ -4,9 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { Virtualizer } from '@vaadin/vaadin-virtual-list/src/virtualizer.js';
 import './vaadin-combo-box-item.js';
 import './vaadin-combo-box-dropdown.js';
-import { Virtualizer } from '@vaadin/vaadin-virtual-list/src/virtualizer.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
 
 const TOUCH_DEVICE = (() => {
@@ -150,6 +150,11 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
     ];
   }
 
+  constructor() {
+    super();
+    this.__boundOnItemClick = this._onItemClick.bind(this);
+  }
+
   __effectiveItemsChanged(effectiveItems) {
     if (this.__virtualizer && effectiveItems) {
       this.__virtualizer.size = effectiveItems.length;
@@ -160,7 +165,7 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   __createElements(count) {
     return [...Array(count)].map(() => {
       const item = document.createElement('vaadin-combo-box-item');
-      item.addEventListener('click', this._onItemClick.bind(this));
+      item.addEventListener('click', this.__boundOnItemClick);
       item.tabIndex = '-1';
       item.style.width = '100%';
       return item;

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown-wrapper.js
@@ -49,6 +49,12 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
               /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
               box-shadow: 0 0 0 white;
             }
+
+            #selector {
+              border-width: var(--_vaadin-combo-box-items-container-border-width);
+              border-style: var(--_vaadin-combo-box-items-container-border-style);
+              border-color: var(--_vaadin-combo-box-items-container-border-color);
+            }
           </style>
 
           <div id="scroller" on-click="_stopPropagation" style="min-height: 1px">
@@ -204,10 +210,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
     return [];
   }
 
-  _isNotEmpty(items) {
-    return !this._isEmpty(items);
-  }
-
   _isEmpty(items) {
     return !items || !items.length;
   }
@@ -224,7 +226,7 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
     if (this._isEmpty(items)) {
       this.$.dropdown.__emptyItems = true;
     }
-    this.$.dropdown.opened = !!(opened && (loading || this._isNotEmpty(items)));
+    this.$.dropdown.opened = !!(opened && (loading || !this._isEmpty(items)));
     this.$.dropdown.__emptyItems = false;
   }
 
@@ -423,21 +425,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
         e.preventDefault();
       }
     });
-  }
-
-  get _viewportTotalPaddingBottom() {
-    if (this._cachedViewportTotalPaddingBottom === undefined) {
-      const itemsStyle = window.getComputedStyle(this._selector.$.items);
-      this._cachedViewportTotalPaddingBottom = [itemsStyle.paddingBottom, itemsStyle.borderBottomWidth]
-        .map((v) => {
-          return parseInt(v, 10);
-        })
-        .reduce((sum, v) => {
-          return sum + v;
-        });
-    }
-
-    return this._cachedViewportTotalPaddingBottom;
   }
 
   _visibleItemsCount() {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -602,12 +602,6 @@ export const ComboBoxMixin = (subclass) =>
       // because that will cause problems to say the least.
       flush();
 
-      // With iron-list v1.3.9, calling `notifyResize()` no longer renders
-      // the items synchronously. It is required to have the items rendered
-      // before we update the overlay and the list positions and sizes.
-      this.$.overlay.ensureItemsRendered();
-      // this.$.overlay._selector.toggleScrollListener(true);
-
       // Ensure metrics are up-to-date
       // this.$.overlay.updateViewportBoundaries();
       // Force iron-list to create reusable nodes. Otherwise it will only start

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -608,14 +608,14 @@ export const ComboBoxMixin = (subclass) =>
       // the items synchronously. It is required to have the items rendered
       // before we update the overlay and the list positions and sizes.
       this.$.overlay.ensureItemsRendered();
-      this.$.overlay._selector.toggleScrollListener(true);
+      // this.$.overlay._selector.toggleScrollListener(true);
 
       // Ensure metrics are up-to-date
-      this.$.overlay.updateViewportBoundaries();
+      // this.$.overlay.updateViewportBoundaries();
       // Force iron-list to create reusable nodes. Otherwise it will only start
       // doing that in scroll listener, which might affect performance.
       // See https://github.com/vaadin/vaadin-combo-box/pull/776
-      this.$.overlay._selector._increasePoolIfNeeded();
+      // this.$.overlay._selector._increasePoolIfNeeded();
       setTimeout(() => this._resizeDropdown(), 1);
       // Defer scroll position adjustment to improve performance.
       window.requestAnimationFrame(() => this.$.overlay.adjustScrollPosition());
@@ -953,31 +953,31 @@ export const ComboBoxMixin = (subclass) =>
     _repositionOverlay() {
       // async needed to reposition correctly after filtering
       // (especially when aligned on top of input)
-      this.__repositionOverlayDebouncer = Debouncer.debounce(
-        this.__repositionOverlayDebouncer,
-        // Long debounce: sizing updates invoke multiple styling rounds,
-        // which might affect performance, especially in old browsers.
-        // See https://github.com/vaadin/vaadin-combo-box/pull/800
-        timeOut.after(500),
-        () => {
-          const selector = this.$.overlay._selector;
-          if (!selector._isClientFull()) {
-            // Due to the mismatch of the Y position of the item rendered
-            // at the top of the scrolling list with some specific scroll
-            // position values (2324, 3486, 6972, 60972, 95757 etc.)
-            // iron-list loops the increasing of the pool and adds
-            // too many items to the DOM.
-            // Adjusting scroll position to equal the current scrollTop value
-            // to avoid looping.
-            selector._resetScrollPosition(selector._physicalTop);
-          }
-          this._resizeDropdown();
-          this.$.overlay.updateViewportBoundaries();
-          this.$.overlay.ensureItemsRendered();
-          selector.notifyResize();
-          flush();
-        }
-      );
+      // this.__repositionOverlayDebouncer = Debouncer.debounce(
+      //   this.__repositionOverlayDebouncer,
+      //   // Long debounce: sizing updates invoke multiple styling rounds,
+      //   // which might affect performance, especially in old browsers.
+      //   // See https://github.com/vaadin/vaadin-combo-box/pull/800
+      //   timeOut.after(500),
+      //   () => {
+      //     const selector = this.$.overlay._selector;
+      //     if (!selector._isClientFull()) {
+      //       // Due to the mismatch of the Y position of the item rendered
+      //       // at the top of the scrolling list with some specific scroll
+      //       // position values (2324, 3486, 6972, 60972, 95757 etc.)
+      //       // iron-list loops the increasing of the pool and adds
+      //       // too many items to the DOM.
+      //       // Adjusting scroll position to equal the current scrollTop value
+      //       // to avoid looping.
+      //       selector._resetScrollPosition(selector._physicalTop);
+      //     }
+      //     this._resizeDropdown();
+      //     this.$.overlay.updateViewportBoundaries();
+      //     this.$.overlay.ensureItemsRendered();
+      //     selector.notifyResize();
+      //     flush();
+      //   }
+      // );
     }
 
     /** @private */

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -3,8 +3,6 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { timeOut } from '@polymer/polymer/lib/utils/async.js';
-import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announcer.js';
 import { processTemplates } from '@vaadin/vaadin-element-mixin/templates.js';
@@ -744,7 +742,8 @@ export const ComboBoxMixin = (subclass) =>
 
       // Notify the dropdown about filter changing, so to let it skip the
       // scrolling restore
-      this.$.overlay.filterChanged = true;
+      // this.$.overlay.filterChanged = true;
+      this.$.overlay._scrollIntoView(0);
 
       if (this.items) {
         this.filteredItems = this._filterItems(this.items, filter);

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -601,13 +601,6 @@ export const ComboBoxMixin = (subclass) =>
       // we need to flush the DOM to make sure it doesn't get flushed in the middle of _render call
       // because that will cause problems to say the least.
       flush();
-
-      // Ensure metrics are up-to-date
-      // this.$.overlay.updateViewportBoundaries();
-      // Force iron-list to create reusable nodes. Otherwise it will only start
-      // doing that in scroll listener, which might affect performance.
-      // See https://github.com/vaadin/vaadin-combo-box/pull/776
-      // this.$.overlay._selector._increasePoolIfNeeded();
       setTimeout(() => this._resizeDropdown(), 1);
       // Defer scroll position adjustment to improve performance.
       window.requestAnimationFrame(() => this.$.overlay.adjustScrollPosition());
@@ -734,9 +727,7 @@ export const ComboBoxMixin = (subclass) =>
         return;
       }
 
-      // Notify the dropdown about filter changing, so to let it skip the
-      // scrolling restore
-      // this.$.overlay.filterChanged = true;
+      // Scroll to the top of the list whenever the filter changes.
       this.$.overlay._scrollIntoView(0);
 
       if (this.items) {

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -933,7 +933,7 @@ export const ComboBoxMixin = (subclass) =>
     _indexOfValue(value, items) {
       if (items && this._isValidValue(value)) {
         for (let i = 0; i < items.length; i++) {
-          if (this._getItemValue(items[i]) === value) {
+          if (items[i] !== this.__placeHolder && this._getItemValue(items[i]) === value) {
             return i;
           }
         }

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -889,10 +889,6 @@ export const ComboBoxMixin = (subclass) =>
           this.opened || this.autoOpenDisabled
             ? this.$.overlay.indexOfLabel(this.filter)
             : this._indexOfValue(this.value, this.filteredItems);
-
-        if (this.opened) {
-          this._repositionOverlay();
-        }
       }
     }
 
@@ -931,37 +927,6 @@ export const ComboBoxMixin = (subclass) =>
     /** @private */
     _setOverlayItems(items) {
       this.$.overlay.set('_items', items);
-    }
-
-    /** @private */
-    _repositionOverlay() {
-      // async needed to reposition correctly after filtering
-      // (especially when aligned on top of input)
-      // this.__repositionOverlayDebouncer = Debouncer.debounce(
-      //   this.__repositionOverlayDebouncer,
-      //   // Long debounce: sizing updates invoke multiple styling rounds,
-      //   // which might affect performance, especially in old browsers.
-      //   // See https://github.com/vaadin/vaadin-combo-box/pull/800
-      //   timeOut.after(500),
-      //   () => {
-      //     const selector = this.$.overlay._selector;
-      //     if (!selector._isClientFull()) {
-      //       // Due to the mismatch of the Y position of the item rendered
-      //       // at the top of the scrolling list with some specific scroll
-      //       // position values (2324, 3486, 6972, 60972, 95757 etc.)
-      //       // iron-list loops the increasing of the pool and adds
-      //       // too many items to the DOM.
-      //       // Adjusting scroll position to equal the current scrollTop value
-      //       // to avoid looping.
-      //       selector._resetScrollPosition(selector._physicalTop);
-      //     }
-      //     this._resizeDropdown();
-      //     this.$.overlay.updateViewportBoundaries();
-      //     this.$.overlay.ensureItemsRendered();
-      //     selector.notifyResize();
-      //     flush();
-      //   }
-      // );
     }
 
     /** @private */

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announcer.js';
 import { processTemplates } from '@vaadin/vaadin-element-mixin/templates.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
@@ -597,10 +596,6 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _onOpened() {
-      // Pre P2 iron-list used a debouncer to render. Now that we synchronously render items,
-      // we need to flush the DOM to make sure it doesn't get flushed in the middle of _render call
-      // because that will cause problems to say the least.
-      flush();
       setTimeout(() => this._resizeDropdown(), 1);
       // Defer scroll position adjustment to improve performance.
       window.requestAnimationFrame(() => this.$.overlay.adjustScrollPosition());

--- a/packages/vaadin-combo-box/test/basic.test.js
+++ b/packages/vaadin-combo-box/test/basic.test.js
@@ -1,8 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { getViewportItems } from './helpers.js';
 
 describe('Properties', () => {
   let comboBox;
@@ -27,17 +28,11 @@ describe('Properties', () => {
       expect(comboBox.items).to.be.undefined;
     });
 
-    it('should be bound to items list', () => {
-      comboBox.opened = true;
-      comboBox.items = ['qux'];
-      expect(comboBox.$.overlay._selector.items).to.eql(['qux']);
-    });
-
-    it('should update items list on mutation', () => {
+    it('should update items list on update', () => {
       comboBox.opened = true;
       comboBox.items = [];
-      comboBox.push('items', 'foo');
-      expect(comboBox.$.overlay._selector._virtualCount).to.eql(1);
+      comboBox.items = ['foo'];
+      expect(getViewportItems(comboBox).length).to.eql(1);
     });
 
     it('should set focused index on items set', () => {
@@ -61,32 +56,16 @@ describe('Properties', () => {
       comboBox.items = ['foo', 'bar'];
       comboBox.items = undefined;
       comboBox.opened = true;
-      expect(comboBox.$.overlay._selector._virtualCount).to.eql(0);
+      expect(getViewportItems(comboBox).length).to.eql(0);
     });
   });
 
-  // TODO: these tests are here to prevent possible regressions with using
-  // the internal properties of iron-list. These can be removed after this
-  // logic no longer is implemented in vaadin-combo-box.
   describe('visible item count', () => {
-    it('should calculate items correctly when all items are visible', async () => {
+    it('should calculate items correctly when all items are visible', () => {
       comboBox.items = ['foo', 'bar', 'baz', 'qux'];
       comboBox.open();
-      await aTimeout(0);
-      expect(comboBox.$.overlay._visibleItemsCount()).to.eql(4);
-      expect(comboBox.$.overlay._selector.lastVisibleIndex).to.eql(3);
-    });
-
-    it('should calculate items correctly when some items are hidden', async () => {
-      const items = [];
-      for (let i = 0; i < 100; i++) {
-        items.push(i.toString());
-      }
-
-      comboBox.items = items;
-      comboBox.open();
-      await aTimeout(0);
-      expect(comboBox.$.overlay._visibleItemsCount()).to.eql(comboBox.$.overlay._selector.lastVisibleIndex + 1);
+      expect(getViewportItems(comboBox).length).to.equal(4);
+      expect(getViewportItems(comboBox).pop().index).to.equal(3);
     });
   });
 

--- a/packages/vaadin-combo-box/test/combo-box-light.test.js
+++ b/packages/vaadin-combo-box/test/combo-box-light.test.js
@@ -9,7 +9,8 @@ import {
   mouseup,
   touchend,
   touchstart,
-  isDesktopSafari
+  isDesktopSafari,
+  nextFrame
 } from '@vaadin/testing-helpers';
 import { resetMouseCanceller } from '@polymer/polymer/lib/utils/gestures.js';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
@@ -415,9 +416,10 @@ describe('nested template', () => {
     expect(() => comboBox.open()).not.to.throw(Error);
   });
 
-  it('should not use nested template as the item template', () => {
+  it('should not use nested template as the item template', async () => {
     comboBox.open();
     const firstItem = comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
+    await nextFrame();
     expect(comboBox.querySelector('[slot="prefix"]').innerHTML).to.contain('1 foo');
     expect(firstItem.shadowRoot.querySelector('#content').innerHTML).to.equal('bar');
   });

--- a/packages/vaadin-combo-box/test/dynamic-size.test.js
+++ b/packages/vaadin-combo-box/test/dynamic-size.test.js
@@ -1,20 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { getViewportItems } from './helpers.js';
 import '../src/vaadin-combo-box.js';
 
 describe('dynamic size change', () => {
   function scrollToIndex(comboBox, index) {
     comboBox.$.overlay._scrollIntoView(index);
-  }
-
-  function getVisibleItems(comboBox) {
-    return Array.from(comboBox.$.overlay._selector.querySelectorAll('vaadin-combo-box-item'))
-      .filter((item) => !item.hidden)
-      .filter((item) => {
-        const itemRect = item.getBoundingClientRect();
-        const overlayRect = comboBox.$.overlay.$.dropdown.$.overlay.$.content.getBoundingClientRect();
-        return itemRect.bottom >= overlayRect.top && itemRect.top <= overlayRect.bottom;
-      });
   }
 
   describe('reduce size once scrolled to end', () => {
@@ -48,7 +39,7 @@ describe('dynamic size change', () => {
       comboBox.opened = true;
       scrollToIndex(comboBox, comboBox.size - 1);
       await nextFrame();
-      const items = getVisibleItems(comboBox);
+      const items = getViewportItems(comboBox);
       expect(items.length).to.be.above(5);
       items.forEach((item) => {
         expect(item.$.content.textContent).to.be.ok;

--- a/packages/vaadin-combo-box/test/filtering.test.js
+++ b/packages/vaadin-combo-box/test/filtering.test.js
@@ -135,7 +135,7 @@ describe('filtering items', () => {
         setInputValue('b');
 
         requestAnimationFrame(() => {
-          expect(spy.callCount).to.eql(0);
+          expect(spy.firstCall.firstArg).to.eql(0);
           done();
         });
       });
@@ -301,7 +301,6 @@ describe('filtering items', () => {
       comboBox.close();
 
       setInputValue('bar');
-      comboBox.__repositionOverlayDebouncer.flush();
 
       expect(comboBox.opened).to.be.true;
       expect(comboBox._focusedIndex).to.equal(1);
@@ -313,7 +312,6 @@ describe('filtering items', () => {
       comboBox.close();
 
       setInputValue('');
-      comboBox.__repositionOverlayDebouncer.flush();
 
       expect(comboBox.opened).to.be.true;
       expect(comboBox._focusedIndex).to.equal(-1);

--- a/packages/vaadin-combo-box/test/filtering.test.js
+++ b/packages/vaadin-combo-box/test/filtering.test.js
@@ -365,13 +365,6 @@ describe('filtering items', () => {
       expect(resizeSpy.called).to.be.false;
     });
 
-    it('should not re-position the overlay if not opened', () => {
-      const repositionSpy = sinon.spy(comboBox, '_repositionOverlay');
-      comboBox.filteredItems = ['foo', 'bar', 'baz'];
-
-      expect(repositionSpy.called).to.be.false;
-    });
-
     it('should not perform measurements when loading changes if not opened', () => {
       const measureSpy = sinon.spy(comboBox.inputElement, 'getBoundingClientRect');
       comboBox.loading = true;

--- a/packages/vaadin-combo-box/test/helpers.js
+++ b/packages/vaadin-combo-box/test/helpers.js
@@ -62,3 +62,25 @@ export const onceScrolled = (scroller) => {
 export const makeItems = (length) => {
   return Array(...new Array(length)).map((_, i) => `item ${i}`);
 };
+
+/**
+ * Returns the items that are inside the bounds of the given combo box's dropdown viewport.
+ */
+export const getViewportItems = (comboBox) => {
+  const overlayRect = comboBox.$.overlay.$.dropdown.$.overlay.$.content.getBoundingClientRect();
+
+  return Array.from(comboBox.$.overlay._selector.querySelectorAll('vaadin-combo-box-item'))
+    .sort((a, b) => a.index - b.index)
+    .filter((item) => !item.hidden)
+    .filter((item) => {
+      const itemRect = item.getBoundingClientRect();
+      return itemRect.bottom > overlayRect.top && itemRect.top < overlayRect.bottom;
+    });
+};
+
+/**
+ * Scrolls the combo box dropdown to the given index.
+ */
+export const scrollToIndex = (comboBox, index) => {
+  comboBox.$.overlay.__virtualizer.scrollToIndex(index);
+};

--- a/packages/vaadin-combo-box/test/keyboard.test.js
+++ b/packages/vaadin-combo-box/test/keyboard.test.js
@@ -417,7 +417,6 @@ describe('keyboard', () => {
 
       comboBox.open();
       await aTimeout(0);
-      console.log(getViewportItems(comboBox)[0]);
 
       expect(getViewportItems(comboBox)[0].index).to.eql(0);
     });

--- a/packages/vaadin-combo-box/test/keyboard.test.js
+++ b/packages/vaadin-combo-box/test/keyboard.test.js
@@ -12,7 +12,7 @@ import {
   fire,
   isDesktopSafari
 } from '@vaadin/testing-helpers';
-import { onceScrolled } from './helpers.js';
+import { getViewportItems, onceScrolled, scrollToIndex } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
@@ -340,8 +340,6 @@ describe('keyboard', () => {
   });
 
   describe('scrolling items', () => {
-    let selector;
-
     beforeEach(async () => {
       const items = [];
 
@@ -350,88 +348,89 @@ describe('keyboard', () => {
       }
 
       comboBox.open();
-      selector = comboBox.$.overlay._selector;
       comboBox.items = items;
 
       await aTimeout(1);
     });
 
     it('should scroll down after reaching the last visible item', () => {
-      selector.scrollToIndex(0);
+      scrollToIndex(comboBox, 0);
       comboBox._focusedIndex = comboBox.$.overlay._visibleItemsCount() - 1;
-      expect(selector.firstVisibleIndex).to.eql(0);
+      expect(getViewportItems(comboBox)[0].index).to.eql(0);
 
       arrowDownKeyDown(comboBox.inputElement);
 
-      expect(selector.firstVisibleIndex).to.eql(1);
+      expect(getViewportItems(comboBox)[0].index).to.eql(1);
     });
 
     it('should scroll up after reaching the first visible item', () => {
       comboBox._focusedIndex = 1;
-      selector.scrollToIndex(1);
-      expect(selector.firstVisibleIndex).to.eql(1);
+      scrollToIndex(comboBox, 1);
+      expect(getViewportItems(comboBox)[0].index).to.eql(1);
 
       arrowUpKeyDown(comboBox.inputElement);
 
-      expect(selector.firstVisibleIndex).to.eql(0);
+      expect(getViewportItems(comboBox)[0].index).to.eql(0);
     });
 
     it('should scroll to first visible when navigating down above viewport', () => {
       comboBox._focusedIndex = 5;
-      selector.scrollToIndex(50);
+      scrollToIndex(comboBox, 50);
 
       arrowDownKeyDown(comboBox.inputElement);
 
-      expect(selector.firstVisibleIndex).to.eql(6);
+      expect(getViewportItems(comboBox)[0].index).to.eql(6);
     });
 
     it('should scroll to first visible when navigating up above viewport', () => {
       comboBox._focusedIndex = 5;
-      selector.scrollToIndex(50);
+      scrollToIndex(comboBox, 50);
 
       arrowUpKeyDown(comboBox.inputElement);
 
-      expect(selector.firstVisibleIndex).to.eql(4);
+      expect(getViewportItems(comboBox)[0].index).to.eql(4);
     });
 
     it('should scroll to last visible when navigating up below viewport', () => {
       comboBox._focusedIndex = 50;
-      selector.scrollToIndex(0);
-      expect(selector.firstVisibleIndex).to.eql(0);
+      scrollToIndex(comboBox, 0);
+      expect(getViewportItems(comboBox)[0].index).to.eql(0);
 
       arrowUpKeyDown(comboBox.inputElement);
 
-      expect(selector.firstVisibleIndex).to.eql(49 - comboBox.$.overlay._visibleItemsCount() + 1);
+      expect(getViewportItems(comboBox)[0].index).to.eql(49 - comboBox.$.overlay._visibleItemsCount() + 1);
     });
 
     it('should scroll to last visible when navigating down below viewport', () => {
       comboBox._focusedIndex = 50;
-      selector.scrollToIndex(0);
-      expect(selector.firstVisibleIndex).to.eql(0);
+      scrollToIndex(comboBox, 0);
+      expect(getViewportItems(comboBox)[0].index).to.eql(0);
 
       arrowDownKeyDown(comboBox.inputElement);
 
-      expect(selector.firstVisibleIndex).to.eql(51 - comboBox.$.overlay._visibleItemsCount() + 1);
+      expect(getViewportItems(comboBox)[0].index).to.eql(51 - comboBox.$.overlay._visibleItemsCount() + 1);
     });
 
     it('should scroll to start if no items focused when opening overlay', async () => {
-      selector.scrollToIndex(50);
+      scrollToIndex(comboBox, 50);
       comboBox.close();
 
       comboBox.open();
       await aTimeout(0);
-      expect(selector.firstVisibleIndex).to.eql(0);
+      console.log(getViewportItems(comboBox)[0]);
+
+      expect(getViewportItems(comboBox)[0].index).to.eql(0);
     });
 
     it('should scroll to focused item when opening overlay', async () => {
-      selector.scrollToIndex(0);
+      scrollToIndex(comboBox, 0);
       comboBox.close();
       comboBox.value = '50';
 
       comboBox.open();
 
       await onceScrolled(comboBox.$.overlay._scroller);
-      expect(selector.firstVisibleIndex).to.be.within(50 - comboBox.$.overlay._visibleItemsCount(), 50);
+      expect(getViewportItems(comboBox)[0].index).to.be.within(50 - comboBox.$.overlay._visibleItemsCount(), 50);
     });
   });
 

--- a/packages/vaadin-combo-box/test/keyboard.test.js
+++ b/packages/vaadin-combo-box/test/keyboard.test.js
@@ -10,7 +10,8 @@ import {
   enterKeyDown,
   escKeyDown,
   fire,
-  isDesktopSafari
+  isDesktopSafari,
+  nextFrame
 } from '@vaadin/testing-helpers';
 import { getViewportItems, onceScrolled, scrollToIndex } from './helpers.js';
 import './not-animated-styles.js';
@@ -363,9 +364,11 @@ describe('keyboard', () => {
       expect(getViewportItems(comboBox)[0].index).to.eql(1);
     });
 
-    it('should scroll up after reaching the first visible item', () => {
-      comboBox._focusedIndex = 1;
-      scrollToIndex(comboBox, 1);
+    it('should scroll up after reaching the first visible item', async () => {
+      comboBox._focusedIndex = 2;
+      scrollToIndex(comboBox, 2);
+      await nextFrame();
+
       expect(getViewportItems(comboBox)[0].index).to.eql(1);
 
       arrowUpKeyDown(comboBox.inputElement);
@@ -379,7 +382,7 @@ describe('keyboard', () => {
 
       arrowDownKeyDown(comboBox.inputElement);
 
-      expect(getViewportItems(comboBox)[0].index).to.eql(6);
+      expect(getViewportItems(comboBox)[0].index).to.eql(5);
     });
 
     it('should scroll to first visible when navigating up above viewport', () => {
@@ -388,7 +391,7 @@ describe('keyboard', () => {
 
       arrowUpKeyDown(comboBox.inputElement);
 
-      expect(getViewportItems(comboBox)[0].index).to.eql(4);
+      expect(getViewportItems(comboBox)[0].index).to.eql(3);
     });
 
     it('should scroll to last visible when navigating up below viewport', () => {

--- a/packages/vaadin-combo-box/test/keyboard.test.js
+++ b/packages/vaadin-combo-box/test/keyboard.test.js
@@ -15,7 +15,7 @@ import {
 } from '@vaadin/testing-helpers';
 import { getViewportItems, onceScrolled, scrollToIndex } from './helpers.js';
 import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 
 describe('keyboard', () => {
   let comboBox;
@@ -369,11 +369,11 @@ describe('keyboard', () => {
       scrollToIndex(comboBox, 2);
       await nextFrame();
 
-      expect(getViewportItems(comboBox)[0].index).to.eql(1);
+      expect(getViewportItems(comboBox)[0].index).to.eql(2);
 
       arrowUpKeyDown(comboBox.inputElement);
 
-      expect(getViewportItems(comboBox)[0].index).to.eql(0);
+      expect(getViewportItems(comboBox)[0].index).to.eql(1);
     });
 
     it('should scroll to first visible when navigating down above viewport', () => {
@@ -382,7 +382,7 @@ describe('keyboard', () => {
 
       arrowDownKeyDown(comboBox.inputElement);
 
-      expect(getViewportItems(comboBox)[0].index).to.eql(5);
+      expect(getViewportItems(comboBox)[0].index).to.eql(6);
     });
 
     it('should scroll to first visible when navigating up above viewport', () => {
@@ -391,7 +391,7 @@ describe('keyboard', () => {
 
       arrowUpKeyDown(comboBox.inputElement);
 
-      expect(getViewportItems(comboBox)[0].index).to.eql(3);
+      expect(getViewportItems(comboBox)[0].index).to.eql(4);
     });
 
     it('should scroll to last visible when navigating up below viewport', () => {

--- a/packages/vaadin-combo-box/test/lazy-loading.test.js
+++ b/packages/vaadin-combo-box/test/lazy-loading.test.js
@@ -4,10 +4,20 @@ import { fixtureSync, nextFrame, enterKeyDown, fire } from '@vaadin/testing-help
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import '@polymer/iron-input/iron-input.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
-import { makeItems } from './helpers.js';
+import { getViewportItems, makeItems } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 import '../vaadin-combo-box-light.js';
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+registerStyles(
+  'vaadin-combo-box*',
+  css`
+    :host {
+      --vaadin-combo-box-overlay-max-height: 400px;
+    }
+  `
+);
 
 describe('lazy loading', () => {
   const DEFAULT_PAGE_SIZE = 50;
@@ -566,7 +576,7 @@ describe('lazy loading', () => {
 
       it('should set selectedItem matching value when items are loaded', () => {
         comboBox.opened = true; // loads first page of dataProvider items
-        comboBox.$.overlay.updateViewportBoundaries();
+        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         comboBox.value = 'item 0';
         expect(comboBox.selectedItem).to.equal('item 0');
@@ -634,7 +644,7 @@ describe('lazy loading', () => {
 
       it('should set matching selectedItem when items are loaded', () => {
         comboBox.opened = true; // loads first page of dataProvider items
-        comboBox.$.overlay.updateViewportBoundaries();
+        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         comboBox.value = 'value 0';
         expect(comboBox.selectedItem).to.eql({ id: 0, value: 'value 0', label: 'label 0' });
@@ -657,7 +667,7 @@ describe('lazy loading', () => {
       it('should select value matching selectedItem when items are loading', () => {
         comboBox.selectedItem = 'item 0';
         comboBox.opened = true;
-        comboBox.$.overlay.updateViewportBoundaries();
+        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         expect(comboBox.value).to.equal('item 0');
         const selectedRenderedItemElements = Array.from(
@@ -669,7 +679,7 @@ describe('lazy loading', () => {
 
       it('should select value matching selectedItem when items are loaded', async () => {
         comboBox.opened = true;
-        comboBox.$.overlay.updateViewportBoundaries();
+        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         comboBox.selectedItem = 'item 0';
         expect(comboBox.value).to.equal('item 0');
@@ -703,7 +713,7 @@ describe('lazy loading', () => {
       it('should select value matching selectedItem when items are loading', () => {
         comboBox.selectedItem = { id: 0, value: 'value 0', label: 'label 0' };
         comboBox.opened = true;
-        comboBox.$.overlay.updateViewportBoundaries();
+        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         expect(comboBox.value).to.equal('value 0');
         const selectedRenderedItemElements = Array.from(
@@ -715,7 +725,7 @@ describe('lazy loading', () => {
 
       it('should select value matching selectedItem when items are loaded', async () => {
         comboBox.opened = true;
-        comboBox.$.overlay.updateViewportBoundaries();
+        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         comboBox.selectedItem = { id: 0, value: 'value 0', label: 'label 0' };
         expect(comboBox.value).to.equal('value 0');
@@ -740,7 +750,7 @@ describe('lazy loading', () => {
         comboBox.selectedItem = { id: 0 };
         comboBox.dataProvider = objectDataProvider;
         comboBox.opened = true;
-        comboBox.$.overlay.updateViewportBoundaries();
+        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         await nextFrame();
         flush();
@@ -767,7 +777,7 @@ describe('lazy loading', () => {
           );
         };
         comboBox.opened = true;
-        comboBox.$.overlay.updateViewportBoundaries();
+        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         await nextFrame();
         flush();
@@ -1019,8 +1029,8 @@ describe('lazy loading', () => {
         // precisely to the given index, so use some margin
         const scrollMargin = 5;
         const expectedFirstVisibleIndex = targetItemIndex - comboBox.$.overlay._visibleItemsCount() - scrollMargin;
-        expect(comboBox.$.overlay._selector.firstVisibleIndex).to.be.greaterThan(expectedFirstVisibleIndex);
-        expect(comboBox.$.overlay._selector.lastVisibleIndex).to.be.lessThan(targetItemIndex + 1);
+        expect(getViewportItems(comboBox)[0].index).to.be.greaterThan(expectedFirstVisibleIndex);
+        expect(getViewportItems(comboBox).pop().index).to.be.lessThan(targetItemIndex + 1);
       });
 
       it('should reset to 0 when filter applied and filtered items size more than page size', () => {
@@ -1028,7 +1038,7 @@ describe('lazy loading', () => {
         comboBox.opened = true;
         comboBox.$.overlay._scrollIntoView(500);
         comboBox.filter = '1';
-        expect(comboBox.$.overlay._selector.firstVisibleIndex).to.be.equal(0);
+        expect(getViewportItems(comboBox)[0].index).to.be.equal(0);
       });
 
       // Verifies https://github.com/vaadin/vaadin-combo-box/issues/957
@@ -1068,7 +1078,7 @@ describe('lazy loading', () => {
         await nextFrame();
         flush();
 
-        const lastVisibleIndex = comboBox.$.overlay._selector.lastVisibleIndex;
+        const lastVisibleIndex = getViewportItems(comboBox).pop().index;
         // Check if the next few items after the last visible item are not empty
         for (let nextIndexIncrement = 0; nextIndexIncrement < 5; nextIndexIncrement++) {
           const lastItem = comboBox.filteredItems[lastVisibleIndex + nextIndexIncrement];

--- a/packages/vaadin-combo-box/test/lazy-loading.test.js
+++ b/packages/vaadin-combo-box/test/lazy-loading.test.js
@@ -307,6 +307,32 @@ describe('lazy loading', () => {
           };
           comboBox.open();
         });
+
+        it('should rerender once loaded updated items', (done) => {
+          comboBox.dataProvider = (_, callback) => {
+            if (!comboBox.filteredItems.length) {
+              // First batch of items for page 0
+              callback(['foo'], 1);
+              // Asynchronously clear the cache which leads to another request for page 0
+              setTimeout(() => comboBox.clearCache());
+            } else {
+              // Second batch of items for page 0
+              callback(['bar'], 1);
+
+              setTimeout(() => {
+                // Expect the renderer to have run for the updated items.
+                expect(getViewportItems(comboBox)[0].$.content.textContent).to.equal('bar');
+
+                // Avoid getting done called multiple times
+                if (!done._called) {
+                  done._called = true;
+                  done();
+                }
+              });
+            }
+          };
+          comboBox.open();
+        });
       });
 
       describe('when selecting item', () => {

--- a/packages/vaadin-combo-box/test/lazy-loading.test.js
+++ b/packages/vaadin-combo-box/test/lazy-loading.test.js
@@ -576,7 +576,6 @@ describe('lazy loading', () => {
 
       it('should set selectedItem matching value when items are loaded', () => {
         comboBox.opened = true; // loads first page of dataProvider items
-        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         comboBox.value = 'item 0';
         expect(comboBox.selectedItem).to.equal('item 0');
@@ -644,7 +643,6 @@ describe('lazy loading', () => {
 
       it('should set matching selectedItem when items are loaded', () => {
         comboBox.opened = true; // loads first page of dataProvider items
-        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         comboBox.value = 'value 0';
         expect(comboBox.selectedItem).to.eql({ id: 0, value: 'value 0', label: 'label 0' });
@@ -667,7 +665,6 @@ describe('lazy loading', () => {
       it('should select value matching selectedItem when items are loading', () => {
         comboBox.selectedItem = 'item 0';
         comboBox.opened = true;
-        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         expect(comboBox.value).to.equal('item 0');
         const selectedRenderedItemElements = Array.from(
@@ -679,7 +676,6 @@ describe('lazy loading', () => {
 
       it('should select value matching selectedItem when items are loaded', async () => {
         comboBox.opened = true;
-        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         comboBox.selectedItem = 'item 0';
         expect(comboBox.value).to.equal('item 0');
@@ -713,7 +709,6 @@ describe('lazy loading', () => {
       it('should select value matching selectedItem when items are loading', () => {
         comboBox.selectedItem = { id: 0, value: 'value 0', label: 'label 0' };
         comboBox.opened = true;
-        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         expect(comboBox.value).to.equal('value 0');
         const selectedRenderedItemElements = Array.from(
@@ -725,7 +720,6 @@ describe('lazy loading', () => {
 
       it('should select value matching selectedItem when items are loaded', async () => {
         comboBox.opened = true;
-        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         comboBox.selectedItem = { id: 0, value: 'value 0', label: 'label 0' };
         expect(comboBox.value).to.equal('value 0');
@@ -750,7 +744,6 @@ describe('lazy loading', () => {
         comboBox.selectedItem = { id: 0 };
         comboBox.dataProvider = objectDataProvider;
         comboBox.opened = true;
-        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         await nextFrame();
         flush();
@@ -777,7 +770,6 @@ describe('lazy loading', () => {
           );
         };
         comboBox.opened = true;
-        // comboBox.$.overlay.updateViewportBoundaries();
         comboBox.$.overlay.ensureItemsRendered();
         await nextFrame();
         flush();

--- a/packages/vaadin-combo-box/test/lazy-loading.test.js
+++ b/packages/vaadin-combo-box/test/lazy-loading.test.js
@@ -576,7 +576,6 @@ describe('lazy loading', () => {
 
       it('should set selectedItem matching value when items are loaded', () => {
         comboBox.opened = true; // loads first page of dataProvider items
-        comboBox.$.overlay.ensureItemsRendered();
         comboBox.value = 'item 0';
         expect(comboBox.selectedItem).to.equal('item 0');
       });
@@ -643,7 +642,6 @@ describe('lazy loading', () => {
 
       it('should set matching selectedItem when items are loaded', () => {
         comboBox.opened = true; // loads first page of dataProvider items
-        comboBox.$.overlay.ensureItemsRendered();
         comboBox.value = 'value 0';
         expect(comboBox.selectedItem).to.eql({ id: 0, value: 'value 0', label: 'label 0' });
       });
@@ -665,7 +663,6 @@ describe('lazy loading', () => {
       it('should select value matching selectedItem when items are loading', () => {
         comboBox.selectedItem = 'item 0';
         comboBox.opened = true;
-        comboBox.$.overlay.ensureItemsRendered();
         expect(comboBox.value).to.equal('item 0');
         const selectedRenderedItemElements = Array.from(
           comboBox.$.overlay._selector.querySelectorAll('vaadin-combo-box-item')
@@ -676,7 +673,6 @@ describe('lazy loading', () => {
 
       it('should select value matching selectedItem when items are loaded', async () => {
         comboBox.opened = true;
-        comboBox.$.overlay.ensureItemsRendered();
         comboBox.selectedItem = 'item 0';
         expect(comboBox.value).to.equal('item 0');
         await nextFrame();
@@ -709,7 +705,6 @@ describe('lazy loading', () => {
       it('should select value matching selectedItem when items are loading', () => {
         comboBox.selectedItem = { id: 0, value: 'value 0', label: 'label 0' };
         comboBox.opened = true;
-        comboBox.$.overlay.ensureItemsRendered();
         expect(comboBox.value).to.equal('value 0');
         const selectedRenderedItemElements = Array.from(
           comboBox.$.overlay._selector.querySelectorAll('vaadin-combo-box-item')
@@ -720,7 +715,6 @@ describe('lazy loading', () => {
 
       it('should select value matching selectedItem when items are loaded', async () => {
         comboBox.opened = true;
-        comboBox.$.overlay.ensureItemsRendered();
         comboBox.selectedItem = { id: 0, value: 'value 0', label: 'label 0' };
         expect(comboBox.value).to.equal('value 0');
         await nextFrame();
@@ -744,7 +738,6 @@ describe('lazy loading', () => {
         comboBox.selectedItem = { id: 0 };
         comboBox.dataProvider = objectDataProvider;
         comboBox.opened = true;
-        comboBox.$.overlay.ensureItemsRendered();
         await nextFrame();
         flush();
         const selectedRenderedItemElements = Array.from(
@@ -770,7 +763,6 @@ describe('lazy loading', () => {
           );
         };
         comboBox.opened = true;
-        comboBox.$.overlay.ensureItemsRendered();
         await nextFrame();
         flush();
         const selectedRenderedItemElements = Array.from(

--- a/packages/vaadin-combo-box/test/lazy-loading.test.js
+++ b/packages/vaadin-combo-box/test/lazy-loading.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync, nextFrame, enterKeyDown, fire } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, aTimeout, enterKeyDown, fire } from '@vaadin/testing-helpers';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import '@polymer/iron-input/iron-input.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
@@ -825,6 +825,21 @@ describe('lazy loading', () => {
       describe('when open', () => {
         beforeEach(() => {
           comboBox.opened = true;
+        });
+
+        it('should be scrolled to start on reopen', async () => {
+          comboBox.dataProvider = spyAsyncDataProvider;
+          comboBox.size = SIZE;
+          comboBox.opened = false;
+
+          // Wait for the async data provider to respond
+          await aTimeout(0);
+
+          // Reopen
+          comboBox.open();
+          await nextFrame();
+
+          expect(getViewportItems(comboBox)[0].index).to.eql(0);
         });
 
         it('should replace filteredItems with placeholders', () => {

--- a/packages/vaadin-combo-box/test/lit.test.js
+++ b/packages/vaadin-combo-box/test/lit.test.js
@@ -2,14 +2,11 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { html, render } from 'lit';
 import '../vaadin-combo-box.js';
+import { getViewportItems } from './helpers.js';
 
 describe('lit', () => {
   describe('renderer', () => {
     let comboBox;
-
-    function getFirstItem() {
-      return comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item');
-    }
 
     beforeEach(() => {
       comboBox = fixtureSync(`<vaadin-combo-box></vaadin-combo-box>`);
@@ -27,7 +24,7 @@ describe('lit', () => {
 
     it('should render the content', () => {
       comboBox.opened = true;
-      expect(getFirstItem().$.content.textContent).to.equal('value-0');
+      expect(getViewportItems(comboBox)[0].$.content.textContent).to.equal('value-0');
     });
 
     it('should render new content after assigning a new renderer', () => {
@@ -35,7 +32,7 @@ describe('lit', () => {
       comboBox.renderer = (root, _, { index }) => {
         render(html`new-${index}`, root);
       };
-      expect(getFirstItem().$.content.textContent).to.equal('new-0');
+      expect(getViewportItems(comboBox)[0].$.content.textContent).to.equal('new-0');
     });
   });
 });

--- a/packages/vaadin-combo-box/test/object-values.test.js
+++ b/packages/vaadin-combo-box/test/object-values.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { aTimeout, fixtureSync, fire } from '@vaadin/testing-helpers';
+import { getViewportItems } from './helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
@@ -83,9 +84,10 @@ describe('object values', () => {
       selectItem(0);
 
       comboBox.itemLabelPath = 'custom';
+      comboBox.opened = true;
 
       expect(comboBox.inputElement.value).to.eql('bazs');
-      expect(comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item').label).to.eql('bazs');
+      expect(getViewportItems(comboBox)[0].label).to.eql('bazs');
     });
 
     it('should use toString if default label and value paths are not found', () => {

--- a/packages/vaadin-combo-box/test/overlay-position.test.js
+++ b/packages/vaadin-combo-box/test/overlay-position.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, isIOS, fire } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { makeItems } from './helpers.js';
@@ -93,32 +92,13 @@ describe('overlay', () => {
       expect(dropContentRect().top).to.be.closeTo(inputContentRect().bottom, 1);
     });
 
-    it('should notify resize on items change', () => {
-      comboBox.opened = true;
-      const spy = sinon.spy();
-      comboBox.$.overlay.$.dropdown.notifyResize = spy;
-      comboBox.items = [1, 2, 3];
-      comboBox.__repositionOverlayDebouncer.flush();
-      expect(spy.called).to.be.true;
-    });
-
-    it('should not notify resize when not opened', () => {
-      comboBox.open();
-      comboBox.close();
-
-      const spy = sinon.spy();
-      comboBox.$.overlay.$.dropdown.notifyResize = spy;
-      comboBox.items = [1, 2, 3];
-      expect(spy.called).to.be.false;
-    });
-
     it('should reposition on scroll', () => {
       comboBox.opened = true;
-      comboBox.$.overlay.updateViewportBoundaries = sinon.spy();
+      // comboBox.$.overlay.updateViewportBoundaries = sinon.spy();
 
       fire(document, 'scroll');
 
-      expect(comboBox.$.overlay.updateViewportBoundaries.callCount).to.eql(1);
+      // expect(comboBox.$.overlay.updateViewportBoundaries.callCount).to.eql(1);
     });
 
     it('should be aligned with input container', () => {

--- a/packages/vaadin-combo-box/test/overlay-position.test.js
+++ b/packages/vaadin-combo-box/test/overlay-position.test.js
@@ -92,15 +92,6 @@ describe('overlay', () => {
       expect(dropContentRect().top).to.be.closeTo(inputContentRect().bottom, 1);
     });
 
-    it('should reposition on scroll', () => {
-      comboBox.opened = true;
-      // comboBox.$.overlay.updateViewportBoundaries = sinon.spy();
-
-      fire(document, 'scroll');
-
-      // expect(comboBox.$.overlay.updateViewportBoundaries.callCount).to.eql(1);
-    });
-
     it('should be aligned with input container', () => {
       comboBox.open();
 

--- a/packages/vaadin-combo-box/test/selecting-items.test.js
+++ b/packages/vaadin-combo-box/test/selecting-items.test.js
@@ -4,6 +4,7 @@ import { aTimeout, click, fixtureSync, fire } from '@vaadin/testing-helpers';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { scrollToIndex } from './helpers.js';
 
 describe('selecting items', () => {
   let comboBox;
@@ -74,7 +75,7 @@ describe('selecting items', () => {
     // Scroll start could delay, for example, with full SD polyfill
     comboBox.$.overlay._scroller.addEventListener('scroll', listener);
 
-    comboBox.$.overlay._selector.scrollToIndex(20);
+    scrollToIndex(comboBox, 20);
   });
 
   it('should select by using JS api', () => {
@@ -150,6 +151,7 @@ describe('selecting items', () => {
       if (comboBox.value === 'foo') {
         comboBox.value = 'bar';
         setTimeout(() => {
+          comboBox.open();
           expect(comboBox.value).to.eql('bar');
           expect(comboBox.selectedItem).to.eql('bar');
           expect(items[0].selected).to.be.false;

--- a/packages/vaadin-combo-box/theme/lumo/vaadin-combo-box-dropdown-styles.js
+++ b/packages/vaadin-combo-box/theme/lumo/vaadin-combo-box-dropdown-styles.js
@@ -13,12 +13,9 @@ registerStyles(
     }
 
     :host {
-      /* TODO: using a legacy mixin (unsupported) */
-      --iron-list-items-container: {
-        border-width: var(--lumo-space-xs);
-        border-style: solid;
-        border-color: transparent;
-      }
+      --_vaadin-combo-box-items-container-border-width: var(--lumo-space-xs);
+      --_vaadin-combo-box-items-container-border-style: solid;
+      --_vaadin-combo-box-items-container-border-color: transparent;
     }
 
     /* Loading state */

--- a/packages/vaadin-combo-box/theme/material/vaadin-combo-box-dropdown-styles.js
+++ b/packages/vaadin-combo-box/theme/material/vaadin-combo-box-dropdown-styles.js
@@ -6,12 +6,9 @@ registerStyles(
   'vaadin-combo-box-overlay',
   css`
     :host {
-      /* TODO using a legacy mixin (unsupported) */
-      --iron-list-items-container: {
-        border-width: 8px 0;
-        border-style: solid;
-        border-color: transparent;
-      }
+      --_vaadin-combo-box-items-container-border-width: 8px 0;
+      --_vaadin-combo-box-items-container-border-style: solid;
+      --_vaadin-combo-box-items-container-border-color: transparent;
     }
 
     [part='overlay'] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,16 +1407,6 @@
     "@polymer/iron-validatable-behavior" "^3.0.0-pre.26"
     "@polymer/polymer" "^3.0.0"
 
-"@polymer/iron-list@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-list/-/iron-list-3.1.0.tgz#9b525249a90a53b6ae249330640b54b12141202a"
-  integrity sha512-Eiv6xd3h3oPmn8SXFntXVfC3ZnegH+KHAxiKLKcOASFSRY3mHnr2AdcnExUJ9ItoCMA5UzKaM/0U22eWzGERtA==
-  dependencies:
-    "@polymer/iron-a11y-keys-behavior" "^3.0.0-pre.26"
-    "@polymer/iron-resizable-behavior" "^3.0.0-pre.26"
-    "@polymer/iron-scroll-target-behavior" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
 "@polymer/iron-location@^3.0.0-pre.26":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@polymer/iron-location/-/iron-location-3.0.2.tgz#7ca2df089c57deb8a6f54f5cc3722af0ff871441"


### PR DESCRIPTION
Replaces the Polymer-based `<iron-list>` used for the dropdown items virtual scrolling with the internal virtualizer from `<vaadin-virtual-list>`.

Certain Flow `ComboBox` tests and the TB element still expect the `<vaadin-combo-box>` Web Component to use an `<iron-list>` internally. There's a [branch](https://github.com/vaadin/flow-components/tree/combo-box-virtualizer) with necessary changes to `ComboBox` that needs to be merged together with the Web Component version bump.