### PR TITLE
refactor: revert button container

### DIFF
--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -30,13 +30,13 @@ class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableM
         }
 
         /* Ensure the button is always aligned on the baseline */
-        [part='button']::before {
+        .vaadin-button-container::before {
           content: '\\2003';
           display: inline-block;
           width: 0;
         }
 
-        [part='button'] {
+        .vaadin-button-container {
           display: inline-flex;
           align-items: center;
           justify-content: center;
@@ -62,7 +62,7 @@ class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableM
           text-overflow: ellipsis;
         }
       </style>
-      <div part="button">
+      <div class="vaadin-button-container">
         <span part="prefix">
           <slot name="prefix"></slot>
         </span>


### PR DESCRIPTION
## Description

Decided not to introduce the `[part=button]` part and revert the `.vaadin-button-container` class in the new `@vaadin/button` package.

Part of #2224

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
