### PR TITLE
refactor: move version getter to ElementMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Prepare a new version for the `updateVersion` script by running the following co
 export npm_config_bump=23.0.0-alpha0
 ```
 
-Run the script to bump static version getters in every component:
+Run the script to bump static version getters in `ElementMixin`, `Lumo` and `Material`:
 
 ```sh
 node scripts/updateVersion.js

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -14,10 +14,6 @@ class Button extends ControlStateMixin(ActiveMixin(ElementMixin(ThemableMixin(Po
     return 'vaadin-button';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get template() {
     return html`
       <style>

--- a/packages/button/test/button.test.js
+++ b/packages/button/test/button.test.js
@@ -36,10 +36,6 @@ describe('vaadin-button', () => {
     it('should have a valid static "is" getter', () => {
       expect(customElements.get(tagName).is).to.equal(tagName);
     });
-
-    it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-    });
   });
 
   describe('default', () => {

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -16,10 +16,6 @@ class CustomField extends FieldAriaMixin(LabelMixin(FocusMixin(ThemableMixin(Ele
     return 'vaadin-custom-field';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get template() {
     return html`
       <style>

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -47,10 +47,6 @@ export class EmailField extends TextField {
     return 'vaadin-email-field';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   constructor() {
     super();
     this._setType('email');

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -51,10 +51,6 @@ export class IntegerField extends NumberField {
     return 'vaadin-integer-field';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -61,10 +61,6 @@ export class NumberField extends InputFieldMixin(InputSlotMixin(ThemableMixin(El
     return 'vaadin-number-field';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get template() {
     return html`
       <style include="vaadin-input-field-shared-styles">

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -51,10 +51,6 @@ export class PasswordField extends TextField {
     return 'vaadin-password-field';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get template() {
     if (!memoizedTemplate) {
       // Clone the superclass template

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -79,10 +79,6 @@ export class TextArea extends CharLengthMixin(
     return 'vaadin-text-area';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get template() {
     return html`
       <style include="vaadin-input-field-shared-styles">

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -16,10 +16,6 @@ export class TextField extends TextFieldMixin(InputSlotMixin(ThemableMixin(Eleme
     return 'vaadin-text-field';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get template() {
     return html`
       <style include="vaadin-input-field-shared-styles">

--- a/packages/vaadin-accordion/src/vaadin-accordion.js
+++ b/packages/vaadin-accordion/src/vaadin-accordion.js
@@ -77,10 +77,6 @@ class AccordionElement extends ThemableMixin(ElementMixin(PolymerElement)) {
     return 'vaadin-accordion';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-accordion/test/accordion.test.js
+++ b/packages/vaadin-accordion/test/accordion.test.js
@@ -40,12 +40,18 @@ describe('vaadin-accordion', () => {
   });
 
   describe('custom element definition', () => {
-    it('should define a custom element with proper tag name', () => {
-      expect(customElements.get('vaadin-accordion')).to.be.ok;
+    let tagName;
+
+    beforeEach(() => {
+      tagName = accordion.tagName.toLowerCase();
     });
 
-    it('should have a valid version number', () => {
-      expect(accordion.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-accordion/test/accordion.test.js
+++ b/packages/vaadin-accordion/test/accordion.test.js
@@ -7,7 +7,8 @@ import {
   arrowUpKeyDown,
   keyboardEventFor,
   homeKeyDown,
-  endKeyDown
+  endKeyDown,
+  nextFrame
 } from '@vaadin/testing-helpers';
 
 import '../vaadin-accordion.js';
@@ -19,7 +20,7 @@ describe('vaadin-accordion', () => {
     return accordion.items[idx].focusElement;
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     accordion = fixtureSync(`
       <vaadin-accordion>
         <vaadin-accordion-panel>
@@ -36,7 +37,7 @@ describe('vaadin-accordion', () => {
         </vaadin-accordion-panel>
       </vaadin-accordion>
     `);
-    accordion._observer.flush();
+    await nextFrame();
   });
 
   describe('custom element definition', () => {

--- a/packages/vaadin-app-layout/src/vaadin-app-layout.js
+++ b/packages/vaadin-app-layout/src/vaadin-app-layout.js
@@ -304,10 +304,6 @@ class AppLayoutElement extends ElementMixin(ThemableMixin(mixinBehaviors([IronRe
     return 'vaadin-app-layout';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-app-layout/test/app-layout.test.js
+++ b/packages/vaadin-app-layout/test/app-layout.test.js
@@ -25,10 +25,6 @@ describe('vaadin-app-layout', () => {
     it('should have a valid static "is" getter', () => {
       expect(customElements.get(tagName).is).to.equal(tagName);
     });
-
-    it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-    });
   });
 
   describe('primarySection', () => {

--- a/packages/vaadin-avatar/src/vaadin-avatar-group.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar-group.js
@@ -163,10 +163,6 @@ class AvatarGroupElement extends ElementMixin(ThemableMixin(mixinBehaviors([Iron
     return 'vaadin-avatar-group';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-avatar/src/vaadin-avatar.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar.js
@@ -146,10 +146,6 @@ class AvatarElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     return 'vaadin-avatar';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-avatar/test/avatar-group.test.js
+++ b/packages/vaadin-avatar/test/avatar-group.test.js
@@ -13,16 +13,18 @@ describe('avatar-group', () => {
   });
 
   describe('custom element definition', () => {
-    it('should be defined with correct tag name', () => {
-      expect(customElements.get('vaadin-avatar-group')).to.be.ok;
+    let tagName;
+
+    beforeEach(() => {
+      tagName = group.tagName.toLowerCase();
     });
 
-    it('should not expose class name globally', () => {
-      expect(window.AvatarGroupElement).not.to.be.ok;
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
     });
 
-    it('should have a valid version number', () => {
-      expect(group.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-avatar/test/avatar.test.js
+++ b/packages/vaadin-avatar/test/avatar.test.js
@@ -9,9 +9,6 @@ describe('vaadin-avatar', () => {
 
   beforeEach(() => {
     avatar = fixtureSync('<vaadin-avatar></vaadin-avatar>');
-    imgElement = avatar.shadowRoot.querySelector('img');
-    iconElement = avatar.shadowRoot.querySelector('#avatar-icon');
-    abbrElement = avatar.shadowRoot.querySelector('#avatar-abbr');
   });
 
   describe('custom element definition', () => {
@@ -31,6 +28,12 @@ describe('vaadin-avatar', () => {
   });
 
   describe('properties', () => {
+    beforeEach(() => {
+      imgElement = avatar.shadowRoot.querySelector('img');
+      iconElement = avatar.shadowRoot.querySelector('#avatar-icon');
+      abbrElement = avatar.shadowRoot.querySelector('#avatar-abbr');
+    });
+
     const validImageSrc =
       'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiI+PHBhdGggZmlsbD0iIzAyMDIwMSIgZD0iTTQ1NC40MjYgMzkyLjU4MmMtNS40MzktMTYuMzItMTUuMjk4LTMyLjc4Mi0yOS44MzktNDIuMzYyLTI3Ljk3OS0xOC41NzItNjAuNTc4LTI4LjQ3OS05Mi4wOTktMzkuMDg1LTcuNjA0LTIuNjY0LTE1LjMzLTUuNTY4LTIyLjI3OS05LjctNi4yMDQtMy42ODYtOC41MzMtMTEuMjQ2LTkuOTc0LTE3Ljg4Ni0uNjM2LTMuNTEyLTEuMDI2LTcuMTE2LTEuMjI4LTEwLjY2MSAyMi44NTctMzEuMjY3IDM4LjAxOS04Mi4yOTUgMzguMDE5LTEyNC4xMzYgMC02NS4yOTgtMzYuODk2LTgzLjQ5NS04Mi40MDItODMuNDk1LTQ1LjUxNSAwLTgyLjQwMyAxOC4xNy04Mi40MDMgODMuNDY4IDAgNDMuMzM4IDE2LjI1NSA5Ni41IDQwLjQ4OSAxMjcuMzgzLS4yMjEgMi40MzgtLjUxMSA0Ljg3Ni0uOTUgNy4zMDMtMS40NDQgNi42MzktMy43NyAxNC4wNTgtOS45NyAxNy43NDMtNi45NTcgNC4xMzMtMTQuNjgyIDYuNzU2LTIyLjI4NyA5LjQyLTMxLjUyMSAxMC42MDUtNjQuMTE5IDE5Ljk1Ny05Mi4wOTEgMzguNTI5LTE0LjU0OSA5LjU4LTI0LjQwMyAyNy4xNTktMjkuODM4IDQzLjQ3OS01LjU5NyAxNi45MzgtNy44ODYgMzcuOTE3LTcuNTQxIDU0LjkxN2g0MTEuOTMyYy4zNDgtMTYuOTk5LTEuOTQ2LTM3Ljk3OC03LjUzOS01NC45MTd6Ii8+PC9zdmc+Cg==';
     const invalidImageSrc = 'thisisnotavalidimagesource';
@@ -198,6 +201,7 @@ describe('vaadin-avatar', () => {
       beforeEach(() => {
         sinon.stub(console, 'warn');
       });
+
       afterEach(() => {
         console.warn.restore();
       });
@@ -332,14 +336,17 @@ describe('vaadin-avatar', () => {
     });
 
     it('should set aria-hidden="true" on the img element', () => {
+      const imgElement = avatar.shadowRoot.querySelector('img');
       expect(imgElement.getAttribute('aria-hidden')).to.equal('true');
     });
 
     it('should set aria-hidden="true" on the icon element', () => {
+      const iconElement = avatar.shadowRoot.querySelector('#avatar-icon');
       expect(iconElement.getAttribute('aria-hidden')).to.equal('true');
     });
 
     it('should set aria-hidden="true" on the abbr element', () => {
+      const abbrElement = avatar.shadowRoot.querySelector('#avatar-abbr');
       expect(abbrElement.getAttribute('aria-hidden')).to.equal('true');
     });
   });

--- a/packages/vaadin-avatar/test/avatar.test.js
+++ b/packages/vaadin-avatar/test/avatar.test.js
@@ -15,16 +15,18 @@ describe('vaadin-avatar', () => {
   });
 
   describe('custom element definition', () => {
-    it('should be defined with correct tag name', () => {
-      expect(customElements.get('vaadin-avatar')).to.be.ok;
+    let tagName;
+
+    beforeEach(() => {
+      tagName = avatar.tagName.toLowerCase();
     });
 
-    it('should not expose class name globally', () => {
-      expect(window.AvatarElement).not.to.be.ok;
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
     });
 
-    it('should have a valid version number', () => {
-      expect(avatar.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-board/src/vaadin-board.js
+++ b/packages/vaadin-board/src/vaadin-board.js
@@ -48,10 +48,6 @@ class BoardElement extends ElementMixin(mixinBehaviors([IronResizableBehavior], 
     return 'vaadin-board';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   /**
    * @protected
    */

--- a/packages/vaadin-board/test/basic.test.js
+++ b/packages/vaadin-board/test/basic.test.js
@@ -2,22 +2,23 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board.js';
 
-describe('vaadin-details', () => {
-  let board;
+describe('vaadin-board', () => {
+  let board, tagName;
 
   beforeEach(() => {
     board = fixtureSync('<vaadin-board></vaadin-board>');
+    tagName = board.tagName.toLowerCase();
   });
 
   it('should define a vaadin-board custom element', () => {
-    expect(customElements.get('vaadin-board')).to.be.ok;
+    expect(customElements.get(tagName)).to.be.ok;
+  });
+
+  it('should have a valid static "is" getter', () => {
+    expect(customElements.get(tagName).is).to.equal(tagName);
   });
 
   it('should define a vaadin-board-row custom element', () => {
     expect(customElements.get('vaadin-board-row')).to.be.ok;
-  });
-
-  it('should have a valid version number', () => {
-    expect(board.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
   });
 });

--- a/packages/vaadin-button/src/vaadin-button.js
+++ b/packages/vaadin-button/src/vaadin-button.js
@@ -127,10 +127,6 @@ class ButtonElement extends ElementMixin(ControlStateMixin(ThemableMixin(Gesture
     return 'vaadin-button';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   ready() {
     super.ready();
 

--- a/packages/vaadin-button/test/button.test.js
+++ b/packages/vaadin-button/test/button.test.js
@@ -25,10 +25,6 @@ describe('vaadin-button', () => {
     label = vaadinButton.shadowRoot.querySelector('[part=label]');
   });
 
-  it('should have a valid version number', () => {
-    expect(vaadinButton.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-  });
-
   it('should define button label using light DOM', () => {
     const children = FlattenedNodesObserver.getFlattenedNodes(label);
     expect(children[1].textContent).to.be.equal('Vaadin ');

--- a/packages/vaadin-charts/src/vaadin-chart.js
+++ b/packages/vaadin-charts/src/vaadin-chart.js
@@ -257,10 +257,6 @@ class ChartElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     return 'vaadin-chart';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   /** @private */
   static __callHighchartsFunction(functionName, redrawCharts) {
     const functionToCall = Highcharts[functionName];

--- a/packages/vaadin-charts/test/chart-element.test.js
+++ b/packages/vaadin-charts/test/chart-element.test.js
@@ -17,11 +17,7 @@ describe('vaadin-chart', () => {
     });
 
     it('should have a valid static "is" getter', () => {
-      expect(chart.constructor.is).to.equal(tagName);
-    });
-
-    it('should have a valid version number', () => {
-      expect(chart.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-checkbox/src/vaadin-checkbox.js
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox.js
@@ -115,10 +115,6 @@ class CheckboxElement extends ElementMixin(ControlStateMixin(ThemableMixin(Gestu
     return 'vaadin-checkbox';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.js
@@ -242,10 +242,6 @@ class ComboBoxElement extends ElementMixin(
     return 'vaadin-combo-box';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js
@@ -130,10 +130,6 @@ class ConfirmDialogElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     return 'vaadin-confirm-dialog';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/vaadin-confirm-dialog/test/confirm-dialog.test.js
@@ -7,18 +7,19 @@ import '../vaadin-confirm-dialog.js';
 
 describe('vaadin-confirm-dialog', () => {
   describe('custom element definition', () => {
-    let confirm;
+    let confirm, tagName;
 
     beforeEach(() => {
       confirm = fixtureSync('<vaadin-confirm-dialog></vaadin-confirm-dialog>');
+      tagName = confirm.tagName.toLowerCase();
     });
 
-    it('should be defined with correct tag name', () => {
-      expect(customElements.get('vaadin-confirm-dialog')).to.be.ok;
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
     });
 
-    it('should have a valid version number', () => {
-      expect(confirm.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.js
@@ -235,10 +235,6 @@ class ContextMenuElement extends ElementMixin(ThemePropertyMixin(ItemsMixin(Gest
     return 'vaadin-context-menu';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/vaadin-cookie-consent/src/vaadin-cookie-consent.js
@@ -52,10 +52,6 @@ class CookieConsentElement extends ElementMixin(PolymerElement) {
     return 'vaadin-cookie-consent';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-cookie-consent/test/cookie-consent.test.js
+++ b/packages/vaadin-cookie-consent/test/cookie-consent.test.js
@@ -4,18 +4,19 @@ import '../vaadin-cookie-consent.js';
 
 describe('vaadin-cookie-consent', () => {
   describe('custom element definition', () => {
-    let consent;
+    let consent, tagName;
 
     beforeEach(() => {
       consent = fixtureSync('<vaadin-cookie-consent></vaadin-cookie-consent>');
+      tagName = consent.tagName.toLowerCase();
     });
 
-    it('should define a custom element with a correct tag name', () => {
-      expect(customElements.get('vaadin-cookie-consent')).to.be.ok;
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
     });
 
-    it('should have a valid version number', () => {
-      expect(consent.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -275,10 +275,6 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     return 'vaadin-crud';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-crud/test/crud-form.test.js
+++ b/packages/vaadin-crud/test/crud-form.test.js
@@ -9,12 +9,20 @@ describe('crud form', () => {
     crudForm = fixtureSync('<vaadin-crud-form style="width: 500px;"></vaadin-crud-form>');
   });
 
-  it('should not expose class name globally', function () {
-    expect(window.CrudFormElement).not.to.be.ok;
-  });
+  describe('custom element definition', () => {
+    let tagName;
 
-  it('should have a version number', () => {
-    expect(customElements.get('vaadin-crud-form').version).to.be.ok;
+    beforeEach(() => {
+      tagName = crudForm.tagName.toLowerCase();
+    });
+
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
+    });
   });
 
   describe('without valid item', () => {

--- a/packages/vaadin-crud/test/crud-grid.test.js
+++ b/packages/vaadin-crud/test/crud-grid.test.js
@@ -18,13 +18,26 @@ describe('crud grid', () => {
     }
   ];
 
+  describe('custom element definition', () => {
+    let tagName;
+
+    beforeEach(() => {
+      grid = fixtureSync('<vaadin-crud-grid></vaadin-crud-grid>');
+      tagName = grid.tagName.toLowerCase();
+    });
+
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
+    });
+  });
+
   describe('basic', () => {
     beforeEach(() => {
       grid = fixtureSync('<vaadin-crud-grid style="width: 500px;" exclude="_id,password"></vaadin-crud-grid>');
-    });
-
-    it('should have a version number', () => {
-      expect(customElements.get('vaadin-crud-grid').version).to.be.ok;
     });
 
     it('should not generate any column when providing an empty item list', () => {

--- a/packages/vaadin-crud/test/crud.test.js
+++ b/packages/vaadin-crud/test/crud.test.js
@@ -23,17 +23,20 @@ describe('crud', () => {
 
   const edit = (item) => crud._grid.dispatchEvent(new CustomEvent('edit', { detail: { item } }));
 
-  describe('basic', () => {
+  describe('custom element definition', () => {
+    let tagName;
+
     beforeEach(() => {
       crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
+      tagName = crud.tagName.toLowerCase();
     });
 
-    it('should not expose class name globally', () => {
-      expect(window.CrudElement).not.to.be.ok;
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
     });
 
-    it('should have a valid version number', () => {
-      expect(customElements.get('vaadin-crud').version).to.be.ok;
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-custom-field/src/vaadin-custom-field.js
+++ b/packages/vaadin-custom-field/src/vaadin-custom-field.js
@@ -106,9 +106,6 @@ class CustomFieldElement extends ElementMixin(CustomFieldMixin(ThemableMixin(Pol
   static get is() {
     return 'vaadin-custom-field';
   }
-  static get version() {
-    return '22.0.0-alpha1';
-  }
 
   static get properties() {
     return {

--- a/packages/vaadin-date-picker/src/vaadin-date-picker.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker.js
@@ -193,10 +193,6 @@ class DatePickerElement extends ElementMixin(
     return 'vaadin-date-picker';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.js
@@ -149,10 +149,6 @@ class DateTimePickerElement extends ElementMixin(ThemableMixin(PolymerElement)) 
     return 'vaadin-date-time-picker';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-date-time-picker/test/basic.test.js
+++ b/packages/vaadin-date-time-picker/test/basic.test.js
@@ -44,14 +44,6 @@ describe('Basic features', () => {
     timePicker = customField.inputs[1];
   });
 
-  it('should not expose class name globally', () => {
-    expect(window.DateTimePickerElement).not.to.be.ok;
-  });
-
-  it('should have a valid version number', () => {
-    expect(dateTimePicker.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-  });
-
   it('should have default value', () => {
     expect(dateTimePicker.value).to.equal('');
   });

--- a/packages/vaadin-details/src/vaadin-details.js
+++ b/packages/vaadin-details/src/vaadin-details.js
@@ -98,10 +98,6 @@ class DetailsElement extends ControlStateMixin(ElementMixin(ThemableMixin(Polyme
     return 'vaadin-details';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-details/test/details.test.js
+++ b/packages/vaadin-details/test/details.test.js
@@ -18,12 +18,18 @@ describe('vaadin-details', () => {
   });
 
   describe('custom element definition', () => {
-    it('should define a custom element with proper tag name', () => {
-      expect(customElements.get('vaadin-details')).to.be.ok;
+    let tagName;
+
+    beforeEach(() => {
+      tagName = details.tagName.toLowerCase();
     });
 
-    it('should have a valid version number', () => {
-      expect(details.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -201,10 +201,6 @@ class DialogElement extends ThemePropertyMixin(
     return 'vaadin-dialog';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-dialog/test/dialog.test.js
+++ b/packages/vaadin-dialog/test/dialog.test.js
@@ -28,6 +28,23 @@ customElements.define(
 );
 
 describe('vaadin-dialog', () => {
+  describe('custom element definition', () => {
+    let dialog, tagName;
+
+    beforeEach(() => {
+      dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+      tagName = dialog.tagName.toLowerCase();
+    });
+
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
+    });
+  });
+
   describe('opened', () => {
     let dialog, backdrop, overlay;
 
@@ -41,10 +58,6 @@ describe('vaadin-dialog', () => {
       `);
       overlay = dialog.$.overlay;
       backdrop = overlay.$.backdrop;
-    });
-
-    it('should have a valid version number', () => {
-      expect(dialog.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
     });
 
     describe('attributes', () => {
@@ -121,7 +134,7 @@ describe('vaadin-dialog', () => {
   });
 
   describe('without template', () => {
-    var dialog;
+    let dialog;
 
     beforeEach(() => {
       dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');

--- a/packages/vaadin-element-mixin/custom_typings/vaadin.d.ts
+++ b/packages/vaadin-element-mixin/custom_typings/vaadin.d.ts
@@ -3,7 +3,7 @@ interface Vaadin {
     'usage-statistics'?: () => void;
     'vaadin-license-checker'?: () => void;
   };
-  registrations?: Array<{ is: string }>;
+  registrations?: Array<{ is: string; version: string }>;
   usageStatsChecker?: {
     maybeGatherAndSend: () => void;
   };

--- a/packages/vaadin-element-mixin/test/element-mixin.test.js
+++ b/packages/vaadin-element-mixin/test/element-mixin.test.js
@@ -20,6 +20,19 @@ describe('ElementMixin', () => {
     });
   });
 
+  describe('version', () => {
+    class XElement extends ElementMixin(PolymerElement) {
+      static get is() {
+        return 'x-element';
+      }
+    }
+    customElements.define(XElement.is, XElement);
+
+    it('should have a valid version number', () => {
+      expect(XElement.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+    });
+  });
+
   describe('registrations', () => {
     it('should store the class entry in registrations once instance created', () => {
       class ElementFoo extends ElementMixin(PolymerElement) {

--- a/packages/vaadin-element-mixin/vaadin-element-mixin.js
+++ b/packages/vaadin-element-mixin/vaadin-element-mixin.js
@@ -31,6 +31,10 @@ const registered = new Set();
  */
 export const ElementMixin = (superClass) =>
   class VaadinElementMixin extends DirMixin(superClass) {
+    static get version() {
+      return '22.0.0-alpha1';
+    }
+
     /** @protected */
     static finalize() {
       super.finalize();

--- a/packages/vaadin-form-layout/src/vaadin-form-layout.js
+++ b/packages/vaadin-form-layout/src/vaadin-form-layout.js
@@ -160,10 +160,6 @@ class FormLayoutElement extends ElementMixin(ThemableMixin(mixinBehaviors([IronR
     return 'vaadin-form-layout';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.js
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.js
@@ -49,10 +49,6 @@ class GridProElement extends InlineEditingMixin(GridElement) {
     return 'vaadin-grid-pro';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   /**
    * @protected
    */

--- a/packages/vaadin-grid-pro/test/grid-pro.test.js
+++ b/packages/vaadin-grid-pro/test/grid-pro.test.js
@@ -7,6 +7,23 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import { flushGrid, infiniteDataProvider } from './helpers.js';
 import '../vaadin-grid-pro.js';
 
+describe('custom element definition', () => {
+  let grid, tagName;
+
+  beforeEach(() => {
+    grid = fixtureSync('<vaadin-grid-pro></vaadin-grid-pro>');
+    tagName = grid.tagName.toLowerCase();
+  });
+
+  it('should be defined in custom element registry', () => {
+    expect(customElements.get(tagName)).to.be.ok;
+  });
+
+  it('should have a valid static "is" getter', () => {
+    expect(customElements.get(tagName).is).to.equal(tagName);
+  });
+});
+
 describe('basic features', () => {
   let grid, column;
 
@@ -21,10 +38,6 @@ describe('basic features', () => {
     column = grid.querySelector('vaadin-grid-column');
     grid.dataProvider = infiniteDataProvider;
     flushGrid(grid);
-  });
-
-  it('should not expose class name globally', function () {
-    expect(window.GridProElement).not.to.be.ok;
   });
 
   it('should extend GridElement', () => {

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -316,10 +316,6 @@ class GridElement extends ElementMixin(
     return 'vaadin-grid';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get observers() {
     return [
       '_columnTreeChanged(_columnTree, _columnTree.*)',

--- a/packages/vaadin-icon/src/vaadin-icon.js
+++ b/packages/vaadin-icon/src/vaadin-icon.js
@@ -93,10 +93,6 @@ class IconElement extends ThemableMixin(ElementMixin(PolymerElement)) {
     return 'vaadin-icon';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-icon/src/vaadin-iconset.js
+++ b/packages/vaadin-icon/src/vaadin-iconset.js
@@ -12,8 +12,6 @@ const iconRegistry = {};
 /**
  * `<vaadin-iconset>` is a Web Component for creating SVG icon collections.
  *
- *
- *
  * @extends HTMLElement
  * @mixes ElementMixin
  */
@@ -24,10 +22,6 @@ class IconsetElement extends ElementMixin(PolymerElement) {
 
   static get is() {
     return 'vaadin-iconset';
-  }
-
-  static get version() {
-    return '22.0.0-alpha1';
   }
 
   static get properties() {

--- a/packages/vaadin-icon/test/icon.test.js
+++ b/packages/vaadin-icon/test/icon.test.js
@@ -15,16 +15,19 @@ describe('vaadin-icon', () => {
   }
 
   describe('custom element definition', () => {
+    let tagName;
+
     beforeEach(() => {
       icon = fixtureSync('<vaadin-icon></vaadin-icon>');
+      tagName = icon.tagName.toLowerCase();
     });
 
-    it('should define a custom element with proper tag name', () => {
-      expect(customElements.get('vaadin-icon')).to.be.ok;
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
     });
 
-    it('should have a valid version number', () => {
-      expect(icon.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-item/src/vaadin-item.js
+++ b/packages/vaadin-item/src/vaadin-item.js
@@ -70,10 +70,6 @@ class ItemElement extends ItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
     return 'vaadin-item';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   constructor() {
     super();
 

--- a/packages/vaadin-item/test/item.test.js
+++ b/packages/vaadin-item/test/item.test.js
@@ -3,14 +3,19 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-item.js';
 
 describe('vaadin-item', () => {
-  let item;
+  let item, tagName;
 
   beforeEach(() => {
     item = fixtureSync('<vaadin-item>label</vaadin-item>');
+    tagName = item.tagName.toLowerCase();
   });
 
-  it('should have a valid version number', () => {
-    expect(item.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+  it('should be defined in custom element registry', () => {
+    expect(customElements.get(tagName)).to.be.ok;
+  });
+
+  it('should have a valid static "is" getter', () => {
+    expect(customElements.get(tagName).is).to.equal(tagName);
   });
 
   it('should extend item-mixin', () => {

--- a/packages/vaadin-list-box/src/vaadin-list-box.js
+++ b/packages/vaadin-list-box/src/vaadin-list-box.js
@@ -68,10 +68,6 @@ class ListBoxElement extends ElementMixin(MultiSelectListMixin(ThemableMixin(Pol
     return 'vaadin-list-box';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       // We don't need to define this property since super default is vertical,

--- a/packages/vaadin-login/src/vaadin-login-form.js
+++ b/packages/vaadin-login/src/vaadin-login-form.js
@@ -107,10 +107,6 @@ class LoginFormElement extends LoginMixin(ElementMixin(ThemableMixin(PolymerElem
     return 'vaadin-login-form';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   /** @protected */
   connectedCallback() {
     super.connectedCallback();

--- a/packages/vaadin-login/test/login-form.test.js
+++ b/packages/vaadin-login/test/login-form.test.js
@@ -68,10 +68,6 @@ describe('login form', () => {
     submitStub.resetHistory();
   });
 
-  it('should have a valid version number', () => {
-    expect(login.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-  });
-
   it('should display default strings', () => {
     const formTitleElement = formWrapper.shadowRoot.querySelector('[part="form"] h2');
     const errorTitleElement = formWrapper.shadowRoot.querySelector('[part="error-message"] h5');

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
@@ -107,10 +107,6 @@ class MenuBarElement extends ButtonsMixin(InteractionsMixin(ElementMixin(Themabl
     return 'vaadin-menu-bar';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-menu-bar/test/menu-bar.test.js
+++ b/packages/vaadin-menu-bar/test/menu-bar.test.js
@@ -19,22 +19,19 @@ const assertVisible = (elem) => {
 };
 
 describe('custom element definition', () => {
-  let menu;
+  let menu, tagName;
 
   beforeEach(() => {
     menu = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
+    tagName = menu.tagName.toLowerCase();
   });
 
-  it('should be defined with correct tag name', () => {
-    expect(customElements.get('vaadin-menu-bar')).to.be.ok;
+  it('should be defined in custom element registry', () => {
+    expect(customElements.get(tagName)).to.be.ok;
   });
 
-  it('should not expose class name globally', () => {
-    expect(window.MenuBarElement).not.to.be.ok;
-  });
-
-  it('should have a valid version number', () => {
-    expect(menu.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+  it('should have a valid static "is" getter', () => {
+    expect(customElements.get(tagName).is).to.equal(tagName);
   });
 });
 

--- a/packages/vaadin-messages/src/vaadin-message-avatar.js
+++ b/packages/vaadin-messages/src/vaadin-message-avatar.js
@@ -27,10 +27,6 @@ class MessageAvatarElement extends AvatarElement {
   static get is() {
     return 'vaadin-message-avatar';
   }
-
-  static get version() {
-    return '22.0.0-alpha1';
-  }
 }
 
 customElements.define(MessageAvatarElement.is, MessageAvatarElement);

--- a/packages/vaadin-messages/src/vaadin-message-input-button.js
+++ b/packages/vaadin-messages/src/vaadin-message-input-button.js
@@ -26,10 +26,6 @@ class MessageInputButtonElement extends ButtonElement {
   static get is() {
     return 'vaadin-message-input-button';
   }
-
-  static get version() {
-    return '22.0.0-alpha1';
-  }
 }
 
 customElements.define(MessageInputButtonElement.is, MessageInputButtonElement);

--- a/packages/vaadin-messages/src/vaadin-message-input-text-area.js
+++ b/packages/vaadin-messages/src/vaadin-message-input-text-area.js
@@ -32,10 +32,6 @@ class MessageInputTextArea extends TextArea {
     return 'vaadin-message-input-text-area';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       ariaLabel: {

--- a/packages/vaadin-messages/src/vaadin-message-input.js
+++ b/packages/vaadin-messages/src/vaadin-message-input.js
@@ -111,10 +111,6 @@ class MessageInputElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     return 'vaadin-message-input';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   /**
    * Submits the current value as an custom event named 'submit'.
    * It also clears the text input and refocuses it for sending another message.

--- a/packages/vaadin-messages/src/vaadin-message-list.js
+++ b/packages/vaadin-messages/src/vaadin-message-list.js
@@ -9,6 +9,7 @@ import '@polymer/polymer/lib/elements/dom-repeat.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import './vaadin-message.js';
+
 /**
  * `<vaadin-message-list>` is a Web Component for showing an ordered list of messages. The messages are rendered as <vaadin-message>
  *
@@ -41,6 +42,10 @@ import './vaadin-message.js';
  * @mixes ElementMixin
  */
 class MessageListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
+  static get is() {
+    return 'vaadin-message-list';
+  }
+
   static get properties() {
     return {
       /**
@@ -204,14 +209,6 @@ class MessageListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   _getIndexOfFocusableElement() {
     const index = this._messages.findIndex((e) => e.tabIndex == 0);
     return index != -1 ? index : 0;
-  }
-
-  static get is() {
-    return 'vaadin-message-list';
-  }
-
-  static get version() {
-    return '22.0.0-alpha1';
   }
 }
 

--- a/packages/vaadin-messages/src/vaadin-message.js
+++ b/packages/vaadin-messages/src/vaadin-message.js
@@ -163,10 +163,7 @@ class MessageElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     return 'vaadin-message';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
+  /** @protected */
   ready() {
     super.ready();
 

--- a/packages/vaadin-messages/test/message-input.test.js
+++ b/packages/vaadin-messages/test/message-input.test.js
@@ -12,10 +12,6 @@ describe('message-input', () => {
     button = messageInput.shadowRoot.querySelector('vaadin-message-input-button');
   });
 
-  it('should have a valid version number', () => {
-    expect(messageInput.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-  });
-
   it('message should be initialized', () => {
     expect(messageInput.shadowRoot.querySelector('vaadin-text-area')).to.be.not.undefined;
     expect(messageInput.shadowRoot.querySelector('vaadin-button')).to.be.not.undefined;

--- a/packages/vaadin-messages/test/message-list.test.js
+++ b/packages/vaadin-messages/test/message-list.test.js
@@ -51,10 +51,6 @@ describe('message-list', () => {
     ];
   });
 
-  it('should have a valid version number', () => {
-    expect(messageList.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-  });
-
   it('message list should be initially empty', () => {
     expect(messageList.items).to.be.empty;
   });

--- a/packages/vaadin-messages/test/message.test.js
+++ b/packages/vaadin-messages/test/message.test.js
@@ -16,10 +16,6 @@ describe('message', () => {
     time = message.shadowRoot.querySelector('[part="time"]');
   });
 
-  it('should have a valid version number', () => {
-    expect(message.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-  });
-
   it('avatar should be initially visible but without data', () => {
     expect(avatar.getAttribute('name')).to.be.null;
     expect(avatar.getAttribute('abbr')).to.be.null;

--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -251,10 +251,6 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
     return 'vaadin-notification';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-ordered-layout/src/vaadin-horizontal-layout.js
+++ b/packages/vaadin-ordered-layout/src/vaadin-horizontal-layout.js
@@ -82,10 +82,6 @@ class HorizontalLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)
   static get is() {
     return 'vaadin-horizontal-layout';
   }
-
-  static get version() {
-    return '22.0.0-alpha1';
-  }
 }
 
 customElements.define(HorizontalLayoutElement.is, HorizontalLayoutElement);

--- a/packages/vaadin-ordered-layout/src/vaadin-scroller.js
+++ b/packages/vaadin-ordered-layout/src/vaadin-scroller.js
@@ -66,10 +66,6 @@ class ScrollerElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       }
     };
   }
-
-  static get version() {
-    return '22.0.0-alpha1';
-  }
 }
 
 customElements.define(ScrollerElement.is, ScrollerElement);

--- a/packages/vaadin-ordered-layout/src/vaadin-vertical-layout.js
+++ b/packages/vaadin-ordered-layout/src/vaadin-vertical-layout.js
@@ -73,10 +73,6 @@ class VerticalLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)) 
   static get is() {
     return 'vaadin-vertical-layout';
   }
-
-  static get version() {
-    return '22.0.0-alpha1';
-  }
 }
 
 customElements.define(VerticalLayoutElement.is, VerticalLayoutElement);

--- a/packages/vaadin-ordered-layout/test/horizontal-layout.js
+++ b/packages/vaadin-ordered-layout/test/horizontal-layout.js
@@ -20,10 +20,6 @@ describe('vaadin-horizontal-layout', () => {
       expect(customElements.get(tagName).is).to.equal(tagName);
     });
 
-    it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-    });
-
     it('should have a box-sizing set to border-box', () => {
       expect(getComputedStyle(layout).boxSizing).to.equal('border-box');
     });

--- a/packages/vaadin-ordered-layout/test/scroller.test.js
+++ b/packages/vaadin-ordered-layout/test/scroller.test.js
@@ -24,10 +24,6 @@ describe('vaadin-scroller', () => {
       expect(customElements.get(tagName).is).to.equal(tagName);
     });
 
-    it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-    });
-
     it('should extend ThemableMixin', () => {
       expect(scroller.constructor._includeStyle).to.be.instanceOf(Function);
     });

--- a/packages/vaadin-ordered-layout/test/vertical-layout.test.js
+++ b/packages/vaadin-ordered-layout/test/vertical-layout.test.js
@@ -20,10 +20,6 @@ describe('vaadin-vertical-layout', () => {
       expect(customElements.get(tagName).is).to.equal(tagName);
     });
 
-    it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-    });
-
     it('should have a box-sizing set to border-box', () => {
       expect(getComputedStyle(layout).boxSizing).to.equal('border-box');
     });

--- a/packages/vaadin-progress-bar/src/vaadin-progress-bar.js
+++ b/packages/vaadin-progress-bar/src/vaadin-progress-bar.js
@@ -84,10 +84,6 @@ class ProgressBarElement extends ElementMixin(ThemableMixin(ProgressMixin(Polyme
   static get is() {
     return 'vaadin-progress-bar';
   }
-
-  static get version() {
-    return '22.0.0-alpha1';
-  }
 }
 
 customElements.define(ProgressBarElement.is, ProgressBarElement);

--- a/packages/vaadin-progress-bar/test/progress-bar.test.js
+++ b/packages/vaadin-progress-bar/test/progress-bar.test.js
@@ -10,10 +10,6 @@ describe('progress bar', () => {
     value = progress.shadowRoot.querySelector('[part="value"]');
   });
 
-  it('should have a valid version number', () => {
-    expect(progress.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-  });
-
   it('should have proper scale', () => {
     progress.value = 0.1;
     expect(value.getBoundingClientRect().width / progress.offsetWidth).to.be.closeTo(0.1, 0.002);

--- a/packages/vaadin-radio-button/src/vaadin-radio-button.js
+++ b/packages/vaadin-radio-button/src/vaadin-radio-button.js
@@ -107,10 +107,6 @@ class RadioButtonElement extends ElementMixin(ControlStateMixin(ThemableMixin(Ge
     return 'vaadin-radio-button';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-radio-button/test/radio-button.test.js
+++ b/packages/vaadin-radio-button/test/radio-button.test.js
@@ -25,10 +25,6 @@ describe('radio-button', () => {
     it('should have a valid static "is" getter', () => {
       expect(customElements.get(tagName).is).to.equal(tagName);
     });
-
-    it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.be.ok;
-    });
   });
 
   describe('native input', () => {

--- a/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
@@ -360,10 +360,6 @@ class RichTextEditorElement extends ElementMixin(ThemableMixin(PolymerElement)) 
     return 'vaadin-rich-text-editor';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-rich-text-editor/test/basic.test.js
+++ b/packages/vaadin-rich-text-editor/test/basic.test.js
@@ -19,12 +19,18 @@ describe('rich text editor', () => {
   });
 
   describe('custom element definition', () => {
-    it('should not expose class name globally', () => {
-      expect(window.RichTextEditorElement).not.to.be.ok;
+    let tagName;
+
+    beforeEach(() => {
+      tagName = rte.tagName.toLowerCase();
     });
 
-    it('should have a valid version number', () => {
-      expect(rte.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\*|\d+)(-(alpha|beta|rc)\d+)?$/);
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-select/src/vaadin-select.js
+++ b/packages/vaadin-select/src/vaadin-select.js
@@ -172,10 +172,6 @@ class SelectElement extends ElementMixin(
     return 'vaadin-select';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-split-layout/src/vaadin-split-layout.js
+++ b/packages/vaadin-split-layout/src/vaadin-split-layout.js
@@ -224,10 +224,6 @@ class SplitLayoutElement extends ElementMixin(
     return 'vaadin-split-layout';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-tabs/src/vaadin-tab.js
+++ b/packages/vaadin-tabs/src/vaadin-tab.js
@@ -44,10 +44,7 @@ class TabElement extends ElementMixin(ThemableMixin(ItemMixin(PolymerElement))) 
     return 'vaadin-tab';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
+  /** @protected */
   ready() {
     super.ready();
     this.setAttribute('role', 'tab');

--- a/packages/vaadin-tabs/src/vaadin-tabs.js
+++ b/packages/vaadin-tabs/src/vaadin-tabs.js
@@ -147,10 +147,6 @@ class TabsElement extends ElementMixin(
     return 'vaadin-tabs';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-tabs/test/tabs.test.js
+++ b/packages/vaadin-tabs/test/tabs.test.js
@@ -35,10 +35,6 @@ describe('tabs', () => {
     it('should have a valid static "is" getter', () => {
       expect(customElements.get(tagName).is).to.equal(tagName);
     });
-
-    it('should have a valid version number', () => {
-      expect(customElements.get(tagName).version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
-    });
   });
 
   describe('items', () => {

--- a/packages/vaadin-text-field/src/vaadin-text-field.js
+++ b/packages/vaadin-text-field/src/vaadin-text-field.js
@@ -114,10 +114,6 @@ class TextFieldElement extends ElementMixin(TextFieldMixin(ControlStateMixin(The
     return 'vaadin-text-field';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-time-picker/src/vaadin-time-picker.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker.js
@@ -132,9 +132,6 @@ class TimePickerElement extends ElementMixin(ControlStateMixin(ThemableMixin(Pol
   static get is() {
     return 'vaadin-time-picker';
   }
-  static get version() {
-    return '22.0.0-alpha1';
-  }
 
   static get properties() {
     return {

--- a/packages/vaadin-time-picker/test/time-picker.test.js
+++ b/packages/vaadin-time-picker/test/time-picker.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { arrowDown, arrowUp, enter, esc, fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
-import { TimePickerElement } from '../vaadin-time-picker.js';
+import '../vaadin-time-picker.js';
 
 describe('time-picker', () => {
   let timePicker, dropdown, inputElement;
@@ -17,17 +17,19 @@ describe('time-picker', () => {
     inputElement = timePicker.__inputElement;
   });
 
-  describe('custom element', () => {
-    it('should have a valid localName', () => {
-      expect(timePicker.localName).to.be.equal('vaadin-time-picker');
+  describe('custom element definition', () => {
+    let tagName;
+
+    beforeEach(() => {
+      tagName = timePicker.tagName.toLowerCase();
     });
 
-    it('should be registered in Vaadin namespace', () => {
-      expect(TimePickerElement.is).to.be.equal('vaadin-time-picker');
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
     });
 
-    it('should have a valid version', () => {
-      expect(TimePickerElement.version).to.be.ok;
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 

--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -122,10 +122,6 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     return 'vaadin-upload';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -61,10 +61,6 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     return 'vaadin-virtual-list';
   }
 
-  static get version() {
-    return '22.0.0-alpha1';
-  }
-
   static get properties() {
     return {
       /**

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -42,7 +42,7 @@ async function main() {
   const fromRegex = new RegExp(`'${oldVersion.split('.').join('\\.')}'`, 'g');
   const newVersion = `'${version.replace(/^v/, '')}'`;
   const results = await replace({
-    files: ['packages/**/version.{js,ts}', 'packages/**/src/*.{js,ts}'],
+    files: ['packages/**/version.{js,ts}', 'packages/vaadin-element-mixin/*.{js,ts}'],
     from: fromRegex,
     to: newVersion
   });


### PR DESCRIPTION
## Description

All the components use the same version now, so we don't need to repeat ourselves.

Fixes #2366

## Type of change

- Internal change