### PR TITLE
fix: create default helper element lazily

### DIFF
--- a/packages/custom-field/test/custom-field.test.js
+++ b/packages/custom-field/test/custom-field.test.js
@@ -172,6 +172,7 @@ describe('custom field', () => {
     let label, helper, error;
 
     beforeEach(() => {
+      customField.helperText = 'Helper';
       label = customField.querySelector('[slot="label"]');
       helper = customField.querySelector('[slot="helper"]');
       error = customField.querySelector('[slot="error-message"]');

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -10,7 +10,7 @@ describe('WAI-ARIA', () => {
     let datepicker, toggleButton, input, label, helper, error;
 
     beforeEach(() => {
-      datepicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+      datepicker = fixtureSync(`<vaadin-date-picker helper-text="Week day"></vaadin-date-picker>`);
       toggleButton = datepicker.shadowRoot.querySelector('[part="toggle-button"]');
       input = datepicker.inputElement;
       label = datepicker.querySelector('[slot=label]');

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-email-field default"] = 
+snapshots["vaadin-email-field shadow default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -42,9 +42,9 @@ snapshots["vaadin-email-field default"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-email-field default */
+/* end snapshot vaadin-email-field shadow default */
 
-snapshots["vaadin-email-field disabled"] = 
+snapshots["vaadin-email-field shadow disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -88,9 +88,9 @@ snapshots["vaadin-email-field disabled"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-email-field disabled */
+/* end snapshot vaadin-email-field shadow disabled */
 
-snapshots["vaadin-email-field readonly"] = 
+snapshots["vaadin-email-field shadow readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -134,9 +134,9 @@ snapshots["vaadin-email-field readonly"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-email-field readonly */
+/* end snapshot vaadin-email-field shadow readonly */
 
-snapshots["vaadin-email-field invalid"] = 
+snapshots["vaadin-email-field shadow invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -180,9 +180,9 @@ snapshots["vaadin-email-field invalid"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-email-field invalid */
+/* end snapshot vaadin-email-field shadow invalid */
 
-snapshots["vaadin-email-field theme"] = 
+snapshots["vaadin-email-field shadow theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -226,9 +226,9 @@ snapshots["vaadin-email-field theme"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-email-field theme */
+/* end snapshot vaadin-email-field shadow theme */
 
-snapshots["vaadin-email-field slots"] = 
+snapshots["vaadin-email-field slots default"] = 
 `<label slot="label">
 </label>
 <div
@@ -236,13 +236,30 @@ snapshots["vaadin-email-field slots"] =
   slot="error-message"
 >
 </div>
-<div slot="helper">
-</div>
 <input
   autocapitalize="off"
   slot="input"
   type="email"
 >
 `;
-/* end snapshot vaadin-email-field slots */
+/* end snapshot vaadin-email-field slots default */
+
+snapshots["vaadin-email-field slots helper"] = 
+`<label slot="label">
+</label>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<input
+  autocapitalize="off"
+  slot="input"
+  type="email"
+>
+<div slot="helper">
+  Helper
+</div>
+`;
+/* end snapshot vaadin-email-field slots helper */
 

--- a/packages/email-field/test/dom/email-field.test.js
+++ b/packages/email-field/test/dom/email-field.test.js
@@ -16,31 +16,40 @@ describe('vaadin-email-field', () => {
     field = fixtureSync('<vaadin-email-field></vaadin-email-field>');
   });
 
-  it('default', async () => {
-    await expect(field).shadowDom.to.equalSnapshot();
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('disabled', async () => {
+      field.disabled = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('readonly', async () => {
+      field.readonly = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('invalid', async () => {
+      field.invalid = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('theme', async () => {
+      field.setAttribute('theme', 'align-right');
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
   });
 
-  it('disabled', async () => {
-    field.disabled = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
+  describe('slots', () => {
+    it('default', async () => {
+      await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
 
-  it('readonly', async () => {
-    field.readonly = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('invalid', async () => {
-    field.invalid = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('theme', async () => {
-    field.setAttribute('theme', 'align-right');
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('slots', async () => {
-    await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    it('helper', async () => {
+      field.helperText = 'Helper';
+      await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
   });
 });

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -93,20 +93,6 @@ export const FieldMixin = (superclass) =>
 
       // Save generated ID to restore later
       this.__savedHelperId = this._helperId;
-
-      this.__helperIdObserver = new MutationObserver((mutationRecord) => {
-        mutationRecord.forEach((mutation) => {
-          // only handle helper nodes
-          if (
-            mutation.type === 'attributes' &&
-            mutation.attributeName === 'id' &&
-            mutation.target === this._currentHelper &&
-            mutation.target.id !== this.__savedHelperId
-          ) {
-            this.__updateHelperId(mutation.target);
-          }
-        });
-      });
     }
 
     /** @protected */
@@ -143,12 +129,30 @@ export const FieldMixin = (superclass) =>
 
           this.__applyCustomHelper(newHelper);
 
+          this.__helperIdObserver = new MutationObserver((mutationRecord) => {
+            mutationRecord.forEach((mutation) => {
+              // only handle helper nodes
+              if (
+                mutation.type === 'attributes' &&
+                mutation.attributeName === 'id' &&
+                mutation.target === this._currentHelper &&
+                mutation.target.id !== this.__savedHelperId
+              ) {
+                this.__updateHelperId(mutation.target);
+              }
+            });
+          });
+
           this.__helperIdObserver.observe(newHelper, { attributes: true, subtree: true });
-        } else if (oldHelper && this.helperText) {
-          // Custom helper is removed, restore the default one.
-          const helper = this.__defaultHelper;
-          helper.textContent = this.helperText;
-          this.__applyDefaultHelper(helper);
+        } else if (oldHelper) {
+          this.__helperIdObserver.disconnect();
+
+          if (this.helperText) {
+            // Custom helper is removed, restore the default one.
+            const helper = this.__defaultHelper;
+            helper.textContent = this.helperText;
+            this.__applyDefaultHelper(helper);
+          }
         }
       });
     }

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -166,7 +166,7 @@ export const FieldMixin = (superclass) =>
     __applyCustomHelper(helper) {
       this.__updateHelperId(helper);
       this._currentHelper = helper;
-      this.setAttribute('has-helper', '');
+      this.__toggleHasHelper(helper.children.length > 0 || helper.textContent.trim() !== '');
     }
 
     /** @private */
@@ -174,6 +174,11 @@ export const FieldMixin = (superclass) =>
       helper.id = this.__savedHelperId;
       this.appendChild(helper);
       this._currentHelper = helper;
+    }
+
+    /** @private */
+    __toggleHasHelper(hasHelper) {
+      this.toggleAttribute('has-helper', hasHelper);
     }
 
     /**
@@ -253,7 +258,7 @@ export const FieldMixin = (superclass) =>
         helper.textContent = helperText;
       }
 
-      this.toggleAttribute('has-helper', Boolean(helperText));
+      this.__toggleHasHelper(Boolean(helperText));
     }
 
     /** @protected */

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -165,13 +165,8 @@ export const FieldMixin = (superclass) =>
     /** @private */
     __applyCustomHelper(helper) {
       this.__updateHelperId(helper);
-
-      const helperText = helper.textContent;
-      if (helperText !== this.helperText) {
-        this.helperText = helperText;
-      }
-
       this._currentHelper = helper;
+      this.setAttribute('has-helper', '');
     }
 
     /** @private */

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -146,12 +146,7 @@ export const FieldMixin = (superclass) =>
           this.__helperIdObserver.observe(newHelper, { attributes: true });
         } else if (oldHelper) {
           this.__helperIdObserver.disconnect();
-
-          if (this.helperText) {
-            // Custom helper is removed, restore the default one.
-            const helper = this.__attachDefaultHelper();
-            helper.textContent = this.helperText;
-          }
+          this.__applyDefaultHelper(this.helperText);
         }
       });
     }
@@ -192,6 +187,24 @@ export const FieldMixin = (superclass) =>
       this._currentHelper = helper;
 
       return helper;
+    }
+
+    /** @private */
+    __applyDefaultHelper(helperText) {
+      let helper = this._helperNode;
+
+      const hasHelperText = this.__isNotEmpty(helperText);
+      if (hasHelperText && !helper) {
+        // Create helper lazily
+        helper = this.__attachDefaultHelper();
+      }
+
+      // Only set text content for default helper
+      if (helper && helper === this.__defaultHelper) {
+        helper.textContent = helperText;
+      }
+
+      this.__toggleHasHelper(hasHelperText);
     }
 
     /** @private */
@@ -259,20 +272,7 @@ export const FieldMixin = (superclass) =>
 
     /** @protected */
     _helperTextChanged(helperText) {
-      let helper = this._helperNode;
-
-      const hasHelperText = this.__isNotEmpty(helperText);
-      if (hasHelperText && !helper) {
-        // Create helper lazily
-        helper = this.__attachDefaultHelper();
-      }
-
-      // Only set text content for default helper
-      if (helper && helper === this.__defaultHelper) {
-        helper.textContent = helperText;
-      }
-
-      this.__toggleHasHelper(hasHelperText);
+      this.__applyDefaultHelper(helperText);
     }
 
     /** @protected */

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -261,11 +261,10 @@ export const FieldMixin = (superclass) =>
     _helperTextChanged(helperText) {
       let helper = this._helperNode;
 
-      const hasHelper = this.__isNotEmpty(helperText);
+      const hasHelperText = this.__isNotEmpty(helperText);
       if (hasHelperText && !helper) {
         // Create helper lazily
         helper = this.__attachDefaultHelper();
-      }
       }
 
       // Only set text content for default helper
@@ -273,7 +272,7 @@ export const FieldMixin = (superclass) =>
         helper.textContent = helperText;
       }
 
-      this.__toggleHasHelper(hasHelper);
+      this.__toggleHasHelper(hasHelperText);
     }
 
     /** @protected */

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -122,7 +122,7 @@ export const FieldMixin = (superclass) =>
         const oldHelper = info.removedNodes.find((node) => node === helper);
 
         if (newHelper) {
-          // Custom helper is added, remove the default one.
+          // Custom helper is added, remove the previous one.
           if (helper && helper.isConnected) {
             this.removeChild(helper);
           }
@@ -262,11 +262,10 @@ export const FieldMixin = (superclass) =>
       let helper = this._helperNode;
 
       const hasHelper = this.__isNotEmpty(helperText);
-      if (hasHelper) {
+      if (hasHelperText && !helper) {
         // Create helper lazily
-        if (!helper) {
-          helper = this.__attachDefaultHelper();
-        }
+        helper = this.__attachDefaultHelper();
+      }
       }
 
       // Only set text content for default helper

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -145,7 +145,11 @@ export const FieldMixin = (superclass) =>
 
           this.__helperIdObserver.observe(newHelper, { attributes: true });
         } else if (oldHelper) {
-          this.__helperIdObserver.disconnect();
+          // The observer does not exist when default helper is removed.
+          if (this.__helperIdObserver) {
+            this.__helperIdObserver.disconnect();
+          }
+
           this.__applyDefaultHelper(this.helperText);
         }
       });

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -203,28 +203,20 @@ describe('field-mixin', () => {
         helper = element.querySelector('[slot=helper]');
       });
 
-      it('should create a helper element', () => {
+      it('should not create a helper element by default', () => {
+        expect(helper).to.be.not.ok;
+      });
+
+      it('should add a helper when helperText property is set', () => {
+        element.helperText = '3 digits';
+        helper = element.querySelector('[slot=helper]');
         expect(helper).to.be.an.instanceof(HTMLDivElement);
       });
 
-      it('should set slot on the helper', () => {
-        expect(helper.getAttribute('slot')).to.equal('helper');
-      });
-
-      it('should set id on the helper element', () => {
-        const id = helper.getAttribute('id');
-        expect(id).to.match(ID_REGEX);
-        expect(id.endsWith(element.constructor._uniqueFieldId)).to.be.true;
-      });
-
-      it('should update helper content on attribute change', () => {
+      it('should add a helper when helper-text attribute is set', () => {
         element.setAttribute('helper-text', '3 digits');
-        expect(helper.textContent).to.equal('3 digits');
-      });
-
-      it('should update helper content on property change', () => {
-        element.helperText = '3 digits';
-        expect(helper.textContent).to.equal('3 digits');
+        helper = element.querySelector('[slot=helper]');
+        expect(helper).to.be.an.instanceof(HTMLDivElement);
       });
 
       it('should not set has-helper attribute with no helper', () => {
@@ -242,6 +234,43 @@ describe('field-mixin', () => {
       });
     });
 
+    describe('property', () => {
+      beforeEach(() => {
+        element = fixtureSync(`<field-mixin-element></field-mixin-element>`);
+        element.helperText = 'Positive number';
+        helper = element.querySelector('[slot=helper]');
+      });
+
+      it('should set slot on the generated helper element', () => {
+        expect(helper.getAttribute('slot')).to.equal('helper');
+      });
+
+      it('should set id on the generated helper element', () => {
+        const id = helper.getAttribute('id');
+        expect(id).to.match(ID_REGEX);
+        expect(id.endsWith(element.constructor._uniqueFieldId)).to.be.true;
+      });
+
+      it('should set content to the generated helper element', () => {
+        expect(helper.textContent).to.equal('Positive number');
+      });
+
+      it('should update helper content on attribute change', () => {
+        element.setAttribute('helper-text', '3 digits');
+        expect(helper.textContent).to.equal('3 digits');
+      });
+
+      it('should update helper content on property change', () => {
+        element.helperText = '3 digits';
+        expect(helper.textContent).to.equal('3 digits');
+      });
+
+      it('should remove has-helper attribute when property is unset', () => {
+        element.helperText = '';
+        expect(element.hasAttribute('has-helper')).to.be.false;
+      });
+    });
+
     describe('attribute', () => {
       beforeEach(() => {
         element = fixtureSync(`
@@ -254,6 +283,11 @@ describe('field-mixin', () => {
 
       it('should set helper text content from attribute', () => {
         expect(helper.textContent).to.equal('3 digits');
+      });
+
+      it('should remove has-helper attribute when attribute is removed', () => {
+        element.removeAttribute('helper-text');
+        expect(element.hasAttribute('has-helper')).to.be.false;
       });
     });
 
@@ -281,9 +315,9 @@ describe('field-mixin', () => {
         expect(element.hasAttribute('has-helper')).to.be.true;
       });
 
-      it('should update slotted helper content on property change', () => {
+      it('should not update slotted helper content on property change', () => {
         element.helperText = '3 digits';
-        expect(helper.textContent).to.equal('3 digits');
+        expect(helper.textContent).to.not.equal('3 digits');
       });
     });
 
@@ -293,6 +327,7 @@ describe('field-mixin', () => {
 
         beforeEach(async () => {
           element = fixtureSync('<field-mixin-element></field-mixin-element>');
+          element.helperText = 'Default helper';
           await nextFrame();
           defaultHelper = element._helperNode;
           helper = document.createElement('div');
@@ -370,6 +405,7 @@ describe('field-mixin', () => {
       describe('ID attribute', () => {
         beforeEach(async () => {
           element = fixtureSync('<field-mixin-element></field-mixin-element>');
+          element.helperText = 'Default';
           await nextFrame();
           helper = document.createElement('div');
           helper.setAttribute('slot', 'helper');
@@ -397,11 +433,22 @@ describe('field-mixin', () => {
           await nextFrame();
           expect(helper.getAttribute('id')).to.match(ID_REGEX);
         });
+
+        it('should apply helper text if the custom helper is removed', async () => {
+          element.appendChild(helper);
+          await nextFrame();
+          element.helperText = 'Default';
+          element.removeChild(helper);
+          await nextFrame();
+          const defaultHelper = element.querySelector('[slot="helper"]');
+          expect(defaultHelper.textContent).to.equal('Default');
+        });
       });
 
       describe('attributes', () => {
         beforeEach(async () => {
           element = fixtureSync('<field-mixin-element></field-mixin-element>');
+          element.helperText = 'Default';
           await nextFrame();
           helper = document.createElement('div');
           helper.setAttribute('slot', 'helper');
@@ -418,9 +465,9 @@ describe('field-mixin', () => {
           expect(element.hasAttribute('has-helper')).to.be.true;
         });
 
-        it('should update lazy helper content on property change', () => {
+        it('should not update lazy helper content on property change', () => {
           element.helperText = '3 digits';
-          expect(helper.textContent).to.equal('3 digits');
+          expect(helper.textContent).to.equal('Lazy');
         });
       });
     });
@@ -428,7 +475,7 @@ describe('field-mixin', () => {
 
   describe('aria-describedby', () => {
     beforeEach(() => {
-      element = fixtureSync(`<field-mixin-element></field-mixin-element>`);
+      element = fixtureSync(`<field-mixin-element helper-text="Helper"></field-mixin-element>`);
       label = element.querySelector('[slot=label]');
       error = element.querySelector('[slot=error-message]');
       helper = element.querySelector('[slot=helper]');
@@ -453,7 +500,7 @@ describe('field-mixin', () => {
 
   describe('aria-labelledby', () => {
     beforeEach(() => {
-      element = fixtureSync(`<field-mixin-group-element></field-mixin-group-element>`);
+      element = fixtureSync(`<field-mixin-group-element helper-text="Helper"></field-mixin-group-element>`);
       label = element.querySelector('[slot=label]');
       error = element.querySelector('[slot=error-message]');
       helper = element.querySelector('[slot=helper]');

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -321,6 +321,20 @@ describe('field-mixin', () => {
       });
     });
 
+    describe('slotted empty', () => {
+      beforeEach(() => {
+        element = fixtureSync(`
+          <field-mixin-element>
+            <div slot="helper"><span></span></div>
+          </field-mixin-element>
+        `);
+      });
+
+      it('should set has-helper attribute when helper children are empty', () => {
+        expect(element.hasAttribute('has-helper')).to.be.true;
+      });
+    });
+
     describe('lazy', () => {
       describe('DOM manipulations', () => {
         let defaultHelper;

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -301,8 +301,8 @@ describe('field-mixin', () => {
         helper = element.querySelector('[slot=helper]');
       });
 
-      it('should return slotted helper content as a helperText', () => {
-        expect(element.helperText).to.equal('Custom');
+      it('should not return slotted helper content as a helperText', () => {
+        expect(element.helperText).to.be.not.ok;
       });
 
       it('should set id on the slotted helper element', () => {
@@ -335,22 +335,22 @@ describe('field-mixin', () => {
           helper.textContent = 'Lazy';
         });
 
-        it('should return lazy helper content as a helperText using appendChild', async () => {
+        it('should handle lazy helper added using appendChild', async () => {
           element.appendChild(helper);
           await nextFrame();
-          expect(element.helperText).to.equal('Lazy');
+          expect(element._helperNode).to.equal(helper);
         });
 
-        it('should return lazy helper content as a helperText using insertBefore', async () => {
+        it('should handle lazy helper added using insertBefore', async () => {
           element.insertBefore(helper, defaultHelper);
           await nextFrame();
-          expect(element.helperText).to.equal('Lazy');
+          expect(element._helperNode).to.equal(helper);
         });
 
-        it('should return lazy helper content as a helperText using replaceChild', async () => {
+        it('should handle lazy helper added using replaceChild', async () => {
           element.replaceChild(helper, defaultHelper);
           await nextFrame();
-          expect(element.helperText).to.equal('Lazy');
+          expect(element._helperNode).to.equal(helper);
         });
 
         it('should remove the default helper from the element when using appendChild', async () => {
@@ -374,7 +374,7 @@ describe('field-mixin', () => {
           div.textContent = 'New';
           element.appendChild(div);
           await nextFrame();
-          expect(element.helperText).to.equal('New');
+          expect(element._helperNode).to.equal(div);
         });
 
         it('should support replacing lazy helper with a new one using insertBefore', async () => {
@@ -386,7 +386,7 @@ describe('field-mixin', () => {
           div.textContent = 'New';
           element.insertBefore(div, helper);
           await nextFrame();
-          expect(element.helperText).to.equal('New');
+          expect(element._helperNode).to.equal(div);
         });
 
         it('should support replacing lazy helper with a new one using replaceChild', async () => {
@@ -398,7 +398,7 @@ describe('field-mixin', () => {
           div.textContent = 'New';
           element.replaceChild(div, helper);
           await nextFrame();
-          expect(element.helperText).to.equal('New');
+          expect(element._helperNode).to.equal(div);
         });
       });
 

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -232,6 +232,16 @@ describe('field-mixin', () => {
         element.helperText = '3 digits';
         expect(element.hasAttribute('has-helper')).to.be.true;
       });
+
+      it('should not add a helper when helperText is whitespace string', () => {
+        element.helperText = ' ';
+        expect(element.querySelector('[slot=helper]')).to.be.not.ok;
+      });
+
+      it('should not set has-helper when helperText is whitespace string', () => {
+        element.helperText = ' ';
+        expect(element.hasAttribute('has-helper')).to.be.false;
+      });
     });
 
     describe('property', () => {

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -425,6 +425,16 @@ describe('field-mixin', () => {
           expect(element._helperNode).to.equal(div);
         });
 
+        it('should support adding lazy helper after removing the default one', async () => {
+          element.removeChild(defaultHelper);
+          await nextFrame();
+
+          element.appendChild(helper);
+          await nextFrame();
+
+          expect(element._helperNode).to.equal(helper);
+        });
+
         it('should restore the default helper when helperText property is set', async () => {
           element.appendChild(helper);
           await nextFrame();

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -424,6 +424,35 @@ describe('field-mixin', () => {
           await nextFrame();
           expect(element._helperNode).to.equal(div);
         });
+
+        it('should restore the default helper when helperText property is set', async () => {
+          element.appendChild(helper);
+          await nextFrame();
+
+          element.removeChild(helper);
+          await nextFrame();
+          expect(element._helperNode).to.equal(defaultHelper);
+        });
+
+        it('should keep has-helper attribute when the default helper is restored', async () => {
+          element.appendChild(helper);
+          await nextFrame();
+
+          element.removeChild(helper);
+          await nextFrame();
+          expect(element.hasAttribute('has-helper')).to.be.true;
+        });
+
+        it('should remove has-helper attribute when helperText is set to empty', async () => {
+          element.appendChild(helper);
+          await nextFrame();
+
+          element.helperText = '';
+
+          element.removeChild(helper);
+          await nextFrame();
+          expect(element.hasAttribute('has-helper')).to.be.false;
+        });
       });
 
       describe('ID attribute', () => {

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-integer-field default"] = 
+snapshots["vaadin-integer-field shadow default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -54,9 +54,9 @@ snapshots["vaadin-integer-field default"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-integer-field default */
+/* end snapshot vaadin-integer-field shadow default */
 
-snapshots["vaadin-integer-field controls"] = 
+snapshots["vaadin-integer-field shadow controls"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -107,9 +107,9 @@ snapshots["vaadin-integer-field controls"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-integer-field controls */
+/* end snapshot vaadin-integer-field shadow controls */
 
-snapshots["vaadin-integer-field disabled"] = 
+snapshots["vaadin-integer-field shadow disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -165,9 +165,9 @@ snapshots["vaadin-integer-field disabled"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-integer-field disabled */
+/* end snapshot vaadin-integer-field shadow disabled */
 
-snapshots["vaadin-integer-field readonly"] = 
+snapshots["vaadin-integer-field shadow readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -223,9 +223,9 @@ snapshots["vaadin-integer-field readonly"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-integer-field readonly */
+/* end snapshot vaadin-integer-field shadow readonly */
 
-snapshots["vaadin-integer-field invalid"] = 
+snapshots["vaadin-integer-field shadow invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -281,9 +281,9 @@ snapshots["vaadin-integer-field invalid"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-integer-field invalid */
+/* end snapshot vaadin-integer-field shadow invalid */
 
-snapshots["vaadin-integer-field theme"] = 
+snapshots["vaadin-integer-field shadow theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -339,17 +339,15 @@ snapshots["vaadin-integer-field theme"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-integer-field theme */
+/* end snapshot vaadin-integer-field shadow theme */
 
-snapshots["vaadin-integer-field slots"] = 
+snapshots["vaadin-integer-field slots default"] = 
 `<label slot="label">
 </label>
 <div
   aria-live="assertive"
   slot="error-message"
 >
-</div>
-<div slot="helper">
 </div>
 <input
   max="undefined"
@@ -359,5 +357,26 @@ snapshots["vaadin-integer-field slots"] =
   type="number"
 >
 `;
-/* end snapshot vaadin-integer-field slots */
+/* end snapshot vaadin-integer-field slots default */
+
+snapshots["vaadin-integer-field slots helper"] = 
+`<label slot="label">
+</label>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<input
+  max="undefined"
+  min="undefined"
+  slot="input"
+  step="any"
+  type="number"
+>
+<div slot="helper">
+  Helper
+</div>
+`;
+/* end snapshot vaadin-integer-field slots helper */
 

--- a/packages/integer-field/test/dom/integer-field.test.js
+++ b/packages/integer-field/test/dom/integer-field.test.js
@@ -15,36 +15,45 @@ describe('vaadin-integer-field', () => {
     field = fixtureSync('<vaadin-integer-field></vaadin-integer-field>');
   });
 
-  it('default', async () => {
-    await expect(field).shadowDom.to.equalSnapshot();
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('controls', async () => {
+      field.hasControls = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('disabled', async () => {
+      field.disabled = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('readonly', async () => {
+      field.readonly = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('invalid', async () => {
+      field.invalid = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('theme', async () => {
+      field.setAttribute('theme', 'align-right');
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
   });
 
-  it('controls', async () => {
-    field.hasControls = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
+  describe('slots', () => {
+    it('default', async () => {
+      await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
 
-  it('disabled', async () => {
-    field.disabled = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('readonly', async () => {
-    field.readonly = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('invalid', async () => {
-    field.invalid = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('theme', async () => {
-    field.setAttribute('theme', 'align-right');
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('slots', async () => {
-    await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    it('helper', async () => {
+      field.helperText = 'Helper';
+      await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
   });
 });

--- a/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
+++ b/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
@@ -10,8 +10,6 @@ snapshots["vaadin-message-input default"] =
     slot="error-message"
   >
   </div>
-  <div slot="helper">
-  </div>
   <textarea
     aria-label="Message"
     placeholder="Message"
@@ -43,8 +41,6 @@ snapshots["vaadin-message-input disabled"] =
     aria-live="assertive"
     slot="error-message"
   >
-  </div>
-  <div slot="helper">
   </div>
   <textarea
     aria-label="Message"

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-number-field default"] = 
+snapshots["vaadin-number-field shadow default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -54,9 +54,9 @@ snapshots["vaadin-number-field default"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-number-field default */
+/* end snapshot vaadin-number-field shadow default */
 
-snapshots["vaadin-number-field controls"] = 
+snapshots["vaadin-number-field shadow controls"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -107,9 +107,9 @@ snapshots["vaadin-number-field controls"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-number-field controls */
+/* end snapshot vaadin-number-field shadow controls */
 
-snapshots["vaadin-number-field disabled"] = 
+snapshots["vaadin-number-field shadow disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -165,9 +165,9 @@ snapshots["vaadin-number-field disabled"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-number-field disabled */
+/* end snapshot vaadin-number-field shadow disabled */
 
-snapshots["vaadin-number-field readonly"] = 
+snapshots["vaadin-number-field shadow readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -223,9 +223,9 @@ snapshots["vaadin-number-field readonly"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-number-field readonly */
+/* end snapshot vaadin-number-field shadow readonly */
 
-snapshots["vaadin-number-field invalid"] = 
+snapshots["vaadin-number-field shadow invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -281,9 +281,9 @@ snapshots["vaadin-number-field invalid"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-number-field invalid */
+/* end snapshot vaadin-number-field shadow invalid */
 
-snapshots["vaadin-number-field theme"] = 
+snapshots["vaadin-number-field shadow theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -339,17 +339,15 @@ snapshots["vaadin-number-field theme"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-number-field theme */
+/* end snapshot vaadin-number-field shadow theme */
 
-snapshots["vaadin-number-field slots"] = 
+snapshots["vaadin-number-field slots default"] = 
 `<label slot="label">
 </label>
 <div
   aria-live="assertive"
   slot="error-message"
 >
-</div>
-<div slot="helper">
 </div>
 <input
   max="undefined"
@@ -359,5 +357,26 @@ snapshots["vaadin-number-field slots"] =
   type="number"
 >
 `;
-/* end snapshot vaadin-number-field slots */
+/* end snapshot vaadin-number-field slots default */
+
+snapshots["vaadin-number-field slots helper"] = 
+`<label slot="label">
+</label>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<input
+  max="undefined"
+  min="undefined"
+  slot="input"
+  step="any"
+  type="number"
+>
+<div slot="helper">
+  Helper
+</div>
+`;
+/* end snapshot vaadin-number-field slots helper */
 

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-password-field default"] = 
+snapshots["vaadin-password-field shadow default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -49,9 +49,9 @@ snapshots["vaadin-password-field default"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-password-field default */
+/* end snapshot vaadin-password-field shadow default */
 
-snapshots["vaadin-password-field disabled"] = 
+snapshots["vaadin-password-field shadow disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -102,9 +102,9 @@ snapshots["vaadin-password-field disabled"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-password-field disabled */
+/* end snapshot vaadin-password-field shadow disabled */
 
-snapshots["vaadin-password-field readonly"] = 
+snapshots["vaadin-password-field shadow readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -155,9 +155,9 @@ snapshots["vaadin-password-field readonly"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-password-field readonly */
+/* end snapshot vaadin-password-field shadow readonly */
 
-snapshots["vaadin-password-field invalid"] = 
+snapshots["vaadin-password-field shadow invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -208,9 +208,9 @@ snapshots["vaadin-password-field invalid"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-password-field invalid */
+/* end snapshot vaadin-password-field shadow invalid */
 
-snapshots["vaadin-password-field theme"] = 
+snapshots["vaadin-password-field shadow theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -261,17 +261,15 @@ snapshots["vaadin-password-field theme"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-password-field theme */
+/* end snapshot vaadin-password-field shadow theme */
 
-snapshots["vaadin-password-field slots"] = 
+snapshots["vaadin-password-field slots default"] = 
 `<label slot="label">
 </label>
 <div
   aria-live="assertive"
   slot="error-message"
 >
-</div>
-<div slot="helper">
 </div>
 <button
   aria-label="Show password"
@@ -287,5 +285,32 @@ snapshots["vaadin-password-field slots"] =
   type="password"
 >
 `;
-/* end snapshot vaadin-password-field slots */
+/* end snapshot vaadin-password-field slots default */
+
+snapshots["vaadin-password-field slots helper"] = 
+`<label slot="label">
+</label>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<button
+  aria-label="Show password"
+  aria-pressed="false"
+  slot="reveal"
+  tabindex="0"
+  type="button"
+>
+</button>
+<input
+  autocapitalize="off"
+  slot="input"
+  type="password"
+>
+<div slot="helper">
+  Helper
+</div>
+`;
+/* end snapshot vaadin-password-field slots helper */
 

--- a/packages/password-field/test/dom/password-field.test.js
+++ b/packages/password-field/test/dom/password-field.test.js
@@ -15,31 +15,40 @@ describe('vaadin-password-field', () => {
     field = fixtureSync('<vaadin-password-field></vaadin-password-field>');
   });
 
-  it('default', async () => {
-    await expect(field).shadowDom.to.equalSnapshot();
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('disabled', async () => {
+      field.disabled = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('readonly', async () => {
+      field.readonly = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('invalid', async () => {
+      field.invalid = true;
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
+
+    it('theme', async () => {
+      field.setAttribute('theme', 'align-right');
+      await expect(field).shadowDom.to.equalSnapshot();
+    });
   });
 
-  it('disabled', async () => {
-    field.disabled = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
+  describe('slots', () => {
+    it('default', async () => {
+      await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
 
-  it('readonly', async () => {
-    field.readonly = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('invalid', async () => {
-    field.invalid = true;
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('theme', async () => {
-    field.setAttribute('theme', 'align-right');
-    await expect(field).shadowDom.to.equalSnapshot();
-  });
-
-  it('slots', async () => {
-    await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    it('helper', async () => {
+      field.helperText = 'Helper';
+      await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
   });
 });

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -5,7 +5,7 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-radio-group.js';
 
 describe('radio-group', () => {
-  let group, label, error, helper, buttons;
+  let group, buttons;
 
   describe('custom element definition', () => {
     let tagName;
@@ -493,10 +493,12 @@ describe('radio-group', () => {
   });
 
   describe('aria-labelledby', () => {
+    let error, helper, label;
+
     beforeEach(() => {
-      group = fixtureSync(`<vaadin-radio-group></vaadin-radio-group>`);
-      helper = group._helperNode;
+      group.helperText = 'Choose one';
       error = group._errorNode;
+      helper = group._helperNode;
       label = group._labelNode;
     });
 

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -496,7 +496,7 @@ describe('radio-group', () => {
     let error, helper, label;
 
     beforeEach(() => {
-      group.helperText = 'Choose one';
+      group = fixtureSync('<vaadin-radio-group helper-text="Choose one"></vaadin-radio-group>');
       error = group._errorNode;
       helper = group._helperNode;
       label = group._labelNode;

--- a/packages/select/test/dom/select.test.js
+++ b/packages/select/test/dom/select.test.js
@@ -15,31 +15,40 @@ describe('vaadin-select', () => {
     select = fixtureSync('<vaadin-select></vaadin-select>');
   });
 
-  it('default', async () => {
-    await expect(select).shadowDom.to.equalSnapshot();
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(select).shadowDom.to.equalSnapshot();
+    });
+
+    it('disabled', async () => {
+      select.disabled = true;
+      await expect(select).shadowDom.to.equalSnapshot();
+    });
+
+    it('readonly', async () => {
+      select.readonly = true;
+      await expect(select).shadowDom.to.equalSnapshot();
+    });
+
+    it('invalid', async () => {
+      select.invalid = true;
+      await expect(select).shadowDom.to.equalSnapshot();
+    });
+
+    it('theme', async () => {
+      select.setAttribute('theme', 'align-right');
+      await expect(select).shadowDom.to.equalSnapshot();
+    });
   });
 
-  it('disabled', async () => {
-    select.disabled = true;
-    await expect(select).shadowDom.to.equalSnapshot();
-  });
+  describe('slots', () => {
+    it('default', async () => {
+      await expect(select).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
 
-  it('readonly', async () => {
-    select.readonly = true;
-    await expect(select).shadowDom.to.equalSnapshot();
-  });
-
-  it('invalid', async () => {
-    select.invalid = true;
-    await expect(select).shadowDom.to.equalSnapshot();
-  });
-
-  it('theme', async () => {
-    select.setAttribute('theme', 'align-right');
-    await expect(select).shadowDom.to.equalSnapshot();
-  });
-
-  it('slots', async () => {
-    await expect(select).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    it('helper', async () => {
+      select.helperText = 'Helper';
+      await expect(select).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
   });
 });

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-text-area default"] = 
+snapshots["vaadin-text-area shadow default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -42,9 +42,9 @@ snapshots["vaadin-text-area default"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-text-area default */
+/* end snapshot vaadin-text-area shadow default */
 
-snapshots["vaadin-text-area disabled"] = 
+snapshots["vaadin-text-area shadow disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -88,9 +88,9 @@ snapshots["vaadin-text-area disabled"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-text-area disabled */
+/* end snapshot vaadin-text-area shadow disabled */
 
-snapshots["vaadin-text-area readonly"] = 
+snapshots["vaadin-text-area shadow readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -134,9 +134,9 @@ snapshots["vaadin-text-area readonly"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-text-area readonly */
+/* end snapshot vaadin-text-area shadow readonly */
 
-snapshots["vaadin-text-area invalid"] = 
+snapshots["vaadin-text-area shadow invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -180,9 +180,9 @@ snapshots["vaadin-text-area invalid"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-text-area invalid */
+/* end snapshot vaadin-text-area shadow invalid */
 
-snapshots["vaadin-text-area theme"] = 
+snapshots["vaadin-text-area shadow theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -226,9 +226,9 @@ snapshots["vaadin-text-area theme"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-text-area theme */
+/* end snapshot vaadin-text-area shadow theme */
 
-snapshots["vaadin-text-area slots"] = 
+snapshots["vaadin-text-area slots default"] = 
 `<label slot="label">
 </label>
 <div
@@ -236,10 +236,24 @@ snapshots["vaadin-text-area slots"] =
   slot="error-message"
 >
 </div>
-<div slot="helper">
-</div>
 <textarea slot="textarea">
 </textarea>
 `;
-/* end snapshot vaadin-text-area slots */
+/* end snapshot vaadin-text-area slots default */
+
+snapshots["vaadin-text-area slots helper"] = 
+`<label slot="label">
+</label>
+<div
+  aria-live="assertive"
+  slot="error-message"
+>
+</div>
+<textarea slot="textarea">
+</textarea>
+<div slot="helper">
+  Helper
+</div>
+`;
+/* end snapshot vaadin-text-area slots helper */
 

--- a/packages/text-area/test/dom/text-area.test.js
+++ b/packages/text-area/test/dom/text-area.test.js
@@ -15,31 +15,40 @@ describe('vaadin-text-area', () => {
     textArea = fixtureSync('<vaadin-text-area></vaadin-text-area>');
   });
 
-  it('default', async () => {
-    await expect(textArea).shadowDom.to.equalSnapshot();
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(textArea).shadowDom.to.equalSnapshot();
+    });
+
+    it('disabled', async () => {
+      textArea.disabled = true;
+      await expect(textArea).shadowDom.to.equalSnapshot();
+    });
+
+    it('readonly', async () => {
+      textArea.readonly = true;
+      await expect(textArea).shadowDom.to.equalSnapshot();
+    });
+
+    it('invalid', async () => {
+      textArea.invalid = true;
+      await expect(textArea).shadowDom.to.equalSnapshot();
+    });
+
+    it('theme', async () => {
+      textArea.setAttribute('theme', 'align-right');
+      await expect(textArea).shadowDom.to.equalSnapshot();
+    });
   });
 
-  it('disabled', async () => {
-    textArea.disabled = true;
-    await expect(textArea).shadowDom.to.equalSnapshot();
-  });
+  describe('slots', () => {
+    it('default', async () => {
+      await expect(textArea).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
 
-  it('readonly', async () => {
-    textArea.readonly = true;
-    await expect(textArea).shadowDom.to.equalSnapshot();
-  });
-
-  it('invalid', async () => {
-    textArea.invalid = true;
-    await expect(textArea).shadowDom.to.equalSnapshot();
-  });
-
-  it('theme', async () => {
-    textArea.setAttribute('theme', 'align-right');
-    await expect(textArea).shadowDom.to.equalSnapshot();
-  });
-
-  it('slots', async () => {
-    await expect(textArea).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    it('helper', async () => {
+      textArea.helperText = 'Helper';
+      await expect(textArea).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
   });
 });

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-select shadow default"] = 
+snapshots["vaadin-text-field shadow default"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -18,10 +18,16 @@ snapshots["vaadin-select shadow default"] =
       slot="prefix"
     >
     </slot>
-    <slot name="value">
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
     </slot>
     <div
-      part="toggle-button"
+      id="clearButton"
+      part="clear-button"
       slot="suffix"
     >
     </div>
@@ -35,14 +41,10 @@ snapshots["vaadin-select shadow default"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay>
-</vaadin-select-overlay>
-<iron-media-query style="display: none;">
-</iron-media-query>
 `;
-/* end snapshot vaadin-select shadow default */
+/* end snapshot vaadin-text-field shadow default */
 
-snapshots["vaadin-select shadow disabled"] = 
+snapshots["vaadin-text-field shadow disabled"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -62,10 +64,16 @@ snapshots["vaadin-select shadow disabled"] =
       slot="prefix"
     >
     </slot>
-    <slot name="value">
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
     </slot>
     <div
-      part="toggle-button"
+      id="clearButton"
+      part="clear-button"
       slot="suffix"
     >
     </div>
@@ -79,14 +87,10 @@ snapshots["vaadin-select shadow disabled"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay>
-</vaadin-select-overlay>
-<iron-media-query style="display: none;">
-</iron-media-query>
 `;
-/* end snapshot vaadin-select shadow disabled */
+/* end snapshot vaadin-text-field shadow disabled */
 
-snapshots["vaadin-select shadow readonly"] = 
+snapshots["vaadin-text-field shadow readonly"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -106,10 +110,16 @@ snapshots["vaadin-select shadow readonly"] =
       slot="prefix"
     >
     </slot>
-    <slot name="value">
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
     </slot>
     <div
-      part="toggle-button"
+      id="clearButton"
+      part="clear-button"
       slot="suffix"
     >
     </div>
@@ -123,14 +133,10 @@ snapshots["vaadin-select shadow readonly"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay>
-</vaadin-select-overlay>
-<iron-media-query style="display: none;">
-</iron-media-query>
 `;
-/* end snapshot vaadin-select shadow readonly */
+/* end snapshot vaadin-text-field shadow readonly */
 
-snapshots["vaadin-select shadow invalid"] = 
+snapshots["vaadin-text-field shadow invalid"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -150,10 +156,16 @@ snapshots["vaadin-select shadow invalid"] =
       slot="prefix"
     >
     </slot>
-    <slot name="value">
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
     </slot>
     <div
-      part="toggle-button"
+      id="clearButton"
+      part="clear-button"
       slot="suffix"
     >
     </div>
@@ -167,14 +179,10 @@ snapshots["vaadin-select shadow invalid"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay>
-</vaadin-select-overlay>
-<iron-media-query style="display: none;">
-</iron-media-query>
 `;
-/* end snapshot vaadin-select shadow invalid */
+/* end snapshot vaadin-text-field shadow invalid */
 
-snapshots["vaadin-select shadow theme"] = 
+snapshots["vaadin-text-field shadow theme"] = 
 `<div part="container">
   <div part="label">
     <slot name="label">
@@ -194,10 +202,16 @@ snapshots["vaadin-select shadow theme"] =
       slot="prefix"
     >
     </slot>
-    <slot name="value">
+    <slot name="input">
+    </slot>
+    <slot
+      name="suffix"
+      slot="suffix"
+    >
     </slot>
     <div
-      part="toggle-button"
+      id="clearButton"
+      part="clear-button"
       slot="suffix"
     >
     </div>
@@ -211,14 +225,10 @@ snapshots["vaadin-select shadow theme"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay theme="align-right">
-</vaadin-select-overlay>
-<iron-media-query style="display: none;">
-</iron-media-query>
 `;
-/* end snapshot vaadin-select shadow theme */
+/* end snapshot vaadin-text-field shadow theme */
 
-snapshots["vaadin-select slots default"] = 
+snapshots["vaadin-text-field slots default"] = 
 `<label slot="label">
 </label>
 <div
@@ -226,19 +236,14 @@ snapshots["vaadin-select slots default"] =
   slot="error-message"
 >
 </div>
-<vaadin-select-value-button
-  aria-expanded="false"
-  aria-haspopup="listbox"
-  aria-required="false"
-  role="button"
-  slot="value"
-  tabindex="0"
+<input
+  slot="input"
+  type="text"
 >
-</vaadin-select-value-button>
 `;
-/* end snapshot vaadin-select slots default */
+/* end snapshot vaadin-text-field slots default */
 
-snapshots["vaadin-select slots helper"] = 
+snapshots["vaadin-text-field slots helper"] = 
 `<label slot="label">
 </label>
 <div
@@ -246,18 +251,13 @@ snapshots["vaadin-select slots helper"] =
   slot="error-message"
 >
 </div>
-<vaadin-select-value-button
-  aria-expanded="false"
-  aria-haspopup="listbox"
-  aria-required="false"
-  role="button"
-  slot="value"
-  tabindex="0"
+<input
+  slot="input"
+  type="text"
 >
-</vaadin-select-value-button>
 <div slot="helper">
   Helper
 </div>
 `;
-/* end snapshot vaadin-select slots helper */
+/* end snapshot vaadin-text-field slots helper */
 

--- a/packages/text-field/test/dom/text-field.test.js
+++ b/packages/text-field/test/dom/text-field.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../../src/vaadin-number-field.js';
+import '../../src/vaadin-text-field.js';
 
-describe('vaadin-number-field', () => {
+describe('vaadin-text-field', () => {
   let field;
 
   // Ignore generated attributes to prevent failures
@@ -12,16 +12,11 @@ describe('vaadin-number-field', () => {
   };
 
   beforeEach(() => {
-    field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+    field = fixtureSync('<vaadin-text-field></vaadin-text-field>');
   });
 
   describe('shadow', () => {
     it('default', async () => {
-      await expect(field).shadowDom.to.equalSnapshot();
-    });
-
-    it('controls', async () => {
-      field.hasControls = true;
       await expect(field).shadowDom.to.equalSnapshot();
     });
 

--- a/packages/vaadin-combo-box/test/aria.test.js
+++ b/packages/vaadin-combo-box/test/aria.test.js
@@ -8,7 +8,7 @@ describe('ARIA', () => {
   let comboBox, input, label, helper, error;
 
   beforeEach(() => {
-    comboBox = fixtureSync('<vaadin-combo-box label="my label"></vaadin-combo-box>');
+    comboBox = fixtureSync('<vaadin-combo-box label="my label" helper-text="Helper"></vaadin-combo-box>');
     comboBox.items = ['foo', 'bar', 'baz'];
     input = comboBox.inputElement;
     label = comboBox.querySelector('[slot=label]');

--- a/packages/vaadin-time-picker/test/aria.test.js
+++ b/packages/vaadin-time-picker/test/aria.test.js
@@ -6,7 +6,7 @@ describe('ARIA', () => {
   let timePicker, comboBox, input, label, helper, error;
 
   beforeEach(() => {
-    timePicker = fixtureSync(`<vaadin-time-picker></vaadin-time-picker>`);
+    timePicker = fixtureSync(`<vaadin-time-picker helper-text="Time slot"></vaadin-time-picker>`);
     comboBox = timePicker.$.comboBox;
     input = timePicker.inputElement;
     label = timePicker.querySelector('[slot=label]');


### PR DESCRIPTION
## Description

Fixes #2382

This is an attempt to make the new behavior more or less aligned with that we used to have previously, i.e.

```html
<slot name="helper">[[helperText]]</slot>
```

Notable changes:

1. Setting `helperText` property (or attribute) only updates text content for the default helper, not for custom one.
2. Text content from the custom helper is set to `helperText` property when it is inserted, but not updated later.
3. When the custom helper is removed, the default one is restored. I had to use `FlattenedNodesObserver` for it.

## Type of change

- Bugfix