### PR TITLE
refactor: improve password-field logic and tests

### DIFF
--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -209,8 +209,9 @@ export class PasswordField extends TextField {
     if (!focused) {
       this._setPasswordVisible(false);
     } else {
+      const isButtonFocused = this.getRootNode().activeElement === this._revealNode;
       // Remove focus-ring from the field when the reveal button gets focused
-      this.toggleAttribute('focus-ring', !this._revealNode.matches(':focus'));
+      this.toggleAttribute('focus-ring', !isButtonFocused);
     }
   }
 

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -85,19 +85,25 @@ describe('password-field', () => {
   });
 
   describe('focus-ring', () => {
+    let button;
+
+    before(() => {
+      button = document.createElement('button');
+      button.textContent = 'Button';
+      document.body.insertBefore(button, document.body.firstChild);
+    });
+
+    beforeEach(() => {
+      button.focus();
+    });
+
+    after(() => {
+      button.remove();
+    });
+
     describe('Tab', () => {
-      let button;
-
-      beforeEach(() => {
-        button = document.createElement('button');
-        button.textContent = 'Button';
-        passwordField.parentNode.insertBefore(button, passwordField);
-        button.focus();
-      });
-
-      afterEach(() => {
-        document.body.focus();
-        button.remove();
+      before(() => {
+        document.body.insertBefore(button, document.body.firstChild);
       });
 
       it('should set focus-ring attribute when focusing the input with Tab', async () => {
@@ -118,18 +124,8 @@ describe('password-field', () => {
     });
 
     describe('Shift Tab', () => {
-      let button;
-
-      beforeEach(() => {
-        button = document.createElement('button');
-        button.textContent = 'Button';
-        passwordField.parentNode.appendChild(button);
-        button.focus();
-      });
-
-      afterEach(() => {
-        document.body.focus();
-        button.remove();
+      before(() => {
+        document.body.appendChild(button);
       });
 
       it('should not set focus-ring attribute when focusing reveal button with Shift Tab', async () => {

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -90,11 +90,6 @@ describe('password-field', () => {
     before(() => {
       button = document.createElement('button');
       button.textContent = 'Button';
-      document.body.insertBefore(button, document.body.firstChild);
-    });
-
-    beforeEach(() => {
-      button.focus();
     });
 
     after(() => {
@@ -104,6 +99,7 @@ describe('password-field', () => {
     describe('Tab', () => {
       before(() => {
         document.body.insertBefore(button, document.body.firstChild);
+        button.focus();
       });
 
       it('should set focus-ring attribute when focusing the input with Tab', async () => {
@@ -126,6 +122,7 @@ describe('password-field', () => {
     describe('Shift Tab', () => {
       before(() => {
         document.body.appendChild(button);
+        button.focus();
       });
 
       it('should not set focus-ring attribute when focusing reveal button with Shift Tab', async () => {

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -113,8 +113,8 @@ describe('password-field', () => {
       });
 
       it('should remove focus-ring attribute when focusing reveal button', async () => {
-        // Tab to the input element
-        await sendKeys({ press: 'Tab' });
+        // Focus the input element
+        input.focus();
 
         // Tab to the reveal button
         await sendKeys({ press: 'Tab' });
@@ -137,10 +137,8 @@ describe('password-field', () => {
       });
 
       it('should set focus-ring attribute when focusing the input with Shift Tab', async () => {
-        // Shift+Tab to the reveal button
-        await sendKeys({ down: 'Shift' });
-        await sendKeys({ press: 'Tab' });
-        await sendKeys({ up: 'Shift' });
+        // Focus the reveal button
+        revealButton.focus();
 
         // Shift+Tab to the input element
         await sendKeys({ down: 'Shift' });


### PR DESCRIPTION
## Description

1. Updated the logic to check `getRootNode().activeElement` instead of using `:matches` selector
2. Changed the tests to reuse single button instance for tests that rely on `sendKeys`

This fixes failing tests in WebKit for `password-field` package.

## Type of change

- Bugfix