### PR TITLE
fix: use full import for iron-resizable-behavior

### DIFF
--- a/packages/vaadin-app-layout/src/vaadin-app-layout.js
+++ b/packages/vaadin-app-layout/src/vaadin-app-layout.js
@@ -8,7 +8,7 @@ import { beforeNextRender, afterNextRender } from '@polymer/polymer/lib/utils/re
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
 import './safe-area-inset.js';
 import './detect-ios-navbar.js';


### PR DESCRIPTION
## Description

There seems to be an issue caused by this import.
See https://stackoverflow.com/questions/68787509/using-vaadin-components-with-snowpack

## Type of change

- Refactor