### PR TITLE
fix: add role grid month calendar

### DIFF
--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -59,10 +59,16 @@ class MonthCalendar extends ThemableMixin(GestureEventListeners(PolymerElement))
       </style>
 
       <div part="month-header" role="heading">[[_getTitle(month, i18n.monthNames)]]</div>
-      <div id="monthGrid" on-tap="_handleTap" on-touchend="_preventDefault" on-touchstart="_onMonthGridTouchStart">
+      <div
+        id="monthGrid"
+        on-tap="_handleTap"
+        on-touchend="_preventDefault"
+        on-touchstart="_onMonthGridTouchStart"
+        role="grid"
+      >
         <div id="weekdays-container">
           <div hidden$="[[!_showWeekSeparator(showWeekNumbers, i18n.firstDayOfWeek)]]" part="weekday"></div>
-          <div part="weekdays">
+          <div part="weekdays" role="rowheader">
             <template
               is="dom-repeat"
               items="[[_getWeekDayNames(i18n.weekdays, i18n.weekdaysShort, showWeekNumbers, i18n.firstDayOfWeek)]]"
@@ -77,7 +83,7 @@ class MonthCalendar extends ThemableMixin(GestureEventListeners(PolymerElement))
               <div part="week-number" role="heading" aria-label$="[[i18n.week]] [[item]]">[[item]]</div>
             </template>
           </div>
-          <div id="days">
+          <div id="days" role="rowgroup">
             <template is="dom-repeat" items="[[_days]]">
               <!-- prettier-ignore -->
               <div

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -151,6 +151,17 @@ describe('vaadin-month-calendar', () => {
     expect(monthCalendar.selectedDate).to.be.undefined;
   });
 
+  it('should have the appropriate roles set ', () => {
+    const monthRole = monthCalendar.$.monthGrid.getAttribute('role');
+    expect(monthRole).to.be.equal('grid');
+
+    const weekdaysRole = monthCalendar.shadowRoot.querySelector('[part="weekdays"]').getAttribute('role');
+    expect(weekdaysRole).to.be.equal('rowheader');
+
+    const daysRole = monthCalendar.$.days.getAttribute('role');
+    expect(daysRole).to.be.equal('rowgroup');
+  });
+
   describe('i18n', () => {
     beforeEach(async () => {
       monthCalendar.i18n = {


### PR DESCRIPTION
## Description
Screen reader users are getting confused about the structure of each month section, in the calendar widget.

This change introduces roles in key divs that aim to better describe the markdown to screen reader users.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
