### PR TITLE
test: introduce coverage CI workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,28 @@
+# Runs tests for all packages after pushes to master to check code coverage on a project level
+name: Coverage
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+
+      - name: Setup Node 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: yarn --frozen-lockfile --no-progress --non-interactive
+
+      - name: Test
+        run: yarn test --all --coverage

--- a/README.md
+++ b/README.md
@@ -174,22 +174,27 @@ Not all variables are necessary for all scripts, individual sections below will 
 
 ### Unit tests
 
-Run all tests in Chrome:
+Run tests in Chrome:
 
 ```sh
 yarn test
 ```
 
-Run all tests in Firefox:
+Run tests in Firefox:
 
 ```sh
 yarn test:firefox
 ```
 
-Run all tests in WebKit:
+Run tests in WebKit:
 
 ```sh
 yarn test:webkit
+```
+
+By default, tests will only run for changed packages. To run tests for all packages, use the `--all` flag:
+```sh
+yarn test --all
 ```
 
 Run tests for single package:
@@ -202,6 +207,11 @@ Debug tests for single package:
 
 ```sh
 yarn debug --group vaadin-upload
+```
+
+Run tests with code coverage:
+```sh
+yarn test --coverage
 ```
 
 ### Visual tests

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ yarn test:webkit
 ```
 
 By default, tests will only run for changed packages. To run tests for all packages, use the `--all` flag:
+
 ```sh
 yarn test --all
 ```
@@ -210,6 +211,7 @@ yarn debug --group vaadin-upload
 ```
 
 Run tests with code coverage:
+
 ```sh
 yarn test --coverage
 ```

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -35,7 +35,9 @@ const filterBrowserLogs = (log) => {
   return !isHidden;
 };
 
-const group = process.argv.indexOf('--group') !== -1;
+const hasGroupParam = process.argv.indexOf('--group') !== -1;
+const hasCoverageParam = process.argv.indexOf('--coverage') !== -1;
+const hasAllParam = process.argv.indexOf('--all') !== -1;
 
 /**
  * Check if lockfile has changed.
@@ -87,7 +89,11 @@ const getAllVisualPackages = () => {
  */
 const getTestPackages = (allPackages) => {
   // If --group flag is passed, return all packages.
-  if (group) {
+  if (hasGroupParam) {
+    return allPackages;
+  }
+  // If --all flag is passed, return all packages.
+  if (hasAllParam) {
     return allPackages;
   }
 
@@ -251,10 +257,6 @@ const createSnapshotTestsConfig = (config) => {
 const createUnitTestsConfig = (config) => {
   const allPackages = getAllUnitPackages();
   const testPackages = getTestPackages(allPackages);
-
-  // only collect coverage if all packages changed
-  const coverage = allPackages.length === testPackages.length;
-
   const groups = getUnitTestGroups(testPackages);
 
   return {
@@ -269,7 +271,7 @@ const createUnitTestsConfig = (config) => {
         timeout: '10000'
       }
     },
-    coverage,
+    coverage: hasCoverageParam,
     groups,
     testRunnerHtml: getTestRunnerHtml(),
     filterBrowserLogs


### PR DESCRIPTION
## Description

The main purpose of this PR is to introduce a new CI workflow to calculate code coverage. The workflow will only run after pushes to master, and is otherwise a duplication of the Chrome workflow.

This PR also contains other changes:
- add a new flag `-all` to the test config in order to force running tests for all packages in CI. Currently the test config will exit the process if there are no changed packages, and the process runs in CI. If we want to keep this behaviour for pull requests, then we need an alternative to force running all packages.
- adds a new flag `--coverage` to the test config in order to collect code coverage from test runs. The previously introduced solution to only collect coverage when all packages are tested is too opaque and difficult to discover. Let's rather make it explicit if you want coverage or not, and document how to get coverage in README.md.