### PR TITLE
test: fix version regex to allow RC (#1999) (#2051)

### DIFF
--- a/packages/vaadin-rich-text-editor/test/basic.test.js
+++ b/packages/vaadin-rich-text-editor/test/basic.test.js
@@ -24,7 +24,7 @@ describe('rich text editor', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(rte.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\*|\d+)(-(alpha|beta)\d+)?$/);
+      expect(rte.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\*|\d+)(-(alpha|beta|rc)\d+)?$/);
     });
   });
 


### PR DESCRIPTION
## Description

Manual cherry-pick of c73dcabee9732c5a589015d1c421aa49b308d02e from `20.0`, to be cherry-picked to `21.0` by bot.