### PR TITLE
fix: reflect tree grid level in a tree column toggle

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid-tree-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-column.js
@@ -57,7 +57,7 @@ class GridTreeColumnElement extends GridColumnElement {
    *
    * @private
    */
-  __defaultRenderer(root, _column, { item, expanded }) {
+  __defaultRenderer(root, _column, { item, expanded, level }) {
     let toggle = root.firstElementChild;
     if (!toggle) {
       toggle = document.createElement('vaadin-grid-tree-toggle');
@@ -70,6 +70,7 @@ class GridTreeColumnElement extends GridColumnElement {
     toggle.expanded = expanded;
     toggle.leaf = this.__isLeafItem(item, this.itemHasChildrenPath);
     toggle.textContent = this.__getToggleContent(this.path, item);
+    toggle.level = level;
   }
 
   /**

--- a/packages/vaadin-grid/test/tree-toggle.test.js
+++ b/packages/vaadin-grid/test/tree-toggle.test.js
@@ -140,6 +140,17 @@ describe('tree toggle', () => {
       expect(toggle.leaf).to.be.true;
     });
 
+    it('should have the default level', () => {
+      expect(toggle.level).to.equal(0);
+    });
+
+    it('should have a higher level', () => {
+      column.itemHasChildrenPath = 'hasChildren';
+      toggle.expanded = true;
+      const childToggle = getBodyCellContent(grid, 1, 0).firstElementChild;
+      expect(childToggle.level).to.equal(1);
+    });
+
     it('should not be a leaf', () => {
       column.itemHasChildrenPath = 'hasChildren';
       expect(toggle.leaf).to.be.false;


### PR DESCRIPTION
A tree grid item's level doesn't get applied to a `<vaadin-grid-tree-toggle>` generated by the `<vaadin-grid-tree-column>` default renderer:

![Screenshot 2021-09-01 at 11 19 20](https://user-images.githubusercontent.com/1222264/131637594-0dfe81fe-0cb8-431d-a8b0-5f347adac990.png)

This PR fixes the issue by applying the level in the column's default renderer:

![Screenshot 2021-09-01 at 11 19 33](https://user-images.githubusercontent.com/1222264/131637567-f4a13d1f-c7eb-4d69-8494-a183946cfc14.png)
