### PR TITLE
fix: re-dispatch focus and blur events

### DIFF
--- a/packages/field-base/src/delegate-focus-mixin.d.ts
+++ b/packages/field-base/src/delegate-focus-mixin.d.ts
@@ -22,8 +22,11 @@ interface DelegateFocusMixin extends DisabledMixin, FocusMixin {
   autofocus: boolean;
 
   /**
-   * Any element extending this mixin is required to implement this getter.
-   * It returns the actual focusable element in the component.
+   * A reference to the focusable element controlled by the mixin.
+   * It can be an input, textarea, button or any element with tabindex > -1.
+   *
+   * Any component implementing this mixin is expected to provide it
+   * by using `this._setFocusElement(input)` Polymer API.
    */
   readonly focusElement: Element | null | undefined;
 }

--- a/packages/field-base/src/delegate-focus-mixin.js
+++ b/packages/field-base/src/delegate-focus-mixin.js
@@ -16,18 +16,23 @@ const DelegateFocusMixinImplementation = (superclass) =>
          */
         autofocus: {
           type: Boolean
+        },
+
+        /**
+         * A reference to the focusable element controlled by the mixin.
+         * It can be an input, textarea, button or any element with tabindex > -1.
+         *
+         * Any component implementing this mixin is expected to provide it
+         * by using `this._setFocusElement(input)` Polymer API.
+         *
+         * @protected
+         * @type {!HTMLElement}
+         */
+        focusElement: {
+          type: Object,
+          readOnly: true
         }
       };
-    }
-
-    /**
-     * Any element extending this mixin is required to implement this getter.
-     * It returns the actual focusable element in the component.
-     * @return {Element | null | undefined}
-     */
-    get focusElement() {
-      console.warn(`Please implement the 'focusElement' property in <${this.localName}>`);
-      return null;
     }
 
     /** @protected */

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -77,13 +77,6 @@ const InputFieldMixinImplementation = (superclass) =>
       return this.inputElement;
     }
 
-    constructor() {
-      super();
-
-      this._boundOnBlur = this._onBlur.bind(this);
-      this._boundOnFocus = this._onFocus.bind(this);
-    }
-
     /** @protected */
     connectedCallback() {
       super.connectedCallback();
@@ -125,36 +118,28 @@ const InputFieldMixinImplementation = (superclass) =>
     }
 
     /**
-     * @param {HTMLInputElement} input
+     * Override an event listener from `DelegatesFocusMixin`.
+     * @param {FocusEvent} event
      * @protected
+     * @override
      */
-    _addInputListeners(input) {
-      super._addInputListeners(input);
+    _onFocus(event) {
+      super._onFocus(event);
 
-      input.addEventListener('blur', this._boundOnBlur);
-      input.addEventListener('focus', this._boundOnFocus);
-    }
-
-    /**
-     * @param {HTMLInputElement} input
-     * @protected
-     */
-    _removeInputListeners(input) {
-      super._addInputListeners(input);
-
-      input.removeEventListener('blur', this._boundOnBlur);
-      input.removeEventListener('focus', this._boundOnFocus);
-    }
-
-    /** @private */
-    _onFocus() {
       if (this.autoselect && this.inputElement) {
         this.inputElement.select();
       }
     }
 
-    /** @private */
-    _onBlur() {
+    /**
+     * Override an event listener from `DelegatesFocusMixin`.
+     * @param {FocusEvent} event
+     * @protected
+     * @override
+     */
+    _onBlur(event) {
+      super._onBlur(event);
+
       this.validate();
     }
 

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -77,14 +77,6 @@ const InputFieldMixinImplementation = (superclass) =>
       return this.inputElement;
     }
 
-    /**
-     * Element used by `DelegatesFocusMixin` to handle focus.
-     * @return {!HTMLInputElement}
-     */
-    get focusElement() {
-      return this.inputElement;
-    }
-
     constructor() {
       super();
 

--- a/packages/field-base/src/input-slot-mixin.d.ts
+++ b/packages/field-base/src/input-slot-mixin.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { DelegatesFocusMixin } from './delegate-focus-mixin.js';
 import { SlotMixin } from './slot-mixin.js';
 import { InputMixin } from './input-mixin.js';
 
@@ -15,7 +16,7 @@ interface InputSlotMixinConstructor {
   new (...args: any[]): InputSlotMixin;
 }
 
-interface InputSlotMixin extends InputMixin, SlotMixin {
+interface InputSlotMixin extends DelegatesFocusMixin, InputMixin, SlotMixin {
   /**
    * String used to define input type.
    */

--- a/packages/field-base/src/input-slot-mixin.js
+++ b/packages/field-base/src/input-slot-mixin.js
@@ -4,11 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { DelegateFocusMixin } from './delegate-focus-mixin.js';
 import { InputMixin } from './input-mixin.js';
 import { SlotMixin } from './slot-mixin.js';
 
 const InputSlotMixinImplementation = (superclass) =>
-  class InputSlotMixinClass extends InputMixin(SlotMixin(superclass)) {
+  class InputSlotMixinClass extends DelegateFocusMixin(InputMixin(SlotMixin(superclass))) {
     static get properties() {
       /**
        * String used to define input type.
@@ -59,6 +60,7 @@ const InputSlotMixinImplementation = (superclass) =>
         inputNode.id = this._inputId;
 
         this._setInputElement(inputNode);
+        this._setFocusElement(inputNode);
       }
     }
   };

--- a/packages/field-base/src/text-area-slot-mixin.d.ts
+++ b/packages/field-base/src/text-area-slot-mixin.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { DelegatesFocusMixin } from './delegate-focus-mixin.js';
 import { SlotMixin } from './slot-mixin.js';
 import { InputMixin } from './input-mixin.js';
 
@@ -15,6 +16,6 @@ interface TextAreaSlotMixinConstructor {
   new (...args: any[]): TextAreaSlotMixin;
 }
 
-interface TextAreaSlotMixin extends InputMixin, SlotMixin {}
+interface TextAreaSlotMixin extends DelegatesFocusMixin, InputMixin, SlotMixin {}
 
 export { TextAreaSlotMixinConstructor, TextAreaSlotMixin };

--- a/packages/field-base/src/text-area-slot-mixin.js
+++ b/packages/field-base/src/text-area-slot-mixin.js
@@ -4,11 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { DelegateFocusMixin } from './delegate-focus-mixin.js';
 import { InputMixin } from './input-mixin.js';
 import { SlotMixin } from './slot-mixin.js';
 
 const TextAreaSlotMixinImplementation = (superclass) =>
-  class TextAreaSlotMixinClass extends InputMixin(SlotMixin(superclass)) {
+  class TextAreaSlotMixinClass extends DelegateFocusMixin(InputMixin(SlotMixin(superclass))) {
     get slots() {
       return {
         ...super.slots,
@@ -44,6 +45,7 @@ const TextAreaSlotMixinImplementation = (superclass) =>
         textArea.id = this._textareaId;
 
         this._setInputElement(textArea);
+        this._setFocusElement(textArea);
       }
     }
   };

--- a/packages/field-base/test/delegate-focus-mixin.test.js
+++ b/packages/field-base/test/delegate-focus-mixin.test.js
@@ -7,13 +7,9 @@ import { InputSlotMixin } from '../src/input-slot-mixin.js';
 
 customElements.define(
   'delegate-focus-mixin-element',
-  class extends DelegateFocusMixin(InputSlotMixin(PolymerElement)) {
+  class extends InputSlotMixin(DelegateFocusMixin(PolymerElement)) {
     static get template() {
       return html`<slot name="input"></slot>`;
-    }
-
-    get focusElement() {
-      return this.inputElement;
     }
   }
 );

--- a/packages/field-base/test/delegate-focus-mixin.test.js
+++ b/packages/field-base/test/delegate-focus-mixin.test.js
@@ -88,6 +88,50 @@ describe('delegate-focus-mixin', () => {
     });
   });
 
+  describe('events', () => {
+    let spy;
+
+    beforeEach(() => {
+      element = fixtureSync(`<delegate-focus-mixin-element></delegate-focus-mixin-element>`);
+      input = element.querySelector('input');
+      spy = sinon.spy();
+    });
+
+    describe('focus', () => {
+      beforeEach(() => {
+        element.addEventListener('focus', spy);
+      });
+
+      it('should re-dispatch focus event on the host element', () => {
+        input.dispatchEvent(new Event('focus'));
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should not re-dispatch focus when focusElement is removed', () => {
+        element._setFocusElement(null);
+        input.dispatchEvent(new Event('focus'));
+        expect(spy.calledOnce).to.be.false;
+      });
+    });
+
+    describe('blur', () => {
+      beforeEach(() => {
+        element.addEventListener('blur', spy);
+      });
+
+      it('should re-dispatch blur event on the host element', () => {
+        input.dispatchEvent(new Event('blur'));
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should not re-dispatch blur when focusElement is removed', () => {
+        element._setFocusElement(null);
+        input.dispatchEvent(new Event('blur'));
+        expect(spy.calledOnce).to.be.false;
+      });
+    });
+  });
+
   describe('autofocus', () => {
     beforeEach(() => {
       element = document.createElement('delegate-focus-mixin-element');


### PR DESCRIPTION
## Description

1. Added `focus` and `blur` listeners in `DelegateFocusMixin` which appears to be the proper place for them
2. Changed `InputSlotMixin` and `TextAreaSlotMixin` to apply `DelegateFocusMixin` together with `InputMixin`
3. Updated `InputFieldMixin` to override and re-use focus and blur event listeners from the new location

Fixes #2387

## Type of change

- Bugfix