### PR TITLE
fix: do not fire custom-value-set event when readonly (CP: 21)

### DIFF
--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -1028,7 +1028,7 @@ export const ComboBoxMixin = (subclass) =>
         event.composedPath()[0].focus();
         return;
       }
-      if (!this._closeOnBlurIsPrevented) {
+      if (!this.readonly && !this._closeOnBlurIsPrevented) {
         this._closeOrCommit();
       }
     }

--- a/packages/vaadin-combo-box/test/basic.test.js
+++ b/packages/vaadin-combo-box/test/basic.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, focusout, nextFrame } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
@@ -216,6 +216,18 @@ describe('Properties', () => {
         comboBox.close();
 
         expect(spy.callCount).to.eql(0);
+      });
+
+      it('should be fired when combo-box is read-only', () => {
+        const spy = sinon.spy();
+        comboBox.addEventListener('custom-value-set', spy);
+
+        comboBox.readonly = true;
+        comboBox.inputElement.value = 'foo';
+        comboBox.focus();
+        focusout(comboBox);
+
+        expect(spy.called).to.be.false;
       });
 
       it('should be cancelable', () => {

--- a/packages/vaadin-combo-box/test/basic.test.js
+++ b/packages/vaadin-combo-box/test/basic.test.js
@@ -218,7 +218,7 @@ describe('Properties', () => {
         expect(spy.callCount).to.eql(0);
       });
 
-      it('should be fired when combo-box is read-only', () => {
+      it('should not be fired when combo-box is read-only', () => {
         const spy = sinon.spy();
         comboBox.addEventListener('custom-value-set', spy);
 


### PR DESCRIPTION
cherry-pick of #2721
(cherry picked from commit 62a9e8af33e6f5c22e3030aaa967f474103e1002)
