### PR TITLE
fix: use lumo iconset with vaadin-icon

### DIFF
--- a/packages/vaadin-lumo-styles/icons.js
+++ b/packages/vaadin-lumo-styles/icons.js
@@ -6,3 +6,4 @@
 import '@polymer/iron-icon/iron-icon.js';
 import './version.js';
 import './iconset.js';
+import './vaadin-iconset.js';


### PR DESCRIPTION
## Description

Currently it is not possible to use the Lumo iconset with the `vaadin-icon` component that was introduced in 21:
```html
<vaadin-icon icon="lumo:bar-chart"></vaadin-icon> <!-- doesn't work -->
```

The issue is that the Lumo iconset is currently not loaded as a `vaadin-iconset`, which means that `vaadin-icon` can not find the icon collection.

To fix this I included the `vaadin-iconset.js` of the Lumo theme into the all imports file (via `icons.js`). That also means that both, the `iron-iconset` and `vaadin-iconset` versions of the Lumo iconset will be loaded, increasing the payload transmitted to the browser. As I understand it that is intended to allow backwards compatibility with `iron-icon` in the meantime.

Also not 100% in which versions this fix should land. For now I targeted master and 21.

## Type of change

- [x] Bugfix
