### PR TITLE
fix: update overlay width when positionTarget is updated

### DIFF
--- a/dev/combo-box.html
+++ b/dev/combo-box.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Combo box</title>
     <script type="module">
       import '@vaadin/vaadin-combo-box';
     </script>

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown.js
@@ -65,7 +65,8 @@ class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElem
        * The element to position/align the dropdown by.
        */
       positionTarget: {
-        type: Object
+        type: Object,
+        observer: '_positionTargetChanged'
       },
 
       /**
@@ -285,7 +286,15 @@ class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElem
     return !this.loading && !(this._items && this._items.length);
   }
 
+  _positionTargetChanged() {
+    // we must update the overlay width when the positionTarget is set (or changes)
+    this._setOverlayWidth();
+  }
+
   _setOverlayWidth() {
+    if (!this.positionTarget) {
+      return;
+    }
     const inputWidth = this.positionTarget.clientWidth + 'px';
     const customWidth = getComputedStyle(this).getPropertyValue('--vaadin-combo-box-overlay-width');
 

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown.js
@@ -286,9 +286,11 @@ class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElem
     return !this.loading && !(this._items && this._items.length);
   }
 
-  _positionTargetChanged() {
+  _positionTargetChanged(target) {
     // we must update the overlay width when the positionTarget is set (or changes)
-    this._setOverlayWidth();
+    if (target) {
+      this._setOverlayWidth();
+    }
   }
 
   _setOverlayWidth() {

--- a/packages/vaadin-combo-box/test/basic.test.js
+++ b/packages/vaadin-combo-box/test/basic.test.js
@@ -468,3 +468,9 @@ describe('value set before attach', () => {
     expect(comboBox.inputElement.value).to.equal('a');
   });
 });
+
+describe('pre-opened', () => {
+  it('should not throw error when adding a pre-opened combo-box', () => {
+    expect(() => fixtureSync(`<vaadin-combo-box opened items="[0]"></vaadin-combo-box>`)).to.not.throw(Error);
+  });
+});


### PR DESCRIPTION
## Description

We need to make sure the overlay width is only updated if a value is set to `positionTarget`. We also need to refresh the overlay's width when the value of `positionTarget` changes. These changes get rid of the error reported in the related issue and makes sure the overlay is properly updated when the necessary requisites are met.

```html
<vaadin-combo-box opened></vaadin-combo-box>
```

Fixes #2597 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.