### PR TITLE
fix: don't prevent space keyup while interacting in grid

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -628,7 +628,7 @@ export const KeyboardNavigationMixin = (superClass) =>
 
     /** @private */
     _onKeyUp(e) {
-      if (!/^( |SpaceBar)$/.test(e.key)) {
+      if (!/^( |SpaceBar)$/.test(e.key) || this.interacting) {
         return;
       }
 

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -27,6 +27,7 @@ import {
 } from './helpers.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
+import '../vaadin-grid-selection-column.js';
 
 let grid, focusable, scroller, header, footer, body;
 
@@ -1365,6 +1366,19 @@ describe('keyboard navigation', () => {
 
         expect(spy.called).to.be.true;
         expect(grid.activeItem).to.be.null;
+      });
+
+      it('should allow toggling a checkbox with space keypress', async () => {
+        // Add a selection column
+        grid.appendChild(document.createElement('vaadin-grid-selection-column'));
+        flushGrid(grid);
+
+        // Get a reference to a checkbox, focus it and hit space
+        const vaadinCheckbox = getCellContent(getRowCell(0, 3)).children[0];
+        vaadinCheckbox.focus();
+        await sendKeys({ press: 'Space' });
+
+        expect(vaadinCheckbox.checked).to.be.true;
       });
     });
   });


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/2610

Space "keyup" event should not be prevented when interacting with controls inside the grid cells.