### PR TITLE
test: add unit tests for autoselect property

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -447,6 +447,27 @@ describe('basic features', () => {
       datepicker.open();
     });
   });
+
+  describe('autoselect', () => {
+    it('should set autoselect to false by default', () => {
+      expect(datepicker.autoselect).to.be.false;
+    });
+
+    it('should not select content on focus when autoselect is false', () => {
+      const spy = sinon.spy(input, 'select');
+      datepicker.value = '2016-07-14';
+      input.focus();
+      expect(spy.called).to.be.false;
+    });
+
+    it('should select content on focus when autoselect is true', () => {
+      const spy = sinon.spy(input, 'select');
+      datepicker.value = '2016-07-14';
+      datepicker.autoselect = true;
+      input.focus();
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
 });
 
 describe('inside flexbox', () => {

--- a/packages/vaadin-combo-box/test/basic.test.js
+++ b/packages/vaadin-combo-box/test/basic.test.js
@@ -300,6 +300,27 @@ describe('Properties', () => {
 
       expect(overlay.opened).not.to.be.true;
     });
+
+    describe('autoselect', () => {
+      it('should set autoselect to false by default', () => {
+        expect(comboBox.autoselect).to.be.false;
+      });
+
+      it('should not select content on focus when autoselect is false', () => {
+        const spy = sinon.spy(input, 'select');
+        comboBox.value = 'foo';
+        input.focus();
+        expect(spy.called).to.be.false;
+      });
+
+      it('should select content on focus when autoselect is true', () => {
+        const spy = sinon.spy(input, 'select');
+        comboBox.value = 'foo';
+        comboBox.autoselect = true;
+        input.focus();
+        expect(spy.calledOnce).to.be.true;
+      });
+    });
   });
 
   describe('focus API', () => {

--- a/packages/vaadin-time-picker/test/time-picker.test.js
+++ b/packages/vaadin-time-picker/test/time-picker.test.js
@@ -247,6 +247,27 @@ describe('time-picker', () => {
     });
   });
 
+  describe('autoselect', () => {
+    it('should set autoselect to false by default', () => {
+      expect(timePicker.autoselect).to.be.false;
+    });
+
+    it('should not select content on focus when autoselect is false', () => {
+      const spy = sinon.spy(inputElement, 'select');
+      timePicker.value = '2016-07-14';
+      inputElement.focus();
+      expect(spy.called).to.be.false;
+    });
+
+    it('should select content on focus when autoselect is true', () => {
+      const spy = sinon.spy(inputElement, 'select');
+      timePicker.value = '00:00';
+      timePicker.autoselect = true;
+      inputElement.focus();
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
+
   describe('change event', () => {
     let spy;
 


### PR DESCRIPTION
## Description

As a result of adding `InputControlMixin` in #2632 we now have `autoselect` available in the following components:

- `vaadin-combo-box`
- `vaadin-date-picker`
- `vaadin-time-picker`

This PR adds unit tests to cover this feature. It does not seem to need any other changes.

Closes #1160
Closes #1801

## Type of change

- Tests