### PR TITLE
chore: bump chai dev dependency version

### DIFF
--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -32,7 +32,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -32,7 +32,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -25,7 +25,7 @@
     "@polymer/polymer": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -30,7 +30,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-icon": "^22.0.0-alpha1",
     "@vaadin/vaadin-icons": "^22.0.0-alpha1"

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -30,7 +30,7 @@
     "@vaadin/vaadin-material-styles": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -34,7 +34,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -30,7 +30,7 @@
     "@vaadin/vaadin-material-styles": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -34,7 +34,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-accordion/package.json
+++ b/packages/vaadin-accordion/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-app-layout/package.json
+++ b/packages/vaadin-app-layout/package.json
@@ -34,7 +34,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-tabs": "^22.0.0-alpha1",
     "sinon": "^9.2.1"

--- a/packages/vaadin-avatar/package.json
+++ b/packages/vaadin-avatar/package.json
@@ -37,7 +37,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-board/package.json
+++ b/packages/vaadin-board/package.json
@@ -34,7 +34,7 @@
     "@vaadin/vaadin-license-checker": "^2.1.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-button/package.json
+++ b/packages/vaadin-button/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-icon": "^22.0.0-alpha1",
     "sinon": "^9.2.4"

--- a/packages/vaadin-charts/package.json
+++ b/packages/vaadin-charts/package.json
@@ -32,7 +32,7 @@
     "highcharts": "8.1.2"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.4"
   },

--- a/packages/vaadin-checkbox/package.json
+++ b/packages/vaadin-checkbox/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.0"
   },

--- a/packages/vaadin-combo-box/package.json
+++ b/packages/vaadin-combo-box/package.json
@@ -38,7 +38,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "4.3.0",
+    "@esm-bundle/chai": "^4.3.4",
     "@polymer/iron-input": "^3.0.1",
     "@polymer/paper-input": "^3.0.0",
     "@vaadin/testing-helpers": "^0.2.1",

--- a/packages/vaadin-confirm-dialog/package.json
+++ b/packages/vaadin-confirm-dialog/package.json
@@ -36,7 +36,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-context-menu/package.json
+++ b/packages/vaadin-context-menu/package.json
@@ -36,7 +36,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha1",
     "sinon": "^9.2.1"

--- a/packages/vaadin-control-state-mixin/package.json
+++ b/packages/vaadin-control-state-mixin/package.json
@@ -26,7 +26,7 @@
     "@polymer/polymer": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.4"
   },

--- a/packages/vaadin-cookie-consent/package.json
+++ b/packages/vaadin-cookie-consent/package.json
@@ -33,7 +33,7 @@
     "cookieconsent": "^3.0.6"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-crud/package.json
+++ b/packages/vaadin-crud/package.json
@@ -40,7 +40,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha1",
     "sinon": "^9.2.1"

--- a/packages/vaadin-custom-field/package.json
+++ b/packages/vaadin-custom-field/package.json
@@ -32,7 +32,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-date-picker": "^22.0.0-alpha1",
     "@vaadin/vaadin-form-layout": "^22.0.0-alpha1",

--- a/packages/vaadin-date-picker/package.json
+++ b/packages/vaadin-date-picker/package.json
@@ -39,7 +39,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-dialog": "^22.0.0-alpha1",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha1",

--- a/packages/vaadin-date-time-picker/package.json
+++ b/packages/vaadin-date-time-picker/package.json
@@ -35,7 +35,7 @@
     "@vaadin/vaadin-time-picker": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-details/package.json
+++ b/packages/vaadin-details/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-dialog/package.json
+++ b/packages/vaadin-dialog/package.json
@@ -34,7 +34,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha1",
     "@vaadin/vaadin-text-field": "^22.0.0-alpha1",

--- a/packages/vaadin-element-mixin/package.json
+++ b/packages/vaadin-element-mixin/package.json
@@ -29,7 +29,7 @@
     "@vaadin/vaadin-usage-statistics": "^2.1.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "0.2.1",
     "sinon": "^9.2.4"
   },

--- a/packages/vaadin-form-layout/package.json
+++ b/packages/vaadin-form-layout/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-ordered-layout": "^22.0.0-alpha1",
     "@vaadin/vaadin-text-field": "^22.0.0-alpha1",

--- a/packages/vaadin-grid-pro/package.json
+++ b/packages/vaadin-grid-pro/package.json
@@ -39,7 +39,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-date-picker": "^22.0.0-alpha1",
     "@vaadin/vaadin-dialog": "^22.0.0-alpha1",

--- a/packages/vaadin-grid/package.json
+++ b/packages/vaadin-grid/package.json
@@ -41,7 +41,7 @@
     "@vaadin/vaadin-virtual-list": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha1",
     "lit": "^2.0.0-rc.1",

--- a/packages/vaadin-item/package.json
+++ b/packages/vaadin-item/package.json
@@ -32,7 +32,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-list-box/package.json
+++ b/packages/vaadin-list-box/package.json
@@ -34,7 +34,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-list-mixin/package.json
+++ b/packages/vaadin-list-mixin/package.json
@@ -27,7 +27,7 @@
     "@vaadin/vaadin-element-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.4"
   },

--- a/packages/vaadin-login/package.json
+++ b/packages/vaadin-login/package.json
@@ -35,7 +35,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-menu-bar/package.json
+++ b/packages/vaadin-menu-bar/package.json
@@ -35,7 +35,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-icon": "^22.0.0-alpha1",
     "sinon": "^9.2.1"

--- a/packages/vaadin-messages/package.json
+++ b/packages/vaadin-messages/package.json
@@ -39,7 +39,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.4"
   },

--- a/packages/vaadin-notification/package.json
+++ b/packages/vaadin-notification/package.json
@@ -32,7 +32,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-button": "^22.0.0-alpha1",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha1",

--- a/packages/vaadin-ordered-layout/package.json
+++ b/packages/vaadin-ordered-layout/package.json
@@ -34,7 +34,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-overlay/package.json
+++ b/packages/vaadin-overlay/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@polymer/iron-overlay-behavior": "^3.0.0",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-button": "^22.0.0-alpha1",

--- a/packages/vaadin-progress-bar/package.json
+++ b/packages/vaadin-progress-bar/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-radio-button/package.json
+++ b/packages/vaadin-radio-button/package.json
@@ -34,7 +34,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-rich-text-editor/package.json
+++ b/packages/vaadin-rich-text-editor/package.json
@@ -40,7 +40,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "gulp": "^4.0.0",
     "gulp-cli": "^2.0.1",

--- a/packages/vaadin-select/package.json
+++ b/packages/vaadin-select/package.json
@@ -40,7 +40,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha1",
     "lit": "^2.0.0-rc.1",

--- a/packages/vaadin-split-layout/package.json
+++ b/packages/vaadin-split-layout/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-tabs/package.json
+++ b/packages/vaadin-tabs/package.json
@@ -35,7 +35,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-template-renderer/package.json
+++ b/packages/vaadin-template-renderer/package.json
@@ -24,7 +24,7 @@
     "@polymer/polymer": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "@vaadin/vaadin-checkbox": "^22.0.0-alpha1",
     "@vaadin/vaadin-grid": "^22.0.0-alpha1",

--- a/packages/vaadin-text-field/package.json
+++ b/packages/vaadin-text-field/package.json
@@ -33,7 +33,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -27,7 +27,7 @@
     "lit": "^2.0.0-rc.1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.4"
   },

--- a/packages/vaadin-time-picker/package.json
+++ b/packages/vaadin-time-picker/package.json
@@ -35,7 +35,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.0"
   },

--- a/packages/vaadin-upload/package.json
+++ b/packages/vaadin-upload/package.json
@@ -34,7 +34,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "sinon": "^9.2.0"
   },

--- a/packages/vaadin-virtual-list/package.json
+++ b/packages/vaadin-virtual-list/package.json
@@ -32,7 +32,7 @@
     "@vaadin/vaadin-themable-mixin": "^22.0.0-alpha1"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.1.5",
+    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.2.1",
     "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -231,14 +231,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@esm-bundle/chai@4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@esm-bundle/chai/-/chai-4.3.0.tgz#4a849d1627f30967cef9c688ee5f2377615ace9a"
-  integrity sha512-Hbg4vBb8ZtZCrtFRKVXy3+V5SFCopVJt1w1bS46rGf+NEVfMqg5QyhsvDRjjYvyKEPTZ2khG6SmcouhVyPWE6g==
-  dependencies:
-    "@types/chai" "^4.2.12"
-
-"@esm-bundle/chai@^4.1.5":
+"@esm-bundle/chai@^4.3.4":
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/@esm-bundle/chai/-/chai-4.3.4.tgz#74ed4a0794b3a9f9517ff235744ac6f4be0d34dc"
   integrity sha512-6Tx35wWiNw7X0nLY9RMx8v3EL8SacCFW+eEZOE9Hc+XxmU5HFE2AFEg+GehUZpiyDGwVvPH75ckGlqC7coIPnA==


### PR DESCRIPTION
## Description

While working on combo-box PR, I noticed that `vaadin-combo-box` still uses hardcoded version of `@esm-bundle/chai`
This PR updates the version and aligns it across all the packages in the monorepo.

## Type of change

- Internal change