### PR TITLE
chore: bump playwright to latest alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lint-staged": "^11.1.2",
     "npm-run-all": "^4.1.5",
     "octokit": "^1.0.4",
-    "playwright": "^1.14.1",
+    "playwright": "^1.15.0-next-alpha-sep-13-2021",
     "prettier": "^2.3.2",
     "replace-in-file": "^6.2.0",
     "rimraf": "^3.0.2",
@@ -71,5 +71,8 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-vaadin": "^0.2.10",
     "typescript": "^4.3.5"
+  },
+  "resolutions": {
+    "playwright": "1.15.0-next-alpha-sep-13-2021"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9224,10 +9224,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-playwright@^1.14.0, playwright@^1.14.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.14.1.tgz#73913d3044a85a58edf13148245279231072532e"
-  integrity sha512-JYNjhwWcfsBkg0FMGLbFO9e58FVdmICE4k97/glIQV7cBULL7oxNjRQC7Ffe+Y70XVNnP0HSJLaA0W5SukyftQ==
+playwright@1.15.0-next-alpha-sep-13-2021, playwright@^1.14.0, playwright@^1.15.0-next-alpha-sep-13-2021:
+  version "1.15.0-next-alpha-sep-13-2021"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.15.0-next-alpha-sep-13-2021.tgz#c70e2f712f43a28b3100c8ca6f2f26ee7d38b5e9"
+  integrity sha512-cmE++f3yyc0lVAhCZQfauAz7YT2x8E6KsfqL6p8v08akNLselpG/NFL7cyabmgSl3D0Yfjt45rO9JharcLlJVw==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"


### PR DESCRIPTION
## Description

This seems to address the WebKit crashes - [example](https://github.com/vaadin/web-components/pull/2511/checks?check_run_id=3585758190)
See https://github.com/microsoft/playwright/issues/8873#issuecomment-917953613

## Type of change

- Dependency bump