### PR TITLE
refactor!: rename indicator part to required-indicator

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -49,7 +49,7 @@ class CustomField extends FieldAriaMixin(LabelMixin(FocusMixin(ThemableMixin(Ele
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
-          <span part="indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
         <div class="inputs-wrapper" on-change="__onInputChange">

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -1,14 +1,14 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-email-field default"] = 
+snapshots["vaadin-email-field default"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -44,14 +44,14 @@ snapshots["vaadin-email-field default"] =
 `;
 /* end snapshot vaadin-email-field default */
 
-snapshots["vaadin-email-field disabled"] = 
+snapshots["vaadin-email-field disabled"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -90,14 +90,14 @@ snapshots["vaadin-email-field disabled"] =
 `;
 /* end snapshot vaadin-email-field disabled */
 
-snapshots["vaadin-email-field readonly"] = 
+snapshots["vaadin-email-field readonly"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -136,14 +136,14 @@ snapshots["vaadin-email-field readonly"] =
 `;
 /* end snapshot vaadin-email-field readonly */
 
-snapshots["vaadin-email-field invalid"] = 
+snapshots["vaadin-email-field invalid"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -182,14 +182,14 @@ snapshots["vaadin-email-field invalid"] =
 `;
 /* end snapshot vaadin-email-field invalid */
 
-snapshots["vaadin-email-field theme"] = 
+snapshots["vaadin-email-field theme"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -228,7 +228,7 @@ snapshots["vaadin-email-field theme"] =
 `;
 /* end snapshot vaadin-email-field theme */
 
-snapshots["vaadin-email-field slots"] = 
+snapshots["vaadin-email-field slots"] =
 `<input
   autocapitalize="off"
   slot="input"

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-email-field default"] =
+snapshots["vaadin-email-field default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -44,7 +44,7 @@ snapshots["vaadin-email-field default"] =
 `;
 /* end snapshot vaadin-email-field default */
 
-snapshots["vaadin-email-field disabled"] =
+snapshots["vaadin-email-field disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -90,7 +90,7 @@ snapshots["vaadin-email-field disabled"] =
 `;
 /* end snapshot vaadin-email-field disabled */
 
-snapshots["vaadin-email-field readonly"] =
+snapshots["vaadin-email-field readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -136,7 +136,7 @@ snapshots["vaadin-email-field readonly"] =
 `;
 /* end snapshot vaadin-email-field readonly */
 
-snapshots["vaadin-email-field invalid"] =
+snapshots["vaadin-email-field invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -182,7 +182,7 @@ snapshots["vaadin-email-field invalid"] =
 `;
 /* end snapshot vaadin-email-field invalid */
 
-snapshots["vaadin-email-field theme"] =
+snapshots["vaadin-email-field theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -228,7 +228,7 @@ snapshots["vaadin-email-field theme"] =
 `;
 /* end snapshot vaadin-email-field theme */
 
-snapshots["vaadin-email-field slots"] =
+snapshots["vaadin-email-field slots"] = 
 `<input
   autocapitalize="off"
   slot="input"

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-integer-field default"] =
+snapshots["vaadin-integer-field default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -56,7 +56,7 @@ snapshots["vaadin-integer-field default"] =
 `;
 /* end snapshot vaadin-integer-field default */
 
-snapshots["vaadin-integer-field controls"] =
+snapshots["vaadin-integer-field controls"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -109,7 +109,7 @@ snapshots["vaadin-integer-field controls"] =
 `;
 /* end snapshot vaadin-integer-field controls */
 
-snapshots["vaadin-integer-field disabled"] =
+snapshots["vaadin-integer-field disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -167,7 +167,7 @@ snapshots["vaadin-integer-field disabled"] =
 `;
 /* end snapshot vaadin-integer-field disabled */
 
-snapshots["vaadin-integer-field readonly"] =
+snapshots["vaadin-integer-field readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -225,7 +225,7 @@ snapshots["vaadin-integer-field readonly"] =
 `;
 /* end snapshot vaadin-integer-field readonly */
 
-snapshots["vaadin-integer-field invalid"] =
+snapshots["vaadin-integer-field invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -283,7 +283,7 @@ snapshots["vaadin-integer-field invalid"] =
 `;
 /* end snapshot vaadin-integer-field invalid */
 
-snapshots["vaadin-integer-field theme"] =
+snapshots["vaadin-integer-field theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -341,7 +341,7 @@ snapshots["vaadin-integer-field theme"] =
 `;
 /* end snapshot vaadin-integer-field theme */
 
-snapshots["vaadin-integer-field slots"] =
+snapshots["vaadin-integer-field slots"] = 
 `<input
   max="undefined"
   min="undefined"

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -1,14 +1,14 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-integer-field default"] = 
+snapshots["vaadin-integer-field default"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -56,14 +56,14 @@ snapshots["vaadin-integer-field default"] =
 `;
 /* end snapshot vaadin-integer-field default */
 
-snapshots["vaadin-integer-field controls"] = 
+snapshots["vaadin-integer-field controls"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -109,14 +109,14 @@ snapshots["vaadin-integer-field controls"] =
 `;
 /* end snapshot vaadin-integer-field controls */
 
-snapshots["vaadin-integer-field disabled"] = 
+snapshots["vaadin-integer-field disabled"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -167,14 +167,14 @@ snapshots["vaadin-integer-field disabled"] =
 `;
 /* end snapshot vaadin-integer-field disabled */
 
-snapshots["vaadin-integer-field readonly"] = 
+snapshots["vaadin-integer-field readonly"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -225,14 +225,14 @@ snapshots["vaadin-integer-field readonly"] =
 `;
 /* end snapshot vaadin-integer-field readonly */
 
-snapshots["vaadin-integer-field invalid"] = 
+snapshots["vaadin-integer-field invalid"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -283,14 +283,14 @@ snapshots["vaadin-integer-field invalid"] =
 `;
 /* end snapshot vaadin-integer-field invalid */
 
-snapshots["vaadin-integer-field theme"] = 
+snapshots["vaadin-integer-field theme"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -341,7 +341,7 @@ snapshots["vaadin-integer-field theme"] =
 `;
 /* end snapshot vaadin-integer-field theme */
 
-snapshots["vaadin-integer-field slots"] = 
+snapshots["vaadin-integer-field slots"] =
 `<input
   max="undefined"
   min="undefined"

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -97,7 +97,7 @@ export class NumberField extends InputFieldMixin(
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
-          <span part="indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-number-field default"] =
+snapshots["vaadin-number-field default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -56,7 +56,7 @@ snapshots["vaadin-number-field default"] =
 `;
 /* end snapshot vaadin-number-field default */
 
-snapshots["vaadin-number-field controls"] =
+snapshots["vaadin-number-field controls"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -109,7 +109,7 @@ snapshots["vaadin-number-field controls"] =
 `;
 /* end snapshot vaadin-number-field controls */
 
-snapshots["vaadin-number-field disabled"] =
+snapshots["vaadin-number-field disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -167,7 +167,7 @@ snapshots["vaadin-number-field disabled"] =
 `;
 /* end snapshot vaadin-number-field disabled */
 
-snapshots["vaadin-number-field readonly"] =
+snapshots["vaadin-number-field readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -225,7 +225,7 @@ snapshots["vaadin-number-field readonly"] =
 `;
 /* end snapshot vaadin-number-field readonly */
 
-snapshots["vaadin-number-field invalid"] =
+snapshots["vaadin-number-field invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -283,7 +283,7 @@ snapshots["vaadin-number-field invalid"] =
 `;
 /* end snapshot vaadin-number-field invalid */
 
-snapshots["vaadin-number-field theme"] =
+snapshots["vaadin-number-field theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -341,7 +341,7 @@ snapshots["vaadin-number-field theme"] =
 `;
 /* end snapshot vaadin-number-field theme */
 
-snapshots["vaadin-number-field slots"] =
+snapshots["vaadin-number-field slots"] = 
 `<input
   max="undefined"
   min="undefined"

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -1,14 +1,14 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-number-field default"] = 
+snapshots["vaadin-number-field default"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -56,14 +56,14 @@ snapshots["vaadin-number-field default"] =
 `;
 /* end snapshot vaadin-number-field default */
 
-snapshots["vaadin-number-field controls"] = 
+snapshots["vaadin-number-field controls"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -109,14 +109,14 @@ snapshots["vaadin-number-field controls"] =
 `;
 /* end snapshot vaadin-number-field controls */
 
-snapshots["vaadin-number-field disabled"] = 
+snapshots["vaadin-number-field disabled"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -167,14 +167,14 @@ snapshots["vaadin-number-field disabled"] =
 `;
 /* end snapshot vaadin-number-field disabled */
 
-snapshots["vaadin-number-field readonly"] = 
+snapshots["vaadin-number-field readonly"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -225,14 +225,14 @@ snapshots["vaadin-number-field readonly"] =
 `;
 /* end snapshot vaadin-number-field readonly */
 
-snapshots["vaadin-number-field invalid"] = 
+snapshots["vaadin-number-field invalid"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -283,14 +283,14 @@ snapshots["vaadin-number-field invalid"] =
 `;
 /* end snapshot vaadin-number-field invalid */
 
-snapshots["vaadin-number-field theme"] = 
+snapshots["vaadin-number-field theme"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -341,7 +341,7 @@ snapshots["vaadin-number-field theme"] =
 `;
 /* end snapshot vaadin-number-field theme */
 
-snapshots["vaadin-number-field slots"] = 
+snapshots["vaadin-number-field slots"] =
 `<input
   max="undefined"
   min="undefined"

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -1,14 +1,14 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-password-field default"] = 
+snapshots["vaadin-password-field default"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -51,14 +51,14 @@ snapshots["vaadin-password-field default"] =
 `;
 /* end snapshot vaadin-password-field default */
 
-snapshots["vaadin-password-field disabled"] = 
+snapshots["vaadin-password-field disabled"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -104,14 +104,14 @@ snapshots["vaadin-password-field disabled"] =
 `;
 /* end snapshot vaadin-password-field disabled */
 
-snapshots["vaadin-password-field readonly"] = 
+snapshots["vaadin-password-field readonly"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -157,14 +157,14 @@ snapshots["vaadin-password-field readonly"] =
 `;
 /* end snapshot vaadin-password-field readonly */
 
-snapshots["vaadin-password-field invalid"] = 
+snapshots["vaadin-password-field invalid"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -210,14 +210,14 @@ snapshots["vaadin-password-field invalid"] =
 `;
 /* end snapshot vaadin-password-field invalid */
 
-snapshots["vaadin-password-field theme"] = 
+snapshots["vaadin-password-field theme"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -263,7 +263,7 @@ snapshots["vaadin-password-field theme"] =
 `;
 /* end snapshot vaadin-password-field theme */
 
-snapshots["vaadin-password-field slots"] = 
+snapshots["vaadin-password-field slots"] =
 `<input
   autocapitalize="off"
   slot="input"

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-password-field default"] =
+snapshots["vaadin-password-field default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -51,7 +51,7 @@ snapshots["vaadin-password-field default"] =
 `;
 /* end snapshot vaadin-password-field default */
 
-snapshots["vaadin-password-field disabled"] =
+snapshots["vaadin-password-field disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -104,7 +104,7 @@ snapshots["vaadin-password-field disabled"] =
 `;
 /* end snapshot vaadin-password-field disabled */
 
-snapshots["vaadin-password-field readonly"] =
+snapshots["vaadin-password-field readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -157,7 +157,7 @@ snapshots["vaadin-password-field readonly"] =
 `;
 /* end snapshot vaadin-password-field readonly */
 
-snapshots["vaadin-password-field invalid"] =
+snapshots["vaadin-password-field invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -210,7 +210,7 @@ snapshots["vaadin-password-field invalid"] =
 `;
 /* end snapshot vaadin-password-field invalid */
 
-snapshots["vaadin-password-field theme"] =
+snapshots["vaadin-password-field theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -263,7 +263,7 @@ snapshots["vaadin-password-field theme"] =
 `;
 /* end snapshot vaadin-password-field theme */
 
-snapshots["vaadin-password-field slots"] =
+snapshots["vaadin-password-field slots"] = 
 `<input
   autocapitalize="off"
   slot="input"

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -128,7 +128,7 @@ class Select extends DelegateFocusMixin(
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
-          <span part="indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-select default"] =
+snapshots["vaadin-select default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -42,7 +42,7 @@ snapshots["vaadin-select default"] =
 `;
 /* end snapshot vaadin-select default */
 
-snapshots["vaadin-select disabled"] =
+snapshots["vaadin-select disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -86,7 +86,7 @@ snapshots["vaadin-select disabled"] =
 `;
 /* end snapshot vaadin-select disabled */
 
-snapshots["vaadin-select readonly"] =
+snapshots["vaadin-select readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -130,7 +130,7 @@ snapshots["vaadin-select readonly"] =
 `;
 /* end snapshot vaadin-select readonly */
 
-snapshots["vaadin-select invalid"] =
+snapshots["vaadin-select invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -174,7 +174,7 @@ snapshots["vaadin-select invalid"] =
 `;
 /* end snapshot vaadin-select invalid */
 
-snapshots["vaadin-select theme"] =
+snapshots["vaadin-select theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -218,7 +218,7 @@ snapshots["vaadin-select theme"] =
 `;
 /* end snapshot vaadin-select theme */
 
-snapshots["vaadin-select slots"] =
+snapshots["vaadin-select slots"] = 
 `<label slot="label">
 </label>
 <div

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -1,14 +1,14 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-select default"] = 
+snapshots["vaadin-select default"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -42,14 +42,14 @@ snapshots["vaadin-select default"] =
 `;
 /* end snapshot vaadin-select default */
 
-snapshots["vaadin-select disabled"] = 
+snapshots["vaadin-select disabled"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -86,14 +86,14 @@ snapshots["vaadin-select disabled"] =
 `;
 /* end snapshot vaadin-select disabled */
 
-snapshots["vaadin-select readonly"] = 
+snapshots["vaadin-select readonly"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -130,14 +130,14 @@ snapshots["vaadin-select readonly"] =
 `;
 /* end snapshot vaadin-select readonly */
 
-snapshots["vaadin-select invalid"] = 
+snapshots["vaadin-select invalid"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -174,14 +174,14 @@ snapshots["vaadin-select invalid"] =
 `;
 /* end snapshot vaadin-select invalid */
 
-snapshots["vaadin-select theme"] = 
+snapshots["vaadin-select theme"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -218,7 +218,7 @@ snapshots["vaadin-select theme"] =
 `;
 /* end snapshot vaadin-select theme */
 
-snapshots["vaadin-select slots"] = 
+snapshots["vaadin-select slots"] =
 `<label slot="label">
 </label>
 <div

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -143,7 +143,7 @@ export class TextArea extends CharLengthMixin(
       <div part="container">
         <div part="label">
           <slot name="label"></slot>
-          <span part="indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-text-area default"] =
+snapshots["vaadin-text-area default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -44,7 +44,7 @@ snapshots["vaadin-text-area default"] =
 `;
 /* end snapshot vaadin-text-area default */
 
-snapshots["vaadin-text-area disabled"] =
+snapshots["vaadin-text-area disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -90,7 +90,7 @@ snapshots["vaadin-text-area disabled"] =
 `;
 /* end snapshot vaadin-text-area disabled */
 
-snapshots["vaadin-text-area readonly"] =
+snapshots["vaadin-text-area readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -136,7 +136,7 @@ snapshots["vaadin-text-area readonly"] =
 `;
 /* end snapshot vaadin-text-area readonly */
 
-snapshots["vaadin-text-area invalid"] =
+snapshots["vaadin-text-area invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -182,7 +182,7 @@ snapshots["vaadin-text-area invalid"] =
 `;
 /* end snapshot vaadin-text-area invalid */
 
-snapshots["vaadin-text-area theme"] =
+snapshots["vaadin-text-area theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -228,7 +228,7 @@ snapshots["vaadin-text-area theme"] =
 `;
 /* end snapshot vaadin-text-area theme */
 
-snapshots["vaadin-text-area slots"] =
+snapshots["vaadin-text-area slots"] = 
 `<textarea slot="textarea">
 </textarea>
 <label slot="label">

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -1,14 +1,14 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-text-area default"] = 
+snapshots["vaadin-text-area default"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -44,14 +44,14 @@ snapshots["vaadin-text-area default"] =
 `;
 /* end snapshot vaadin-text-area default */
 
-snapshots["vaadin-text-area disabled"] = 
+snapshots["vaadin-text-area disabled"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -90,14 +90,14 @@ snapshots["vaadin-text-area disabled"] =
 `;
 /* end snapshot vaadin-text-area disabled */
 
-snapshots["vaadin-text-area readonly"] = 
+snapshots["vaadin-text-area readonly"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -136,14 +136,14 @@ snapshots["vaadin-text-area readonly"] =
 `;
 /* end snapshot vaadin-text-area readonly */
 
-snapshots["vaadin-text-area invalid"] = 
+snapshots["vaadin-text-area invalid"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -182,14 +182,14 @@ snapshots["vaadin-text-area invalid"] =
 `;
 /* end snapshot vaadin-text-area invalid */
 
-snapshots["vaadin-text-area theme"] = 
+snapshots["vaadin-text-area theme"] =
 `<div part="container">
   <div part="label">
     <slot name="label">
     </slot>
     <span
       aria-hidden="true"
-      part="indicator"
+      part="required-indicator"
     >
     </span>
   </div>
@@ -228,7 +228,7 @@ snapshots["vaadin-text-area theme"] =
 `;
 /* end snapshot vaadin-text-area theme */
 
-snapshots["vaadin-text-area slots"] = 
+snapshots["vaadin-text-area slots"] =
 `<textarea slot="textarea">
 </textarea>
 <label slot="label">

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -30,7 +30,7 @@ export class TextField extends TextFieldMixin(InputSlotMixin(ThemableMixin(Eleme
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
-          <span part="indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.js
@@ -197,7 +197,7 @@ class ComboBox extends ComboBoxDataProviderMixin(
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
-          <span part="indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/vaadin-date-picker/src/vaadin-date-picker.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker.js
@@ -133,7 +133,7 @@ class DatePicker extends DatePickerMixin(
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
-          <span part="indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -43,7 +43,7 @@ const requiredField = css`
   /* TODO: remove old pseudo element when the following components are updated to use new indicator:
     combo-box, date-picker, time-picker, date-time-picker, select. */
   [part='label']::after,
-  [part='indicator']::after {
+  [part='required-indicator']::after {
     content: var(--lumo-required-field-indicator, '•');
     transition: opacity 0.2s;
     opacity: 0;
@@ -55,12 +55,12 @@ const requiredField = css`
   }
 
   :host([required]:not([has-value])) [part='label']::after,
-  :host([required]:not([has-value])) [part='indicator']::after {
+  :host([required]:not([has-value])) [part='required-indicator']::after {
     opacity: 1;
   }
 
   :host([invalid]) [part='label']::after,
-  :host([invalid]) [part='indicator']::after {
+  :host([invalid]) [part='required-indicator']::after {
     color: var(--lumo-error-text-color);
   }
 
@@ -101,7 +101,7 @@ const requiredField = css`
   }
 
   :host([dir='rtl']) [part='label']::after,
-  :host([dir='rtl']) [part='indicator']::after {
+  :host([dir='rtl']) [part='required-indicator']::after {
     right: auto;
     left: 0;
   }

--- a/packages/vaadin-material-styles/mixins/required-field.js
+++ b/packages/vaadin-material-styles/mixins/required-field.js
@@ -26,7 +26,7 @@ const requiredField = css`
   /* TODO: remove old pseudo element when the following components are updated to use new indicator:
     combo-box, date-picker, time-picker, date-time-picker, select. */
   :host([required]) [part='label']::after,
-  :host([required]) [part='indicator']::after {
+  :host([required]) [part='required-indicator']::after {
     content: ' *';
     color: inherit;
   }

--- a/packages/vaadin-time-picker/src/vaadin-time-picker.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker.js
@@ -106,7 +106,7 @@ class TimePicker extends PatternMixin(
       <div part="container">
         <div part="label" on-click="focus">
           <slot name="label"></slot>
-          <span part="indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
         <vaadin-time-picker-combo-box


### PR DESCRIPTION
## Description

Renames the `indicator` part to `required-indicator`. 

The `required-indicator` name was chosen to align the name with the existing `setRequiredIndicatorVisible` Flow method.

Fixes #2621

## Type of change

- [x] Breaking change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
