### PR TITLE
fix: generate sentence case header for camel case columns

### DIFF
--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -113,6 +113,20 @@ class CrudGridElement extends IncludedMixin(GridElement) {
     this.__toggleEditColumn();
   }
 
+  /**
+   * Parse the camelCase column names into sentence case column names
+   *
+   * @private
+   */  
+   _generateHeader(path) {
+    return path
+      .substr(path.lastIndexOf('.') + 1)
+      .replace(/([A-Z])/g, '-$1')
+      .toLowerCase()
+      .replace(/-/g, ' ')
+      .replace(/^./, (match) => match.toUpperCase());
+  }
+
   /** @private */
   __createColumn(parent, path) {
     const col = document.createElement('vaadin-grid-column');
@@ -123,7 +137,7 @@ class CrudGridElement extends IncludedMixin(GridElement) {
 
     if (!this.noHead && path) {
       col.headerRenderer = (root) => {
-        const label = this.__capitalize(path.replace(/^.*\./, ''));
+        const label = this._generateHeader(path);
 
         if (!this.noSort) {
           const sorter = window.document.createElement('vaadin-grid-sorter');

--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -114,11 +114,12 @@ class CrudGridElement extends IncludedMixin(GridElement) {
   }
 
   /**
-   * Parse the camelCase column names into sentence case column names
-   *
-   * @private
-   */  
-   _generateHeader(path) {
+   * Parse the camelCase column names into sentence case headers.
+   * @param {string} path
+   * @return {string}
+   * @protected
+   */
+  _generateHeader(path) {
     return path
       .substr(path.lastIndexOf('.') + 1)
       .replace(/([A-Z])/g, '-$1')

--- a/packages/crud/test/crud-grid.test.js
+++ b/packages/crud/test/crud-grid.test.js
@@ -67,6 +67,18 @@ describe('crud grid', () => {
         expect(getHeaderCellContent(grid, 1, 3).textContent.trim()).to.be.equal('Last');
       });
 
+      it('should convert camelCase fields label into sentence field label', async () => {
+        grid.include = 'role,passwordField,name.firstName,name.last';
+        flushGrid(grid);
+        await aTimeout(100);
+        expect(getHeaderCellContent(grid, 0, 2).textContent.trim()).to.be.equal('Name');
+        expect(getHeaderCellContent(grid, 1, 0).textContent.trim()).to.be.equal('Role');
+        expect(getHeaderCellContent(grid, 1, 1).textContent.trim()).to.be.equal('Password field');
+        expect(getHeaderCellContent(grid, 1, 2).textContent.trim()).to.be.equal('First name');
+        expect(getHeaderCellContent(grid, 1, 3).textContent.trim()).to.be.equal('Last');
+      });
+
+
       it('should configure include fields in the provided order when items is provided', () => {
         grid.include = 'a, b, c';
         grid.items = [{ d: 1 }];

--- a/packages/crud/test/crud-grid.test.js
+++ b/packages/crud/test/crud-grid.test.js
@@ -59,7 +59,7 @@ describe('crud grid', () => {
       it('should configure include fields in the provided order', async () => {
         grid.include = 'role,password,name.first,name.last';
         flushGrid(grid);
-        await aTimeout(100);
+        await nextRender(grid);
         expect(getHeaderCellContent(grid, 0, 2).textContent.trim()).to.be.equal('Name');
         expect(getHeaderCellContent(grid, 1, 0).textContent.trim()).to.be.equal('Role');
         expect(getHeaderCellContent(grid, 1, 1).textContent.trim()).to.be.equal('Password');
@@ -68,16 +68,12 @@ describe('crud grid', () => {
       });
 
       it('should convert camelCase fields label into sentence field label', async () => {
-        grid.include = 'role,passwordField,name.firstName,name.last';
+        grid.include = 'passwordField,name.firstName';
         flushGrid(grid);
-        await aTimeout(100);
-        expect(getHeaderCellContent(grid, 0, 2).textContent.trim()).to.be.equal('Name');
-        expect(getHeaderCellContent(grid, 1, 0).textContent.trim()).to.be.equal('Role');
-        expect(getHeaderCellContent(grid, 1, 1).textContent.trim()).to.be.equal('Password field');
-        expect(getHeaderCellContent(grid, 1, 2).textContent.trim()).to.be.equal('First name');
-        expect(getHeaderCellContent(grid, 1, 3).textContent.trim()).to.be.equal('Last');
+        await nextRender(grid);
+        expect(getHeaderCellContent(grid, 1, 0).textContent.trim()).to.be.equal('Password field');
+        expect(getHeaderCellContent(grid, 1, 1).textContent.trim()).to.be.equal('First name');
       });
-
 
       it('should configure include fields in the provided order when items is provided', () => {
         grid.include = 'a, b, c';


### PR DESCRIPTION
# Description

Parse camel case field label to sentence case and use for column header e.g. 'passwordField' should be converted to 'Password field'.

Fixes #533 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
