### PR TITLE
refactor: restructure mixins to fix text-area

### DIFF
--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -12,5 +12,6 @@ export { InputSlotMixin } from './src/input-slot-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { PatternMixin } from './src/pattern-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
+export { TextAreaSlotMixin } from './src/text-area-slot-mixin.js';
 export { TextFieldMixin } from './src/text-field-mixin.js';
 export { ValidateMixin } from './src/validate-mixin.js';

--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -1,13 +1,14 @@
 export { AriaLabelMixin } from './src/aria-label-mixin.js';
+export { CharLengthMixin } from './src/char-length-mixin.js';
 export { ClearButtonMixin } from './src/clear-button-mixin.js';
 export { DelegateFocusMixin } from './src/delegate-focus-mixin.js';
 export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';
+export { ForwardInputPropsMixin } from './src/forward-input-props-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputFieldMixin } from './src/input-field-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
-export { ForwardInputPropsMixin } from './src/forward-input-props-mixin.js';
 export { InputSlotMixin } from './src/input-slot-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { PatternMixin } from './src/pattern-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -12,5 +12,6 @@ export { InputSlotMixin } from './src/input-slot-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { PatternMixin } from './src/pattern-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
+export { TextAreaSlotMixin } from './src/text-area-slot-mixin.js';
 export { TextFieldMixin } from './src/text-field-mixin.js';
 export { ValidateMixin } from './src/validate-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -1,13 +1,14 @@
 export { AriaLabelMixin } from './src/aria-label-mixin.js';
+export { CharLengthMixin } from './src/char-length-mixin.js';
 export { ClearButtonMixin } from './src/clear-button-mixin.js';
 export { DelegateFocusMixin } from './src/delegate-focus-mixin.js';
 export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaMixin } from './src/field-aria-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';
+export { ForwardInputPropsMixin } from './src/forward-input-props-mixin.js';
 export { HelperTextMixin } from './src/helper-text-mixin.js';
 export { InputFieldMixin } from './src/input-field-mixin.js';
 export { InputMixin } from './src/input-mixin.js';
-export { ForwardInputPropsMixin } from './src/forward-input-props-mixin.js';
 export { InputSlotMixin } from './src/input-slot-mixin.js';
 export { LabelMixin } from './src/label-mixin.js';
 export { PatternMixin } from './src/pattern-mixin.js';

--- a/packages/field-base/src/aria-label-mixin.d.ts
+++ b/packages/field-base/src/aria-label-mixin.d.ts
@@ -4,10 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { LabelMixin } from './label-mixin.js';
-import { InputSlotMixin } from './input-slot-mixin.js';
+import { InputMixin } from './input-mixin.js';
 
 /**
- * A mixin to link slotted `<input>` and `<label>` elements.
+ * A mixin to link an input element with a slotted `<label>` element.
  */
 declare function AriaLabelMixin<T extends new (...args: any[]) => {}>(base: T): T & AriaLabelMixinConstructor;
 
@@ -15,6 +15,6 @@ interface AriaLabelMixinConstructor {
   new (...args: any[]): AriaLabelMixin;
 }
 
-interface AriaLabelMixin extends InputSlotMixin, LabelMixin {}
+interface AriaLabelMixin extends InputMixin, LabelMixin {}
 
 export { AriaLabelMixin, AriaLabelMixinConstructor };

--- a/packages/field-base/src/aria-label-mixin.js
+++ b/packages/field-base/src/aria-label-mixin.js
@@ -5,10 +5,10 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { LabelMixin } from './label-mixin.js';
-import { InputSlotMixin } from './input-slot-mixin.js';
+import { InputMixin } from './input-mixin.js';
 
 const AriaLabelMixinImplementation = (superclass) =>
-  class AriaLabelMixinClass extends InputSlotMixin(LabelMixin(superclass)) {
+  class AriaLabelMixinClass extends InputMixin(LabelMixin(superclass)) {
     constructor() {
       super();
 
@@ -18,8 +18,6 @@ const AriaLabelMixinImplementation = (superclass) =>
     /** @protected */
     connectedCallback() {
       super.connectedCallback();
-
-      this._enhanceLightDomA11y();
 
       if (this._labelNode) {
         this._labelNode.addEventListener('click', this.__preventDuplicateLabelClick);
@@ -35,14 +33,18 @@ const AriaLabelMixinImplementation = (superclass) =>
       }
     }
 
-    /** @protected */
-    _enhanceLightDomA11y() {
-      if (this.inputElement) {
-        this.inputElement.setAttribute('aria-labelledby', this._labelId);
-      }
+    /**
+     * Override an observer from `InputMixin`.
+     * @protected
+     * @override
+     */
+    _inputElementChanged(input) {
+      super._inputElementChanged(input);
 
-      if (this._labelNode) {
-        this._labelNode.setAttribute('for', this._inputId);
+      if (input) {
+        input.setAttribute('aria-labelledby', this._labelId);
+
+        this._labelNode.setAttribute('for', input.id);
       }
     }
 
@@ -64,6 +66,6 @@ const AriaLabelMixinImplementation = (superclass) =>
   };
 
 /**
- * A mixin to link slotted `<input>` and `<label>` elements.
+ * A mixin to link an input element with a slotted `<label>` element.
  */
 export const AriaLabelMixin = dedupingMixin(AriaLabelMixinImplementation);

--- a/packages/field-base/src/char-length-mixin.d.ts
+++ b/packages/field-base/src/char-length-mixin.d.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ForwardInputPropsMixin } from './forward-input-props-mixin.js';
+
+/**
+ * A mixin to provide `minlength` and `maxlength` properties
+ * for components that use `<input>` or `<textarea>`.
+ */
+declare function CharLengthMixin<T extends new (...args: any[]) => {}>(base: T): T & CharLengthMixinConstructor;
+
+interface CharLengthMixinConstructor {
+  new (...args: any[]): CharLengthMixin;
+}
+
+interface CharLengthMixin extends ForwardInputPropsMixin {
+  /**
+   * Maximum number of characters (in Unicode code points) that the user can enter.
+   */
+  maxlength: number | null | undefined;
+
+  /**
+   * Minimum number of characters (in Unicode code points) that the user can enter.
+   */
+  minlength: number | null | undefined;
+
+  /**
+   * Returns true if the current input value satisfies all constraints (if any).
+   */
+  checkValidity(): boolean;
+}
+
+export { CharLengthMixin, CharLengthMixinConstructor };

--- a/packages/field-base/src/char-length-mixin.d.ts
+++ b/packages/field-base/src/char-length-mixin.d.ts
@@ -25,11 +25,6 @@ interface CharLengthMixin extends ForwardInputPropsMixin {
    * Minimum number of characters (in Unicode code points) that the user can enter.
    */
   minlength: number | null | undefined;
-
-  /**
-   * Returns true if the current input value satisfies all constraints (if any).
-   */
-  checkValidity(): boolean;
 }
 
 export { CharLengthMixin, CharLengthMixinConstructor };

--- a/packages/field-base/src/char-length-mixin.js
+++ b/packages/field-base/src/char-length-mixin.js
@@ -33,40 +33,6 @@ const CharLengthMixinImplementation = (superclass) =>
     static get constraints() {
       return [...super.constraints, 'maxlength', 'minlength'];
     }
-
-    /**
-     * Override an observer from `ValidateMixin` to add `minlength` and `maxlength` constraints.
-     * @param {boolean | undefined} required
-     * @param {number | undefined} minlength
-     * @param {number | undefined} maxlength
-     * @protected
-     * @override
-     */
-    _constraintsChanged(required, minlength, maxlength) {
-      // Prevent marking field as invalid when setting required state
-      // or any other constraint before a user has entered the value.
-      if (!this.invalid) {
-        return;
-      }
-
-      if (required || minlength || maxlength) {
-        this.validate();
-      } else {
-        this.invalid = false;
-      }
-    }
-
-    /**
-     * Returns true if the current input value satisfies all constraints (if any).
-     * @return {boolean}
-     */
-    checkValidity() {
-      if (this.inputElement && (this.required || this.maxlength || this.minlength)) {
-        return this.inputElement.checkValidity();
-      } else {
-        return !this.invalid;
-      }
-    }
   };
 
 /**

--- a/packages/field-base/src/char-length-mixin.js
+++ b/packages/field-base/src/char-length-mixin.js
@@ -49,10 +49,10 @@ const CharLengthMixinImplementation = (superclass) =>
         return;
       }
 
-      if (!required && !minlength && !maxlength) {
-        this.invalid = false;
-      } else {
+      if (required || minlength || maxlength) {
         this.validate();
+      } else {
+        this.invalid = false;
       }
     }
 
@@ -61,8 +61,8 @@ const CharLengthMixinImplementation = (superclass) =>
      * @return {boolean}
      */
     checkValidity() {
-      if (this.required || this.maxlength || this.minlength) {
-        return this.inputElement ? this.inputElement.checkValidity() : undefined;
+      if (this.inputElement && (this.required || this.maxlength || this.minlength)) {
+        return this.inputElement.checkValidity();
       } else {
         return !this.invalid;
       }

--- a/packages/field-base/src/char-length-mixin.js
+++ b/packages/field-base/src/char-length-mixin.js
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { ForwardInputPropsMixin } from './forward-input-props-mixin.js';
+
+const CharLengthMixinImplementation = (superclass) =>
+  class CharLengthMixinClass extends ForwardInputPropsMixin(superclass) {
+    static get properties() {
+      return {
+        /**
+         * Maximum number of characters (in Unicode code points) that the user can enter.
+         */
+        maxlength: {
+          type: Number
+        },
+
+        /**
+         * Minimum number of characters (in Unicode code points) that the user can enter.
+         */
+        minlength: {
+          type: Number
+        }
+      };
+    }
+
+    static get forwardProps() {
+      return [...super.forwardProps, 'maxlength', 'minlength'];
+    }
+
+    static get constraints() {
+      return [...super.constraints, 'maxlength', 'minlength'];
+    }
+
+    /**
+     * Override an observer from `ValidateMixin` to add `minlength` and `maxlength` constraints.
+     * @param {boolean | undefined} required
+     * @param {number | undefined} minlength
+     * @param {number | undefined} maxlength
+     * @protected
+     * @override
+     */
+    _constraintsChanged(required, minlength, maxlength) {
+      // Prevent marking field as invalid when setting required state
+      // or any other constraint before a user has entered the value.
+      if (!this.invalid) {
+        return;
+      }
+
+      if (!required && !minlength && !maxlength) {
+        this.invalid = false;
+      } else {
+        this.validate();
+      }
+    }
+
+    /**
+     * Returns true if the current input value satisfies all constraints (if any).
+     * @return {boolean}
+     */
+    checkValidity() {
+      if (this.required || this.maxlength || this.minlength) {
+        return this.inputElement ? this.inputElement.checkValidity() : undefined;
+      } else {
+        return !this.invalid;
+      }
+    }
+  };
+
+/**
+ * A mixin to provide `minlength` and `maxlength` properties
+ * for components that use `<input>` or `<textarea>`.
+ */
+export const CharLengthMixin = dedupingMixin(CharLengthMixinImplementation);

--- a/packages/field-base/src/forward-input-props-mixin.d.ts
+++ b/packages/field-base/src/forward-input-props-mixin.d.ts
@@ -3,8 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { InputMixin } from './input-mixin.js';
-import { ValidateMixin } from './validate-mixin.js';
+import { InputConstraintsMixin } from './input-constraints-mixin.js';
 
 /**
  * A mixin to forward properties to the input element.
@@ -17,7 +16,7 @@ interface ForwardInputPropsMixinConstructor {
   new (...args: any[]): ForwardInputPropsMixin;
 }
 
-interface ForwardInputPropsMixin extends InputMixin, ValidateMixin {
+interface ForwardInputPropsMixin extends InputConstraintsMixin {
   /**
    * The name of this field.
    */

--- a/packages/field-base/src/forward-input-props-mixin.js
+++ b/packages/field-base/src/forward-input-props-mixin.js
@@ -50,7 +50,7 @@ const ForwardInputPropsMixinImplementation = (superclass) =>
     ready() {
       // Create observer dynamically to allow subclasses to override forwardProps
       // Note, this needs to be done before calling `super.ready()` to allow constraints
-      // observer created by `ValidateMixin` to run first and update `invalid` properly.
+      // observer created by `InputConstraintsMixin` to run first and update `invalid`.
       this._createMethodObserver(`_forwardPropsChanged(${this.constructor.forwardProps.join(', ')})`);
 
       super.ready();

--- a/packages/field-base/src/forward-input-props-mixin.js
+++ b/packages/field-base/src/forward-input-props-mixin.js
@@ -49,10 +49,12 @@ const ForwardInputPropsMixinImplementation = (superclass) =>
 
     /** @protected */
     ready() {
-      super.ready();
-
-      // create observer dynamically to allow subclasses to override forwardProps
+      // Create observer dynamically to allow subclasses to override forwardProps
+      // Note, this needs to be done before calling `super.ready()` to allow constraints
+      // observer created by `ValidateMixin` to run first and update `invalid` properly.
       this._createMethodObserver(`_forwardPropsChanged(${this.constructor.forwardProps.join(', ')})`);
+
+      super.ready();
     }
 
     /** @protected */

--- a/packages/field-base/src/forward-input-props-mixin.js
+++ b/packages/field-base/src/forward-input-props-mixin.js
@@ -4,11 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
-import { InputMixin } from './input-mixin.js';
-import { ValidateMixin } from './validate-mixin.js';
+import { InputConstraintsMixin } from './input-constraints-mixin.js';
 
 const ForwardInputPropsMixinImplementation = (superclass) =>
-  class ForwardInputPropsMixinClass extends ValidateMixin(InputMixin(superclass)) {
+  class ForwardInputPropsMixinClass extends InputConstraintsMixin(superclass) {
     static get properties() {
       return {
         /**

--- a/packages/field-base/src/forward-input-props-mixin.js
+++ b/packages/field-base/src/forward-input-props-mixin.js
@@ -49,8 +49,9 @@ const ForwardInputPropsMixinImplementation = (superclass) =>
     /** @protected */
     ready() {
       // Create observer dynamically to allow subclasses to override forwardProps
-      // Note, this needs to be done before calling `super.ready()` to allow constraints
-      // observer created by `InputConstraintsMixin` to run first and update `invalid`.
+      // Note, this needs to be done before calling `super.ready()` to propagate changes
+      // to the validation constraints, e.g. when setting `required` property to `false`,
+      // before the observer created by `InputConstraintsMixin` to validate properly.
       this._createMethodObserver(`_forwardPropsChanged(${this.constructor.forwardProps.join(', ')})`);
 
       super.ready();

--- a/packages/field-base/src/input-constraints-mixin.d.ts
+++ b/packages/field-base/src/input-constraints-mixin.d.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { InputMixin } from './input-mixin.js';
+import { ValidateMixin } from './validate-mixin.js';
+
+/**
+ * A mixin to combine multiple input validation constraints.
+ */
+declare function InputConstraintsMixin<T extends new (...args: any[]) => {}>(
+  base: T
+): T & InputConstraintsMixinConstructor;
+
+interface InputConstraintsMixinConstructor {
+  new (...args: any[]): InputConstraintsMixin;
+}
+
+interface InputConstraintsMixin extends InputMixin, ValidateMixin {
+  /**
+   * Returns true if the current input value satisfies all constraints (if any).
+   */
+  checkValidity(): boolean;
+}
+
+export { InputConstraintsMixin, InputConstraintsMixinConstructor };

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { InputMixin } from './input-mixin.js';
+import { ValidateMixin } from './validate-mixin.js';
+
+const InputConstraintsMixinImplementation = (superclass) =>
+  class InputConstraintsMixinClass extends ValidateMixin(InputMixin(superclass)) {
+    /**
+     * Returns true if the current input value satisfies all constraints (if any).
+     * @return {boolean}
+     */
+    checkValidity() {
+      if (this.inputElement && this.constructor.constraints.some((c) => this.__isValidConstraint(this[c]))) {
+        return this.inputElement.checkValidity();
+      } else {
+        return !this.invalid;
+      }
+    }
+
+    /**
+     * Override an observer from `ValidateMixin` to add support for multiple constraints.
+     * @param {unknown[]} constraints
+     * @protected
+     * @override
+     */
+    _constraintsChanged(...constraints) {
+      // Prevent marking field as invalid when setting required state
+      // or any other constraint before a user has entered the value.
+      if (!this.invalid) {
+        return;
+      }
+
+      if (constraints.some((c) => this.__isValidConstraint(c))) {
+        this.validate();
+      } else {
+        this.invalid = false;
+      }
+    }
+
+    /** @private */
+    __isValidConstraint(constraint) {
+      // 0 is valid for `minlength` and `maxlength`
+      return Boolean(constraint) || constraint === 0;
+    }
+  };
+
+/**
+ * A mixin to combine multiple input validation constraints.
+ */
+export const InputConstraintsMixin = dedupingMixin(InputConstraintsMixinImplementation);

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -9,6 +9,17 @@ import { ValidateMixin } from './validate-mixin.js';
 
 const InputConstraintsMixinImplementation = (superclass) =>
   class InputConstraintsMixinClass extends ValidateMixin(InputMixin(superclass)) {
+    static get constraints() {
+      return ['required'];
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this._createConstraintsObserver();
+    }
+
     /**
      * Returns true if the current input value satisfies all constraints (if any).
      * @return {boolean}
@@ -22,10 +33,19 @@ const InputConstraintsMixinImplementation = (superclass) =>
     }
 
     /**
-     * Override an observer from `ValidateMixin` to add support for multiple constraints.
+     * Override this method to customize setting up constraints observer.
+     * @protected
+     */
+    _createConstraintsObserver() {
+      // This complex observer needs to be added dynamically instead of using `static get observers()`
+      // to make it possible to tweak this behavior in classes that apply this mixin.
+      this._createMethodObserver(`_constraintsChanged(${this.constructor.constraints.join(', ')})`);
+    }
+
+    /**
+     * Override this method to implement custom validation constraints.
      * @param {unknown[]} constraints
      * @protected
-     * @override
      */
     _constraintsChanged(...constraints) {
       // Prevent marking field as invalid when setting required state

--- a/packages/field-base/src/input-field-mixin.d.ts
+++ b/packages/field-base/src/input-field-mixin.d.ts
@@ -55,11 +55,6 @@ interface InputFieldMixin
    * Specify that the value should be automatically selected when the field gains focus.
    */
   autoselect: boolean;
-
-  /**
-   * Returns true if the current input value satisfies all constraints (if any).
-   */
-  checkValidity(): boolean;
 }
 
 export { InputFieldMixin, InputFieldMixinConstructor };

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -128,8 +128,8 @@ const InputFieldMixinImplementation = (superclass) =>
      * @return {boolean}
      */
     checkValidity() {
-      if (this.required) {
-        return this.inputElement ? this.inputElement.checkValidity() : undefined;
+      if (this.inputElement && this.required) {
+        return this.inputElement.checkValidity();
       } else {
         return !this.invalid;
       }

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -123,18 +123,6 @@ const InputFieldMixinImplementation = (superclass) =>
       }
     }
 
-    /**
-     * Returns true if the current input value satisfies all constraints (if any).
-     * @return {boolean}
-     */
-    checkValidity() {
-      if (this.inputElement && this.required) {
-        return this.inputElement.checkValidity();
-      } else {
-        return !this.invalid;
-      }
-    }
-
     // Workaround for https://github.com/Polymer/polymer/issues/5259
     get __data() {
       return this.__dataValue || {};

--- a/packages/field-base/src/pattern-mixin.js
+++ b/packages/field-base/src/pattern-mixin.js
@@ -39,27 +39,6 @@ const PatternMixinImplementation = (superclass) =>
       return [...super.constraints, 'pattern'];
     }
 
-    /**
-     * Override an observer from `ValidateMixin` to add `pattern` constraint.
-     * @param {boolean | undefined} required
-     * @param {string | undefined} pattern
-     * @protected
-     * @override
-     */
-    _constraintsChanged(required, pattern) {
-      // Prevent marking field as invalid when setting required state
-      // or any other constraint before a user has entered the value.
-      if (!this.invalid) {
-        return;
-      }
-
-      if (required || pattern) {
-        this.validate();
-      } else {
-        this.invalid = false;
-      }
-    }
-
     /** @private */
     _checkInputValue() {
       if (this.preventInvalidInput) {
@@ -84,18 +63,6 @@ const PatternMixinImplementation = (superclass) =>
       this._checkInputValue();
 
       super._onInput(event);
-    }
-
-    /**
-     * Returns true if the current input value satisfies all constraints (if any).
-     * @return {boolean}
-     */
-    checkValidity() {
-      if (this.inputElement && (this.required || this.pattern)) {
-        return this.inputElement.checkValidity();
-      } else {
-        return !this.invalid;
-      }
     }
   };
 

--- a/packages/field-base/src/pattern-mixin.js
+++ b/packages/field-base/src/pattern-mixin.js
@@ -35,25 +35,16 @@ const PatternMixinImplementation = (superclass) =>
       return [...super.forwardProps, 'pattern'];
     }
 
-    /** @protected */
-    ready() {
-      super.ready();
-
-      this._createConstraintsObserver();
-    }
-
-    /** @protected */
-    _createConstraintsObserver() {
-      // This complex observer needs to be added dynamically instead of using `static get observers()`
-      // to make it possible to tweak this behavior in classes that apply this mixin.
-      // An example is `vaadin-email-field` where the pattern is set before defining the observer.
-      this._createMethodObserver('_constraintsChanged(required, pattern)');
+    static get constraints() {
+      return [...super.constraints, 'pattern'];
     }
 
     /**
+     * Override an observer from `ValidateMixin` to add `pattern` constraint.
      * @param {boolean | undefined} required
      * @param {string | undefined} pattern
      * @protected
+     * @override
      */
     _constraintsChanged(required, pattern) {
       // Prevent marking field as invalid when setting required state

--- a/packages/field-base/src/pattern-mixin.js
+++ b/packages/field-base/src/pattern-mixin.js
@@ -53,10 +53,10 @@ const PatternMixinImplementation = (superclass) =>
         return;
       }
 
-      if (!required && !pattern) {
-        this.invalid = false;
-      } else {
+      if (required || pattern) {
         this.validate();
+      } else {
+        this.invalid = false;
       }
     }
 
@@ -91,8 +91,8 @@ const PatternMixinImplementation = (superclass) =>
      * @return {boolean}
      */
     checkValidity() {
-      if (this.required || this.pattern) {
-        return this.inputElement ? this.inputElement.checkValidity() : undefined;
+      if (this.inputElement && (this.required || this.pattern)) {
+        return this.inputElement.checkValidity();
       } else {
         return !this.invalid;
       }

--- a/packages/field-base/src/text-area-slot-mixin.d.ts
+++ b/packages/field-base/src/text-area-slot-mixin.d.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotMixin } from './slot-mixin.js';
+import { InputMixin } from './input-mixin.js';
+
+/**
+ * A mixin to add `<textarea>` element to the corresponding named slot.
+ */
+declare function TextAreaSlotMixin<T extends new (...args: any[]) => {}>(base: T): T & TextAreaSlotMixinConstructor;
+
+interface TextAreaSlotMixinConstructor {
+  new (...args: any[]): TextAreaSlotMixin;
+}
+
+interface TextAreaSlotMixin extends InputMixin, SlotMixin {}
+
+export { TextAreaSlotMixinConstructor, TextAreaSlotMixin };

--- a/packages/field-base/src/text-area-slot-mixin.js
+++ b/packages/field-base/src/text-area-slot-mixin.js
@@ -32,7 +32,7 @@ const TextAreaSlotMixinImplementation = (superclass) =>
 
       // Ensure every instance has unique ID
       const uniqueId = (TextAreaSlotMixinClass._uniqueId = 1 + TextAreaSlotMixinClass._uniqueId || 0);
-      this._inputId = `${this.localName}-${uniqueId}`;
+      this._textareaId = `${this.localName}-${uniqueId}`;
     }
 
     /** @protected */
@@ -41,7 +41,7 @@ const TextAreaSlotMixinImplementation = (superclass) =>
 
       const textArea = this._getDirectSlotChild('textarea');
       if (textArea) {
-        textArea.id = this._inputId;
+        textArea.id = this._textareaId;
 
         this._setInputElement(textArea);
       }

--- a/packages/field-base/src/text-area-slot-mixin.js
+++ b/packages/field-base/src/text-area-slot-mixin.js
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { InputMixin } from './input-mixin.js';
+import { SlotMixin } from './slot-mixin.js';
+
+const TextAreaSlotMixinImplementation = (superclass) =>
+  class TextAreaSlotMixinClass extends InputMixin(SlotMixin(superclass)) {
+    get slots() {
+      return {
+        ...super.slots,
+        textarea: () => {
+          const native = document.createElement('textarea');
+          const value = this.getAttribute('value');
+          if (value) {
+            native.value = value;
+          }
+          const name = this.getAttribute('name');
+          if (name) {
+            native.setAttribute('name', name);
+          }
+          return native;
+        }
+      };
+    }
+
+    constructor() {
+      super();
+
+      // Ensure every instance has unique ID
+      const uniqueId = (TextAreaSlotMixinClass._uniqueId = 1 + TextAreaSlotMixinClass._uniqueId || 0);
+      this._inputId = `${this.localName}-${uniqueId}`;
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      const textArea = this._getDirectSlotChild('textarea');
+      if (textArea) {
+        textArea.id = this._inputId;
+
+        this._setInputElement(textArea);
+      }
+    }
+  };
+
+/**
+ * A mixin to add `<textarea>` element to the corresponding named slot.
+ */
+export const TextAreaSlotMixin = dedupingMixin(TextAreaSlotMixinImplementation);

--- a/packages/field-base/src/text-field-mixin.d.ts
+++ b/packages/field-base/src/text-field-mixin.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { CharLengthMixin } from './char-length-mixin.js';
 import { InputFieldMixin } from './input-field-mixin.js';
 import { PatternMixin } from './pattern-mixin.js';
 
@@ -15,17 +16,7 @@ interface TextFieldMixinConstructor {
   new (...args: any[]): TextFieldMixin;
 }
 
-interface TextFieldMixin extends InputFieldMixin, PatternMixin {
-  /**
-   * Maximum number of characters (in Unicode code points) that the user can enter.
-   */
-  maxlength: number | null | undefined;
-
-  /**
-   * Minimum number of characters (in Unicode code points) that the user can enter.
-   */
-  minlength: number | null | undefined;
-
+interface TextFieldMixin extends CharLengthMixin, InputFieldMixin, PatternMixin {
   /**
    * Returns true if the current input value satisfies all constraints (if any).
    */

--- a/packages/field-base/src/text-field-mixin.d.ts
+++ b/packages/field-base/src/text-field-mixin.d.ts
@@ -16,11 +16,6 @@ interface TextFieldMixinConstructor {
   new (...args: any[]): TextFieldMixin;
 }
 
-interface TextFieldMixin extends CharLengthMixin, InputFieldMixin, PatternMixin {
-  /**
-   * Returns true if the current input value satisfies all constraints (if any).
-   */
-  checkValidity(): boolean;
-}
+interface TextFieldMixin extends CharLengthMixin, InputFieldMixin, PatternMixin {}
 
 export { TextFieldMixin, TextFieldMixinConstructor };

--- a/packages/field-base/src/text-field-mixin.js
+++ b/packages/field-base/src/text-field-mixin.js
@@ -4,60 +4,29 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { CharLengthMixin } from './char-length-mixin.js';
 import { InputFieldMixin } from './input-field-mixin.js';
 import { PatternMixin } from './pattern-mixin.js';
 
 const TextFieldMixinImplementation = (superclass) =>
-  class TextFieldMixinClass extends InputFieldMixin(PatternMixin(superclass)) {
-    static get properties() {
-      return {
-        /**
-         * Maximum number of characters (in Unicode code points) that the user can enter.
-         */
-        maxlength: {
-          type: Number
-        },
-
-        /**
-         * Minimum number of characters (in Unicode code points) that the user can enter.
-         */
-        minlength: {
-          type: Number
-        }
-      };
-    }
-
-    static get forwardProps() {
-      return [...super.forwardProps, 'maxlength', 'minlength'];
-    }
-
+  class TextFieldMixinClass extends InputFieldMixin(CharLengthMixin(PatternMixin(superclass))) {
     /**
-     * Override the method inherited from `PatternMixin` to add minlength and maxlength.
-     * @protected
-     */
-    _createConstraintsObserver() {
-      // This complex observer needs to be added dynamically instead of using `static get observers()`
-      // to make it possible to tweak this behavior in classes that apply this mixin.
-      // An example is `vaadin-email-field` where the pattern is set before defining the observer.
-      this._createMethodObserver('_constraintsChanged(required, minlength, maxlength, pattern)');
-    }
-
-    /**
-     * * Override the method inherited from `PatternMixin` to add minlength and maxlength.
+     * Override an observer from `ValidateMixin` to combine `pattern`, `minlength` and `maxlength`.
      * @param {boolean | undefined} required
+     * @param {string | undefined} pattern
      * @param {number | undefined} minlength
      * @param {number | undefined} maxlength
-     * @param {string | undefined} pattern
      * @protected
+     * @override
      */
-    _constraintsChanged(required, minlength, maxlength, pattern) {
+    _constraintsChanged(required, pattern, minlength, maxlength) {
       // Prevent marking field as invalid when setting required state
       // or any other constraint before a user has entered the value.
       if (!this.invalid) {
         return;
       }
 
-      if (!required && !minlength && !maxlength && !pattern) {
+      if (!required && !pattern && !minlength && !maxlength) {
         this.invalid = false;
       } else {
         this.validate();
@@ -65,7 +34,7 @@ const TextFieldMixinImplementation = (superclass) =>
     }
 
     /**
-     * Returns true if the current input value satisfies all constraints (if any)
+     * Returns true if the current input value satisfies all constraints (if any).
      * @return {boolean}
      */
     checkValidity() {

--- a/packages/field-base/src/text-field-mixin.js
+++ b/packages/field-base/src/text-field-mixin.js
@@ -9,42 +9,7 @@ import { InputFieldMixin } from './input-field-mixin.js';
 import { PatternMixin } from './pattern-mixin.js';
 
 const TextFieldMixinImplementation = (superclass) =>
-  class TextFieldMixinClass extends InputFieldMixin(CharLengthMixin(PatternMixin(superclass))) {
-    /**
-     * Override an observer from `ValidateMixin` to combine `pattern`, `minlength` and `maxlength`.
-     * @param {boolean | undefined} required
-     * @param {string | undefined} pattern
-     * @param {number | undefined} minlength
-     * @param {number | undefined} maxlength
-     * @protected
-     * @override
-     */
-    _constraintsChanged(required, pattern, minlength, maxlength) {
-      // Prevent marking field as invalid when setting required state
-      // or any other constraint before a user has entered the value.
-      if (!this.invalid) {
-        return;
-      }
-
-      if (required || pattern || minlength || maxlength) {
-        this.validate();
-      } else {
-        this.invalid = false;
-      }
-    }
-
-    /**
-     * Returns true if the current input value satisfies all constraints (if any).
-     * @return {boolean}
-     */
-    checkValidity() {
-      if (this.inputElement && (this.required || this.pattern || this.maxlength || this.minlength)) {
-        return this.inputElement.checkValidity();
-      } else {
-        return !this.invalid;
-      }
-    }
-  };
+  class TextFieldMixinClass extends InputFieldMixin(CharLengthMixin(PatternMixin(superclass))) {};
 
 /**
  * A mixin to provide validation constraints for vaadin-text-field and related components.

--- a/packages/field-base/src/text-field-mixin.js
+++ b/packages/field-base/src/text-field-mixin.js
@@ -26,10 +26,10 @@ const TextFieldMixinImplementation = (superclass) =>
         return;
       }
 
-      if (!required && !pattern && !minlength && !maxlength) {
-        this.invalid = false;
-      } else {
+      if (required || pattern || minlength || maxlength) {
         this.validate();
+      } else {
+        this.invalid = false;
       }
     }
 
@@ -38,8 +38,8 @@ const TextFieldMixinImplementation = (superclass) =>
      * @return {boolean}
      */
     checkValidity() {
-      if (this.required || this.pattern || this.maxlength || this.minlength) {
-        return this.inputElement ? this.inputElement.checkValidity() : undefined;
+      if (this.inputElement && (this.required || this.pattern || this.maxlength || this.minlength)) {
+        return this.inputElement.checkValidity();
       } else {
         return !this.invalid;
       }

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -55,10 +55,6 @@ const ValidateMixinImplementation = (superclass) =>
       return ['_updateErrorMessage(invalid, errorMessage)'];
     }
 
-    static get constraints() {
-      return ['required'];
-    }
-
     /** @protected */
     get _errorNode() {
       return this._getDirectSlotChild('error-message');
@@ -81,13 +77,6 @@ const ValidateMixinImplementation = (superclass) =>
 
         this._applyCustomError();
       }
-    }
-
-    /** @protected */
-    ready() {
-      super.ready();
-
-      this._createConstraintsObserver();
     }
 
     /**
@@ -114,35 +103,6 @@ const ValidateMixinImplementation = (superclass) =>
       if (error && error !== this.errorMessage) {
         this.errorMessage = error;
         delete this.__errorMessage;
-      }
-    }
-
-    /**
-     * Override this observer to customize setting up constraints observer.
-     * @protected
-     */
-    _createConstraintsObserver() {
-      // This complex observer needs to be added dynamically instead of using `static get observers()`
-      // to make it possible to tweak this behavior in classes that apply this mixin.
-      this._createMethodObserver(`_constraintsChanged(${this.constructor.constraints.join(', ')})`);
-    }
-
-    /**
-     * Override this method to add other validation constraints.
-     * @param {boolean | undefined} required
-     * @protected
-     */
-    _constraintsChanged(required) {
-      // Prevent marking field as invalid when setting required state
-      // or any other constraint before a user has entered the value.
-      if (!this.invalid) {
-        return;
-      }
-
-      if (required) {
-        this.validate();
-      } else {
-        this.invalid = false;
       }
     }
 

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -55,6 +55,10 @@ const ValidateMixinImplementation = (superclass) =>
       return ['_updateErrorMessage(invalid, errorMessage)'];
     }
 
+    static get constraints() {
+      return ['required'];
+    }
+
     /** @protected */
     get _errorNode() {
       return this._getDirectSlotChild('error-message');
@@ -77,6 +81,13 @@ const ValidateMixinImplementation = (superclass) =>
 
         this._applyCustomError();
       }
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this._createConstraintsObserver();
     }
 
     /**
@@ -103,6 +114,35 @@ const ValidateMixinImplementation = (superclass) =>
       if (error && error !== this.errorMessage) {
         this.errorMessage = error;
         delete this.__errorMessage;
+      }
+    }
+
+    /**
+     * Override this observer to customize setting up constraints observer.
+     * @protected
+     */
+    _createConstraintsObserver() {
+      // This complex observer needs to be added dynamically instead of using `static get observers()`
+      // to make it possible to tweak this behavior in classes that apply this mixin.
+      this._createMethodObserver(`_constraintsChanged(${this.constructor.constraints.join(', ')})`);
+    }
+
+    /**
+     * Override this method to add other validation constraints.
+     * @param {boolean | undefined} required
+     * @protected
+     */
+    _constraintsChanged(required) {
+      // Prevent marking field as invalid when setting required state
+      // or any other constraint before a user has entered the value.
+      if (!this.invalid) {
+        return;
+      }
+
+      if (!required) {
+        this.invalid = false;
+      } else {
+        this.validate();
       }
     }
 

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -139,10 +139,10 @@ const ValidateMixinImplementation = (superclass) =>
         return;
       }
 
-      if (!required) {
-        this.invalid = false;
-      } else {
+      if (required) {
         this.validate();
+      } else {
+        this.invalid = false;
       }
     }
 

--- a/packages/field-base/test/aria-label-mixin.test.js
+++ b/packages/field-base/test/aria-label-mixin.test.js
@@ -3,37 +3,52 @@ import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { AriaLabelMixin } from '../src/aria-label-mixin.js';
+import { InputSlotMixin } from '../src/input-slot-mixin.js';
+import { TextAreaSlotMixin } from '../src/text-area-slot-mixin.js';
 
 customElements.define(
-  'aria-label-mixin-element',
-  class extends AriaLabelMixin(PolymerElement) {
+  'aria-label-input-mixin-element',
+  class extends AriaLabelMixin(InputSlotMixin(PolymerElement)) {
     static get template() {
       return html`<slot name="label"></slot><slot name="input"></slot>`;
     }
   }
 );
 
+customElements.define(
+  'aria-label-textarea-mixin-element',
+  class extends AriaLabelMixin(TextAreaSlotMixin(PolymerElement)) {
+    static get template() {
+      return html`<slot name="label"></slot><slot name="textarea"></slot>`;
+    }
+  }
+);
+
 describe('aria-label-mixin', () => {
-  let element, input, label;
+  let element, target, label;
 
-  beforeEach(() => {
-    element = fixtureSync('<aria-label-mixin-element></aria-label-mixin-element>');
-    input = element.querySelector('[slot=input]');
-    label = element.querySelector('[slot=label]');
-  });
+  ['input', 'textarea'].forEach((el) => {
+    describe(el, () => {
+      beforeEach(() => {
+        element = fixtureSync(`<aria-label-${el}-mixin-element></aria-label-${el}-mixin-element>`);
+        target = element.querySelector(`[slot=${el}]`);
+        label = element.querySelector('[slot=label]');
+      });
 
-  it('should set for attribute on the label', () => {
-    expect(label.getAttribute('for')).to.equal(input.id);
-  });
+      it('should set for attribute on the label', () => {
+        expect(label.getAttribute('for')).to.equal(target.id);
+      });
 
-  it('should set aria-labelledby attribute on the input', () => {
-    expect(input.getAttribute('aria-labelledby')).to.equal(label.id);
-  });
+      it('should set aria-labelledby attribute on the ' + el, () => {
+        expect(target.getAttribute('aria-labelledby')).to.equal(label.id);
+      });
 
-  it('should only run click handler once on label click', () => {
-    const spy = sinon.spy();
-    element.addEventListener('click', spy);
-    label.click();
-    expect(spy.calledOnce).to.be.true;
+      it('should only run click handler once on label click', () => {
+        const spy = sinon.spy();
+        element.addEventListener('click', spy);
+        label.click();
+        expect(spy.calledOnce).to.be.true;
+      });
+    });
   });
 });

--- a/packages/field-base/test/char-length-mixin.test.js
+++ b/packages/field-base/test/char-length-mixin.test.js
@@ -65,17 +65,4 @@ describe('char-length-mixin', () => {
       expect(spy.calledOnce).to.be.true;
     });
   });
-
-  describe('checkValidity', () => {
-    it('should return true when called before connected to the DOM', () => {
-      const field = document.createElement('char-length-mixin-element');
-      expect(field.checkValidity()).to.be.true;
-    });
-
-    it('should return false when called before connected to the DOM and invalid', () => {
-      const field = document.createElement('char-length-mixin-element');
-      field.invalid = true;
-      expect(field.checkValidity()).to.be.false;
-    });
-  });
 });

--- a/packages/field-base/test/char-length-mixin.test.js
+++ b/packages/field-base/test/char-length-mixin.test.js
@@ -1,0 +1,68 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { CharLengthMixin } from '../src/char-length-mixin.js';
+import { InputSlotMixin } from '../src/input-slot-mixin.js';
+
+customElements.define(
+  'char-length-mixin-element',
+  class extends CharLengthMixin(InputSlotMixin(PolymerElement)) {
+    static get template() {
+      return html`
+        <slot name="input"></slot>
+        <div part="error-message">
+          <slot name="error-message"></slot>
+        </div>
+        <slot name="helper"></slot>
+      `;
+    }
+  }
+);
+
+describe('char-length-mixin', () => {
+  let element, input;
+
+  beforeEach(() => {
+    element = fixtureSync('<char-length-mixin-element></char-length-mixin-element>');
+    input = element.querySelector('[slot=input]');
+  });
+
+  describe('properties', () => {
+    it('should propagate maxlength property to the input', () => {
+      element.maxlength = 8;
+      expect(input.maxLength).to.equal(8);
+    });
+
+    it('should propagate minlength property to the input', () => {
+      element.minlength = 8;
+      expect(input.minLength).to.equal(8);
+    });
+  });
+
+  describe('validation', () => {
+    it('should not validate the field when minlength is set', () => {
+      element.minlength = 2;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should not validate the field when maxlength is set', () => {
+      element.maxlength = 6;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should validate the field when invalid after minlength is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.minlength = 2;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate the field when invalid after maxlength is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.maxlength = 6;
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
+});

--- a/packages/field-base/test/char-length-mixin.test.js
+++ b/packages/field-base/test/char-length-mixin.test.js
@@ -65,4 +65,17 @@ describe('char-length-mixin', () => {
       expect(spy.calledOnce).to.be.true;
     });
   });
+
+  describe('checkValidity', () => {
+    it('should return true when called before connected to the DOM', () => {
+      const field = document.createElement('char-length-mixin-element');
+      expect(field.checkValidity()).to.be.true;
+    });
+
+    it('should return false when called before connected to the DOM and invalid', () => {
+      const field = document.createElement('char-length-mixin-element');
+      field.invalid = true;
+      expect(field.checkValidity()).to.be.false;
+    });
+  });
 });

--- a/packages/field-base/test/forward-input-props-mixin.test.js
+++ b/packages/field-base/test/forward-input-props-mixin.test.js
@@ -3,10 +3,11 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { ForwardInputPropsMixin } from '../src/forward-input-props-mixin.js';
 import { AriaLabelMixin } from '../src/aria-label-mixin.js';
+import { InputSlotMixin } from '../src/input-slot-mixin.js';
 
 customElements.define(
   'forward-input-props-mixin-element',
-  class extends ForwardInputPropsMixin(AriaLabelMixin(PolymerElement)) {
+  class extends ForwardInputPropsMixin(AriaLabelMixin(InputSlotMixin(PolymerElement))) {
     static get template() {
       return html`<slot name="label"></slot><slot name="input"></slot>`;
     }

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -1,0 +1,167 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { ForwardInputPropsMixin } from '../src/forward-input-props-mixin.js';
+import { InputConstraintsMixin } from '../src/input-constraints-mixin.js';
+import { InputSlotMixin } from '../src/input-slot-mixin.js';
+
+customElements.define(
+  'input-constraints-mixin-element',
+  class extends ForwardInputPropsMixin(InputConstraintsMixin(InputSlotMixin(PolymerElement))) {
+    static get template() {
+      return html`
+        <slot name="input"></slot>
+        <div part="error-message">
+          <slot name="error-message"></slot>
+        </div>
+        <slot name="helper"></slot>
+      `;
+    }
+
+    static get properties() {
+      return {
+        minlength: {
+          type: Number
+        },
+        maxlength: {
+          type: Number
+        },
+        pattern: {
+          type: String
+        }
+      };
+    }
+
+    static get forwardProps() {
+      return ['required', 'minlength', 'maxlength', 'pattern'];
+    }
+
+    static get constraints() {
+      return [...super.constraints, 'minlength', 'maxlength', 'pattern'];
+    }
+  }
+);
+
+describe('input-constraints-mixin', () => {
+  let element, input;
+
+  beforeEach(() => {
+    element = fixtureSync('<input-constraints-mixin-element></input-constraints-mixin-element>');
+    input = element.querySelector('[slot=input]');
+  });
+
+  describe('validation', () => {
+    it('should not validate the field when minlength is set', () => {
+      element.minlength = 2;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should not validate the field when maxlength is set', () => {
+      element.maxlength = 6;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should not validate the field when pattern is set', () => {
+      element.pattern = '[-+\\d]';
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should validate the field when invalid after minlength is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.minlength = 2;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate the field when invalid after maxlength is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.maxlength = 6;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate the field when invalid after minlength is set to 0', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.minlength = 0;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate the field when invalid after maxlength is set to 0', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.maxlength = 0;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate the field when invalid after pattern is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(element, 'validate');
+      element.pattern = '[-+\\d]';
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should call checkValidity on the input when invalid after minlength is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(input, 'checkValidity');
+      element.minlength = 2;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should call checkValidity on the input when invalid after maxlength is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(input, 'checkValidity');
+      element.maxlength = 6;
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should call checkValidity on the input when invalid after pattern is changed', () => {
+      element.invalid = true;
+      const spy = sinon.spy(input, 'checkValidity');
+      element.pattern = '[-+\\d]';
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should update invalid state when required is removed', () => {
+      element.required = true;
+      element.validate();
+      expect(element.invalid).to.be.true;
+
+      element.required = false;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should update invalid state when pattern is removed', () => {
+      input.value = '123foo';
+      element.pattern = '\\d+';
+
+      element.validate();
+      expect(element.invalid).to.be.true;
+
+      element.pattern = '';
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should override explicitly set invalid when required is set', () => {
+      element.invalid = true;
+      element.value = 'foo';
+
+      element.required = true;
+      expect(element.invalid).to.be.false;
+    });
+  });
+
+  describe('checkValidity', () => {
+    it('should return true when called before connected to the DOM', () => {
+      const field = document.createElement('input-constraints-mixin-element');
+      expect(field.checkValidity()).to.be.true;
+    });
+
+    it('should return false when called before connected to the DOM and invalid', () => {
+      const field = document.createElement('input-constraints-mixin-element');
+      field.invalid = true;
+      expect(field.checkValidity()).to.be.false;
+    });
+  });
+});

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -143,6 +143,16 @@ describe('input-constraints-mixin', () => {
       expect(element.invalid).to.be.false;
     });
 
+    it('should update invalid state when a constraint is removed even if other constraints are active', () => {
+      element.required = true;
+      element.pattern = '\\d*';
+      element.validate();
+      expect(element.invalid).to.be.true;
+
+      element.required = false;
+      expect(element.invalid).to.be.false;
+    });
+
     it('should override explicitly set invalid when required is set', () => {
       element.invalid = true;
       element.value = 'foo';

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -108,19 +108,6 @@ describe('input-field-mixin', () => {
     });
   });
 
-  describe('checkValidity', () => {
-    it('should return true when called before connected to the DOM', () => {
-      const field = document.createElement('input-field-mixin-element');
-      expect(field.checkValidity()).to.be.true;
-    });
-
-    it('should return false when called before connected to the DOM and invalid', () => {
-      const field = document.createElement('input-field-mixin-element');
-      field.invalid = true;
-      expect(field.checkValidity()).to.be.false;
-    });
-  });
-
   describe('iron-resize', () => {
     let spy;
 

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -3,10 +3,11 @@ import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { InputFieldMixin } from '../src/input-field-mixin.js';
+import { InputSlotMixin } from '../src/input-slot-mixin.js';
 
 customElements.define(
   'input-field-mixin-element',
-  class extends InputFieldMixin(PolymerElement) {
+  class extends InputFieldMixin(InputSlotMixin(PolymerElement)) {
     static get template() {
       return html`
         <style>

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -108,6 +108,19 @@ describe('input-field-mixin', () => {
     });
   });
 
+  describe('checkValidity', () => {
+    it('should return true when called before connected to the DOM', () => {
+      const field = document.createElement('input-field-mixin-element');
+      expect(field.checkValidity()).to.be.true;
+    });
+
+    it('should return false when called before connected to the DOM and invalid', () => {
+      const field = document.createElement('input-field-mixin-element');
+      field.invalid = true;
+      expect(field.checkValidity()).to.be.false;
+    });
+  });
+
   describe('iron-resize', () => {
     let spy;
 

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -123,17 +123,4 @@ describe('pattern-mixin', () => {
       expect(input.value).to.equal('');
     });
   });
-
-  describe('checkValidity', () => {
-    it('should return true when called before connected to the DOM', () => {
-      const field = document.createElement('pattern-mixin-element');
-      expect(field.checkValidity()).to.be.true;
-    });
-
-    it('should return false when called before connected to the DOM and invalid', () => {
-      const field = document.createElement('pattern-mixin-element');
-      field.invalid = true;
-      expect(field.checkValidity()).to.be.false;
-    });
-  });
 });

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -123,4 +123,17 @@ describe('pattern-mixin', () => {
       expect(input.value).to.equal('');
     });
   });
+
+  describe('checkValidity', () => {
+    it('should return true when called before connected to the DOM', () => {
+      const field = document.createElement('pattern-mixin-element');
+      expect(field.checkValidity()).to.be.true;
+    });
+
+    it('should return false when called before connected to the DOM and invalid', () => {
+      const field = document.createElement('pattern-mixin-element');
+      field.invalid = true;
+      expect(field.checkValidity()).to.be.false;
+    });
+  });
 });

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -4,10 +4,11 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { AriaLabelMixin } from '../src/aria-label-mixin.js';
 import { PatternMixin } from '../src/pattern-mixin.js';
+import { InputSlotMixin } from '../src/input-slot-mixin.js';
 
 customElements.define(
   'pattern-mixin-element',
-  class extends PatternMixin(AriaLabelMixin(PolymerElement)) {
+  class extends PatternMixin(AriaLabelMixin(InputSlotMixin(PolymerElement))) {
     static get template() {
       return html`<slot name="label"></slot><slot name="input"></slot>`;
     }

--- a/packages/field-base/test/text-area-slot-mixin.test.js
+++ b/packages/field-base/test/text-area-slot-mixin.test.js
@@ -1,0 +1,67 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { TextAreaSlotMixin } from '../src/text-area-slot-mixin.js';
+
+customElements.define(
+  'textarea-slot-mixin-element',
+  class extends TextAreaSlotMixin(PolymerElement) {
+    static get template() {
+      return html`<slot name="textarea"></slot>`;
+    }
+  }
+);
+
+describe('text-area-slot-mixin', () => {
+  let element, textarea;
+
+  describe('default', () => {
+    beforeEach(() => {
+      element = fixtureSync('<textarea-slot-mixin-element></textarea-slot-mixin-element>');
+      textarea = element.querySelector('[slot=textarea]');
+    });
+
+    it('should create a textarea element', () => {
+      expect(textarea).to.be.an.instanceof(HTMLTextAreaElement);
+    });
+
+    it('should store a reference as inputElement', () => {
+      expect(element.inputElement).to.equal(textarea);
+    });
+
+    it('should set id attribute on the textarea', () => {
+      const idRegex = /^textarea-slot-mixin-element-\d$/;
+      expect(textarea.getAttribute('id')).to.match(idRegex);
+    });
+
+    it('should have an empty name by default', () => {
+      expect(textarea.name).to.equal('');
+    });
+
+    it('should have an empty value by default', () => {
+      expect(textarea.value).to.equal('');
+    });
+  });
+
+  describe('name', () => {
+    beforeEach(() => {
+      element = fixtureSync('<textarea-slot-mixin-element name="foo"></textarea-slot-mixin-element>');
+      textarea = element.querySelector('[slot=textarea]');
+    });
+
+    it('should forward name attribute to the textarea', () => {
+      expect(textarea.name).to.equal('foo');
+    });
+  });
+
+  describe('value', () => {
+    beforeEach(() => {
+      element = fixtureSync('<textarea-slot-mixin-element value="foo"></textarea-slot-mixin-element>');
+      textarea = element.querySelector('[slot=textarea]');
+    });
+
+    it('should forward value attribute to the textarea', () => {
+      expect(textarea.value).to.equal('foo');
+    });
+  });
+});

--- a/packages/field-base/test/text-field-mixin.test.js
+++ b/packages/field-base/test/text-field-mixin.test.js
@@ -3,10 +3,11 @@ import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { TextFieldMixin } from '../src/text-field-mixin.js';
+import { InputSlotMixin } from '../src/input-slot-mixin.js';
 
 customElements.define(
   'text-field-mixin-element',
-  class extends TextFieldMixin(PolymerElement) {
+  class extends TextFieldMixin(InputSlotMixin(PolymerElement)) {
     static get template() {
       return html`
         <slot name="label"></slot>

--- a/packages/field-base/test/text-field-mixin.test.js
+++ b/packages/field-base/test/text-field-mixin.test.js
@@ -135,19 +135,6 @@ describe('text-field-mixin', () => {
     });
   });
 
-  describe('checkValidity', () => {
-    it('should return true when called before connected to the DOM', () => {
-      const field = document.createElement('text-field-mixin-element');
-      expect(field.checkValidity()).to.be.true;
-    });
-
-    it('should return false when called before connected to the DOM and invalid', () => {
-      const field = document.createElement('text-field-mixin-element');
-      field.invalid = true;
-      expect(field.checkValidity()).to.be.false;
-    });
-  });
-
   describe('prevent invalid input', () => {
     beforeEach(() => {
       element.preventInvalidInput = true;

--- a/packages/field-base/test/text-field-mixin.test.js
+++ b/packages/field-base/test/text-field-mixin.test.js
@@ -135,6 +135,19 @@ describe('text-field-mixin', () => {
     });
   });
 
+  describe('checkValidity', () => {
+    it('should return true when called before connected to the DOM', () => {
+      const field = document.createElement('text-field-mixin-element');
+      expect(field.checkValidity()).to.be.true;
+    });
+
+    it('should return false when called before connected to the DOM and invalid', () => {
+      const field = document.createElement('text-field-mixin-element');
+      field.invalid = true;
+      expect(field.checkValidity()).to.be.false;
+    });
+  });
+
   describe('prevent invalid input', () => {
     beforeEach(() => {
       element.preventInvalidInput = true;

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -185,21 +185,5 @@ describe('validate-mixin', () => {
       element.validate();
       expect(element.invalid).to.be.false;
     });
-
-    it('should override explicitly set invalid when required is set', () => {
-      element.invalid = true;
-      element.value = 'foo';
-      element.required = true;
-      expect(element.invalid).to.be.false;
-    });
-
-    it('should update invalid state when required is removed', () => {
-      element.required = true;
-      element.validate();
-      expect(element.invalid).to.be.true;
-
-      element.required = false;
-      expect(element.invalid).to.be.false;
-    });
   });
 });

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -185,5 +185,21 @@ describe('validate-mixin', () => {
       element.validate();
       expect(element.invalid).to.be.false;
     });
+
+    it('should override explicitly set invalid when required is set', () => {
+      element.invalid = true;
+      element.value = 'foo';
+      element.required = true;
+      expect(element.invalid).to.be.false;
+    });
+
+    it('should update invalid state when required is removed', () => {
+      element.required = true;
+      element.validate();
+      expect(element.invalid).to.be.true;
+
+      element.required = false;
+      expect(element.invalid).to.be.false;
+    });
   });
 });

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -5,9 +5,10 @@
  */
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
+import { InputSlotMixin } from '@vaadin/field-base/src/input-slot-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-declare class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(HTMLElement))) {
+declare class NumberField extends InputFieldMixin(InputSlotMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
   /**
    * Set to true to display value increase/decrease controls.
    * @attr {boolean} has-controls

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -7,10 +7,11 @@ import { PolymerElement, html } from '@polymer/polymer';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
+import { InputSlotMixin } from '@vaadin/field-base/src/input-slot-mixin.js';
 import '@vaadin/input-container/src/vaadin-input-container.js';
 import '@vaadin/text-field/src/vaadin-input-field-shared-styles.js';
 
-export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(PolymerElement))) {
+export class NumberField extends InputFieldMixin(InputSlotMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-number-field';
   }

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -5,8 +5,9 @@
  */
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import { TextFieldMixin } from '@vaadin/field-base/src/text-field-mixin.js';
+import { TextAreaSlotMixin } from '@vaadin/field-base/src/text-area-slot-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-declare class TextArea extends TextFieldMixin(ThemableMixin(ElementMixin(HTMLElement))) {}
+declare class TextArea extends TextFieldMixin(TextAreaSlotMixin(ThemableMixin(ElementMixin(HTMLElement)))) {}
 
 export { TextArea };

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -4,10 +4,13 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
-import { TextFieldMixin } from '@vaadin/field-base/src/text-field-mixin.js';
+import { CharLengthMixin } from '@vaadin/field-base/src/char-length-mixin.js';
+import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { TextAreaSlotMixin } from '@vaadin/field-base/src/text-area-slot-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-declare class TextArea extends TextFieldMixin(TextAreaSlotMixin(ThemableMixin(ElementMixin(HTMLElement)))) {}
+declare class TextArea extends CharLengthMixin(
+  InputFieldMixin(TextAreaSlotMixin(ThemableMixin(ElementMixin(HTMLElement))))
+) {}
 
 export { TextArea };

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -5,13 +5,16 @@
  */
 import { PolymerElement, html } from '@polymer/polymer';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
-import { TextFieldMixin } from '@vaadin/field-base/src/text-field-mixin.js';
+import { CharLengthMixin } from '@vaadin/field-base/src/char-length-mixin.js';
+import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { TextAreaSlotMixin } from '@vaadin/field-base/src/text-area-slot-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import '@vaadin/input-container/src/vaadin-input-container.js';
 import '@vaadin/text-field/src/vaadin-input-field-shared-styles.js';
 
-export class TextArea extends TextFieldMixin(TextAreaSlotMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
+export class TextArea extends CharLengthMixin(
+  InputFieldMixin(TextAreaSlotMixin(ThemableMixin(ElementMixin(PolymerElement))))
+) {
   static get is() {
     return 'vaadin-text-area';
   }

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -6,11 +6,12 @@
 import { PolymerElement, html } from '@polymer/polymer';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import { TextFieldMixin } from '@vaadin/field-base/src/text-field-mixin.js';
+import { TextAreaSlotMixin } from '@vaadin/field-base/src/text-area-slot-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import '@vaadin/input-container/src/vaadin-input-container.js';
 import '@vaadin/text-field/src/vaadin-input-field-shared-styles.js';
 
-export class TextArea extends TextFieldMixin(ThemableMixin(ElementMixin(PolymerElement))) {
+export class TextArea extends TextFieldMixin(TextAreaSlotMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-text-area';
   }
@@ -131,28 +132,6 @@ export class TextArea extends TextFieldMixin(ThemableMixin(ElementMixin(PolymerE
     `;
   }
 
-  get slots() {
-    const slots = super.slots;
-
-    delete slots.input;
-
-    return {
-      ...slots,
-      textarea: () => {
-        const native = document.createElement('textarea');
-        const value = this.getAttribute('value');
-        if (value) {
-          native.setAttribute('value', value);
-        }
-        const name = this.getAttribute('name');
-        if (name) {
-          native.setAttribute('name', name);
-        }
-        return native;
-      }
-    };
-  }
-
   /**
    * Used by `ClearButtonMixin` as a reference to the clear button element.
    * @protected
@@ -164,9 +143,6 @@ export class TextArea extends TextFieldMixin(ThemableMixin(ElementMixin(PolymerE
   /** @protected */
   connectedCallback() {
     super.connectedCallback();
-
-    const textarea = this._getDirectSlotChild('textarea');
-    this._setInputElement(textarea);
 
     this._updateHeight();
   }

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -5,8 +5,9 @@
  */
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import { TextFieldMixin } from '@vaadin/field-base/src/text-field-mixin.js';
+import { InputSlotMixin } from '@vaadin/field-base/src/input-slot-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-declare class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(HTMLElement))) {}
+declare class TextField extends TextFieldMixin(InputSlotMixin(ThemableMixin(ElementMixin(HTMLElement)))) {}
 
 export { TextField };

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -7,10 +7,11 @@ import { PolymerElement, html } from '@polymer/polymer';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TextFieldMixin } from '@vaadin/field-base/src/text-field-mixin.js';
+import { InputSlotMixin } from '@vaadin/field-base/src/input-slot-mixin.js';
 import '@vaadin/input-container/src/vaadin-input-container.js';
 import './vaadin-input-field-shared-styles.js';
 
-export class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(PolymerElement))) {
+export class TextField extends TextFieldMixin(InputSlotMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-text-field';
   }


### PR DESCRIPTION
## Description

1. Added `TextAreaSlotMixin` similar to `InputSlotMixin` to `@vaadin/field-base`
2. Updated `AriaLabelMixin` to use `InputMixin` and to not apply `InputSlotMixin`
3. Updated `vaadin-text-field` and `vaadin-number-field` to use `InputSlotMixin`
4. Added `CharLengthMixin` to provide `minlength` and `maxlength` properties
5. Updated all the mixins adding validation constraints to use `static get constaints`
6. Moved the constraints observer initialization to `ready` block of `ValidateMixin`
7. Fixed `ForwardInputPropsMixin` to call multi property observers in the right order
8. Fixed `vaadin-text-area` to not use `TextFieldMixin` and remove unsupported `pattern`

Fixes #2349

## Type of change

- Feature