### PR TITLE
fix: fire change event after validate

### DIFF
--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -79,7 +79,7 @@ const InputConstraintsMixinImplementation = (superclass) =>
      * @override
      */
     _onChange(event) {
-      event.stopImmediatePropagation();
+      event.stopPropagation();
 
       this.validate();
 

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -70,6 +70,30 @@ const InputConstraintsMixinImplementation = (superclass) =>
       }
     }
 
+    /**
+     * Override an event listener inherited from `InputMixin`
+     * to capture native `change` event and make sure that
+     * a new one is dispatched after validation runs.
+     * @param {Event} event
+     * @protected
+     * @override
+     */
+    _onChange(event) {
+      event.stopImmediatePropagation();
+
+      this.validate();
+
+      this.dispatchEvent(
+        new CustomEvent('change', {
+          detail: {
+            sourceEvent: event
+          },
+          bubbles: event.bubbles,
+          cancelable: event.cancelable
+        })
+      );
+    }
+
     /** @private */
     __isValidConstraint(constraint) {
       // 0 is valid for `minlength` and `maxlength`

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -159,6 +159,32 @@ describe('input-constraints-mixin', () => {
       element.required = true;
       expect(element.invalid).to.be.false;
     });
+
+    it('should call validate on change event from the input', () => {
+      const spy = sinon.spy(element, 'validate');
+      input.value = '123foo';
+      input.dispatchEvent(new CustomEvent('change'));
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should dispatch change event after validation', () => {
+      const validateSpy = sinon.spy(element, 'validate');
+      const changeSpy = sinon.spy();
+      element.addEventListener('change', changeSpy);
+      input.value = '123foo';
+      input.dispatchEvent(new CustomEvent('change'));
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledAfter(validateSpy)).to.be.true;
+    });
+
+    it('should store reference on the original change event', () => {
+      const changeSpy = sinon.spy();
+      element.addEventListener('change', changeSpy);
+      input.value = '123foo';
+      const event = new CustomEvent('change');
+      input.dispatchEvent(event);
+      expect(changeSpy.firstCall.args[0].detail.sourceEvent).to.equal(event);
+    });
   });
 
   describe('checkValidity', () => {

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -456,16 +456,6 @@ export class NumberField extends InputFieldMixin(
   }
 
   /**
-   * Override an event listener inherited from `InputMixin`.
-   * @param {Event} _event
-   * @protected
-   * @override
-   */
-  _onChange(_event) {
-    this.validate();
-  }
-
-  /**
    * Returns true if the current input value satisfies all constraints (if any).
    * @return {boolean}
    */

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -730,6 +730,17 @@ describe('number-field', () => {
       expect(numberField.validate(), 'value should not be greater than max').to.be.false;
     });
 
+    it('should dispatch change event after validation', () => {
+      const validateSpy = sinon.spy(numberField, 'validate');
+      const changeSpy = sinon.spy();
+      numberField.required = true;
+      numberField.addEventListener('change', changeSpy);
+      numberField.value = '123';
+      input.dispatchEvent(new CustomEvent('change'));
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledAfter(validateSpy)).to.be.true;
+    });
+
     it('should validate by step when defined by user', () => {
       numberField.step = 1.5;
 


### PR DESCRIPTION
## Description

Updated `InputConstraintsMixin` which is responsible for validation to also validate on `change` event.
Then the `change` event is manually re-dispatched on the host, with a reference to the original event.

Fixes #2517

## Type of change

-  Bugfix