### PR TITLE
fix: screen reader should not read back/fwd button in tabs

### DIFF
--- a/packages/vaadin-tabs/src/vaadin-tabs.js
+++ b/packages/vaadin-tabs/src/vaadin-tabs.js
@@ -133,13 +133,13 @@ class TabsElement extends ElementMixin(
           content: '◀';
         }
       </style>
-      <div on-click="_scrollBack" part="back-button"></div>
+      <div on-click="_scrollBack" part="back-button" aria-hidden="true"></div>
 
       <div id="scroll" part="tabs">
         <slot></slot>
       </div>
 
-      <div on-click="_scrollForward" part="forward-button"></div>
+      <div on-click="_scrollForward" part="forward-button" aria-hidden="true"></div>
     `;
   }
 

--- a/packages/vaadin-tabs/test/dom/__snapshots__/tabs.test.snap.js
+++ b/packages/vaadin-tabs/test/dom/__snapshots__/tabs.test.snap.js
@@ -1,0 +1,24 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-tabs default"] = 
+`<div
+  aria-hidden="true"
+  part="back-button"
+>
+</div>
+<div
+  id="scroll"
+  part="tabs"
+>
+  <slot>
+  </slot>
+</div>
+<div
+  aria-hidden="true"
+  part="forward-button"
+>
+</div>
+`;
+/* end snapshot vaadin-tabs default */
+

--- a/packages/vaadin-tabs/test/dom/tabs.test.js
+++ b/packages/vaadin-tabs/test/dom/tabs.test.js
@@ -5,12 +5,6 @@ import '../../src/vaadin-tabs.js';
 describe('vaadin-tabs', () => {
   let tabs;
 
-  // Ignore generated attributes to prevent failures
-  // when running snapshot tests in a different order
-  const SNAPSHOT_CONFIG = {
-    ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for']
-  };
-
   beforeEach(() => {
     tabs = fixtureSync(`
     <vaadin-tabs>

--- a/packages/vaadin-tabs/test/dom/tabs.test.js
+++ b/packages/vaadin-tabs/test/dom/tabs.test.js
@@ -1,0 +1,26 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-tabs.js';
+
+describe('vaadin-tabs', () => {
+  let tabs;
+
+  // Ignore generated attributes to prevent failures
+  // when running snapshot tests in a different order
+  const SNAPSHOT_CONFIG = {
+    ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for']
+  };
+
+  beforeEach(() => {
+    tabs = fixtureSync(`
+    <vaadin-tabs>
+      <vaadin-tab>Analytics</vaadin-tab>
+      <vaadin-tab>Customers</vaadin-tab>
+      <vaadin-tab>Dashboards</vaadin-tab>
+    </vaadin-tabs>`);
+  });
+
+  it('default', async () => {
+    await expect(tabs).shadowDom.to.equalSnapshot();
+  });
+});

--- a/packages/vaadin-tabs/test/dom/tabs.test.js
+++ b/packages/vaadin-tabs/test/dom/tabs.test.js
@@ -6,12 +6,7 @@ describe('vaadin-tabs', () => {
   let tabs;
 
   beforeEach(() => {
-    tabs = fixtureSync(`
-    <vaadin-tabs>
-      <vaadin-tab>Analytics</vaadin-tab>
-      <vaadin-tab>Customers</vaadin-tab>
-      <vaadin-tab>Dashboards</vaadin-tab>
-    </vaadin-tabs>`);
+    tabs = fixtureSync('<vaadin-tabs></vaadin-tabs>');
   });
 
   it('default', async () => {


### PR DESCRIPTION
## Description

Set `aria-hidden` to back / forward button in tabs as it shouldn't be read by screen reader.

Fixes #443 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

