### PR TITLE
chore: remove duplicate CSS in typography modules

### DIFF
--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -29,16 +29,7 @@ const font = css`
 `;
 
 const typography = css`
-  html {
-    font-family: var(--lumo-font-family);
-    font-size: var(--lumo-font-size, var(--lumo-font-size-m));
-    line-height: var(--lumo-line-height-m);
-    -webkit-text-size-adjust: 100%;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
-  /* Can’t combine with the above selector because that doesn’t work in browsers without native shadow dom */
+  html,
   :host {
     font-family: var(--lumo-font-family);
     font-size: var(--lumo-font-size, var(--lumo-font-size-m));

--- a/packages/vaadin-material-styles/typography.js
+++ b/packages/vaadin-material-styles/typography.js
@@ -29,16 +29,7 @@ const font = css`
 `;
 
 const typography = css`
-  body {
-    font-family: var(--material-font-family);
-    font-size: var(--material-body-font-size);
-    line-height: 1.4;
-    -webkit-text-size-adjust: 100%;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
-  /* Can’t combine with the above selector because that doesn’t work in browsers without native shadow dom */
+  body,
   :host {
     font-family: var(--material-font-family);
     font-size: var(--material-body-font-size);


### PR DESCRIPTION
Not needed anymore, native shadow DOM is supported in all the browsers we support.