### PR TITLE
Revert: don't create unnecessary virtualizer elements on size change (#2403)

### DIFF
--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -160,11 +160,6 @@ export class IronListAdapter {
 
     // Change the size
     this.__size = size;
-
-    // Flush before invoking items change to avoid
-    // creating excess elements on the following flush()
-    flush();
-
     this._itemsChanged({
       path: 'items'
     });

--- a/packages/vaadin-virtual-list/test/virtualizer.test.js
+++ b/packages/vaadin-virtual-list/test/virtualizer.test.js
@@ -187,15 +187,6 @@ describe('virtualizer', () => {
     expect(elementsContainer.childElementCount).to.be.above(0);
   });
 
-  it('should not create unnecessary elements on size change', () => {
-    const initialCount = elementsContainer.childElementCount;
-    virtualizer.size = 1;
-    virtualizer.scrollToIndex(0);
-    virtualizer.size = 1000;
-
-    expect(elementsContainer.childElementCount).to.equal(initialCount);
-  });
-
   describe('lazy rendering', () => {
     let render = false;
 


### PR DESCRIPTION
Seems that after #2403 the test suite for grid's keyboard-navigation-mixin became flaky.

This PR reverts the change.

Need to find another solution for the issue addressed in #2403