### PR TITLE
refactor: remove grid._toggleAttribute

### DIFF
--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -65,7 +65,7 @@ export const InlineEditingMixin = (superClass) =>
       this._addEditColumnListener('mousedown', (e) => {
         // prevent grid from resetting navigating state
         e.stopImmediatePropagation();
-        this._toggleAttribute('navigating', true, this);
+        this.toggleAttribute('navigating', true);
       });
 
       this._addEditColumnListener('focusout', (e) => {

--- a/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column-reordering-mixin.js
@@ -129,7 +129,7 @@ export const ColumnReorderingMixin = (superClass) =>
         return;
       }
 
-      this._toggleAttribute('reordering', true, this);
+      this.toggleAttribute('reordering', true);
       this._draggedColumn = headerCell._column;
       while (this._draggedColumn.parentElement.childElementCount === 1) {
         // This is the only column in the group, drag the whole group instead
@@ -175,7 +175,7 @@ export const ColumnReorderingMixin = (superClass) =>
         return;
       }
 
-      this._toggleAttribute('reordering', false, this);
+      this.toggleAttribute('reordering', false);
       this._draggedColumn._reorderStatus = '';
       this._setSiblingsReorderStatus(this._draggedColumn, '');
       this._draggedColumn = null;
@@ -213,10 +213,10 @@ export const ColumnReorderingMixin = (superClass) =>
       x = x || 0;
       y = y || 0;
       if (!this._draggedColumn) {
-        this._toggleAttribute('no-content-pointer-events', true, this.$.scroller);
+        this.$.scroller.toggleAttribute('no-content-pointer-events', true);
       }
       const cell = this.shadowRoot.elementFromPoint(x, y);
-      this._toggleAttribute('no-content-pointer-events', false, this.$.scroller);
+      this.$.scroller.toggleAttribute('no-content-pointer-events', false);
 
       // Make sure the element is actually a cell
       if (cell && cell._column) {

--- a/packages/vaadin-grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column-resizing-mixin.js
@@ -39,7 +39,7 @@ export const ColumnResizingMixin = (superClass) =>
         const cell = handle.parentElement;
         let column = cell._column;
 
-        this._toggleAttribute('column-resizing', true, this.$.scroller);
+        this.$.scroller.toggleAttribute('column-resizing', true);
 
         // Get the target column to resize
         while (column.localName === 'vaadin-grid-column-group') {
@@ -88,7 +88,7 @@ export const ColumnResizingMixin = (superClass) =>
           });
 
         if (e.detail.state === 'end') {
-          this._toggleAttribute('column-resizing', false, this.$.scroller);
+          this.$.scroller.toggleAttribute('column-resizing', false);
           this.dispatchEvent(
             new CustomEvent('column-resize', {
               detail: { resizedColumn: column }

--- a/packages/vaadin-grid/src/vaadin-grid-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column.d.ts
@@ -69,8 +69,6 @@ interface ColumnBaseMixin<TItem> {
   _findHostGrid(): GridElement<TItem> | undefined;
 
   _generateHeader(path: string): string;
-
-  _toggleAttribute(name: string, bool: boolean, node: Element): void;
 }
 
 /**

--- a/packages/vaadin-grid/src/vaadin-grid-column.js
+++ b/packages/vaadin-grid/src/vaadin-grid-column.js
@@ -312,14 +312,14 @@ export const ColumnBaseMixin = (superClass) =>
         this.parentElement._columnPropChanged('frozen', frozen);
       }
 
-      this._allCells.forEach((cell) => this._toggleAttribute('frozen', frozen, cell));
+      this._allCells.forEach((cell) => cell.toggleAttribute('frozen', frozen));
 
       this._grid && this._grid._frozenCellsChanged && this._grid._frozenCellsChanged();
     }
 
     /** @private */
     _lastFrozenChanged(lastFrozen) {
-      this._allCells.forEach((cell) => this._toggleAttribute('last-frozen', lastFrozen, cell));
+      this._allCells.forEach((cell) => cell.toggleAttribute('last-frozen', lastFrozen));
 
       if (this.parentElement && this.parentElement._columnPropChanged) {
         this.parentElement._lastFrozen = lastFrozen;
@@ -338,22 +338,6 @@ export const ColumnBaseMixin = (superClass) =>
         .toLowerCase()
         .replace(/-/g, ' ')
         .replace(/^./, (match) => match.toUpperCase());
-    }
-
-    /**
-     * @param {string} name
-     * @param {boolean} bool
-     * @param {!Element} node
-     * @protected
-     */
-    _toggleAttribute(name, bool, node) {
-      if (node.hasAttribute(name) === !bool) {
-        if (bool) {
-          node.setAttribute(name, '');
-        } else {
-          node.removeAttribute(name);
-        }
-      }
     }
 
     /** @private */

--- a/packages/vaadin-grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-data-provider-mixin.js
@@ -241,13 +241,13 @@ export const DataProviderMixin = (superClass) =>
       const { cache, scaledIndex } = this._cache.getCacheAndIndex(index);
       const item = cache.items[scaledIndex];
       if (item) {
-        this._toggleAttribute('loading', false, el);
+        el.toggleAttribute('loading', false);
         this._updateItem(el, item);
         if (this._isExpanded(item)) {
           cache.ensureSubCacheForScaledIndex(scaledIndex);
         }
       } else {
-        this._toggleAttribute('loading', true, el);
+        el.toggleAttribute('loading', true);
         this._loadPage(this._getPageForIndex(scaledIndex), cache);
       }
     }

--- a/packages/vaadin-grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -117,7 +117,7 @@ export const DragAndDropMixin = (superClass) =>
         }
 
         e.stopPropagation();
-        this._toggleAttribute('dragging-rows', true, this);
+        this.toggleAttribute('dragging-rows', true);
 
         if (this._safari) {
           // Safari doesn't position drag images from transformed
@@ -174,7 +174,7 @@ export const DragAndDropMixin = (superClass) =>
 
     /** @private */
     _onDragEnd(e) {
-      this._toggleAttribute('dragging-rows', false, this);
+      this.toggleAttribute('dragging-rows', false);
       e.stopPropagation();
       const event = new CustomEvent('grid-dragend');
       event.originalEvent = e;
@@ -245,7 +245,7 @@ export const DragAndDropMixin = (superClass) =>
         e.preventDefault();
 
         if (this._dropLocation === DropLocation.EMPTY) {
-          this._toggleAttribute('dragover', true, this);
+          this.toggleAttribute('dragover', true);
         } else if (row) {
           this._dragOverItem = row._item;
           if (row.getAttribute('dragover') !== this._dropLocation) {
@@ -389,8 +389,8 @@ export const DragAndDropMixin = (superClass) =>
         }
       });
 
-      this._toggleAttribute('drag-disabled', dragDisabled, row);
-      this._toggleAttribute('drop-disabled', dropDisabled, row);
+      row.toggleAttribute('drag-disabled', !!dragDisabled);
+      row.toggleAttribute('drop-disabled', !!dropDisabled);
     }
 
     /**

--- a/packages/vaadin-grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -164,8 +164,8 @@ export const DynamicColumnsMixin = (superClass) =>
           return a._column._order - b._column._order;
         })
         .forEach((cell, cellIndex, children) => {
-          this._toggleAttribute('first-column', cellIndex === 0, cell);
-          this._toggleAttribute('last-column', cellIndex === children.length - 1, cell);
+          cell.toggleAttribute('first-column', cellIndex === 0);
+          cell.toggleAttribute('last-column', cellIndex === children.length - 1);
         });
     }
 

--- a/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -89,7 +89,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       this.$.table.addEventListener('focusin', this._onContentFocusIn.bind(this));
 
       this.addEventListener('mousedown', () => {
-        this._toggleAttribute('navigating', false, this);
+        this.toggleAttribute('navigating', false);
         this._isMousedown = true;
       });
       this.addEventListener('mouseup', () => (this._isMousedown = false));
@@ -387,7 +387,7 @@ export const KeyboardNavigationMixin = (superClass) =>
           }
         }
 
-        this._toggleAttribute('navigating', true, this);
+        this.toggleAttribute('navigating', true);
 
         return { dstRow: activeRowGroup.children[dstRowIndex] };
       } else {
@@ -428,7 +428,7 @@ export const KeyboardNavigationMixin = (superClass) =>
 
         // This has to be set after scrolling, otherwise it can be removed by
         // `_preventScrollerRotatingCellFocus(row, index)` during scrolling.
-        this._toggleAttribute('navigating', true, this);
+        this.toggleAttribute('navigating', true);
 
         return {
           dstRow: [...activeRowGroup.children].find((el) => !el.hidden && el.index === dstRowIndex),
@@ -535,14 +535,14 @@ export const KeyboardNavigationMixin = (superClass) =>
             e.preventDefault();
             focusTarget.focus();
             this._setInteracting(true);
-            this._toggleAttribute('navigating', false, this);
+            this.toggleAttribute('navigating', false);
           }
         } else {
           e.preventDefault();
           this._focusedColumnOrder = undefined;
           cell.focus();
           this._setInteracting(false);
-          this._toggleAttribute('navigating', true, this);
+          this.toggleAttribute('navigating', true);
         }
       }
     }
@@ -606,7 +606,7 @@ export const KeyboardNavigationMixin = (superClass) =>
         focusTarget.focus();
       }
 
-      this._toggleAttribute('navigating', true, this);
+      this.toggleAttribute('navigating', true);
     }
 
     /** @private */
@@ -638,7 +638,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       if (cell._content && cell._content.firstElementChild) {
         const wasNavigating = this.hasAttribute('navigating');
         cell._content.firstElementChild.click();
-        this._toggleAttribute('navigating', wasNavigating, this);
+        this.toggleAttribute('navigating', wasNavigating);
       }
     }
 
@@ -648,7 +648,7 @@ export const KeyboardNavigationMixin = (superClass) =>
      */
     _onFocusIn(e) {
       if (!this._isMousedown) {
-        this._toggleAttribute('navigating', true, this);
+        this.toggleAttribute('navigating', true);
       }
 
       const rootTarget = e.composedPath()[0];
@@ -669,7 +669,7 @@ export const KeyboardNavigationMixin = (superClass) =>
      * @protected
      */
     _onFocusOut(e) {
-      this._toggleAttribute('navigating', false, this);
+      this.toggleAttribute('navigating', false);
       this._detectInteracting(e);
     }
 
@@ -746,12 +746,12 @@ export const KeyboardNavigationMixin = (superClass) =>
       ) {
         // Focused item has went, hide navigation mode
         this._navigatingIsHidden = true;
-        this._toggleAttribute('navigating', false, this);
+        this.toggleAttribute('navigating', false);
       }
       if (index === this._focusedItemIndex && this._navigatingIsHidden) {
         // Focused item is back, restore navigation mode
         this._navigatingIsHidden = false;
-        this._toggleAttribute('navigating', true, this);
+        this.toggleAttribute('navigating', true);
       }
     }
 

--- a/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-row-details-mixin.js
@@ -119,7 +119,7 @@ export const RowDetailsMixin = (superClass) =>
       cell.setAttribute('part', 'cell details-cell');
       // Freeze the details cell, so that it does not scroll horizontally
       // with the normal cells. This way it looks less weird.
-      this._toggleAttribute('frozen', true, cell);
+      cell.toggleAttribute('frozen', true);
 
       this._detailsCellResizeObserver.observe(cell);
     }

--- a/packages/vaadin-grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/vaadin-grid/src/vaadin-grid-scroll-mixin.js
@@ -103,12 +103,12 @@ export const ScrollMixin = (superClass) =>
     _scheduleScrolling() {
       if (!this._scrollingFrame) {
         // Defer setting state attributes to avoid Edge hiccups
-        this._scrollingFrame = requestAnimationFrame(() => this._toggleAttribute('scrolling', true, this.$.scroller));
+        this._scrollingFrame = requestAnimationFrame(() => this.$.scroller.toggleAttribute('scrolling', true));
       }
       this._debounceScrolling = Debouncer.debounce(this._debounceScrolling, timeOut.after(timeouts.SCROLLING), () => {
         cancelAnimationFrame(this._scrollingFrame);
         delete this._scrollingFrame;
-        this._toggleAttribute('scrolling', false, this.$.scroller);
+        this.$.scroller.toggleAttribute('scrolling', false);
       });
     }
 

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -354,8 +354,6 @@ declare class GridElement<TItem = GridDefaultItem> extends HTMLElement {
 
   _updateItem(row: HTMLElement, item: TItem | null): void;
 
-  _toggleAttribute(name: string, bool: boolean, node: Element): void;
-
   __getRowModel(row: HTMLTableRowElement): GridItemModel<TItem>;
 
   /**

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -805,8 +805,8 @@ class GridElement extends ElementMixin(
       return;
     }
 
-    this._toggleAttribute('first', index === 0, row);
-    this._toggleAttribute('odd', index % 2, row);
+    row.toggleAttribute('first', index === 0);
+    row.toggleAttribute('odd', index % 2);
     this._a11yUpdateRowRowindex(row, index);
     this._getItem(index, row);
   }
@@ -891,9 +891,9 @@ class GridElement extends ElementMixin(
     this._a11yUpdateRowExpanded(row, model.expanded);
     this._a11yUpdateRowDetailsOpened(row, model.detailsOpened);
 
-    this._toggleAttribute('expanded', model.expanded, row);
-    this._toggleAttribute('selected', model.selected, row);
-    this._toggleAttribute('details-opened', model.detailsOpened, row);
+    row.toggleAttribute('expanded', model.expanded);
+    row.toggleAttribute('selected', model.selected);
+    row.toggleAttribute('details-opened', model.detailsOpened);
 
     this._generateCellClassNames(row, model);
     this._filterDragAndDrop(row, model);
@@ -927,22 +927,6 @@ class GridElement extends ElementMixin(
         // This needs to be set programmatically in order to avoid an iOS 10 bug (disappearing grid)
         this.$.table.style.webkitOverflowScrolling = 'touch';
       });
-    }
-  }
-
-  /**
-   * @param {string} name
-   * @param {boolean} bool
-   * @param {!Element} node
-   * @protected
-   */
-  _toggleAttribute(name, bool, node) {
-    if (node.hasAttribute(name) === !bool) {
-      if (bool) {
-        node.setAttribute(name, '');
-      } else {
-        node.removeAttribute(name);
-      }
     }
   }
 

--- a/packages/vaadin-grid/test/basic.test.js
+++ b/packages/vaadin-grid/test/basic.test.js
@@ -32,44 +32,6 @@ describe('basic features', () => {
     flushGrid(grid);
   });
 
-  describe('toggle attribute', () => {
-    let node;
-
-    beforeEach(() => {
-      node = {};
-      node.setAttribute = sinon.spy();
-      node.removeAttribute = sinon.spy();
-    });
-
-    it('should set attribute', () => {
-      node.hasAttribute = () => false;
-      grid._toggleAttribute('foo', true, node);
-      expect(node.setAttribute.called).to.be.true;
-    });
-
-    it('should not re-set attribute', () => {
-      node.hasAttribute = () => true;
-      grid._toggleAttribute('foo', true, node);
-      expect(node.setAttribute.called).to.be.false;
-    });
-
-    it('should remove attribute', () => {
-      node.hasAttribute = () => true;
-      grid._toggleAttribute('foo', false, node);
-      grid._toggleAttribute('foo', '', node);
-      grid._toggleAttribute('foo', undefined, node);
-      expect(node.removeAttribute.callCount).to.equal(3);
-    });
-
-    it('should not re-remove attribute', () => {
-      node.hasAttribute = () => false;
-      grid._toggleAttribute('foo', false, node);
-      grid._toggleAttribute('foo', '', node);
-      grid._toggleAttribute('foo', undefined, node);
-      expect(node.removeAttribute.called).to.be.false;
-    });
-  });
-
   it('should notify `size` property', () => {
     const spy = sinon.spy();
     grid.addEventListener('size-changed', spy);

--- a/packages/vaadin-grid/test/column-reordering.test.js
+++ b/packages/vaadin-grid/test/column-reordering.test.js
@@ -290,16 +290,6 @@ describe('reordering simple grid', () => {
       expect(col._order).to.equal(50000000);
     });
 
-    it('should not toggle last-column for cells on existing rows', () => {
-      const attributeSpy = sinon.spy(grid, '_toggleAttribute');
-      grid.size++;
-      flushGrid(grid);
-
-      const calls = attributeSpy.getCalls().filter((f) => f.args[0] === 'last-column');
-      const columnCount = grid.querySelectorAll('vaadin-grid-column').length;
-      expect(calls.length).to.equal(columnCount);
-    });
-
     it('should fire `column-reorder` event with columns', () => {
       const spy = sinon.spy();
       grid.addEventListener('column-reorder', spy);


### PR DESCRIPTION
All the currently supported browsers have the native `Element.toggleAttribute()` API built-in, so there's no longer a need for the `grid._toggleAttribute()` helper.