### PR TITLE
chore: add vscode config folder and macos DS_Store files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ yarn-error.log
 
 # Failures from visual tests
 packages/*/test/visual/*/screenshots/*/failed
+
+# MacOS DS_Store files
+.DS_Store
+
+# VSCode user configuration folders
+.vscode


### PR DESCRIPTION
I don't want to accidentally add unnecessary files to the repository. 

Avoid accidentally committing `.vscode` folder and `.DS_Store` files.
