### PR TITLE
refactor: use separate fields to store unique IDs

### DIFF
--- a/packages/field-base/src/helper-text-mixin.js
+++ b/packages/field-base/src/helper-text-mixin.js
@@ -44,7 +44,7 @@ const HelperTextMixinImplementation = (superclass) =>
       super();
 
       // Ensure every instance has unique ID
-      const uniqueId = (HelperTextMixinClass._uniqueId = 1 + HelperTextMixinClass._uniqueId || 0);
+      const uniqueId = (HelperTextMixinClass._uniqueHelperId = 1 + HelperTextMixinClass._uniqueHelperId || 0);
       this._helperId = `helper-${this.localName}-${uniqueId}`;
 
       // Save generated ID to restore later

--- a/packages/field-base/src/input-slot-mixin.js
+++ b/packages/field-base/src/input-slot-mixin.js
@@ -47,7 +47,7 @@ const InputSlotMixinImplementation = (superclass) =>
       super();
 
       // Ensure every instance has unique ID
-      const uniqueId = (InputSlotMixinClass._uniqueId = 1 + InputSlotMixinClass._uniqueId || 0);
+      const uniqueId = (InputSlotMixinClass._uniqueInputId = 1 + InputSlotMixinClass._uniqueInputId || 0);
       this._inputId = `${this.localName}-${uniqueId}`;
     }
 

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -41,7 +41,7 @@ const LabelMixinImplementation = (superclass) =>
       super();
 
       // Ensure every instance has unique ID
-      const uniqueId = (LabelMixinClass._uniqueId = 1 + LabelMixinClass._uniqueId || 0);
+      const uniqueId = (LabelMixinClass._uniqueLabelId = 1 + LabelMixinClass._uniqueLabelId || 0);
       this._labelId = `label-${this.localName}-${uniqueId}`;
 
       /**

--- a/packages/field-base/src/text-area-slot-mixin.js
+++ b/packages/field-base/src/text-area-slot-mixin.js
@@ -32,7 +32,7 @@ const TextAreaSlotMixinImplementation = (superclass) =>
       super();
 
       // Ensure every instance has unique ID
-      const uniqueId = (TextAreaSlotMixinClass._uniqueId = 1 + TextAreaSlotMixinClass._uniqueId || 0);
+      const uniqueId = (TextAreaSlotMixinClass._uniqueTextAreaId = 1 + TextAreaSlotMixinClass._uniqueTextAreaId || 0);
       this._textareaId = `${this.localName}-${uniqueId}`;
     }
 

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -64,7 +64,7 @@ const ValidateMixinImplementation = (superclass) =>
       super();
 
       // Ensure every instance has unique ID
-      const uniqueId = (ValidateMixinClass._uniqueId = 1 + ValidateMixinClass._uniqueId || 0);
+      const uniqueId = (ValidateMixinClass._uniqueErrorId = 1 + ValidateMixinClass._uniqueErrorId || 0);
       this._errorId = `error-${this.localName}-${uniqueId}`;
     }
 

--- a/packages/field-base/test/helper-text-mixin.test.js
+++ b/packages/field-base/test/helper-text-mixin.test.js
@@ -15,6 +15,8 @@ customElements.define(
 describe('helper-text-mixin', () => {
   let element, helper;
 
+  const ID_REGEX = /^helper-helper-text-mixin-element-\d+$/;
+
   describe('default', () => {
     beforeEach(() => {
       element = fixtureSync(`<helper-text-mixin-element></helper-text-mixin-element>`);
@@ -30,8 +32,9 @@ describe('helper-text-mixin', () => {
     });
 
     it('should set id on the helper element', () => {
-      const idRegex = /^helper-helper-text-mixin-element-\d+$/;
-      expect(helper.getAttribute('id')).to.match(idRegex);
+      const id = helper.getAttribute('id');
+      expect(id).to.match(ID_REGEX);
+      expect(id.endsWith(element.constructor._uniqueHelperId)).to.be.true;
     });
 
     it('should update helper content on attribute change', () => {
@@ -89,8 +92,9 @@ describe('helper-text-mixin', () => {
     });
 
     it('should set id on the slotted helper element', () => {
-      const idRegex = /^helper-helper-text-mixin-element-\d+$/;
-      expect(helper.getAttribute('id')).to.match(idRegex);
+      const id = helper.getAttribute('id');
+      expect(id).to.match(ID_REGEX);
+      expect(id.endsWith(element.constructor._uniqueHelperId)).to.be.true;
     });
 
     it('should set has-helper attribute with slotted helper', () => {
@@ -184,8 +188,6 @@ describe('helper-text-mixin', () => {
     });
 
     describe('ID attribute', () => {
-      const idRegex = /^helper-helper-text-mixin-element-\d+$/;
-
       beforeEach(async () => {
         element = fixtureSync('<helper-text-mixin-element></helper-text-mixin-element>');
         await nextFrame();
@@ -197,7 +199,7 @@ describe('helper-text-mixin', () => {
       it('should set id on the lazily added helper element', async () => {
         element.appendChild(helper);
         await nextFrame();
-        expect(helper.getAttribute('id')).to.match(idRegex);
+        expect(helper.getAttribute('id')).to.match(ID_REGEX);
       });
 
       it('should not override custom id on the lazily added helper', async () => {
@@ -213,7 +215,7 @@ describe('helper-text-mixin', () => {
         await nextFrame();
         helper.removeAttribute('id');
         await nextFrame();
-        expect(helper.getAttribute('id')).to.match(idRegex);
+        expect(helper.getAttribute('id')).to.match(ID_REGEX);
       });
     });
 

--- a/packages/field-base/test/input-slot-mixin.test.js
+++ b/packages/field-base/test/input-slot-mixin.test.js
@@ -46,7 +46,7 @@ describe('input-slot-mixin', () => {
     });
 
     it('should set id attribute on the input', () => {
-      const ID_REGEX = /^input-slot-mixin-element-\d$/;
+      const ID_REGEX = /^input-slot-mixin-element-\d+$/;
       const id = input.getAttribute('id');
       expect(id).to.match(ID_REGEX);
       expect(id.endsWith(element.constructor._uniqueInputId)).to.be.true;

--- a/packages/field-base/test/input-slot-mixin.test.js
+++ b/packages/field-base/test/input-slot-mixin.test.js
@@ -46,8 +46,10 @@ describe('input-slot-mixin', () => {
     });
 
     it('should set id attribute on the input', () => {
-      const idRegex = /^input-slot-mixin-element-\d$/;
-      expect(input.getAttribute('id')).to.match(idRegex);
+      const ID_REGEX = /^input-slot-mixin-element-\d$/;
+      const id = input.getAttribute('id');
+      expect(id).to.match(ID_REGEX);
+      expect(id.endsWith(element.constructor._uniqueInputId)).to.be.true;
     });
 
     it('should have a read-only type property', () => {

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -15,6 +15,8 @@ customElements.define(
 describe('label-mixin', () => {
   let element, label;
 
+  const ID_REGEX = /^label-label-mixin-element-\d+$/;
+
   describe('default', () => {
     beforeEach(() => {
       element = fixtureSync(`<label-mixin-element></label-mixin-element>`);
@@ -30,8 +32,9 @@ describe('label-mixin', () => {
     });
 
     it('should set id on the label element', () => {
-      const idRegex = /^label-label-mixin-element-\d+$/;
-      expect(label.getAttribute('id')).to.match(idRegex);
+      const id = label.getAttribute('id');
+      expect(id).to.match(ID_REGEX);
+      expect(id.endsWith(element.constructor._uniqueLabelId)).to.be.true;
     });
 
     describe('label property', () => {
@@ -89,8 +92,9 @@ describe('label-mixin', () => {
     });
 
     it('should set id on the slotted label element', () => {
-      const idRegex = /^label-label-mixin-element-\d+$/;
-      expect(label.getAttribute('id')).to.match(idRegex);
+      const id = label.getAttribute('id');
+      expect(id).to.match(ID_REGEX);
+      expect(id.endsWith(element.constructor._uniqueLabelId)).to.be.true;
     });
 
     it('should update slotted label content on property change', () => {

--- a/packages/field-base/test/text-area-slot-mixin.test.js
+++ b/packages/field-base/test/text-area-slot-mixin.test.js
@@ -30,8 +30,10 @@ describe('text-area-slot-mixin', () => {
     });
 
     it('should set id attribute on the textarea', () => {
-      const idRegex = /^textarea-slot-mixin-element-\d$/;
-      expect(textarea.getAttribute('id')).to.match(idRegex);
+      const ID_REGEX = /^textarea-slot-mixin-element-\d$/;
+      const id = textarea.getAttribute('id');
+      expect(id).to.match(ID_REGEX);
+      expect(id.endsWith(element.constructor._uniqueTextAreaId)).to.be.true;
     });
 
     it('should have an empty name by default', () => {

--- a/packages/field-base/test/text-area-slot-mixin.test.js
+++ b/packages/field-base/test/text-area-slot-mixin.test.js
@@ -30,7 +30,7 @@ describe('text-area-slot-mixin', () => {
     });
 
     it('should set id attribute on the textarea', () => {
-      const ID_REGEX = /^textarea-slot-mixin-element-\d$/;
+      const ID_REGEX = /^textarea-slot-mixin-element-\d+$/;
       const id = textarea.getAttribute('id');
       expect(id).to.match(ID_REGEX);
       expect(id.endsWith(element.constructor._uniqueTextAreaId)).to.be.true;

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -15,6 +15,8 @@ customElements.define(
 describe('validate-mixin', () => {
   let element, error;
 
+  const ID_REGEX = /^error-validate-mixin-element-\d+$/;
+
   describe('default', () => {
     beforeEach(() => {
       element = fixtureSync(`<validate-mixin-element></validate-mixin-element>`);
@@ -31,8 +33,9 @@ describe('validate-mixin', () => {
     });
 
     it('should set id on the error message element', () => {
-      const idRegex = /^error-validate-mixin-element-\d+$/;
-      expect(error.getAttribute('id')).to.match(idRegex);
+      const id = error.getAttribute('id');
+      expect(id).to.match(ID_REGEX);
+      expect(id.endsWith(element.constructor._uniqueErrorId)).to.be.true;
     });
 
     it('should update error message content on attribute change', () => {
@@ -108,8 +111,9 @@ describe('validate-mixin', () => {
     });
 
     it('should set id on the slotted error message element', () => {
-      const idRegex = /^error-validate-mixin-element-\d+$/;
-      expect(error.getAttribute('id')).to.match(idRegex);
+      const id = error.getAttribute('id');
+      expect(id).to.match(ID_REGEX);
+      expect(id.endsWith(element.constructor._uniqueErrorId)).to.be.true;
     });
 
     it('should set has-error-message attribute with slotted error message', () => {

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -296,7 +296,7 @@ class Select extends DelegateFocusMixin(
     super();
 
     // Ensure every instance has unique ID
-    const uniqueId = (Select._uniqueId = 1 + Select._uniqueId || 0);
+    const uniqueId = (Select._uniqueSelectId = 1 + Select._uniqueSelectId || 0);
     this._fieldId = `${this.localName}-${uniqueId}`;
 
     this._boundOnKeyDown = this._onKeyDown.bind(this);

--- a/packages/select/test/accessibility.test.js
+++ b/packages/select/test/accessibility.test.js
@@ -65,4 +65,21 @@ describe('accessibility', () => {
     expect(select._items[0].getAttribute('role')).to.equal('option');
     expect(select._items[1].getAttribute('role')).to.equal('option');
   });
+
+  it('should set ID attribute on the selected item', async () => {
+    // Wait for items
+    await nextFrame();
+    select.value = 'Option 1';
+    const ID_REGEX = /^vaadin-select-\d+$/;
+    const id = valueButton.firstChild.getAttribute('id');
+    expect(id).to.match(ID_REGEX);
+  });
+
+  it('should include selected item ID to aria-labelledby', async () => {
+    // Wait for items
+    await nextFrame();
+    select.value = 'Option 1';
+    const id = valueButton.firstChild.getAttribute('id');
+    expect(valueButton.getAttribute('aria-labelledby')).to.include(id);
+  });
 });


### PR DESCRIPTION
## Description

This is a small change to make generated IDs use the same numbers as much as possible.
Added some tests using private APIs which is something I'm not happy about 😕 

We can separately consider using the same as Lion which generates one random ID per component instance.

### Before

![Screenshot 2021-09-20 at 14 21 33](https://user-images.githubusercontent.com/10589913/133994411-dc5027e7-237f-467b-9c4a-272f9cda2e4d.png)

### After

![Screenshot 2021-09-20 at 14 20 51](https://user-images.githubusercontent.com/10589913/133994335-d31aeaff-4931-4ab8-980b-2bb787db5c19.png)

## Type of change

- Refactor