### PR TITLE
fix: set font smoothing to slotted input

### DIFF
--- a/packages/text-field/theme/lumo/vaadin-input-field-shared-styles.js
+++ b/packages/text-field/theme/lumo/vaadin-input-field-shared-styles.js
@@ -59,6 +59,12 @@ registerStyles(
       transition: color 0.2s;
     }
 
+    [part='input-field'] ::slotted(:is(input, textarea)) {
+      /* Slotted input does not inherit these from the host */
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
     :host([focused]) [part='input-field'] ::slotted(:is(input, textarea)) {
       -webkit-mask-image: none;
       mask-image: none;

--- a/packages/text-field/theme/material/vaadin-input-field-shared-styles.js
+++ b/packages/text-field/theme/material/vaadin-input-field-shared-styles.js
@@ -106,6 +106,9 @@ registerStyles(
       background-color: transparent;
       /* Disable default invalid style in Firefox */
       box-shadow: none;
+      /* Slotted input does not inherit these from the host */
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
     }
 
     /* TODO: the text opacity should be 42%, but the disabled style is 38%.


### PR DESCRIPTION
## Description

The old implementations with the `input` in Shadow DOM apply these styles (they get inherited from the `:host`).
We need to update the new components to apply them too, it should prevent regressions in some visual tests.

## Type of change

- Bugfix