### PR TITLE
refactor: use CSS gap property for ordered layout spacing

### DIFF
--- a/packages/horizontal-layout/src/vaadin-horizontal-layout.js
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout.js
@@ -53,25 +53,8 @@ class HorizontalLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)
           padding: 1em;
         }
 
-        :host([theme~='spacing']:not([dir='rtl'])) ::slotted(*) {
-          margin-left: 1em;
-        }
-
-        :host([theme~='spacing'][dir='rtl']) ::slotted(*) {
-          margin-right: 1em;
-        }
-
-        /* Compensate for the first item margin, so that there is no gap around the layout itself. */
-        :host([theme~='spacing'])::before {
-          content: '';
-        }
-
-        :host([theme~='spacing']:not([dir='rtl']))::before {
-          margin-left: -1em;
-        }
-
-        :host([theme~='spacing'][dir='rtl'])::before {
-          margin-right: -1em;
+        :host([theme~='spacing']) {
+          gap: 1em;
         }
       </style>
 

--- a/packages/horizontal-layout/test/horizontal-layout.test.js
+++ b/packages/horizontal-layout/test/horizontal-layout.test.js
@@ -89,14 +89,8 @@ describe('vaadin-horizontal-layout', () => {
 
     it('should support theme="spacing"', () => {
       layout.setAttribute('theme', 'spacing');
-      expect(getComputedStyle(c1).getPropertyValue('margin-left')).to.equal(space);
-      expect(getComputedStyle(c2).getPropertyValue('margin-left')).to.equal(space);
-    });
-
-    it('should compensate first item margin for theme="spacing"', () => {
-      layout.setAttribute('theme', 'spacing');
-      const margin = getComputedStyle(layout, '::before').getPropertyValue('margin-left');
-      expect(margin).to.equal('-' + space);
+      const style = getComputedStyle(layout);
+      expect(style.getPropertyValue('gap')).to.equal(space);
     });
   });
 

--- a/packages/horizontal-layout/test/horizontal-layout.test.js
+++ b/packages/horizontal-layout/test/horizontal-layout.test.js
@@ -90,7 +90,10 @@ describe('vaadin-horizontal-layout', () => {
     it('should support theme="spacing"', () => {
       layout.setAttribute('theme', 'spacing');
       const style = getComputedStyle(layout);
-      expect(style.getPropertyValue('gap')).to.equal(space);
+      // Browsers can return either one or two values (e.g. '16px' or '16px 16px', vertical
+      // and horizontal gap) even if just one was provided by the author
+      const gap = style.getPropertyValue('gap').split(' ')[0];
+      expect(gap).to.equal(space);
     });
   });
 

--- a/packages/horizontal-layout/test/horizontal-layout.test.js
+++ b/packages/horizontal-layout/test/horizontal-layout.test.js
@@ -89,11 +89,7 @@ describe('vaadin-horizontal-layout', () => {
 
     it('should support theme="spacing"', () => {
       layout.setAttribute('theme', 'spacing');
-      const style = getComputedStyle(layout);
-      // Browsers can return either one or two values (e.g. '16px' or '16px 16px', vertical
-      // and horizontal gap) even if just one was provided by the author
-      const gap = style.getPropertyValue('gap').split(' ')[0];
-      expect(gap).to.equal(space);
+      expect(getComputedStyle(layout).columnGap).to.equal(space);
     });
   });
 

--- a/packages/horizontal-layout/theme/lumo/vaadin-horizontal-layout-styles.js
+++ b/packages/horizontal-layout/theme/lumo/vaadin-horizontal-layout-styles.js
@@ -10,95 +10,24 @@ const horizontalLayout = css`
     padding: var(--lumo-space-m);
   }
 
-  :host([theme~='spacing-xs']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: var(--lumo-space-xs);
+  :host([theme~='spacing-xs']) {
+    gap: var(--lumo-space-xs);
   }
 
-  :host([theme~='spacing-s']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: var(--lumo-space-s);
+  :host([theme~='spacing-s']) {
+    gap: var(--lumo-space-s);
   }
 
-  :host([theme~='spacing']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: var(--lumo-space-m);
+  :host([theme~='spacing']) {
+    gap: var(--lumo-space-m);
   }
 
-  :host([theme~='spacing-l']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: var(--lumo-space-l);
+  :host([theme~='spacing-l']) {
+    gap: var(--lumo-space-l);
   }
 
-  :host([theme~='spacing-xl']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: var(--lumo-space-xl);
-  }
-
-  /* Compensate for the first item margin, so that there is no gap around the layout itself. */
-  :host([theme~='spacing-xs'])::before,
-  :host([theme~='spacing-s'])::before,
-  :host([theme~='spacing'])::before,
-  :host([theme~='spacing-l'])::before,
-  :host([theme~='spacing-xl'])::before {
-    content: '';
-  }
-
-  :host([theme~='spacing-xs']:not([dir='rtl']))::before {
-    margin-left: calc(var(--lumo-space-xs) * -1);
-  }
-
-  :host([theme~='spacing-s']:not([dir='rtl']))::before {
-    margin-left: calc(var(--lumo-space-s) * -1);
-  }
-
-  :host([theme~='spacing']:not([dir='rtl']))::before {
-    margin-left: calc(var(--lumo-space-m) * -1);
-  }
-
-  :host([theme~='spacing-l']:not([dir='rtl']))::before {
-    margin-left: calc(var(--lumo-space-l) * -1);
-  }
-
-  :host([theme~='spacing-xl']:not([dir='rtl']))::before {
-    margin-left: calc(var(--lumo-space-xl) * -1);
-  }
-
-  /* RTL styles */
-  :host([dir='rtl'][theme~='spacing-xs']) ::slotted(*) {
-    margin-right: var(--lumo-space-xs);
-  }
-
-  :host([dir='rtl'][theme~='spacing-s']) ::slotted(*) {
-    margin-right: var(--lumo-space-s);
-  }
-
-  :host([dir='rtl'][theme~='spacing']) ::slotted(*) {
-    margin-right: var(--lumo-space-m);
-  }
-
-  :host([dir='rtl'][theme~='spacing-l']) ::slotted(*) {
-    margin-right: var(--lumo-space-l);
-  }
-
-  :host([dir='rtl'][theme~='spacing-xl']) ::slotted(*) {
-    margin-right: var(--lumo-space-xl);
-  }
-
-  /* Compensate for the first item margin, so that there is no gap around the layout itself. */
-  :host([dir='rtl'][theme~='spacing-xs'])::before {
-    margin-right: calc(var(--lumo-space-xs) * -1);
-  }
-
-  :host([dir='rtl'][theme~='spacing-s'])::before {
-    margin-right: calc(var(--lumo-space-s) * -1);
-  }
-
-  :host([dir='rtl'][theme~='spacing'])::before {
-    margin-right: calc(var(--lumo-space-m) * -1);
-  }
-
-  :host([dir='rtl'][theme~='spacing-l'])::before {
-    margin-right: calc(var(--lumo-space-l) * -1);
-  }
-
-  :host([dir='rtl'][theme~='spacing-xl'])::before {
-    margin-right: calc(var(--lumo-space-xl) * -1);
+  :host([theme~='spacing-xl']) {
+    gap: var(--lumo-space-xl);
   }
 `;
 

--- a/packages/horizontal-layout/theme/material/vaadin-horizontal-layout-styles.js
+++ b/packages/horizontal-layout/theme/material/vaadin-horizontal-layout-styles.js
@@ -9,95 +9,24 @@ const horizontalLayout = css`
     padding: 16px;
   }
 
-  :host([theme~='spacing-xs']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: 4px;
+  :host([theme~='spacing-xs']) {
+    gap: 4px;
   }
 
-  :host([theme~='spacing-s']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: 8px;
+  :host([theme~='spacing-s']) {
+    gap: 8px;
   }
 
-  :host([theme~='spacing']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: 16px;
+  :host([theme~='spacing']) {
+    gap: 16px;
   }
 
-  :host([theme~='spacing-l']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: 24px;
+  :host([theme~='spacing-l']) {
+    gap: 24px;
   }
 
-  :host([theme~='spacing-xl']:not([dir='rtl'])) ::slotted(*) {
-    margin-left: 40px;
-  }
-
-  /* Compensate for the first item margin, so that there is no gap around the layout itself. */
-  :host([theme~='spacing-xs'])::before,
-  :host([theme~='spacing-s'])::before,
-  :host([theme~='spacing'])::before,
-  :host([theme~='spacing-l'])::before,
-  :host([theme~='spacing-xl'])::before {
-    content: '';
-  }
-
-  :host([theme~='spacing-xs']:not([dir='rtl']))::before {
-    margin-left: -4px;
-  }
-
-  :host([theme~='spacing-s']:not([dir='rtl']))::before {
-    margin-left: -8px;
-  }
-
-  :host([theme~='spacing']:not([dir='rtl']))::before {
-    margin-left: -16px;
-  }
-
-  :host([theme~='spacing-l']:not([dir='rtl']))::before {
-    margin-left: -24px;
-  }
-
-  :host([theme~='spacing-xl']:not([dir='rtl']))::before {
-    margin-left: -40px;
-  }
-
-  /* RTL styles */
-  :host([dir='rtl'][theme~='spacing-xs']) ::slotted(*) {
-    margin-right: 4px;
-  }
-
-  :host([dir='rtl'][theme~='spacing-s']) ::slotted(*) {
-    margin-right: 8px;
-  }
-
-  :host([dir='rtl'][theme~='spacing']) ::slotted(*) {
-    margin-right: 16px;
-  }
-
-  :host([dir='rtl'][theme~='spacing-l']) ::slotted(*) {
-    margin-right: 24px;
-  }
-
-  :host([dir='rtl'][theme~='spacing-xl']) ::slotted(*) {
-    margin-right: 40px;
-  }
-
-  /* Compensate for the first item margin, so that there is no gap around the layout itself. */
-  :host([dir='rtl'][theme~='spacing-xs'])::before {
-    margin-right: -4px;
-  }
-
-  :host([dir='rtl'][theme~='spacing-s'])::before {
-    margin-right: -8px;
-  }
-
-  :host([dir='rtl'][theme~='spacing'])::before {
-    margin-right: -16px;
-  }
-
-  :host([dir='rtl'][theme~='spacing-l'])::before {
-    margin-right: -24px;
-  }
-
-  :host([dir='rtl'][theme~='spacing-xl'])::before {
-    margin-right: -40px;
+  :host([theme~='spacing-xl']) {
+    gap: 40px;
   }
 `;
 

--- a/packages/vertical-layout/src/vaadin-vertical-layout.js
+++ b/packages/vertical-layout/src/vaadin-vertical-layout.js
@@ -55,14 +55,8 @@ class VerticalLayoutElement extends ElementMixin(ThemableMixin(PolymerElement)) 
           padding: 1em;
         }
 
-        :host([theme~='spacing']) ::slotted(*) {
-          margin-top: 1em;
-        }
-
-        /* Compensate for the first item margin, so that there is no gap around the layout itself. */
-        :host([theme~='spacing'])::before {
-          content: '';
-          margin-top: -1em;
+        :host([theme~='spacing']) {
+          gap: 1em;
         }
       </style>
 

--- a/packages/vertical-layout/test/vertical-layout.test.js
+++ b/packages/vertical-layout/test/vertical-layout.test.js
@@ -90,11 +90,7 @@ describe('vaadin-vertical-layout', () => {
 
     it('should support theme="spacing"', () => {
       layout.setAttribute('theme', 'spacing');
-      const style = getComputedStyle(layout);
-      // Browsers can return either one or two values (e.g. '16px' or '16px 16px', vertical
-      // and horizontal gap) even if just one was provided by the author
-      const gap = style.getPropertyValue('gap').split(' ')[0];
-      expect(gap).to.equal(space);
+      expect(getComputedStyle(layout).rowGap).to.equal(space);
     });
   });
 

--- a/packages/vertical-layout/test/vertical-layout.test.js
+++ b/packages/vertical-layout/test/vertical-layout.test.js
@@ -90,14 +90,8 @@ describe('vaadin-vertical-layout', () => {
 
     it('should support theme="spacing"', () => {
       layout.setAttribute('theme', 'spacing');
-      expect(getComputedStyle(c1).getPropertyValue('margin-top')).to.equal(space);
-      expect(getComputedStyle(c2).getPropertyValue('margin-top')).to.equal(space);
-    });
-
-    it('should compensate first item margin for theme="spacing"', () => {
-      layout.setAttribute('theme', 'spacing');
-      const margin = getComputedStyle(layout, '::before').getPropertyValue('margin-top');
-      expect(margin).to.equal('-' + space);
+      const style = getComputedStyle(layout);
+      expect(style.getPropertyValue('gap')).to.equal(space);
     });
   });
 

--- a/packages/vertical-layout/test/vertical-layout.test.js
+++ b/packages/vertical-layout/test/vertical-layout.test.js
@@ -91,7 +91,10 @@ describe('vaadin-vertical-layout', () => {
     it('should support theme="spacing"', () => {
       layout.setAttribute('theme', 'spacing');
       const style = getComputedStyle(layout);
-      expect(style.getPropertyValue('gap')).to.equal(space);
+      // Browsers can return either one or two values (e.g. '16px' or '16px 16px', vertical
+      // and horizontal gap) even if just one was provided by the author
+      const gap = style.getPropertyValue('gap').split(' ')[0];
+      expect(gap).to.equal(space);
     });
   });
 

--- a/packages/vertical-layout/theme/lumo/vaadin-vertical-layout-styles.js
+++ b/packages/vertical-layout/theme/lumo/vaadin-vertical-layout-styles.js
@@ -10,50 +10,24 @@ const verticalLayout = css`
     padding: var(--lumo-space-m);
   }
 
-  :host([theme~='spacing-xs']) ::slotted(*) {
-    margin-top: var(--lumo-space-xs);
+  :host([theme~='spacing-xs']) {
+    gap: var(--lumo-space-xs);
   }
 
-  :host([theme~='spacing-s']) ::slotted(*) {
-    margin-top: var(--lumo-space-s);
+  :host([theme~='spacing-s']) {
+    gap: var(--lumo-space-s);
   }
 
-  :host([theme~='spacing']) ::slotted(*) {
-    margin-top: var(--lumo-space-m);
+  :host([theme~='spacing']) {
+    gap: var(--lumo-space-m);
   }
 
-  :host([theme~='spacing-l']) ::slotted(*) {
-    margin-top: var(--lumo-space-l);
+  :host([theme~='spacing-l']) {
+    gap: var(--lumo-space-l);
   }
 
-  :host([theme~='spacing-xl']) ::slotted(*) {
-    margin-top: var(--lumo-space-xl);
-  }
-
-  /* Compensate for the first item margin, so that there is no gap around the layout itself. */
-  :host([theme~='spacing-xs'])::before {
-    content: '';
-    margin-top: calc(var(--lumo-space-xs) * -1);
-  }
-
-  :host([theme~='spacing-s'])::before {
-    content: '';
-    margin-top: calc(var(--lumo-space-s) * -1);
-  }
-
-  :host([theme~='spacing'])::before {
-    content: '';
-    margin-top: calc(var(--lumo-space-m) * -1);
-  }
-
-  :host([theme~='spacing-l'])::before {
-    content: '';
-    margin-top: calc(var(--lumo-space-l) * -1);
-  }
-
-  :host([theme~='spacing-xl'])::before {
-    content: '';
-    margin-top: calc(var(--lumo-space-xl) * -1);
+  :host([theme~='spacing-xl']) {
+    gap: var(--lumo-space-xl);
   }
 `;
 

--- a/packages/vertical-layout/theme/material/vaadin-vertical-layout-styles.js
+++ b/packages/vertical-layout/theme/material/vaadin-vertical-layout-styles.js
@@ -9,50 +9,24 @@ const verticalLayout = css`
     padding: 16px;
   }
 
-  :host([theme~='spacing-xs']) ::slotted(*) {
-    margin-top: 4px;
+  :host([theme~='spacing-xs']) {
+    gap: 4px;
   }
 
-  :host([theme~='spacing-s']) ::slotted(*) {
-    margin-top: 8px;
+  :host([theme~='spacing-s']) {
+    gap: 8px;
   }
 
-  :host([theme~='spacing']) ::slotted(*) {
-    margin-top: 16px;
+  :host([theme~='spacing']) {
+    gap: 16px;
   }
 
-  :host([theme~='spacing-l']) ::slotted(*) {
-    margin-top: 32px;
+  :host([theme~='spacing-l']) {
+    gap: 24px;
   }
 
-  :host([theme~='spacing-xl']) ::slotted(*) {
-    margin-top: 64px;
-  }
-
-  /* Compensate for the first item margin, so that there is no gap around the layout itself. */
-  :host([theme~='spacing-xs'])::before {
-    content: '';
-    margin-top: -4px;
-  }
-
-  :host([theme~='spacing-s'])::before {
-    content: '';
-    margin-top: -8px;
-  }
-
-  :host([theme~='spacing'])::before {
-    content: '';
-    margin-top: -16px;
-  }
-
-  :host([theme~='spacing-l'])::before {
-    content: '';
-    margin-top: -32px;
-  }
-
-  :host([theme~='spacing-xl'])::before {
-    content: '';
-    margin-top: -64px;
+  :host([theme~='spacing-xl']) {
+    gap: 40px;
   }
 `;
 


### PR DESCRIPTION
Use standard `gap` property instead of margins on the slotted child elements to create spacing between layout items.

Closes #2174 

Fixes #804 
Fixes #854 
Fixes https://github.com/vaadin/flow-components/issues/1159