### PR TITLE
fix: disable skipLibCheck in tsconfig.json

### DIFF
--- a/packages/field-base/src/helper-text-mixin.d.ts
+++ b/packages/field-base/src/helper-text-mixin.d.ts
@@ -18,7 +18,7 @@ interface HelperTextMixin extends SlotMixin {
   /**
    * String used for the helper text.
    */
-  helperText: string;
+  helperText: string | null | undefined;
 }
 
 export { HelperTextMixinConstructor, HelperTextMixin };

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -113,7 +113,7 @@ const InputFieldMixinImplementation = (superclass) =>
     }
 
     /**
-     * Override an event listener from `DelegatesFocusMixin`.
+     * Override an event listener from `DelegateFocusMixin`.
      * @param {FocusEvent} event
      * @protected
      * @override
@@ -127,7 +127,7 @@ const InputFieldMixinImplementation = (superclass) =>
     }
 
     /**
-     * Override an event listener from `DelegatesFocusMixin`.
+     * Override an event listener from `DelegateFocusMixin`.
      * @param {FocusEvent} event
      * @protected
      * @override

--- a/packages/field-base/src/input-slot-mixin.d.ts
+++ b/packages/field-base/src/input-slot-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DelegatesFocusMixin } from './delegate-focus-mixin.js';
+import { DelegateFocusMixin } from './delegate-focus-mixin.js';
 import { SlotMixin } from './slot-mixin.js';
 import { InputMixin } from './input-mixin.js';
 
@@ -16,7 +16,7 @@ interface InputSlotMixinConstructor {
   new (...args: any[]): InputSlotMixin;
 }
 
-interface InputSlotMixin extends DelegatesFocusMixin, InputMixin, SlotMixin {
+interface InputSlotMixin extends DelegateFocusMixin, InputMixin, SlotMixin {
   /**
    * String used to define input type.
    */

--- a/packages/field-base/src/text-area-slot-mixin.d.ts
+++ b/packages/field-base/src/text-area-slot-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DelegatesFocusMixin } from './delegate-focus-mixin.js';
+import { DelegateFocusMixin } from './delegate-focus-mixin.js';
 import { SlotMixin } from './slot-mixin.js';
 import { InputMixin } from './input-mixin.js';
 
@@ -16,6 +16,6 @@ interface TextAreaSlotMixinConstructor {
   new (...args: any[]): TextAreaSlotMixin;
 }
 
-interface TextAreaSlotMixin extends DelegatesFocusMixin, InputMixin, SlotMixin {}
+interface TextAreaSlotMixin extends DelegateFocusMixin, InputMixin, SlotMixin {}
 
 export { TextAreaSlotMixinConstructor, TextAreaSlotMixin };

--- a/packages/select/src/interfaces.d.ts
+++ b/packages/select/src/interfaces.d.ts
@@ -1,4 +1,4 @@
-import { SelectElement } from './vaadin-select';
+import { Select } from './vaadin-select';
 
 /**
  * Function for rendering the content of the `<vaadin-select>`.
@@ -8,7 +8,7 @@ import { SelectElement } from './vaadin-select';
  *   DOM element. Append your content to it.
  * - `select` The reference to the `<vaadin-select>` element.
  */
-export type SelectRenderer = (root: HTMLElement, select?: SelectElement) => void;
+export type SelectRenderer = (root: HTMLElement, select?: Select) => void;
 
 /**
  * Fired when the `opened` property changes.

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -140,11 +140,6 @@ declare class Select extends DelegateFocusMixin(
   placeholder: string | null | undefined;
 
   /**
-   * String used for the helper text.
-   */
-  helperText: string | null | undefined;
-
-  /**
    * When present, it specifies that the element is read-only.
    */
   readonly: boolean;

--- a/packages/vaadin-notification/src/vaadin-notification.d.ts
+++ b/packages/vaadin-notification/src/vaadin-notification.d.ts
@@ -1,4 +1,4 @@
-import { TemplateResult } from 'lit-html';
+import { TemplateResult } from 'lit';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';

--- a/packages/vaadin-notification/src/vaadin-notification.d.ts
+++ b/packages/vaadin-notification/src/vaadin-notification.d.ts
@@ -1,10 +1,8 @@
+import { TemplateResult } from 'lit-html';
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
-
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
-
-import { NotificationEventMap, NotificationPosition, NotificationRenderer } from './interfaces';
+import { NotificationEventMap, NotificationPosition, NotificationRenderer, ShowOptions } from './interfaces';
 
 /**
  * An element used internally by `<vaadin-notification>`. Not intended to be used separately.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,11 @@
     "moduleResolution": "node",
     "lib": [ "esnext", "es2018", "dom" ],
     "noEmit": true,
-    "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    // WARNING: Avoid enabling the `skipLibCheck` option as it disables type checking
+    // for the components' type declarations (e.g packages/button/src/vaadin-button.d.ts).
+    "skipLibCheck": false,
+    "skipDefaultLibCheck": true
   },
   "include": [
     "packages/**/test/typings"


### PR DESCRIPTION
## Description

Disables `skipLibCheck` in `tsconfig.json` in order to make the TypeScript compiler checking the components' type declarations again, e.g: `packages/button/src/vaadin-button.d.ts`.

The PR also fixes regressions in the type declarations which occurred during the period the option was enabled.

Fixes #2501

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
