### PR TITLE
refactor: remove unnecessary duplicate selector from compact preset

### DIFF
--- a/packages/vaadin-lumo-styles/presets/compact.js
+++ b/packages/vaadin-lumo-styles/presets/compact.js
@@ -9,34 +9,7 @@ const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `
   <style>
-    /* Browsers that fall back to the polyfill require plain html selector */
-    html {
-      --lumo-size-xl: 3rem;
-      --lumo-size-l: 2.5rem;
-      --lumo-size-m: 2rem;
-      --lumo-size-s: 1.75rem;
-      --lumo-size-xs: 1.5rem;
-      --lumo-font-size: 1rem;
-      --lumo-font-size-xxxl: 1.75rem;
-      --lumo-font-size-xxl: 1.375rem;
-      --lumo-font-size-xl: 1.125rem;
-      --lumo-font-size-l: 1rem;
-      --lumo-font-size-m: 0.875rem;
-      --lumo-font-size-s: 0.8125rem;
-      --lumo-font-size-xs: 0.75rem;
-      --lumo-font-size-xxs: 0.6875rem;
-      --lumo-line-height-m: 1.4;
-      --lumo-line-height-s: 1.2;
-      --lumo-line-height-xs: 1.1;
-      --lumo-space-xl: 1.875rem;
-      --lumo-space-l: 1.25rem;
-      --lumo-space-m: 0.625rem;
-      --lumo-space-s: 0.3125rem;
-      --lumo-space-xs: 0.1875rem;
-    }
-
-    /* Need to use a separate and stronger selector for other browsers where
-    the imports added later would otherwise override the property values */
+    /* Use a stronger selector so that imports added later do not override the property values */
     html:not(div) {
       --lumo-size-xl: 3rem;
       --lumo-size-l: 2.5rem;


### PR DESCRIPTION
Shady CSS is no longer needed by any supported browsers.