### PR TITLE
fix: static show helper should accept zero duration

### DIFF
--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -509,7 +509,7 @@ class NotificationElement extends ThemePropertyMixin(ElementMixin(PolymerElement
   /** @private */
   static _createAndShowNotification(renderer, options) {
     const notification = document.createElement(NotificationElement.is);
-    if (options && options.duration) {
+    if (options && Number.isFinite(options.duration)) {
       notification.duration = options.duration;
     }
     if (options && options.position) {

--- a/packages/vaadin-notification/test/statichelper.test.js
+++ b/packages/vaadin-notification/test/statichelper.test.js
@@ -13,7 +13,7 @@ describe('static helpers', () => {
     expect(notification._card.innerText.trim()).to.equal('Hello world');
   });
 
-  it('show should show a Lit template notificatipn', () => {
+  it('show should show a Lit template notification', () => {
     const notification = NotificationElement.show(html`Hello world`);
 
     //const notificationDom = document.body.querySelector('vaadin-notification');
@@ -33,6 +33,11 @@ describe('static helpers', () => {
     const notification = NotificationElement.show('Hello world', { duration: 123, position: 'top-center' });
     expect(notification.duration).to.equal(123);
     expect(notification.position).to.equal('top-center');
+  });
+
+  it('show work with a duration of zero', () => {
+    const notification = NotificationElement.show('Hello world', { duration: 0 });
+    expect(notification.duration).to.equal(0);
   });
 
   it('show remove the element from the document after closing', async () => {

--- a/packages/vaadin-notification/test/statichelper.test.js
+++ b/packages/vaadin-notification/test/statichelper.test.js
@@ -35,7 +35,7 @@ describe('static helpers', () => {
     expect(notification.position).to.equal('top-center');
   });
 
-  it('show work with a duration of zero', () => {
+  it('show should work with a duration of zero', () => {
     const notification = NotificationElement.show('Hello world', { duration: 0 });
     expect(notification.duration).to.equal(0);
   });


### PR DESCRIPTION
## Description

Fixed the recently introduced `NotificationElement.show` helper to handle a duration value of zero.

## Type of change

- [x] Bugfix
