### PR TITLE
refactor: update grid dragover=on-top visual style (Lumo)

### DIFF
--- a/packages/vaadin-grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/vaadin-grid/theme/lumo/vaadin-grid-styles.js
@@ -115,6 +115,10 @@ registerStyles(
       background: var(--lumo-primary-color-50pct);
     }
 
+    [part~='row'][dragover] [part~='cell'][last-frozen]::after {
+      right: -1px;
+    }
+
     :host([theme~='no-row-borders']) [dragover] [part~='cell']::after {
       height: 2px;
     }
@@ -138,13 +142,7 @@ registerStyles(
 
     [part~='row'][dragover][dragover='on-top'] [part~='cell']::after {
       height: 100%;
-    }
-
-    [part~='row'][dragstart] {
-      /* Add bottom-space to the row so the drag number doesn't get clipped. Needed for IE/Edge */
-      border-bottom: 100px solid transparent;
-      z-index: 100 !important;
-      opacity: 0.9;
+      opacity: 0.5;
     }
 
     [part~='row'][dragstart] [part~='cell'] {


### PR DESCRIPTION
Reduce the opacity of the drag overlay when `dragover="on-top"`.

Extend the drag overlay to cover the frozen column divider (right border of the last frozen column), so that the overlay is perceived as one single element on top of all columns (no gaps).

Remove unnecessary styles that target IE/Edge (no longer supported).

This PR is required before merging #2626 (see https://github.com/vaadin/web-components/pull/2626#issuecomment-927725400).