### PR TITLE
refactor: re-create vaadin-icon for backwards compatibility

### DIFF
--- a/packages/vaadin-icon/README.md
+++ b/packages/vaadin-icon/README.md
@@ -1,0 +1,54 @@
+# &lt;vaadin-icon&gt;
+
+[&lt;vaadin-icon&gt;](https://vaadin.com/docs/latest/ds/components/icon) is a Web Component for creating SVG icons, part of the [Vaadin components](https://vaadin.com/docs/latest/ds/components).
+
+[![npm version](https://badgen.net/npm/v/@vaadin/vaadin-icon)](https://www.npmjs.com/package/@vaadin/vaadin-icon)
+[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
+
+```html
+<vaadin-icon name="vaadin:user"></vaadin-icon>
+```
+
+## Installation
+
+Install `vaadin-icon`:
+
+```sh
+npm i @vaadin/vaadin-icon --save
+```
+
+Once installed, import it in your application:
+
+```js
+import '@vaadin/vaadin-icon/vaadin-icon.js';
+```
+
+## Getting started
+
+Vaadin components use the Lumo theme by default.
+
+To use the Material theme, import the corresponding file from the `theme/material` folder.
+
+## Entry points
+
+- The component with the Lumo theme:
+
+  `theme/lumo/vaadin-icon.js`
+
+- The component with the Material theme:
+
+  `theme/material/vaadin-icon.js`
+
+- Alias for `theme/lumo/vaadin-icon.js`:
+
+  `vaadin-icon.js`
+
+## Contributing
+
+Read the [contributing guide](https://vaadin.com/docs/latest/guide/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+
+## License
+
+Apache License 2.0
+
+Vaadin collects development time usage statistics to improve this product. For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.

--- a/packages/vaadin-icon/package.json
+++ b/packages/vaadin-icon/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@vaadin/vaadin-icon",
+  "version": "22.0.0-alpha6",
+  "description": "Web component for creating SVG icons",
+  "main": "vaadin-icon.js",
+  "module": "vaadin-icon.js",
+  "repository": "vaadin/web-components",
+  "keywords": [
+    "Vaadin",
+    "icon",
+    "web-components",
+    "web-component"
+  ],
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/vaadin/web-components/issues"
+  },
+  "homepage": "https://vaadin.com/components",
+  "files": [
+    "vaadin-*.d.ts",
+    "vaadin-*.js",
+    "src",
+    "theme"
+  ],
+  "dependencies": {
+    "@vaadin/icon": "^22.0.0-alpha6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/vaadin-icon/src/vaadin-icon-svg.d.ts
+++ b/packages/vaadin-icon/src/vaadin-icon-svg.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from '@vaadin/icon/src/vaadin-icon-svg.js';

--- a/packages/vaadin-icon/src/vaadin-icon-svg.js
+++ b/packages/vaadin-icon/src/vaadin-icon-svg.js
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from '@vaadin/icon/src/vaadin-icon-svg.js';

--- a/packages/vaadin-icon/src/vaadin-icon.d.ts
+++ b/packages/vaadin-icon/src/vaadin-icon.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from '@vaadin/icon/src/vaadin-icon.js';

--- a/packages/vaadin-icon/src/vaadin-icon.js
+++ b/packages/vaadin-icon/src/vaadin-icon.js
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from '@vaadin/icon/src/vaadin-icon.js';

--- a/packages/vaadin-icon/src/vaadin-iconset.d.ts
+++ b/packages/vaadin-icon/src/vaadin-iconset.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from '@vaadin/icon/src/vaadin-iconset.js';

--- a/packages/vaadin-icon/src/vaadin-iconset.js
+++ b/packages/vaadin-icon/src/vaadin-iconset.js
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from '@vaadin/icon/src/vaadin-iconset.js';

--- a/packages/vaadin-icon/theme/lumo/vaadin-icon.js
+++ b/packages/vaadin-icon/theme/lumo/vaadin-icon.js
@@ -1,0 +1,1 @@
+import '@vaadin/icon/theme/lumo/vaadin-icon.js';

--- a/packages/vaadin-icon/theme/material/vaadin-icon.js
+++ b/packages/vaadin-icon/theme/material/vaadin-icon.js
@@ -1,0 +1,1 @@
+import '@vaadin/icon/theme/material/vaadin-icon.js';

--- a/packages/vaadin-icon/vaadin-icon.d.ts
+++ b/packages/vaadin-icon/vaadin-icon.d.ts
@@ -1,0 +1,2 @@
+export * from './src/vaadin-icon-svg.js';
+export * from './src/vaadin-icon.js';

--- a/packages/vaadin-icon/vaadin-icon.js
+++ b/packages/vaadin-icon/vaadin-icon.js
@@ -1,0 +1,4 @@
+import './theme/lumo/vaadin-icon.js';
+
+export * from './src/vaadin-icon-svg.js';
+export * from './src/vaadin-icon.js';

--- a/packages/vaadin-icon/vaadin-iconset.d.ts
+++ b/packages/vaadin-icon/vaadin-iconset.d.ts
@@ -1,0 +1,2 @@
+export * from './src/vaadin-icon-svg.js';
+export * from './src/vaadin-iconset.js';

--- a/packages/vaadin-icon/vaadin-iconset.js
+++ b/packages/vaadin-icon/vaadin-iconset.js
@@ -1,0 +1,4 @@
+import './src/vaadin-iconset.js';
+
+export * from './src/vaadin-icon-svg.js';
+export * from './src/vaadin-iconset.js';


### PR DESCRIPTION
## Description

Re-create `@vaadin/vaadin-icon` for backwards compatibility.

Part of #1992
Fixes #2667 