### PR TITLE
feat: add i18n property to password-field

### DIFF
--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -17,6 +17,19 @@ declare class PasswordField extends TextField {
    * @attr {boolean} password-visible
    */
   readonly passwordVisible: boolean;
+
+  /**
+   * An object with translated strings used for localization.
+   * It has the following structure and default values:
+   *
+   * ```
+   * {
+   *   // Translation of the reveal icon button accessible label
+   *   reveal: 'Show password'
+   * }
+   * ```
+   */
+  i18n: { reveal: string };
 }
 
 export { PasswordField };

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -61,8 +61,32 @@ export class PasswordField extends TextField {
         reflectToAttribute: true,
         observer: '_passwordVisibleChanged',
         readOnly: true
+      },
+
+      /**
+       * An object with translated strings used for localization.
+       * It has the following structure and default values:
+       *
+       * ```
+       * {
+       *   // Translation of the reveal icon button accessible label
+       *   reveal: 'Show password'
+       * }
+       * ```
+       */
+      i18n: {
+        type: Object,
+        value: () => {
+          return {
+            reveal: 'Show password'
+          };
+        }
       }
     };
+  }
+
+  static get observers() {
+    return ['__i18nChanged(i18n.*)'];
   }
 
   get slots() {
@@ -101,6 +125,7 @@ export class PasswordField extends TextField {
     super.connectedCallback();
 
     if (this._revealNode) {
+      this.__updateAriaLabel(this.i18n);
       this._revealNode.setAttribute('aria-label', 'Show password');
       this._revealNode.addEventListener('click', this.__boundRevealButtonClick);
       this._revealNode.addEventListener('touchend', this.__boundRevealButtonTouchend);
@@ -156,6 +181,18 @@ export class PasswordField extends TextField {
     if (!focused) {
       this._setPasswordVisible(false);
     }
+  }
+
+  /** @private */
+  __updateAriaLabel(i18n) {
+    if (i18n.reveal && this._revealNode) {
+      this._revealNode.setAttribute('aria-label', i18n.reveal);
+    }
+  }
+
+  /** @private */
+  __i18nChanged(i18n) {
+    this.__updateAriaLabel(i18n.base);
   }
 
   /** @private */

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -22,6 +22,15 @@ describe('password-field', () => {
     expect(revealButton.hidden).to.be.false;
   });
 
+  it('should set default accessible label to reveal button', () => {
+    expect(revealButton.getAttribute('aria-label')).to.equal('Show password');
+  });
+
+  it('should translate accessible label when setting new i18n object', () => {
+    passwordField.i18n = { reveal: 'Näytä salasana' };
+    expect(revealButton.getAttribute('aria-label')).to.equal('Näytä salasana');
+  });
+
   it('should reveal the password on reveal button click', () => {
     revealButton.click();
     expect(input.type).to.equal('text');


### PR DESCRIPTION
## Description

Added `i18n` object to the new version of `vaadin-password-field` to allow customizing the reveal button `aria-label`.

Fixes #2327

## Type of change

- Feature