### PR TITLE
refactor: reduce chart redraws for updateConfiguration()

### DIFF
--- a/packages/vaadin-charts/src/vaadin-chart.js
+++ b/packages/vaadin-charts/src/vaadin-chart.js
@@ -1154,20 +1154,22 @@ class ChartElement extends ElementMixin(ThemableMixin(PolymerElement)) {
         return;
       }
 
-      this.configuration.update(this._jsonConfigurationBuffer);
+      this.configuration.update(this._jsonConfigurationBuffer, false);
       if (this._jsonConfigurationBuffer.credits) {
         this.__updateOrAddCredits(this._jsonConfigurationBuffer.credits);
       }
       if (this._jsonConfigurationBuffer.xAxis) {
-        this.__updateOrAddAxes(this._jsonConfigurationBuffer.xAxis, true);
+        this.__updateOrAddAxes(this._jsonConfigurationBuffer.xAxis, true, false);
       }
       if (this._jsonConfigurationBuffer.yAxis) {
-        this.__updateOrAddAxes(this._jsonConfigurationBuffer.yAxis, false);
+        this.__updateOrAddAxes(this._jsonConfigurationBuffer.yAxis, false, false);
       }
       if (this._jsonConfigurationBuffer.series) {
-        this.__updateOrAddSeries(this._jsonConfigurationBuffer.series);
+        this.__updateOrAddSeries(this._jsonConfigurationBuffer.series, false);
       }
       this._jsonConfigurationBuffer = null;
+
+      this.configuration.redraw();
     });
   }
 
@@ -1425,7 +1427,7 @@ class ChartElement extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @private */
-  __updateOrAddAxes(axes, isX) {
+  __updateOrAddAxes(axes, isX, redraw) {
     if (!Array.isArray(axes)) {
       axes = [axes];
     }
@@ -1433,21 +1435,21 @@ class ChartElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     for (let i = 0; i < axes.length; i++) {
       const axis = axes[i];
       if (confAxes[i]) {
-        confAxes[i].update(axis);
+        confAxes[i].update(axis, redraw);
       } else {
-        this.configuration.addAxis(axis, isX);
+        this.configuration.addAxis(axis, isX, redraw);
       }
     }
   }
 
   /** @private */
-  __updateOrAddSeries(series) {
+  __updateOrAddSeries(series, redraw) {
     if (!Array.isArray(series)) {
       throw new Error('The type of jsonConfiguration.series should be Object[]');
     }
     for (let i = 0; i < series.length; i++) {
       const currentSeries = series[i];
-      this.__updateOrAddSeriesInstance(currentSeries, i);
+      this.__updateOrAddSeriesInstance(currentSeries, i, redraw);
     }
   }
 

--- a/packages/vaadin-charts/test/chart-element.test.js
+++ b/packages/vaadin-charts/test/chart-element.test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart', () => {
@@ -122,6 +122,14 @@ describe('vaadin-chart', () => {
       const title = chart.$.chart.querySelector('.highcharts-title');
       expect(title).to.be.ok;
       expect(title.textContent).to.equal('Custom title');
+    });
+
+    it('should set chart credits using update', async () => {
+      chart.updateConfiguration({ credits: { enabled: true, text: 'Vaadin' } });
+      await oneEvent(chart, 'chart-redraw');
+      const credits = chart.$.chart.querySelector('.highcharts-credits');
+      expect(credits).to.be.ok;
+      expect(credits.textContent).to.equal('Vaadin');
     });
 
     it('should create chart series using update', async () => {
@@ -394,9 +402,39 @@ describe('vaadin-chart', () => {
 
     beforeEach(async () => {
       chart = fixtureSync(`<vaadin-chart></vaadin-chart>`);
-      await oneEvent(chart, 'chart-load');
+      await nextRender();
 
       redrawSpy = sinon.spy(chart.configuration, 'redraw');
+    });
+
+    it('should redraw the chart only 1 time when using update', async () => {
+      chart.updateConfiguration({
+        title: 'Title',
+        xAxis: {
+          categories: ['2021', '2022', '2023', '2024']
+        },
+        yAxis: {
+          title: 'Values'
+        },
+        credits: {
+          enabled: true,
+          title: 'Vaadin'
+        },
+        series: [
+          {
+            name: 'Series 1',
+            data: [0, 100, 200, 300]
+          },
+          {
+            name: 'Series 2',
+            data: [0, 100, 200, 300]
+          }
+        ]
+      });
+
+      await nextRender();
+
+      expect(redrawSpy.calledOnce).to.be.true;
     });
 
     describe('adding a series', () => {


### PR DESCRIPTION
## Description

The PR reduces chart redraws when updating a chart via `updateConfiguration()` method so that the chart is now re-drawn only 1 time after `updateConfiguration()` is called.

This significantly improves the time of updating a chart with many series (up to 29x in case of 20 series).

Part of #227

Related to https://github.com/vaadin/flow-components/issues/937

## Benchmarks

**Machine:** Mac Mini M1 16gb.

**Browser:** Chrome 93.

**Screen size:** 1000x900.

- The chart represents 20 series
- Each series represents 20 values

```html
<vaadin-chart id="chart"></vaadin-chart>

<script type="module">
  import '@vaadin/vaadin-charts';
  import { nextRender } from '@vaadin/testing-helpers';

  const series = [...new Array(20)].map((_, i) => {
    return {
      name: `Series ${i}`,
      data: [...new Array(20)].map(() => i)
    };
  });

  await nextRender();

  document.querySelector('#chart').updateConfiguration({
    title: 'Title',
    xAxis: {
      title: 'Time'
    },
    yAxis: {
      title: 'Values'
    },
    credits: {
      enabled: true,
      text: 'Vaadin'
    },
    series
  });
</script>
```

**Master branch:** 1.79 s ([screenshot](https://user-images.githubusercontent.com/5039436/133041677-1559ed58-e444-4354-ac21-358bdb81ff38.png))

**Current branch:** 61 ms ([screenshot](https://user-images.githubusercontent.com/5039436/133041735-b8b935f4-608c-49c5-860d-f7714ff63f96.png))

**Total:** up to ~29x

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
