### PR TITLE
fix: convert themes to style modules synchronously

### DIFF
--- a/packages/polymer-legacy-adapter/style-modules.js
+++ b/packages/polymer-legacy-adapter/style-modules.js
@@ -6,8 +6,7 @@
 import { DomModule } from '@polymer/polymer/lib/elements/dom-module.js';
 import { stylesFromTemplate } from '@polymer/polymer/lib/utils/style-gather.js';
 import { unsafeCSS } from 'lit';
-
-const styleModules = {};
+import { __themeRegistry as themeRegistry } from '@vaadin/vaadin-themable-mixin';
 
 /**
  * @typedef CSSResult
@@ -29,7 +28,7 @@ let moduleIdIndex = 0;
  * @param {{moduleId?: string, include?: string | string[]}} options Additional options
  * @return {void}
  */
-styleModules.registerStyles = (themeFor, styles = [], options = {}) => {
+function registerStyles(themeFor, styles = [], options = {}) {
   const themeId = options.moduleId || `custom-style-module-${moduleIdIndex++}`;
 
   /** @type {DomModuleWithCachedStyles} */
@@ -65,7 +64,7 @@ styleModules.registerStyles = (themeFor, styles = [], options = {}) => {
   `;
 
   module.register(themeId);
-};
+}
 
 /**
  * Returns an array of CSS results obtained from the style module
@@ -89,7 +88,7 @@ function getModuleStyles(module) {
  * Returns all the registered dom-modules mapped as themable-mixin -compatible Theme objects
  * @returns {Theme[]}
  */
-styleModules.getAllThemes = () => {
+function getAllThemes() {
   const domModule = DomModule;
   const modules = domModule.prototype.modules;
 
@@ -105,7 +104,22 @@ styleModules.getAllThemes = () => {
       styles: module.__allStyles
     };
   });
-};
+}
 
 window.Vaadin = window.Vaadin || {};
-window.Vaadin.styleModules = styleModules;
+window.Vaadin.styleModules = {
+  getAllThemes,
+  registerStyles
+};
+
+// Convert any existing themes from the themable-mixin's themeRegistry to the style modules format
+if (themeRegistry && themeRegistry.length > 0) {
+  themeRegistry.forEach((theme) => {
+    registerStyles(theme.themeFor, theme.styles, {
+      moduleId: theme.moduleId,
+      include: theme.include
+    });
+  });
+  // Clear the themeRegistry
+  themeRegistry.length = 0;
+}

--- a/packages/polymer-legacy-adapter/test/style-modules-lazy-import.test.js
+++ b/packages/polymer-legacy-adapter/test/style-modules-lazy-import.test.js
@@ -83,6 +83,8 @@ describe('lazy import', () => {
     // Import the adapter lazily
     await import('../style-modules.js');
 
+    expect(window.Vaadin.styleModules.getAllThemes()).not.to.be.empty;
+
     // Define the custom element
     const customElement = fixtureSync('<custom-element>');
     defineCustomElement(customElementName);

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResultGroup } from 'lit';
+import { CSSResult, CSSResultGroup } from 'lit';
 import { ThemePropertyMixin, ThemePropertyMixinConstructor } from './vaadin-theme-property-mixin.js';
 
 declare function ThemableMixin<T extends new (...args: any[]) => {}>(
@@ -23,6 +23,18 @@ interface ThemableMixin extends ThemePropertyMixin {}
  */
 declare function registerStyles(themeFor: string | null, styles: CSSResultGroup, options?: object | null): void;
 
+type Theme = {
+  themeFor: string;
+  styles: CSSResult[];
+  moduleId?: string;
+  include?: string | string[];
+};
+
+/**
+ * For internal purposes only.
+ */
+declare const __themeRegistry: Theme[];
+
 export { css, unsafeCSS } from 'lit';
 
-export { ThemableMixin, ThemableMixinConstructor, registerStyles };
+export { ThemableMixin, ThemableMixinConstructor, registerStyles, __themeRegistry };

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -65,19 +65,6 @@ export function registerStyles(themeFor, styles, options = {}) {
  */
 function getAllThemes() {
   if (window.Vaadin && window.Vaadin.styleModules) {
-    if (themeRegistry.length > 0) {
-      // Some styles were registered before the style-modules adapter was imported.
-      // Convert the registry to dom-modules by using the adapter.
-      themeRegistry.forEach((theme) => {
-        window.Vaadin.styleModules.registerStyles(theme.themeFor, theme.styles, {
-          moduleId: theme.moduleId,
-          include: theme.include
-        });
-      });
-      // Clear the themeRegistry
-      themeRegistry.length = 0;
-    }
-
     return window.Vaadin.styleModules.getAllThemes();
   } else {
     return themeRegistry;
@@ -239,3 +226,5 @@ export const ThemableMixin = (superClass) =>
       );
     }
   };
+
+export { themeRegistry as __themeRegistry };


### PR DESCRIPTION
Follow-up from https://github.com/vaadin/web-components/pull/2683

The current version of themable-mixin converts pre-imported styles as `<dom-module>` after the `style-modules.js` adapter is imported but [does so](https://github.com/vaadin/web-components/blob/db4436a80c173ce11c63df4252f1f7949bf9e6e6/packages/vaadin-themable-mixin/vaadin-themable-mixin.js#L69-L78) lazily only after a component is being finalized.

This may be too late for applications where a `<custom-style>` is used:
![Screenshot 2021-09-30 at 17 58 34](https://user-images.githubusercontent.com/1222264/135481043-57ed8ff4-6a6a-4403-a3db-b02569f3bfe1.png)

This PR changes the logic so that any pre-imported styles in themable-mixin get converted as `<dom-module>` synchronously right as the `style-modules.js` adapter is being imported
