### PR TITLE
fix: do not override custom helper component ID

### DIFF
--- a/packages/field-base/src/field-aria-mixin.js
+++ b/packages/field-base/src/field-aria-mixin.js
@@ -20,24 +20,24 @@ const FieldAriaMixinImplementation = (superclass) =>
     }
 
     static get observers() {
-      return ['_invalidChanged(invalid)'];
+      return ['__ariaChanged(invalid, _helperId)'];
     }
 
     /** @protected */
     connectedCallback() {
       super.connectedCallback();
 
-      this._updateAriaAttribute(this.invalid);
+      this._updateAriaAttribute(this.invalid, this._helperId);
     }
 
     /** @protected */
-    _updateAriaAttribute(invalid) {
+    _updateAriaAttribute(invalid, helperId) {
       const attr = this._ariaAttr;
 
       if (this._ariaTarget && attr) {
         // For groups, add all IDs to aria-labelledby rather than aria-describedby -
         // that should guarantee that it's announced when the group is entered.
-        const ariaIds = attr === 'aria-describedby' ? [this._helperId] : [this._labelId, this._helperId];
+        const ariaIds = attr === 'aria-describedby' ? [helperId] : [this._labelId, helperId];
 
         // Error message ID needs to be dynamically added / removed based on the validity
         // Otherwise assistive technologies would announce the error, even if we hide it.
@@ -49,9 +49,9 @@ const FieldAriaMixinImplementation = (superclass) =>
       }
     }
 
-    /** @protected */
-    _invalidChanged(invalid) {
-      this._updateAriaAttribute(invalid);
+    /** @private */
+    __ariaChanged(invalid, helperId) {
+      this._updateAriaAttribute(invalid, helperId);
     }
   };
 

--- a/packages/field-base/src/helper-text-mixin.js
+++ b/packages/field-base/src/helper-text-mixin.js
@@ -71,11 +71,19 @@ const HelperTextMixinImplementation = (superclass) =>
       this.__helperSlot.addEventListener('slotchange', this.__onHelperSlotChange.bind(this));
       this.__helperIdObserver = new MutationObserver((mutationRecord) => {
         mutationRecord.forEach((mutation) => {
-          if (mutation.type === 'attributes' && mutation.attributeName === 'id') {
+          // only handle helper nodes
+          if (
+            mutation.type === 'attributes' &&
+            mutation.attributeName === 'id' &&
+            mutation.target === this._currentHelper &&
+            mutation.target.id !== this.__savedHelperId
+          ) {
             this.__updateHelperId(mutation.target);
           }
         });
       });
+
+      this.__helperIdObserver.observe(this, { attributes: true, subtree: true });
     }
 
     /** @private */
@@ -101,7 +109,6 @@ const HelperTextMixinImplementation = (superclass) =>
 
       if (customHelper) {
         this.__updateHelperId(customHelper);
-        this.__helperIdObserver.observe(customHelper, { attributes: true });
 
         if (this._currentHelper.isConnected) {
           this._currentHelper.remove();

--- a/packages/field-base/src/helper-text-mixin.js
+++ b/packages/field-base/src/helper-text-mixin.js
@@ -69,19 +69,13 @@ const HelperTextMixinImplementation = (superclass) =>
 
       this.__helperSlot = this.shadowRoot.querySelector('[name="helper"]');
       this.__helperSlot.addEventListener('slotchange', this.__onHelperSlotChange.bind(this));
-    }
-
-    /** @private */
-    __observeCustomHelperId(helper) {
       this.__helperIdObserver = new MutationObserver((mutationRecord) => {
         mutationRecord.forEach((mutation) => {
           if (mutation.type === 'attributes' && mutation.attributeName === 'id') {
-            this.__updateHelperId(helper);
+            this.__updateHelperId(mutation.target);
           }
         });
       });
-
-      this.__helperIdObserver.observe(helper, { attributes: true });
     }
 
     /** @private */
@@ -107,7 +101,7 @@ const HelperTextMixinImplementation = (superclass) =>
 
       if (customHelper) {
         this.__updateHelperId(customHelper);
-        this.__observeCustomHelperId(customHelper);
+        this.__helperIdObserver.observe(customHelper, { attributes: true });
 
         if (this._currentHelper.isConnected) {
           this._currentHelper.remove();

--- a/packages/field-base/test/field-aria-mixin.test.js
+++ b/packages/field-base/test/field-aria-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { FieldAriaMixin } from '../src/field-aria-mixin.js';
 import { LabelMixin } from '../src/label-mixin.js';
@@ -89,6 +89,34 @@ describe('field-aria-mixin', () => {
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);
       expect(aria).to.include(label.id);
+    });
+  });
+
+  describe('custom helper', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<field-aria-mixin-element></field-aria-mixin-element>`);
+      label = element.querySelector('[slot=label]');
+      error = element.querySelector('[slot=error-message]');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should handle custom id of a lazily added helper', async () => {
+      helper = document.createElement('div');
+      helper.setAttribute('slot', 'helper');
+      helper.id = 'helper-component';
+      element.appendChild(helper);
+      await nextFrame();
+      expect(input.getAttribute('aria-describedby')).to.include('helper-component');
+    });
+
+    it('should handle restored id of a lazily added helper', async () => {
+      helper = document.createElement('div');
+      helper.setAttribute('slot', 'helper');
+      helper.id = 'helper-component';
+      element.appendChild(helper);
+      await nextFrame();
+      helper.removeAttribute('id');
+      expect(input.getAttribute('aria-describedby')).to.include(helper.id);
     });
   });
 });

--- a/packages/field-base/test/helper-text-mixin.test.js
+++ b/packages/field-base/test/helper-text-mixin.test.js
@@ -183,6 +183,40 @@ describe('helper-text-mixin', () => {
       });
     });
 
+    describe('ID attribute', () => {
+      const idRegex = /^helper-helper-text-mixin-element-\d+$/;
+
+      beforeEach(async () => {
+        element = fixtureSync('<helper-text-mixin-element></helper-text-mixin-element>');
+        await nextFrame();
+        helper = document.createElement('div');
+        helper.setAttribute('slot', 'helper');
+        helper.textContent = 'Lazy';
+      });
+
+      it('should set id on the lazily added helper element', async () => {
+        element.appendChild(helper);
+        await nextFrame();
+        expect(helper.getAttribute('id')).to.match(idRegex);
+      });
+
+      it('should not override custom id on the lazily added helper', async () => {
+        helper.id = 'helper-component';
+        element.appendChild(helper);
+        await nextFrame();
+        expect(helper.getAttribute('id')).to.equal('helper-component');
+      });
+
+      it('should restore default id if the custom helper id is removed', async () => {
+        helper.id = 'helper-component';
+        element.appendChild(helper);
+        await nextFrame();
+        helper.removeAttribute('id');
+        await nextFrame();
+        expect(helper.getAttribute('id')).to.match(idRegex);
+      });
+    });
+
     describe('attributes', () => {
       beforeEach(async () => {
         element = fixtureSync('<helper-text-mixin-element></helper-text-mixin-element>');
@@ -196,11 +230,6 @@ describe('helper-text-mixin', () => {
 
       it('should store a reference to the lazily added helper', () => {
         expect(element._helperNode).to.equal(helper);
-      });
-
-      it('should set id on the lazily added helper element', () => {
-        const idRegex = /^helper-helper-text-mixin-element-\d+$/;
-        expect(helper.getAttribute('id')).to.match(idRegex);
       });
 
       it('should set has-helper attribute with lazy helper', () => {


### PR DESCRIPTION
## Description

1. Added a check for custom helper `id` to not override it with the generated one (to now break component ITs)
2. Added a `MutationObserver` to detect removal of a custom `id` on the helper and restore the generated one

Fixes #2382

## Type of change

- Bugfix