### PR TITLE
fix: fire click on Enter and Space, but not when disabled

### DIFF
--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -137,6 +137,31 @@ class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableM
       this.setAttribute('role', 'button');
     }
   }
+
+  /**
+   * Since the button component is designed on the base of the `[role=button]` attribute,
+   * and doesn't have a native <button> inside, in order to be fully accessible from the keyboard,
+   * it should manually fire the `click` event once an activation key is pressed,
+   * as it follows from the WAI-ARIA specifications:
+   * https://www.w3.org/TR/wai-aria-practices-1.1/#button
+   *
+   * According to the UI Events specifications,
+   * the `click` event should be fired exactly on `keydown`:
+   * https://www.w3.org/TR/uievents/#event-type-keydown
+   *
+   * Note, the `click` event should not be fired when the button is disabled.
+   *
+   * @param {KeyboardEvent} event
+   * @protected
+   * @override
+   */
+  _onKeyDown(event) {
+    super._onKeyDown(event);
+
+    if (!this.disabled && this._activeKeys.includes(event.key)) {
+      this.click();
+    }
+  }
 }
 
 customElements.define(Button.is, Button);

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -149,8 +149,6 @@ class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableM
    * the `click` event should be fired exactly on `keydown`:
    * https://www.w3.org/TR/uievents/#event-type-keydown
    *
-   * Note, the `click` event should not be fired when the button is disabled.
-   *
    * @param {KeyboardEvent} event
    * @protected
    * @override
@@ -158,7 +156,9 @@ class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableM
   _onKeyDown(event) {
     super._onKeyDown(event);
 
-    if (!this.disabled && this._activeKeys.includes(event.key)) {
+    if (this._activeKeys.includes(event.key)) {
+      // `DisabledMixin` overrides the standard `click()` method
+      // so that it doesn't fire the `click` event when the element is disabled.
       this.click();
     }
   }

--- a/packages/button/test/button.test.js
+++ b/packages/button/test/button.test.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { sendKeys } from '@web/test-runner-commands';
 import {
@@ -69,6 +70,34 @@ describe('vaadin-button', () => {
     it('should define the button label using light DOM', () => {
       const children = FlattenedNodesObserver.getFlattenedNodes(label);
       expect(children[1].textContent).to.be.equal('Press me');
+    });
+  });
+
+  describe('keyboard', () => {
+    beforeEach(() => {
+      element = fixtureSync('<vaadin-button>Press me</vaadin-button>');
+      element.focus();
+    });
+
+    ['Enter', 'Space'].forEach((key) => {
+      it(`should fire click event on ${key}`, async () => {
+        const spy = sinon.spy();
+        element.addEventListener('click', spy);
+
+        await sendKeys({ down: key });
+
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it(`should not fire click event on ${key} when disabled`, async () => {
+        const spy = sinon.spy();
+        element.addEventListener('click', spy);
+        element.disabled = true;
+
+        await sendKeys({ down: key });
+
+        expect(spy.called).to.be.false;
+      });
     });
   });
 

--- a/packages/field-base/src/disabled-mixin.js
+++ b/packages/field-base/src/disabled-mixin.js
@@ -40,6 +40,18 @@ const DisabledMixinImplementation = (superclass) =>
         this.removeAttribute('aria-disabled');
       }
     }
+
+    /**
+     * Overrides the default element `click` method in order to prevent
+     * firing the `click` event when the element is disabled.
+     *
+     * @override
+     */
+    click() {
+      if (!this.disabled) {
+        super.click();
+      }
+    }
   };
 
 /**

--- a/packages/field-base/test/disabled-mixin.test.js
+++ b/packages/field-base/test/disabled-mixin.test.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
@@ -37,5 +38,13 @@ describe('disabled-mixin', () => {
 
     element.disabled = false;
     expect(element.hasAttribute('aria-disabled')).to.be.false;
+  });
+
+  it('should prevent firing click event when disabled', () => {
+    const spy = sinon.spy();
+    element.addEventListener('click', spy);
+    element.disabled = true;
+    element.click();
+    expect(spy.called).to.be.false;
   });
 });

--- a/packages/vaadin-app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/vaadin-app-layout/src/vaadin-drawer-toggle.js
@@ -80,15 +80,7 @@ class DrawerToggleElement extends Button {
     super();
 
     this.addEventListener('click', () => {
-      if (!this.disabled) {
-        this.__fireClick();
-      }
-    });
-
-    this.addEventListener('keyup', (event) => {
-      if (/^( |SpaceBar|Enter)$/.test(event.key) && !this.disabled) {
-        this.__fireClick();
-      }
+      this.__fireClick();
     });
   }
 

--- a/packages/vaadin-app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/vaadin-app-layout/src/vaadin-drawer-toggle.js
@@ -80,13 +80,8 @@ class DrawerToggleElement extends Button {
     super();
 
     this.addEventListener('click', () => {
-      this.__fireClick();
+      this.dispatchEvent(new CustomEvent('drawer-toggle-click', { bubbles: true, composed: true }));
     });
-  }
-
-  /** @private */
-  __fireClick() {
-    this.dispatchEvent(new CustomEvent('drawer-toggle-click', { bubbles: true, composed: true }));
   }
 }
 


### PR DESCRIPTION
## Description

The PR fixes a regression that appeared after we released the new `@vaadin/button` package:

> The `click` event doesn't get fired on the button once the user presses an activation key (Enter, Space) so that the button ends up not fully accessible from the keyboard.

Note, `<vaadin-drawer-toggle>` now fires the `drawer-toggle-click` event on `keydown` rather than `keyup` the way it was before. This might be considered as a breaking-change.

Fixes #2437

~~**WARNING:** Please, do not merge this PR before #2432 is merged.~~ (merged)

## Specs

- https://www.w3.org/TR/wai-aria-practices/examples/button/button.html
- https://www.w3.org/TR/uievents/#event-type-keydown

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
