### PR TITLE
feat: add SlotLabelMixin for checkbox and radio-button

### DIFF
--- a/packages/custom-field/test/custom-field.test.js
+++ b/packages/custom-field/test/custom-field.test.js
@@ -64,8 +64,8 @@ describe('custom field', () => {
       labelElement = customField.querySelector('[slot="label"]');
     });
 
-    it('should be empty by default', () => {
-      expect(customField.label).to.equal('');
+    it('should be undefined by default', () => {
+      expect(customField.label).to.be.undefined;
     });
 
     it('should be displayed when assigned', () => {

--- a/packages/field-base/src/label-mixin.d.ts
+++ b/packages/field-base/src/label-mixin.d.ts
@@ -18,7 +18,7 @@ interface LabelMixin extends SlotMixin {
   /**
    * String used for a label element.
    */
-  label: string;
+  label: string | null | undefined;
 }
 
 export { LabelMixinConstructor, LabelMixin };

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -43,24 +43,24 @@ const LabelMixinImplementation = (superclass) =>
       // Ensure every instance has unique ID
       const uniqueId = (LabelMixinClass._uniqueId = 1 + LabelMixinClass._uniqueId || 0);
       this._labelId = `label-${this.localName}-${uniqueId}`;
+
+      /**
+       * @type {MutationObserver}
+       * @private
+       */
+      this.__labelNodeObserver = new MutationObserver(() => {
+        this._toggleHasLabelAttribute();
+      });
     }
 
     /** @protected */
-    connectedCallback() {
-      super.connectedCallback();
+    ready() {
+      super.ready();
 
       if (this._labelNode) {
         this._labelNode.id = this._labelId;
-
-        this._applyCustomLabel();
-      }
-    }
-
-    /** @protected */
-    _applyCustomLabel() {
-      const label = this._labelNode.textContent;
-      if (label !== this.label) {
-        this.label = label;
+        this.__labelNodeObserver.observe(this._labelNode, { childList: true });
+        this._toggleHasLabelAttribute();
       }
     }
 
@@ -68,9 +68,17 @@ const LabelMixinImplementation = (superclass) =>
     _labelChanged(label) {
       if (this._labelNode) {
         this._labelNode.textContent = label;
+        this._toggleHasLabelAttribute();
       }
+    }
 
-      this.toggleAttribute('has-label', Boolean(label));
+    /** @protected */
+    _toggleHasLabelAttribute() {
+      if (this._labelNode) {
+        const hasLabel = this._labelNode.children > 0 || this._labelNode.textContent.trim() !== '';
+
+        this.toggleAttribute('has-label', hasLabel);
+      }
     }
   };
 

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -16,8 +16,7 @@ const LabelMixinImplementation = (superclass) =>
          */
         label: {
           type: String,
-          observer: '_labelChanged',
-          reflectToAttribute: true
+          observer: '_labelChanged'
         }
       };
     }

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -16,7 +16,8 @@ const LabelMixinImplementation = (superclass) =>
          */
         label: {
           type: String,
-          observer: '_labelChanged'
+          observer: '_labelChanged',
+          reflectToAttribute: true
         }
       };
     }
@@ -59,8 +60,9 @@ const LabelMixinImplementation = (superclass) =>
 
       if (this._labelNode) {
         this._labelNode.id = this._labelId;
-        this.__labelNodeObserver.observe(this._labelNode, { childList: true });
         this._toggleHasLabelAttribute();
+
+        this.__labelNodeObserver.observe(this._labelNode, { childList: true });
       }
     }
 

--- a/packages/field-base/src/slot-label-mixin.d.ts
+++ b/packages/field-base/src/slot-label-mixin.d.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-
 import { LabelMixin } from './label-mixin.js';
 import { SlotTargetMixin } from './slot-target-mixin.js';
 

--- a/packages/field-base/src/slot-label-mixin.d.ts
+++ b/packages/field-base/src/slot-label-mixin.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+import { LabelMixin } from './label-mixin.js';
+import { SlotTargetMixin } from './slot-target-mixin.js';
+
+/**
+ * A mixin to forward any content from the default slot to the label node.
+ */
+declare function SlotLabelMixin<T extends new (...args: any[]) => {}>(base: T): T & SlotLabelMixinConstructor;
+
+interface SlotLabelMixinConstructor {
+  new (...args: any[]): SlotLabelMixin;
+}
+
+interface SlotLabelMixin extends SlotTargetMixin, LabelMixin {}
+
+export { SlotLabelMixinConstructor, SlotLabelMixin };

--- a/packages/field-base/src/slot-label-mixin.js
+++ b/packages/field-base/src/slot-label-mixin.js
@@ -1,3 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { LabelMixin } from './label-mixin.js';
 import { SlotTargetMixin } from './slot-target-mixin.js';
@@ -14,6 +19,10 @@ const SlotLabelMixinImplementation = (superclass) =>
       super.ready();
 
       if (this._labelNode) {
+        // The default slot's content is moved to the label node
+        // only after `LabelMixin` is initialized which means
+        // we should manually toggle the `has-label` attribute
+        // respecting the new label content.
         this._toggleHasLabelAttribute();
       }
     }

--- a/packages/field-base/src/slot-label-mixin.js
+++ b/packages/field-base/src/slot-label-mixin.js
@@ -1,0 +1,22 @@
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { LabelMixin } from './label-mixin.js';
+import { SlotTargetMixin } from './slot-target-mixin.js';
+
+const SlotLabelMixinImplementation = (superclass) =>
+  class SlotLabelMixinClass extends SlotTargetMixin(LabelMixin(superclass)) {
+    /** @protected */
+    get _slotTarget() {
+      return this._labelNode;
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      if (this._labelNode) {
+        this._toggleHasLabelAttribute();
+      }
+    }
+  };
+
+export const SlotLabelMixin = dedupingMixin(SlotLabelMixinImplementation);

--- a/packages/field-base/src/slot-label-mixin.js
+++ b/packages/field-base/src/slot-label-mixin.js
@@ -19,4 +19,7 @@ const SlotLabelMixinImplementation = (superclass) =>
     }
   };
 
+/**
+ * A mixin to forward any content from the default slot to the label node.
+ */
 export const SlotLabelMixin = dedupingMixin(SlotLabelMixinImplementation);

--- a/packages/field-base/src/slot-target-mixin.d.ts
+++ b/packages/field-base/src/slot-target-mixin.d.ts
@@ -7,15 +7,13 @@
 /**
  * A mixin to forward the content from a source slot to a target element.
  */
-declare function SlotTargetMixinMixin<T extends new (...args: any[]) => {}>(
-  base: T
-): T & SlotTargetMixinMixinConstructor;
+declare function SlotTargetMixin<T extends new (...args: any[]) => {}>(base: T): T & SlotTargetMixinConstructor;
 
-interface SlotTargetMixinMixinConstructor {
-  new (...args: any[]): SlotTargetMixinMixin;
+interface SlotTargetMixinConstructor {
+  new (...args: any[]): SlotTargetMixin;
 }
 
-interface SlotTargetMixinMixin {
+interface SlotTargetMixin {
   /**
    * A reference to the source slot from which the content is forwarded to the target element.
    *
@@ -31,4 +29,4 @@ interface SlotTargetMixinMixin {
   _slotTarget: HTMLElement;
 }
 
-export { SlotTargetMixinMixinConstructor, SlotTargetMixinMixin };
+export { SlotTargetMixinConstructor, SlotTargetMixin };

--- a/packages/field-base/src/slot-target-mixin.d.ts
+++ b/packages/field-base/src/slot-target-mixin.d.ts
@@ -29,15 +29,6 @@ interface SlotTargetMixinMixin {
    * @protected
    */
   _slotTarget: HTMLElement;
-
-  /**
-   * A callback method that is called once the target element's content is changed.
-   *
-   * By default, it does nothing. Override the method to implement your own behavior.
-   *
-   * @protected
-   */
-  _onSlotTargetContentChange(): void;
 }
 
 export { SlotTargetMixinMixinConstructor, SlotTargetMixinMixin };

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -6,7 +6,7 @@ const SlotTargetMixinImplementation = (superclass) =>
     ready() {
       super.ready();
 
-      if (this._sourceSlot && this._slotTarget) {
+      if (this._sourceSlot) {
         this.__forwardNodesToSlotTarget();
 
         this._sourceSlot.addEventListener('slotchange', () => {

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -2,41 +2,21 @@ import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
 const SlotTargetMixinImplementation = (superclass) =>
   class SlotTargetMixinClass extends superclass {
-    constructor() {
-      super();
-
-      /**
-       * @type {MutationObserver}
-       * @private
-       */
-      this.__slotTargetObserver = new MutationObserver(() => {
-        this._onSlotTargetContentChange();
-      });
-    }
-
     /** @protected */
     ready() {
       super.ready();
 
-      if (this._slotTarget) {
-        // Observe for changes in the target element.
-        this.__slotTargetObserver.observe(this._slotTarget, {
-          childList: true
-        });
-      }
+      if (this._sourceSlot && this._slotTarget) {
+        this.__forwardNodesToSlotTarget();
 
-      if (this._sourceSlot) {
-        // Observe for changes in the source slot.
         this._sourceSlot.addEventListener('slotchange', () => {
-          this.__onSourceSlotContentChange();
+          this.__forwardNodesToSlotTarget();
         });
-
-        this.__onSourceSlotContentChange();
       }
     }
 
     /**
-     * A reference to the source slot from which the content is forwarded to the target element.
+     * A reference to the source slot from which the nodes are forwarded to the target element.
      *
      * @type {HTMLSlotElement | null}
      * @protected
@@ -47,7 +27,7 @@ const SlotTargetMixinImplementation = (superclass) =>
     }
 
     /**
-     * A reference to the target element to which the content is forwarded from the source slot.
+     * A reference to the target element to which the nodes are forwarded from the source slot.
      *
      * @type {HTMLElement | null}
      * @protected
@@ -58,21 +38,12 @@ const SlotTargetMixinImplementation = (superclass) =>
     }
 
     /**
-     * A callback method that is called once the target element's content is changed.
-     *
-     * By default, it does nothing. Override the method to implement your own behavior.
-     *
-     * @protected
-     */
-    _onSlotTargetContentChange() {}
-
-    /**
      * Forwards every node from the source slot to the target element
      * once the source slot' content is changed.
      *
      * @private
      */
-    __onSourceSlotContentChange() {
+    __forwardNodesToSlotTarget() {
       if (!this._slotTarget) {
         return;
       }

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { LabelMixin } from '../src/label-mixin.js';
 
@@ -48,14 +48,20 @@ describe('label-mixin', () => {
       expect(element.hasAttribute('has-label')).to.be.false;
     });
 
-    it('should set has-label attribute when attribute is set', () => {
+    it('should toggle has-label attribute on attribute change', () => {
       element.setAttribute('label', 'Email');
       expect(element.hasAttribute('has-label')).to.be.true;
+
+      element.removeAttribute('label');
+      expect(element.hasAttribute('has-label')).to.be.false;
     });
 
-    it('should set has-label attribute when property is set', () => {
+    it('should toggle has-label attribute on property change', () => {
       element.label = 'Email';
       expect(element.hasAttribute('has-label')).to.be.true;
+
+      element.label = '';
+      expect(element.hasAttribute('has-label')).to.be.false;
     });
   });
 
@@ -78,7 +84,17 @@ describe('label-mixin', () => {
       expect(label.getAttribute('id')).to.match(idRegex);
     });
 
-    it('should set has-label attribute with slotted label', () => {
+    it('should set has-label attribute', () => {
+      expect(element.hasAttribute('has-label')).to.be.true;
+    });
+
+    it('should toggle has-label attribute on label content change', async () => {
+      label.textContent = '';
+      await nextFrame();
+      expect(element.hasAttribute('has-label')).to.be.false;
+
+      label.textContent = 'New Label';
+      await nextFrame();
       expect(element.hasAttribute('has-label')).to.be.true;
     });
 

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -30,38 +30,51 @@ describe('label-mixin', () => {
     });
 
     it('should set id on the label element', () => {
-      const idRegex = /^label-label-mixin-element-\d$/;
+      const idRegex = /^label-label-mixin-element-\d+$/;
       expect(label.getAttribute('id')).to.match(idRegex);
     });
 
-    it('should update label content on attribute change', () => {
-      element.setAttribute('label', 'Email');
-      expect(label.textContent).to.equal('Email');
+    describe('label property', () => {
+      it('should be undefined by default', () => {
+        expect(element.label).to.be.undefined;
+      });
+
+      it('should reflect label attribute to the property', () => {
+        element.setAttribute('label', 'Email');
+        expect(element.label).to.equal('Email');
+
+        element.removeAttribute('label');
+        expect(element.label).to.equal(null);
+      });
+
+      it('should update label content on property change', () => {
+        element.label = 'Email';
+        expect(label.textContent).to.equal('Email');
+      });
     });
 
-    it('should update label content on property change', () => {
-      element.label = 'Email';
-      expect(label.textContent).to.equal('Email');
-    });
+    describe('has-label attribute', () => {
+      it('should not set the attribute by default', () => {
+        expect(element.hasAttribute('has-label')).to.be.false;
+      });
 
-    it('should not set has-label attribute by default', () => {
-      expect(element.hasAttribute('has-label')).to.be.false;
-    });
+      it('should toggle the attribute on label property change', () => {
+        element.label = 'Email';
+        expect(element.hasAttribute('has-label')).to.be.true;
 
-    it('should toggle has-label attribute on attribute change', () => {
-      element.setAttribute('label', 'Email');
-      expect(element.hasAttribute('has-label')).to.be.true;
+        element.label = null;
+        expect(element.hasAttribute('has-label')).to.be.false;
+      });
 
-      element.removeAttribute('label');
-      expect(element.hasAttribute('has-label')).to.be.false;
-    });
+      it('should not set the attribute when label is only whitespaces', () => {
+        element.label = ' ';
+        expect(element.hasAttribute('has-label')).to.be.false;
+      });
 
-    it('should toggle has-label attribute on property change', () => {
-      element.label = 'Email';
-      expect(element.hasAttribute('has-label')).to.be.true;
-
-      element.label = '';
-      expect(element.hasAttribute('has-label')).to.be.false;
+      it('should not set the attribute when label is empty', () => {
+        element.label = '';
+        expect(element.hasAttribute('has-label')).to.be.false;
+      });
     });
   });
 
@@ -76,35 +89,37 @@ describe('label-mixin', () => {
     });
 
     it('should set id on the slotted label element', () => {
-      const idRegex = /^label-label-mixin-element-\d$/;
+      const idRegex = /^label-label-mixin-element-\d+$/;
       expect(label.getAttribute('id')).to.match(idRegex);
-    });
-
-    it('should set has-label attribute', () => {
-      expect(element.hasAttribute('has-label')).to.be.true;
-    });
-
-    it('should remove has-label attribute when label content is only whitespaces', async () => {
-      label.textContent = ' ';
-      await nextFrame();
-      expect(element.hasAttribute('has-label')).to.be.false;
-    });
-
-    it('should remove has-label attribute when label content is empty', async () => {
-      label.textContent = '';
-      await nextFrame();
-      expect(element.hasAttribute('has-label')).to.be.false;
-    });
-
-    it('should not remove has-label attribute when label children are empty', async () => {
-      label.firstChild.textContent = '';
-      await nextFrame();
-      expect(element.hasAttribute('has-label')).to.be.true;
     });
 
     it('should update slotted label content on property change', () => {
       element.label = 'Email';
       expect(label.textContent).to.equal('Email');
+    });
+
+    describe('has-label attribute', () => {
+      it('should set the attribute', () => {
+        expect(element.hasAttribute('has-label')).to.be.true;
+      });
+
+      it('should remove the attribute when label content is only whitespaces', async () => {
+        label.textContent = ' ';
+        await nextFrame();
+        expect(element.hasAttribute('has-label')).to.be.false;
+      });
+
+      it('should remove the attribute when label content is empty', async () => {
+        label.textContent = '';
+        await nextFrame();
+        expect(element.hasAttribute('has-label')).to.be.false;
+      });
+
+      it('should not remove the attribute when label children are empty', async () => {
+        label.firstChild.textContent = '';
+        await nextFrame();
+        expect(element.hasAttribute('has-label')).to.be.true;
+      });
     });
   });
 });

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -44,7 +44,7 @@ describe('label-mixin', () => {
       expect(label.textContent).to.equal('Email');
     });
 
-    it('should not set has-label attribute with no label', () => {
+    it('should not set has-label attribute by default', () => {
       expect(element.hasAttribute('has-label')).to.be.false;
     });
 
@@ -69,14 +69,10 @@ describe('label-mixin', () => {
     beforeEach(() => {
       element = fixtureSync(`
         <label-mixin-element>
-          <label slot="label">Custom</label>
+          <label slot="label"><div>Custom</div></label>
         </label-mixin-element>
       `);
       label = element.querySelector('label');
-    });
-
-    it('should return slotted label content as a label', () => {
-      expect(element.label).to.equal('Custom');
     });
 
     it('should set id on the slotted label element', () => {
@@ -88,12 +84,20 @@ describe('label-mixin', () => {
       expect(element.hasAttribute('has-label')).to.be.true;
     });
 
-    it('should toggle has-label attribute on label content change', async () => {
+    it('should remove has-label attribute when label content is only whitespaces', async () => {
+      label.textContent = ' ';
+      await nextFrame();
+      expect(element.hasAttribute('has-label')).to.be.false;
+    });
+
+    it('should remove has-label attribute when label content is empty', async () => {
       label.textContent = '';
       await nextFrame();
       expect(element.hasAttribute('has-label')).to.be.false;
+    });
 
-      label.textContent = 'New Label';
+    it('should not remove has-label attribute when label children are empty', async () => {
+      label.firstChild.textContent = '';
       await nextFrame();
       expect(element.hasAttribute('has-label')).to.be.true;
     });

--- a/packages/field-base/test/slot-label-mixin.test.js
+++ b/packages/field-base/test/slot-label-mixin.test.js
@@ -25,29 +25,29 @@ customElements.define(
 describe('slot-label-mixin', () => {
   let element;
 
-  describe('default', () => {
+  describe('slot label', () => {
     beforeEach(() => {
-      element = fixtureSync(`<slot-label-mixin-element>Label</slot-label-mixin-element>`);
+      element = fixtureSync(`<slot-label-mixin-element>Slot Label</slot-label-mixin-element>`);
     });
 
-    it('should render the label', () => {
-      expect(element._labelNode.textContent).to.equal('Label');
+    it('should display the slot label', () => {
+      expect(element._labelNode.textContent).to.equal('Slot Label');
     });
 
-    it('should set has-label attribute on the element', () => {
+    it('should set has-label attribute', () => {
       expect(element.hasAttribute('has-label')).to.be.true;
     });
 
-    describe('label property change', () => {
+    describe('overriden with label property', () => {
       beforeEach(() => {
-        element.label = 'New Label';
+        element.label = 'Label Property';
       });
 
-      it('should render the new label from the property', () => {
-        expect(element._labelNode.textContent).to.equal('New Label');
+      it('should display the label property', () => {
+        expect(element._labelNode.textContent).to.equal('Label Property');
       });
 
-      it('should set has-label attribute on the element', () => {
+      it('should keep has-label attribute', () => {
         expect(element.hasAttribute('has-label')).to.be.true;
       });
     });
@@ -55,27 +55,41 @@ describe('slot-label-mixin', () => {
 
   describe('label property', () => {
     beforeEach(() => {
-      element = fixtureSync(`<slot-label-mixin-element label="Label"></slot-label-mixin-element>`);
+      element = fixtureSync(`<slot-label-mixin-element label="Label Property"></slot-label-mixin-element>`);
     });
 
-    it('should render the label', () => {
-      expect(element._labelNode.textContent).to.equal('Label');
+    it('should display the label property', () => {
+      expect(element._labelNode.textContent).to.equal('Label Property');
     });
 
-    describe('slot change', () => {
+    describe('overriden with slot label', () => {
       beforeEach(async () => {
-        const label = document.createTextNode('New Label');
+        const label = document.createTextNode('Slot Label');
         element.appendChild(label);
         await nextFrame();
       });
 
-      it('should render the new label from the slot', () => {
-        expect(element._labelNode.textContent).to.equal('New Label');
+      it('should display the slot label', () => {
+        expect(element._labelNode.textContent).to.equal('Slot Label');
       });
 
-      it('should set has-label attribute on the element', () => {
+      it('should keep has-label attribute', () => {
         expect(element.hasAttribute('has-label')).to.be.true;
       });
+    });
+  });
+
+  describe('label property and slot label', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<slot-label-mixin-element label="Label Property">Slot Label</slot-label-mixin-element>`);
+    });
+
+    it('should display the slot label', () => {
+      expect(element._labelNode.textContent).to.equal('Slot Label');
+    });
+
+    it('should set has-label attribute', () => {
+      expect(element.hasAttribute('has-label')).to.be.true;
     });
   });
 });

--- a/packages/field-base/test/slot-label-mixin.test.js
+++ b/packages/field-base/test/slot-label-mixin.test.js
@@ -1,0 +1,81 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { SlotLabelMixin } from '../src/slot-label-mixin.js';
+
+customElements.define(
+  'slot-label-mixin-element',
+  class extends SlotLabelMixin(PolymerElement) {
+    static get template() {
+      return html`
+        <div>
+          <slot name="label"></slot>
+          <slot id="default"></slot>
+        </div>
+      `;
+    }
+
+    /** @protected */
+    get _sourceSlot() {
+      return this.$.default;
+    }
+  }
+);
+
+describe('slot-label-mixin', () => {
+  let element;
+
+  describe('default', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<slot-label-mixin-element>Label</slot-label-mixin-element>`);
+    });
+
+    it('should render the label', () => {
+      expect(element._labelNode.textContent).to.equal('Label');
+    });
+
+    it('should set has-label attribute on the element', () => {
+      expect(element.hasAttribute('has-label')).to.be.true;
+    });
+
+    describe('label property change', () => {
+      beforeEach(() => {
+        element.label = 'New Label';
+      });
+
+      it('should render the new label from the property', () => {
+        expect(element._labelNode.textContent).to.equal('New Label');
+      });
+
+      it('should set has-label attribute on the element', () => {
+        expect(element.hasAttribute('has-label')).to.be.true;
+      });
+    });
+  });
+
+  describe('label property', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<slot-label-mixin-element label="Label"></slot-label-mixin-element>`);
+    });
+
+    it('should render the label', () => {
+      expect(element._labelNode.textContent).to.equal('Label');
+    });
+
+    describe('slot change', () => {
+      beforeEach(async () => {
+        const label = document.createTextNode('New Label');
+        element.appendChild(label);
+        await nextFrame();
+      });
+
+      it('should render the new label from the slot', () => {
+        expect(element._labelNode.textContent).to.equal('New Label');
+      });
+
+      it('should set has-label attribute on the element', () => {
+        expect(element.hasAttribute('has-label')).to.be.true;
+      });
+    });
+  });
+});

--- a/packages/field-base/test/slot-label-mixin.test.js
+++ b/packages/field-base/test/slot-label-mixin.test.js
@@ -53,7 +53,7 @@ describe('slot-label-mixin', () => {
       expect(element._labelNode.textContent).to.equal('Label Property');
     });
 
-    it('should be overridable with the slot label', () => {
+    it('should be overridable with the slot label', async () => {
       const label = document.createTextNode('Slot Label');
       element.appendChild(label);
       await nextFrame();

--- a/packages/field-base/test/slot-label-mixin.test.js
+++ b/packages/field-base/test/slot-label-mixin.test.js
@@ -38,18 +38,9 @@ describe('slot-label-mixin', () => {
       expect(element.hasAttribute('has-label')).to.be.true;
     });
 
-    describe('overriden with label property', () => {
-      beforeEach(() => {
-        element.label = 'Label Property';
-      });
-
-      it('should display the label property', () => {
-        expect(element._labelNode.textContent).to.equal('Label Property');
-      });
-
-      it('should keep has-label attribute', () => {
-        expect(element.hasAttribute('has-label')).to.be.true;
-      });
+    it('should be overridable with the label property', () => {
+      element.label = 'Label Property';
+      expect(element._labelNode.textContent).to.equal('Label Property');
     });
   });
 
@@ -62,20 +53,11 @@ describe('slot-label-mixin', () => {
       expect(element._labelNode.textContent).to.equal('Label Property');
     });
 
-    describe('overriden with slot label', () => {
-      beforeEach(async () => {
-        const label = document.createTextNode('Slot Label');
-        element.appendChild(label);
-        await nextFrame();
-      });
-
-      it('should display the slot label', () => {
-        expect(element._labelNode.textContent).to.equal('Slot Label');
-      });
-
-      it('should keep has-label attribute', () => {
-        expect(element.hasAttribute('has-label')).to.be.true;
-      });
+    it('should be overridable with the slot label', () => {
+      const label = document.createTextNode('Slot Label');
+      element.appendChild(label);
+      await nextFrame();
+      expect(element._labelNode.textContent).to.equal('Slot Label');
     });
   });
 

--- a/packages/field-base/test/slot-target-mixin.test.js
+++ b/packages/field-base/test/slot-target-mixin.test.js
@@ -5,49 +5,55 @@ import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { SlotTargetMixin } from '../src/slot-target-mixin.js';
 
 customElements.define(
-  'slot-target-mixin-element-warnings',
+  'slot-target-mixin-element-without-source',
   class extends SlotTargetMixin(PolymerElement) {
     static get template() {
-      return html`<div></div>`;
+      return html`
+        <slot id="source"></slot>
+        <div id="target"></div>
+      `;
+    }
+  }
+);
+
+customElements.define(
+  'slot-target-mixin-element-without-target',
+  class extends SlotTargetMixin(PolymerElement) {
+    static get template() {
+      return html`
+        <slot id="source"></slot>
+        <div id="target"></div>
+      `;
+    }
+
+    get _sourceSlot() {
+      return this.$.source;
+    }
+  }
+);
+
+customElements.define(
+  'slot-target-mixin-element',
+  class extends SlotTargetMixin(PolymerElement) {
+    static get template() {
+      return html`
+        <slot id="source"></slot>
+        <div id="target"></div>
+      `;
+    }
+
+    get _sourceSlot() {
+      return this.$.source;
+    }
+
+    get _slotTarget() {
+      return this.$.target;
     }
   }
 );
 
 describe('slot-target-mixin', () => {
-  let element, slotTargetContentChangeSpy;
-
-  before(() => {
-    slotTargetContentChangeSpy = sinon.spy();
-
-    customElements.define(
-      'slot-target-mixin-element',
-      class extends SlotTargetMixin(PolymerElement) {
-        static get template() {
-          return html`
-            <slot id="source"></slot>
-
-            <div id="target"></div>
-          `;
-        }
-
-        get _sourceSlot() {
-          return this.$.source;
-        }
-
-        get _slotTarget() {
-          return this.$.target;
-        }
-
-        _onSlotTargetContentChange() {
-          slotTargetContentChangeSpy();
-        }
-      }
-    );
-  });
-
-  afterEach(() => {
-    slotTargetContentChangeSpy.resetHistory();
-  });
+  let element;
 
   describe('default', () => {
     let node1, node2;
@@ -100,90 +106,31 @@ describe('slot-target-mixin', () => {
     });
   });
 
-  // describe('target element observer', () => {
-  //   it('should notify when the target element is populated at the initialization', async () => {
-  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
-  //     await nextFrame();
+  describe('warnings', () => {
+    beforeEach(() => {
+      sinon.stub(console, 'warn');
+    });
 
-  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-  //   });
+    afterEach(() => {
+      console.warn.restore();
+    });
 
-  //   it('should notify when the target element is populated lazily', async () => {
-  //     element = fixtureSync(`<slot-target-mixin-element></slot-target-mixin-element>`);
+    it('should warn about no implementation for _sourceSlot', () => {
+      element = fixtureSync('<slot-target-mixin-element-without-source></slot-target-mixin-element-without-source>');
 
-  //     const node = document.createElement('div');
-  //     element.appendChild(node);
-  //     await nextFrame();
+      expect(console.warn.calledOnce).to.be.true;
+      expect(console.warn.args[0][0]).to.equal(
+        `Please implement the '_sourceSlot' property in <slot-target-mixin-element-without-source>`
+      );
+    });
 
-  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-  //   });
+    it('should warn about no implementation for _slotTarget', () => {
+      element = fixtureSync('<slot-target-mixin-element-without-target></slot-target-mixin-element-without-target>');
 
-  //   it('should notify when adding new nodes directly to the target element', async () => {
-  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
-
-  //     const node = document.createElement('div');
-  //     element._slotTarget.appendChild(node);
-  //     await nextFrame();
-
-  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-  //   });
-
-  //   it('should notify when replacing nodes directly in the target element', async () => {
-  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
-
-  //     const node = document.createElement('div');
-  //     element._slotTarget.replaceChildren(node);
-  //     await nextFrame();
-
-  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-  //   });
-
-  //   it('should notify when removing nodes directly from the target element', async () => {
-  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
-
-  //     element._slotTarget.removeChild(element._slotTarget.firstChild);
-  //     await nextFrame();
-
-  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-  //   });
-
-  //   it('should notify when adding new nodes to the source slot', async () => {
-  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
-  //     await nextFrame();
-
-  //     slotTargetContentChangeSpy.resetHistory();
-
-  //     const node = document.createElement('div');
-  //     element.appendChild(node);
-  //     await nextFrame();
-
-  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-  //   });
-  // });
-
-  // describe('warnings', () => {
-  //   beforeEach(() => {
-  //     sinon.stub(console, 'warn');
-
-  //     element = fixtureSync('<slot-target-mixin-element-warnings>Content</slot-target-mixin-element-warnings>');
-  //   });
-
-  //   afterEach(() => {
-  //     console.warn.restore();
-  //   });
-
-  //   it('should warn about no implementation for _sourceSlot', () => {
-  //     expect(console.warn.calledOnce).to.be.true;
-  //     expect(console.warn.args[0][0]).to.equal(
-  //       `Please implement the '_sourceSlot' property in <slot-target-mixin-element-warnings>`
-  //     );
-  //   });
-
-  //   it('should warn about no implementation for _slotTarget', () => {
-  //     expect(console.warn.calledOnce).to.be.true;
-  //     expect(console.warn.args[0][0]).to.equal(
-  //       `Please implement the '_slotTarget' property in <slot-target-mixin-element-warnings>`
-  //     );
-  //   });
-  // });
+      expect(console.warn.calledOnce).to.be.true;
+      expect(console.warn.args[0][0]).to.equal(
+        `Please implement the '_slotTarget' property in <slot-target-mixin-element-without-target>`
+      );
+    });
+  });
 });

--- a/packages/field-base/test/slot-target-mixin.test.js
+++ b/packages/field-base/test/slot-target-mixin.test.js
@@ -100,90 +100,90 @@ describe('slot-target-mixin', () => {
     });
   });
 
-  describe('target element observer', () => {
-    it('should notify when the target element is populated at the initialization', async () => {
-      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
-      await nextFrame();
+  // describe('target element observer', () => {
+  //   it('should notify when the target element is populated at the initialization', async () => {
+  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+  //     await nextFrame();
 
-      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-    });
+  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+  //   });
 
-    it('should notify when the target element is populated lazily', async () => {
-      element = fixtureSync(`<slot-target-mixin-element></slot-target-mixin-element>`);
+  //   it('should notify when the target element is populated lazily', async () => {
+  //     element = fixtureSync(`<slot-target-mixin-element></slot-target-mixin-element>`);
 
-      const node = document.createElement('div');
-      element.appendChild(node);
-      await nextFrame();
+  //     const node = document.createElement('div');
+  //     element.appendChild(node);
+  //     await nextFrame();
 
-      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-    });
+  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+  //   });
 
-    it('should notify when adding new nodes directly to the target element', async () => {
-      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+  //   it('should notify when adding new nodes directly to the target element', async () => {
+  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
 
-      const node = document.createElement('div');
-      element._slotTarget.appendChild(node);
-      await nextFrame();
+  //     const node = document.createElement('div');
+  //     element._slotTarget.appendChild(node);
+  //     await nextFrame();
 
-      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-    });
+  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+  //   });
 
-    it('should notify when replacing nodes directly in the target element', async () => {
-      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+  //   it('should notify when replacing nodes directly in the target element', async () => {
+  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
 
-      const node = document.createElement('div');
-      element._slotTarget.replaceChildren(node);
-      await nextFrame();
+  //     const node = document.createElement('div');
+  //     element._slotTarget.replaceChildren(node);
+  //     await nextFrame();
 
-      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-    });
+  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+  //   });
 
-    it('should notify when removing nodes directly from the target element', async () => {
-      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+  //   it('should notify when removing nodes directly from the target element', async () => {
+  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
 
-      element._slotTarget.removeChild(element._slotTarget.firstChild);
-      await nextFrame();
+  //     element._slotTarget.removeChild(element._slotTarget.firstChild);
+  //     await nextFrame();
 
-      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-    });
+  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+  //   });
 
-    it('should notify when adding new nodes to the source slot', async () => {
-      element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
-      await nextFrame();
+  //   it('should notify when adding new nodes to the source slot', async () => {
+  //     element = fixtureSync(`<slot-target-mixin-element><div>Content<div></slot-target-mixin-element>`);
+  //     await nextFrame();
 
-      slotTargetContentChangeSpy.resetHistory();
+  //     slotTargetContentChangeSpy.resetHistory();
 
-      const node = document.createElement('div');
-      element.appendChild(node);
-      await nextFrame();
+  //     const node = document.createElement('div');
+  //     element.appendChild(node);
+  //     await nextFrame();
 
-      expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
-    });
-  });
+  //     expect(slotTargetContentChangeSpy.calledOnce).to.be.true;
+  //   });
+  // });
 
-  describe('warnings', () => {
-    beforeEach(() => {
-      sinon.stub(console, 'warn');
+  // describe('warnings', () => {
+  //   beforeEach(() => {
+  //     sinon.stub(console, 'warn');
 
-      element = fixtureSync('<slot-target-mixin-element-warnings></slot-target-mixin-element-warnings>');
-    });
+  //     element = fixtureSync('<slot-target-mixin-element-warnings>Content</slot-target-mixin-element-warnings>');
+  //   });
 
-    afterEach(() => {
-      console.warn.restore();
-    });
+  //   afterEach(() => {
+  //     console.warn.restore();
+  //   });
 
-    it('should warn about no implementation for _slotTarget', () => {
-      expect(console.warn.calledTwice).to.be.true;
-      expect(console.warn.args[0][0]).to.equal(
-        `Please implement the '_slotTarget' property in <slot-target-mixin-element-warnings>`
-      );
-    });
+  //   it('should warn about no implementation for _sourceSlot', () => {
+  //     expect(console.warn.calledOnce).to.be.true;
+  //     expect(console.warn.args[0][0]).to.equal(
+  //       `Please implement the '_sourceSlot' property in <slot-target-mixin-element-warnings>`
+  //     );
+  //   });
 
-    it('should warn about no implementation for _sourceSlot', () => {
-      expect(console.warn.calledTwice).to.be.true;
-      expect(console.warn.args[1][0]).to.equal(
-        `Please implement the '_sourceSlot' property in <slot-target-mixin-element-warnings>`
-      );
-    });
-  });
+  //   it('should warn about no implementation for _slotTarget', () => {
+  //     expect(console.warn.calledOnce).to.be.true;
+  //     expect(console.warn.args[0][0]).to.equal(
+  //       `Please implement the '_slotTarget' property in <slot-target-mixin-element-warnings>`
+  //     );
+  //   });
+  // });
 });


### PR DESCRIPTION
## Description

This PR introduces `SlotLabelMixin` that forwards any content from the default slot to the label node which makes it possible to define a label for a component not only with the `label` property but also with the default slot.

The mixin is required for the new checkbox and radio-button accessible implementations.

Note, the PR also changes the rule of when to set the `has-label` attribute on the host element:

**Before:** 

```js
// The element is considered to have a label if its content is not an empty string.
const hasLabel = this._labelNode.textContent !== '';

this.toggleAttribute('has-label', hasLabel);
```

**Now:**

```js
const hasLabel = (
  // 1. The element is considered to have a label if it has any element children.
  this._labelNode.children.length > 0 || 
  // 2. The element is considered to have a label if its trimmed content is not empty.
  this._labelNode.textContent.trim() !== '';
);

this.toggleAttribute('has-label', hasLabel);
```

Fixes #2211

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
