### PR TITLE
fix: Limit the requested pages to a given threshold

### DIFF
--- a/packages/virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/virtual-list/src/virtualizer-iron-list-adapter.js
@@ -191,8 +191,6 @@ export class IronListAdapter {
     }
 
     this.__preventElementUpdates = false;
-    // Update all the elements currently in the DOM
-    this.update();
     // Schedule and flush a resize handler
     this._resizeHandler();
     flush();


### PR DESCRIPTION
## Description

When the grid web-component is used with Flow Grid component with the undefined lazy loading,
grid's size change leads to scroller jump to 0 index (iron list specifics).
It causes as many pages requested from backend, as the current page is.
E.g. if the page is 20, then the requested items range would be about 1000 items.
And the requested items count increases as grid is being scrolled further.

This issue is also observed within fast scroll, so the number of requested pages increases significantly.
With this fix, if the pending pages count is too much and the current requested page is far away of pending page range,
this page request will be ignored and the data provider wouldn't be called.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
