### PR TITLE
fix: add itemValuePath to selectItemChanged observer (#2718)

### DIFF
--- a/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-mixin.js
@@ -249,7 +249,7 @@ export const ComboBoxMixin = (subclass) =>
         '_itemsOrPathsChanged(items.*, itemValuePath, itemLabelPath)',
         '_filteredItemsChanged(filteredItems.*, itemValuePath, itemLabelPath)',
         '_loadingChanged(loading)',
-        '_selectedItemChanged(selectedItem, itemLabelPath)',
+        '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
         '_toggleElementChanged(_toggleElement)'
       ];
     }

--- a/packages/vaadin-combo-box/test/object-values.test.js
+++ b/packages/vaadin-combo-box/test/object-values.test.js
@@ -34,6 +34,12 @@ describe('object values', () => {
       comboBox.open();
     });
 
+    it('it should change combo-box value when value path changes', () => {
+      selectItem(comboBox, 0);
+      comboBox.itemValuePath = 'custom';
+      expect(comboBox.value).to.be.equal('bazs');
+    });
+
     it('should use the default label property on input field', () => {
       selectItem(0);
 
@@ -69,9 +75,9 @@ describe('object values', () => {
     });
 
     it('should use toString if provided label and value paths are not found', () => {
+      comboBox.items[0].toString = () => 'default';
       comboBox.itemValuePath = 'not.found';
       comboBox.itemLabelPath = 'not.found';
-      comboBox.items[0].toString = () => 'default';
 
       selectItem(0);
 

--- a/packages/vaadin-combo-box/test/object-values.test.js
+++ b/packages/vaadin-combo-box/test/object-values.test.js
@@ -35,7 +35,7 @@ describe('object values', () => {
     });
 
     it('it should change combo-box value when value path changes', () => {
-      selectItem(comboBox, 0);
+      selectItem(0);
       comboBox.itemValuePath = 'custom';
       expect(comboBox.value).to.be.equal('bazs');
     });


### PR DESCRIPTION
cherry-pick of  https://github.com/vaadin/web-components/pull/2718
cherry-picked from commit `cc1b2ed`