### PR TITLE
chore: add test to check for overlay content's width when combo-box is pre-opened

### DIFF
--- a/packages/vaadin-combo-box/test/basic.test.js
+++ b/packages/vaadin-combo-box/test/basic.test.js
@@ -473,4 +473,11 @@ describe('pre-opened', () => {
   it('should not throw error when adding a pre-opened combo-box', () => {
     expect(() => fixtureSync(`<vaadin-combo-box opened items="[0]"></vaadin-combo-box>`)).to.not.throw(Error);
   });
+
+  it('should have overlay with correct width', () => {
+    const comboBox = fixtureSync(`<vaadin-combo-box opened items="[0]"></vaadin-combo-box>`);
+    const expectedOverlayWidth = comboBox.clientWidth;
+    const actualOverlayWidth = comboBox.$.dropdown.$.overlay.$.content.clientWidth;
+    expect(actualOverlayWidth).to.eq(expectedOverlayWidth);
+  });
 });


### PR DESCRIPTION
## Description

In https://github.com/vaadin/web-components/pull/2611 a change was introduced to update the overlay once the `positionTarget` is loaded, but no test was added to make sure the overlay's content is of the expected width.

This PR adds the missing test.