### PR TITLE
fix: set disabled on lazily added focusElement

### DIFF
--- a/packages/field-base/src/delegate-focus-mixin.js
+++ b/packages/field-base/src/delegate-focus-mixin.js
@@ -81,9 +81,7 @@ const DelegateFocusMixinImplementation = (superclass) =>
     /** @protected */
     _focusElementChanged(element, oldElement) {
       if (element) {
-        if (this.disabled) {
-          element.disabled = true;
-        }
+        element.disabled = this.disabled;
         this._addFocusListeners(element);
       } else if (oldElement) {
         this._removeFocusListeners(oldElement);

--- a/packages/field-base/src/delegate-focus-mixin.js
+++ b/packages/field-base/src/delegate-focus-mixin.js
@@ -81,6 +81,9 @@ const DelegateFocusMixinImplementation = (superclass) =>
     /** @protected */
     _focusElementChanged(element, oldElement) {
       if (element) {
+        if (this.disabled) {
+          element.disabled = true;
+        }
         this._addFocusListeners(element);
       } else if (oldElement) {
         this._removeFocusListeners(oldElement);

--- a/packages/field-base/test/delegate-focus-mixin.test.js
+++ b/packages/field-base/test/delegate-focus-mixin.test.js
@@ -94,6 +94,14 @@ describe('delegate-focus-mixin', () => {
       element._setFocusElement(target);
       expect(target.disabled).to.be.true;
     });
+
+    it('should override disabled property on the newly added input', () => {
+      element._setFocusElement(null);
+      const target = document.createElement('input');
+      target.setAttribute('disabled', '');
+      element._setFocusElement(target);
+      expect(target.disabled).to.be.false;
+    });
   });
 
   describe('events', () => {

--- a/packages/field-base/test/delegate-focus-mixin.test.js
+++ b/packages/field-base/test/delegate-focus-mixin.test.js
@@ -86,6 +86,14 @@ describe('delegate-focus-mixin', () => {
       element.click();
       expect(spy.calledOnce).to.be.false;
     });
+
+    it('should propagate disabled property to the newly added input', () => {
+      element.disabled = true;
+      element._setFocusElement(null);
+      const target = document.createElement('input');
+      element._setFocusElement(target);
+      expect(target.disabled).to.be.true;
+    });
   });
 
   describe('events', () => {


### PR DESCRIPTION
## Description

The original problem happens because of how we apply mixins: unlike other fields, in case of `vaadin-select` we initialize `focusElement` in the component itself, and not in a deeply nested mixins like `InputSlotMixin`.

But the root cause is the fact that `disabled` property is not set on the lazily added `focusElement`. This PR fixes it.

Fixes #2472

## Type of change

- Bugfix