### PR TITLE
refactor: split code into smaller methods

### DIFF
--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -47,7 +47,7 @@ export const ButtonsMixin = (superClass) =>
     connectedCallback() {
       super.connectedCallback();
 
-      this._setButtonAttrs(this._overflow);
+      this._initButtonAttrs(this._overflow);
       this.addEventListener('iron-resize', this.__boundOnResize);
     }
 
@@ -193,7 +193,7 @@ export const ButtonsMixin = (superClass) =>
         button.textContent = item.text;
       }
 
-      if (this.theme && this.theme !== '') {
+      if (this.theme) {
         button.setAttribute('theme', this.theme);
       }
 
@@ -201,23 +201,19 @@ export const ButtonsMixin = (superClass) =>
     }
 
     /** @protected */
-    _setButtonDisabled(button, disabled) {
-      if (disabled) {
-        button.disabled = true;
-        button.setAttribute('tabindex', '-1');
-      } else {
-        button.setAttribute('tabindex', '0');
-      }
-    }
-
-    /** @protected */
-    _setButtonAttrs(button) {
+    _initButtonAttrs(button) {
       button.setAttribute('role', 'menuitem');
 
       if (button === this._overflow || (button.item && button.item.children)) {
         button.setAttribute('aria-haspopup', 'true');
         button.setAttribute('aria-expanded', 'false');
       }
+    }
+
+    /** @protected */
+    _setButtonDisabled(button, disabled) {
+      button.disabled = true;
+      button.setAttribute('tabindex', disabled ? '-1' : '0');
     }
 
     /** @protected */
@@ -259,7 +255,7 @@ export const ButtonsMixin = (superClass) =>
         const button = this._initButton(item);
         this._appendButton(button);
         this._setButtonDisabled(button, item.disabled);
-        this._setButtonAttrs(button);
+        this._initButtonAttrs(button);
       });
 
       this.__detectOverflow();

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -30,17 +30,32 @@ export const ButtonsMixin = (superClass) =>
       return ['_menuItemsChanged(items, items.splices)'];
     }
 
+    constructor() {
+      super();
+
+      this.__boundOnResize = this.__onResize.bind(this);
+    }
+
     /** @protected */
     ready() {
       super.ready();
 
       this.setAttribute('role', 'menubar');
+    }
 
-      this.addEventListener('iron-resize', () => this.__onResize());
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
 
-      this._overflow.setAttribute('role', 'menuitem');
-      this._overflow.setAttribute('aria-haspopup', 'true');
-      this._overflow.setAttribute('aria-expanded', 'false');
+      this._setButtonAttrs(this._overflow);
+      this.addEventListener('iron-resize', this.__boundOnResize);
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+
+      this.removeEventListener('iron-resize', this.__boundOnResize);
     }
 
     /**
@@ -85,7 +100,7 @@ export const ButtonsMixin = (superClass) =>
       // reset all buttons in the menu bar and the overflow button
       for (let i = 0; i < buttons.length; i++) {
         const btn = buttons[i];
-        btn.disabled = btn.item.disabled;
+        btn.disabled = btn.item && btn.item.disabled;
         btn.style.visibility = '';
         btn.style.position = '';
 
@@ -151,59 +166,100 @@ export const ButtonsMixin = (superClass) =>
       this.__renderButtons(this.items);
     }
 
-    /** @private */
-    __renderButtons(items = []) {
+    /** @protected */
+    _removeButtons() {
       const container = this._container;
-      const overflow = this._overflow;
 
       while (container.children.length > 1) {
         container.removeChild(container.firstElementChild);
       }
+    }
+
+    /** @protected */
+    _initButton(item) {
+      const button = document.createElement('vaadin-menu-bar-button');
+      button.setAttribute('part', 'menu-bar-button');
+
+      const itemCopy = Object.assign({}, item);
+      button.item = itemCopy;
+
+      if (item.component) {
+        const component = this.__getComponent(itemCopy);
+        itemCopy.component = component;
+        // save item for overflow menu
+        component.item = itemCopy;
+        button.appendChild(component);
+      } else if (item.text) {
+        button.textContent = item.text;
+      }
+
+      if (this.theme && this.theme !== '') {
+        button.setAttribute('theme', this.theme);
+      }
+
+      return button;
+    }
+
+    /** @protected */
+    _setButtonDisabled(button, disabled) {
+      if (disabled) {
+        button.disabled = true;
+        button.setAttribute('tabindex', '-1');
+      } else {
+        button.setAttribute('tabindex', '0');
+      }
+    }
+
+    /** @protected */
+    _setButtonAttrs(button) {
+      button.setAttribute('role', 'menuitem');
+
+      if (button === this._overflow || (button.item && button.item.children)) {
+        button.setAttribute('aria-haspopup', 'true');
+        button.setAttribute('aria-expanded', 'false');
+      }
+    }
+
+    /** @protected */
+    _appendButton(button) {
+      this._container.insertBefore(button, this._overflow);
+    }
+
+    /** @private */
+    __getComponent(item) {
+      const itemComponent = item.component;
+      let component;
+
+      const isElement = itemComponent instanceof HTMLElement;
+      // use existing item component, if any
+      if (isElement && itemComponent.localName === 'vaadin-context-menu-item') {
+        component = itemComponent;
+      } else {
+        component = document.createElement('vaadin-context-menu-item');
+        component.appendChild(isElement ? itemComponent : document.createElement(itemComponent));
+      }
+      if (item.text) {
+        const node = component.firstChild || component;
+        node.textContent = item.text;
+      }
+      component.setAttribute('theme', 'menu-bar-item');
+      return component;
+    }
+
+    /** @private */
+    __renderButtons(items = []) {
+      this._removeButtons();
+
+      /* Empty array, do nothing */
+      if (items.length === 0) {
+        return;
+      }
 
       items.forEach((item) => {
-        const button = document.createElement('vaadin-menu-bar-button');
-        const itemCopy = Object.assign({}, item);
-        button.item = itemCopy;
-
-        const itemComponent = item.component;
-        if (itemComponent) {
-          let component;
-          const isElement = itemComponent instanceof HTMLElement;
-          // use existing item component, if any
-          if (isElement && itemComponent.localName === 'vaadin-context-menu-item') {
-            component = itemComponent;
-          } else {
-            component = document.createElement('vaadin-context-menu-item');
-            component.appendChild(isElement ? itemComponent : document.createElement(itemComponent));
-          }
-          if (item.text) {
-            const node = component.firstChild || component;
-            node.textContent = item.text;
-          }
-          itemCopy.component = component;
-          // save item for overflow menu
-          component.item = itemCopy;
-          component.setAttribute('theme', 'menu-bar-item');
-          button.appendChild(component);
-        } else if (item.text) {
-          button.textContent = item.text;
-        }
-        if (item.disabled) {
-          button.disabled = true;
-          button.setAttribute('tabindex', '-1');
-        } else {
-          button.setAttribute('tabindex', '0');
-        }
-        if (button.item.children) {
-          button.setAttribute('aria-haspopup', 'true');
-          button.setAttribute('aria-expanded', 'false');
-        }
-        button.setAttribute('part', 'menu-bar-button');
-        if (this.theme && this.theme !== '') {
-          button.setAttribute('theme', this.theme);
-        }
-        container.insertBefore(button, overflow);
-        button.setAttribute('role', 'menuitem');
+        const button = this._initButton(item);
+        this._appendButton(button);
+        this._setButtonDisabled(button, item.disabled);
+        this._setButtonAttrs(button);
       });
 
       this.__detectOverflow();

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -65,18 +65,34 @@ export const InteractionsMixin = (superClass) =>
       }
     }
 
+    /** @protected */
+    _setExpanded(button, expanded) {
+      button.toggleAttribute('expanded', expanded);
+      button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    }
+
+    /** @protected */
+    _setTabindex(button, focused) {
+      button.setAttribute('tabindex', focused ? '0' : '-1');
+    }
+
     /** @private */
     _focusButton(button) {
       button.focus();
       button.setAttribute('focus-ring', '');
       this._buttons.forEach((btn) => {
-        btn.setAttribute('tabindex', btn === button ? '0' : '-1');
+        this._setTabindex(btn, btn === button);
       });
     }
 
     /** @private */
     _getButtonFromEvent(e) {
       return Array.from(e.composedPath()).filter((el) => el.localName === 'vaadin-menu-bar-button')[0];
+    }
+
+    /** @private */
+    _getCurrentButton() {
+      return this.shadowRoot.activeElement || this._expandedButton;
     }
 
     /**
@@ -87,7 +103,7 @@ export const InteractionsMixin = (superClass) =>
       const target = this.shadowRoot.querySelector('[part$="button"][tabindex="0"]');
       if (target) {
         this._buttons.forEach((btn) => {
-          btn.setAttribute('tabindex', btn === target ? '0' : '-1');
+          this._setTabindex(btn, btn === target);
         });
       }
     }
@@ -130,7 +146,7 @@ export const InteractionsMixin = (superClass) =>
       // IE names for arrows do not include the Arrow prefix
       const key = event.key.replace(/^Arrow/, '');
       const buttons = this._buttons;
-      const currentBtn = this.shadowRoot.activeElement || this._expandedButton;
+      const currentBtn = this._getCurrentButton();
       const currentIdx = buttons.indexOf(currentBtn);
       let idx;
       let increment;
@@ -314,8 +330,7 @@ export const InteractionsMixin = (superClass) =>
           })
         );
 
-        button.setAttribute('expanded', '');
-        button.setAttribute('aria-expanded', 'true');
+        this._setExpanded(button, true);
       });
 
       if (options.focusLast) {
@@ -376,8 +391,7 @@ export const InteractionsMixin = (superClass) =>
     __deactivateButton(restoreFocus) {
       const button = this._expandedButton;
       if (button && button.hasAttribute('expanded')) {
-        button.removeAttribute('expanded');
-        button.setAttribute('aria-expanded', 'false');
+        this._setExpanded(button, false);
         if (restoreFocus) {
           this._focusButton(button);
         }


### PR DESCRIPTION
## Description

Refactored `vaadin-menu-bar` mixins to move some code into separate methods.

The idea behind this approach is to override some of them when updating component to place buttons in light DOM.
At the same time, most of the implementation will remain unchanged to make the diff smaller and easier to review.

Related to #2227

## Type of change

- Internal change