### PR TITLE
fix: accept custom tabindex attribute

### DIFF
--- a/packages/field-base/src/tabindex-mixin.js
+++ b/packages/field-base/src/tabindex-mixin.js
@@ -41,13 +41,13 @@ const TabindexMixinImplementation = (superclass) =>
      * @protected
      * @override
      */
-    _disabledChanged(disabled) {
-      super._disabledChanged(disabled);
+    _disabledChanged(disabled, oldDisabled) {
+      super._disabledChanged(disabled, oldDisabled);
 
       if (disabled) {
         this.__lastTabIndex = this.tabindex;
         this.tabindex = -1;
-      } else {
+      } else if (oldDisabled) {
         this.tabindex = this.__lastTabIndex;
       }
     }

--- a/packages/field-base/test/tabindex-mixin.test.js
+++ b/packages/field-base/test/tabindex-mixin.test.js
@@ -24,11 +24,6 @@ describe('tabindex-mixin', () => {
       expect(element.getAttribute('tabindex')).to.be.equal('0');
     });
 
-    it('should reflect tabindex attribute to the property', () => {
-      element.tabindex = 1;
-      expect(element.getAttribute('tabindex')).to.be.equal('1');
-    });
-
     it('should reflect tabindex property to the attribute', () => {
       element.tabindex = 1;
       expect(element.getAttribute('tabindex')).to.be.equal('1');
@@ -37,6 +32,11 @@ describe('tabindex-mixin', () => {
     it('should reflect native tabIndex property to the attribute', () => {
       element.tabIndex = 1;
       expect(element.getAttribute('tabindex')).to.be.equal('1');
+    });
+
+    it('should reflect tabindex attribute to the property', () => {
+      element.setAttribute('tabindex', '1');
+      expect(element.tabindex).to.be.equal(1);
     });
 
     it('should set tabindex attribute to -1 when disabled', () => {

--- a/packages/field-base/test/tabindex-mixin.test.js
+++ b/packages/field-base/test/tabindex-mixin.test.js
@@ -15,44 +15,61 @@ customElements.define(
 describe('tabindex-mixin', () => {
   let element;
 
-  beforeEach(() => {
-    element = fixtureSync(`<tabindex-mixin-element></tabindex-mixin-element>`);
+  describe('default', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<tabindex-mixin-element></tabindex-mixin-element>`);
+    });
+
+    it('should set tabindex attribute to 0 by default', () => {
+      expect(element.getAttribute('tabindex')).to.be.equal('0');
+    });
+
+    it('should reflect tabindex attribute to the property', () => {
+      element.tabindex = 1;
+      expect(element.getAttribute('tabindex')).to.be.equal('1');
+    });
+
+    it('should reflect tabindex property to the attribute', () => {
+      element.tabindex = 1;
+      expect(element.getAttribute('tabindex')).to.be.equal('1');
+    });
+
+    it('should reflect native tabIndex property to the attribute', () => {
+      element.tabIndex = 1;
+      expect(element.getAttribute('tabindex')).to.be.equal('1');
+    });
+
+    it('should set tabindex attribute to -1 when disabled', () => {
+      element.tabIndex = 1;
+      element.disabled = true;
+      expect(element.getAttribute('tabindex')).to.be.equal('-1');
+    });
+
+    it('should restore tabindex attribute when enabled', () => {
+      element.tabIndex = 1;
+      element.disabled = true;
+      element.disabled = false;
+      expect(element.getAttribute('tabindex')).to.be.equal('1');
+    });
+
+    it('should restore tabindex attribute with the last known value when enabled', () => {
+      element.tabIndex = 1;
+      element.disabled = true;
+      element.tabIndex = 2;
+      expect(element.getAttribute('tabindex')).to.be.equal('-1');
+
+      element.disabled = false;
+      expect(element.getAttribute('tabindex')).to.be.equal('2');
+    });
   });
 
-  it('should set tabindex attribute to 0 by default', () => {
-    expect(element.getAttribute('tabindex')).to.be.equal('0');
-  });
+  describe('custom', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<tabindex-mixin-element tabindex="1"></tabindex-mixin-element>`);
+    });
 
-  it('should reflect tabindex property to the attribute', () => {
-    element.tabindex = 1;
-    expect(element.getAttribute('tabindex')).to.be.equal('1');
-  });
-
-  it('should reflect native tabIndex property to the attribute', () => {
-    element.tabIndex = 1;
-    expect(element.getAttribute('tabindex')).to.be.equal('1');
-  });
-
-  it('should set tabindex attribute to -1 when disabled', () => {
-    element.tabIndex = 1;
-    element.disabled = true;
-    expect(element.getAttribute('tabindex')).to.be.equal('-1');
-  });
-
-  it('should restore tabindex attribute when enabled', () => {
-    element.tabIndex = 1;
-    element.disabled = true;
-    element.disabled = false;
-    expect(element.getAttribute('tabindex')).to.be.equal('1');
-  });
-
-  it('should restore tabindex attribute with the last known value when enabled', () => {
-    element.tabIndex = 1;
-    element.disabled = true;
-    element.tabIndex = 2;
-    expect(element.getAttribute('tabindex')).to.be.equal('-1');
-
-    element.disabled = false;
-    expect(element.getAttribute('tabindex')).to.be.equal('2');
+    it('should set tabindex property to the custom value', () => {
+      expect(element.tabindex).to.equal(1);
+    });
   });
 });


### PR DESCRIPTION
## Description

This PR fixes a regression that appeared in Flow ITs after we released the new `@vaadin/button` package:

> When setting a custom `tabindex` attribute before the initialization of the button, the attribute gets overridden with the default `tabindex` value (`0`).

Fixes #2442

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
