### PR TITLE
feat: add i18n to menu bar

### DIFF
--- a/packages/vaadin-menu-bar/src/interfaces.d.ts
+++ b/packages/vaadin-menu-bar/src/interfaces.d.ts
@@ -13,6 +13,10 @@ export interface SubMenuItem {
   children?: SubMenuItem[];
 }
 
+export interface MenuBarI18n {
+  moreOptions: string;
+}
+
 /**
  * Fired when a submenu item or menu bar button without children is clicked.
  */

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
@@ -95,7 +95,7 @@ class MenuBarElement extends ButtonsMixin(InteractionsMixin(ElementMixin(Themabl
       </style>
 
       <div part="container">
-        <vaadin-menu-bar-button part="overflow-button" hidden$="[[!_hasOverflow]]">
+        <vaadin-menu-bar-button part="overflow-button" hidden$="[[!_hasOverflow]]" aria-label="[[i18n.moreOptions]]">
           <div class="dots"></div>
         </vaadin-menu-bar-button>
       </div>
@@ -163,6 +163,38 @@ class MenuBarElement extends ButtonsMixin(InteractionsMixin(ElementMixin(Themabl
       items: {
         type: Array,
         value: () => []
+      },
+
+      /**
+       * The object used to localize this component.
+       * To change the default localization, replace the entire
+       * `i18n` object with a custom one.
+       *
+       * To update individual properties, extend the existing i18n object like so:
+       * ```
+       * menuBar.i18n = {
+       *   ...menuBar.i18n,
+       *   moreOptions: 'More options'
+       * }
+       * ```
+       *
+       * The object has the following JSON structure and default values:
+       * ```
+       * {
+       *   moreOptions: 'More options'
+       * }
+       * ```
+       *
+       * @type {!MenuBarI18n}
+       * @default {English/US}
+       */
+      i18n: {
+        type: Object,
+        value: () => {
+          return {
+            moreOptions: 'More options'
+          };
+        }
       }
     };
   }

--- a/packages/vaadin-menu-bar/test/menu-bar.test.js
+++ b/packages/vaadin-menu-bar/test/menu-bar.test.js
@@ -360,6 +360,13 @@ describe('overflow button', () => {
     expect(overflow.hasAttribute('hidden')).to.be.true;
     expect(overflow.item.children.length).to.equal(0);
   });
+
+  it('should set the aria-label of the overflow button according to the i18n of the menu bar', async () => {
+    const moreOptionsSv = 'Fler alternativ';
+    expect(overflow.getAttribute('aria-label')).to.equal('More options');
+    menu.i18n = { ...menu.i18n, moreOptions: moreOptionsSv };
+    expect(overflow.getAttribute('aria-label')).to.equal(moreOptionsSv);
+  });
 });
 
 describe('responsive behaviour in container', () => {


### PR DESCRIPTION
To be accessible, the menu bar overflow button needs the aria-label attribute to be set.
The attribute should be localizable. As such, this adds an i18n object to the menu bar,
and uses it to set the aria-label of the overflow button.

Connected to #87

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
