### PR TITLE
fix: restore iron-icon specific styles

### DIFF
--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -78,6 +78,7 @@ registerStyles(
     }
 
     /* Slotted icons */
+    ::slotted(iron-icon),
     ::slotted(vaadin-icon) {
       color: var(--lumo-contrast-60pct);
       width: var(--lumo-icon-size-m);
@@ -85,6 +86,7 @@ registerStyles(
     }
 
     /* Vaadin icons are based on a 16x16 grid (unlike Lumo and Material icons with 24x24), so they look too big by default */
+    ::slotted(iron-icon[icon^='vaadin:']),
     ::slotted(vaadin-icon[icon^='vaadin:']) {
       padding: 0.25em;
       box-sizing: border-box !important;

--- a/packages/text-area/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area-styles.js
@@ -60,6 +60,7 @@ registerStyles(
     }
 
     /* Vertically align icon prefix/suffix with the first line of text */
+    [part='input-field'] ::slotted(icon-icon),
     [part='input-field'] ::slotted(vaadin-icon) {
       margin-top: calc((var(--lumo-icon-size-m) - 1em * var(--lumo-line-height-s)) / -2);
     }

--- a/packages/text-field/theme/lumo/vaadin-input-field-shared-styles.js
+++ b/packages/text-field/theme/lumo/vaadin-input-field-shared-styles.js
@@ -182,7 +182,7 @@ registerStyles(
     }
 
     /* Slotted content */
-    [part='input-field'] ::slotted(:not(vaadin-icon):not(input):not(textarea)) {
+    [part='input-field'] ::slotted(:not(iron-icon):not(vaadin-icon):not(input):not(textarea)) {
       color: var(--lumo-secondary-text-color);
       font-weight: 400;
     }


### PR DESCRIPTION
## Description

Polymer-specific stuff can be only removed  after the next LTS and that includes `iron-icon` support.

## Type of change

- Fix