### PR TITLE
chore: open dev page listing by default

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dev pages</title>
+</head>
+<body>
+  <h1>Web Component development pages</h1>
+
+  <ul id="listing"><li><a href="/dev/index.html">listing</a></li></ul>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:js": "eslint --ext .js,.ts *.js scripts packages",
     "lint:types": "tsc",
     "serve:dist": "web-dev-server --app-index dist/index.html --open",
-    "start": "web-dev-server --node-resolve --open /dev/button.html",
+    "start": "web-dev-server --node-resolve --open /dev/index.html",
     "test": "web-test-runner --coverage",
     "test:firefox": "web-test-runner --config web-test-runner-firefox.config.js",
     "test:lumo": "web-test-runner --config web-test-runner-lumo.config.js",

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -1,6 +1,7 @@
-import fs from 'fs';
+/* eslint-env node */
+const fs = require('fs');
 
-export default {
+module.exports = {
   plugins: [
     {
       name: 'dev-page-listing',

--- a/web-dev-server.config.mjs
+++ b/web-dev-server.config.mjs
@@ -1,0 +1,22 @@
+import fs from 'fs';
+
+export default {
+  plugins: [
+    {
+      name: 'dev-page-listing',
+      transform(context) {
+        if (context.path === '/dev/index.html') {
+          const listing = `
+            <ul id="listing">
+              ${fs
+                .readdirSync('./dev')
+                .map((file) => `<li><a href="/dev/${file}">${file}</a></li>`)
+                .join('')}
+            </ul>`;
+
+          return { body: context.body.replace(/<ul id="listing">.*<\/ul>/, listing) };
+        }
+      }
+    }
+  ]
+};


### PR DESCRIPTION
Open a listing of dev pages on `npm start`