### PR TITLE
feat: add KeyboardMixin and make other mixins use it

### DIFF
--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -115,6 +115,18 @@ class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableM
     `;
   }
 
+  /**
+   * By default, `Space` is the only possible activation key for a focusable HTML element.
+   * Nonetheless, the button is an exception as it can be also activated by pressing `Enter`.
+   * See the "Keyboard Support" section in https://www.w3.org/TR/wai-aria-practices/examples/button/button.html.
+   *
+   * @protected
+   * @override
+   */
+  get _activeKeys() {
+    return ['Enter', ' '];
+  }
+
   /** @protected */
   ready() {
     super.ready();

--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -18,3 +18,4 @@ export { TextFieldMixin } from './src/text-field-mixin.js';
 export { ValidateMixin } from './src/validate-mixin.js';
 export { TabindexMixin } from './src/tabindex-mixin.js';
 export { ActiveMixin } from './src/active-mixin.js';
+export { KeyboardMixin } from './src/keyboard-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -18,3 +18,4 @@ export { TextFieldMixin } from './src/text-field-mixin.js';
 export { ValidateMixin } from './src/validate-mixin.js';
 export { TabindexMixin } from './src/tabindex-mixin.js';
 export { ActiveMixin } from './src/active-mixin.js';
+export { KeyboardMixin } from './src/keyboard-mixin.js';

--- a/packages/field-base/src/active-mixin.d.ts
+++ b/packages/field-base/src/active-mixin.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { DisabledMixin } from './disabled-mixin.js';
+import { KeyboardMixin } from './keyboard-mixin.js';
 
 /**
  * A mixin to toggle the `active` attribute.
@@ -20,6 +21,6 @@ interface ActiveMixinConstructor {
   new (...args: any[]): ActiveMixin;
 }
 
-interface ActiveMixin extends DisabledMixin {}
+interface ActiveMixin extends DisabledMixin, KeyboardMixin {}
 
 export { ActiveMixinConstructor, ActiveMixin };

--- a/packages/field-base/src/active-mixin.js
+++ b/packages/field-base/src/active-mixin.js
@@ -5,10 +5,11 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { GestureEventListeners } from '@polymer/polymer/lib/mixins/gesture-event-listeners.js';
+import { KeyboardMixin } from './keyboard-mixin.js';
 import { DisabledMixin } from './disabled-mixin.js';
 
 const ActiveMixinImplementation = (superclass) =>
-  class ActiveMixinClass extends DisabledMixin(GestureEventListeners(superclass)) {
+  class ActiveMixinClass extends DisabledMixin(GestureEventListeners(KeyboardMixin(superclass))) {
     /**
      * An array of activation keys.
      *
@@ -19,44 +20,25 @@ const ActiveMixinImplementation = (superclass) =>
      * @return {!Array<!string>}
      */
     get _activeKeys() {
-      return ['Enter', ' '];
+      return [' '];
     }
 
     /** @protected */
     ready() {
       super.ready();
 
-      // POINTERDOWN
       this._addEventListenerToNode(this, 'down', () => {
         if (this.disabled) return;
 
-        this.setAttribute('active', '');
+        this._setActive(true);
       });
 
-      // POINTERUP
       this._addEventListenerToNode(this, 'up', () => {
-        this.removeAttribute('active');
+        this._setActive(false);
       });
 
-      // KEYDOWN
-      this.addEventListener('keydown', (event) => {
-        if (this.disabled) return;
-
-        if (this._activeKeys.includes(event.key)) {
-          this.setAttribute('active', '');
-        }
-      });
-
-      // KEYUP
-      this.addEventListener('keyup', (event) => {
-        if (this._activeKeys.includes(event.key)) {
-          this.removeAttribute('active');
-        }
-      });
-
-      // BLUR
       this.addEventListener('blur', () => {
-        this.removeAttribute('active');
+        this._setActive(false);
       });
     }
 
@@ -68,7 +50,49 @@ const ActiveMixinImplementation = (superclass) =>
       // the `active` attribute needs to be manually removed from the element.
       // Otherwise, it will preserve on the element until the element is activated once again.
       // The case reproduces for `<vaadin-date-picker>` when closing on `Cancel` or `Today` click.
-      this.removeAttribute('active');
+      this._setActive(false);
+    }
+
+    /**
+     * Sets the `active` attribute on the element if an activation key is pressed.
+     *
+     * @param {KeyboardEvent} event
+     * @protected
+     * @override
+     */
+    _onKeyDown(event) {
+      super._onKeyDown(event);
+
+      if (this.disabled) return;
+
+      if (this._activeKeys.includes(event.key)) {
+        this._setActive(true);
+      }
+    }
+
+    /**
+     * Removes the `active` attribute from the element if the activation key is released.
+     *
+     * @param {KeyboardEvent} event
+     * @protected
+     * @override
+     */
+    _onKeyUp(event) {
+      super._onKeyUp(event);
+
+      if (this._activeKeys.includes(event.key)) {
+        this._setActive(false);
+      }
+    }
+
+    /**
+     * Toggles the `active` attribute on the element.
+     *
+     * @param {boolean} active
+     * @protected
+     */
+    _setActive(active) {
+      this.toggleAttribute('active', active);
     }
   };
 

--- a/packages/field-base/src/active-mixin.js
+++ b/packages/field-base/src/active-mixin.js
@@ -63,9 +63,7 @@ const ActiveMixinImplementation = (superclass) =>
     _onKeyDown(event) {
       super._onKeyDown(event);
 
-      if (this.disabled) return;
-
-      if (this._activeKeys.includes(event.key)) {
+      if (!this.disabled && this._activeKeys.includes(event.key)) {
         this._setActive(true);
       }
     }

--- a/packages/field-base/src/clear-button-mixin.d.ts
+++ b/packages/field-base/src/clear-button-mixin.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { InputMixin } from './input-mixin.js';
+import { KeyboardMixin } from './keyboard-mixin.js';
 
 /**
  * A mixin to add clear button support to field components.
@@ -14,7 +15,7 @@ interface ClearButtonMixinConstructor {
   new (...args: any[]): ClearButtonMixin;
 }
 
-interface ClearButtonMixin extends InputMixin {
+interface ClearButtonMixin extends InputMixin, KeyboardMixin {
   /**
    * Set to true to display the clear icon which clears the input.
    * @attr {boolean} clear-button-visible

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -5,9 +5,10 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { InputMixin } from './input-mixin.js';
+import { KeyboardMixin } from './keyboard-mixin.js';
 
 const ClearButtonMixinImplementation = (superclass) =>
-  class ClearButtonMixinClass extends InputMixin(superclass) {
+  class ClearButtonMixinClass extends InputMixin(KeyboardMixin(superclass)) {
     static get properties() {
       return {
         /**
@@ -42,8 +43,6 @@ const ClearButtonMixinImplementation = (superclass) =>
     ready() {
       super.ready();
 
-      this.addEventListener('keydown', (e) => this._onKeyDown(e));
-
       if (this.clearElement) {
         this.clearElement.addEventListener('click', (e) => this._onClearButtonClick(e));
       }
@@ -62,10 +61,13 @@ const ClearButtonMixinImplementation = (superclass) =>
     }
 
     /**
-     * @param {Event} event
+     * @param {KeyboardEvent} event
      * @protected
+     * @override
      */
     _onKeyDown(event) {
+      super._onKeyDown(event);
+
       if (event.key === 'Escape' && this.clearButtonVisible && this._clearOnEsc) {
         const dispatchChange = !!this.value;
         this.clear();

--- a/packages/field-base/src/keyboard-mixin.d.ts
+++ b/packages/field-base/src/keyboard-mixin.d.ts
@@ -4,7 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 /**
- * A mixin to listen to keyboard events, such as `keydown`, `keyup`.
+ * A mixin that manages keyboard handling.
+ * It subscribes to the keyboard events while providing an actual implementation
+ * for the event handlers is left for the client (a component or another mixin).
  */
 declare function KeyboardMixin<T extends new (...args: any[]) => {}>(base: T): T & KeyboardMixinConstructor;
 

--- a/packages/field-base/src/keyboard-mixin.d.ts
+++ b/packages/field-base/src/keyboard-mixin.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+
 /**
  * A mixin that manages keyboard handling.
  * It subscribes to the keyboard events while providing an actual implementation
@@ -19,13 +20,13 @@ interface KeyboardMixin {
    * A handler for the `keydown` event. By default, it does nothing.
    * Override the method to implement your own behavior.
    */
-  _onKeyDown(_event: KeyboardEvent): void;
+  _onKeyDown(event: KeyboardEvent): void;
 
   /**
    * A handler for the `keyup` event. By default, it does nothing.
    * Override the method to implement your own behavior.
    */
-  _onKeyUp(_event: KeyboardEvent): void;
+  _onKeyUp(event: KeyboardEvent): void;
 }
 
 export { KeyboardMixinConstructor, KeyboardMixin };

--- a/packages/field-base/src/keyboard-mixin.d.ts
+++ b/packages/field-base/src/keyboard-mixin.d.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+/**
+ * A mixin to listen to keyboard events, such as `keydown`, `keyup`.
+ */
+declare function KeyboardMixin<T extends new (...args: any[]) => {}>(base: T): T & KeyboardMixinConstructor;
+
+interface KeyboardMixinConstructor {
+  new (...args: any[]): KeyboardMixin;
+}
+
+interface KeyboardMixin {
+  /**
+   * A handler for the `keydown` event. By default, it does nothing.
+   * Override the method to implement your own behavior.
+   */
+  _onKeyDown(_event: KeyboardEvent): void;
+
+  /**
+   * A handler for the `keyup` event. By default, it does nothing.
+   * Override the method to implement your own behavior.
+   */
+  _onKeyUp(_event: KeyboardEvent): void;
+}
+
+export { KeyboardMixinConstructor, KeyboardMixin };

--- a/packages/field-base/src/keyboard-mixin.d.ts
+++ b/packages/field-base/src/keyboard-mixin.d.ts
@@ -6,8 +6,8 @@
 
 /**
  * A mixin that manages keyboard handling.
- * It subscribes to the keyboard events while providing an actual implementation
- * for the event handlers is left for the client (a component or another mixin).
+ * The mixin subscribes to the keyboard events while an actual implementation
+ * for the event handlers is left to the client (a component or another mixin).
  */
 declare function KeyboardMixin<T extends new (...args: any[]) => {}>(base: T): T & KeyboardMixinConstructor;
 

--- a/packages/field-base/src/keyboard-mixin.js
+++ b/packages/field-base/src/keyboard-mixin.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+
+const KeyboardMixinImplementation = (superclass) =>
+  class KeyboardMixinClass extends superclass {
+    ready() {
+      super.ready();
+
+      this.addEventListener('keydown', (event) => {
+        this._onKeyDown(event);
+      });
+
+      this.addEventListener('keyup', (event) => {
+        this._onKeyUp(event);
+      });
+    }
+
+    /**
+     * A handler for the `keydown` event. By default, it does nothing.
+     * Override the method to implement your own behavior.
+     *
+     * @protected
+     */
+    _onKeyDown(_event) {
+      // To be implemented.
+    }
+
+    /**
+     * A handler for the `keyup` event. By default, it does nothing.
+     * Override the method to implement your own behavior.
+     *
+     * @protected
+     */
+    _onKeyUp(_event) {
+      // To be implemented.
+    }
+  };
+
+/**
+ * A mixin to listen to keyboard events, such as `keydown`, `keyup`.
+ */
+export const KeyboardMixin = dedupingMixin(KeyboardMixinImplementation);

--- a/packages/field-base/src/keyboard-mixin.js
+++ b/packages/field-base/src/keyboard-mixin.js
@@ -45,7 +45,7 @@ const KeyboardMixinImplementation = (superclass) =>
 
 /**
  * A mixin that manages keyboard handling.
- * It subscribes to the keyboard events while providing an actual implementation
- * for the event handlers is left for the client (a component or another mixin).
+ * The mixin subscribes to the keyboard events while an actual implementation
+ * for the event handlers is left to the client (a component or another mixin).
  */
 export const KeyboardMixin = dedupingMixin(KeyboardMixinImplementation);

--- a/packages/field-base/src/keyboard-mixin.js
+++ b/packages/field-base/src/keyboard-mixin.js
@@ -7,6 +7,7 @@ import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
 const KeyboardMixinImplementation = (superclass) =>
   class KeyboardMixinClass extends superclass {
+    /** @protected */
     ready() {
       super.ready();
 
@@ -23,6 +24,7 @@ const KeyboardMixinImplementation = (superclass) =>
      * A handler for the `keydown` event. By default, it does nothing.
      * Override the method to implement your own behavior.
      *
+     * @param {KeyboardEvent} _event
      * @protected
      */
     _onKeyDown(_event) {
@@ -33,6 +35,7 @@ const KeyboardMixinImplementation = (superclass) =>
      * A handler for the `keyup` event. By default, it does nothing.
      * Override the method to implement your own behavior.
      *
+     * @param {KeyboardEvent} _event
      * @protected
      */
     _onKeyUp(_event) {

--- a/packages/field-base/src/keyboard-mixin.js
+++ b/packages/field-base/src/keyboard-mixin.js
@@ -41,6 +41,8 @@ const KeyboardMixinImplementation = (superclass) =>
   };
 
 /**
- * A mixin to listen to keyboard events, such as `keydown`, `keyup`.
+ * A mixin that manages keyboard handling.
+ * It subscribes to the keyboard events while providing an actual implementation
+ * for the event handlers is left for the client (a component or another mixin).
  */
 export const KeyboardMixin = dedupingMixin(KeyboardMixinImplementation);

--- a/packages/field-base/test/active-mixin.test.js
+++ b/packages/field-base/test/active-mixin.test.js
@@ -1,18 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import {
-  arrowDownKeyDown,
-  enterKeyDown,
-  enterKeyUp,
-  fire,
-  fixtureSync,
-  isIOS,
-  mousedown,
-  mouseup,
-  spaceKeyDown,
-  spaceKeyUp,
-  touchend,
-  touchstart
-} from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import { fire, fixtureSync, isIOS, mousedown, mouseup, touchend, touchstart } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { ActiveMixin } from '../src/active-mixin.js';
 
@@ -29,7 +17,9 @@ describe('active-mixin', () => {
   let element;
 
   beforeEach(() => {
-    element = fixtureSync(`<active-mixin-element></active-mixin-element>`);
+    // Sets tabindex to 0 in order to make the element focusable for the time of testing.
+    element = fixtureSync(`<active-mixin-element tabindex="0"></active-mixin-element>`);
+    element.focus();
   });
 
   (isIOS ? describe.skip : describe)('mouse', () => {
@@ -71,42 +61,25 @@ describe('active-mixin', () => {
   });
 
   describe('keyboard', () => {
-    it('should set active attribute when Enter is pressed', async () => {
-      enterKeyDown(element);
+    it('should set active attribute when Space is pressed', async () => {
+      await sendKeys({ down: 'Space' });
       expect(element.hasAttribute('active')).to.be.true;
     });
 
-    it('should remove active attribute when Enter is released', () => {
-      enterKeyDown(element);
-      enterKeyUp(element);
+    it('should remove active attribute when Space is released', async () => {
+      await sendKeys({ down: 'Space' });
+      await sendKeys({ up: 'Space' });
       expect(element.hasAttribute('active')).to.be.false;
     });
 
-    it('should not set active attribute when disabled and Enter is pressed', () => {
+    it('should not set active attribute when disabled and Space is pressed', async () => {
       element.disabled = true;
-      enterKeyDown(element);
+      await sendKeys({ down: 'Space' });
       expect(element.hasAttribute('active')).to.be.false;
     });
 
-    it('should set active attribute when Space is pressed', () => {
-      spaceKeyDown(element);
-      expect(element.hasAttribute('active')).to.be.true;
-    });
-
-    it('should remove active attribute when Space is released', () => {
-      spaceKeyDown(element);
-      spaceKeyUp(element);
-      expect(element.hasAttribute('active')).to.be.false;
-    });
-
-    it('should not set active attribute when disabled and Space is pressed', () => {
-      element.disabled = true;
-      spaceKeyDown(element);
-      expect(element.hasAttribute('active')).to.be.false;
-    });
-
-    it('should not set active attribute when ArrowDown is pressed', () => {
-      arrowDownKeyDown(element);
+    it('should not set active attribute when a non-activation key is pressed', async () => {
+      await sendKeys({ down: 'ArrowDown' });
       expect(element.hasAttribute('active')).to.be.false;
     });
 
@@ -114,26 +87,26 @@ describe('active-mixin', () => {
       beforeEach(() => {
         Object.defineProperty(element, '_activeKeys', {
           get() {
-            return ['ArrowDown'];
+            return ['Enter'];
           }
         });
       });
 
-      it('should set active attribute when ArrowDown is pressed', () => {
-        arrowDownKeyDown(element);
+      it('should set active attribute when Enter is pressed', async () => {
+        await sendKeys({ down: 'Enter' });
         expect(element.hasAttribute('active')).to.be.true;
       });
     });
   });
 
-  it('should not preserve active attribute when disconnecting from the DOM', () => {
-    spaceKeyDown(element);
+  it('should not preserve active attribute when disconnecting from the DOM', async () => {
+    await sendKeys({ down: 'Space' });
     element.parentNode.removeChild(element);
     expect(element.hasAttribute('active')).to.be.false;
   });
 
-  it('should remove active attribute on blur', () => {
-    spaceKeyDown(element);
+  it('should remove active attribute on blur', async () => {
+    await sendKeys({ down: 'Space' });
     fire(element, 'blur');
     expect(element.hasAttribute('active')).to.be.false;
   });

--- a/packages/field-base/test/keyboard-mixin.test.js
+++ b/packages/field-base/test/keyboard-mixin.test.js
@@ -5,39 +5,55 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { KeyboardMixin } from '../src/keyboard-mixin.js';
 
-customElements.define(
-  'keyboard-mixin-element',
-  class extends KeyboardMixin(PolymerElement) {
-    static get template() {
-      return html`<div></div>`;
-    }
-  }
-);
-
 describe('keyboard-mixin', () => {
-  let element;
+  let element, keyDownSpy, keyUpSpy;
+
+  before(() => {
+    keyDownSpy = sinon.spy();
+    keyUpSpy = sinon.spy();
+
+    customElements.define(
+      'keyboard-mixin-element',
+      class extends KeyboardMixin(PolymerElement) {
+        static get template() {
+          return html`<div></div>`;
+        }
+
+        _onKeyDown(event) {
+          keyDownSpy(event);
+        }
+
+        _onKeyUp(event) {
+          keyUpSpy(event);
+        }
+      }
+    );
+  });
 
   beforeEach(() => {
     // Sets tabindex to 0 in order to make the element focusable for the time of testing.
     element = fixtureSync(`<keyboard-mixin-element tabindex="0"></keyboard-mixin-element>`);
-    element._onKeyDown = sinon.spy();
-    element._onKeyUp = sinon.spy();
     element.focus();
+  });
+
+  afterEach(() => {
+    keyDownSpy.resetHistory();
+    keyUpSpy.resetHistory();
   });
 
   it('should handle keydown event', async () => {
     await sendKeys({ down: 'A' });
 
-    expect(element._onKeyDown.calledOnce).to.be.true;
-    expect(element._onKeyDown.args[0][0]).to.be.an.instanceOf(KeyboardEvent);
-    expect(element._onKeyDown.args[0][0].type).to.equal('keydown');
+    expect(keyDownSpy.calledOnce).to.be.true;
+    expect(keyDownSpy.args[0][0]).to.be.an.instanceOf(KeyboardEvent);
+    expect(keyDownSpy.args[0][0].type).to.equal('keydown');
   });
 
   it('should handle keyup event', async () => {
     await sendKeys({ up: 'A' });
 
-    expect(element._onKeyUp.calledOnce).to.be.true;
-    expect(element._onKeyUp.args[0][0]).to.be.an.instanceOf(KeyboardEvent);
-    expect(element._onKeyUp.args[0][0].type).to.equal('keyup');
+    expect(keyUpSpy.calledOnce).to.be.true;
+    expect(keyUpSpy.args[0][0]).to.be.an.instanceOf(KeyboardEvent);
+    expect(keyUpSpy.args[0][0].type).to.equal('keyup');
   });
 });

--- a/packages/field-base/test/keyboard-mixin.test.js
+++ b/packages/field-base/test/keyboard-mixin.test.js
@@ -1,0 +1,43 @@
+import sinon from 'sinon';
+import { expect } from '@esm-bundle/chai';
+import { sendKeys } from '@web/test-runner-commands';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { KeyboardMixin } from '../src/keyboard-mixin.js';
+
+customElements.define(
+  'keyboard-mixin-element',
+  class extends KeyboardMixin(PolymerElement) {
+    static get template() {
+      return html`<div></div>`;
+    }
+  }
+);
+
+describe('keyboard-mixin', () => {
+  let element;
+
+  beforeEach(() => {
+    // Sets tabindex to 0 in order to make the element focusable for the time of testing.
+    element = fixtureSync(`<keyboard-mixin-element tabindex="0"></keyboard-mixin-element>`);
+    element._onKeyDown = sinon.spy();
+    element._onKeyUp = sinon.spy();
+    element.focus();
+  });
+
+  it('should handle keydown event', async () => {
+    await sendKeys({ down: 'A' });
+
+    expect(element._onKeyDown.calledOnce).to.be.true;
+    expect(element._onKeyDown.args[0][0]).to.be.an.instanceOf(KeyboardEvent);
+    expect(element._onKeyDown.args[0][0].type).to.equal('keydown');
+  });
+
+  it('should handle keyup event', async () => {
+    await sendKeys({ up: 'A' });
+
+    expect(element._onKeyUp.calledOnce).to.be.true;
+    expect(element._onKeyUp.args[0][0]).to.be.an.instanceOf(KeyboardEvent);
+    expect(element._onKeyUp.args[0][0].type).to.equal('keyup');
+  });
+});


### PR DESCRIPTION
## Description

The `ActiveMixin`, `ClearButtonMixin` and future [`CheckedMixin`](https://github.com/web-padawan/a11y-vaadin-proto/blob/master/src/mixins/checked-mixin.js) all need to handle the `keyup` and `keydown` events. 

Along with that, [the prototype](https://github.com/web-padawan/a11y-vaadin-proto/blob/master/src/v-checkbox.js#L9) of the new Checkbox component supposes it to inherit both `ActiveMixin` and `CheckedMixin`. This being so, these mixins will end up in the same scope and there may happen a naming collision (in case both define a `_onKeyDown` method, for example).

So it was decided to introduce `KeyboardMixin` that is responsible for subscribing to the keyboard events while leaving actual implementation of the event handlers to the client (a component or another mixin).

See the prototype: https://github.com/vaadin/component-mixins/blob/master/packages/keyboard-mixin/keyboard-mixin.ts

Part of https://github.com/vaadin/web-components/issues/2210.

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.