### PR TITLE
fix: don't create unnecessary virtualizer elements on size change

### DIFF
--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -160,6 +160,11 @@ export class IronListAdapter {
 
     // Change the size
     this.__size = size;
+
+    // Flush before invoking items change to avoid
+    // creating excess elements on the following flush()
+    flush();
+
     this._itemsChanged({
       path: 'items'
     });

--- a/packages/vaadin-virtual-list/test/virtualizer.test.js
+++ b/packages/vaadin-virtual-list/test/virtualizer.test.js
@@ -187,6 +187,15 @@ describe('virtualizer', () => {
     expect(elementsContainer.childElementCount).to.be.above(0);
   });
 
+  it('should not create unnecessary elements on size change', () => {
+    const initialCount = elementsContainer.childElementCount;
+    virtualizer.size = 1;
+    virtualizer.scrollToIndex(0);
+    virtualizer.size = 1000;
+
+    expect(elementsContainer.childElementCount).to.equal(initialCount);
+  });
+
   describe('lazy rendering', () => {
     let render = false;
 


### PR DESCRIPTION
This PR adds a fix that prevents virtualizer from creating unnecessary elements under specific conditions:
1. size is larger than zero but less than the existing physical elements count
2. iron-list's `_increasePoolIfNeeded` gets scheduled (for example by `scrollToIndex()` call)
3. size gets synchronously increased before the debouncer for `_increasePoolIfNeeded` is flushed