### PR TITLE
refactor: make slot-target-mixin clone instead of moving

### DIFF
--- a/dev/checkbox.html
+++ b/dev/checkbox.html
@@ -12,6 +12,10 @@
   </head>
 
   <body>
-    <vaadin-checkbox>I accept <a href="http://vaadin.com">the terms and conditions</a></vaadin-checkbox>
+    <vaadin-checkbox>
+      <label slot="label">
+        I accept <a href="http://vaadin.com">the terms and conditions</a>
+      </label>
+    </vaadin-checkbox>
   </body>
 </html>

--- a/dev/radio-group.html
+++ b/dev/radio-group.html
@@ -13,9 +13,9 @@
 
   <body>
     <vaadin-radio-group label="Travel class">
-      <vaadin-radio-button value="economy">Economy</vaadin-radio-button>
-      <vaadin-radio-button value="business">Business</vaadin-radio-button>
-      <vaadin-radio-button value="firstClass">First Class</vaadin-radio-button>
+      <vaadin-radio-button value="economy" label="Economy"></vaadin-radio-button>
+      <vaadin-radio-button value="business" label="Business"></vaadin-radio-button>
+      <vaadin-radio-button value="firstClass" label="First Class"></vaadin-radio-button>
     </vaadin-radio-group>
   </body>
 </html>

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -174,7 +174,7 @@ class Checkbox extends SlotLabelMixin(
   }
 
   /**
-   * A reference to the default slot from which nodes are forwarded to the label node.
+   * A reference to the default slot from which nodes are copied to the label node.
    *
    * @override
    * @protected
@@ -182,6 +182,21 @@ class Checkbox extends SlotLabelMixin(
    */
   get _sourceSlot() {
     return this.$.noop;
+  }
+
+  /**
+   * Override __copyNodesToSlotTarget from SlotTargetMixin to show a warning.
+   * @override
+   * @protected
+   * @param {Array<Node>} nodes
+   **/
+  __copyNodesToSlotTarget(nodes) {
+    super.__copyNodesToSlotTarget(nodes);
+
+    console.warn(
+      `WARNING: Since Vaadin 22, placing the label as a direct child of a <vaadin-checkbox> is deprecated.
+Please use <label slot="label"> wrapper or the "label"-property instead.`
+    );
   }
 
   /**

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -195,7 +195,7 @@ class Checkbox extends SlotLabelMixin(
 
     console.warn(
       `WARNING: Since Vaadin 22, placing the label as a direct child of a <vaadin-checkbox> is deprecated.
-Please use <label slot="label"> wrapper or the "label"-property instead.`
+Please use <label slot="label"> wrapper or the label property instead.`
     );
   }
 

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -188,7 +188,7 @@ class Checkbox extends SlotLabelMixin(
    * Override __copyNodesToSlotTarget from SlotTargetMixin to show a warning.
    * @override
    * @protected
-   * @param {Array<Node>} nodes
+   * @param {!Array<!Node>} nodes
    **/
   __copyNodesToSlotTarget(nodes) {
     super.__copyNodesToSlotTarget(nodes);

--- a/packages/checkbox/test/checkbox.test.js
+++ b/packages/checkbox/test/checkbox.test.js
@@ -281,4 +281,23 @@ describe('checkbox', () => {
       });
     });
   });
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      sinon.stub(console, 'warn');
+    });
+
+    afterEach(() => {
+      console.warn.restore();
+    });
+
+    it('should warn about using default slot label', () => {
+      fixtureSync('<vaadin-checkbox>label</vaadin-checkbox>');
+
+      expect(console.warn.calledOnce).to.be.true;
+      expect(console.warn.args[0][0]).to.include(
+        'WARNING: Since Vaadin 22, placing the label as a direct child of a <vaadin-checkbox> is deprecated.'
+      );
+    });
+  });
 });

--- a/packages/checkbox/test/visual/lumo/checkbox.test.js
+++ b/packages/checkbox/test/visual/lumo/checkbox.test.js
@@ -10,7 +10,7 @@ describe('checkbox', () => {
     div = document.createElement('div');
     div.style.display = 'inline-block';
     div.style.padding = '10px';
-    element = fixtureSync('<vaadin-checkbox>Checkbox</vaadin-checkbox>', div);
+    element = fixtureSync('<vaadin-checkbox label="Checkbox"></vaadin-checkbox>', div);
   });
 
   it('basic', async () => {

--- a/packages/checkbox/test/visual/material/checkbox.test.js
+++ b/packages/checkbox/test/visual/material/checkbox.test.js
@@ -10,7 +10,7 @@ describe('checkbox', () => {
     div = document.createElement('div');
     div.style.display = 'inline-block';
     div.style.padding = '10px';
-    element = fixtureSync('<vaadin-checkbox>Checkbox</vaadin-checkbox>', div);
+    element = fixtureSync('<vaadin-checkbox label="Checkbox"></vaadin-checkbox>', div);
   });
 
   it('basic', async () => {

--- a/packages/field-base/src/slot-target-mixin.d.ts
+++ b/packages/field-base/src/slot-target-mixin.d.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * A mixin to forward the content from a source slot to a target element.
+ * A mixin to copy the content from a source slot to a target element.
  */
 declare function SlotTargetMixin<T extends new (...args: any[]) => {}>(base: T): T & SlotTargetMixinConstructor;
 
@@ -15,14 +15,14 @@ interface SlotTargetMixinConstructor {
 
 interface SlotTargetMixin {
   /**
-   * A reference to the source slot from which the content is forwarded to the target element.
+   * A reference to the source slot from which the content is copied to the target element.
    *
    * @protected
    */
   _sourceSlot: HTMLSlotElement;
 
   /**
-   * A reference to the target element to which the content is forwarded from the source slot.
+   * A reference to the target element to which the content is copied from the source slot.
    *
    * @protected
    */

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -52,6 +52,12 @@ const SlotTargetMixinImplementation = (superclass) =>
         return;
       }
 
+      // Remove any existing clones from the slot target
+      if (this.__slotTargetClones) {
+        this.__slotTargetClones.forEach((node) => this._slotTarget.removeChild(node));
+        delete this.__slotTargetClones;
+      }
+
       // Exclude whitespace text nodes
       const nodes = this._sourceSlot
         .assignedNodes({ flatten: true })
@@ -63,18 +69,18 @@ const SlotTargetMixinImplementation = (superclass) =>
     }
 
     /**
-     * Copies the nodes to the target element. Target element is cleared before
-     * the nodes are copied.
+     * Copies the nodes to the target element.
      *
      * @protected
      * @param {Array<Node>} nodes
      */
     __copyNodesToSlotTarget(nodes) {
-      this._slotTarget.innerHTML = '';
-
+      this.__slotTargetClones = this.__slotTargetClones || [];
       nodes.forEach((node) => {
         // Clone the nodes and append the clones to the target slot
-        this._slotTarget.appendChild(node.cloneNode(true));
+        const clone = node.cloneNode(true);
+        this.__slotTargetClones.push(clone);
+        this._slotTarget.appendChild(clone);
         // Observe all changes to the source node to have the clones updated
         this.__sourceSlotObserver.observe(node, {
           attributes: true,

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -18,7 +18,7 @@ const SlotTargetMixinImplementation = (superclass) =>
     }
 
     /**
-     * A reference to the source slot from which the nodes are copies to the target element.
+     * A reference to the source slot from which the nodes are copied to the target element.
      *
      * @type {HTMLSlotElement | null}
      * @protected

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -54,7 +54,11 @@ const SlotTargetMixinImplementation = (superclass) =>
 
       // Remove any existing clones from the slot target
       if (this.__slotTargetClones) {
-        this.__slotTargetClones.forEach((node) => this._slotTarget.removeChild(node));
+        this.__slotTargetClones.forEach((node) => {
+          if (node.parentElement === this._slotTarget) {
+            this._slotTarget.removeChild(node);
+          }
+        });
         delete this.__slotTargetClones;
       }
 
@@ -64,6 +68,7 @@ const SlotTargetMixinImplementation = (superclass) =>
         .filter((node) => !(node.nodeType == Node.TEXT_NODE && node.textContent.trim() === ''));
 
       if (nodes.length > 0) {
+        this._slotTarget.innerHTML = '';
         this.__copyNodesToSlotTarget(nodes);
       }
     }

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -7,6 +7,8 @@ const SlotTargetMixinImplementation = (superclass) =>
       super.ready();
 
       if (this._sourceSlot) {
+        this.__sourceSlotObserver = new MutationObserver(() => this.__forwardNodesToSlotTarget());
+
         this.__forwardNodesToSlotTarget();
 
         this._sourceSlot.addEventListener('slotchange', () => {
@@ -16,7 +18,7 @@ const SlotTargetMixinImplementation = (superclass) =>
     }
 
     /**
-     * A reference to the source slot from which the nodes are forwarded to the target element.
+     * A reference to the source slot from which the nodes are copies to the target element.
      *
      * @type {HTMLSlotElement | null}
      * @protected
@@ -27,7 +29,7 @@ const SlotTargetMixinImplementation = (superclass) =>
     }
 
     /**
-     * A reference to the target element to which the nodes are forwarded from the source slot.
+     * A reference to the target element to which the nodes are copied from the source slot.
      *
      * @type {HTMLElement | null}
      * @protected
@@ -38,12 +40,14 @@ const SlotTargetMixinImplementation = (superclass) =>
     }
 
     /**
-     * Forwards every node from the source slot to the target element
+     * Copies every node from the source slot to the target element
      * once the source slot' content is changed.
      *
      * @private
      */
     __forwardNodesToSlotTarget() {
+      this.__sourceSlotObserver.disconnect();
+
       if (!this._slotTarget) {
         return;
       }
@@ -54,12 +58,24 @@ const SlotTargetMixinImplementation = (superclass) =>
         .filter((node) => !(node.nodeType == Node.TEXT_NODE && node.textContent.trim() === ''));
 
       if (nodes.length > 0) {
-        this._slotTarget.replaceChildren(...nodes);
+        this._slotTarget.innerHTML = '';
+
+        nodes.forEach((node) => {
+          // Clone the nodes and append the clones to the target slot
+          this._slotTarget.appendChild(node.cloneNode(true));
+          // Observe all changes to the source node to have the clones updated
+          this.__sourceSlotObserver.observe(node, {
+            attributes: true,
+            childList: true,
+            subtree: true,
+            characterData: true
+          });
+        });
       }
     }
   };
 
 /**
- * A mixin to forward the content from a source slot to a target element.
+ * A mixin to copy the content from a source slot to a target element.
  */
 export const SlotTargetMixin = dedupingMixin(SlotTargetMixinImplementation);

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -7,12 +7,12 @@ const SlotTargetMixinImplementation = (superclass) =>
       super.ready();
 
       if (this._sourceSlot) {
-        this.__sourceSlotObserver = new MutationObserver(() => this.__forwardNodesToSlotTarget());
+        this.__sourceSlotObserver = new MutationObserver(() => this.__checkAndCopyNodesToSlotTarget());
 
-        this.__forwardNodesToSlotTarget();
+        this.__checkAndCopyNodesToSlotTarget();
 
         this._sourceSlot.addEventListener('slotchange', () => {
-          this.__forwardNodesToSlotTarget();
+          this.__checkAndCopyNodesToSlotTarget();
         });
       }
     }
@@ -45,7 +45,7 @@ const SlotTargetMixinImplementation = (superclass) =>
      *
      * @private
      */
-    __forwardNodesToSlotTarget() {
+    __checkAndCopyNodesToSlotTarget() {
       this.__sourceSlotObserver.disconnect();
 
       if (!this._slotTarget) {
@@ -58,20 +58,31 @@ const SlotTargetMixinImplementation = (superclass) =>
         .filter((node) => !(node.nodeType == Node.TEXT_NODE && node.textContent.trim() === ''));
 
       if (nodes.length > 0) {
-        this._slotTarget.innerHTML = '';
-
-        nodes.forEach((node) => {
-          // Clone the nodes and append the clones to the target slot
-          this._slotTarget.appendChild(node.cloneNode(true));
-          // Observe all changes to the source node to have the clones updated
-          this.__sourceSlotObserver.observe(node, {
-            attributes: true,
-            childList: true,
-            subtree: true,
-            characterData: true
-          });
-        });
+        this.__copyNodesToSlotTarget(nodes);
       }
+    }
+
+    /**
+     * Copies the nodes to the target element. Target element is cleared before
+     * the nodes are copied.
+     *
+     * @protected
+     * @param {Array<Node>} nodes
+     */
+    __copyNodesToSlotTarget(nodes) {
+      this._slotTarget.innerHTML = '';
+
+      nodes.forEach((node) => {
+        // Clone the nodes and append the clones to the target slot
+        this._slotTarget.appendChild(node.cloneNode(true));
+        // Observe all changes to the source node to have the clones updated
+        this.__sourceSlotObserver.observe(node, {
+          attributes: true,
+          childList: true,
+          subtree: true,
+          characterData: true
+        });
+      });
     }
   };
 

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -77,7 +77,7 @@ const SlotTargetMixinImplementation = (superclass) =>
      * Copies the nodes to the target element.
      *
      * @protected
-     * @param {Array<Node>} nodes
+     * @param {!Array<!Node>} nodes
      */
     __copyNodesToSlotTarget(nodes) {
       this.__slotTargetClones = this.__slotTargetClones || [];

--- a/packages/field-base/test/slot-target-mixin.test.js
+++ b/packages/field-base/test/slot-target-mixin.test.js
@@ -61,6 +61,7 @@ describe('slot-target-mixin', () => {
     beforeEach(() => {
       element = document.createElement('slot-target-mixin-element');
       node1 = document.createElement('div');
+      node1.textContent = 'node1';
       node2 = document.createTextNode('');
       element.append(node1, node2);
 
@@ -72,13 +73,12 @@ describe('slot-target-mixin', () => {
     });
 
     it('should populate the target element with non-empty nodes from the source slot', () => {
-      expect(element._slotTarget.childNodes).to.have.lengthOf(1);
-      expect(element._slotTarget.firstChild).to.equal(node1);
+      expect(element._slotTarget.firstChild.textContent).to.eql('node1');
     });
 
-    it('should keep whitespace text nodes in the source slot', () => {
-      expect(element.childNodes).to.have.lengthOf(1);
-      expect(element.firstChild).to.equal(node2);
+    it('should not clone whitespace text nodes', () => {
+      expect(element.childNodes).to.have.lengthOf(2);
+      expect(element._slotTarget.childNodes).to.have.lengthOf(1);
     });
   });
 
@@ -103,6 +103,14 @@ describe('slot-target-mixin', () => {
 
       expect(element._slotTarget.childNodes).to.have.lengthOf(1);
       expect(element._slotTarget.firstChild).to.equal(node);
+    });
+
+    it('should reflect content mutations to the target slot content', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content</div></slot-target-mixin-element>`);
+      expect(element._slotTarget.textContent).to.equal('Content');
+      element.firstChild.textContent = 'New content';
+      await nextFrame();
+      expect(element._slotTarget.textContent).to.equal('New content');
     });
   });
 

--- a/packages/field-base/test/slot-target-mixin.test.js
+++ b/packages/field-base/test/slot-target-mixin.test.js
@@ -111,9 +111,36 @@ describe('slot-target-mixin', () => {
     it('should reflect content mutations to the target slot content', async () => {
       element = fixtureSync(`<slot-target-mixin-element><div>Content</div></slot-target-mixin-element>`);
       expect(element._slotTarget.textContent).to.equal('Content');
+      await nextFrame();
       element.firstChild.textContent = 'New content';
       await nextFrame();
       expect(element._slotTarget.textContent).to.equal('New content');
+    });
+
+    it('should reflect content attribute mutations to the target slot content', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content</div></slot-target-mixin-element>`);
+      await nextFrame();
+      element.firstChild.setAttribute('data-name', 'content');
+      await nextFrame();
+      expect(element._slotTarget.firstElementChild.dataset.name).to.equal('content');
+    });
+
+    it('should reflect content subtree mutations to the target slot content', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content</div></slot-target-mixin-element>`);
+      const subtree = document.createElement('div');
+      element.firstChild.appendChild(subtree);
+      await nextFrame();
+      subtree.textContent = 'New content';
+      await nextFrame();
+      expect(element._slotTarget.firstElementChild.firstElementChild.textContent).to.equal('New content');
+    });
+
+    it('should reflect content character data mutations to the target slot content', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content</div></slot-target-mixin-element>`);
+      await nextFrame();
+      element.firstChild.firstChild.textContent = 'New content';
+      await nextFrame();
+      expect(element._slotTarget.firstElementChild.textContent).to.equal('New content');
     });
   });
 

--- a/packages/field-base/test/slot-target-mixin.test.js
+++ b/packages/field-base/test/slot-target-mixin.test.js
@@ -73,7 +73,7 @@ describe('slot-target-mixin', () => {
     });
 
     it('should populate the target element with non-empty nodes from the source slot', () => {
-      expect(element._slotTarget.firstChild.textContent).to.eql('node1');
+      expect(element._slotTarget.firstChild.textContent).to.equal('node1');
     });
 
     it('should not clone whitespace text nodes', () => {

--- a/packages/field-base/test/slot-target-mixin.test.js
+++ b/packages/field-base/test/slot-target-mixin.test.js
@@ -142,6 +142,14 @@ describe('slot-target-mixin', () => {
       await nextFrame();
       expect(element._slotTarget.firstElementChild.textContent).to.equal('New content');
     });
+
+    it('should reflect cleared content to the target slot content', async () => {
+      element = fixtureSync(`<slot-target-mixin-element><div>Content</div></slot-target-mixin-element>`);
+      await nextFrame();
+      element.firstChild.remove();
+      await nextFrame();
+      expect(element._slotTarget.children).to.be.empty;
+    });
   });
 
   describe('warnings', () => {

--- a/packages/field-base/test/slot-target-mixin.test.js
+++ b/packages/field-base/test/slot-target-mixin.test.js
@@ -87,22 +87,25 @@ describe('slot-target-mixin', () => {
       element = fixtureSync(`<slot-target-mixin-element></slot-target-mixin-element>`);
 
       const node = document.createElement('div');
+      node.textContent = 'node';
       element.appendChild(node);
       await nextFrame();
 
       expect(element._slotTarget.childNodes).to.have.lengthOf(1);
-      expect(element._slotTarget.firstChild).to.equal(node);
+      expect(element._slotTarget.firstChild.textContent).to.equal('node');
     });
 
-    it('should re-populate the target element when adding new nodes to the source slot', async () => {
+    it('should add new nodes to the target slot', async () => {
       element = fixtureSync(`<slot-target-mixin-element><div>Content</div></slot-target-mixin-element>`);
 
       const node = document.createElement('div');
+      node.textContent = 'New content';
       element.appendChild(node);
       await nextFrame();
 
-      expect(element._slotTarget.childNodes).to.have.lengthOf(1);
-      expect(element._slotTarget.firstChild).to.equal(node);
+      expect(element._slotTarget.childNodes).to.have.lengthOf(2);
+      expect(element._slotTarget.children[0].textContent).to.equal('Content');
+      expect(element._slotTarget.children[1].textContent).to.equal('New content');
     });
 
     it('should reflect content mutations to the target slot content', async () => {

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -141,7 +141,7 @@ class RadioButton extends SlotLabelMixin(
   }
 
   /**
-   * A reference to the default slot from which nodes are forwarded to the label node.
+   * A reference to the default slot from which nodes are copied to the label node.
    *
    * @override
    * @protected
@@ -149,6 +149,21 @@ class RadioButton extends SlotLabelMixin(
    */
   get _sourceSlot() {
     return this.$.noop;
+  }
+
+  /**
+   * Override __copyNodesToSlotTarget from SlotTargetMixin to show a warning.
+   * @override
+   * @protected
+   * @param {Array<Node>} nodes
+   **/
+  __copyNodesToSlotTarget(nodes) {
+    super.__copyNodesToSlotTarget(nodes);
+
+    console.warn(
+      `WARNING: Since Vaadin 22, placing the label as a direct child of a <vaadin-radio-button> is deprecated.
+  Please use <label slot="label"> wrapper or the "label"-property instead.`
+    );
   }
 
   /** @protected */

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -155,7 +155,7 @@ class RadioButton extends SlotLabelMixin(
    * Override __copyNodesToSlotTarget from SlotTargetMixin to show a warning.
    * @override
    * @protected
-   * @param {Array<Node>} nodes
+   * @param {!Array<!Node>} nodes
    **/
   __copyNodesToSlotTarget(nodes) {
     super.__copyNodesToSlotTarget(nodes);

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -162,7 +162,7 @@ class RadioButton extends SlotLabelMixin(
 
     console.warn(
       `WARNING: Since Vaadin 22, placing the label as a direct child of a <vaadin-radio-button> is deprecated.
-  Please use <label slot="label"> wrapper or the "label"-property instead.`
+  Please use <label slot="label"> wrapper or the label property instead.`
     );
   }
 

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -276,4 +276,23 @@ describe('radio-button', () => {
       expect(radio.hasAttribute('has-label')).to.be.true;
     });
   });
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      sinon.stub(console, 'warn');
+    });
+
+    afterEach(() => {
+      console.warn.restore();
+    });
+
+    it('should warn about using default slot label', () => {
+      fixtureSync('<vaadin-radio-button>label</vaadin-radio-button>');
+
+      expect(console.warn.calledOnce).to.be.true;
+      expect(console.warn.args[0][0]).to.include(
+        'WARNING: Since Vaadin 22, placing the label as a direct child of a <vaadin-radio-button> is deprecated.'
+      );
+    });
+  });
 });

--- a/packages/radio-group/test/visual/lumo/radio-button.test.js
+++ b/packages/radio-group/test/visual/lumo/radio-button.test.js
@@ -10,7 +10,7 @@ describe('radio-button', () => {
     div = document.createElement('div');
     div.style.display = 'inline-block';
     div.style.padding = '10px';
-    element = fixtureSync('<vaadin-radio-button>Radio button</vaadin-radio-button>', div);
+    element = fixtureSync('<vaadin-radio-button label="Radio button"></vaadin-radio-button>', div);
   });
 
   it('basic', async () => {

--- a/packages/radio-group/test/visual/material/radio-button.test.js
+++ b/packages/radio-group/test/visual/material/radio-button.test.js
@@ -10,7 +10,7 @@ describe('radio-button', () => {
     div = document.createElement('div');
     div.style.display = 'inline-block';
     div.style.padding = '10px';
-    element = fixtureSync('<vaadin-radio-button>Radio button</vaadin-radio-button>', div);
+    element = fixtureSync('<vaadin-radio-button label="Radio button"></vaadin-radio-button>', div);
   });
 
   it('basic', async () => {

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -13,7 +13,7 @@ const HIDDEN_WARNINGS = [
   'WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.',
   'WARNING: Since Vaadin 21, render() is deprecated. The items value is immutable. Please replace it with a new value instead of mutating in place.',
   'WARNING: Since Vaadin 21, render() is deprecated. Please use requestContentUpdate() instead.',
-  `WARNING: Since Vaadin 22, notifyResize() is deprecated. The component uses a ResizeObserver internally and doesn't need to be explicitly notified of resizes.`,
+  /^WARNING: Since Vaadin 22, .* is deprecated.*/,
   /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/
 ];
 


### PR DESCRIPTION
Fixes #2609 

This PR changes the behavior of `slot-target-mixin` so that the nodes in the source slot are no longer moved but copied inside the slot target.

Also, a warning is now shown if the default slot is used for defining a label for checkbox / radio-button