### PR TITLE
chore: change test coverage to only run when running all tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:types": "tsc",
     "serve:dist": "web-dev-server --app-index dist/index.html --open",
     "start": "web-dev-server --node-resolve --open /dev/index.html",
-    "test": "web-test-runner --coverage",
+    "test": "web-test-runner",
     "test:firefox": "web-test-runner --config web-test-runner-firefox.config.js",
     "test:lumo": "web-test-runner --config web-test-runner-lumo.config.js",
     "test:material": "web-test-runner --config web-test-runner-material.config.js",

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -5,10 +5,10 @@ module.exports = createUnitTestsConfig({
   coverageConfig: {
     include: ['packages/**/src/*', 'packages/**/*.js'],
     threshold: {
-      statements: 75,
-      branches: 50,
-      functions: 56,
-      lines: 75
+      statements: 95,
+      branches: 90,
+      functions: 92,
+      lines: 95
     }
   }
 });

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -115,30 +115,6 @@ const getTestPackages = (allPackages) => {
 };
 
 /**
- * Get packages for running snapshot tests.
- */
-const getSnapshotTestPackages = () => {
-  let snapshotPackages = getAllSnapshotPackages();
-  return getTestPackages(snapshotPackages);
-};
-
-/**
- * Get packages for running unit tests.
- */
-const getUnitTestPackages = () => {
-  const unitPackages = getAllUnitPackages();
-  return getTestPackages(unitPackages);
-};
-
-/**
- * Get packages for running visual tests.
- */
-const getVisualTestPackages = () => {
-  const visualPackages = getAllVisualPackages();
-  return getTestPackages(visualPackages);
-};
-
-/**
  * Get unit test groups based on packages.
  */
 const getSnapshotTestGroups = (packages) => {
@@ -254,7 +230,8 @@ const getDiffScreenshotName = (args) => getScreenshotFileName(args, 'failed', tr
 const getFailedScreenshotName = (args) => getScreenshotFileName(args, 'failed');
 
 const createSnapshotTestsConfig = (config) => {
-  const packages = getSnapshotTestPackages();
+  const snapshotPackages = getAllSnapshotPackages();
+  const packages = getTestPackages(snapshotPackages);
   const groups = getSnapshotTestGroups(packages);
 
   return {
@@ -267,8 +244,13 @@ const createSnapshotTestsConfig = (config) => {
 };
 
 const createUnitTestsConfig = (config) => {
-  const packages = getUnitTestPackages();
-  const groups = getUnitTestGroups(packages);
+  const allPackages = getAllUnitPackages();
+  const testPackages = getTestPackages(allPackages);
+
+  // only collect coverage if all packages changed
+  const coverage = allPackages.length === testPackages.length;
+
+  const groups = getUnitTestGroups(testPackages);
 
   return {
     ...config,
@@ -282,6 +264,7 @@ const createUnitTestsConfig = (config) => {
         timeout: '10000'
       }
     },
+    coverage,
     groups,
     testRunnerHtml,
     filterBrowserLogs
@@ -289,7 +272,8 @@ const createUnitTestsConfig = (config) => {
 };
 
 const createVisualTestsConfig = (theme) => {
-  const packages = getVisualTestPackages();
+  const visualPackages = getAllVisualPackages();
+  const packages = getTestPackages(visualPackages);
   const groups = getVisualTestGroups(packages, theme);
 
   const sauceLabsLauncher = createSauceLabsLauncher(


### PR DESCRIPTION
## Description

We've been having issues with code coverage with tests when running tests for a single package. By changing the web test runner configuration so that coverage is only used when running tests from all packages we can avoid CI failing because of not meeting the testing threshold. We can also increase the coverage threshold again.