### PR TITLE
refactor!: use more generic custom property name

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -109,9 +109,10 @@ import { ComboBoxDefaultItem, ComboBoxEventMap } from './interfaces';
  *
  * The following custom properties are available for styling:
  *
- * Custom property | Description | Default
- * ----------------|-------------|-------------
- * `--vaadin-combo-box-overlay-max-height` | Property that determines the max height of overlay | `65vh`
+ * Custom property                         | Description                | Default
+ * ----------------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width`          | Default width of the field | `12em`
+ * `--vaadin-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
  *
  * The following shadow DOM parts are available for styling:
  *

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -117,9 +117,10 @@ registerStyles('vaadin-combo-box', inputFieldShared, { moduleId: 'vaadin-combo-b
  *
  * The following custom properties are available for styling:
  *
- * Custom property | Description | Default
- * ----------------|-------------|-------------
- * `--vaadin-combo-box-overlay-max-height` | Property that determines the max height of overlay | `65vh`
+ * Custom property                         | Description                | Default
+ * ----------------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width`          | Default width of the field | `12em`
+ * `--vaadin-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
  *
  * The following shadow DOM parts are available for styling:
  *

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -23,6 +23,12 @@ import { DatePickerEventMap } from './interfaces';
  *
  * ### Styling
  *
+ * The following custom properties are available for styling:
+ *
+ * Custom property                | Description                | Default
+ * -------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width` | Default width of the field | `12em`
+ *
  * The following shadow DOM parts are available for styling:
  *
  * Part name | Description | Theme for Element

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -35,6 +35,12 @@ registerStyles('vaadin-date-picker', [inputFieldShared, datePickerStyles], { mod
  *
  * ### Styling
  *
+ * The following custom properties are available for styling:
+ *
+ * Custom property                | Description                | Default
+ * -------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width` | Default width of the field | `12em`
+ *
  * The following shadow DOM parts are available for styling:
  *
  * Part name | Description | Theme for Element

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -97,12 +97,12 @@ class DateTimePicker extends FieldMixin(SlotMixin(DisabledMixin(ThemableMixin(El
     return html`
       <style>
         .vaadin-date-time-picker-container {
-          --vaadin-text-field-default-width: auto;
+          --vaadin-field-default-width: auto;
         }
 
         .slots {
           display: flex;
-          --vaadin-text-field-default-width: 12em;
+          --vaadin-field-default-width: 12em;
         }
 
         [part='date'],

--- a/packages/field-base/src/styles/input-field-container-styles.js
+++ b/packages/field-base/src/styles/input-field-container-styles.js
@@ -11,6 +11,6 @@ export const inputFieldContainer = css`
     flex-direction: column;
     min-width: 100%;
     max-width: 100%;
-    width: var(--vaadin-text-field-default-width, 12em);
+    width: var(--vaadin-field-default-width, 12em);
   }
 `;

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -51,6 +51,13 @@ import { SelectEventMap, SelectRenderer } from './interfaces';
  *
  * ### Styling
  *
+ * The following custom properties are available for styling:
+ *
+ * Custom property                    | Description                  | Target element          | Default
+ * -----------------------------------|------------------------------|----------------------------------
+ * `--vaadin-field-default-width`     | Default width of the field   | :host                   | `12em`
+ * `--vaadin-select-text-field-width` | Effective width of the field | `vaadin-select-overlay` |
+ *
  * The following shadow DOM parts are available for styling:
  *
  * Part name | Description
@@ -67,12 +74,6 @@ import { SelectEventMap, SelectRenderer } from './interfaces';
  * `focus-ring` | Set when the element is keyboard focused | :host
  * `readonly` | Set when the select is read only | :host
  *
- * `<vaadin-select>` element sets these custom CSS properties:
- *
- * Property name | Description | Theme for element
- * --- | --- | ---
- * `--vaadin-select-text-field-width` | Width of the select text field | `vaadin-select-overlay`
- *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components
@@ -80,7 +81,6 @@ import { SelectEventMap, SelectRenderer } from './interfaces';
  * In addition to `<vaadin-select>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-select-text-field>` - has the same API as [`<vaadin-text-field>`](#/elements/vaadin-text-field).
  * - `<vaadin-select-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  *
  * Note: the `theme` attribute value set on `<vaadin-select>` is

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -61,6 +61,13 @@ registerStyles('vaadin-select', [fieldShared, inputFieldContainer], { moduleId: 
  *
  * ### Styling
  *
+ * The following custom properties are available for styling:
+ *
+ * Custom property                    | Description                  | Target element          | Default
+ * -----------------------------------|------------------------------|----------------------------------
+ * `--vaadin-field-default-width`     | Default width of the field   | :host                   | `12em`
+ * `--vaadin-select-text-field-width` | Effective width of the field | `vaadin-select-overlay` |
+ *
  * The following shadow DOM parts are available for styling:
  *
  * Part name | Description
@@ -76,12 +83,6 @@ registerStyles('vaadin-select', [fieldShared, inputFieldContainer], { moduleId: 
  * `focused`    | Set when the element is focused | :host
  * `focus-ring` | Set when the element is keyboard focused | :host
  * `readonly`   | Set when the select is read only | :host
- *
- * `<vaadin-select>` element sets these custom CSS properties:
- *
- * Property name | Description | Theme for element
- * --- | --- | ---
- * `--vaadin-select-text-field-width` | Width of the select text field | `vaadin-select-overlay`
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -48,6 +48,12 @@ export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEve
  *
  * ### Styling
  *
+ * The following custom properties are available for styling:
+ *
+ * Custom property                | Description                | Default
+ * -------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width` | Default width of the field | `12em`
+ *
  * The following shadow DOM parts are available for styling:
  *
  * Part name       | Description

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -38,6 +38,12 @@ registerStyles('vaadin-text-area', inputFieldShared, { moduleId: 'vaadin-text-ar
  *
  * ### Styling
  *
+ * The following custom properties are available for styling:
+ *
+ * Custom property                | Description                | Default
+ * -------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width` | Default width of the field | `12em`
+ *
  * The following shadow DOM parts are available for styling:
  *
  * Part name       | Description

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -51,9 +51,9 @@ export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomE
  *
  * The following custom properties are available for styling:
  *
- * Custom property | Description | Default
- * ----------------|-------------|-------------
- * `--vaadin-text-field-default-width` | Set the default width of the input field | `12em`
+ * Custom property                | Description                | Default
+ * -------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width` | Default width of the field | `12em`
  *
  * The following shadow DOM parts are available for styling:
  *

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -41,9 +41,9 @@ registerStyles('vaadin-text-field', inputFieldShared, { moduleId: 'vaadin-text-f
  *
  * The following custom properties are available for styling:
  *
- * Custom property | Description | Default
- * ----------------|-------------|-------------
- * `--vaadin-text-field-default-width` | Set the default width of the input field | `12em`
+ * Custom property                | Description                | Default
+ * -------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width` | Default width of the field | `12em`
  *
  * The following shadow DOM parts are available for styling:
  *

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -23,6 +23,13 @@ import { TimePickerEventMap, TimePickerI18n } from './interfaces';
  *
  * ### Styling
  *
+ * The following custom properties are available for styling:
+ *
+ * Custom property                           | Description                | Default
+ * ------------------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width`            | Default width of the field | `12em`
+ * `--vaadin-time-picker-overlay-max-height` | Max height of the overlay  | `65vh`
+ *
  * The following shadow DOM parts are available for styling:
  *
  * Part name       | Description

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -31,6 +31,13 @@ registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-
  *
  * ### Styling
  *
+ * The following custom properties are available for styling:
+ *
+ * Custom property                           | Description                | Default
+ * ------------------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width`            | Default width of the field | `12em`
+ * `--vaadin-time-picker-overlay-max-height` | Max height of the overlay  | `65vh`
+ *
  * The following shadow DOM parts are available for styling:
  *
  * Part name       | Description


### PR DESCRIPTION
## Description

Updated the `--vaadin-field-default-width` and documented it in components that support it.

Fixes #2791

## Type of change

- Refactor (breaking change).