### PR TITLE
fix: use correct type for ariaLabel property

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "stylelint": "^13.13.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-vaadin": "^0.2.10",
-    "typescript": "4.3.5"
+    "typescript": "^4.4.3"
   }
 }

--- a/packages/app-layout/src/vaadin-drawer-toggle.d.ts
+++ b/packages/app-layout/src/vaadin-drawer-toggle.d.ts
@@ -10,7 +10,7 @@ import { Button } from '@vaadin/button/src/vaadin-button.js';
  * ```
  */
 declare class DrawerToggleElement extends Button {
-  ariaLabel: string | null | undefined;
+  ariaLabel: string;
 }
 
 declare global {

--- a/packages/crud/src/vaadin-crud-edit-column.d.ts
+++ b/packages/crud/src/vaadin-crud-edit-column.d.ts
@@ -19,7 +19,7 @@ declare class CrudEditColumnElement extends GridColumnElement {
   /**
    * The arial-label for the edit button
    */
-  ariaLabel: string | null | undefined;
+  ariaLabel: string;
 }
 
 declare global {

--- a/packages/vaadin-dialog/src/vaadin-dialog.d.ts
+++ b/packages/vaadin-dialog/src/vaadin-dialog.d.ts
@@ -73,9 +73,8 @@ declare class DialogElement extends ThemePropertyMixin(
 
   /**
    * Set the `aria-label` attribute for assistive technologies like
-   * screen readers. An `undefined` value for this property (the
-   * default) means that the `aria-label` attribute is not present at
-   * all.
+   * screen readers. An empty string value for this property (the
+   * default) means that the `aria-label` attribute is not present.
    */
   ariaLabel: string;
 

--- a/packages/vaadin-dialog/src/vaadin-dialog.d.ts
+++ b/packages/vaadin-dialog/src/vaadin-dialog.d.ts
@@ -77,7 +77,7 @@ declare class DialogElement extends ThemePropertyMixin(
    * default) means that the `aria-label` attribute is not present at
    * all.
    */
-  ariaLabel: string | null | undefined;
+  ariaLabel: string;
 
   /**
    * Custom function for rendering the content of the dialog.

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -235,12 +235,12 @@ class DialogElement extends ThemePropertyMixin(
 
       /**
        * Set the `aria-label` attribute for assistive technologies like
-       * screen readers. An `undefined` value for this property (the
-       * default) means that the `aria-label` attribute is not present at
-       * all.
+       * screen readers. An empty string value for this property (the
+       * default) means that the `aria-label` attribute is not present.
        */
       ariaLabel: {
-        type: String
+        type: String,
+        value: ''
       },
 
       /**
@@ -317,7 +317,7 @@ class DialogElement extends ThemePropertyMixin(
 
   /** @private */
   _ariaLabelChanged(ariaLabel) {
-    if (ariaLabel !== undefined && ariaLabel !== null) {
+    if (ariaLabel != null && ariaLabel != '') {
       this.$.overlay.setAttribute('aria-label', ariaLabel);
     } else {
       this.$.overlay.removeAttribute('aria-label');

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -317,7 +317,7 @@ class DialogElement extends ThemePropertyMixin(
 
   /** @private */
   _ariaLabelChanged(ariaLabel) {
-    if (ariaLabel != null && ariaLabel != '') {
+    if (ariaLabel) {
       this.$.overlay.setAttribute('aria-label', ariaLabel);
     } else {
       this.$.overlay.removeAttribute('aria-label');

--- a/packages/vaadin-dialog/test/dialog.test.js
+++ b/packages/vaadin-dialog/test/dialog.test.js
@@ -74,10 +74,21 @@ describe('vaadin-dialog', () => {
         expect(overlay.getAttribute('aria-label')).to.be.null;
       });
 
-      it('overlay should get an updated `aria-label` attribute (if changed)', () => {
+      it('overlay should not have `aria-label` attribute if set to undefined', () => {
         dialog.ariaLabel = 'accessible';
-        expect(overlay.getAttribute('aria-label')).to.be.eql('accessible');
         dialog.ariaLabel = undefined;
+        expect(overlay.getAttribute('aria-label')).to.be.null;
+      });
+
+      it('overlay should not have `aria-label` attribute if set to null', () => {
+        dialog.ariaLabel = 'accessible';
+        dialog.ariaLabel = null;
+        expect(overlay.getAttribute('aria-label')).to.be.null;
+      });
+
+      it('overlay should not have `aria-label` attribute if set to empty string', () => {
+        dialog.ariaLabel = 'accessible';
+        dialog.ariaLabel = '';
         expect(overlay.getAttribute('aria-label')).to.be.null;
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11430,10 +11430,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description

Changed `ariaLabel` property type to align with the one present in `HTMLElement`.

Fixes #2585 

## Type of change

- Bugfix