### PR TITLE
refactor: use overlay-position-mixin with date-picker

### DIFF
--- a/packages/vaadin-date-picker/package.json
+++ b/packages/vaadin-date-picker/package.json
@@ -27,7 +27,6 @@
     "@polymer/iron-a11y-announcer": "^3.0.0",
     "@polymer/iron-a11y-keys-behavior": "^3.0.0",
     "@polymer/iron-media-query": "^3.0.0",
-    "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.2.0",
     "@vaadin/button": "^22.0.0-alpha6",
     "@vaadin/component-base": "^22.0.0-alpha6",

--- a/packages/vaadin-date-picker/src/vaadin-date-picker-light.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker-light.js
@@ -72,6 +72,8 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
         id="overlay"
         fullscreen$="[[_fullscreen]]"
         opened="{{opened}}"
+        position-target="[[inputElement]]"
+        no-vertical-overlap
         on-vaadin-overlay-open="_onOverlayOpened"
         on-vaadin-overlay-close="_onOverlayClosed"
         theme$="[[__getOverlayTheme(theme, _overlayInitialized)]]"

--- a/packages/vaadin-date-picker/src/vaadin-date-picker-overlay.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker-overlay.js
@@ -5,6 +5,7 @@
  */
 import { OverlayElement } from '@vaadin/vaadin-overlay/src/vaadin-overlay.js';
 import { DisableUpgradeMixin } from '@polymer/polymer/lib/mixins/disable-upgrade-mixin.js';
+import { PositionMixin } from '@vaadin/vaadin-overlay/src/vaadin-overlay-position-mixin.js';
 
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
@@ -12,7 +13,7 @@ import { DisableUpgradeMixin } from '@polymer/polymer/lib/mixins/disable-upgrade
  * @extends OverlayElement
  * @private
  */
-class DatePickerOverlayElement extends DisableUpgradeMixin(OverlayElement) {
+class DatePickerOverlayElement extends DisableUpgradeMixin(PositionMixin(OverlayElement)) {
   static get is() {
     return 'vaadin-date-picker-overlay';
   }

--- a/packages/vaadin-date-picker/src/vaadin-date-picker-styles.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker-styles.js
@@ -13,22 +13,6 @@ registerStyles(
       justify-content: flex-start;
     }
 
-    :host([bottom-aligned]) {
-      justify-content: flex-end;
-    }
-
-    :host([right-aligned]) {
-      align-items: flex-end;
-    }
-
-    :host([dir='rtl']) {
-      align-items: flex-end;
-    }
-
-    :host([dir='rtl'][right-aligned]) {
-      align-items: flex-start;
-    }
-
     [part='overlay'] {
       display: flex;
       flex: auto;

--- a/packages/vaadin-date-picker/src/vaadin-date-picker.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker.js
@@ -158,6 +158,7 @@ class DatePicker extends DatePickerMixin(
         id="overlay"
         fullscreen$="[[_fullscreen]]"
         theme$="[[__getOverlayTheme(theme, _overlayInitialized)]]"
+        no-vertical-overlap
         on-vaadin-overlay-open="_onOverlayOpened"
         on-vaadin-overlay-close="_onOverlayClosed"
         disable-upgrade
@@ -193,6 +194,13 @@ class DatePicker extends DatePickerMixin(
    */
   get clearElement() {
     return this.$.clearButton;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.$.overlay.positionTarget = this.shadowRoot.querySelector('[part="input-field"]');
   }
 
   /** @private */

--- a/packages/vaadin-date-picker/test/basic.test.js
+++ b/packages/vaadin-date-picker/test/basic.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, click, fixtureSync, isIOS, oneEvent, tap } from '@vaadin/testing-helpers';
+import { aTimeout, click, fixtureSync, oneEvent, tap } from '@vaadin/testing-helpers';
 import { close, getOverlayContent, monthsEqual, open } from './common.js';
 import '../src/vaadin-date-picker.js';
 
@@ -201,39 +201,6 @@ describe('basic features', () => {
   it('should set has-value attribute when value is set', () => {
     datepicker.value = '2000-02-01';
     expect(datepicker.hasAttribute('has-value')).to.be.true;
-  });
-
-  describe('realign', () => {
-    beforeEach(async () => {
-      await open(datepicker);
-    });
-
-    it('should realign on iron-resize', async () => {
-      const spy = sinon.spy(datepicker._overlayContent, '_repositionYearScroller');
-      datepicker.dispatchEvent(new CustomEvent('iron-resize', { bubbles: false }));
-      expect(spy.called).to.be.true;
-    });
-
-    it('should realign on window scroll', () => {
-      const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
-      window.dispatchEvent(new CustomEvent('scroll'));
-      expect(spy.called).to.be.true;
-    });
-
-    // https://github.com/vaadin/vaadin-date-picker/issues/330
-    (isIOS ? it.skip : it)('should not realign on year/month scroll', async () => {
-      const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
-      getOverlayContent(datepicker).$.yearScroller.$.scroller.scrollTop += 100;
-      await aTimeout(1);
-      expect(spy.called).to.be.false;
-    });
-
-    it('should not realign once closed', async () => {
-      const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
-      await close(datepicker);
-      window.dispatchEvent(new CustomEvent('scroll'));
-      expect(spy.called).to.be.false;
-    });
   });
 
   describe('value property formats', () => {
@@ -546,13 +513,6 @@ describe('wrapped', () => {
       </div>
     `);
     datepicker = container.querySelector('vaadin-date-picker');
-  });
-
-  it('should realign on container scroll', async () => {
-    const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
-    await open(datepicker);
-    container.scrollTop += 100;
-    expect(spy.called).to.be.true;
   });
 
   it('should match the parent width', () => {

--- a/packages/vaadin-date-picker/test/dropdown.test.js
+++ b/packages/vaadin-date-picker/test/dropdown.test.js
@@ -39,65 +39,6 @@ describe('dropdown', () => {
     });
   });
 
-  describe('alignment', () => {
-    function assertEdgesAligned(datepickerEdge, overlayEdge) {
-      expect(datepicker.getBoundingClientRect()[datepickerEdge]).to.equal(
-        datepicker.$.overlay.$.content.getBoundingClientRect()[overlayEdge]
-      );
-    }
-
-    it('should align below the field, by left edge', () => {
-      datepicker.style.position = 'fixed';
-      datepicker.style.top = '10px';
-      datepicker.style.left = '10px';
-      datepicker.open();
-      assertEdgesAligned('left', 'left');
-      assertEdgesAligned('bottom', 'top');
-    });
-
-    it('should flip to align by right edge', () => {
-      datepicker.style.position = 'fixed';
-      datepicker.style.top = '10px';
-      datepicker.style.left = window.innerWidth / 2 + 'px';
-
-      datepicker.open();
-      assertEdgesAligned('right', 'right');
-      assertEdgesAligned('bottom', 'top');
-    });
-
-    it('should flip to align above the field', () => {
-      datepicker.style.position = 'fixed';
-      datepicker.style.bottom = 0 + 'px';
-
-      datepicker.open();
-      assertEdgesAligned('left', 'left');
-      assertEdgesAligned('top', 'bottom');
-    });
-
-    describe('right-to-left', () => {
-      before(() => {
-        document.body.setAttribute('dir', 'rtl');
-      });
-
-      after(() => {
-        document.body.removeAttribute('dir');
-      });
-
-      it('should align by right edge', () => {
-        datepicker.open();
-        assertEdgesAligned('right', 'right');
-      });
-
-      it('should flip to align by left edge', () => {
-        datepicker.style.position = 'fixed';
-        datepicker.style.right = window.innerWidth / 2 + 'px';
-
-        datepicker.open();
-        assertEdgesAligned('left', 'left');
-      });
-    });
-  });
-
   describe('sizing', () => {
     beforeEach(() => {
       const viewport = document.createElement('meta');

--- a/packages/vaadin-date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
+++ b/packages/vaadin-date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
@@ -36,6 +36,14 @@ const datePickerOverlay = css`
     mask-image: none;
   }
 
+  :host([top-aligned]) [part~='overlay'] {
+    margin-top: var(--lumo-space-xs);
+  }
+
+  :host([bottom-aligned]) [part~='overlay'] {
+    margin-bottom: var(--lumo-space-xs);
+  }
+
   @media (max-width: 420px), (max-height: 420px) {
     [part='overlay'] {
       width: 100vw;

--- a/packages/vaadin-date-picker/theme/material/vaadin-date-picker-overlay-styles.js
+++ b/packages/vaadin-date-picker/theme/material/vaadin-date-picker-overlay-styles.js
@@ -22,7 +22,9 @@ const datePickerOverlay = css`
     border-radius: 0 4px 4px;
   }
 
-  :host(:not([fullscreen])[right-aligned]) [part='overlay'] {
+  /* TODO: add start-aligned / end-aligned to position-mixin */
+  :host([dir='ltr']:not([fullscreen])[end-aligned]) [part='overlay'],
+  :host([dir='rtl']:not([fullscreen])[start-aligned]) [part='overlay'] {
     border-radius: 4px 0 4px 4px;
   }
 

--- a/packages/vaadin-date-picker/theme/material/vaadin-date-picker-overlay-styles.js
+++ b/packages/vaadin-date-picker/theme/material/vaadin-date-picker-overlay-styles.js
@@ -22,7 +22,6 @@ const datePickerOverlay = css`
     border-radius: 0 4px 4px;
   }
 
-  /* TODO: add start-aligned / end-aligned to position-mixin */
   :host([dir='ltr']:not([fullscreen])[end-aligned]) [part='overlay'],
   :host([dir='rtl']:not([fullscreen])[start-aligned]) [part='overlay'] {
     border-radius: 4px 0 4px 4px;

--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -107,12 +107,16 @@ export const PositionMixin = (superClass) =>
             this.__margins[propName] = parseInt(computedStyle[propName], 10);
           });
         }
-        this.__isRTL = computedStyle.direction === 'rtl';
+        this.setAttribute('dir', computedStyle.direction);
 
         this._updatePosition();
         // Schedule another position update (to cover virtual keyboard opening for example)
         requestAnimationFrame(() => this._updatePosition());
       }
+    }
+
+    get __isRTL() {
+      return this.getAttribute('dir') === 'rtl';
     }
 
     __positionSettingsChanged() {
@@ -161,8 +165,11 @@ export const PositionMixin = (superClass) =>
       // Apply the positioning properties to the overlay
       Object.assign(this.style, verticalProps, horizontalProps);
 
-      this.toggleAttribute('bottom-aligned', verticalProps.bottom != '');
-      this.toggleAttribute('top-aligned', verticalProps.top != '');
+      this.toggleAttribute('bottom-aligned', !shouldAlignStartVertically);
+      this.toggleAttribute('top-aligned', shouldAlignStartVertically);
+
+      this.toggleAttribute('end-aligned', !flexStart);
+      this.toggleAttribute('start-aligned', flexStart);
     }
 
     __shouldAlignStartHorizontally(targetRect, rtl) {

--- a/packages/vaadin-overlay/test/position-target.test.js
+++ b/packages/vaadin-overlay/test/position-target.test.js
@@ -324,6 +324,11 @@ describe('position target', () => {
       expectEdgesAligned(LEFT, LEFT);
     });
 
+    it('should set start-aligned attribute', () => {
+      expect(overlay.hasAttribute('start-aligned')).to.be.true;
+      expect(overlay.hasAttribute('end-aligned')).to.be.false;
+    });
+
     it('should align right edges with right-to-left', () => {
       overlay.opened = false;
       document.dir = 'rtl';
@@ -361,10 +366,12 @@ describe('position target', () => {
       target.style.left = targetPositionForCentering - 3 + 'px';
       updatePosition();
       expectEdgesAligned(LEFT, LEFT);
+      expect(overlay.hasAttribute('start-aligned')).to.be.true;
 
       target.style.left = targetPositionForCentering + 3 + 'px';
       updatePosition();
       expectEdgesAligned(RIGHT, RIGHT);
+      expect(overlay.hasAttribute('end-aligned')).to.be.true;
     });
 
     describe('no overlap', () => {
@@ -420,6 +427,11 @@ describe('position target', () => {
 
     it('should align right edges', () => {
       expectEdgesAligned(RIGHT, RIGHT);
+    });
+
+    it('should set end-aligned attribute', () => {
+      expect(overlay.hasAttribute('end-aligned')).to.be.true;
+      expect(overlay.hasAttribute('start-aligned')).to.be.false;
     });
 
     it('should align left edges with right-to-left', () => {


### PR DESCRIPTION
Removes internal overlay positioning logic from `<vaadin-date-picker>` in favour of using the `vaadin-overlay-position-mixin`.

Related https://github.com/vaadin/web-components/pull/2497 and https://github.com/vaadin/web-components/pull/2510