### PR TITLE
fix!: remove label part and enhance clickable area

### DIFF
--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -84,8 +84,13 @@ class RadioButton extends SlotLabelMixin(
           align-items: baseline;
         }
 
+        .vaadin-radio-button-wrapper {
+          position: relative;
+          flex: none;
+        }
+
         /* visually hidden */
-        [part='radio'] ::slotted(input) {
+        ::slotted(input) {
           position: absolute;
           top: 0;
           left: 0;
@@ -98,12 +103,13 @@ class RadioButton extends SlotLabelMixin(
         }
       </style>
       <div class="vaadin-radio-button-container">
-        <div part="radio">
+        <div class="vaadin-radio-button-wrapper">
+          <div part="radio"></div>
           <slot name="input"></slot>
         </div>
-        <div part="label">
-          <slot name="label"></slot>
-        </div>
+
+        <slot name="label"></slot>
+
         <div style="display: none !important">
           <slot id="noop"></slot>
         </div>

--- a/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
@@ -23,8 +23,8 @@ registerStyles(
       outline: none;
     }
 
-    :host([has-label]) [part='label'] {
-      margin: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
+    :host([has-label]) ::slotted(label) {
+      padding: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
     }
 
     [part='radio'] {
@@ -38,7 +38,6 @@ registerStyles(
       will-change: transform;
       line-height: 1.2;
       cursor: var(--lumo-clickable-cursor);
-      flex: none;
     }
 
     /* Used for activation "halo" */
@@ -111,7 +110,7 @@ registerStyles(
       color: var(--lumo-disabled-text-color);
     }
 
-    :host([disabled]) [part='label'] ::slotted(*) {
+    :host([disabled]) ::slotted(label) {
       color: inherit;
     }
 
@@ -124,8 +123,8 @@ registerStyles(
     }
 
     /* RTL specific styles */
-    :host([dir='rtl'][has-label]) [part='label'] {
-      margin: var(--lumo-space-xs) var(--lumo-space-xs) var(--lumo-space-xs) var(--lumo-space-s);
+    :host([dir='rtl'][has-label]) ::slotted(label) {
+      padding: var(--lumo-space-xs) var(--lumo-space-xs) var(--lumo-space-xs) var(--lumo-space-s);
     }
   `,
   { moduleId: 'lumo-radio-button' }

--- a/packages/radio-group/theme/material/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/material/vaadin-radio-button-styles.js
@@ -13,15 +13,14 @@ registerStyles(
       -webkit-tap-highlight-color: transparent;
     }
 
-    :host([has-label]) [part='label'] {
-      margin: 4px 0.875em 4px 0.375em;
+    :host([has-label]) ::slotted(label) {
+      padding: 4px 0.875em 4px 0.375em;
     }
 
     [part='radio'] {
       display: inline-block;
       width: 16px;
       height: 16px;
-      flex: none;
       margin: 4px;
       position: relative;
       border: 2px solid;
@@ -93,7 +92,7 @@ registerStyles(
       color: var(--material-disabled-text-color);
     }
 
-    :host([disabled]) [part='label'] ::slotted(*) {
+    :host([disabled]) ::slotted(label) {
       color: inherit;
     }
 
@@ -106,8 +105,8 @@ registerStyles(
     }
 
     /* RTL specific styles */
-    :host([dir='rtl'][has-label]) [part='label'] {
-      margin: 4px 0.375em 4px 0.875em;
+    :host([dir='rtl'][has-label]) ::slotted(label) {
+      padding: 4px 0.375em 4px 0.875em;
     }
   `,
   { moduleId: 'material-radio-button' }


### PR DESCRIPTION
## Description

The PR enhances the radio-button's clickable area so that it becomes clickable over the whole area.

- Removed the `label` part ([proposal](https://github.com/vaadin/web-components/pull/2739#issuecomment-935794813)).
- Set `padding` on the slotted `<label>` element.
- Stretched the input element over the `checkbox` part including its margins.

Fixes #2690

## Type of change

- [x] Breaking change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.