### PR TITLE
fix!: enhance clickable area for radio-button and checkbox (WIP – 1)

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -44,6 +44,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
+ * @fires {CustomEvent} change - Fired when the user commits a value change.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  * @fires {CustomEvent} indeterminate-changed - Fired when the `indeterminate` property changes.
  *
@@ -185,8 +186,9 @@ class Checkbox extends SlotLabelMixin(
   }
 
   /**
-   * Extends the method from `ActiveMixin` in order to
-   * prevent setting the `active` attribute when interacting with a link inside the label.
+   * Override method inherited from `ActiveMixin`
+   * to prevent setting the `active` attribute
+   * when the user interacts with a link inside the label.
    *
    * @param {Event} event
    * @return {boolean}
@@ -202,19 +204,36 @@ class Checkbox extends SlotLabelMixin(
   }
 
   /**
-   * Extends the method from `CheckedMixin` in order to
-   * reset the indeterminate state once the user switches the checkbox.
+   * Override method inherited from `CheckedMixin`
+   * to prevent toggling the `checked` state
+   * when the user interacts with a link inside the label.
    *
-   * @param {boolean} checked
+   * @param {MouseEvent} event
+   * @return {boolean}
    * @protected
    * @override
    */
-  _toggleChecked(checked) {
+  _shouldToggleChecked(event) {
+    if (event.target.localName === 'a') {
+      return false;
+    }
+
+    return super._shouldToggleChecked(event);
+  }
+
+  /**
+   * Override method inherited from `CheckedMixin`
+   * to reset the indeterminate state once the user switches the checkbox.
+   *
+   * @protected
+   * @override
+   */
+  _toggleChecked() {
     if (this.indeterminate) {
       this.indeterminate = false;
     }
 
-    super._toggleChecked(checked);
+    super._toggleChecked();
   }
 }
 

--- a/packages/checkbox/test/checkbox.test.js
+++ b/packages/checkbox/test/checkbox.test.js
@@ -63,6 +63,14 @@ describe('checkbox', () => {
       expect(getComputedStyle(checkbox).display).to.equal('none');
     });
 
+    it('should toggle checked property on click', () => {
+      checkbox.click();
+      expect(checkbox.checked).to.be.true;
+
+      checkbox.click();
+      expect(checkbox.checked).to.be.false;
+    });
+
     it('should toggle checked property on input click', () => {
       input.click();
       expect(checkbox.checked).to.be.true;

--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -7,9 +7,10 @@ import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { DelegateStateMixin } from './delegate-state-mixin.js';
 import { InputMixin } from './input-mixin.js';
+import { LabelMixin } from './label-mixin.js';
 
 const CheckedMixinImplementation = (superclass) =>
-  class CheckedMixinClass extends DelegateStateMixin(DisabledMixin(InputMixin(superclass))) {
+  class CheckedMixinClass extends DelegateStateMixin(DisabledMixin(LabelMixin(InputMixin(superclass)))) {
     static get properties() {
       return {
         /**
@@ -25,21 +26,52 @@ const CheckedMixinImplementation = (superclass) =>
       };
     }
 
+    /** @override */
     static get delegateProps() {
       return [...super.delegateProps, 'checked'];
     }
 
-    /**
-     * @protected
-     * @override
-     */
-    _onChange(event) {
-      this._toggleChecked(event.target.checked);
+    constructor() {
+      super();
+
+      this._onClick = this._onClick.bind(this);
     }
 
     /** @protected */
-    _toggleChecked(checked) {
-      this.checked = checked;
+    ready() {
+      super.ready();
+
+      this.addEventListener('click', this._onClick);
+    }
+
+    /**
+     * @param {MouseEvent} _event
+     * @return {boolean}
+     * @protected
+     */
+    _shouldToggleChecked(_event) {
+      return !this.disabled;
+    }
+
+    /**
+     * @param {MouseEvent} event
+     * @protected
+     */
+    _onClick(event) {
+      if ([this._labelNode, this.inputElement].includes(event.target)) {
+        event.preventDefault();
+      }
+
+      if (this._shouldToggleChecked(event)) {
+        this._toggleChecked();
+      }
+    }
+
+    /** @protected */
+    _toggleChecked() {
+      this.checked = !this.checked;
+
+      this.dispatchEvent(new CustomEvent('change', { composed: false, bubbles: true }));
     }
   };
 

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,17 +1,17 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, fire } from '@vaadin/testing-helpers';
+import { fixtureSync, click } from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { CheckedMixin } from '../src/checked-mixin.js';
-import { DelegateFocusMixin } from '../src/delegate-focus-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
 customElements.define(
   'checked-mixin-element',
-  class extends CheckedMixin(DelegateFocusMixin(ElementMixin(PolymerElement))) {
+  class extends CheckedMixin(ElementMixin(PolymerElement)) {
     static get template() {
       return html`<div>
-        <slot></slot>
+        <slot name="label"></slot>
         <slot name="input"></slot>
       </div>`;
     }
@@ -23,7 +23,6 @@ customElements.define(
       this.addController(
         new InputController(this, (input) => {
           this._setInputElement(input);
-          this._setFocusElement(input);
           this.stateTarget = input;
         })
       );
@@ -32,18 +31,14 @@ customElements.define(
 );
 
 describe('checked-mixin', () => {
-  let element, input, link;
+  let element, input, label;
 
   describe('default', () => {
     beforeEach(() => {
-      element = fixtureSync(`
-        <checked-mixin-element>
-          I accept <a href="#">the terms and conditions</a>
-        </checked-mixin-element>
-      `);
+      element = fixtureSync(`<checked-mixin-element></checked-mixin-element>`);
 
-      link = element.querySelector('a');
       input = element.querySelector('[slot=input]');
+      label = element.querySelector('[slot=label]');
     });
 
     it('should set checked property to false by default', () => {
@@ -62,17 +57,15 @@ describe('checked-mixin', () => {
       expect(element.hasAttribute('checked')).to.be.false;
     });
 
-    it('should toggle checked property on change', () => {
-      input.checked = true;
-      fire(input, 'change');
-      expect(element.checked).to.be.true;
-
-      input.checked = false;
-      fire(input, 'change');
-      expect(element.checked).to.be.false;
-    });
-
     it('should toggle checked property on click', () => {
+      element.click();
+      expect(element.checked).to.be.true;
+
+      element.click();
+      expect(element.checked).to.be.false;
+    });
+
+    it('should toggle checked property on input click', () => {
       input.click();
       expect(element.checked).to.be.true;
 
@@ -80,15 +73,88 @@ describe('checked-mixin', () => {
       expect(element.checked).to.be.false;
     });
 
-    it('should not toggle checked property when clicked a link', () => {
-      link.click();
+    it('should toggle checked property on label click', () => {
+      label.click();
+      expect(element.checked).to.be.true;
+
+      label.click();
       expect(element.checked).to.be.false;
     });
 
-    it('should not toggle checked property when disabled', () => {
-      element.disabled = true;
-      input.click();
-      expect(element.checked).to.be.false;
+    it('should prevent default behaviour for label click event', () => {
+      const event = click(label);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should prevent default behaviour for input click event', () => {
+      const event = click(input);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    describe('disabled', () => {
+      beforeEach(() => {
+        element.disabled = true;
+      });
+
+      it('should not toggle checked property on click', () => {
+        element.click();
+        expect(element.checked).to.be.false;
+      });
+
+      it('should not toggle checked property on label click', () => {
+        label.click();
+        expect(element.checked).to.be.false;
+      });
+
+      it('should not toggle checked property on input click', () => {
+        input.click();
+        expect(element.checked).to.be.false;
+      });
+    });
+
+    describe('change event', () => {
+      let changeSpy;
+
+      beforeEach(() => {
+        changeSpy = sinon.spy();
+        element.addEventListener('change', changeSpy);
+      });
+
+      it('should fire change event on click', () => {
+        element.click();
+        expect(changeSpy.calledOnce).to.be.true;
+      });
+
+      it('should fire change event on label click', () => {
+        label.click();
+        expect(changeSpy.calledOnce).to.be.true;
+      });
+
+      it('should fire change event on input click', () => {
+        input.click();
+        expect(changeSpy.calledOnce).to.be.true;
+      });
+
+      describe('disabled', () => {
+        beforeEach(() => {
+          element.disabled = true;
+        });
+
+        it('should not fire change event on click', () => {
+          element.click();
+          expect(changeSpy.called).to.be.false;
+        });
+
+        it('should not fire change event on label click', () => {
+          label.click();
+          expect(changeSpy.called).to.be.false;
+        });
+
+        it('should not fire change event on input click', () => {
+          input.click();
+          expect(changeSpy.called).to.be.false;
+        });
+      });
     });
   });
 

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -48,6 +48,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
+ * @fires {CustomEvent} change - Fired when the user commits a value change.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  *
  * @extends HTMLElement
@@ -145,7 +146,7 @@ class RadioButton extends SlotLabelMixin(
    *
    * @override
    * @protected
-   * @type {HTMLSlotElement}
+   * @return {HTMLSlotElement}
    */
   get _sourceSlot() {
     return this.$.noop;
@@ -164,6 +165,19 @@ class RadioButton extends SlotLabelMixin(
       })
     );
     this.addController(new AriaLabelController(this.inputElement, this._labelNode));
+  }
+
+  /**
+   * Override method inherited from `CheckedMixin`
+   * to prevent the radio button from toggling off.
+   *
+   * @override
+   * @protected
+   */
+  _toggleChecked() {
+    if (!this.checked) {
+      super._toggleChecked();
+    }
   }
 }
 

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { sendKeys } from '@web/test-runner-commands';
-import { fixtureSync, nextFrame, fire, mousedown, mouseup } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, mousedown, mouseup } from '@vaadin/testing-helpers';
 import '../vaadin-radio-button.js';
 
 describe('radio-button', () => {

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -65,12 +65,26 @@ describe('radio-button', () => {
       expect(input.value).to.equal('on');
     });
 
+    it('should set checked property on click', () => {
+      radio.click();
+      expect(radio.checked).to.be.true;
+
+      radio.click();
+      expect(radio.checked).to.be.true;
+    });
+
     it('should set checked property on input click', () => {
+      input.click();
+      expect(radio.checked).to.be.true;
+
       input.click();
       expect(radio.checked).to.be.true;
     });
 
     it('should set checked property on label click', () => {
+      label.click();
+      expect(radio.checked).to.be.true;
+
       label.click();
       expect(radio.checked).to.be.true;
     });
@@ -81,12 +95,6 @@ describe('radio-button', () => {
       // Press Space on the input
       await sendKeys({ press: 'Space' });
 
-      expect(radio.checked).to.be.true;
-    });
-
-    it('should set checked property on input change', () => {
-      input.checked = true;
-      fire(input, 'change');
       expect(radio.checked).to.be.true;
     });
 

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -403,7 +403,7 @@ describe('radio-group', () => {
       expect(changeSpy.calledOnce).to.be.true;
 
       const event = changeSpy.firstCall.args[0];
-      expect(event.target).to.equal(buttons[0].inputElement);
+      expect(event.target).to.equal(buttons[0]);
       expect(event.target.value).to.equal(buttons[0].value);
     });
   });


### PR DESCRIPTION
## Description

This PR fixes the regression that occurred after the a11y refactoring of the radio-button and checkbox:

> The radio-button and checkbox are not clickable over the whole area.

Fixes #2690
Fixes #2693

## Type of change

- [x] Breaking change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
