### PR TITLE
refactor: avoid input placeholder styles duplication

### DIFF
--- a/packages/input-container/src/vaadin-input-container.js
+++ b/packages/input-container/src/vaadin-input-container.js
@@ -6,6 +6,7 @@
 import { PolymerElement, html } from '@polymer/polymer';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
   static get is() {
@@ -57,6 +58,16 @@ export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
         ::slotted(*) {
           flex: none;
         }
+
+        ::slotted(:is(input, textarea))::placeholder {
+          /* Use ::slotted(input:placeholder-shown) in themes to style the placeholder. */
+          /* because ::slotted(...)::placeholder does not work in Safari. */
+          /* See the workaround at the end of this file. */
+          font: inherit;
+          color: inherit;
+          /* Override default opacity in Firefox */
+          opacity: 1;
+        }
       </style>
       <slot name="prefix"></slot>
       <slot></slot>
@@ -94,3 +105,15 @@ export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
 }
 
 customElements.define(InputContainer.is, InputContainer);
+
+const placeholderStyleWorkaround = css`
+  /* Needed for Safari, where ::slotted(...)::placeholder does not work */
+  :is(input[slot='input'], textarea[slot='textarea'])::placeholder {
+    font: inherit;
+    color: inherit;
+  }
+`;
+
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<style>${placeholderStyleWorkaround.toString()}</style>`;
+document.head.appendChild($tpl.content);

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -60,7 +60,7 @@ const inputField = css`
     mask-image: none;
   }
 
-  ::slotted(:is(input, textarea))::placeholder {
+  ::slotted(:is(input, textarea):placeholder-shown) {
     color: inherit;
     transition: opacity 0.175s 0.1s;
     opacity: 0.5;
@@ -102,8 +102,7 @@ const inputField = css`
   }
 
   /* Read-only and disabled */
-  :host([readonly]) ::slotted(:is(input, textarea))::placeholder,
-  :host([disabled]) ::slotted(:is(input, textarea))::placeholder {
+  :host(:is([readonly], [disabled])) ::slotted(:is(input, textarea):placeholder-shown) {
     opacity: 0;
   }
 

--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -144,25 +144,8 @@ const typography = css`
 
 registerStyles('', typography, { moduleId: 'lumo-typography' });
 
-const inputs = css`
-  /* Slotted input styles */
-  input[slot='input']::placeholder,
-  textarea[slot='textarea']::placeholder {
-    color: inherit;
-    transition: opacity 0.175s 0.1s;
-    opacity: 0.5;
-  }
-
-  [readonly] > input[slot='input']::placeholder,
-  [readonly] > textarea[slot='textarea']::placeholder,
-  [disabled] > input[slot='input']::placeholder,
-  [disabled] > textarea[slot='textarea']::placeholder {
-    opacity: 0;
-  }
-`;
-
 const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${font.toString().replace(':host', 'html')}${inputs.toString()}</style>`;
+$tpl.innerHTML = `<style>${font.toString().replace(':host', 'html')}</style>`;
 document.head.appendChild($tpl.content);
 
-export { font, inputs, typography };
+export { font, typography };

--- a/packages/vaadin-material-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-material-styles/mixins/input-field-shared.js
@@ -117,14 +117,13 @@ const inputField = css`
 
   /* TODO: the text opacity should be 42%, but the disabled style is 38%.
   Would need to introduce another property for it if we want to be 100% accurate. */
-  ::slotted(:is(input, textarea))::placeholder {
+  ::slotted(:is(input, textarea):placeholder-shown) {
     color: var(--material-disabled-text-color);
     transition: opacity 0.175s 0.1s;
-    opacity: 1;
   }
 
   /* prettier-ignore */
-  :host([has-label]:not([focused]):not([invalid]):not([theme='always-float-label'])) ::slotted(:is(input, textarea))::placeholder {
+  :host([has-label]:not([focused]):not([invalid]):not([theme='always-float-label'])) ::slotted(:is(input, textarea):placeholder-shown) {
     opacity: 0;
     transition-delay: 0;
   }

--- a/packages/vaadin-material-styles/typography.js
+++ b/packages/vaadin-material-styles/typography.js
@@ -114,27 +114,11 @@ const typography = css`
 
 registerStyles('', typography, { moduleId: 'material-typography' });
 
-const inputs = css`
-  /* Slotted input styles */
-  input[slot='input']::placeholder,
-  textarea[slot='textarea']::placeholder {
-    color: var(--material-disabled-text-color);
-    transition: opacity 0.175s 0.1s;
-    opacity: 1;
-  }
-
-  [has-label]:not([focused]):not([invalid]):not([theme~='always-float-label']) > input[slot='input']::placeholder,
-  [has-label]:not([focused]):not([invalid]):not([theme~='always-float-label']) > input[slot='textarea']::placeholder {
-    opacity: 0;
-    transition-delay: 0;
-  }
-`;
-
 const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${font.toString().replace(':host', 'html')}${inputs.toString()}</style>`;
+$tpl.innerHTML = `<style>${font.toString().replace(':host', 'html')}</style>`;
 document.head.appendChild($tpl.content);
 
-export { font, inputs, typography };
+export { font, typography };
 
 /* Import Roboto from Google Fonts */
 if (!window.polymerSkipLoadingFontRoboto) {


### PR DESCRIPTION
Do not duplicate the theme styles (Lumo and Material) in `typography.js`, but keep them only in `input-field-shared.js`. This makes it easier for custom themes to override the styles.

This is basically another way of solving the same issue as with #2184