### PR TITLE
feat: add i18n property to password-field (#2346)

### DIFF
--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -17,6 +17,12 @@ import './vaadin-dialog-layout.js';
 import './vaadin-crud-grid.js';
 import './vaadin-crud-form.js';
 
+const HOST_PROPS = {
+  save: [{ attr: 'disabled', prop: '__isDirty', parseProp: (prop) => !prop }, { prop: 'i18n.saveItem' }],
+  cancel: [{ prop: 'i18n.cancel' }],
+  delete: [{ attr: 'hidden', prop: '__isNew', parseProp: (prop) => prop }, { prop: 'i18n.deleteItem' }]
+};
+
 /**
  * `<vaadin-crud>` is a Web Component for [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operations.
  *
@@ -213,6 +219,9 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         <vaadin-dialog-layout
           theme$="[[theme]]"
           form="[[_form]]"
+          save-button="[[_saveButton]]"
+          cancel-button="[[_cancelButton]]"
+          delete-button="[[_deleteButton]]"
           id="dialog"
           no-close-on-outside-click="[[__isDirty]]"
           no-close-on-esc="[[__isDirty]]"
@@ -233,14 +242,20 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
             </slot>
           </div>
 
-          <vaadin-button slot="footer" on-click="__save" theme="primary" disabled="[[!__isDirty]]"
-            >[[i18n.saveItem]]</vaadin-button
-          >
-          <vaadin-button slot="footer" on-click="__cancel" theme="tertiary">[[i18n.cancel]]</vaadin-button>
+          <slot name="save-button">
+            <vaadin-button id="save" on-click="__save" theme="primary" disabled$="[[!__isDirty]]"
+              >[[i18n.saveItem]]</vaadin-button
+            >
+          </slot>
+          <slot name="cancel-button">
+            <vaadin-button id="cancel" on-click="__cancelBound" theme="tertiary">[[i18n.cancel]]</vaadin-button>
+          </slot>
           <div slot="footer" style="flex: auto;"></div>
-          <vaadin-button slot="footer" on-click="__delete" theme="tertiary error" hidden="[[__isNew]]"
-            >[[i18n.deleteItem]]</vaadin-button
-          >
+          <slot name="delete-button">
+            <vaadin-button id="delete" on-click="__delete" theme="tertiary error" hidden$="[[__isNew]]"
+              >[[i18n.deleteItem]]</vaadin-button
+            >
+          </slot>
         </vaadin-dialog-layout>
       </div>
 
@@ -297,6 +312,33 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
       _form: {
         type: HTMLElement,
         observer: '__onFormChange'
+      },
+
+      /**
+       * A reference to the save button which will be teleported to the dialog
+       * @private
+       */
+      _saveButton: {
+        type: HTMLElement,
+        observer: '__onSaveButtonChange'
+      },
+
+      /**
+       * A reference to the save button which will be teleported to the dialog
+       * @private
+       */
+      _deleteButton: {
+        type: HTMLElement,
+        observer: '__onDeleteButtonChange'
+      },
+
+      /**
+       * A reference to the save button which will be teleported to the dialog
+       * @private
+       */
+      _cancelButton: {
+        type: HTMLElement,
+        observer: '__onCancelButtonChange'
       },
 
       /**
@@ -513,7 +555,17 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   static get observers() {
-    return ['__onI18Change(i18n, _grid)', '__onEditOnClickChange(editOnClick, _grid)'];
+    return [
+      '__onI18Change(i18n, _grid)',
+      '__onEditOnClickChange(editOnClick, _grid)',
+      '__hostPropsChanged(' +
+        HOST_PROPS.save.map(({ prop }) => prop).join(',') +
+        ',' +
+        HOST_PROPS.cancel.map(({ prop }) => prop).join(',') +
+        ',' +
+        HOST_PROPS.delete.map(({ prop }) => prop).join(',') +
+        ')'
+    ];
   }
 
   /** @protected */
@@ -539,12 +591,18 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     super.ready();
     this.__editListener = (e) => this.__onCrudGridEdit(e);
     this.__changeListener = (e) => this.__onFormChanges(e);
+    this.__saveBound = this.__save.bind(this);
+    this.__cancelBound = this.__cancel.bind(this);
+    this.__deleteBound = this.__delete.bind(this);
     this.__gridSizeListener = this.__onGridSizeChanges.bind(this);
     this.__boundEditOnClickListener = this.__editOnClickListener.bind(this);
     this._grid = this.$.grid;
     this._form = this.$.form;
-    this.$.dialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-outside-click', this.__cancel.bind(this));
-    this.$.dialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-escape-press', this.__cancel.bind(this));
+    this._saveButton = this.$.save;
+    this._deleteButton = this.$.delete;
+    this._cancelButton = this.$.cancel;
+    this.$.dialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-outside-click', this.__cancelBound);
+    this.$.dialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-escape-press', this.__cancelBound);
   }
 
   /** @private */
@@ -606,13 +664,21 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   __onDomChange(nodes) {
     nodes.forEach((node) => {
       if (node.getAttribute) {
-        if (node.getAttribute('slot') == 'grid') {
+        const slotAttributeValue = node.getAttribute('slot');
+        if (!slotAttributeValue) {
+          return;
+        }
+
+        if (slotAttributeValue == 'grid') {
           // Force to remove listener on previous grid first
           this.__onEditOnClickChange(false, this._grid);
           this._grid = node;
           this.__onEditOnClickChange(this.editOnClick, this._grid);
-        } else if (node.getAttribute('slot') == 'form') {
+        } else if (slotAttributeValue == 'form') {
           this._form = node;
+        } else if (slotAttributeValue.indexOf('button') >= 0) {
+          const [button] = slotAttributeValue.split('-');
+          this[`_${button}Button`] = node;
         }
       }
     });
@@ -669,6 +735,62 @@ class CrudElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
     form.addEventListener('change', this.__changeListener);
     form.addEventListener('input', this.__changeListener);
+  }
+
+  __onSaveButtonChange(save, old) {
+    this.__setupSlottedButton(save, old, this.__saveBound);
+  }
+
+  __onDeleteButtonChange(deleteButton, old) {
+    this.__setupSlottedButton(deleteButton, old, this.__deleteBound);
+  }
+
+  __onCancelButtonChange(cancel, old) {
+    this.__setupSlottedButton(cancel, old, this.__cancelBound);
+  }
+
+  __setupSlottedButton(slottedButton, currentButton, clickListener) {
+    if (currentButton && currentButton.parentElement) {
+      currentButton.parentElement.removeChild(currentButton);
+    }
+
+    if (slottedButton.parentElement === this) {
+      slottedButton.addEventListener('click', clickListener);
+    }
+  }
+
+  __hostPropsChanged() {
+    this.__propagateHostAttributes();
+  }
+
+  __propagateHostAttributes() {
+    this.__propagateHostAttributesToButton(this._saveButton, HOST_PROPS.save);
+    this.__propagateHostAttributesToButton(this._cancelButton, HOST_PROPS.cancel);
+    this.__propagateHostAttributesToButton(this._deleteButton, HOST_PROPS.delete);
+  }
+
+  __propagateHostAttributesToButton(button, props) {
+    if (button) {
+      props.forEach(({ attr, prop, parseProp }) => {
+        if (prop.indexOf('i18n') >= 0) {
+          button.textContent = this.i18n[prop.split('.')[1]];
+        } else {
+          this._setOrToggleAttribute(attr, parseProp(this[prop]), button);
+        }
+      });
+    }
+  }
+
+  _setOrToggleAttribute(name, value, node) {
+    if (!name || !node) {
+      return;
+    }
+
+    if (value) {
+      node.setAttribute(name, typeof value === 'boolean' ? '' : value);
+    } else {
+      node.removeAttribute(name);
+    }
   }
 
   /** @private */

--- a/packages/vaadin-crud/src/vaadin-dialog-layout.js
+++ b/packages/vaadin-crud/src/vaadin-dialog-layout.js
@@ -128,6 +128,15 @@ class DialogLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
       /** Reference to the edit form */
       form: Object,
 
+      /** Reference to the edit save button */
+      saveButton: Object,
+
+      /** Reference to the edit delete button */
+      deleteButton: Object,
+
+      /** Reference to the edit cancel button */
+      cancelButton: Object,
+
       mobile: {
         type: Boolean,
         observer: '__mobileChanged',
@@ -179,8 +188,24 @@ class DialogLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
     // Teleport edit form
     target.appendChild(this.form);
 
+    // This order is important so the spacing (coming from this.__footer) is correctly placed
+    if (this.saveButton) {
+      this.saveButton.setAttribute('slot', 'footer');
+      target.appendChild(this.saveButton);
+    }
+
+    if (this.cancelButton) {
+      this.cancelButton.setAttribute('slot', 'footer');
+      target.appendChild(this.cancelButton);
+    }
+
     // Teleport footer nodes
     this.__footer.forEach((node) => target.appendChild(node));
+
+    if (this.deleteButton) {
+      this.deleteButton.setAttribute('slot', 'footer');
+      target.appendChild(this.deleteButton);
+    }
 
     // Wait to set label until slotted element has been moved.
     setTimeout(() => {

--- a/packages/vaadin-crud/test/crud.test.js
+++ b/packages/vaadin-crud/test/crud.test.js
@@ -133,513 +133,525 @@ describe('crud', () => {
       expect(crud._form._fields).to.be.not.ok;
     });
   });
-
-  describe('items', () => {
-    beforeEach(async () => {
-      crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
-      crud.items = [{ foo: 'bar' }];
-      await nextRender(crud._grid);
-    });
-
-    describe('editor header', () => {
-      it('should have new item title', () => {
-        crud.$.new.click();
-        expect(editorHeader().textContent).to.be.equal('New item');
-      });
-
-      it('should have edit item title', () => {
-        crud.editedItem = crud.items[0];
-        expect(editorHeader().textContent).to.be.equal('Edit item');
-      });
-
-      it('should change to new item title', () => {
-        crud.editedItem = crud.items[0];
-        expect(editorHeader().textContent).to.be.equal('Edit item');
-        crud.$.new.click();
-        expect(editorHeader().textContent).to.be.equal('New item');
-      });
-    });
-
-    describe('actions', () => {
-      it('should save an edited item', () => {
-        edit(crud.items[0]);
-        crud._form._fields[0].value = 'baz';
-        change();
-        btnSave().click();
-        expect(crud.items[0].foo).to.be.equal('baz');
-      });
-
-      it('should save a new item', () => {
-        crud.$.new.click();
-        crud._form._fields[0].value = 'baz';
-        change();
-        btnSave().click();
-        expect(crud.items[1].foo).to.be.equal('baz');
-      });
-
-      it('should delete a item', () => {
-        edit(crud.items[0]);
-        btnDelete().click();
-        btnConfDialog(crud.$.confirmDelete, 'confirm').click();
-        expect(crud.items.length).to.be.equal(0);
-      });
-
-      it('should notify size changes', (done) => {
-        listenOnce(crud, 'size-changed', () => {
-          expect(crud.size).to.be.equal(2);
-          done();
-        });
-        crud.items = [{ foo: 'bar' }, { foo: 'baz' }];
-      });
-
-      it('should notify editedItem changes', (done) => {
-        listenOnce(crud, 'edited-item-changed', () => {
-          expect(crud.editedItem).to.deep.equal({ foo: 'bar' });
-          done();
-        });
-        edit(crud.items[0]);
-      });
-
-      it('should save a new pre-filled item', () => {
-        crud.editedItem = { foo: 'baz' };
-        crud._form._fields[0].value = 'baz';
-        change();
-        btnSave().click();
-        expect(crud.items[1].foo).to.be.equal('baz');
-      });
-
-      it('should not delete any item if item was not in items array', () => {
-        crud.editedItem = { foo: 'baz' };
-        btnDelete().click();
-        btnConfDialog(crud.$.confirmDelete, 'confirm').click();
-        expect(crud.items.length).to.be.equal(1);
-      });
-
-      it('should highlight the edited item', () => {
-        edit(crud.items[0]);
-        expect(crud._grid.selectedItems).to.eql([crud.items[0]]);
-      });
-
-      it('should clear highlighting of the edited item after closing the editor', () => {
-        edit(crud.items[0]);
-        crud.editorOpened = false;
-        expect(crud._grid.selectedItems).to.eql([]);
-      });
-    });
-
-    describe('confirmation', () => {
-      afterEach(async () => {
-        crud.$.dialog.opened = crud.$.confirmCancel.opened = crud.$.confirmDelete.opened = false;
-        await aTimeout(0);
-      });
-
-      describe('cancel', () => {
-        it('should not ask for confirmation on cancel when not modified', () => {
-          edit(crud.items[0]);
-          btnCancel().click();
-          expect(crud.$.confirmCancel.opened).not.to.be.ok;
-        });
-
-        it('should not ask for confirmation on cancel when not modified - click out', () => {
-          edit(crud.items[0]);
-          crud.$.new.click();
-          expect(crud.$.confirmCancel.opened).not.to.be.ok;
-        });
-
-        it('should not ask for confirmation on cancel when not modified - esc', () => {
-          edit(crud.items[0]);
-          crud.$.dialog.$.dialog.$.overlay.dispatchEvent(new CustomEvent('vaadin-overlay-escape-press'));
-          expect(crud.$.confirmCancel.opened).not.to.be.ok;
-        });
-
-        it('should ask for confirmation on cancel when modified', () => {
-          edit(crud.items[0]);
-          change();
-          btnCancel().click();
-          expect(crud.$.confirmCancel.opened).to.be.true;
-        });
-
-        it('should ask for confirmation on cancel when modified - click out', () => {
-          edit(crud.items[0]);
-          change();
-          crud.$.new.click();
-          expect(crud.$.confirmCancel.opened).to.be.true;
-        });
-
-        it('should ask for confirmation on cancel when modified - esc', () => {
-          edit(crud.items[0]);
-          change();
-          crud.$.dialog.$.dialog.$.overlay.dispatchEvent(new CustomEvent('vaadin-overlay-escape-press'));
-          expect(crud.$.confirmCancel.opened).to.be.true;
-        });
-
-        it('should continue editing when closing confirmation with confirm', () => {
-          edit(crud.items[0]);
-          change();
-          btnCancel().click();
-          btnConfDialog(crud.$.confirmCancel, 'cancel').click();
-          expect(crud.$.confirmCancel.opened).not.to.be.ok;
-          expect(crud.$.dialog.opened).to.be.true;
-        });
-
-        it('should cancel editing when closing confirmation with reject', () => {
-          edit(crud.items[0]);
-          change();
-          btnCancel().click();
-          btnConfDialog(crud.$.confirmCancel, 'confirm').click();
-          expect(crud.$.confirmCancel.opened).not.to.be.ok;
-          expect(crud.$.dialog.opened).not.to.be.ok;
-        });
-
-        it('should trigger "cancel" only once after user hits "Cancel"', async () => {
-          crud.editOnClick = true;
-
-          const cancelSpyListener = sinon.spy();
-          crud.addEventListener('cancel', cancelSpyListener);
-
-          crud._grid.activeItem = crud.items[0];
-          btnCancel().click();
-          await aTimeout(0);
-          expect(cancelSpyListener.calledOnce).to.be.ok;
-        });
-
-        it('should trigger "cancel" only once after user clicks out', async () => {
-          crud.editOnClick = true;
-
-          const cancelSpyListener = sinon.spy();
-          crud.addEventListener('cancel', cancelSpyListener);
-
-          crud._grid.activeItem = crud.items[0];
-          crud.$.new.dispatchEvent(
-            new CustomEvent('click', {
-              bubbles: true,
-              cancelable: true,
-              composed: true
-            })
+  ['default', 'slotted buttons'].forEach((mode) => {
+    describe(`[${mode}] items`, () => {
+      beforeEach(async () => {
+        if (mode === 'default') {
+          crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
+        } else {
+          crud = fixtureSync(
+            `<vaadin-crud style="width: 300px;">
+              <vaadin-button slot="save-button"></vaadin-button>
+              <vaadin-button slot="cancel-button"></vaadin-button>
+              <vaadin-button slot="delete-button"></vaadin-button>
+            </vaadin-crud>`
           );
+        }
+        crud.items = [{ foo: 'bar' }];
+        await nextRender(crud._grid);
+      });
 
-          await aTimeout(0);
-          expect(cancelSpyListener.calledOnce).to.be.ok;
+      describe('editor header', () => {
+        it('should have new item title', () => {
+          crud.$.new.click();
+          expect(editorHeader().textContent).to.be.equal('New item');
         });
 
-        it('should trigger "cancel" only once after user hits esc', async () => {
-          crud.editOnClick = true;
-
-          const cancelSpyListener = sinon.spy();
-          crud.addEventListener('cancel', cancelSpyListener);
-
-          crud._grid.activeItem = crud.items[0];
-          crud.$.dialog.$.dialog.$.overlay.dispatchEvent(new CustomEvent('vaadin-overlay-escape-press'));
-          await aTimeout(0);
-          expect(cancelSpyListener.calledOnce).to.be.ok;
+        it('should have edit item title', () => {
+          crud.editedItem = crud.items[0];
+          expect(editorHeader().textContent).to.be.equal('Edit item');
         });
 
-        it('should not trigger "cancel" after user hits "Save"', async () => {
-          crud.editOnClick = true;
+        it('should change to new item title', () => {
+          crud.editedItem = crud.items[0];
+          expect(editorHeader().textContent).to.be.equal('Edit item');
+          crud.$.new.click();
+          expect(editorHeader().textContent).to.be.equal('New item');
+        });
+      });
 
-          const cancelSpyListener = sinon.spy();
-          crud.addEventListener('cancel', cancelSpyListener);
-
-          crud._grid.activeItem = crud.items[0];
+      describe('actions', () => {
+        it('should save an edited item', () => {
           edit(crud.items[0]);
+          crud._form._fields[0].value = 'baz';
           change();
           btnSave().click();
-          await aTimeout(0);
-          expect(cancelSpyListener.notCalled).to.be.ok;
-        });
-      });
-
-      describe('delete', () => {
-        it('should ask for confirmation on delete', () => {
-          edit(crud.items[0]);
-          btnDelete().click();
-          expect(crud.$.confirmDelete.opened).to.be.true;
+          expect(crud.items[0].foo).to.be.equal('baz');
         });
 
-        it('should continue editing when closing confirmation with cancel', () => {
-          edit(crud.items[0]);
-          btnDelete().click();
-          btnConfDialog(crud.$.confirmDelete, 'cancel').click();
-          expect(crud.$.confirmDelete.opened).not.to.be.ok;
-          expect(crud.$.dialog.opened).to.be.true;
+        it('should save a new item', () => {
+          crud.$.new.click();
+          crud._form._fields[0].value = 'baz';
+          change();
+          btnSave().click();
+          expect(crud.items[1].foo).to.be.equal('baz');
         });
 
-        it('should delete when closing confirmation with confirm', () => {
+        it('should delete a item', () => {
           edit(crud.items[0]);
           btnDelete().click();
           btnConfDialog(crud.$.confirmDelete, 'confirm').click();
-          expect(crud.$.confirmDelete.opened).not.to.be.ok;
-          expect(crud.$.dialog.opened).not.to.be.ok;
+          expect(crud.items.length).to.be.equal(0);
+        });
+
+        it('should notify size changes', (done) => {
+          listenOnce(crud, 'size-changed', () => {
+            expect(crud.size).to.be.equal(2);
+            done();
+          });
+          crud.items = [{ foo: 'bar' }, { foo: 'baz' }];
+        });
+
+        it('should notify editedItem changes', (done) => {
+          listenOnce(crud, 'edited-item-changed', () => {
+            expect(crud.editedItem).to.deep.equal({ foo: 'bar' });
+            done();
+          });
+          edit(crud.items[0]);
+        });
+
+        it('should save a new pre-filled item', () => {
+          crud.editedItem = { foo: 'baz' };
+          crud._form._fields[0].value = 'baz';
+          change();
+          btnSave().click();
+          expect(crud.items[1].foo).to.be.equal('baz');
+        });
+
+        it('should not delete any item if item was not in items array', () => {
+          crud.editedItem = { foo: 'baz' };
+          btnDelete().click();
+          btnConfDialog(crud.$.confirmDelete, 'confirm').click();
+          expect(crud.items.length).to.be.equal(1);
+        });
+
+        it('should highlight the edited item', () => {
+          edit(crud.items[0]);
+          expect(crud._grid.selectedItems).to.eql([crud.items[0]]);
+        });
+
+        it('should clear highlighting of the edited item after closing the editor', () => {
+          edit(crud.items[0]);
+          crud.editorOpened = false;
+          expect(crud._grid.selectedItems).to.eql([]);
         });
       });
-    });
 
-    describe('flags', () => {
-      afterEach(async () => {
-        crud.$.dialog.opened = false;
-        await aTimeout(0);
+      describe('confirmation', () => {
+        afterEach(async () => {
+          crud.$.dialog.opened = crud.$.confirmCancel.opened = crud.$.confirmDelete.opened = false;
+          await aTimeout(0);
+        });
+
+        describe('cancel', () => {
+          it('should not ask for confirmation on cancel when not modified', () => {
+            edit(crud.items[0]);
+            btnCancel().click();
+            expect(crud.$.confirmCancel.opened).not.to.be.ok;
+          });
+
+          it('should not ask for confirmation on cancel when not modified - click out', () => {
+            edit(crud.items[0]);
+            crud.$.new.click();
+            expect(crud.$.confirmCancel.opened).not.to.be.ok;
+          });
+
+          it('should not ask for confirmation on cancel when not modified - esc', () => {
+            edit(crud.items[0]);
+            crud.$.dialog.$.dialog.$.overlay.dispatchEvent(new CustomEvent('vaadin-overlay-escape-press'));
+            expect(crud.$.confirmCancel.opened).not.to.be.ok;
+          });
+
+          it('should ask for confirmation on cancel when modified', () => {
+            edit(crud.items[0]);
+            change();
+            btnCancel().click();
+            expect(crud.$.confirmCancel.opened).to.be.true;
+          });
+
+          it('should ask for confirmation on cancel when modified - click out', () => {
+            edit(crud.items[0]);
+            change();
+            crud.$.new.click();
+            expect(crud.$.confirmCancel.opened).to.be.true;
+          });
+
+          it('should ask for confirmation on cancel when modified - esc', () => {
+            edit(crud.items[0]);
+            change();
+            crud.$.dialog.$.dialog.$.overlay.dispatchEvent(new CustomEvent('vaadin-overlay-escape-press'));
+            expect(crud.$.confirmCancel.opened).to.be.true;
+          });
+
+          it('should continue editing when closing confirmation with confirm', () => {
+            edit(crud.items[0]);
+            change();
+            btnCancel().click();
+            btnConfDialog(crud.$.confirmCancel, 'cancel').click();
+            expect(crud.$.confirmCancel.opened).not.to.be.ok;
+            expect(crud.$.dialog.opened).to.be.true;
+          });
+
+          it('should cancel editing when closing confirmation with reject', () => {
+            edit(crud.items[0]);
+            change();
+            btnCancel().click();
+            btnConfDialog(crud.$.confirmCancel, 'confirm').click();
+            expect(crud.$.confirmCancel.opened).not.to.be.ok;
+            expect(crud.$.dialog.opened).not.to.be.ok;
+          });
+
+          it('should trigger "cancel" only once after user hits "Cancel"', async () => {
+            crud.editOnClick = true;
+
+            const cancelSpyListener = sinon.spy();
+            crud.addEventListener('cancel', () => {
+              cancelSpyListener();
+            });
+
+            crud._grid.activeItem = crud.items[0];
+            btnCancel().click();
+            await aTimeout(0);
+            expect(cancelSpyListener.calledOnce).to.be.ok;
+          });
+
+          it('should trigger "cancel" only once after user clicks out', async () => {
+            crud.editOnClick = true;
+
+            const cancelSpyListener = sinon.spy();
+            crud.addEventListener('cancel', cancelSpyListener);
+
+            crud._grid.activeItem = crud.items[0];
+            crud.$.new.dispatchEvent(
+              new CustomEvent('click', {
+                bubbles: true,
+                cancelable: true,
+                composed: true
+              })
+            );
+
+            await aTimeout(0);
+            expect(cancelSpyListener.calledOnce).to.be.ok;
+          });
+
+          it('should trigger "cancel" only once after user hits esc', async () => {
+            crud.editOnClick = true;
+
+            const cancelSpyListener = sinon.spy();
+            crud.addEventListener('cancel', cancelSpyListener);
+
+            crud._grid.activeItem = crud.items[0];
+            crud.$.dialog.$.dialog.$.overlay.dispatchEvent(new CustomEvent('vaadin-overlay-escape-press'));
+            await aTimeout(0);
+            expect(cancelSpyListener.calledOnce).to.be.ok;
+          });
+
+          it('should not trigger "cancel" after user hits "Save"', async () => {
+            crud.editOnClick = true;
+
+            const cancelSpyListener = sinon.spy();
+            crud.addEventListener('cancel', cancelSpyListener);
+
+            crud._grid.activeItem = crud.items[0];
+            edit(crud.items[0]);
+            change();
+            btnSave().click();
+            await aTimeout(0);
+            expect(cancelSpyListener.notCalled).to.be.ok;
+          });
+        });
+
+        describe('delete', () => {
+          it('should ask for confirmation on delete', () => {
+            edit(crud.items[0]);
+            btnDelete().click();
+            expect(crud.$.confirmDelete.opened).to.be.true;
+          });
+
+          it('should continue editing when closing confirmation with cancel', () => {
+            edit(crud.items[0]);
+            btnDelete().click();
+            btnConfDialog(crud.$.confirmDelete, 'cancel').click();
+            expect(crud.$.confirmDelete.opened).not.to.be.ok;
+            expect(crud.$.dialog.opened).to.be.true;
+          });
+
+          it('should delete when closing confirmation with confirm', () => {
+            edit(crud.items[0]);
+            btnDelete().click();
+            btnConfDialog(crud.$.confirmDelete, 'confirm').click();
+            expect(crud.$.confirmDelete.opened).not.to.be.ok;
+            expect(crud.$.dialog.opened).not.to.be.ok;
+          });
+        });
       });
 
-      it('should configure dirty and new flags on new', () => {
-        crud.$.new.click();
-        expect(crud.__isDirty).not.to.be.true;
-        expect(crud.__isNew).to.be.true;
-      });
+      describe('flags', () => {
+        afterEach(async () => {
+          crud.$.dialog.opened = false;
+          await aTimeout(0);
+        });
 
-      it('should configure dirty and new flags on edit', () => {
-        edit(crud.items[0]);
-        expect(crud.__isDirty).not.to.be.true;
-        expect(crud.__isNew).not.to.be.true;
-      });
+        it('should configure dirty and new flags on new', () => {
+          crud.$.new.click();
+          expect(crud.__isDirty).not.to.be.true;
+          expect(crud.__isNew).to.be.true;
+        });
 
-      it('should configure new flag when editedItem changed', async () => {
-        crud.editedItem = crud.items[0];
-        btnCancel().click();
-        await nextRender(crud);
-        expect(crud.__isNew).not.to.be.true;
-      });
+        it('should configure dirty and new flags on edit', () => {
+          edit(crud.items[0]);
+          expect(crud.__isDirty).not.to.be.true;
+          expect(crud.__isNew).not.to.be.true;
+        });
 
-      it('should set dirty on editor changes', () => {
-        edit(crud.items[0]);
-        change();
-        expect(crud.__isDirty).to.be.true;
-      });
+        it('should configure new flag when editedItem changed', async () => {
+          crud.editedItem = crud.items[0];
+          btnCancel().click();
+          await nextRender(crud);
+          expect(crud.__isNew).not.to.be.true;
+        });
 
-      it('should hide delete button on new', async () => {
-        crud.$.new.click();
-        await nextRender(crud.$.dialog.$.overlay);
-        expect(btnDelete().hasAttribute('hidden')).to.be.true;
-      });
+        it('should set dirty on editor changes', () => {
+          edit(crud.items[0]);
+          change();
+          expect(crud.__isDirty).to.be.true;
+        });
 
-      it('should show delete button and disable save button on edit', async () => {
-        edit(crud.items[0]);
-        await nextRender(crud.$.dialog.$.overlay);
-        expect(btnSave().hasAttribute('disabled')).to.be.true;
-        expect(btnDelete().hasAttribute('hidden')).not.to.be.true;
-      });
+        it('should hide delete button on new', async () => {
+          crud.$.new.click();
+          await nextRender(crud.$.dialog.$.overlay);
+          expect(btnDelete().hasAttribute('hidden')).to.be.true;
+        });
 
-      ['change', 'input'].forEach((type) => {
-        it('should enable save button on ' + type, async () => {
+        it('should show delete button and disable save button on edit', async () => {
           edit(crud.items[0]);
           await nextRender(crud.$.dialog.$.overlay);
-          crud._form.dispatchEvent(new Event(type, { bubbles: true }));
-          expect(btnSave().hasAttribute('disabled')).not.to.be.true;
-        });
-      });
-
-      describe('editor position', () => {
-        beforeEach(async () => {
-          crud.editorPosition = 'bottom';
-          crud.editOnClick = true;
-          await nextRender(crud);
-          flushGrid(crud._grid);
-          crud.set('items', [{ foo: 'bar' }, { foo: 'baz' }]);
+          expect(btnSave().hasAttribute('disabled')).to.be.true;
+          expect(btnDelete().hasAttribute('hidden')).not.to.be.true;
         });
 
-        it('should prevent changing edited items if dirty', () => {
-          crud._grid.activeItem = crud.items[0];
-          expect(crud.editorOpened).to.be.true;
-
-          change();
-          crud._grid.activeItem = crud.items[1];
-          expect(crud.$.confirmCancel.opened).to.be.true;
-          expect(crud.editedItem).to.be.equal(crud.items[0]);
-        });
-
-        it('should prompt confirm if dirty and new button is clicked', () => {
-          crud._grid.activeItem = crud.items[0];
-          expect(crud.editorOpened).to.be.true;
-
-          change();
-          crud.$.new.click();
-          expect(crud.$.confirmCancel.opened).to.be.true;
-        });
-
-        it('should keep editor opened if dirty, new button is clicked and changes are discarded', () => {
-          crud._grid.activeItem = crud.items[0];
-          expect(crud.editorOpened).to.be.true;
-
-          change();
-          crud.$.new.click();
-          expect(crud.$.confirmCancel.opened).to.be.true;
-
-          btnConfDialog(crud.$.confirmCancel, 'confirm').click();
-          expect(crud.editorOpened).to.be.true;
-        });
-
-        it('should change edited items if dirty when user discard changes', () => {
-          crud._grid.activeItem = crud.items[0];
-          change();
-
-          crud._grid.activeItem = crud.items[1];
-          expect(crud.$.confirmCancel.opened).to.be.true;
-
-          btnConfDialog(crud.$.confirmCancel, 'confirm').click();
-          expect(crud.editedItem).to.be.equal(crud.items[1]);
-        });
-      });
-    });
-
-    describe('events', () => {
-      afterEach(async () => {
-        crud.$.dialog.opened = false;
-        await aTimeout(0);
-      });
-
-      describe('new', () => {
-        it('should fire the new event', (done) => {
-          listenOnce(crud, 'new', () => done());
-          crud.$.new.click();
-        });
-
-        it('on new should set the item and open dialog if not default prevented', () => {
-          expect(crud.editedItem).not.to.be.ok;
-          crud.$.new.click();
-          expect(crud.editedItem).to.be.ok;
-          expect(crud.$.dialog.opened).to.be.true;
-        });
-
-        it('on new should not set the item but open dialog if default prevented', () => {
-          listenOnce(crud, 'new', (e) => e.preventDefault());
-          crud.$.new.click();
-          expect(crud.editedItem).not.to.be.ok;
-          expect(crud.$.dialog.opened).to.be.true;
-        });
-      });
-
-      describe('edit', () => {
-        it('should fire the edit event', (done) => {
-          listenOnce(crud, 'edit', (e) => {
-            expect(e.detail.item).to.be.equal(crud.items[0]);
-            done();
+        ['change', 'input'].forEach((type) => {
+          it('should enable save button on ' + type, async () => {
+            edit(crud.items[0]);
+            await nextRender(crud.$.dialog.$.overlay);
+            crud._form.dispatchEvent(new Event(type, { bubbles: true }));
+            expect(btnSave().hasAttribute('disabled')).not.to.be.true;
           });
-          edit(crud.items[0]);
         });
 
-        it('should not fire the edit event over the same opened item', () => {
-          const editListener = sinon.spy();
-          crud.addEventListener('edit', editListener);
-          edit(crud.items[0]);
-          edit(crud.items[0]);
-          expect(editListener.calledOnce).to.be.true;
-        });
+        describe('editor position', () => {
+          beforeEach(async () => {
+            crud.editorPosition = 'bottom';
+            crud.editOnClick = true;
+            await nextRender(crud);
+            flushGrid(crud._grid);
+            crud.set('items', [{ foo: 'bar' }, { foo: 'baz' }]);
+          });
 
-        it('on edit should set the item and open dialog if not default prevented', () => {
-          edit(crud.items[0]);
-          expect(crud.editedItem).to.be.equal(crud.items[0]);
-          expect(crud.$.dialog.opened).to.be.true;
-          expect(crud.editorOpened).to.be.true;
-        });
+          it('should prevent changing edited items if dirty', () => {
+            crud._grid.activeItem = crud.items[0];
+            expect(crud.editorOpened).to.be.true;
 
-        it('on edit should not set the item nor open dialog if default prevented', () => {
-          listenOnce(crud, 'edit', (e) => e.preventDefault());
-          edit(crud.items[0]);
-          expect(crud.editedItem).not.to.be.ok;
+            change();
+            crud._grid.activeItem = crud.items[1];
+            expect(crud.$.confirmCancel.opened).to.be.true;
+            expect(crud.editedItem).to.be.equal(crud.items[0]);
+          });
+
+          it('should prompt confirm if dirty and new button is clicked', () => {
+            crud._grid.activeItem = crud.items[0];
+            expect(crud.editorOpened).to.be.true;
+
+            change();
+            crud.$.new.click();
+            expect(crud.$.confirmCancel.opened).to.be.true;
+          });
+
+          it('should keep editor opened if dirty, new button is clicked and changes are discarded', () => {
+            crud._grid.activeItem = crud.items[0];
+            expect(crud.editorOpened).to.be.true;
+
+            change();
+            crud.$.new.click();
+            expect(crud.$.confirmCancel.opened).to.be.true;
+
+            btnConfDialog(crud.$.confirmCancel, 'confirm').click();
+            expect(crud.editorOpened).to.be.true;
+          });
+
+          it('should change edited items if dirty when user discard changes', () => {
+            crud._grid.activeItem = crud.items[0];
+            change();
+
+            crud._grid.activeItem = crud.items[1];
+            expect(crud.$.confirmCancel.opened).to.be.true;
+
+            btnConfDialog(crud.$.confirmCancel, 'confirm').click();
+            expect(crud.editedItem).to.be.equal(crud.items[1]);
+          });
         });
       });
 
-      describe('save', () => {
-        it('should fire the save event', (done) => {
-          listenOnce(crud, 'save', (e) => {
-            expect(e.detail.item).to.be.deep.equal(crud.items[0]);
-            done();
+      describe('events', () => {
+        afterEach(async () => {
+          crud.$.dialog.opened = false;
+          await aTimeout(0);
+        });
+
+        describe('new', () => {
+          it('should fire the new event', (done) => {
+            listenOnce(crud, 'new', () => done());
+            crud.$.new.click();
           });
-          edit(crud.items[0]);
-          change();
-          btnSave().click();
-        });
 
-        it('on save should close dialog if not default prevented', () => {
-          edit(crud.items[0]);
-          change();
-          btnSave().click();
-          expect(crud.$.dialog.opened).not.to.be.ok;
-        });
-
-        it('on save should keep opened dialog if default prevented', () => {
-          listenOnce(crud, 'save', (e) => e.preventDefault());
-          edit(crud.items[0]);
-          btnSave().click();
-          expect(crud.$.dialog.opened).to.be.true;
-        });
-
-        it('on save should keep item unmodified if default prevented', () => {
-          listenOnce(crud, 'save', (e) => e.preventDefault());
-
-          const originalItem = Object.assign({}, crud.items[0]);
-          edit(crud.items[0]);
-          crud._fields[0].value = 'Modified';
-          change();
-          btnSave().click();
-
-          expect(crud.items[0]).to.be.deep.equal(originalItem);
-        });
-
-        it('on save should modify item if not default prevented', () => {
-          const originalItem = Object.assign({}, crud.items[0]);
-          edit(crud.items[0]);
-          crud._fields[0].value = 'Modified';
-          change();
-          btnSave().click();
-
-          expect(crud.items[0]).to.not.be.deep.equal(originalItem);
-        });
-      });
-
-      describe('cancel', () => {
-        it('should fire the cancel event', (done) => {
-          listenOnce(crud, 'cancel', (e) => {
-            expect(e.detail.item).to.be.equal(crud.items[0]);
-            done();
+          it('on new should set the item and open dialog if not default prevented', () => {
+            expect(crud.editedItem).not.to.be.ok;
+            crud.$.new.click();
+            expect(crud.editedItem).to.be.ok;
+            expect(crud.$.dialog.opened).to.be.true;
           });
-          edit(crud.items[0]);
-          btnCancel().click();
-        });
 
-        it('on cancel should close dialog if not default prevented', () => {
-          edit(crud.items[0]);
-          btnCancel().click();
-          expect(crud.$.dialog.opened).not.to.be.ok;
-          expect(crud.editorOpened).not.to.be.ok;
-        });
-
-        it('on cancel should keep opened dialog if default prevented', () => {
-          listenOnce(crud, 'cancel', (e) => e.preventDefault());
-          edit(crud.items[0]);
-          btnCancel().click();
-          expect(crud.$.dialog.opened).to.be.true;
-        });
-      });
-
-      describe('delete', () => {
-        it('should fire the delete event', (done) => {
-          listenOnce(crud, 'delete', (e) => {
-            expect(e.detail.item).to.be.equal(crud.items[0]);
-            done();
+          it('on new should not set the item but open dialog if default prevented', () => {
+            listenOnce(crud, 'new', (e) => e.preventDefault());
+            crud.$.new.click();
+            expect(crud.editedItem).not.to.be.ok;
+            expect(crud.$.dialog.opened).to.be.true;
           });
-          edit(crud.items[0]);
-          btnDelete().click();
-          btnConfDialog(crud.$.confirmDelete, 'confirm').click();
         });
 
-        it('on delete should close dialog if not default prevented', () => {
-          edit(crud.items[0]);
-          btnDelete().click();
-          btnConfDialog(crud.$.confirmDelete, 'confirm').click();
-          expect(crud.$.dialog.opened).not.to.be.ok;
+        describe('edit', () => {
+          it('should fire the edit event', (done) => {
+            listenOnce(crud, 'edit', (e) => {
+              expect(e.detail.item).to.be.equal(crud.items[0]);
+              done();
+            });
+            edit(crud.items[0]);
+          });
+
+          it('should not fire the edit event over the same opened item', () => {
+            const editListener = sinon.spy();
+            crud.addEventListener('edit', editListener);
+            edit(crud.items[0]);
+            edit(crud.items[0]);
+            expect(editListener.calledOnce).to.be.true;
+          });
+
+          it('on edit should set the item and open dialog if not default prevented', () => {
+            edit(crud.items[0]);
+            expect(crud.editedItem).to.be.equal(crud.items[0]);
+            expect(crud.$.dialog.opened).to.be.true;
+            expect(crud.editorOpened).to.be.true;
+          });
+
+          it('on edit should not set the item nor open dialog if default prevented', () => {
+            listenOnce(crud, 'edit', (e) => e.preventDefault());
+            edit(crud.items[0]);
+            expect(crud.editedItem).not.to.be.ok;
+          });
         });
 
-        it('on delete should keep opened dialog if default prevented', () => {
-          listenOnce(crud, 'delete', (e) => e.preventDefault());
-          edit(crud.items[0]);
-          btnDelete().click();
-          btnConfDialog(crud.$.confirmDelete, 'confirm').click();
-          expect(crud.$.dialog.opened).to.be.true;
+        describe('save', () => {
+          it('should fire the save event', (done) => {
+            listenOnce(crud, 'save', (e) => {
+              expect(e.detail.item).to.be.deep.equal(crud.items[0]);
+              done();
+            });
+            edit(crud.items[0]);
+            change();
+            btnSave().click();
+          });
+
+          it('on save should close dialog if not default prevented', () => {
+            edit(crud.items[0]);
+            change();
+            btnSave().click();
+            expect(crud.$.dialog.opened).not.to.be.ok;
+          });
+
+          it('on save should keep opened dialog if default prevented', () => {
+            listenOnce(crud, 'save', (e) => e.preventDefault());
+            edit(crud.items[0]);
+            btnSave().click();
+            expect(crud.$.dialog.opened).to.be.true;
+          });
+
+          it('on save should keep item unmodified if default prevented', () => {
+            listenOnce(crud, 'save', (e) => e.preventDefault());
+
+            const originalItem = Object.assign({}, crud.items[0]);
+            edit(crud.items[0]);
+            crud._fields[0].value = 'Modified';
+            change();
+            btnSave().click();
+
+            expect(crud.items[0]).to.be.deep.equal(originalItem);
+          });
+
+          it('on save should modify item if not default prevented', () => {
+            const originalItem = Object.assign({}, crud.items[0]);
+            edit(crud.items[0]);
+            crud._fields[0].value = 'Modified';
+            change();
+            btnSave().click();
+
+            expect(crud.items[0]).to.not.be.deep.equal(originalItem);
+          });
+        });
+
+        describe('cancel', () => {
+          it('should fire the cancel event', (done) => {
+            listenOnce(crud, 'cancel', (e) => {
+              expect(e.detail.item).to.be.equal(crud.items[0]);
+              done();
+            });
+            edit(crud.items[0]);
+            btnCancel().click();
+          });
+
+          it('on cancel should close dialog if not default prevented', () => {
+            edit(crud.items[0]);
+            btnCancel().click();
+            expect(crud.$.dialog.opened).not.to.be.ok;
+            expect(crud.editorOpened).not.to.be.ok;
+          });
+
+          it('on cancel should keep opened dialog if default prevented', () => {
+            listenOnce(crud, 'cancel', (e) => e.preventDefault());
+            edit(crud.items[0]);
+            btnCancel().click();
+            expect(crud.$.dialog.opened).to.be.true;
+          });
+        });
+
+        describe('delete', () => {
+          it('should fire the delete event', (done) => {
+            listenOnce(crud, 'delete', (e) => {
+              expect(e.detail.item).to.be.equal(crud.items[0]);
+              done();
+            });
+            edit(crud.items[0]);
+            btnDelete().click();
+            btnConfDialog(crud.$.confirmDelete, 'confirm').click();
+          });
+
+          it('on delete should close dialog if not default prevented', () => {
+            edit(crud.items[0]);
+            btnDelete().click();
+            btnConfDialog(crud.$.confirmDelete, 'confirm').click();
+            expect(crud.$.dialog.opened).not.to.be.ok;
+          });
+
+          it('on delete should keep opened dialog if default prevented', () => {
+            listenOnce(crud, 'delete', (e) => e.preventDefault());
+            edit(crud.items[0]);
+            btnDelete().click();
+            btnConfDialog(crud.$.confirmDelete, 'confirm').click();
+            expect(crud.$.dialog.opened).to.be.true;
+          });
         });
       });
     });
   });
-
   describe('objects', () => {
     beforeEach(() => {
       crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');


### PR DESCRIPTION
## Description

This is an internal API to be used by the Flow counterpat.

Create slots on the editor buttons (save, cancel and delete) to enable the Flow counterpart to pass its own button instances to the Crud WC.

Part of https://github.com/vaadin/flow-components/issues/1112

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
