### PR TITLE
refactor: sort import statements

### DIFF
--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
+import { fixtureSync, oneEvent, nextRender } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-import { fixtureSync, oneEvent, nextRender } from '@vaadin/testing-helpers';
-import { chartDefaultTheme } from '../theme/vaadin-chart-default-theme.js';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 import HttpUtilities from 'highcharts/es-modules/Core/HttpUtilities.js';
+import { chartDefaultTheme } from '../theme/vaadin-chart-default-theme.js';
 
 import '../vaadin-chart.js';
 

--- a/packages/charts/test/styling.test.js
+++ b/packages/charts/test/styling.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import { chartDefaultTheme } from '../theme/vaadin-chart-default-theme.js';
 import '../vaadin-chart.js';
 

--- a/packages/component-base/test/dir-mixin.test.js
+++ b/packages/component-base/test/dir-mixin.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DirMixin } from '../src/dir-mixin.js';
-import sinon from 'sinon';
 
 class DirMixinElement extends DirMixin(PolymerElement) {
   static get is() {

--- a/packages/vaadin-combo-box/test/combo-box-light.test.js
+++ b/packages/vaadin-combo-box/test/combo-box-light.test.js
@@ -13,8 +13,8 @@ import {
   isDesktopSafari,
   nextFrame
 } from '@vaadin/testing-helpers';
-import { resetMouseCanceller } from '@polymer/polymer/lib/utils/gestures.js';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { resetMouseCanceller } from '@polymer/polymer/lib/utils/gestures.js';
 import '@vaadin/vaadin-text-field/vaadin-text-field.js';
 import '@vaadin/vaadin-template-renderer';
 import { createEventSpy, getFirstItem } from './helpers.js';

--- a/packages/vaadin-combo-box/test/filtering.test.js
+++ b/packages/vaadin-combo-box/test/filtering.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { getAllItems, onceOpened } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';

--- a/packages/vaadin-combo-box/test/lazy-loading.test.js
+++ b/packages/vaadin-combo-box/test/lazy-loading.test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { fixtureSync, nextFrame, aTimeout, enterKeyDown, fire } from '@vaadin/testing-helpers';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import '@vaadin/vaadin-text-field/vaadin-text-field.js';
+import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import {
   flushComboBox,
@@ -16,7 +17,6 @@ import {
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 import '../vaadin-combo-box-light.js';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-combo-box*',

--- a/packages/vaadin-custom-field/test/helper.test.js
+++ b/packages/vaadin-custom-field/test/helper.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import sinon from 'sinon';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '../vaadin-custom-field.js';
 
 class XHelper extends PolymerElement {

--- a/packages/vaadin-date-picker/test/form-input.test.js
+++ b/packages/vaadin-date-picker/test/form-input.test.js
@@ -2,8 +2,8 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
-import { close, open } from './common.js';
 import { DatePicker } from '../vaadin-date-picker.js';
+import { close, open } from './common.js';
 
 class DatePicker2016 extends DatePicker {
   checkValidity() {

--- a/packages/vaadin-grid-pro/test/grid-pro.test.js
+++ b/packages/vaadin-grid-pro/test/grid-pro.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { GridElement } from '@vaadin/vaadin-grid/src/vaadin-grid.js';
 import { GridColumnElement } from '@vaadin/vaadin-grid/src/vaadin-grid-column.js';
 import '@vaadin/vaadin-template-renderer';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import { flushGrid, infiniteDataProvider } from './helpers.js';
 import '../vaadin-grid-pro.js';
 

--- a/packages/vaadin-grid/test/column-group.test.js
+++ b/packages/vaadin-grid/test/column-group.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import '@vaadin/vaadin-template-renderer';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';

--- a/packages/vaadin-notification/test/statichelper.test.js
+++ b/packages/vaadin-notification/test/statichelper.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
+import { aTimeout } from '@vaadin/testing-helpers';
+import { html } from 'lit';
 import { NotificationElement } from '../src/vaadin-notification.js';
 import '../vaadin-notification.js';
-import { html } from 'lit';
-import { aTimeout } from '@vaadin/testing-helpers';
 
 describe('static helpers', () => {
   it('show should show a text notification', () => {

--- a/packages/vaadin-overlay/test/position-target.test.js
+++ b/packages/vaadin-overlay/test/position-target.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { css } from 'lit';
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
 import { PositionMixin } from '../src/vaadin-overlay-position-mixin.js';
 import { OverlayElement } from '../src/vaadin-overlay.js';
-import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
-import { css } from 'lit';
 import '../vaadin-overlay.js';
 
 class PositionedOverlay extends PositionMixin(OverlayElement) {


### PR DESCRIPTION
## Description

This PR is the result of a one-pass run of the `import/order` ESLint rule with the following configuration:

```json
"import/order": ["error", {
  "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
  "pathGroups": [
    { "pattern": "@vaadin/testing-helpers", "group": "external" },
    { "pattern": "@vaadin/testing-helpers/**", "group": "external" },
    { "pattern": "@polymer/polymer/polymer-element.js", "group": "internal", "position": "after" },
    { "pattern": "@polymer/**", "group": "internal", "position": "after" },
    { "pattern": "lit", "group": "internal", "position": "after" },
    { "pattern": "lit/**", "group": "internal", "position": "after" },
    { "pattern": "@vaadin/component-base/**", "group": "internal", "position": "after" },
    { "pattern": "@vaadin/field-base/**", "group": "internal", "position": "after" },
    { "pattern": "@vaadin/**", "group": "internal", "position": "after" },
    { "pattern": "highcharts/**", "group": "internal", "position": "after" }
  ],
  "pathGroupsExcludedImportTypes": []
}]
```

Part of #2537 (issue)

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
