### PR TITLE
refactor!: drop paper-input and iron-input support

### DIFF
--- a/packages/vaadin-combo-box/package.json
+++ b/packages/vaadin-combo-box/package.json
@@ -39,8 +39,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@polymer/iron-input": "^3.0.1",
-    "@polymer/paper-input": "^3.0.0",
     "@vaadin/testing-helpers": "^0.3.0",
     "@vaadin/vaadin-dialog": "^22.0.0-alpha6",
     "@vaadin/vaadin-template-renderer": "^22.0.0-alpha6",

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-light.d.ts
@@ -26,28 +26,24 @@ import { ComboBoxDefaultItem, ComboBoxEventMap } from './interfaces';
  * </vaadin-combo-box-light>
  * ```
  *
- * If you are using other custom input fields like `<iron-input>`, you
- * need to define the name of the bindable property with the `attrForValue` attribute.
+ * If you are using custom input field that has other property for value,
+ * set `class="input"` to enable corresponding logic, and use `attr-for-value`
+ * attribute to specify which property to use:
  *
  * ```html
- * <vaadin-combo-box-light attr-for-value="bind-value">
- *   <iron-input>
- *     <input>
- *   </iron-input>
+ * <vaadin-combo-box-light attr-for-value="input-value">
+ *   <custom-input class="input"></custom-input>
  * </vaadin-combo-box-light>
  * ```
  *
- * In the next example you can see how to create a custom input field based
- * on a `<paper-input>` decorated with a custom `<iron-icon>` and
- * two `<paper-button>`s to act as the clear and toggle controls.
+ * You can also pass custom toggle and clear buttons with corresponding classes:
  *
  * ```html
  * <vaadin-combo-box-light>
- *   <paper-input label="Elements" class="input">
- *     <iron-icon icon="toll" slot="prefix"></iron-icon>
- *     <paper-button slot="suffix" class="clear-button">Clear</paper-button>
- *     <paper-button slot="suffix" class="toggle-button">Toggle</paper-button>
- *   </paper-input>
+ *   <custom-input class="input" attr-for-value="input-value">
+ *     <button slot="suffix" class="clear-button">Clear</button>
+ *     <button slot="suffix" class="toggle-button">Toggle</button>
+ *   </custom-input>
  * </vaadin-combo-box-light>
  * ```
  *

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-light.d.ts
@@ -16,13 +16,11 @@ import { ComboBoxDefaultItem, ComboBoxEventMap } from './interfaces';
  *
  * To create a custom input field, you need to add a child element which has a two-way
  * data-bindable property representing the input value. The property name is expected
- * to be `value` by default. See the example below for a simplest possible example
- * using a `<vaadin-text-field>` element.
+ * to be `value` by default. For example, you can use `<vaadin-text-field>` element:
  *
  * ```html
  * <vaadin-combo-box-light>
- *   <vaadin-text-field>
- *   </vaadin-text-field>
+ *   <vaadin-text-field></vaadin-text-field>
  * </vaadin-combo-box-light>
  * ```
  *

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-light.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-light.js
@@ -18,13 +18,11 @@ import './vaadin-combo-box-dropdown.js';
  *
  * To create a custom input field, you need to add a child element which has a two-way
  * data-bindable property representing the input value. The property name is expected
- * to be `value` by default. See the example below for a simplest possible example
- * using a `<vaadin-text-field>` element.
+ * to be `value` by default. For example, you can use `<vaadin-text-field>` element:
  *
  * ```html
  * <vaadin-combo-box-light>
- *   <vaadin-text-field>
- *   </vaadin-text-field>
+ *   <vaadin-text-field></vaadin-text-field>
  * </vaadin-combo-box-light>
  * ```
  *

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-light.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-light.js
@@ -28,28 +28,24 @@ import './vaadin-combo-box-dropdown.js';
  * </vaadin-combo-box-light>
  * ```
  *
- * If you are using other custom input fields like `<iron-input>`, you
- * need to define the name of the bindable property with the `attrForValue` attribute.
+ * If you are using custom input field that has other property for value,
+ * set `class="input"` to enable corresponding logic, and use `attr-for-value`
+ * attribute to specify which property to use:
  *
  * ```html
- * <vaadin-combo-box-light attr-for-value="bind-value">
- *   <iron-input>
- *     <input>
- *   </iron-input>
+ * <vaadin-combo-box-light attr-for-value="input-value">
+ *   <custom-input class="input"></custom-input>
  * </vaadin-combo-box-light>
  * ```
  *
- * In the next example you can see how to create a custom input field based
- * on a `<paper-input>` decorated with a custom `<iron-icon>` and
- * two `<paper-button>`s to act as the clear and toggle controls.
+ * You can also pass custom toggle and clear buttons with corresponding classes:
  *
  * ```html
  * <vaadin-combo-box-light>
- *   <paper-input label="Elements" class="input">
- *     <iron-icon icon="toll" slot="prefix"></iron-icon>
- *     <paper-button slot="suffix" class="clear-button">Clear</paper-button>
- *     <paper-button slot="suffix" class="toggle-button">Toggle</paper-button>
- *   </paper-input>
+ *   <custom-input class="input" attr-for-value="input-value">
+ *     <button slot="suffix" class="clear-button">Clear</button>
+ *     <button slot="suffix" class="toggle-button">Toggle</button>
+ *   </custom-input>
  * </vaadin-combo-box-light>
  * ```
  *

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-light.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-light.js
@@ -123,21 +123,12 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixi
   ready() {
     super.ready();
     this._toggleElement = this.querySelector('.toggle-button');
-
-    if (this.clearElement) {
-      this.clearElement.addEventListener('mousedown', (e) => {
-        e.preventDefault(); // Prevent native focus changes
-        // _focusableElement is needed for paper-input
-        (this.inputElement._focusableElement || this.inputElement).focus();
-      });
-    }
   }
 
   /** @protected */
   connectedCallback() {
     super.connectedCallback();
-    const cssSelector = 'vaadin-text-field,iron-input,paper-input,.paper-input-input,.input';
-    this._setInputElement(this.querySelector(cssSelector));
+    this._setInputElement(this.querySelector('vaadin-text-field,.input'));
     this._revertInputValue();
   }
 

--- a/packages/vaadin-combo-box/test/combo-box-light.test.js
+++ b/packages/vaadin-combo-box/test/combo-box-light.test.js
@@ -15,8 +15,6 @@ import {
 } from '@vaadin/testing-helpers';
 import { resetMouseCanceller } from '@polymer/polymer/lib/utils/gestures.js';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import '@polymer/iron-input/iron-input.js';
-import '@polymer/paper-input/paper-input.js';
 import '@vaadin/vaadin-text-field/vaadin-text-field.js';
 import '@vaadin/vaadin-template-renderer';
 import { createEventSpy, getFirstItem } from './helpers.js';
@@ -31,9 +29,7 @@ class MyInput extends PolymerElement {
           display: inline-block;
         }
       </style>
-      <iron-input id="input" bind-value="{{customValue}}">
-        <input />
-      </iron-input>
+      <vaadin-text-field id="input" value="{{customValue}}"></vaadin-text-field>
     `;
   }
 
@@ -50,35 +46,29 @@ class MyInput extends PolymerElement {
 customElements.define('my-input', MyInput);
 
 describe('vaadin-combo-box-light', () => {
-  let comboBox, overlay, ironInput;
+  let comboBox, overlay, inputElement;
 
   beforeEach(() => {
     comboBox = fixtureSync(`
-      <vaadin-combo-box-light attr-for-value="bind-value">
-        <iron-input>
-          <input>
-        </iron-input>
+      <vaadin-combo-box-light>
+        <vaadin-text-field></vaadin-text-field>
       </vaadin-combo-box-light>
     `);
     comboBox.items = ['foo', 'bar', 'baz'];
     overlay = comboBox.$.dropdown.$.overlay;
-    ironInput = comboBox.querySelector('iron-input');
+    inputElement = comboBox.querySelector('vaadin-text-field');
   });
 
-  describe('using iron-input', () => {
-    it('should find the input element correctly', () => {
-      expect(comboBox.inputElement).to.eql(ironInput);
-    });
+  it('should find the input element correctly', () => {
+    expect(comboBox.inputElement).to.eql(inputElement);
+  });
 
-    it('should bind the input value correctly when setting combo box value', () => {
-      // Empty string by default.
-      expect(comboBox._inputElementValue).to.eql('');
-      expect(ironInput.value).to.eql('');
+  it('should update input element value when setting combo box value', () => {
+    // Empty string by default.
+    expect(inputElement.value).to.eql('');
 
-      comboBox.value = 'foo';
-      expect(comboBox._inputElementValue).to.eql('foo');
-      expect(ironInput.value).to.eql('foo');
-    });
+    comboBox.value = 'foo';
+    expect(inputElement.value).to.eql('foo');
   });
 
   it('should prevent default on overlay down', () => {
@@ -91,7 +81,7 @@ describe('vaadin-combo-box-light', () => {
   it('should not prevent default on input down', () => {
     const e = new CustomEvent('mousedown', { bubbles: true });
     const spy = sinon.spy(e, 'preventDefault');
-    ironInput.dispatchEvent(e);
+    inputElement.dispatchEvent(e);
     expect(spy.calledOnce).to.be.false;
   });
 
@@ -104,34 +94,34 @@ describe('vaadin-combo-box-light', () => {
     });
 
     it('should toggle overlay on input click', () => {
-      ironInput.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      inputElement.click();
       expect(comboBox.opened).to.be.true;
     });
 
     (isDesktopSafari ? it.skip : it)('should toggle on input click on touch devices', () => {
-      touchstart(ironInput);
-      touchend(ironInput);
-      mousedown(ironInput);
-      mouseup(ironInput);
-      click(ironInput);
+      touchstart(inputElement);
+      touchend(inputElement);
+      mousedown(inputElement);
+      mouseup(inputElement);
+      click(inputElement);
 
       expect(comboBox.opened).to.be.true;
     });
 
     it('should not clear on input click', () => {
       comboBox.value = 'foo';
-      ironInput.dispatchEvent(new CustomEvent('click', { bubbles: true }));
+      inputElement.click();
       expect(comboBox.value).to.equal('foo');
     });
 
     (isDesktopSafari ? it.skip : it)('should not clear on input click on touch devices', () => {
       comboBox.value = 'foo';
 
-      touchstart(ironInput);
-      touchend(ironInput);
-      mousedown(ironInput);
-      mouseup(ironInput);
-      click(ironInput);
+      touchstart(inputElement);
+      touchend(inputElement);
+      mousedown(inputElement);
+      mouseup(inputElement);
+      click(inputElement);
 
       expect(comboBox.value).to.equal('foo');
     });
@@ -150,10 +140,39 @@ describe('vaadin-combo-box-light', () => {
       expect(preventDefaultSpy.called).to.be.true;
     });
   });
+
+  describe('clear-button-visible', () => {
+    let clearButton;
+
+    beforeEach(() => {
+      inputElement.clearButtonVisible = true;
+      clearButton = inputElement.$.clearButton;
+      comboBox.value = 'bar';
+    });
+
+    it('should immediately clear value when using clear button of vaadin-text-field', () => {
+      click(clearButton);
+      expect(comboBox.value).not.to.be.ok;
+    });
+
+    it('should not close the dropdown after clearing a selection', () => {
+      comboBox.open();
+
+      click(clearButton);
+
+      expect(comboBox.opened).to.be.true;
+    });
+
+    it('should not open the dropdown after clearing a selection', () => {
+      click(clearButton);
+
+      expect(comboBox.opened).to.be.false;
+    });
+  });
 });
 
 describe('attr-for-value', () => {
-  let comboBox, customInput, ironInput, nativeInput;
+  let comboBox, customInput, inputElement;
 
   beforeEach(() => {
     comboBox = fixtureSync(`
@@ -163,8 +182,7 @@ describe('attr-for-value', () => {
     `);
     comboBox.items = ['foo', 'bar', 'baz'];
     customInput = comboBox.querySelector('.input');
-    ironInput = customInput.$.input;
-    nativeInput = ironInput.querySelector('input');
+    inputElement = customInput.$.input;
   });
 
   describe('using custom input with custom attr-for-value', () => {
@@ -174,81 +192,68 @@ describe('attr-for-value', () => {
 
     it('should bind the input value correctly when setting combo box value', () => {
       // Empty string by default.
-      expect(comboBox._inputElementValue).to.eql('');
       expect(customInput.customValue).to.eql('');
 
       comboBox.value = 'foo';
-      expect(comboBox._inputElementValue).to.eql('foo');
       expect(customInput.customValue).to.eql('foo');
     });
 
     it('should bind the input value correctly when getting input', () => {
       // Empty string by default.
-      expect(comboBox._inputElementValue).to.eql('');
       expect(customInput.customValue).to.eql('');
-      expect(nativeInput.value).to.eql('');
-
-      // Make sure the slotted <input> has been detected by <iron-input>
-      // before trying to modify the value of the <input>.
-      // Otherwise iron-input will throw an error (in `_onInput`) because
-      // it tries to read `inputElement.value` but `inputElement` is still
-      // undefined.
-      ironInput._observer.flush();
+      expect(inputElement.value).to.eql('');
 
       // Simulate typing an option with a keyboard and confirming it via Enter
-      nativeInput.value = 'foo';
-      fire(nativeInput, 'input');
+      inputElement.value = 'foo';
+      fire(inputElement, 'input');
 
-      enter(nativeInput);
+      enter(inputElement);
 
       expect(comboBox.value).to.eql('foo');
-      expect(comboBox._inputElementValue).to.eql('foo');
       expect(customInput.customValue).to.eql('foo');
     });
   });
 });
 
-describe('paper-input', () => {
+describe('custom buttons', () => {
   let comboBox;
 
   beforeEach(() => {
     comboBox = fixtureSync(`
       <vaadin-combo-box-light>
-        <paper-input>
+        <vaadin-text-field>
           <button slot="suffix" class="clear-button">Clear</button>
           <button slot="suffix" class="toggle-button">Toggle</button>
-        </paper-input>
+        </vaadin-text-field>
       </vaadin-combo-box-light>
     `);
     comboBox.items = ['foo', 'bar', 'baz'];
   });
 
-  it('should toggle overlay by clicking toggle element', () => {
-    click(comboBox._toggleElement);
-    expect(comboBox.opened).to.be.true;
+  describe('toggle-button', () => {
+    let toggleButton;
 
-    click(comboBox._toggleElement);
-    expect(comboBox.opened).to.be.false;
+    beforeEach(() => {
+      toggleButton = comboBox.querySelector('.toggle-button');
+    });
+
+    it('should toggle overlay by clicking toggle element', () => {
+      click(toggleButton);
+      expect(comboBox.opened).to.be.true;
+
+      click(toggleButton);
+      expect(comboBox.opened).to.be.false;
+    });
+
+    it('should prevent default on toggle element down', () => {
+      const e = new CustomEvent('mousedown', { bubbles: true });
+      const spy = sinon.spy(e, 'preventDefault');
+      toggleButton.dispatchEvent(e);
+      expect(spy.calledOnce).to.be.true;
+    });
   });
 
-  it('should prevent default on toggle element down', () => {
-    const e = new CustomEvent('mousedown', { bubbles: true });
-    const spy = sinon.spy(e, 'preventDefault');
-    comboBox._toggleElement.dispatchEvent(e);
-    expect(spy.calledOnce).to.be.true;
-  });
-
-  it('should validate the paper-input element on checkValidity', () => {
-    const spy = sinon.spy(comboBox.inputElement, 'validate');
-
-    comboBox.required = true;
-    comboBox.value = 'foo';
-    comboBox.checkValidity();
-
-    expect(spy.calledOnce).to.be.true;
-  });
-
-  describe('custom clear-button', () => {
+  describe('clear-button', () => {
     let clearButton;
 
     /**
@@ -294,12 +299,6 @@ describe('paper-input', () => {
       let target = elementFromPointDeep(x, y, elem.ownerDocument);
       if (!target) {
         return;
-      }
-
-      // Check if the found element contains a slot (needed for other browsers than Chrome)
-      const slot = target.querySelector('slot');
-      if (slot && slot.assignedNodes({ flatten: true }).indexOf(elem) !== -1) {
-        target = elem;
       }
 
       click(target);
@@ -369,10 +368,8 @@ describe('theme attribute', () => {
 
   beforeEach(() => {
     comboBox = fixtureSync(`
-      <vaadin-combo-box-light attr-for-value="bind-value" theme="foo">
-        <iron-input>
-          <input>
-        </iron-input>
+      <vaadin-combo-box-light theme="foo">
+        <vaadin-text-field></vaadin-text-field>
       </vaadin-combo-box-light>
     `);
   });
@@ -417,48 +414,5 @@ describe('nested template', () => {
     await nextFrame();
     expect(comboBox.querySelector('[slot="prefix"]').innerHTML).to.contain('1 foo');
     expect(getFirstItem(comboBox).shadowRoot.querySelector('#content').innerHTML).to.equal('bar');
-  });
-});
-
-describe('vaadin-text-field', () => {
-  let comboBox, textField;
-
-  beforeEach(() => {
-    comboBox = fixtureSync(`
-      <vaadin-combo-box-light>
-        <vaadin-text-field></vaadin-text-field>
-      </vaadin-combo-box-light>
-    `);
-    comboBox.items = ['bar', 'baz', 'qux'];
-    textField = comboBox.inputElement;
-  });
-
-  describe('clear-button-visible', () => {
-    let clearButton;
-
-    beforeEach(() => {
-      textField.clearButtonVisible = true;
-      clearButton = textField.$.clearButton;
-      comboBox.value = 'bar';
-    });
-
-    it('should immediately clear value when using clear button of vaadin-text-field', () => {
-      click(clearButton);
-      expect(comboBox.value).not.to.be.ok;
-    });
-
-    it('should not close the dropdown after clearing a selection', () => {
-      comboBox.open();
-
-      click(clearButton);
-
-      expect(comboBox.opened).to.be.true;
-    });
-
-    it('should not open the dropdown after clearing a selection', () => {
-      click(clearButton);
-
-      expect(comboBox.opened).to.be.false;
-    });
   });
 });


### PR DESCRIPTION
## Description

We no longer want to support `iron-` and `paper-` elements as these are deprecated.
Updated the implementation and tests to use `vaadin-text-field` and custom input.

## Type of change

- Breaking change