### PR TITLE
test: add snapshots tests for web components (part 1)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 packages/**/vendor/*.js
 packages/**/dist/*.js
+packages/**/test/dom/__snapshots__/*.snap.js

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -1,0 +1,24 @@
+name: Snapshots
+
+on: pull_request
+
+jobs:
+  tests:
+    name: Snapshot tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+
+      - name: Setup Node 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: yarn --frozen-lockfile --no-progress --non-interactive
+
+      - name: Test
+        run: yarn test:snapshots

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+packages/**/test/dom/__snapshots__/*.snap.js

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lint-staged": "^11.1.2",
     "npm-run-all": "^4.1.5",
     "octokit": "^1.0.4",
+    "playwright": "^1.14.1",
     "prettier": "^2.3.2",
     "replace-in-file": "^6.2.0",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
     "test:firefox": "web-test-runner --config web-test-runner-firefox.config.js",
     "test:lumo": "web-test-runner --config web-test-runner-lumo.config.js",
     "test:material": "web-test-runner --config web-test-runner-material.config.js",
+    "test:snapshots": "web-test-runner --config web-test-runner-snapshots.config.js",
     "test:webkit": "web-test-runner --config web-test-runner-webkit.config.js",
     "update:lumo": "TEST_ENV=update web-test-runner --config web-test-runner-lumo.config.js",
-    "update:material": "TEST_ENV=update web-test-runner --config web-test-runner-material.config.js"
+    "update:material": "TEST_ENV=update web-test-runner --config web-test-runner-material.config.js",
+    "update:snapshots": "web-test-runner --config web-test-runner-snapshots.config.js --update-snapshots"
   },
   "devDependencies": {
     "@polymer/iron-component-page": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@polymer/iron-component-page": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^4.29.2",
     "@typescript-eslint/parser": "^4.29.2",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@web/dev-server": "^0.1.22",
     "@web/rollup-plugin-html": "^1.9.1",
     "@web/test-runner": "^0.13.16",

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -39,12 +39,6 @@ describe('avatar-group', () => {
       expect(items.length).to.equal(group.items.length + 1);
     });
 
-    it('should make the overflow avatar hidden by default', () => {
-      const items = group.shadowRoot.querySelectorAll('vaadin-avatar');
-      const overflow = items[group.items.length];
-      expect(overflow.hasAttribute('hidden')).to.be.true;
-    });
-
     it('should propagate theme attribute to all avatars', () => {
       group.setAttribute('theme', 'small');
       const items = group.shadowRoot.querySelectorAll('vaadin-avatar');
@@ -538,10 +532,6 @@ describe('avatar-group', () => {
 
     afterEach(() => {
       overlay.close();
-    });
-
-    it('should set aria-haspopup="listbox" on the overflow avatar', () => {
-      expect(overflow.getAttribute('aria-haspopup')).to.equal('listbox');
     });
 
     it('should set aria-expanded="false" on the overflow avatar', () => {

--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -1,0 +1,138 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-avatar-group default"] = 
+`<div
+  id="container"
+  part="container"
+>
+  <dom-repeat
+    id="items"
+    style="display: none;"
+  >
+    <template is="dom-repeat">
+    </template>
+  </dom-repeat>
+  <vaadin-avatar
+    abbr="+NaN"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    hidden=""
+    id="overflow"
+    part="avatar"
+    role="button"
+    tabindex="0"
+    title=""
+  >
+  </vaadin-avatar>
+</div>
+<vaadin-avatar-group-overlay id="overlay">
+  <template>
+  </template>
+</vaadin-avatar-group-overlay>
+`;
+/* end snapshot vaadin-avatar-group default */
+
+snapshots["vaadin-avatar-group items"] = 
+`<div
+  id="container"
+  part="container"
+>
+  <vaadin-avatar
+    abbr="YY"
+    part="avatar"
+    role="button"
+    tabindex="0"
+    title="YY"
+  >
+  </vaadin-avatar>
+  <vaadin-avatar
+    abbr="TV"
+    name="Tomi Virkki"
+    part="avatar"
+    role="button"
+    tabindex="0"
+    title="Tomi Virkki"
+  >
+  </vaadin-avatar>
+  <dom-repeat
+    id="items"
+    style="display: none;"
+  >
+    <template is="dom-repeat">
+    </template>
+  </dom-repeat>
+  <vaadin-avatar
+    abbr="+2"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    hidden=""
+    id="overflow"
+    part="avatar"
+    role="button"
+    tabindex="0"
+    title="YY
+Tomi Virkki"
+  >
+  </vaadin-avatar>
+</div>
+<vaadin-avatar-group-overlay id="overlay">
+  <template>
+  </template>
+</vaadin-avatar-group-overlay>
+`;
+/* end snapshot vaadin-avatar-group items */
+
+snapshots["vaadin-avatar-group theme"] = 
+`<div
+  id="container"
+  part="container"
+>
+  <vaadin-avatar
+    abbr="YY"
+    part="avatar"
+    role="button"
+    tabindex="0"
+    theme="small"
+    title="YY"
+  >
+  </vaadin-avatar>
+  <vaadin-avatar
+    abbr="TV"
+    name="Tomi Virkki"
+    part="avatar"
+    role="button"
+    tabindex="0"
+    theme="small"
+    title="Tomi Virkki"
+  >
+  </vaadin-avatar>
+  <dom-repeat
+    id="items"
+    style="display: none;"
+  >
+    <template is="dom-repeat">
+    </template>
+  </dom-repeat>
+  <vaadin-avatar
+    abbr="+2"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    hidden=""
+    id="overflow"
+    part="avatar"
+    role="button"
+    tabindex="0"
+    theme="small"
+    title="YY
+Tomi Virkki"
+  >
+  </vaadin-avatar>
+</div>
+<vaadin-avatar-group-overlay id="overlay">
+  <template>
+  </template>
+</vaadin-avatar-group-overlay>
+`;
+/* end snapshot vaadin-avatar-group theme */
+

--- a/packages/avatar-group/test/dom/avatar-group.test.js
+++ b/packages/avatar-group/test/dom/avatar-group.test.js
@@ -1,0 +1,28 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import '../../src/vaadin-avatar-group.js';
+
+describe('vaadin-avatar-group', () => {
+  let group;
+
+  beforeEach(() => {
+    group = fixtureSync('<vaadin-avatar-group></vaadin-avatar-group>');
+  });
+
+  it('default', async () => {
+    await expect(group).shadowDom.to.equalSnapshot();
+  });
+
+  it('items', async () => {
+    group.items = [{ abbr: 'YY' }, { name: 'Tomi Virkki' }];
+    await nextFrame();
+    await expect(group).shadowDom.to.equalSnapshot();
+  });
+
+  it('theme', async () => {
+    group.items = [{ abbr: 'YY' }, { name: 'Tomi Virkki' }];
+    await nextFrame();
+    group.setAttribute('theme', 'small');
+    await expect(group).shadowDom.to.equalSnapshot();
+  });
+});

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/avatar/test/avatar.test.js
+++ b/packages/avatar/test/avatar.test.js
@@ -48,18 +48,6 @@ describe('vaadin-avatar', () => {
         expect(avatar.getAttribute('img')).to.equal(validImageSrc);
       });
 
-      it('should propagate "img" to the internal img', () => {
-        avatar.img = validImageSrc;
-        expect(imgElement.src).to.equal(validImageSrc);
-      });
-
-      it('img should be visible when "img" property is provided', () => {
-        expect(imgElement.hasAttribute('hidden')).to.be.true;
-
-        avatar.img = validImageSrc;
-        expect(imgElement.hasAttribute('hidden')).to.be.false;
-      });
-
       it('icon should be hidden when "img" property is provided', () => {
         expect(iconElement.hasAttribute('hidden')).to.be.false;
 

--- a/packages/avatar/test/dom/__snapshots__/avatar.test.snap.js
+++ b/packages/avatar/test/dom/__snapshots__/avatar.test.snap.js
@@ -1,0 +1,19 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-avatar default"] = 
+`<img
+  aria-hidden="true"
+  hidden=""
+>
+`;
+/* end snapshot vaadin-avatar default */
+
+snapshots["vaadin-avatar img"] = 
+`<img
+  aria-hidden="true"
+  src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
+>
+`;
+/* end snapshot vaadin-avatar img */
+

--- a/packages/avatar/test/dom/avatar.test.js
+++ b/packages/avatar/test/dom/avatar.test.js
@@ -1,0 +1,20 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-avatar.js';
+
+describe('vaadin-avatar', () => {
+  let avatar;
+
+  beforeEach(() => {
+    avatar = fixtureSync('<vaadin-avatar></vaadin-avatar>');
+  });
+
+  it('default', async () => {
+    await expect(avatar).shadowDom.to.equalSnapshot();
+  });
+
+  it('img', async () => {
+    avatar.img = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+    await expect(avatar).shadowDom.to.equalSnapshot();
+  });
+});

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/button/test/button.test.js
+++ b/packages/button/test/button.test.js
@@ -14,7 +14,6 @@ import {
   touchend,
   touchstart
 } from '@vaadin/testing-helpers';
-import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import '../vaadin-button.js';
 
 describe('vaadin-button', () => {
@@ -56,20 +55,6 @@ describe('vaadin-button', () => {
       it('should not override custom role attribute', () => {
         expect(element.getAttribute('role')).to.equal('menuitem');
       });
-    });
-  });
-
-  describe('label', () => {
-    let label;
-
-    beforeEach(() => {
-      element = fixtureSync('<vaadin-button>Press me</vaadin-button>');
-      label = element.shadowRoot.querySelector('[part=label]');
-    });
-
-    it('should define the button label using light DOM', () => {
-      const children = FlattenedNodesObserver.getFlattenedNodes(label);
-      expect(children[1].textContent).to.be.equal('Press me');
     });
   });
 

--- a/packages/button/test/dom/__snapshots__/button.test.snap.js
+++ b/packages/button/test/dom/__snapshots__/button.test.snap.js
@@ -1,0 +1,21 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-button default"] = 
+`<div class="vaadin-button-container">
+  <span part="prefix">
+    <slot name="prefix">
+    </slot>
+  </span>
+  <span part="label">
+    <slot>
+    </slot>
+  </span>
+  <span part="suffix">
+    <slot name="suffix">
+    </slot>
+  </span>
+</div>
+`;
+/* end snapshot vaadin-button default */
+

--- a/packages/button/test/dom/button.test.js
+++ b/packages/button/test/dom/button.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-button.js';
+
+describe('vaadin-button', () => {
+  let button;
+
+  beforeEach(() => {
+    button = fixtureSync('<vaadin-button>Confirm</vaadin-button>');
+  });
+
+  it('default', async () => {
+    await expect(button).shadowDom.to.equalSnapshot();
+  });
+});

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.0"
   },
   "publishConfig": {

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.0"
   },
   "publishConfig": {

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -36,7 +36,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/email-field": "^22.0.0-alpha5",
     "@vaadin/password-field": "^22.0.0-alpha5",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -1,0 +1,248 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-email-field default"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container part="input-field">
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-email-field default */
+
+snapshots["vaadin-email-field disabled"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    disabled=""
+    part="input-field"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-email-field disabled */
+
+snapshots["vaadin-email-field readonly"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    readonly=""
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-email-field readonly */
+
+snapshots["vaadin-email-field invalid"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    invalid=""
+    part="input-field"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-email-field invalid */
+
+snapshots["vaadin-email-field theme"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    theme="align-right"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-email-field theme */
+
+snapshots["vaadin-email-field slots"] = 
+`<input
+  autocapitalize="off"
+  slot="input"
+  type="email"
+>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<label slot="label">
+</label>
+<div slot="helper">
+</div>
+`;
+/* end snapshot vaadin-email-field slots */
+

--- a/packages/email-field/test/dom/email-field.test.js
+++ b/packages/email-field/test/dom/email-field.test.js
@@ -1,0 +1,46 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-email-field.js';
+
+describe('vaadin-email-field', () => {
+  let field;
+
+  // Ignore generated attributes to prevent failures
+  // when running snapshot tests in a different order
+  // Also ignore pattern because of escape characters
+  const SNAPSHOT_CONFIG = {
+    ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for', 'pattern']
+  };
+
+  beforeEach(() => {
+    field = fixtureSync('<vaadin-email-field></vaadin-email-field>');
+  });
+
+  it('default', async () => {
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('disabled', async () => {
+    field.disabled = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('readonly', async () => {
+    field.readonly = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('invalid', async () => {
+    field.invalid = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('theme', async () => {
+    field.setAttribute('theme', 'align-right');
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('slots', async () => {
+    await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});

--- a/packages/email-field/test/email-field.test.js
+++ b/packages/email-field/test/email-field.test.js
@@ -32,35 +32,28 @@ const invalidAddresses = [
 
 describe('email-field', () => {
   describe('default', () => {
-    let emailField, input;
+    let emailField;
 
     beforeEach(() => {
       emailField = fixtureSync('<vaadin-email-field></vaadin-email-field>');
-      input = emailField.inputElement;
     });
 
-    it('should have [type=email]', () => {
-      expect(input.type).to.equal('email');
-    });
-
-    describe('validation', () => {
-      describe('valid email addresses', () => {
-        validAddresses.forEach((address) => {
-          it(`should treat ${address} as valid`, () => {
-            emailField.value = address;
-            emailField.validate();
-            expect(emailField.invalid).to.be.false;
-          });
+    describe('valid email addresses', () => {
+      validAddresses.forEach((address) => {
+        it(`should treat ${address} as valid`, () => {
+          emailField.value = address;
+          emailField.validate();
+          expect(emailField.invalid).to.be.false;
         });
       });
+    });
 
-      describe('invalid email addresses', () => {
-        invalidAddresses.forEach((address) => {
-          it(`should treat ${address} as invalid`, () => {
-            emailField.value = address;
-            emailField.validate();
-            expect(emailField.invalid).to.be.true;
-          });
+    describe('invalid email addresses', () => {
+      invalidAddresses.forEach((address) => {
+        it(`should treat ${address} as invalid`, () => {
+          emailField.value = address;
+          emailField.validate();
+          expect(emailField.invalid).to.be.true;
         });
       });
     });

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1"
+    "@vaadin/testing-helpers": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-icon": "^22.0.0-alpha5",
     "@vaadin/vaadin-icons": "^22.0.0-alpha5"
   },

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -1,0 +1,363 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-integer-field default"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container part="input-field">
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-integer-field default */
+
+snapshots["vaadin-integer-field controls"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container part="input-field">
+    <div
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-integer-field controls */
+
+snapshots["vaadin-integer-field disabled"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    disabled=""
+    part="input-field"
+  >
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-integer-field disabled */
+
+snapshots["vaadin-integer-field readonly"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    readonly=""
+  >
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-integer-field readonly */
+
+snapshots["vaadin-integer-field invalid"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    invalid=""
+    part="input-field"
+  >
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-integer-field invalid */
+
+snapshots["vaadin-integer-field theme"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    theme="align-right"
+  >
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-integer-field theme */
+
+snapshots["vaadin-integer-field slots"] = 
+`<input
+  max="undefined"
+  min="undefined"
+  slot="input"
+  step="any"
+  type="number"
+>
+<label slot="label">
+</label>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<div slot="helper">
+</div>
+`;
+/* end snapshot vaadin-integer-field slots */
+

--- a/packages/integer-field/test/dom/integer-field.test.js
+++ b/packages/integer-field/test/dom/integer-field.test.js
@@ -1,0 +1,50 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-integer-field.js';
+
+describe('vaadin-integer-field', () => {
+  let field;
+
+  // Ignore generated attributes to prevent failures
+  // when running snapshot tests in a different order
+  const SNAPSHOT_CONFIG = {
+    ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for']
+  };
+
+  beforeEach(() => {
+    field = fixtureSync('<vaadin-integer-field></vaadin-integer-field>');
+  });
+
+  it('default', async () => {
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('controls', async () => {
+    field.hasControls = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('disabled', async () => {
+    field.disabled = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('readonly', async () => {
+    field.readonly = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('invalid', async () => {
+    field.invalid = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('theme', async () => {
+    field.setAttribute('theme', 'align-right');
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('slots', async () => {
+    await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
+++ b/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
@@ -1,0 +1,70 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-message-input default"] = 
+`<vaadin-message-input-text-area placeholder="Message">
+  <textarea
+    aria-label="Message"
+    placeholder="Message"
+    rows="1"
+    slot="textarea"
+    style="min-height: 0px;"
+  >
+  </textarea>
+  <label slot="label">
+  </label>
+  <div
+    aria-live="assertive"
+    slot="error-message"
+  >
+  </div>
+  <div slot="helper">
+  </div>
+</vaadin-message-input-text-area>
+<vaadin-message-input-button
+  role="button"
+  tabindex="0"
+  theme="primary contained"
+>
+  Send
+</vaadin-message-input-button>
+`;
+/* end snapshot vaadin-message-input default */
+
+snapshots["vaadin-message-input disabled"] = 
+`<vaadin-message-input-text-area
+  aria-disabled="true"
+  disabled=""
+  placeholder="Message"
+>
+  <textarea
+    aria-label="Message"
+    disabled=""
+    placeholder="Message"
+    rows="1"
+    slot="textarea"
+    style="min-height: 0px;"
+  >
+  </textarea>
+  <label slot="label">
+  </label>
+  <div
+    aria-live="assertive"
+    slot="error-message"
+  >
+  </div>
+  <div slot="helper">
+  </div>
+</vaadin-message-input-text-area>
+<vaadin-message-input-button
+  aria-disabled="true"
+  disabled=""
+  role="button"
+  tabindex="-1"
+  theme="primary contained"
+>
+  Send
+</vaadin-message-input-button>
+`;
+/* end snapshot vaadin-message-input disabled */
+

--- a/packages/message-input/test/dom/message-input.test.js
+++ b/packages/message-input/test/dom/message-input.test.js
@@ -1,0 +1,26 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-message-input.js';
+
+describe('vaadin-message-input', () => {
+  let input;
+
+  // Ignore generated attributes to prevent failures
+  // when running snapshot tests in a different order
+  const SNAPSHOT_CONFIG = {
+    ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for', 'pattern']
+  };
+
+  beforeEach(() => {
+    input = fixtureSync('<vaadin-message-input></vaadin-message-input>');
+  });
+
+  it('default', async () => {
+    await expect(input).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+
+  it('disabled', async () => {
+    input.disabled = true;
+    await expect(input).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});

--- a/packages/message-input/test/message-input.test.js
+++ b/packages/message-input/test/message-input.test.js
@@ -12,9 +12,20 @@ describe('message-input', () => {
     button = messageInput.shadowRoot.querySelector('vaadin-message-input-button');
   });
 
-  it('message should be initialized', () => {
-    expect(messageInput.shadowRoot.querySelector('vaadin-text-area')).to.be.not.undefined;
-    expect(messageInput.shadowRoot.querySelector('vaadin-button')).to.be.not.undefined;
+  describe('custom element definition', () => {
+    let tagName;
+
+    beforeEach(() => {
+      tagName = messageInput.tagName.toLowerCase();
+    });
+
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
+    });
   });
 
   describe('submit functionality', () => {
@@ -74,18 +85,6 @@ describe('message-input', () => {
   });
 
   describe('i18n', () => {
-    it('should have default button text', () => {
-      expect(button.innerText).to.be.equal('Send');
-    });
-
-    it('should have default placeholder', () => {
-      expect(textArea.placeholder).to.be.equal('Message');
-    });
-
-    it('should have default aria-label', () => {
-      expect(textArea.inputElement.getAttribute('aria-label')).to.be.equal('Message');
-    });
-
     it('should translate button text', () => {
       messageInput.i18n = { ...messageInput.i18n, send: 'Lähetä' };
       expect(button.innerText).to.be.equal('Lähetä');
@@ -115,16 +114,6 @@ describe('message-input', () => {
     it('should be reflected to the attribute', () => {
       messageInput.disabled = true;
       expect(messageInput.getAttribute('disabled')).to.exist;
-    });
-
-    it('should be propagated to text-area', () => {
-      messageInput.disabled = true;
-      expect(textArea.disabled).to.be.true;
-    });
-
-    it('should be propagated to button', () => {
-      messageInput.disabled = true;
-      expect(button.disabled).to.be.true;
     });
   });
 });

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/message-list/test/dom/__snapshots__/message-list.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message-list.test.snap.js
@@ -1,0 +1,61 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-message-list default"] = 
+`<div
+  part="list"
+  role="list"
+>
+  <dom-repeat style="display: none;">
+    <template is="dom-repeat">
+    </template>
+  </dom-repeat>
+</div>
+`;
+/* end snapshot vaadin-message-list default */
+
+snapshots["vaadin-message-list items"] = 
+`<div
+  part="list"
+  role="list"
+>
+  <vaadin-message
+    role="listitem"
+    tabindex="0"
+  >
+    Hi folks!
+  </vaadin-message>
+  <vaadin-message
+    role="listitem"
+    tabindex="-1"
+  >
+    Good morning!
+  </vaadin-message>
+  <dom-repeat style="display: none;">
+    <template is="dom-repeat">
+    </template>
+  </dom-repeat>
+</div>
+`;
+/* end snapshot vaadin-message-list items */
+
+snapshots["vaadin-message-list theme"] = 
+`<div
+  part="list"
+  role="list"
+>
+  <vaadin-message
+    role="listitem"
+    tabindex="0"
+    theme="danger"
+  >
+    Partial service outage.
+  </vaadin-message>
+  <dom-repeat style="display: none;">
+    <template is="dom-repeat">
+    </template>
+  </dom-repeat>
+</div>
+`;
+/* end snapshot vaadin-message-list theme */
+

--- a/packages/message-list/test/dom/__snapshots__/message.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message.test.snap.js
@@ -1,0 +1,155 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-message default"] = 
+`<vaadin-message-avatar
+  aria-hidden="true"
+  part="avatar"
+  role="button"
+  tabindex="-1"
+  title="anonymous"
+>
+</vaadin-message-avatar>
+<div part="content">
+  <div part="header">
+    <span part="name">
+    </span>
+    <span part="time">
+    </span>
+  </div>
+  <div part="message">
+    <slot>
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-message default */
+
+snapshots["vaadin-message userName"] = 
+`<vaadin-message-avatar
+  abbr="JD"
+  aria-hidden="true"
+  name="Joan Doe"
+  part="avatar"
+  role="button"
+  tabindex="-1"
+  title="Joan Doe"
+>
+</vaadin-message-avatar>
+<div part="content">
+  <div part="header">
+    <span part="name">
+      Joan Doe
+    </span>
+    <span part="time">
+    </span>
+  </div>
+  <div part="message">
+    <slot>
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-message userName */
+
+snapshots["vaadin-message userAbbr"] = 
+`<vaadin-message-avatar
+  abbr="JD"
+  aria-hidden="true"
+  part="avatar"
+  role="button"
+  tabindex="-1"
+  title="JD"
+>
+</vaadin-message-avatar>
+<div part="content">
+  <div part="header">
+    <span part="name">
+    </span>
+    <span part="time">
+    </span>
+  </div>
+  <div part="message">
+    <slot>
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-message userAbbr */
+
+snapshots["vaadin-message userImg"] = 
+`<vaadin-message-avatar
+  aria-hidden="true"
+  img="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
+  part="avatar"
+  role="button"
+  tabindex="-1"
+  title="anonymous"
+>
+</vaadin-message-avatar>
+<div part="content">
+  <div part="header">
+    <span part="name">
+    </span>
+    <span part="time">
+    </span>
+  </div>
+  <div part="message">
+    <slot>
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-message userImg */
+
+snapshots["vaadin-message userColorIndex"] = 
+`<vaadin-message-avatar
+  aria-hidden="true"
+  has-color-index=""
+  part="avatar"
+  role="button"
+  style="--vaadin-avatar-user-color:var(--vaadin-user-color-2);"
+  tabindex="-1"
+  title="anonymous"
+>
+</vaadin-message-avatar>
+<div part="content">
+  <div part="header">
+    <span part="name">
+    </span>
+    <span part="time">
+    </span>
+  </div>
+  <div part="message">
+    <slot>
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-message userColorIndex */
+
+snapshots["vaadin-message time"] = 
+`<vaadin-message-avatar
+  aria-hidden="true"
+  part="avatar"
+  role="button"
+  tabindex="-1"
+  title="anonymous"
+>
+</vaadin-message-avatar>
+<div part="content">
+  <div part="header">
+    <span part="name">
+    </span>
+    <span part="time">
+      long ago
+    </span>
+  </div>
+  <div part="message">
+    <slot>
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-message time */
+

--- a/packages/message-list/test/dom/message-list.test.js
+++ b/packages/message-list/test/dom/message-list.test.js
@@ -1,0 +1,30 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import '../../src/vaadin-message-list.js';
+
+describe('vaadin-message-list', () => {
+  let list;
+
+  beforeEach(() => {
+    list = fixtureSync('<vaadin-message-list></vaadin-message-list>');
+  });
+
+  it('default', async () => {
+    await expect(list).shadowDom.to.equalSnapshot();
+  });
+
+  it('items', async () => {
+    list.items = [
+      { text: 'Hi folks!', userName: 'Jane Doe' },
+      { text: 'Good morning!', userName: 'Lina Roy' }
+    ];
+    await nextFrame();
+    await expect(list).shadowDom.to.equalSnapshot();
+  });
+
+  it('theme', async () => {
+    list.items = [{ text: 'Partial service outage.', userName: 'Admin', theme: 'danger' }];
+    await nextFrame();
+    await expect(list).shadowDom.to.equalSnapshot();
+  });
+});

--- a/packages/message-list/test/dom/message.test.js
+++ b/packages/message-list/test/dom/message.test.js
@@ -1,0 +1,40 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-message.js';
+
+describe('vaadin-message', () => {
+  let message;
+
+  beforeEach(() => {
+    message = fixtureSync('<vaadin-message></vaadin-message>');
+  });
+
+  it('default', async () => {
+    await expect(message).shadowDom.to.equalSnapshot();
+  });
+
+  it('userName', async () => {
+    message.userName = 'Joan Doe';
+    await expect(message).shadowDom.to.equalSnapshot();
+  });
+
+  it('userAbbr', async () => {
+    message.userAbbr = 'JD';
+    await expect(message).shadowDom.to.equalSnapshot();
+  });
+
+  it('userImg', async () => {
+    message.userImg = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+    await expect(message).shadowDom.to.equalSnapshot();
+  });
+
+  it('userColorIndex', async () => {
+    message.userColorIndex = 2;
+    await expect(message).shadowDom.to.equalSnapshot();
+  });
+
+  it('time', async () => {
+    message.time = 'long ago';
+    await expect(message).shadowDom.to.equalSnapshot();
+  });
+});

--- a/packages/message-list/test/message-list.test.js
+++ b/packages/message-list/test/message-list.test.js
@@ -51,6 +51,22 @@ describe('message-list', () => {
     ];
   });
 
+  describe('custom element definition', () => {
+    let tagName;
+
+    beforeEach(() => {
+      tagName = messageList.tagName.toLowerCase();
+    });
+
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
+    });
+  });
+
   it('message list should be initially empty', () => {
     expect(messageList.items).to.be.empty;
   });
@@ -79,11 +95,6 @@ describe('message-list', () => {
       expect(firstMessage.userColorIndex).to.be.equal(messages[0].userColorIndex);
       expect(firstMessage.textContent).to.be.equal(messages[0].text);
       expect(firstMessage.theme).to.be.equal(messages[0].theme);
-    });
-
-    it('should propagate theme to attribute', () => {
-      const firstMessage = messageList.shadowRoot.querySelector('vaadin-message');
-      expect(firstMessage.getAttribute('theme')).to.be.equal(messages[0].theme);
     });
 
     it('message list should scroll when height is less than content', () => {

--- a/packages/message-list/test/message.test.js
+++ b/packages/message-list/test/message.test.js
@@ -3,69 +3,18 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-message.js';
 
 describe('message', () => {
-  let message, avatar, content, time, name;
+  let message, tagName;
 
   beforeEach(() => {
-    let root = document.documentElement;
-    root.style.setProperty('--vaadin-user-color-2', 'blue');
-
     message = fixtureSync('<vaadin-message>Hello</vaadin-message>');
-    avatar = message.shadowRoot.querySelector('vaadin-message-avatar');
-    name = message.shadowRoot.querySelector('[part="name"]');
-    content = message.shadowRoot.querySelector('[part="content"]');
-    time = message.shadowRoot.querySelector('[part="time"]');
+    tagName = message.tagName.toLowerCase();
   });
 
-  it('avatar should be initially visible but without data', () => {
-    expect(avatar.getAttribute('name')).to.be.null;
-    expect(avatar.getAttribute('abbr')).to.be.null;
-    expect(avatar.getAttribute('img')).to.be.null;
-    expect(avatar.getAttribute('title')).to.be.equal('anonymous');
-    expect(avatar.getAttribute('has-color-index')).to.be.null;
+  it('should be defined in custom element registry', () => {
+    expect(customElements.get(tagName)).to.be.ok;
   });
 
-  it('name should be initially empty', () => {
-    expect(name.textContent.trim()).to.be.equal('');
-  });
-
-  it('time should be initially empty', () => {
-    expect(time.textContent.trim()).to.be.equal('');
-  });
-
-  it('avatar should be set with provided user name', () => {
-    message.userName = 'Joan Doe';
-    expect(avatar.name).to.be.equal('Joan Doe');
-  });
-
-  it('avatar should be set with provided user abbreviation', () => {
-    message.userAbbr = 'JD';
-    expect(avatar.abbr).to.be.equal('JD');
-  });
-
-  it('avatar should be set with provided user image', () => {
-    message.userImg = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
-    expect(avatar.img).to.be.equal('data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=');
-  });
-
-  it('avatar should be set with provided user color', () => {
-    message.userColorIndex = 2;
-    expect(avatar.getAttribute('has-color-index')).to.be.not.null;
-    expect(avatar.colorIndex).to.be.equal(2);
-  });
-
-  it('name should be set with provided user', () => {
-    message.userName = 'Joan Doe';
-    expect(name.textContent).to.be.equal('Joan Doe');
-  });
-
-  it('time should be set', () => {
-    message.time = 'long ago';
-    expect(time.textContent).to.be.equal('long ago');
-  });
-
-  it('content should be set', () => {
-    const slot = content.querySelector('slot');
-    const nodes = slot.assignedNodes({ flatten: true });
-    expect(nodes[0].textContent).to.be.equal('Hello');
+  it('should have a valid static "is" getter', () => {
+    expect(customElements.get(tagName).is).to.equal(tagName);
   });
 });

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -1,0 +1,363 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-number-field default"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container part="input-field">
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-number-field default */
+
+snapshots["vaadin-number-field controls"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container part="input-field">
+    <div
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-number-field controls */
+
+snapshots["vaadin-number-field disabled"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    disabled=""
+    part="input-field"
+  >
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-number-field disabled */
+
+snapshots["vaadin-number-field readonly"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    readonly=""
+  >
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-number-field readonly */
+
+snapshots["vaadin-number-field invalid"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    invalid=""
+    part="input-field"
+  >
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-number-field invalid */
+
+snapshots["vaadin-number-field theme"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    theme="align-right"
+  >
+    <div
+      hidden=""
+      part="decrease-button"
+      slot="prefix"
+    >
+    </div>
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      hidden=""
+      part="increase-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-number-field theme */
+
+snapshots["vaadin-number-field slots"] = 
+`<input
+  max="undefined"
+  min="undefined"
+  slot="input"
+  step="any"
+  type="number"
+>
+<label slot="label">
+</label>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<div slot="helper">
+</div>
+`;
+/* end snapshot vaadin-number-field slots */
+

--- a/packages/number-field/test/dom/number-field.test.js
+++ b/packages/number-field/test/dom/number-field.test.js
@@ -1,0 +1,50 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-number-field.js';
+
+describe('vaadin-number-field', () => {
+  let field;
+
+  // Ignore generated attributes to prevent failures
+  // when running snapshot tests in a different order
+  const SNAPSHOT_CONFIG = {
+    ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for']
+  };
+
+  beforeEach(() => {
+    field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+  });
+
+  it('default', async () => {
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('controls', async () => {
+    field.hasControls = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('disabled', async () => {
+    field.disabled = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('readonly', async () => {
+    field.readonly = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('invalid', async () => {
+    field.invalid = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('theme', async () => {
+    field.setAttribute('theme', 'align-right');
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('slots', async () => {
+    await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -18,11 +18,6 @@ describe('number-field', () => {
       expect(input.type).to.equal('number');
     });
 
-    it('should have hidden controls', () => {
-      expect(decreaseButton.hidden).to.be.true;
-      expect(increaseButton.hidden).to.be.true;
-    });
-
     ['min', 'max'].forEach(function (attr) {
       it('should set numeric attribute ' + attr, () => {
         const value = 5;
@@ -73,18 +68,6 @@ describe('number-field', () => {
   });
 
   describe('value control buttons', () => {
-    it('should not have value controls by default', () => {
-      expect(decreaseButton.hidden).to.be.true;
-      expect(increaseButton.hidden).to.be.true;
-    });
-
-    it('should have value controls when hasControls is set to true', () => {
-      numberField.hasControls = true;
-
-      expect(decreaseButton.hidden).to.be.false;
-      expect(increaseButton.hidden).to.be.false;
-    });
-
     it('should increase value by 1 on plus button click', () => {
       numberField.value = 0;
 
@@ -834,43 +817,6 @@ describe('number-field', () => {
         numberField.max = 0;
         expect(numberField.invalid).to.be.true;
       });
-    });
-  });
-
-  describe('input field', () => {
-    let inputField;
-
-    beforeEach(() => {
-      inputField = numberField.shadowRoot.querySelector('[part="input-field"]');
-    });
-
-    it('should propagate invalid property to the input container', () => {
-      numberField.invalid = true;
-      expect(inputField.invalid).to.be.true;
-
-      numberField.invalid = false;
-      expect(inputField.invalid).to.be.false;
-    });
-
-    it('should propagate readonly property to the input container', () => {
-      numberField.readonly = true;
-      expect(inputField.readonly).to.be.true;
-
-      numberField.readonly = false;
-      expect(inputField.readonly).to.be.false;
-    });
-
-    it('should propagate disabled property to the input container', () => {
-      numberField.disabled = true;
-      expect(inputField.disabled).to.be.true;
-
-      numberField.disabled = false;
-      expect(inputField.disabled).to.be.false;
-    });
-
-    it('should propagate theme attribute to the input container', () => {
-      numberField.setAttribute('theme', 'align-center');
-      expect(inputField.getAttribute('theme')).to.equal('align-center');
     });
   });
 });

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -1,0 +1,291 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-password-field default"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container part="input-field">
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      part="reveal-button"
+      slot="suffix"
+    >
+      <slot name="reveal">
+      </slot>
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-password-field default */
+
+snapshots["vaadin-password-field disabled"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    disabled=""
+    part="input-field"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      part="reveal-button"
+      slot="suffix"
+    >
+      <slot name="reveal">
+      </slot>
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-password-field disabled */
+
+snapshots["vaadin-password-field readonly"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    readonly=""
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      part="reveal-button"
+      slot="suffix"
+    >
+      <slot name="reveal">
+      </slot>
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-password-field readonly */
+
+snapshots["vaadin-password-field invalid"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    invalid=""
+    part="input-field"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      part="reveal-button"
+      slot="suffix"
+    >
+      <slot name="reveal">
+      </slot>
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-password-field invalid */
+
+snapshots["vaadin-password-field theme"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    theme="align-right"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+    <div
+      part="reveal-button"
+      slot="suffix"
+    >
+      <slot name="reveal">
+      </slot>
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-password-field theme */
+
+snapshots["vaadin-password-field slots"] = 
+`<input
+  autocapitalize="off"
+  slot="input"
+  type="password"
+>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<label slot="label">
+</label>
+<div slot="helper">
+</div>
+<button
+  aria-label="Show password"
+  aria-pressed="false"
+  slot="reveal"
+  tabindex="0"
+  type="button"
+>
+</button>
+`;
+/* end snapshot vaadin-password-field slots */
+

--- a/packages/password-field/test/dom/password-field.test.js
+++ b/packages/password-field/test/dom/password-field.test.js
@@ -1,0 +1,45 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-password-field.js';
+
+describe('vaadin-password-field', () => {
+  let field;
+
+  // Ignore generated attributes to prevent failures
+  // when running snapshot tests in a different order
+  const SNAPSHOT_CONFIG = {
+    ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for']
+  };
+
+  beforeEach(() => {
+    field = fixtureSync('<vaadin-password-field></vaadin-password-field>');
+  });
+
+  it('default', async () => {
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('disabled', async () => {
+    field.disabled = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('readonly', async () => {
+    field.readonly = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('invalid', async () => {
+    field.invalid = true;
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('theme', async () => {
+    field.setAttribute('theme', 'align-right');
+    await expect(field).shadowDom.to.equalSnapshot();
+  });
+
+  it('slots', async () => {
+    await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -13,14 +13,6 @@ describe('password-field', () => {
     revealButton = passwordField.querySelector('[slot=reveal]');
   });
 
-  it('should have [type=password]', () => {
-    expect(input.type).to.equal('password');
-  });
-
-  it('should show reveal button by default', () => {
-    expect(revealButton.hidden).to.be.false;
-  });
-
   it('should set default accessible label to reveal button', () => {
     expect(revealButton.getAttribute('aria-label')).to.equal('Show password');
   });
@@ -82,10 +74,6 @@ describe('password-field', () => {
     revealButton.dispatchEvent(e);
 
     expect(spy.calledOnce).to.be.true;
-  });
-
-  it('should set aria-pressed attribute on reveal button to false', () => {
-    expect(revealButton.getAttribute('aria-pressed')).to.equal('false');
   });
 
   it('should toggle aria-pressed attribute on reveal button click', () => {

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1"
+    "@vaadin/testing-helpers": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha5",
     "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.0"

--- a/packages/select/test/accessibility.test.js
+++ b/packages/select/test/accessibility.test.js
@@ -39,10 +39,6 @@ describe('accessibility', () => {
     expect(select.getAttribute('aria-disabled')).to.be.equal('true');
   });
 
-  it('should set aria-haspopup="listbox" on the value button', () => {
-    expect(valueButton.getAttribute('aria-haspopup')).to.be.equal('listbox');
-  });
-
   it('should set aria-expanded attribute on the value button', () => {
     expect(valueButton.getAttribute('aria-expanded')).to.be.equal('false');
     select.opened = true;

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -1,0 +1,242 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-select default"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container part="input-field">
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="value">
+    </slot>
+    <div
+      part="toggle-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+<vaadin-select-overlay>
+</vaadin-select-overlay>
+<iron-media-query style="display: none;">
+</iron-media-query>
+`;
+/* end snapshot vaadin-select default */
+
+snapshots["vaadin-select disabled"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    disabled=""
+    part="input-field"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="value">
+    </slot>
+    <div
+      part="toggle-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+<vaadin-select-overlay>
+</vaadin-select-overlay>
+<iron-media-query style="display: none;">
+</iron-media-query>
+`;
+/* end snapshot vaadin-select disabled */
+
+snapshots["vaadin-select readonly"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    readonly=""
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="value">
+    </slot>
+    <div
+      part="toggle-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+<vaadin-select-overlay>
+</vaadin-select-overlay>
+<iron-media-query style="display: none;">
+</iron-media-query>
+`;
+/* end snapshot vaadin-select readonly */
+
+snapshots["vaadin-select invalid"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    invalid=""
+    part="input-field"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="value">
+    </slot>
+    <div
+      part="toggle-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+<vaadin-select-overlay>
+</vaadin-select-overlay>
+<iron-media-query style="display: none;">
+</iron-media-query>
+`;
+/* end snapshot vaadin-select invalid */
+
+snapshots["vaadin-select theme"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    theme="align-right"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="value">
+    </slot>
+    <div
+      part="toggle-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+<vaadin-select-overlay theme="align-right">
+</vaadin-select-overlay>
+<iron-media-query style="display: none;">
+</iron-media-query>
+`;
+/* end snapshot vaadin-select theme */
+
+snapshots["vaadin-select slots"] = 
+`<label slot="label">
+</label>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<div slot="helper">
+</div>
+<vaadin-select-value-button
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-required="false"
+  role="button"
+  slot="value"
+  tabindex="0"
+>
+</vaadin-select-value-button>
+`;
+/* end snapshot vaadin-select slots */
+

--- a/packages/select/test/dom/select.test.js
+++ b/packages/select/test/dom/select.test.js
@@ -1,0 +1,45 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-select.js';
+
+describe('vaadin-select', () => {
+  let select;
+
+  // Ignore generated attributes to prevent failures
+  // when running snapshot tests in a different order
+  const SNAPSHOT_CONFIG = {
+    ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for']
+  };
+
+  beforeEach(() => {
+    select = fixtureSync('<vaadin-select></vaadin-select>');
+  });
+
+  it('default', async () => {
+    await expect(select).shadowDom.to.equalSnapshot();
+  });
+
+  it('disabled', async () => {
+    select.disabled = true;
+    await expect(select).shadowDom.to.equalSnapshot();
+  });
+
+  it('readonly', async () => {
+    select.readonly = true;
+    await expect(select).shadowDom.to.equalSnapshot();
+  });
+
+  it('invalid', async () => {
+    select.invalid = true;
+    await expect(select).shadowDom.to.equalSnapshot();
+  });
+
+  it('theme', async () => {
+    select.setAttribute('theme', 'align-right');
+    await expect(select).shadowDom.to.equalSnapshot();
+  });
+
+  it('slots', async () => {
+    await expect(select).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -585,53 +585,6 @@ describe('vaadin-select', () => {
     });
   });
 
-  describe('input field', () => {
-    let inputField;
-
-    beforeEach(() => {
-      select = fixtureSync('<vaadin-select></vaadin-select>');
-      inputField = select._inputContainer;
-    });
-
-    it('should propagate invalid property to the input container', () => {
-      select.invalid = true;
-      expect(inputField.invalid).to.be.true;
-
-      select.invalid = false;
-      expect(inputField.invalid).to.be.false;
-    });
-
-    it('should propagate readonly property to the input container', () => {
-      select.readonly = true;
-      expect(inputField.readonly).to.be.true;
-
-      select.readonly = false;
-      expect(inputField.readonly).to.be.false;
-    });
-
-    it('should propagate disabled property to the input container', () => {
-      select.disabled = true;
-      expect(inputField.disabled).to.be.true;
-
-      select.disabled = false;
-      expect(inputField.disabled).to.be.false;
-    });
-  });
-
-  describe('theme attribute', () => {
-    beforeEach(() => {
-      select = fixtureSync('<vaadin-select theme="foo"></vaadin-select>');
-    });
-
-    it('should propagate theme attribute to overlay', () => {
-      expect(select._overlayElement.getAttribute('theme')).to.equal('foo');
-    });
-
-    it('should propagate theme attribute to the input container', () => {
-      expect(select._inputContainer.getAttribute('theme')).to.equal('foo');
-    });
-  });
-
   describe('inside flexbox', () => {
     let container;
 

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -1,0 +1,245 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-text-area default"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container part="input-field">
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="textarea">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-text-area default */
+
+snapshots["vaadin-text-area disabled"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    disabled=""
+    part="input-field"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="textarea">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-text-area disabled */
+
+snapshots["vaadin-text-area readonly"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    readonly=""
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="textarea">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-text-area readonly */
+
+snapshots["vaadin-text-area invalid"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    invalid=""
+    part="input-field"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="textarea">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-text-area invalid */
+
+snapshots["vaadin-text-area theme"] = 
+`<div part="container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="indicator"
+    >
+    </span>
+  </div>
+  <vaadin-input-container
+    part="input-field"
+    theme="align-right"
+  >
+    <slot
+      name="prefix"
+      slot="prefix"
+    >
+    </slot>
+    <slot name="textarea">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
+    </slot>
+    <div
+      id="clearButton"
+      part="clear-button"
+      slot="suffix"
+    >
+    </div>
+  </vaadin-input-container>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-text-area theme */
+
+snapshots["vaadin-text-area slots"] = 
+`<textarea slot="textarea">
+</textarea>
+<label slot="label">
+</label>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<div slot="helper">
+</div>
+`;
+/* end snapshot vaadin-text-area slots */
+

--- a/packages/text-area/test/dom/text-area.test.js
+++ b/packages/text-area/test/dom/text-area.test.js
@@ -1,0 +1,45 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-text-area.js';
+
+describe('vaadin-text-area', () => {
+  let textArea;
+
+  // Ignore generated attributes to prevent failures
+  // when running snapshot tests in a different order
+  const SNAPSHOT_CONFIG = {
+    ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for']
+  };
+
+  beforeEach(() => {
+    textArea = fixtureSync('<vaadin-text-area></vaadin-text-area>');
+  });
+
+  it('default', async () => {
+    await expect(textArea).shadowDom.to.equalSnapshot();
+  });
+
+  it('disabled', async () => {
+    textArea.disabled = true;
+    await expect(textArea).shadowDom.to.equalSnapshot();
+  });
+
+  it('readonly', async () => {
+    textArea.readonly = true;
+    await expect(textArea).shadowDom.to.equalSnapshot();
+  });
+
+  it('invalid', async () => {
+    textArea.invalid = true;
+    await expect(textArea).shadowDom.to.equalSnapshot();
+  });
+
+  it('theme', async () => {
+    textArea.setAttribute('theme', 'align-right');
+    await expect(textArea).shadowDom.to.equalSnapshot();
+  });
+
+  it('slots', async () => {
+    await expect(textArea).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -76,43 +76,6 @@ describe('text-area', () => {
           assertAttrCanBeSet(prop, false);
         });
       });
-
-      describe('input field', () => {
-        let inputField;
-
-        beforeEach(() => {
-          inputField = textArea.shadowRoot.querySelector('[part="input-field"]');
-        });
-
-        it('should propagate invalid property to the input container', () => {
-          textArea.invalid = true;
-          expect(inputField.invalid).to.be.true;
-
-          textArea.invalid = false;
-          expect(inputField.invalid).to.be.false;
-        });
-
-        it('should propagate readonly property to the input container', () => {
-          textArea.readonly = true;
-          expect(inputField.readonly).to.be.true;
-
-          textArea.readonly = false;
-          expect(inputField.readonly).to.be.false;
-        });
-
-        it('should propagate disabled property to the input container', () => {
-          textArea.disabled = true;
-          expect(inputField.disabled).to.be.true;
-
-          textArea.disabled = false;
-          expect(inputField.disabled).to.be.false;
-        });
-
-        it('should propagate theme attribute to the input container', () => {
-          textArea.setAttribute('theme', 'align-center');
-          expect(inputField.getAttribute('theme')).to.equal('align-center');
-        });
-      });
     });
 
     describe('binding', () => {

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-accordion/package.json
+++ b/packages/vaadin-accordion/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-app-layout/package.json
+++ b/packages/vaadin-app-layout/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-tabs": "^22.0.0-alpha5",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-avatar/package.json
+++ b/packages/vaadin-avatar/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-board/package.json
+++ b/packages/vaadin-board/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-charts/package.json
+++ b/packages/vaadin-charts/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-combo-box/package.json
+++ b/packages/vaadin-combo-box/package.json
@@ -41,7 +41,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@polymer/iron-input": "^3.0.1",
     "@polymer/paper-input": "^3.0.0",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-dialog": "^22.0.0-alpha5",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha5",
     "lit": "^2.0.0-rc.1",

--- a/packages/vaadin-confirm-dialog/package.json
+++ b/packages/vaadin-confirm-dialog/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-context-menu/package.json
+++ b/packages/vaadin-context-menu/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha5",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-control-state-mixin/package.json
+++ b/packages/vaadin-control-state-mixin/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-cookie-consent/package.json
+++ b/packages/vaadin-cookie-consent/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1"
+    "@vaadin/testing-helpers": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vaadin-crud/package.json
+++ b/packages/vaadin-crud/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha5",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-custom-field/package.json
+++ b/packages/vaadin-custom-field/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/select": "^22.0.0-alpha5",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-date-picker": "^22.0.0-alpha5",
     "@vaadin/vaadin-form-layout": "^22.0.0-alpha5",
     "@vaadin/vaadin-list-box": "^22.0.0-alpha5",

--- a/packages/vaadin-date-picker/package.json
+++ b/packages/vaadin-date-picker/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-dialog": "^22.0.0-alpha5",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha5",
     "sinon": "^9.2.0"

--- a/packages/vaadin-date-time-picker/package.json
+++ b/packages/vaadin-date-time-picker/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-details/package.json
+++ b/packages/vaadin-details/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-dialog/package.json
+++ b/packages/vaadin-dialog/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/text-area": "^22.0.0-alpha5",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha5",
     "sinon": "^9.2.1"

--- a/packages/vaadin-element-mixin/package.json
+++ b/packages/vaadin-element-mixin/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-form-layout/package.json
+++ b/packages/vaadin-form-layout/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-text-field": "^22.0.0-alpha5",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-grid-pro/package.json
+++ b/packages/vaadin-grid-pro/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-date-picker": "^22.0.0-alpha5",
     "@vaadin/vaadin-dialog": "^22.0.0-alpha5",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha5",

--- a/packages/vaadin-grid/package.json
+++ b/packages/vaadin-grid/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha5",
     "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.0"

--- a/packages/vaadin-icon/package.json
+++ b/packages/vaadin-icon/package.json
@@ -31,7 +31,7 @@
     "lit": "^2.0.0-rc.1"
   },
   "devDependencies": {
-    "@vaadin/testing-helpers": "^0.2.1"
+    "@vaadin/testing-helpers": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vaadin-item/package.json
+++ b/packages/vaadin-item/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-list-box/package.json
+++ b/packages/vaadin-list-box/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-list-mixin/package.json
+++ b/packages/vaadin-list-mixin/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-login/package.json
+++ b/packages/vaadin-login/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-menu-bar/package.json
+++ b/packages/vaadin-menu-bar/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-icon": "^22.0.0-alpha5",
     "sinon": "^9.2.1"
   },

--- a/packages/vaadin-messages/package.json
+++ b/packages/vaadin-messages/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-notification/package.json
+++ b/packages/vaadin-notification/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/button": "^22.0.0-alpha5",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha5",
     "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.1"

--- a/packages/vaadin-ordered-layout/package.json
+++ b/packages/vaadin-ordered-layout/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1"
+    "@vaadin/testing-helpers": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vaadin-overlay/package.json
+++ b/packages/vaadin-overlay/package.json
@@ -37,7 +37,7 @@
     "@polymer/iron-overlay-behavior": "^3.0.0",
     "@vaadin/button": "^22.0.0-alpha5",
     "@vaadin/radio-group": "^22.0.0-alpha5",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-text-field": "^22.0.0-alpha5",
     "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.1"

--- a/packages/vaadin-progress-bar/package.json
+++ b/packages/vaadin-progress-bar/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1"
+    "@vaadin/testing-helpers": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vaadin-rich-text-editor/package.json
+++ b/packages/vaadin-rich-text-editor/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "gulp": "^4.0.0",
     "gulp-cli": "^2.0.1",
     "gulp-iconfont": "^11.0.0",

--- a/packages/vaadin-split-layout/package.json
+++ b/packages/vaadin-split-layout/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-tabs/package.json
+++ b/packages/vaadin-tabs/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-template-renderer/package.json
+++ b/packages/vaadin-template-renderer/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/checkbox": "^22.0.0-alpha5",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-grid": "^22.0.0-alpha5",
     "@vaadin/vaadin-grid-pro": "^22.0.0-alpha5"
   },

--- a/packages/vaadin-text-field/package.json
+++ b/packages/vaadin-text-field/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.1"
   },
   "publishConfig": {

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/packages/vaadin-time-picker/package.json
+++ b/packages/vaadin-time-picker/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.0"
   },
   "publishConfig": {

--- a/packages/vaadin-upload/package.json
+++ b/packages/vaadin-upload/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "sinon": "^9.2.0"
   },
   "publishConfig": {

--- a/packages/vaadin-virtual-list/package.json
+++ b/packages/vaadin-virtual-list/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1",
+    "@vaadin/testing-helpers": "^0.3.0",
     "lit": "^2.0.0-rc.1",
     "sinon": "^9.2.4"
   },

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.2.1"
+    "@vaadin/testing-helpers": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/web-test-runner-snapshots.config.js
+++ b/web-test-runner-snapshots.config.js
@@ -1,0 +1,4 @@
+/* eslint-env node */
+const { createSnapshotTestsConfig } = require('./wtr-utils.js');
+
+module.exports = createSnapshotTestsConfig();

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -65,6 +65,15 @@ const getAllUnitPackages = () => {
 };
 
 /**
+ * Get all available packages with snapshot tests.
+ */
+const getAllSnapshotPackages = () => {
+  return fs
+    .readdirSync('packages')
+    .filter((dir) => fs.statSync(`packages/${dir}`).isDirectory() && fs.existsSync(`packages/${dir}/test/dom`));
+};
+
+/**
  * Get all available packages with visual tests.
  */
 const getAllVisualPackages = () => {
@@ -107,6 +116,14 @@ const getTestPackages = (allPackages) => {
 };
 
 /**
+ * Get packages for running snapshot tests.
+ */
+const getSnapshotTestPackages = () => {
+  let snapshotPackages = getAllSnapshotPackages();
+  return getTestPackages(snapshotPackages);
+};
+
+/**
  * Get packages for running unit tests.
  */
 const getUnitTestPackages = () => {
@@ -120,6 +137,18 @@ const getUnitTestPackages = () => {
 const getVisualTestPackages = () => {
   const visualPackages = getAllVisualPackages();
   return getTestPackages(visualPackages);
+};
+
+/**
+ * Get unit test groups based on packages.
+ */
+const getSnapshotTestGroups = (packages) => {
+  return packages.map((pkg) => {
+    return {
+      name: pkg,
+      files: `packages/${pkg}/test/dom/*.test.js`
+    };
+  });
 };
 
 /**
@@ -227,6 +256,19 @@ const getDiffScreenshotName = (args) => getScreenshotFileName(args, 'failed', tr
 
 const getFailedScreenshotName = (args) => getScreenshotFileName(args, 'failed');
 
+const createSnapshotTestsConfig = (config) => {
+  const packages = getSnapshotTestPackages();
+  const groups = getSnapshotTestGroups(packages);
+
+  return {
+    ...config,
+    nodeResolve: true,
+    groups,
+    testRunnerHtml,
+    filterBrowserLogs
+  };
+};
+
 const createUnitTestsConfig = (config) => {
   const packages = getUnitTestPackages();
   const groups = getUnitTestGroups(packages);
@@ -300,6 +342,7 @@ const createVisualTestsConfig = (theme) => {
 };
 
 module.exports = {
+  createSnapshotTestsConfig,
   createUnitTestsConfig,
   createVisualTestsConfig
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,7 +238,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@esm-bundle/chai@^4.3.4":
+"@esm-bundle/chai@^4.3.1", "@esm-bundle/chai@^4.3.4":
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/@esm-bundle/chai/-/chai-4.3.4.tgz#74ed4a0794b3a9f9517ff235744ac6f4be0d34dc"
   integrity sha512-6Tx35wWiNw7X0nLY9RMx8v3EL8SacCFW+eEZOE9Hc+XxmU5HFE2AFEg+GehUZpiyDGwVvPH75ckGlqC7coIPnA==
@@ -1262,6 +1262,14 @@
     "@octokit/webhooks-types" "4.3.0"
     aggregate-error "^3.1.0"
 
+"@open-wc/semantic-dom-diff@^0.19.5-next.1":
+  version "0.19.5-next.2"
+  resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.19.5-next.2.tgz#272acd6935a75e8fc5a287aff50c3b588b17004e"
+  integrity sha512-T7GPbhcXwbT+FriO/7aa3Kp5iIGqf8l7SL7rSNVa0mqzBUmZ1Gfyxy965ZS/kRtGc6ytnbJ1Gqnr2GHN/brftA==
+  dependencies:
+    "@types/chai" "^4.2.11"
+    "@web/test-runner-commands" "^0.5.7"
+
 "@polymer/app-layout@^3.0.0-pre.26":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@polymer/app-layout/-/app-layout-3.1.0.tgz#b146cd2ce202e079ac51059a4fcaef03f5b2f3c4"
@@ -1669,7 +1677,7 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/chai@^4.2.12":
+"@types/chai@^4.2.11", "@types/chai@^4.2.12":
   version "4.2.21"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.21.tgz#9f35a5643129df132cf3b5c1ec64046ea1af0650"
   integrity sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==
@@ -2040,11 +2048,13 @@
     "@typescript-eslint/types" "4.29.2"
     eslint-visitor-keys "^2.0.0"
 
-"@vaadin/testing-helpers@0.2.1", "@vaadin/testing-helpers@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.2.1.tgz#b71c1905974a8f2fab836df5d6d0323d71d193ff"
-  integrity sha512-hN/OC/r31CciBeoWGJhB7/1i8gfB106fG7/KUii5S8G27EvzmiBBRIyWsJKW8M0uAJatC843DnQ+hDhpnRqDcQ==
+"@vaadin/testing-helpers@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.3.0.tgz#b8f98c72aa389985c9d6071bfd2049374b323461"
+  integrity sha512-y6oWPo5NvDXXKyZd6sC4P3lVmEcCCfq5+wvVSy46gIq31rb2VRoJl+BOtTfyof05QMJkjXb5vklDZcTfQ0zlfQ==
   dependencies:
+    "@esm-bundle/chai" "^4.3.1"
+    "@open-wc/semantic-dom-diff" "^0.19.5-next.1"
     "@polymer/polymer" "^3.4.1"
 
 "@vaadin/vaadin-development-mode-detector@^2.0.0":
@@ -2213,7 +2223,7 @@
     chrome-launcher "^0.14.0"
     puppeteer-core "^9.1.0"
 
-"@web/test-runner-commands@^0.5.10", "@web/test-runner-commands@^0.5.12":
+"@web/test-runner-commands@^0.5.10", "@web/test-runner-commands@^0.5.12", "@web/test-runner-commands@^0.5.7":
   version "0.5.12"
   resolved "https://registry.yarnpkg.com/@web/test-runner-commands/-/test-runner-commands-0.5.12.tgz#1a5940505994acfa05585ad7ecd8ad8f6e91c725"
   integrity sha512-W5ajWzO7+d3u1R0/FPBU8q3d4y5faOQVIWnOruFNvXu3Qjfg2VCWFOtARegA7ATNCE18H0dGRuF4KGxHDmMe3g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9234,10 +9234,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-playwright@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.14.0.tgz#18301b11f5278a446d36b5cf96f67db36ce2cd20"
-  integrity sha512-aR5oZ1iVsjQkGfYCjgYAmyMAVu0MQ0i8MgdnfdqDu9EVLfbnpuuFmTv/Rb7/Yjno1kOrDUP9+RyNC+zfG3wozA==
+playwright@^1.14.0, playwright@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.14.1.tgz#73913d3044a85a58edf13148245279231072532e"
+  integrity sha512-JYNjhwWcfsBkg0FMGLbFO9e58FVdmICE4k97/glIQV7cBULL7oxNjRQC7Ffe+Y70XVNnP0HSJLaA0W5SukyftQ==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"


### PR DESCRIPTION
## Description

Added the first batch of snapshot tests for 12 components listed below.

Also updated playwright to get `1.14.1` which should fix some of WebKit crashes.

Connected to #2499

## Type of change

- Internal change

## Components

- `avatar`
- `avatar-group`
- `button`
- `email-field`
- `integer-field`
- `message`
- `message-input`
- `message-list`
- `number-field`
- `password-field`
- `select`
- `text-area`
