### PR TITLE
fix: remove has-helper attribute when helper node is removed

### DIFF
--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -115,7 +115,7 @@ export const FieldMixin = (superclass) =>
 
       this.__helperSlot = this.shadowRoot.querySelector('[name="helper"]');
 
-      this._observer = new FlattenedNodesObserver(this.__helperSlot, (info) => {
+      this.__helperSlotObserver = new FlattenedNodesObserver(this.__helperSlot, (info) => {
         const helper = this._currentHelper;
 
         const newHelper = info.addedNodes.find((node) => node !== helper);

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -518,6 +518,30 @@ describe('radio-group', () => {
     });
   });
 
+  describe('custom helper', () => {
+    let group, helper;
+
+    beforeEach(async () => {
+      group = fixtureSync(`
+        <vaadin-radio-group>
+          <div slot="helper">Custom helper</div>
+        </vaadin-radio-group>
+      `);
+      await nextFrame();
+      helper = group.querySelector('[slot=helper]');
+    });
+
+    it('should set has-helper attribute', () => {
+      expect(group.hasAttribute('has-helper')).to.be.true;
+    });
+
+    it('should remove has-helper attribute when the custom helper is removed', async () => {
+      group.removeChild(helper);
+      await nextFrame();
+      expect(group.hasAttribute('has-helper')).to.be.false;
+    });
+  });
+
   describe('initial value', () => {
     beforeEach(async () => {
       group = fixtureSync(`


### PR DESCRIPTION
## Description

This PR fixes the regression that has occurred since the last a11y refactoring of the radio-group:

> Removing the custom helper node doesn't lead to removing the `has-helper` attribute on the radio-group.

Fixes #2755

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
