### PR TITLE
fix!: enhance clickable area for checkbox

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -67,7 +67,6 @@ class Checkbox extends SlotLabelMixin(
       <style>
         :host {
           display: inline-block;
-          position: relative;
         }
 
         :host([hidden]) {
@@ -88,15 +87,20 @@ class Checkbox extends SlotLabelMixin(
           position: absolute;
           top: 0;
           left: 0;
+          right: 0;
+          width: 100%;
+          height: 100%;
           opacity: 0;
           cursor: inherit;
           margin: 0;
         }
       </style>
       <div class="vaadin-checkbox-container">
-        <div part="checkbox">
+        <div part="checkbox-wrapper">
+          <div part="checkbox"></div>
           <slot name="input"></slot>
         </div>
+
         <div part="label">
           <slot name="label"></slot>
         </div>

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -67,6 +67,7 @@ class Checkbox extends SlotLabelMixin(
       <style>
         :host {
           display: inline-block;
+          position: relative;
         }
 
         :host([hidden]) {
@@ -83,13 +84,10 @@ class Checkbox extends SlotLabelMixin(
         }
 
         /* visually hidden */
-        [part='checkbox'] ::slotted(input) {
+        ::slotted(input) {
           position: absolute;
           top: 0;
           left: 0;
-          right: 0;
-          width: 100%;
-          height: 100%;
           opacity: 0;
           cursor: inherit;
           margin: 0;

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -84,6 +84,7 @@ class Checkbox extends SlotLabelMixin(
 
         .vaadin-checkbox-wrapper {
           position: relative;
+          flex: none;
         }
 
         /* visually hidden */
@@ -105,9 +106,8 @@ class Checkbox extends SlotLabelMixin(
           <slot name="input"></slot>
         </div>
 
-        <div part="label">
-          <slot name="label"></slot>
-        </div>
+        <slot name="label"></slot>
+
         <div style="display: none !important">
           <slot id="noop"></slot>
         </div>

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -82,6 +82,10 @@ class Checkbox extends SlotLabelMixin(
           align-items: baseline;
         }
 
+        .vaadin-checkbox-wrapper {
+          position: relative;
+        }
+
         /* visually hidden */
         ::slotted(input) {
           position: absolute;
@@ -96,7 +100,7 @@ class Checkbox extends SlotLabelMixin(
         }
       </style>
       <div class="vaadin-checkbox-container">
-        <div part="checkbox-wrapper">
+        <div class="vaadin-checkbox-wrapper">
           <div part="checkbox"></div>
           <slot name="input"></slot>
         </div>

--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -23,7 +23,7 @@ registerStyles(
       outline: none;
     }
 
-    :host([has-label]) [part='label'] ::slotted(*) {
+    :host([has-label]) ::slotted(label) {
       padding: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
     }
 
@@ -99,7 +99,7 @@ registerStyles(
       color: var(--lumo-disabled-text-color);
     }
 
-    :host([disabled]) [part='label'] ::slotted(*) {
+    :host([disabled]) ::slotted(label) {
       color: inherit;
     }
 
@@ -116,8 +116,8 @@ registerStyles(
     }
 
     /* RTL specific styles */
-    :host([dir='rtl'][has-label]) [part='label'] {
-      margin: var(--lumo-space-xs) var(--lumo-space-xs) var(--lumo-space-xs) var(--lumo-space-s);
+    :host([dir='rtl'][has-label]) ::slotted(label) {
+      padding: var(--lumo-space-xs) var(--lumo-space-xs) var(--lumo-space-xs) var(--lumo-space-s);
     }
 
     /* Transition the checkmark if activated with the mouse (disabled for grid select-all this way) */

--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -23,8 +23,8 @@ registerStyles(
       outline: none;
     }
 
-    :host([has-label]) [part='label'] {
-      margin: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
+    :host([has-label]) [part='label'] ::slotted(*) {
+      padding: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
     }
 
     [part='checkbox'] {
@@ -38,6 +38,14 @@ registerStyles(
       line-height: 1.2;
       cursor: var(--lumo-clickable-cursor);
       flex: none;
+    }
+
+    /* Enhance the clickable area for the input */
+    [part='checkbox'] ::slotted(input) {
+      top: -0.1875em;
+      left: -0.1875em;
+      width: calc(100% + 0.1875em * 2);
+      height: calc(100% + 0.1875em * 2);
     }
 
     :host([indeterminate]) [part='checkbox'],

--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -41,11 +41,13 @@ registerStyles(
     }
 
     /* Enhance the clickable area for the input */
-    [part='checkbox'] ::slotted(input) {
-      top: -0.1875em;
-      left: -0.1875em;
-      width: calc(100% + 0.1875em * 2);
-      height: calc(100% + 0.1875em * 2);
+    ::slotted(input) {
+      /* TODO: Remove when CSS variables will be used instead of em units. */
+      font: inherit;
+      /* TODO: Use CSS variables instead of em units. */
+      width: calc(1em + 2px + 0.1875em * 2);
+      /* TODO: Use CSS variables instead of em units. */
+      height: calc(1em + 2px + 0.1875em * 2);
     }
 
     :host([indeterminate]) [part='checkbox'],

--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -27,10 +27,6 @@ registerStyles(
       padding: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
     }
 
-    [part='checkbox-wrapper'] {
-      position: relative;
-    }
-
     [part='checkbox'] {
       width: calc(var(--lumo-size-m) / 2);
       height: calc(var(--lumo-size-m) / 2);

--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -27,6 +27,10 @@ registerStyles(
       padding: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
     }
 
+    [part='checkbox-wrapper'] {
+      position: relative;
+    }
+
     [part='checkbox'] {
       width: calc(var(--lumo-size-m) / 2);
       height: calc(var(--lumo-size-m) / 2);
@@ -38,16 +42,6 @@ registerStyles(
       line-height: 1.2;
       cursor: var(--lumo-clickable-cursor);
       flex: none;
-    }
-
-    /* Enhance the clickable area for the input */
-    ::slotted(input) {
-      /* TODO: Remove when CSS variables will be used instead of em units. */
-      font: inherit;
-      /* TODO: Use CSS variables instead of em units. */
-      width: calc(1em + 2px + 0.1875em * 2);
-      /* TODO: Use CSS variables instead of em units. */
-      height: calc(1em + 2px + 0.1875em * 2);
     }
 
     :host([indeterminate]) [part='checkbox'],

--- a/packages/checkbox/theme/material/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/material/vaadin-checkbox-styles.js
@@ -14,7 +14,7 @@ registerStyles(
       -webkit-tap-highlight-color: transparent;
     }
 
-    :host([has-label]) [part='label'] ::slotted(*) {
+    :host([has-label]) ::slotted(label) {
       padding: 3px 12px 3px 6px;
     }
 
@@ -22,7 +22,6 @@ registerStyles(
       display: inline-block;
       width: 16px;
       height: 16px;
-      flex: none;
       margin: 4px;
       position: relative;
       border-radius: 2px;
@@ -109,7 +108,7 @@ registerStyles(
       color: var(--material-disabled-text-color);
     }
 
-    :host([disabled]) ::slotted(*) {
+    :host([disabled]) ::slotted(label) {
       color: inherit;
     }
 
@@ -123,8 +122,8 @@ registerStyles(
     }
 
     /* RTL specific styles */
-    :host([dir='rtl'][has-label]) [part='label'] {
-      margin: 3px 6px 3px 12px;
+    :host([dir='rtl'][has-label]) ::slotted(label) {
+      padding: 3px 6px 3px 12px;
     }
   `,
   { moduleId: 'material-checkbox' }

--- a/packages/checkbox/theme/material/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/material/vaadin-checkbox-styles.js
@@ -18,11 +18,6 @@ registerStyles(
       padding: 3px 12px 3px 6px;
     }
 
-    [part='native-checkbox'] {
-      opacity: 0;
-      position: absolute;
-    }
-
     [part='checkbox'] {
       display: inline-block;
       width: 16px;
@@ -34,12 +29,6 @@ registerStyles(
       box-shadow: inset 0 0 0 2px var(--material-secondary-text-color);
       line-height: 1.275;
       background-color: transparent;
-    }
-
-    /* Enhance the clickable area for the input */
-    ::slotted(input) {
-      width: calc(16px + 4px * 2);
-      height: calc(16px + 4px * 2);
     }
 
     /* Used for the ripple */

--- a/packages/checkbox/theme/material/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/material/vaadin-checkbox-styles.js
@@ -37,11 +37,9 @@ registerStyles(
     }
 
     /* Enhance the clickable area for the input */
-    [part='checkbox'] ::slotted(input) {
-      top: -4px;
-      left: -4px;
-      width: calc(100% + 4px * 2);
-      height: calc(100% + 4px * 2);
+    ::slotted(input) {
+      width: calc(16px + 4px * 2);
+      height: calc(16px + 4px * 2);
     }
 
     /* Used for the ripple */

--- a/packages/checkbox/theme/material/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/material/vaadin-checkbox-styles.js
@@ -14,8 +14,8 @@ registerStyles(
       -webkit-tap-highlight-color: transparent;
     }
 
-    :host([has-label]) [part='label'] {
-      margin: 3px 12px 3px 6px;
+    :host([has-label]) [part='label'] ::slotted(*) {
+      padding: 3px 12px 3px 6px;
     }
 
     [part='native-checkbox'] {
@@ -34,6 +34,14 @@ registerStyles(
       box-shadow: inset 0 0 0 2px var(--material-secondary-text-color);
       line-height: 1.275;
       background-color: transparent;
+    }
+
+    /* Enhance the clickable area for the input */
+    [part='checkbox'] ::slotted(input) {
+      top: -4px;
+      left: -4px;
+      width: calc(100% + 4px * 2);
+      height: calc(100% + 4px * 2);
     }
 
     /* Used for the ripple */


### PR DESCRIPTION
## Description

The PR enhances the checkbox's clickable area so that it becomes clickable over the whole area. This is done by:

- Setting `padding` on the slotted `<label>` element rather than `margin` on the `label` part.
- Stretching the input element over the `checkbox` part including its margins.

Fixes #2693

## Type of change

- [x] Breaking change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.