### PR TITLE
chore: remove unnecessary CSS

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -49,12 +49,6 @@ const inputField = css`
     display: none;
   }
 
-  [part='input-field'] ::slotted(:is(input, textarea)) {
-    /* Slotted input does not inherit these from the host */
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
   :host([focused]) [part='input-field'] ::slotted(:is(input, textarea)) {
     -webkit-mask-image: none;
     mask-image: none;

--- a/packages/vaadin-material-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-material-styles/mixins/input-field-shared.js
@@ -110,9 +110,6 @@ const inputField = css`
     background-color: transparent;
     /* Disable default invalid style in Firefox */
     box-shadow: none;
-    /* Slotted input does not inherit these from the host */
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
   }
 
   /* TODO: the text opacity should be 42%, but the disabled style is 38%.


### PR DESCRIPTION
The font-smooth property is inherited according to MDN, and at least in my testing, it is enough that the host specifies it, it affects the rendering of the slotted input as well.