### PR TITLE
refactor: override internal elements in time-picker

### DIFF
--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown.js
@@ -25,18 +25,13 @@ const TOUCH_DEVICE = (() => {
  * @extends HTMLElement
  * @private
  */
-class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElement) {
+export class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElement) {
   static get is() {
     return 'vaadin-combo-box-dropdown';
   }
 
   static get template() {
     return html`
-      <style>
-        :host {
-          display: block;
-        }
-      </style>
       <vaadin-combo-box-overlay
         id="overlay"
         hidden$="[[_isOverlayHidden(_items.*, loading)]]"
@@ -137,11 +132,15 @@ class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElem
   ready() {
     super.ready();
 
+    // Allow extensions to customize tag name for the items
+    this.__hostTagName = this.constructor.is.replace('-dropdown', '');
+
     const overlay = this.$.overlay;
+    const scrollerTag = `${this.__hostTagName}-scroller`;
 
     overlay.renderer = (root) => {
       if (!root.firstChild) {
-        const scroller = document.createElement('vaadin-combo-box-scroller');
+        const scroller = document.createElement(scrollerTag);
         root.appendChild(scroller);
       }
     };
@@ -149,7 +148,7 @@ class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElem
     // Ensure the scroller is rendered
     overlay.requestContentUpdate();
 
-    this._scroller = overlay.content.querySelector('vaadin-combo-box-scroller');
+    this._scroller = overlay.content.querySelector(scrollerTag);
 
     this._scroller.getItemLabel = this.getItemLabel.bind(this);
     this._scroller.comboBox = this.getRootNode().host;
@@ -201,7 +200,7 @@ class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElem
       this._setOverlayWidth();
 
       this._scroller.style.maxHeight =
-        getComputedStyle(this).getPropertyValue('--vaadin-combo-box-overlay-max-height') || '65vh';
+        getComputedStyle(this).getPropertyValue(`--${this.__hostTagName}-overlay-max-height`) || '65vh';
 
       this.dispatchEvent(new CustomEvent('vaadin-combo-box-dropdown-opened', { bubbles: true, composed: true }));
     } else if (wasOpened && !this.__emptyItems) {
@@ -298,14 +297,15 @@ class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElem
       return;
     }
     const inputWidth = this.positionTarget.clientWidth + 'px';
-    const customWidth = getComputedStyle(this).getPropertyValue('--vaadin-combo-box-overlay-width');
+    const propPrefix = `${this.__hostTagName}-overlay`;
+    const customWidth = getComputedStyle(this).getPropertyValue(`--${propPrefix}-width`);
 
-    this.$.overlay.style.setProperty('--_vaadin-combo-box-overlay-default-width', inputWidth);
+    this.$.overlay.style.setProperty(`--_${propPrefix}-default-width`, inputWidth);
 
     if (customWidth === '') {
-      this.$.overlay.style.removeProperty('--vaadin-combo-box-overlay-width');
+      this.$.overlay.style.removeProperty(`--${propPrefix}-width`);
     } else {
-      this.$.overlay.style.setProperty('--vaadin-combo-box-overlay-width', customWidth);
+      this.$.overlay.style.setProperty(`--${propPrefix}-width`, customWidth);
     }
 
     this.$.overlay._updatePosition();

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-item.js
@@ -28,9 +28,10 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @mixes ThemableMixin
+ * @mixes DirMixin
  * @private
  */
-class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
+export class ComboBoxItem extends ThemableMixin(DirMixin(PolymerElement)) {
   static get template() {
     return html`
       <style>
@@ -164,4 +165,4 @@ class ComboBoxItemElement extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 }
 
-customElements.define(ComboBoxItemElement.is, ComboBoxItemElement);
+customElements.define(ComboBoxItem.is, ComboBoxItem);

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-overlay.js
@@ -29,7 +29,7 @@ registerStyles(
  * @extends OverlayElement
  * @private
  */
-class ComboBoxOverlayElement extends PositionMixin(OverlayElement) {
+export class ComboBoxOverlay extends PositionMixin(OverlayElement) {
   static get is() {
     return 'vaadin-combo-box-overlay';
   }
@@ -61,4 +61,4 @@ class ComboBoxOverlayElement extends PositionMixin(OverlayElement) {
   }
 }
 
-customElements.define(ComboBoxOverlayElement.is, ComboBoxOverlayElement);
+customElements.define(ComboBoxOverlay.is, ComboBoxOverlay);

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-scroller.js
@@ -13,7 +13,7 @@ import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
  * @extends HTMLElement
  * @private
  */
-class ComboBoxScroller extends PolymerElement {
+export class ComboBoxScroller extends PolymerElement {
   static get is() {
     return 'vaadin-combo-box-scroller';
   }
@@ -138,6 +138,9 @@ class ComboBoxScroller extends PolymerElement {
   ready() {
     super.ready();
 
+    // Allow extensions to customize tag name for the items
+    this.__hostTagName = this.constructor.is.replace('-scroller', '');
+
     this.setAttribute('role', 'listbox');
 
     this.addEventListener('click', (e) => e.stopPropagation());
@@ -248,7 +251,7 @@ class ComboBoxScroller extends PolymerElement {
   /** @private */
   __createElements(count) {
     return [...Array(count)].map(() => {
-      const item = document.createElement('vaadin-combo-box-item');
+      const item = document.createElement(`${this.__hostTagName}-item`);
       item.addEventListener('click', this.__boundOnItemClick);
       item.tabIndex = '-1';
       item.style.width = '100%';

--- a/packages/vaadin-time-picker/src/vaadin-time-picker-combo-box.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker-combo-box.js
@@ -3,16 +3,19 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { ComboBoxLight } from '@vaadin/vaadin-combo-box/src/vaadin-combo-box-light.js';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ComboBoxMixin } from '@vaadin/vaadin-combo-box/src/vaadin-combo-box-mixin.js';
+import './vaadin-time-picker-dropdown.js';
 
 /**
  * An element used internally by `<vaadin-time-picker>`. Not intended to be used separately.
  *
- * @extends ComboBoxLight
- * @private
+ * @extends HTMLElement
+ * @mixes ComboBoxMixin
+ * @mixes ThemableMixin
  */
-class TimePickerComboBox extends ComboBoxLight {
+class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
   static get is() {
     return 'vaadin-time-picker-combo-box';
   }
@@ -27,7 +30,7 @@ class TimePickerComboBox extends ComboBoxLight {
 
       <slot></slot>
 
-      <vaadin-combo-box-dropdown
+      <vaadin-time-picker-dropdown
         id="dropdown"
         opened="[[opened]]"
         position-target="[[positionTarget]]"
@@ -37,7 +40,7 @@ class TimePickerComboBox extends ComboBoxLight {
         _item-label-path="[[itemLabelPath]]"
         loading="[[loading]]"
         theme="[[theme]]"
-      ></vaadin-combo-box-dropdown>
+      ></vaadin-time-picker-dropdown>
     `;
   }
 
@@ -63,9 +66,41 @@ class TimePickerComboBox extends ComboBoxLight {
     super.ready();
 
     this.allowCustomValue = true;
+    this._toggleElement = this.querySelector('.toggle-button');
 
     // See https://github.com/vaadin/vaadin-time-picker/issues/145
     this.setAttribute('dir', 'ltr');
+  }
+
+  /** @protected */
+  connectedCallback() {
+    super.connectedCallback();
+
+    this._revertInputValue();
+    this._preventInputBlur();
+  }
+
+  /** @protected */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._restoreInputBlur();
+  }
+
+  /** @protected */
+  _isClearButton(event) {
+    return super._isClearButton(event) || event.composedPath()[0].getAttribute('part') === 'clear-button';
+  }
+
+  /**
+   * @param {!Event} event
+   * @protected
+   */
+  _onChange(event) {
+    super._onChange(event);
+
+    if (this._isClearButton(event)) {
+      this._clear();
+    }
   }
 }
 

--- a/packages/vaadin-time-picker/src/vaadin-time-picker-combo-box.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker-combo-box.js
@@ -73,20 +73,6 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-
-    this._revertInputValue();
-    this._preventInputBlur();
-  }
-
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._restoreInputBlur();
-  }
-
-  /** @protected */
   _isClearButton(event) {
     return super._isClearButton(event) || event.composedPath()[0].getAttribute('part') === 'clear-button';
   }

--- a/packages/vaadin-time-picker/src/vaadin-time-picker-dropdown.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker-dropdown.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { ComboBoxDropdown } from '@vaadin/vaadin-combo-box/src/vaadin-combo-box-dropdown.js';
+import './vaadin-time-picker-item.js';
+import './vaadin-time-picker-overlay.js';
+import './vaadin-time-picker-scroller.js';
+
+/**
+ * An element used internally by `<vaadin-time-picker>`. Not intended to be used separately.
+ *
+ * @extends ComboBoxOverlay
+ * @private
+ */
+class TimePickerDropdown extends ComboBoxDropdown {
+  static get is() {
+    return 'vaadin-time-picker-dropdown';
+  }
+
+  static get template() {
+    return html`
+      <vaadin-time-picker-overlay
+        id="overlay"
+        hidden$="[[_isOverlayHidden(_items.*, loading)]]"
+        loading$="[[loading]]"
+        opened="{{_overlayOpened}}"
+        theme$="[[theme]]"
+        position-target="[[positionTarget]]"
+        no-vertical-overlap
+      ></vaadin-time-picker-overlay>
+    `;
+  }
+}
+
+customElements.define(TimePickerDropdown.is, TimePickerDropdown);

--- a/packages/vaadin-time-picker/src/vaadin-time-picker-item.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker-item.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ComboBoxItem } from '@vaadin/vaadin-combo-box/src/vaadin-combo-box-item.js';
+
+/**
+ * An element used for items in `<vaadin-time-picker>`.
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name | Description
+ * ----------|-------------
+ * `content` | The element that wraps the item content
+ *
+ * The following state attributes are exposed for styling:
+ *
+ * Attribute  | Description                   | Part name
+ * -----------|-------------------------------|-----------
+ * `selected` | Set when the item is selected | :host
+ * `focused`  | Set when the item is focused  | :host
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
+ *
+ * @extends ComboBoxItem
+ * @private
+ */
+class TimePickerItem extends ComboBoxItem {
+  static get is() {
+    return 'vaadin-time-picker-item';
+  }
+}
+
+customElements.define(TimePickerItem.is, TimePickerItem);

--- a/packages/vaadin-time-picker/src/vaadin-time-picker-overlay.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker-overlay.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ComboBoxOverlay } from '@vaadin/vaadin-combo-box/src/vaadin-combo-box-overlay.js';
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+registerStyles(
+  'vaadin-time-picker-overlay',
+  css`
+    #overlay {
+      width: var(--vaadin-time-picker-overlay-width, var(--_vaadin-time-picker-overlay-default-width, auto));
+    }
+  `,
+  { moduleId: 'vaadin-time-picker-overlay-styles' }
+);
+
+/**
+ * An element used internally by `<vaadin-time-picker>`. Not intended to be used separately.
+ *
+ * @extends ComboBoxOverlay
+ * @private
+ */
+class TimePickerOverlay extends ComboBoxOverlay {
+  static get is() {
+    return 'vaadin-time-picker-overlay';
+  }
+}
+
+customElements.define(TimePickerOverlay.is, TimePickerOverlay);

--- a/packages/vaadin-time-picker/src/vaadin-time-picker-scroller.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker-scroller.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ComboBoxScroller } from '@vaadin/vaadin-combo-box/src/vaadin-combo-box-scroller.js';
+
+/**
+ * An element used internally by `<vaadin-time-picker>`. Not intended to be used separately.
+ *
+ * @extends ComboBoxOverlay
+ * @private
+ */
+class TimePickerScroller extends ComboBoxScroller {
+  static get is() {
+    return 'vaadin-time-picker-scroller';
+  }
+}
+
+customElements.define(TimePickerScroller.is, TimePickerScroller);

--- a/packages/vaadin-time-picker/test/aria.test.js
+++ b/packages/vaadin-time-picker/test/aria.test.js
@@ -69,7 +69,7 @@ describe('ARIA', () => {
       timePicker.value = '00:00';
       arrowDownKeyDown(input); // 'focus moves to 2nd item'
 
-      const items = comboBox.$.dropdown._scroller.querySelectorAll('vaadin-combo-box-item');
+      const items = comboBox.$.dropdown._scroller.querySelectorAll('vaadin-time-picker-item');
       expect(items[0].getAttribute('role')).to.equal('option');
       expect(items[0].getAttribute('aria-selected')).to.equal('false');
       expect(items[1].getAttribute('aria-selected')).to.equal('true');

--- a/packages/vaadin-time-picker/test/keyboard-navigation.test.js
+++ b/packages/vaadin-time-picker/test/keyboard-navigation.test.js
@@ -184,7 +184,7 @@ describe('keyboard navigation', () => {
 
     it('should open the overlay on arrow up', () => {
       arrowUp(inputElement);
-      expect(document.querySelector('vaadin-combo-box-overlay')).to.be.ok;
+      expect(document.querySelector('vaadin-time-picker-overlay')).to.be.ok;
     });
   });
 


### PR DESCRIPTION
## Description

Update the implementation to make `vaadin-time-picker` use own tag names for internal elements:

- `vaddin-time-picker-dropdown`
- `vaddin-time-picker-overlay`
- `vaadin-time-picker-scroller`
- `vaadin-time-picker-item`

This also removes `ComboBoxDataProviderMixin` which we don't really need in time-picker.

## Type of change

- Refactor