### PR TITLE
fix: prevent scrolling when pressing Space on button

### DIFF
--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -157,6 +157,8 @@ class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableM
     super._onKeyDown(event);
 
     if (this._activeKeys.includes(event.key)) {
+      event.preventDefault();
+
       // `DisabledMixin` overrides the standard `click()` method
       // so that it doesn't fire the `click` event when the element is disabled.
       this.click();

--- a/packages/button/test/button.test.js
+++ b/packages/button/test/button.test.js
@@ -83,6 +83,28 @@ describe('vaadin-button', () => {
 
         expect(spy.called).to.be.false;
       });
+
+      it(`should prevent default behaviour for keydown event on ${key}`, async () => {
+        const spy = sinon.spy();
+        element.addEventListener('keydown', spy);
+
+        await sendKeys({ down: key });
+
+        const event = spy.args[0][0];
+        expect(event).to.be.an.instanceOf(KeyboardEvent);
+        expect(event.defaultPrevented).to.be.true;
+      });
+    });
+
+    it('should not prevent default behaviour for keydown event on non-activation key', async () => {
+      const spy = sinon.spy();
+      element.addEventListener('keydown', spy);
+
+      await sendKeys({ down: 'ArrowDown' });
+
+      const event = spy.args[0][0];
+      expect(event).to.be.an.instanceOf(KeyboardEvent);
+      expect(event.defaultPrevented).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

This PR fixes a regression that occurred after we released the new `@vaadin/button` component:

> The new implementation of vaadin-button scrolls the page on Space key press.

Fixes #2478 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
