### PR TITLE
fix: make label with empty children add has-label attribute

### DIFF
--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -76,7 +76,7 @@ const LabelMixinImplementation = (superclass) =>
     /** @protected */
     _toggleHasLabelAttribute() {
       if (this._labelNode) {
-        const hasLabel = this._labelNode.children > 0 || this._labelNode.textContent.trim() !== '';
+        const hasLabel = this._labelNode.children.length > 0 || this._labelNode.textContent.trim() !== '';
 
         this.toggleAttribute('has-label', hasLabel);
       }

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -124,6 +124,15 @@ describe('label-mixin', () => {
         await nextFrame();
         expect(element.hasAttribute('has-label')).to.be.true;
       });
+
+      it('should add the attribute when label children are initially empty', () => {
+        element = fixtureSync(`
+          <label-mixin-element>
+            <label slot="label"><div></div></label>
+          </label-mixin-element>
+        `);
+        expect(element.hasAttribute('has-label')).to.be.true;
+      });
     });
   });
 });


### PR DESCRIPTION
If a field has a slotted label with empty child elements, the field should still get `has-label` attribute added