### PR TITLE
refactor!: remove native button from drawer toggle

### DIFF
--- a/packages/vaadin-app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/vaadin-app-layout/src/vaadin-drawer-toggle.js
@@ -14,6 +14,8 @@ import { Button } from '@vaadin/button/src/vaadin-button.js';
  *   <vaadin-drawer-toggle slot="navbar">Toggle drawer</vaadin-drawer-toggle>
  * </vaadin-app-layout>
  * ```
+ *
+ * @extends Button
  */
 class DrawerToggleElement extends Button {
   static get template() {
@@ -29,16 +31,6 @@ class DrawerToggleElement extends Button {
           height: 24px;
           width: 24px;
           padding: 4px;
-        }
-
-        #button {
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          opacity: 0;
-          cursor: inherit;
         }
 
         [part='icon'],
@@ -67,7 +59,6 @@ class DrawerToggleElement extends Button {
       <slot>
         <div part="icon"></div>
       </slot>
-      <button id="button" type="button" aria-label$="[[ariaLabel]]"></button>
     `;
   }
 
@@ -79,7 +70,8 @@ class DrawerToggleElement extends Button {
     return {
       ariaLabel: {
         type: String,
-        value: 'Toggle'
+        value: 'Toggle',
+        reflectToAttribute: true
       }
     };
   }
@@ -89,18 +81,19 @@ class DrawerToggleElement extends Button {
 
     this.addEventListener('click', () => {
       if (!this.disabled) {
-        this._fireClick();
+        this.__fireClick();
       }
     });
 
     this.addEventListener('keyup', (event) => {
       if (/^( |SpaceBar|Enter)$/.test(event.key) && !this.disabled) {
-        this._fireClick();
+        this.__fireClick();
       }
     });
   }
 
-  _fireClick() {
+  /** @private */
+  __fireClick() {
     this.dispatchEvent(new CustomEvent('drawer-toggle-click', { bubbles: true, composed: true }));
   }
 }

--- a/packages/vaadin-app-layout/test/drawer-toggle.test.js
+++ b/packages/vaadin-app-layout/test/drawer-toggle.test.js
@@ -79,18 +79,13 @@ describe('drawer-toggle', () => {
   });
 
   describe('aria-label', () => {
-    it('should have ariaLabel property set to "Toggle"', () => {
-      expect(toggle.ariaLabel).to.equal('Toggle');
+    it('should set aria-label attribute to "Toggle" by default', () => {
+      expect(toggle.getAttribute('aria-label')).to.equal('Toggle');
     });
 
-    it('should sync ariaLabel property with aria-label attribute', () => {
-      toggle.setAttribute('aria-label', 'Label');
-      expect(toggle.ariaLabel).to.equal('Label');
-    });
-
-    it('should set "aria-label" on the native button', () => {
-      const button = toggle.shadowRoot.querySelector('button');
-      expect(button.getAttribute('aria-label')).to.equal('Toggle');
+    it('should reflect ariaLabel property to the attribute', () => {
+      toggle.ariaLabel = 'Label';
+      expect(toggle.getAttribute('aria-label')).to.equal('Label');
     });
   });
 });


### PR DESCRIPTION
## Description

This PR is a follow-up for https://github.com/vaadin/web-components/pull/2373#discussion_r698256932. 

The new accessible implementation of `<vaadin-button>` doesn't utilize the native button anymore; thus, the native button should be also removed from `<vaadin-drawer-toggle>` (because it extends `<vaadin-button>`).

Part of #2224.

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
