### PR TITLE
refactor: prevent mousedown to keep focus on clear

### DIFF
--- a/packages/vaadin-combo-box/src/vaadin-combo-box-light.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-light.js
@@ -139,13 +139,6 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixi
     const cssSelector = 'vaadin-text-field,iron-input,paper-input,.paper-input-input,.input';
     this._setInputElement(this.querySelector(cssSelector));
     this._revertInputValue();
-    this._preventInputBlur();
-  }
-
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._restoreInputBlur();
   }
 
   /**

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -206,6 +206,7 @@ export const ComboBoxMixin = (subclass) =>
       super();
       this._boundOnFocusout = this._onFocusout.bind(this);
       this._boundOverlaySelectedItemChanged = this._overlaySelectedItemChanged.bind(this);
+      this._boundOnClearButtonMouseDown = this.__onClearButtonMouseDown.bind(this);
       this._boundClose = this.close.bind(this);
       this._boundOnOpened = this._onOpened.bind(this);
       this._boundOnClick = this._onClick.bind(this);
@@ -249,6 +250,10 @@ export const ComboBoxMixin = (subclass) =>
         input.setAttribute('aria-expanded', this.opened);
 
         this._revertInputValueToValue();
+
+        if (this.clearElement) {
+          this.clearElement.addEventListener('mousedown', this._boundOnClearButtonMouseDown);
+        }
       }
     }
 
@@ -374,7 +379,6 @@ export const ComboBoxMixin = (subclass) =>
     _handleClearButtonClick(event) {
       event.preventDefault();
       this._clear();
-      this.focus();
     }
 
     /** @private */
@@ -972,6 +976,12 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /** @private */
+    __onClearButtonMouseDown(event) {
+      event.preventDefault(); // Prevent native focusout event
+      this.inputElement.focus();
+    }
+
+    /** @private */
     _onFocusout(event) {
       // Fixes the problem with `focusout` happening when clicking on the scroll bar on Edge
       if (event.relatedTarget === this.$.dropdown.$.overlay) {
@@ -1014,31 +1024,6 @@ export const ComboBoxMixin = (subclass) =>
       }
 
       return !this.required || !!this.value;
-    }
-
-    /** @protected */
-    _preventInputBlur() {
-      if (this._toggleElement) {
-        this._toggleElement.addEventListener('click', this._preventDefault);
-      }
-      if (this._clearElement) {
-        this._clearElement.addEventListener('click', this._preventDefault);
-      }
-    }
-
-    /** @protected */
-    _restoreInputBlur() {
-      if (this._toggleElement) {
-        this._toggleElement.removeEventListener('click', this._preventDefault);
-      }
-      if (this._clearElement) {
-        this._clearElement.removeEventListener('click', this._preventDefault);
-      }
-    }
-
-    /** @private */
-    _preventDefault(e) {
-      e.preventDefault();
     }
 
     /**

--- a/packages/vaadin-combo-box/test/combo-box-light.test.js
+++ b/packages/vaadin-combo-box/test/combo-box-light.test.js
@@ -353,10 +353,11 @@ describe('paper-input', () => {
       expect(comboBox.opened).to.be.false;
     });
 
-    it('should cancel click event to avoid input blur', () => {
+    it('should prevent mousedown event to avoid input blur', () => {
       comboBox.open();
 
-      const event = click(clearButton);
+      const event = new CustomEvent('mousedown', { cancelable: true });
+      clearButton.dispatchEvent(event);
 
       expect(event.defaultPrevented).to.be.true;
     });

--- a/packages/vaadin-combo-box/test/selecting-items.test.js
+++ b/packages/vaadin-combo-box/test/selecting-items.test.js
@@ -288,13 +288,13 @@ describe('clearing a selection', () => {
     expect(comboBox.opened).to.eql(false);
   });
 
-  it('should cancel click event to avoid input blur', () => {
+  it('should prevent mousedown event to avoid input blur', () => {
     comboBox.open();
 
-    const event = new CustomEvent('click', { composed: true, cancelable: true });
+    const event = new CustomEvent('mousedown', { cancelable: true });
     clearIcon.dispatchEvent(event);
 
-    expect(event.defaultPrevented).to.eql(true);
+    expect(event.defaultPrevented).to.be.true;
   });
 });
 

--- a/packages/vaadin-time-picker/test/time-picker.test.js
+++ b/packages/vaadin-time-picker/test/time-picker.test.js
@@ -236,6 +236,15 @@ describe('time-picker', () => {
       clearButton.click();
       expect(comboBox.opened).to.be.false;
     });
+
+    it('should prevent mousedown event to avoid input blur', () => {
+      timePicker.$.comboBox.open();
+
+      const event = new CustomEvent('mousedown', { cancelable: true });
+      clearButton.dispatchEvent(event);
+
+      expect(event.defaultPrevented).to.be.true;
+    });
   });
 
   describe('change event', () => {


### PR DESCRIPTION
## Description

Currently there is a regression in `vaadin-time-picker`: on clear button click the input loses focus.
Updated to use the same approach as with toggle button and prevent `mousedown`.

Also removed the `click` listeners which are no longer needed, and updated tests.

## Type of change

- Bugfix