### PR TITLE
fix: add itemValuePath to selectItemChanged observer.

### DIFF
--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -198,7 +198,7 @@ export const ComboBoxMixin = (subclass) =>
         '_filterChanged(filter, itemValuePath, itemLabelPath)',
         '_itemsOrPathsChanged(items.*, itemValuePath, itemLabelPath)',
         '_filteredItemsChanged(filteredItems.*, itemValuePath, itemLabelPath)',
-        '_selectedItemChanged(selectedItem, itemLabelPath)'
+        '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)'
       ];
     }
 

--- a/packages/vaadin-combo-box/test/object-values.test.js
+++ b/packages/vaadin-combo-box/test/object-values.test.js
@@ -29,6 +29,12 @@ describe('object values', () => {
       comboBox.open();
     });
 
+    it('it should change combo-box value when value path changes', () => {
+      selectItem(comboBox, 0);
+      comboBox.itemValuePath = 'custom';
+      expect(comboBox.value).to.be.equal('bazs');
+    });
+
     it('should use the default label property on input field', () => {
       selectItem(comboBox, 0);
 
@@ -63,9 +69,9 @@ describe('object values', () => {
     });
 
     it('should use toString if provided label and value paths are not found', () => {
+      comboBox.items[0].toString = () => 'default';
       comboBox.itemValuePath = 'not.found';
       comboBox.itemLabelPath = 'not.found';
-      comboBox.items[0].toString = () => 'default';
 
       selectItem(comboBox, 0);
 


### PR DESCRIPTION
## Description

When ComboBox is used inside polymer template and referenced inside a Java view, some property updates are not happening in order like other use cases, this caused the web component break on a very specific usage. 
After some investigation we found out that in the list of values that `selectItemChanged` observer should be run, `itemValuePath` is missing, so when `itemValuePath` is changed, `value` is not changed respectively (which happens in `selectItemChanged`).
The proposed solution is to add `itemValuePath` to  list of parameters for computed observer `selectItemChanged`.

Fixes https://github.com/vaadin/flow-components/issues/1880

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
