### PR TITLE
refactor: do not use color when preventing invalid input (Lumo)

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -115,7 +115,16 @@ const inputField = css`
   }
 
   :host([input-prevented]) [part='input-field'] {
-    color: var(--lumo-error-text-color);
+    animation: shake 0.15s infinite;
+  }
+
+  @keyframes shake {
+    25% {
+      transform: translateX(4px);
+    }
+    75% {
+      transform: translateX(-4px);
+    }
   }
 
   /* Small theme */


### PR DESCRIPTION
Connected to #119 

Use a "shake" animation instead of text color change to indicate that the character/input was rejected/prevented.

Note, that the placeholder styles were already updated in another PR, and the exact issue listed in #119 does not happen any longer (the placeholder text color is not affected, only if the user has already entered some characters then the color of those would change).