### PR TITLE
fix: set ARIA attributes properly, add tests

### DIFF
--- a/packages/vaadin-combo-box/src/vaadin-combo-box.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.js
@@ -248,6 +248,14 @@ class ComboBox extends ComboBoxDataProviderMixin(
   }
 
   /**
+   * Element used by `FieldAriaMixin` to set ARIA attributes.
+   * @protected
+   */
+  get _ariaTarget() {
+    return this.inputElement;
+  }
+
+  /**
    * Used by `ClearButtonMixin` as a reference to the clear button element.
    * @protected
    * @return {!HTMLElement}

--- a/packages/vaadin-combo-box/test/aria.test.js
+++ b/packages/vaadin-combo-box/test/aria.test.js
@@ -5,12 +5,15 @@ import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
 describe('ARIA', () => {
-  let comboBox, input;
+  let comboBox, input, label, helper, error;
 
   beforeEach(() => {
     comboBox = fixtureSync('<vaadin-combo-box label="my label"></vaadin-combo-box>');
     comboBox.items = ['foo', 'bar', 'baz'];
     input = comboBox.inputElement;
+    label = comboBox.querySelector('[slot=label]');
+    error = comboBox.querySelector('[slot=error-message]');
+    helper = comboBox.querySelector('[slot=helper]');
   });
 
   afterEach(() => {
@@ -24,6 +27,23 @@ describe('ARIA', () => {
 
     it('should set aria-autocomplete attribute on the native input', () => {
       expect(input.getAttribute('aria-autocomplete')).to.equal('list');
+    });
+
+    it('should set aria-labelledby attribute on the native input', () => {
+      expect(input.getAttribute('aria-labelledby')).to.equal(label.id);
+    });
+
+    it('should set aria-describedby with helper text ID when valid', () => {
+      const aria = input.getAttribute('aria-describedby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.not.include(error.id);
+    });
+
+    it('should add error message ID to aria-describedby when invalid', () => {
+      comboBox.invalid = true;
+      const aria = input.getAttribute('aria-describedby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.include(error.id);
     });
   });
 

--- a/packages/vaadin-date-picker/src/vaadin-date-picker.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker.js
@@ -192,6 +192,14 @@ class DatePicker extends DatePickerMixin(
   }
 
   /**
+   * Element used by `FieldAriaMixin` to set ARIA attributes.
+   * @protected
+   */
+  get _ariaTarget() {
+    return this.inputElement;
+  }
+
+  /**
    * Used by `ClearButtonMixin` as a reference to the clear button element.
    * @protected
    * @return {!HTMLElement}

--- a/packages/vaadin-date-picker/test/wai-aria.test.js
+++ b/packages/vaadin-date-picker/test/wai-aria.test.js
@@ -7,12 +7,32 @@ import '../src/vaadin-date-picker.js';
 
 describe('WAI-ARIA', () => {
   describe('date picker', () => {
-    let datepicker, toggleButton, input;
+    let datepicker, toggleButton, input, label, helper, error;
 
     beforeEach(() => {
       datepicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
       toggleButton = datepicker.shadowRoot.querySelector('[part="toggle-button"]');
       input = datepicker.inputElement;
+      label = datepicker.querySelector('[slot=label]');
+      error = datepicker.querySelector('[slot=error-message]');
+      helper = datepicker.querySelector('[slot=helper]');
+    });
+
+    it('should set aria-labelledby attribute on the native input', () => {
+      expect(input.getAttribute('aria-labelledby')).to.equal(label.id);
+    });
+
+    it('should set aria-describedby with helper text ID when valid', () => {
+      const aria = input.getAttribute('aria-describedby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.not.include(error.id);
+    });
+
+    it('should add error message ID to aria-describedby when invalid', () => {
+      datepicker.invalid = true;
+      const aria = input.getAttribute('aria-describedby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.include(error.id);
     });
 
     it('should have button roles on buttons', () => {


### PR DESCRIPTION
## Description

Currently both `vaadin-combo-box` and `vaadin-date-picker` have `aria-describedby` set incorrectly on the host.
Updated to override `_ariaTarget` and added missing tests to cover the ARIA attributes that it refers to.

## Type of change

- Bugfix