### PR TITLE
feat: add SlotTargetMixin for checkbox and radio-button

### DIFF
--- a/packages/field-base/src/slot-target-mixin.d.ts
+++ b/packages/field-base/src/slot-target-mixin.d.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A mixin to forward the content from a source slot to a target element.
+ */
+declare function SlotTargetMixinMixin<T extends new (...args: any[]) => {}>(
+  base: T
+): T & SlotTargetMixinMixinConstructor;
+
+interface SlotTargetMixinMixinConstructor {
+  new (...args: any[]): SlotTargetMixinMixin;
+}
+
+interface SlotTargetMixinMixin {
+  /**
+   * A reference to the source slot from which the content is forwarded to the target element.
+   *
+   * @protected
+   */
+  _sourceSlot: HTMLSlotElement;
+
+  /**
+   * A reference to the target element to which the content is forwarded from the source slot.
+   *
+   * @protected
+   */
+  _slotTarget: HTMLElement;
+
+  /**
+   * A callback method that is called once the target element's content is changed.
+   *
+   * By default, it does nothing. Override the method to implement your own behavior.
+   *
+   * @protected
+   */
+  _onSlotTargetContentChange(): void;
+}
+
+export { SlotTargetMixinMixinConstructor, SlotTargetMixinMixin };

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -1,0 +1,113 @@
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+
+const SlotTargetMixinImplementation = (superclass) =>
+  class SlotTargetMixinClass extends superclass {
+    constructor() {
+      super();
+
+      /**
+       * @type {MutationObserver}
+       * @private
+       */
+      this.__slotTargetObserver = new MutationObserver(() => {
+        this._onSlotTargetContentChange();
+      });
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      if (this._slotTarget) {
+        // Observe for changes in the target element.
+        this.__slotTargetObserver.observe(this._slotTarget, {
+          childList: true
+        });
+      }
+
+      if (this._sourceSlot) {
+        // Observe for changes in the source slot.
+        this._sourceSlot.addEventListener('slotchange', () => {
+          this.__onSourceSlotContentChange();
+        });
+
+        this.__onSourceSlotContentChange();
+      }
+    }
+
+    /**
+     * @type {HTMLSlotElement}
+     * @protected
+     */
+    get _sourceSlot() {
+      console.warn(`Please implement the '_sourceSlot' property in <${this.localName}>`);
+      return null;
+    }
+
+    /**
+     * @type {HTMLElement}
+     * @protected
+     */
+    get _slotTarget() {
+      console.warn(`Please implement the '_slotTarget' property in <${this.localName}>`);
+      return null;
+    }
+
+    /** @protected */
+    _onSlotTargetContentChange() {}
+
+    /** @private */
+    __onSourceSlotContentChange() {
+      if (!this._slotTarget) {
+        return;
+      }
+
+      const nodes = this._sourceSlot.assignedNodes({ flatten: true });
+      if (nodes.length > 0) {
+        this._slotTarget.replaceChildren(...nodes);
+      }
+    }
+
+    /** @override */
+    set textContent(text) {
+      if (this._slotTarget) {
+        this._slotTarget.textContent = text;
+        return;
+      }
+
+      super.textContent = text;
+    }
+
+    /** @override */
+    get textContent() {
+      if (this._slotTarget) {
+        return this._slotTarget.textContent;
+      }
+
+      return super.textContent;
+    }
+
+    /** @override */
+    set innerHTML(html) {
+      if (this._slotTarget) {
+        this._slotTarget.innerHTML = html;
+        return;
+      }
+
+      super.innerHTML = html;
+    }
+
+    /** @override */
+    get innerHTML() {
+      if (this._slotTarget) {
+        return this._slotTarget.innerHTML;
+      }
+
+      return super.innerHTML;
+    }
+  };
+
+/**
+ * Mixin that moves any nodes added to a source slot to a target element.
+ */
+export const SlotTargetMixin = dedupingMixin(SlotTargetMixinImplementation);

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -36,7 +36,9 @@ const SlotTargetMixinImplementation = (superclass) =>
     }
 
     /**
-     * @type {HTMLSlotElement}
+     * A reference to the source slot from which the content is forwarded to the target element.
+     *
+     * @type {HTMLSlotElement | null}
      * @protected
      */
     get _sourceSlot() {
@@ -45,7 +47,9 @@ const SlotTargetMixinImplementation = (superclass) =>
     }
 
     /**
-     * @type {HTMLElement}
+     * A reference to the target element to which the content is forwarded from the source slot.
+     *
+     * @type {HTMLElement | null}
      * @protected
      */
     get _slotTarget() {
@@ -53,10 +57,21 @@ const SlotTargetMixinImplementation = (superclass) =>
       return null;
     }
 
-    /** @protected */
+    /**
+     * A callback method that is called once the target element's content is changed.
+     *
+     * By default, it does nothing. Override the method to implement your own behavior.
+     *
+     * @protected
+     */
     _onSlotTargetContentChange() {}
 
-    /** @private */
+    /**
+     * Forwards every node from the source slot to the target element
+     * once the source slot' content is changed.
+     *
+     * @private
+     */
     __onSourceSlotContentChange() {
       if (!this._slotTarget) {
         return;
@@ -67,47 +82,9 @@ const SlotTargetMixinImplementation = (superclass) =>
         this._slotTarget.replaceChildren(...nodes);
       }
     }
-
-    /** @override */
-    set textContent(text) {
-      if (this._slotTarget) {
-        this._slotTarget.textContent = text;
-        return;
-      }
-
-      super.textContent = text;
-    }
-
-    /** @override */
-    get textContent() {
-      if (this._slotTarget) {
-        return this._slotTarget.textContent;
-      }
-
-      return super.textContent;
-    }
-
-    /** @override */
-    set innerHTML(html) {
-      if (this._slotTarget) {
-        this._slotTarget.innerHTML = html;
-        return;
-      }
-
-      super.innerHTML = html;
-    }
-
-    /** @override */
-    get innerHTML() {
-      if (this._slotTarget) {
-        return this._slotTarget.innerHTML;
-      }
-
-      return super.innerHTML;
-    }
   };
 
 /**
- * Mixin that moves any nodes added to a source slot to a target element.
+ * A mixin to forward the content from a source slot to a target element.
  */
 export const SlotTargetMixin = dedupingMixin(SlotTargetMixinImplementation);

--- a/packages/field-base/test/delegate-state-mixin.test.js
+++ b/packages/field-base/test/delegate-state-mixin.test.js
@@ -91,7 +91,7 @@ describe('delegate-state-mixin', () => {
       console.warn.restore();
     });
 
-    it('should show a warning', () => {
+    it('should warn about no implementation for _delegateStateTarget', () => {
       expect(console.warn.calledTwice).to.be.true;
       expect(console.warn.args[0][0]).to.equal(
         `Please implement the '_delegateStateTarget' property in <delegate-state-mixin-element-without-target>`

--- a/packages/field-base/test/slot-target-mixin.test.js
+++ b/packages/field-base/test/slot-target-mixin.test.js
@@ -1,0 +1,189 @@
+import sinon from 'sinon';
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { SlotTargetMixin } from '../src/slot-target-mixin.js';
+
+customElements.define(
+  'slot-target-mixin-element-warnings',
+  class extends SlotTargetMixin(PolymerElement) {
+    static get template() {
+      return html`<div></div>`;
+    }
+  }
+);
+
+describe('slot-target-mixin', () => {
+  let element, slotTargetContentChangeSpy;
+
+  before(() => {
+    slotTargetContentChangeSpy = sinon.spy();
+
+    customElements.define(
+      'slot-target-mixin-element',
+      class extends SlotTargetMixin(PolymerElement) {
+        static get template() {
+          return html`
+            <slot id="source"></slot>
+
+            <div id="target"></div>
+          `;
+        }
+
+        get _sourceSlot() {
+          return this.$.source;
+        }
+
+        get _slotTarget() {
+          return this.$.target;
+        }
+
+        _onSlotTargetContentChange() {
+          slotTargetContentChangeSpy();
+        }
+      }
+    );
+  });
+
+  afterEach(() => {
+    slotTargetContentChangeSpy.resetHistory();
+  });
+
+  describe('default', () => {
+    let node1, node2;
+
+    beforeEach(() => {
+      element = document.createElement('slot-target-mixin-element');
+      node1 = document.createElement('div');
+      node2 = document.createTextNode('');
+      element.append(node1, node2);
+
+      document.body.appendChild(element);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(element);
+    });
+
+    it('should populate the target element with nodes from the source slot', () => {
+      expect(element._slotTarget.childNodes).to.have.lengthOf(2);
+      expect(element._slotTarget.childNodes[0]).to.include(node1);
+      expect(element._slotTarget.childNodes[1]).to.include(node2);
+    });
+
+    it('should not have any nodes in the source slot', () => {
+      expect(element.childNodes).to.have.lengthOf(0);
+    });
+  });
+
+  describe('source slot observer', () => {
+    it('should populate the target element when adding nodes to the source slot lazily', async () => {
+      element = fixtureSync(`<slot-target-mixin-element></slot-target-mixin-element>`);
+
+      const node = document.createElement('div');
+      element.appendChild(node);
+      await nextFrame();
+
+      expect(element._slotTarget.childNodes).to.have.lengthOf(1);
+      expect(element._slotTarget.childNodes[0]).to.equal(node);
+    });
+
+    it('should re-populate the target element when adding new nodes to the source slot', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content</div></slot-target-mixin-element>`);
+
+      const node = document.createElement('div');
+      element.appendChild(node);
+      await nextFrame();
+
+      expect(element._slotTarget.childNodes).to.have.lengthOf(1);
+      expect(element._slotTarget.childNodes[0]).to.equal(node);
+    });
+  });
+
+  describe('target element observer', () => {
+    it('should notify when the target element is populated at the initialization', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+      await nextFrame();
+
+      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+    });
+
+    it('should notify when the target element is populated lazily', async () => {
+      element = fixtureSync(`<slot-target-mixin-element></slot-target-mixin-element>`);
+
+      const node = document.createElement('div');
+      element.appendChild(node);
+      await nextFrame();
+
+      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+    });
+
+    it('should notify when adding new nodes directly to the target element', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+
+      const node = document.createElement('div');
+      element._slotTarget.appendChild(node);
+      await nextFrame();
+
+      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+    });
+
+    it('should notify when replacing nodes directly in the target element', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+
+      const node = document.createElement('div');
+      element._slotTarget.replaceChildren(node);
+      await nextFrame();
+
+      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+    });
+
+    it('should notify when removing nodes directly from the target element', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+
+      element._slotTarget.removeChild(element._slotTarget.firstChild);
+      await nextFrame();
+
+      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+    });
+
+    it('should notify when adding new nodes to the source slot', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+      await nextFrame();
+
+      slotTargetContentChangeSpy.resetHistory();
+
+      const node = document.createElement('div');
+      element.appendChild(node);
+      await nextFrame();
+
+      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      sinon.stub(console, 'warn');
+
+      element = fixtureSync('<slot-target-mixin-element-warnings></slot-target-mixin-element-warnings>');
+    });
+
+    afterEach(() => {
+      console.warn.restore();
+    });
+
+    it('should warn about no implementation for _slotTarget', () => {
+      expect(console.warn.calledTwice).to.be.true;
+      expect(console.warn.args[0][0]).to.equal(
+        `Please implement the '_slotTarget' property in <slot-target-mixin-element-warnings>`
+      );
+    });
+
+    it('should warn about no implementation for _sourceSlot', () => {
+      expect(console.warn.calledTwice).to.be.true;
+      expect(console.warn.args[1][0]).to.equal(
+        `Please implement the '_sourceSlot' property in <slot-target-mixin-element-warnings>`
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces `SlotTargetMixin` that forwards every node from a source slot to a target element.

The `SlotTargetMixin` is based on [the prototype](https://github.com/web-padawan/a11y-vaadin-proto/blob/master/src/mixins/slot-target-mixin.js).

The `SlotTargetMixin` is needed by the future [`SlotLabelMixin`](https://github.com/web-padawan/a11y-vaadin-proto/blob/master/src/mixins/slot-label-mixin.js) to move the content from the default slot (a conventional way to define a label for a checkbox) to the slotted `<label>` element.

Part of #2211

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
