### PR TITLE
fix: remove unused cancel key on vaadin-upload

### DIFF
--- a/packages/vaadin-upload/src/interfaces.d.ts
+++ b/packages/vaadin-upload/src/interfaces.d.ts
@@ -25,7 +25,6 @@ export interface UploadI18n {
     one: string;
     many: string;
   };
-  cancel: string;
   error: {
     tooManyFiles: string;
     fileIsTooBig: string;

--- a/packages/vaadin-upload/src/vaadin-upload.d.ts
+++ b/packages/vaadin-upload/src/vaadin-upload.d.ts
@@ -183,7 +183,6 @@ declare class UploadElement extends ThemableMixin(ElementMixin(HTMLElement)) {
    *     one: 'Select File...',
    *     many: 'Upload Files...'
    *   },
-   *   cancel: 'Cancel',
    *   error: {
    *     tooManyFiles: 'Too Many Files.',
    *     fileIsTooBig: 'File is Too Big.',

--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -344,7 +344,6 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
        *     one: 'Select File...',
        *     many: 'Upload Files...'
        *   },
-       *   cancel: 'Cancel',
        *   error: {
        *     tooManyFiles: 'Too Many Files.',
        *     fileIsTooBig: 'File is Too Big.',
@@ -400,7 +399,6 @@ class UploadElement extends ElementMixin(ThemableMixin(PolymerElement)) {
               one: 'Upload File...',
               many: 'Upload Files...'
             },
-            cancel: 'Cancel',
             error: {
               tooManyFiles: 'Too Many Files.',
               fileIsTooBig: 'File is Too Big.',


### PR DESCRIPTION
## Description

fix: Remove Cancel key from i18n file on vaadin-upload component

Remove unused Cancel key on vaadin-upload.js and vaadin-upload.d.ts

Fixes #2337 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
