### PR TITLE
fix: forward value property to input element

### DIFF
--- a/packages/field-base/src/input-controller.js
+++ b/packages/field-base/src/input-controller.js
@@ -14,13 +14,8 @@ export class InputController extends SlotController {
       'input',
       () => document.createElement('input'),
       (host, node) => {
-        const value = host.getAttribute('value');
-        if (value) {
-          node.setAttribute('value', value);
-        }
-        const name = host.getAttribute('name');
-        if (name) {
-          node.setAttribute('name', name);
+        if (host.value) {
+          node.setAttribute('value', host.value);
         }
         if (host.type) {
           node.setAttribute('type', host.type);

--- a/packages/field-base/test/input-controller.test.js
+++ b/packages/field-base/test/input-controller.test.js
@@ -51,19 +51,7 @@ describe('input-controller', () => {
     });
   });
 
-  describe('name', () => {
-    beforeEach(() => {
-      element = fixtureSync('<input-controller-element name="foo"></input-controller-element>');
-    });
-
-    it('should forward name attribute to the input', () => {
-      element.addController(new InputController(element));
-      input = element.querySelector('[slot=input]');
-      expect(input.name).to.equal('foo');
-    });
-  });
-
-  describe('value', () => {
+  describe('value attribute', () => {
     beforeEach(() => {
       element = fixtureSync('<input-controller-element value="foo"></input-controller-element>');
     });
@@ -75,7 +63,20 @@ describe('input-controller', () => {
     });
   });
 
-  describe('type', () => {
+  describe('value property', () => {
+    beforeEach(() => {
+      element = fixtureSync('<input-controller-element></input-controller-element>');
+      element.value = 'foo';
+    });
+
+    it('should forward value property to the input', () => {
+      element.addController(new InputController(element));
+      input = element.querySelector('[slot=input]');
+      expect(input.value).to.equal('foo');
+    });
+  });
+
+  describe('type property', () => {
     beforeEach(() => {
       element = fixtureSync('<input-controller-element value="foo"></input-controller-element>');
     });


### PR DESCRIPTION
## Description

The PR fixes the regression that occurred after the a11y refactorings:

> The `value` property is not forwarded to the input element, only the `value` attribute is forwarded.

Fixes #2692.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
