### PR TITLE
chore: deprecate grid.notifyResize()

### DIFF
--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -354,6 +354,9 @@ declare class GridElement<TItem = GridDefaultItem> extends HTMLElement {
    * (row/details cell positioning etc). Needs to be invoked whenever the sizing of grid
    * content changes asynchronously to ensure consistent appearance (e.g. when a
    * contained image whose bounds aren't known beforehand finishes loading).
+   *
+   * @deprecated Since Vaadin 22, `notifyResize()` is deprecated. The component uses a
+   * ResizeObserver internally and doesn't need to be explicitly notified of resizes.
    */
   notifyResize(): void;
 

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -988,9 +988,14 @@ class GridElement extends ElementMixin(
    * (row/details cell positioning etc). Needs to be invoked whenever the sizing of grid
    * content changes asynchronously to ensure consistent appearance (e.g. when a
    * contained image whose bounds aren't known beforehand finishes loading).
+   *
+   * @deprecated Since Vaadin 22, `notifyResize()` is deprecated. The component uses a
+   * ResizeObserver internally and doesn't need to be explicitly notified of resizes.
    */
   notifyResize() {
-    // To be removed in https://github.com/vaadin/web-components/issues/331
+    console.warn(
+      `WARNING: Since Vaadin 22, notifyResize() is deprecated. The component uses a ResizeObserver internally and doesn't need to be explicitly notified of resizes.`
+    );
   }
 }
 

--- a/packages/vaadin-grid/test/resizing.test.js
+++ b/packages/vaadin-grid/test/resizing.test.js
@@ -15,6 +15,7 @@ import {
 } from './helpers.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
+import sinon from 'sinon';
 
 class TestComponent extends PolymerElement {
   static get template() {
@@ -50,6 +51,15 @@ describe('resizing', () => {
     grid.hidden = false;
     await oneEvent(grid, 'animationend');
     flushGrid(grid);
+  });
+
+  it('should warn when calling deprecated notifyResize()', () => {
+    const stub = sinon.stub(console, 'warn');
+    grid.notifyResize();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.args[0][0]).to.include('WARNING: Since Vaadin 22, notifyResize() is deprecated.');
   });
 
   it('should align rows correctly', () => {

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -13,6 +13,7 @@ const HIDDEN_WARNINGS = [
   'WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.',
   'WARNING: Since Vaadin 21, render() is deprecated. The items value is immutable. Please replace it with a new value instead of mutating in place.',
   'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.',
+  `WARNING: Since Vaadin 22, notifyResize() is deprecated. The component uses a ResizeObserver internally and doesn't need to be explicitly notified of resizes.`,
   /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/
 ];
 


### PR DESCRIPTION
`grid.notifyResize` has been a no-op since Vaadin 21. Add a deprecation warning message and documentation to the function.

Related: https://github.com/vaadin/flow-components/pull/2167