### PR TITLE
feat: add controllers support to ElementMixin

### DIFF
--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-    "@vaadin/vaadin-usage-statistics": "^2.1.0"
+    "@vaadin/vaadin-usage-statistics": "^2.1.0",
+    "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/component-base/src/element-mixin.d.ts
+++ b/packages/component-base/src/element-mixin.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ReactiveControllerHost } from 'lit';
 import '../custom_typings/vaadin-usage-statistics.js';
 import '../custom_typings/vaadin.js';
 import { DirMixin, DirMixinConstructor } from './dir-mixin.js';
@@ -16,6 +17,6 @@ interface ElementMixinConstructor {
   finalize(): void;
 }
 
-interface ElementMixin extends DirMixin {}
+interface ElementMixin extends ReactiveControllerHost, DirMixin {}
 
 export { ElementMixin, ElementMixinConstructor };

--- a/packages/component-base/src/element-mixin.d.ts
+++ b/packages/component-base/src/element-mixin.d.ts
@@ -17,6 +17,6 @@ interface ElementMixinConstructor {
   finalize(): void;
 }
 
-interface ElementMixin extends ReactiveControllerHost, DirMixin {}
+interface ElementMixin extends Pick<ReactiveControllerHost, 'addController' | 'removeController'>, DirMixin {}
 
 export { ElementMixin, ElementMixinConstructor };

--- a/packages/component-base/src/element-mixin.js
+++ b/packages/component-base/src/element-mixin.js
@@ -57,10 +57,51 @@ export const ElementMixin = (superClass) =>
 
     constructor() {
       super();
+
+      this.__controllers = new Set();
+
       if (document.doctype === null) {
         console.warn(
           'Vaadin components require the "standards mode" declaration. Please add <!DOCTYPE html> to the HTML document.'
         );
       }
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      this.__controllers.forEach((c) => {
+        c.hostConnected && c.hostConnected();
+      });
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+
+      this.__controllers.forEach((c) => {
+        c.hostDisconnected && c.hostDisconnected();
+      });
+    }
+
+    /**
+     * Registers a controller to participate in the element update cycle.
+     * @protected
+     */
+    addController(controller) {
+      this.__controllers.add(controller);
+      // Call hostConnected if a controller is added after the element is attached.
+      if (this.$ !== undefined && this.isConnected && controller.hostConnected) {
+        controller.hostConnected();
+      }
+    }
+
+    /**
+     * Removes a controller from the element.
+     * @protected
+     */
+    removeController(controller) {
+      this.__controllers.delete(controller);
     }
   };

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '../src/element-mixin.js';
 import { flush } from '../src/debounce.js';
 
@@ -123,6 +123,84 @@ describe('ElementMixin', () => {
       customElements.define(ElementQux.is, ElementQux);
       document.createElement('element-qux');
       expect(console.warn.calledOnce).to.be.true;
+    });
+  });
+
+  describe('controllers', () => {
+    let element, controller;
+
+    class ControllerHost extends ElementMixin(PolymerElement) {
+      static get is() {
+        return 'controller-host';
+      }
+
+      static get template() {
+        return html`Content`;
+      }
+    }
+    customElements.define(ControllerHost.is, ControllerHost);
+
+    class SpyController {
+      constructor(host) {
+        this.host = host;
+      }
+
+      hostConnected() {
+        // Used in spy
+      }
+
+      hostDisconnected() {
+        // Used in spy
+      }
+    }
+
+    beforeEach(() => {
+      element = document.createElement('controller-host');
+      controller = new SpyController(element);
+      sinon.stub(controller, 'hostConnected');
+      sinon.stub(controller, 'hostDisconnected');
+    });
+
+    describe('hostConnected', () => {
+      afterEach(() => {
+        document.body.removeChild(element);
+      });
+
+      it('should run hostConnected when controller is added before host is attached', () => {
+        element.addController(controller);
+        document.body.appendChild(element);
+        expect(controller.hostConnected.calledOnce).to.be.true;
+      });
+
+      it('should run hostConnected when controller is added after host is attached', () => {
+        document.body.appendChild(element);
+        element.addController(controller);
+        expect(controller.hostConnected.calledOnce).to.be.true;
+      });
+    });
+
+    describe('hostDisconnected', () => {
+      beforeEach(() => {
+        document.body.appendChild(element);
+        element.addController(controller);
+      });
+
+      it('should run hostDisconnected when host is detached', () => {
+        document.body.removeChild(element);
+        expect(controller.hostDisconnected.calledOnce).to.be.true;
+      });
+
+      it('should not run hostDisconnected if controller is removed', () => {
+        element.removeController(controller);
+        document.body.removeChild(element);
+        expect(controller.hostDisconnected.calledOnce).to.be.false;
+      });
+
+      it('should run hostConnected when host is reattached', () => {
+        document.body.removeChild(element);
+        document.body.appendChild(element);
+        expect(controller.hostConnected.calledTwice).to.be.true;
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Added support for reactive controllers to `ElementMixin`. 
Currently only `hostConnected` and `hostDisconnected` are implemented.

First step of #2632

## Type of change

- Internal feature