### PR TITLE
test: use a new grid instance in each keyboard navigation test

### DIFF
--- a/packages/vaadin-grid/test/keyboard-navigation.test.js
+++ b/packages/vaadin-grid/test/keyboard-navigation.test.js
@@ -11,7 +11,7 @@ import {
   listenOnce,
   nextFrame,
   up as mouseUp
-} from '@vaadin/testing-helpers/dist/index-no-side-effects.js';
+} from '@vaadin/testing-helpers';
 import '@vaadin/vaadin-template-renderer';
 import { sendKeys } from '@web/test-runner-commands';
 import {
@@ -23,70 +23,10 @@ import {
   getRowCells,
   infiniteDataProvider,
   scrollToEnd,
-  getLastVisibleItem,
-  nextResize
+  getLastVisibleItem
 } from './helpers.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
-
-window.top.focus && window.top.focus();
-window.focus();
-
-if (
-  (window.chrome ||
-    /HeadlessChrome/.test(window.navigator.userAgent) ||
-    window.navigator.userAgent.toLowerCase().indexOf('firefox') > -1) &&
-  !window.document.hasFocus()
-) {
-  // Oh no! Focus kinda works, but no native events are dispatched. Let’s fake them.
-  const nativeFocus = HTMLElement.prototype.focus;
-  let fakeFocusCurrentTarget, recursiveFocusInterrupt;
-  HTMLElement.prototype.focus = function () {
-    const dispatchMockFocusEvent = function (type, bubbles, composed, target, relatedTarget) {
-      if (!target) {
-        return;
-      }
-      const e = new CustomEvent(type, { bubbles, composed: composed });
-      e.relatedTarget = relatedTarget;
-      target.dispatchEvent(e);
-    };
-
-    let activeElement,
-      recursiveFocusInvoke = false;
-    if (fakeFocusCurrentTarget) {
-      // When focus is called from a focusin/focusout listener (e. g.,
-      // recursive .focus()), activeElement might not be shifted yet.
-      // The true activeElement is a target of the previous .focus call.
-      activeElement = fakeFocusCurrentTarget;
-      recursiveFocusInvoke = true;
-    } else {
-      activeElement = document.activeElement;
-      if (activeElement) {
-        while (activeElement.shadowRoot && activeElement.shadowRoot.activeElement) {
-          activeElement = activeElement.shadowRoot.activeElement;
-        }
-      }
-    }
-
-    if (activeElement === this) {
-      // Prevent duplicate events when focus stays on the same element
-      nativeFocus.apply(this, arguments);
-    } else {
-      fakeFocusCurrentTarget = this;
-      // If shadow roots match, the events are shadow-internal, not composed
-      const composed = this.getRootNode() !== activeElement.getRootNode();
-      dispatchMockFocusEvent('focusout', true, composed, activeElement, this);
-      !recursiveFocusInterrupt && dispatchMockFocusEvent('focusin', true, composed, this, activeElement);
-      !recursiveFocusInterrupt && nativeFocus.apply(this, arguments);
-      !recursiveFocusInterrupt && dispatchMockFocusEvent('blur', false, composed, activeElement, this);
-      !recursiveFocusInterrupt && dispatchMockFocusEvent('focus', false, composed, this, activeElement);
-      fakeFocusCurrentTarget = undefined;
-    }
-
-    // Recursive focus invoke should interrupt the parent
-    recursiveFocusInterrupt = recursiveFocusInvoke;
-  };
-}
 
 let grid, focusable, scroller, header, footer, body;
 
@@ -237,7 +177,7 @@ function getTabbableElements(root) {
 }
 
 describe('keyboard navigation', () => {
-  before(async () => {
+  beforeEach(async () => {
     grid = fixtureSync(`
       <vaadin-grid theme="no-border">
         <template class="row-details">
@@ -279,6 +219,8 @@ describe('keyboard navigation', () => {
     body = grid.$.items;
     footer = grid.$.footer;
 
+    grid.items = ['foo', 'bar'];
+
     grid._observer.flush();
     flushGrid(grid);
 
@@ -287,40 +229,6 @@ describe('keyboard navigation', () => {
     grid.parentNode.appendChild(focusable);
 
     await aTimeout(0);
-  });
-
-  after(() => {
-    focusable.remove();
-    grid.remove();
-  });
-
-  beforeEach(async () => {
-    // Reset side effects from tests
-    grid.style.width = '';
-    grid.style.border = '';
-
-    if (!grid.items || grid.items[0] !== 'foo' || grid.items[1] !== 'bar') {
-      grid.size = undefined;
-      grid.dataProvider = undefined;
-      grid.items = ['foo', 'bar'];
-      flushGrid(grid);
-    }
-    grid.activeItem = null;
-    grid.detailsOpenedItems = [];
-    grid._columnTree[0].forEach((column) => {
-      column.hidden = false;
-      column.frozen = false;
-    });
-
-    grid._focusedItemIndex = 0;
-    grid._focusedColumnOrder = undefined;
-    grid._resetKeyboardNavigation();
-    grid.removeAttribute('navigating');
-
-    focusable.focus();
-    flushGrid(grid);
-
-    await nextResize(grid);
   });
 
   describe('navigation mode', () => {
@@ -426,6 +334,14 @@ describe('keyboard navigation', () => {
       mouseDown(grid);
 
       expect(grid.hasAttribute('navigating')).to.be.false;
+    });
+
+    it('should enable navigation mode on header navigation', () => {
+      focusFirstHeaderCell();
+
+      right();
+
+      expect(grid.hasAttribute('navigating')).to.be.true;
     });
   });
 
@@ -822,7 +738,7 @@ describe('keyboard navigation', () => {
         expect(getFocusedCellIndex()).to.equal(1);
       });
 
-      it('should not navigate to hidden column with end', () => {
+      it('should not navigate to hidden column with home', () => {
         grid._columnTree[0][0].hidden = true;
         flushGrid(grid);
 
@@ -835,7 +751,7 @@ describe('keyboard navigation', () => {
         expect(columnFocusedCell.hidden).to.be.false;
       });
 
-      it('should not navigate to hidden column with home', () => {
+      it('should not navigate to hidden column with end', () => {
         grid._columnTree[0][2].hidden = true;
         flushGrid(grid);
 
@@ -1279,7 +1195,7 @@ describe('keyboard navigation', () => {
         });
 
         it('should not hide navigation mode if a header cell is focused', () => {
-          focusFirstHeaderCell();
+          tabToHeader();
           right();
 
           expect(grid.hasAttribute('navigating')).to.be.true;
@@ -1492,7 +1408,7 @@ describe('keyboard navigation', () => {
   });
 
   describe('interaction mode', () => {
-    before(async () => {
+    beforeEach(async () => {
       grid = fixtureSync(`
       <vaadin-grid theme="no-border">
         <template class="row-details">
@@ -1537,9 +1453,9 @@ describe('keyboard navigation', () => {
       flushGrid(grid);
 
       await aTimeout(0);
-    });
 
-    beforeEach(() => {
+      grid.items = ['foo', 'bar'];
+
       focusItem(0);
       clickItem(0);
     });


### PR DESCRIPTION
cherry-pick from https://github.com/vaadin/web-components/pull/2434