### PR TITLE
feat: add CheckedMixin for checkbox and radio-button

### DIFF
--- a/packages/field-base/index.d.ts
+++ b/packages/field-base/index.d.ts
@@ -1,6 +1,7 @@
 export { ActiveMixin } from './src/active-mixin.js';
 export { AriaLabelMixin } from './src/aria-label-mixin.js';
 export { CharLengthMixin } from './src/char-length-mixin.js';
+export { CheckedMixin } from './src/checked-mixin.js';
 export { ClearButtonMixin } from './src/clear-button-mixin.js';
 export { DelegateFocusMixin } from './src/delegate-focus-mixin.js';
 export { DelegateInputStateMixin } from './src/delegate-input-state-mixin.js';

--- a/packages/field-base/index.js
+++ b/packages/field-base/index.js
@@ -1,6 +1,7 @@
 export { ActiveMixin } from './src/active-mixin.js';
 export { AriaLabelMixin } from './src/aria-label-mixin.js';
 export { CharLengthMixin } from './src/char-length-mixin.js';
+export { CheckedMixin } from './src/checked-mixin.js';
 export { ClearButtonMixin } from './src/clear-button-mixin.js';
 export { DelegateFocusMixin } from './src/delegate-focus-mixin.js';
 export { DelegateInputStateMixin } from './src/delegate-input-state-mixin.js';

--- a/packages/field-base/src/checked-mixin.d.ts
+++ b/packages/field-base/src/checked-mixin.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { DelegateStateMixin } from './delegate-state-mixin.js';
+import { DisabledMixin } from './disabled-mixin.js';
+import { InputMixin } from './input-mixin.js';
+
+/**
+ * A mixin to manage the checked state.
+ */
+declare function CheckedMixin<T extends new (...args: any[]) => {}>(base: T): T & CheckedMixinConstructor;
+
+interface CheckedMixinConstructor {
+  new (...args: any[]): CheckedMixin;
+}
+
+interface CheckedMixin extends DelegateStateMixin, DisabledMixin, InputMixin {}
+
+export { CheckedMixinConstructor, CheckedMixin };

--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { DelegateStateMixin } from './delegate-state-mixin.js';
+import { DisabledMixin } from './disabled-mixin.js';
+import { InputMixin } from './input-mixin.js';
+
+const CheckedMixinImplementation = (superclass) =>
+  class CheckedMixinClass extends DelegateStateMixin(DisabledMixin(InputMixin(superclass))) {
+    static get properties() {
+      return {
+        /**
+         * True if the element is checked.
+         * @type {boolean}
+         */
+        checked: {
+          type: Boolean,
+          value: false,
+          notify: true,
+          reflectToAttribute: true
+        }
+      };
+    }
+
+    static get delegateAttrs() {
+      return [...super.delegateAttrs, 'checked'];
+    }
+
+    get _delegateStateTarget() {
+      return this.inputElement;
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.addEventListener('click', (event) => {
+        this._onClick(event);
+      });
+    }
+
+    /**
+     * @param {!MouseEvent} event
+     * @return {boolean}
+     * @protected
+     */
+    _interactionsAllowed(event) {
+      if (this.disabled) {
+        return false;
+      }
+
+      if (event.target.localName === 'a') {
+        return false;
+      }
+
+      return true;
+    }
+
+    /**
+     * @param {!MouseEvent} event
+     * @protected
+     */
+    _onClick(event) {
+      if (!this._interactionsAllowed(event)) {
+        event.preventDefault();
+        return;
+      }
+
+      this._toggleChecked();
+    }
+
+    /** @protected */
+    _toggleChecked() {
+      this.checked = !this.checked;
+    }
+  };
+
+/**
+ * A mixin to manage the checked state.
+ */
+export const CheckedMixin = dedupingMixin(CheckedMixinImplementation);

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -34,10 +34,8 @@ describe('checked-mixin', () => {
 
       it('should delegate checked attribute to the input', () => {
         expect(input.hasAttribute('checked')).to.be.true;
-      });
 
-      it('should update checked attribute on the input', () => {
-        element.checked = false;
+        element.removeAttribute('checked');
         expect(input.hasAttribute('checked')).to.be.false;
       });
     });
@@ -55,8 +53,20 @@ describe('checked-mixin', () => {
       input = element.querySelector('[slot=input]');
     });
 
-    it('should not be checked by default', () => {
+    it('should set checked property to false by default', () => {
       expect(element.checked).to.be.false;
+    });
+
+    it('should not have checked attribute by default', () => {
+      expect(element.hasAttribute('checked')).to.be.false;
+    });
+
+    it('should reflect checked property to the attribute', () => {
+      element.checked = true;
+      expect(element.hasAttribute('checked')).to.be.true;
+
+      element.checked = false;
+      expect(element.hasAttribute('checked')).to.be.false;
     });
 
     it('should toggle checked state on click', () => {

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, click } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { CheckedMixin } from '../src/checked-mixin.js';
 import { InputSlotMixin } from '../src/input-slot-mixin.js';
@@ -24,22 +24,6 @@ customElements.define(
 
 describe('checked-mixin', () => {
   let element, input, link;
-
-  describe('delegation', () => {
-    describe('checked attribute', () => {
-      beforeEach(() => {
-        element = fixtureSync(`<checked-mixin-element checked></checked-mixin-element>`);
-        input = element.querySelector('[slot=input]');
-      });
-
-      it('should delegate checked attribute to the input', () => {
-        expect(input.hasAttribute('checked')).to.be.true;
-
-        element.removeAttribute('checked');
-        expect(input.hasAttribute('checked')).to.be.false;
-      });
-    });
-  });
 
   describe('default', () => {
     beforeEach(() => {
@@ -69,7 +53,7 @@ describe('checked-mixin', () => {
       expect(element.hasAttribute('checked')).to.be.false;
     });
 
-    it('should toggle checked state on click', () => {
+    it('should toggle checked property on click', () => {
       input.click();
       expect(element.checked).to.be.true;
 
@@ -77,12 +61,12 @@ describe('checked-mixin', () => {
       expect(element.checked).to.be.false;
     });
 
-    it('should not toggle checked state when clicked a link', () => {
+    it('should not toggle checked property when clicked a link', () => {
       link.click();
       expect(element.checked).to.be.false;
     });
 
-    it('should not toggle checked state when disabled', () => {
+    it('should not toggle checked property when disabled', () => {
       element.disabled = true;
       input.click();
       expect(element.checked).to.be.false;
@@ -90,8 +74,26 @@ describe('checked-mixin', () => {
 
     it('should prevent default behaviour for click event when disabled', () => {
       element.disabled = true;
-      input.click();
-      expect(input.checked).to.be.false;
+
+      const event = click(input);
+
+      expect(event.defaultPrevented).to.be.true;
+    });
+  });
+
+  describe('delegation', () => {
+    describe('checked attribute', () => {
+      beforeEach(() => {
+        element = fixtureSync(`<checked-mixin-element checked></checked-mixin-element>`);
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should delegate checked attribute to the input', () => {
+        expect(input.hasAttribute('checked')).to.be.true;
+
+        element.removeAttribute('checked');
+        expect(input.hasAttribute('checked')).to.be.false;
+      });
     });
   });
 });

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,0 +1,87 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { CheckedMixin } from '../src/checked-mixin.js';
+import { InputSlotMixin } from '../src/input-slot-mixin.js';
+
+customElements.define(
+  'checked-mixin-element',
+  class extends CheckedMixin(InputSlotMixin(PolymerElement)) {
+    static get template() {
+      return html`<div>
+        <slot></slot>
+        <slot name="input"></slot>
+      </div>`;
+    }
+
+    constructor() {
+      super();
+
+      this._setType('checkbox');
+    }
+  }
+);
+
+describe('checked-mixin', () => {
+  let element, input, link;
+
+  describe('delegation', () => {
+    describe('checked attribute', () => {
+      beforeEach(() => {
+        element = fixtureSync(`<checked-mixin-element checked></checked-mixin-element>`);
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should delegate checked attribute to the input', () => {
+        expect(input.hasAttribute('checked')).to.be.true;
+      });
+
+      it('should update checked attribute on the input', () => {
+        element.checked = false;
+        expect(input.hasAttribute('checked')).to.be.false;
+      });
+    });
+  });
+
+  describe('default', () => {
+    beforeEach(() => {
+      element = fixtureSync(`
+        <checked-mixin-element>
+          I accept <a href="#">the terms and conditions</a>
+        </checked-mixin-element>
+      `);
+
+      link = element.querySelector('a');
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should not be checked by default', () => {
+      expect(element.checked).to.be.false;
+    });
+
+    it('should toggle checked state on click', () => {
+      input.click();
+      expect(element.checked).to.be.true;
+
+      input.click();
+      expect(element.checked).to.be.false;
+    });
+
+    it('should not toggle checked state when clicked a link', () => {
+      link.click();
+      expect(element.checked).to.be.false;
+    });
+
+    it('should not toggle checked state when disabled', () => {
+      element.disabled = true;
+      input.click();
+      expect(element.checked).to.be.false;
+    });
+
+    it('should prevent default behaviour for click event when disabled', () => {
+      element.disabled = true;
+      input.click();
+      expect(input.checked).to.be.false;
+    });
+  });
+});

--- a/packages/field-base/test/delegate-state-mixin.test.js
+++ b/packages/field-base/test/delegate-state-mixin.test.js
@@ -76,7 +76,7 @@ customElements.define(
 );
 
 describe('delegate-state-mixin', () => {
-  let element, input;
+  let element, target;
 
   describe('without target', () => {
     beforeEach(() => {
@@ -99,64 +99,91 @@ describe('delegate-state-mixin', () => {
     });
   });
 
-  describe('attributes', () => {
-    describe('title', () => {
+  describe('title attribute', () => {
+    describe('default', () => {
       beforeEach(() => {
-        element = fixtureSync('<delegate-state-mixin-element title="foo"></delegate-state-mixin-element>');
-        input = element.shadowRoot.querySelector('input');
+        element = fixtureSync('<delegate-state-mixin-element></delegate-state-mixin-element>');
+        target = element._delegateStateTarget;
       });
 
-      it('should delegate title attribute to the input', () => {
-        expect(input.getAttribute('title')).to.equal('foo');
-      });
+      it('should delegate title attribute to the target', () => {
+        expect(target.hasAttribute('title')).to.be.false;
 
-      it('should update title attribute on the input', () => {
-        element.setAttribute('title', 'bar');
-        expect(input.getAttribute('title')).to.equal('bar');
+        element.setAttribute('title', 'foo');
+        expect(target.getAttribute('title')).to.equal('foo');
       });
     });
 
-    describe('invalid', () => {
+    describe('initially set', () => {
       beforeEach(() => {
-        element = fixtureSync('<delegate-state-mixin-element invalid></delegate-state-mixin-element>');
-        input = element.shadowRoot.querySelector('input');
+        element = fixtureSync('<delegate-state-mixin-element title="foo"></delegate-state-mixin-element>');
+        target = element._delegateStateTarget;
       });
 
-      it('should delegate invalid attribute to the input', () => {
-        expect(input.hasAttribute('invalid')).to.be.true;
-      });
+      it('should delegate title attribute to the target', () => {
+        expect(target.getAttribute('title')).to.equal('foo');
 
-      it('should delegate aria-invalid attribute to the input', () => {
-        expect(input.getAttribute('aria-invalid')).to.equal('true');
-      });
-
-      it('should remove invalid attribute when valid', () => {
-        element.removeAttribute('invalid');
-        expect(input.hasAttribute('invalid')).to.be.false;
-      });
-
-      it('should remove aria-invalid attribute when valid', () => {
-        element.removeAttribute('invalid');
-        expect(input.hasAttribute('aria-invalid')).to.be.false;
+        element.removeAttribute('title');
+        expect(target.hasAttribute('title')).to.be.false;
       });
     });
   });
 
-  describe('properties', () => {
-    beforeEach(() => {
-      element = fixtureSync('<delegate-state-mixin-element></delegate-state-mixin-element>');
-      input = element.shadowRoot.querySelector('input');
+  describe('invalid attribute', () => {
+    describe('default', () => {
+      beforeEach(() => {
+        element = fixtureSync('<delegate-state-mixin-element></delegate-state-mixin-element>');
+        target = element._delegateStateTarget;
+      });
+
+      it('should delegate invalid attribute to the target', () => {
+        expect(target.hasAttribute('invalid')).to.be.false;
+
+        element.toggleAttribute('invalid', true);
+        expect(target.hasAttribute('invalid')).to.be.true;
+      });
+
+      it('should delegate aria-invalid attribute to the target', () => {
+        expect(target.hasAttribute('aria-invalid')).to.be.false;
+
+        element.toggleAttribute('invalid', true);
+        expect(target.hasAttribute('aria-invalid')).to.be.true;
+      });
     });
 
-    describe('indeterminate', () => {
-      it('should delegate indeterminate property to the input', () => {
-        expect(input.indeterminate).to.be.true;
+    describe('initially set', () => {
+      beforeEach(() => {
+        element = fixtureSync('<delegate-state-mixin-element invalid></delegate-state-mixin-element>');
+        target = element._delegateStateTarget;
       });
 
-      it('should update indeterminate property on the input', () => {
-        input.indeterminate = false;
-        expect(input.indeterminate).to.be.false;
+      it('should delegate invalid attribute to the target', () => {
+        expect(target.hasAttribute('invalid')).to.be.true;
+
+        element.removeAttribute('invalid');
+        expect(target.hasAttribute('invalid')).to.be.false;
       });
+
+      it('should delegate aria-invalid attribute to the target', () => {
+        expect(target.hasAttribute('aria-invalid')).to.be.true;
+
+        element.removeAttribute('invalid');
+        expect(target.hasAttribute('aria-invalid')).to.be.false;
+      });
+    });
+  });
+
+  describe('indeterminate property', () => {
+    beforeEach(() => {
+      element = fixtureSync('<delegate-state-mixin-element></delegate-state-mixin-element>');
+      target = element._delegateStateTarget;
+    });
+
+    it('should delegate indeterminate property to the target', () => {
+      expect(target.indeterminate).to.be.true;
+
+      target.indeterminate = false;
+      expect(target.indeterminate).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

This PR introduces `CheckedMixin` that manages the `checked` state of a component. 

This mixin is based on [the a11y prototype](https://github.com/web-padawan/a11y-vaadin-proto/blob/master/src/mixins/checked-mixin.js).

Note, the prototype implementation also manages the `aria-checked` attribute on the element. However, according to [the documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaChecked), there is no need for `aria-checked` when using the native checkbox or radio button, hence `aria-checked` is not included in the final implementation.

This mixin is going to be used within the new accessible implementation for:

- `<vaadin-checkbox>` (#2212).
- `<vaadin-radio-button>` (#2213) 

Fixes #2210

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
