### PR TITLE
docs: use correct JSDoc for all mixins

### DIFF
--- a/packages/component-base/src/active-mixin.js
+++ b/packages/component-base/src/active-mixin.js
@@ -3,12 +3,22 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { GestureEventListeners } from '@polymer/polymer/lib/mixins/gesture-event-listeners.js';
 import { DisabledMixin } from './disabled-mixin.js';
 import { KeyboardMixin } from './keyboard-mixin.js';
 
-const ActiveMixinImplementation = (superclass) =>
+/**
+ * A mixin to toggle the `active` attribute.
+ *
+ * The attribute is set whenever the user activates the element by a pointer
+ * or presses an activation key on the element from the keyboard.
+ *
+ * The attribute is removed as soon as the element is deactivated
+ * by the pointer or by releasing the activation key.
+ *
+ * @polymerMixin
+ */
+export const ActiveMixin = (superclass) =>
   class ActiveMixinClass extends DisabledMixin(GestureEventListeners(KeyboardMixin(superclass))) {
     /**
      * An array of activation keys.
@@ -97,14 +107,3 @@ const ActiveMixinImplementation = (superclass) =>
       this.toggleAttribute('active', active);
     }
   };
-
-/**
- * A mixin to toggle the `active` attribute.
- *
- * The attribute is set whenever the user activates the element by a pointer
- * or presses an activation key on the element from the keyboard.
- *
- * The attribute is removed as soon as the element is deactivated
- * by the pointer or by releasing the activation key.
- */
-export const ActiveMixin = dedupingMixin(ActiveMixinImplementation);

--- a/packages/component-base/src/disabled-mixin.js
+++ b/packages/component-base/src/disabled-mixin.js
@@ -5,56 +5,58 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
-const DisabledMixinImplementation = (superclass) =>
-  class DisabledMixinClass extends superclass {
-    static get properties() {
-      return {
-        /**
-         * If true, the user cannot interact with this element.
-         */
-        disabled: {
-          type: Boolean,
-          value: false,
-          observer: '_disabledChanged',
-          reflectToAttribute: true
-        }
-      };
-    }
-
-    /**
-     * @param {boolean} disabled
-     * @protected
-     */
-    _disabledChanged(disabled) {
-      this._setAriaDisabled(disabled);
-    }
-
-    /**
-     * @param {boolean} disabled
-     * @protected
-     */
-    _setAriaDisabled(disabled) {
-      if (disabled) {
-        this.setAttribute('aria-disabled', 'true');
-      } else {
-        this.removeAttribute('aria-disabled');
-      }
-    }
-
-    /**
-     * Overrides the default element `click` method in order to prevent
-     * firing the `click` event when the element is disabled.
-     *
-     * @override
-     */
-    click() {
-      if (!this.disabled) {
-        super.click();
-      }
-    }
-  };
-
 /**
  * A mixin to provide disabled property for field components.
+ *
+ * @polymerMixin
  */
-export const DisabledMixin = dedupingMixin(DisabledMixinImplementation);
+export const DisabledMixin = dedupingMixin(
+  (superclass) =>
+    class DisabledMixinClass extends superclass {
+      static get properties() {
+        return {
+          /**
+           * If true, the user cannot interact with this element.
+           */
+          disabled: {
+            type: Boolean,
+            value: false,
+            observer: '_disabledChanged',
+            reflectToAttribute: true
+          }
+        };
+      }
+
+      /**
+       * @param {boolean} disabled
+       * @protected
+       */
+      _disabledChanged(disabled) {
+        this._setAriaDisabled(disabled);
+      }
+
+      /**
+       * @param {boolean} disabled
+       * @protected
+       */
+      _setAriaDisabled(disabled) {
+        if (disabled) {
+          this.setAttribute('aria-disabled', 'true');
+        } else {
+          this.removeAttribute('aria-disabled');
+        }
+      }
+
+      /**
+       * Overrides the default element `click` method in order to prevent
+       * firing the `click` event when the element is disabled.
+       * @protected
+       * @override
+       */
+      click() {
+        if (!this.disabled) {
+          super.click();
+        }
+      }
+    }
+);

--- a/packages/component-base/src/focus-mixin.js
+++ b/packages/component-base/src/focus-mixin.js
@@ -27,78 +27,80 @@ window.addEventListener(
   { capture: true }
 );
 
-const FocusMixinImplementation = (superclass) =>
-  class FocusMixinClass extends superclass {
-    /** @protected */
-    ready() {
-      this.addEventListener('focusin', (e) => {
-        if (this._shouldSetFocus(e)) {
-          this._setFocused(true);
-        }
-      });
-
-      this.addEventListener('focusout', (e) => {
-        if (this._shouldRemoveFocus(e)) {
-          this._setFocused(false);
-        }
-      });
-
-      // In super.ready() other 'focusin' and 'focusout' listeners might be
-      // added, so we call it after our own ones to ensure they execute first.
-      // Issue to watch out: when incorrect, <vaadin-combo-box> refocuses the
-      // input field on iOS after “Done” is pressed.
-      super.ready();
-    }
-
-    /** @protected */
-    disconnectedCallback() {
-      super.disconnectedCallback();
-
-      // in non-Chrome browsers, blur does not fire on the element when it is disconnected.
-      // reproducible in `<vaadin-date-picker>` when closing on `Cancel` or `Today` click.
-      if (this.hasAttribute('focused')) {
-        this._setFocused(false);
-      }
-    }
-
-    /**
-     * Override to change how focused and focus-ring attributes are set.
-     *
-     * @param {boolean} focused
-     * @protected
-     */
-    _setFocused(focused) {
-      this.toggleAttribute('focused', focused);
-
-      // focus-ring is true when the element was focused from the keyboard.
-      // Focus Ring [A11ycasts]: https://youtu.be/ilj2P5-5CjI
-      this.toggleAttribute('focus-ring', focused && keyboardActive);
-    }
-
-    /**
-     * Override to define if the field receives focus based on the event.
-     *
-     * @param {FocusEvent} event
-     * @return {boolean}
-     * @protected
-     */
-    _shouldSetFocus(_event) {
-      return true;
-    }
-
-    /**
-     * Override to define if the field loses focus based on the event.
-     *
-     * @param {FocusEvent} event
-     * @return {boolean}
-     * @protected
-     */
-    _shouldRemoveFocus(_event) {
-      return true;
-    }
-  };
-
 /**
  * A mixin to handle `focused` and `focus-ring` attributes based on focus.
+ *
+ * @polymerMixin
  */
-export const FocusMixin = dedupingMixin(FocusMixinImplementation);
+export const FocusMixin = dedupingMixin(
+  (superclass) =>
+    class FocusMixinClass extends superclass {
+      /** @protected */
+      ready() {
+        this.addEventListener('focusin', (e) => {
+          if (this._shouldSetFocus(e)) {
+            this._setFocused(true);
+          }
+        });
+
+        this.addEventListener('focusout', (e) => {
+          if (this._shouldRemoveFocus(e)) {
+            this._setFocused(false);
+          }
+        });
+
+        // In super.ready() other 'focusin' and 'focusout' listeners might be
+        // added, so we call it after our own ones to ensure they execute first.
+        // Issue to watch out: when incorrect, <vaadin-combo-box> refocuses the
+        // input field on iOS after “Done” is pressed.
+        super.ready();
+      }
+
+      /** @protected */
+      disconnectedCallback() {
+        super.disconnectedCallback();
+
+        // in non-Chrome browsers, blur does not fire on the element when it is disconnected.
+        // reproducible in `<vaadin-date-picker>` when closing on `Cancel` or `Today` click.
+        if (this.hasAttribute('focused')) {
+          this._setFocused(false);
+        }
+      }
+
+      /**
+       * Override to change how focused and focus-ring attributes are set.
+       *
+       * @param {boolean} focused
+       * @protected
+       */
+      _setFocused(focused) {
+        this.toggleAttribute('focused', focused);
+
+        // focus-ring is true when the element was focused from the keyboard.
+        // Focus Ring [A11ycasts]: https://youtu.be/ilj2P5-5CjI
+        this.toggleAttribute('focus-ring', focused && keyboardActive);
+      }
+
+      /**
+       * Override to define if the field receives focus based on the event.
+       *
+       * @param {FocusEvent} event
+       * @return {boolean}
+       * @protected
+       */
+      _shouldSetFocus(_event) {
+        return true;
+      }
+
+      /**
+       * Override to define if the field loses focus based on the event.
+       *
+       * @param {FocusEvent} event
+       * @return {boolean}
+       * @protected
+       */
+      _shouldRemoveFocus(_event) {
+        return true;
+      }
+    }
+);

--- a/packages/component-base/src/keyboard-mixin.js
+++ b/packages/component-base/src/keyboard-mixin.js
@@ -5,47 +5,49 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
-const KeyboardMixinImplementation = (superclass) =>
-  class KeyboardMixinClass extends superclass {
-    /** @protected */
-    ready() {
-      super.ready();
-
-      this.addEventListener('keydown', (event) => {
-        this._onKeyDown(event);
-      });
-
-      this.addEventListener('keyup', (event) => {
-        this._onKeyUp(event);
-      });
-    }
-
-    /**
-     * A handler for the `keydown` event. By default, it does nothing.
-     * Override the method to implement your own behavior.
-     *
-     * @param {KeyboardEvent} _event
-     * @protected
-     */
-    _onKeyDown(_event) {
-      // To be implemented.
-    }
-
-    /**
-     * A handler for the `keyup` event. By default, it does nothing.
-     * Override the method to implement your own behavior.
-     *
-     * @param {KeyboardEvent} _event
-     * @protected
-     */
-    _onKeyUp(_event) {
-      // To be implemented.
-    }
-  };
-
 /**
  * A mixin that manages keyboard handling.
  * The mixin subscribes to the keyboard events while an actual implementation
  * for the event handlers is left to the client (a component or another mixin).
+ *
+ * @polymerMixin
  */
-export const KeyboardMixin = dedupingMixin(KeyboardMixinImplementation);
+export const KeyboardMixin = dedupingMixin(
+  (superclass) =>
+    class KeyboardMixinClass extends superclass {
+      /** @protected */
+      ready() {
+        super.ready();
+
+        this.addEventListener('keydown', (event) => {
+          this._onKeyDown(event);
+        });
+
+        this.addEventListener('keyup', (event) => {
+          this._onKeyUp(event);
+        });
+      }
+
+      /**
+       * A handler for the `keydown` event. By default, it does nothing.
+       * Override the method to implement your own behavior.
+       *
+       * @param {KeyboardEvent} _event
+       * @protected
+       */
+      _onKeyDown(_event) {
+        // To be implemented.
+      }
+
+      /**
+       * A handler for the `keyup` event. By default, it does nothing.
+       * Override the method to implement your own behavior.
+       *
+       * @param {KeyboardEvent} _event
+       * @protected
+       */
+      _onKeyUp(_event) {
+        // To be implemented.
+      }
+    }
+);

--- a/packages/component-base/src/slot-mixin.js
+++ b/packages/component-base/src/slot-mixin.js
@@ -5,45 +5,48 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
-const SlotMixinImplementation = (superclass) =>
-  class SlotMixinClass extends superclass {
-    /**
-     * List of named slots to initialize.
-     */
-    get slots() {
-      return {};
-    }
-
-    /** @protected */
-    ready() {
-      super.ready();
-      this._connectSlotMixin();
-    }
-
-    /** @private */
-    _connectSlotMixin() {
-      Object.keys(this.slots).forEach((slotName) => {
-        // Ignore labels of nested components, if any
-        const hasContent = this._getDirectSlotChild(slotName) !== undefined;
-
-        if (!hasContent) {
-          const slotFactory = this.slots[slotName];
-          const slotContent = slotFactory();
-          if (slotContent instanceof Element) {
-            slotContent.setAttribute('slot', slotName);
-            this.appendChild(slotContent);
-          }
-        }
-      });
-    }
-
-    /** @protected */
-    _getDirectSlotChild(slotName) {
-      return Array.from(this.children).find((el) => el.slot === slotName);
-    }
-  };
-
 /**
  * A mixin to provide content for named slots defined by component.
+ *
+ * @polymerMixin
  */
-export const SlotMixin = dedupingMixin(SlotMixinImplementation);
+export const SlotMixin = dedupingMixin(
+  (superclass) =>
+    class SlotMixinClass extends superclass {
+      /**
+       * List of named slots to initialize.
+       * @protected
+       */
+      get slots() {
+        return {};
+      }
+
+      /** @protected */
+      ready() {
+        super.ready();
+        this._connectSlotMixin();
+      }
+
+      /** @private */
+      _connectSlotMixin() {
+        Object.keys(this.slots).forEach((slotName) => {
+          // Ignore labels of nested components, if any
+          const hasContent = this._getDirectSlotChild(slotName) !== undefined;
+
+          if (!hasContent) {
+            const slotFactory = this.slots[slotName];
+            const slotContent = slotFactory();
+            if (slotContent instanceof Element) {
+              slotContent.setAttribute('slot', slotName);
+              this.appendChild(slotContent);
+            }
+          }
+        });
+      }
+
+      /** @protected */
+      _getDirectSlotChild(slotName) {
+        return Array.from(this.children).find((el) => el.slot === slotName);
+      }
+    }
+);

--- a/packages/component-base/src/tabindex-mixin.js
+++ b/packages/component-base/src/tabindex-mixin.js
@@ -3,15 +3,26 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { DisabledMixin } from './disabled-mixin.js';
 
-const TabindexMixinImplementation = (superclass) =>
+/**
+ * A mixin to provide the `tabindex` attribute.
+ *
+ * By default, the attribute is set to 0 that makes the element focusable.
+ *
+ * The attribute is set to -1 whenever the user disables the element
+ * and restored with the last known value once the element is enabled.
+ *
+ * @polymerMixin
+ * @mixes DisabledMixin
+ */
+export const TabindexMixin = (superclass) =>
   class TabindexMixinClass extends DisabledMixin(superclass) {
     static get properties() {
       return {
         /**
          * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
+         * @protected
          */
         tabindex: {
           type: Number,
@@ -66,13 +77,3 @@ const TabindexMixinImplementation = (superclass) =>
       }
     }
   };
-
-/**
- * A mixin to provide the `tabindex` attribute.
- *
- * By default, the attribute is set to 0 that makes the element focusable.
- *
- * The attribute is set to -1 whenever the user disables the element
- * and restored with the last known value once the element is enabled.
- */
-export const TabindexMixin = dedupingMixin(TabindexMixinImplementation);

--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -8,42 +8,47 @@ import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { DelegateStateMixin } from './delegate-state-mixin.js';
 import { InputMixin } from './input-mixin.js';
 
-const CheckedMixinImplementation = (superclass) =>
-  class CheckedMixinClass extends DelegateStateMixin(DisabledMixin(InputMixin(superclass))) {
-    static get properties() {
-      return {
-        /**
-         * True if the element is checked.
-         * @type {boolean}
-         */
-        checked: {
-          type: Boolean,
-          value: false,
-          notify: true,
-          reflectToAttribute: true
-        }
-      };
-    }
-
-    static get delegateProps() {
-      return [...super.delegateProps, 'checked'];
-    }
-
-    /**
-     * @protected
-     * @override
-     */
-    _onChange(event) {
-      this._toggleChecked(event.target.checked);
-    }
-
-    /** @protected */
-    _toggleChecked(checked) {
-      this.checked = checked;
-    }
-  };
-
 /**
  * A mixin to manage the checked state.
+ *
+ * @polymerMixin
+ * @mixes DelegateStateMixin
+ * @mixes DisabledMixin
+ * @mixes InputMixin
  */
-export const CheckedMixin = dedupingMixin(CheckedMixinImplementation);
+export const CheckedMixin = dedupingMixin(
+  (superclass) =>
+    class CheckedMixinClass extends DelegateStateMixin(DisabledMixin(InputMixin(superclass))) {
+      static get properties() {
+        return {
+          /**
+           * True if the element is checked.
+           * @type {boolean}
+           */
+          checked: {
+            type: Boolean,
+            value: false,
+            notify: true,
+            reflectToAttribute: true
+          }
+        };
+      }
+
+      static get delegateProps() {
+        return [...super.delegateProps, 'checked'];
+      }
+
+      /**
+       * @protected
+       * @override
+       */
+      _onChange(event) {
+        this._toggleChecked(event.target.checked);
+      }
+
+      /** @protected */
+      _toggleChecked(checked) {
+        this.checked = checked;
+      }
+    }
+);

--- a/packages/field-base/src/delegate-focus-mixin.js
+++ b/packages/field-base/src/delegate-focus-mixin.js
@@ -7,157 +7,173 @@ import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 
-const DelegateFocusMixinImplementation = (superclass) =>
-  class DelegateFocusMixinClass extends FocusMixin(DisabledMixin(superclass)) {
-    static get properties() {
-      return {
-        /**
-         * Specify that this control should have input focus when the page loads.
-         */
-        autofocus: {
-          type: Boolean
-        },
-
-        /**
-         * A reference to the focusable element controlled by the mixin.
-         * It can be an input, textarea, button or any element with tabindex > -1.
-         *
-         * Any component implementing this mixin is expected to provide it
-         * by using `this._setFocusElement(input)` Polymer API.
-         *
-         * @protected
-         * @type {!HTMLElement}
-         */
-        focusElement: {
-          type: Object,
-          readOnly: true,
-          observer: '_focusElementChanged'
-        }
-      };
-    }
-
-    constructor() {
-      super();
-
-      this._boundOnBlur = this._onBlur.bind(this);
-      this._boundOnFocus = this._onFocus.bind(this);
-    }
-
-    /** @protected */
-    ready() {
-      super.ready();
-
-      if (this.autofocus && !this.disabled) {
-        requestAnimationFrame(() => {
-          this.focus();
-          this.setAttribute('focus-ring', '');
-        });
-      }
-    }
-
-    focus() {
-      if (!this.focusElement || this.disabled) {
-        return;
-      }
-
-      this.focusElement.focus();
-      this._setFocused(true);
-    }
-
-    blur() {
-      if (!this.focusElement) {
-        return;
-      }
-      this.focusElement.blur();
-      this._setFocused(false);
-    }
-
-    click() {
-      if (this.focusElement && !this.disabled) {
-        this.focusElement.click();
-      }
-    }
-
-    /** @protected */
-    _focusElementChanged(element, oldElement) {
-      if (element) {
-        element.disabled = this.disabled;
-        this._addFocusListeners(element);
-      } else if (oldElement) {
-        this._removeFocusListeners(oldElement);
-      }
-    }
-
-    /**
-     * @param {HTMLElement} element
-     * @protected
-     */
-    _addFocusListeners(element) {
-      element.addEventListener('blur', this._boundOnBlur);
-      element.addEventListener('focus', this._boundOnFocus);
-    }
-
-    /**
-     * @param {HTMLElement} element
-     * @protected
-     */
-    _removeFocusListeners(element) {
-      element.removeEventListener('blur', this._boundOnBlur);
-      element.removeEventListener('focus', this._boundOnFocus);
-    }
-
-    /**
-     * Focus event does not bubble, so we dispatch it manually
-     * on the host element to support adding focus listeners
-     * when the focusable element is placed in light DOM.
-     * @param {FocusEvent} event
-     * @protected
-     */
-    _onFocus(event) {
-      event.stopPropagation();
-      this.dispatchEvent(new Event('focus'));
-    }
-
-    /**
-     * Blur event does not bubble, so we dispatch it manually
-     * on the host element to support adding blur listeners
-     * when the focusable element is placed in light DOM.
-     * @param {FocusEvent} event
-     * @protected
-     */
-    _onBlur(event) {
-      event.stopPropagation();
-      this.dispatchEvent(new Event('blur'));
-    }
-
-    /**
-     * @param {Event} event
-     * @return {boolean}
-     * @protected
-     * @override
-     */
-    _shouldSetFocus(event) {
-      return event.target === this.focusElement;
-    }
-
-    /**
-     * @param {boolean} disabled
-     * @protected
-     */
-    _disabledChanged(disabled) {
-      super._disabledChanged(disabled);
-
-      if (this.focusElement) {
-        this.focusElement.disabled = disabled;
-      }
-
-      if (disabled) {
-        this.blur();
-      }
-    }
-  };
-
 /**
  * A mixin to forward focus to an element in the light DOM.
+ *
+ * @polymerMixin
+ * @mixes DisabledMixin
+ * @mixes FocusMixin
  */
-export const DelegateFocusMixin = dedupingMixin(DelegateFocusMixinImplementation);
+export const DelegateFocusMixin = dedupingMixin(
+  (superclass) =>
+    class DelegateFocusMixinClass extends FocusMixin(DisabledMixin(superclass)) {
+      static get properties() {
+        return {
+          /**
+           * Specify that this control should have input focus when the page loads.
+           */
+          autofocus: {
+            type: Boolean
+          },
+
+          /**
+           * A reference to the focusable element controlled by the mixin.
+           * It can be an input, textarea, button or any element with tabindex > -1.
+           *
+           * Any component implementing this mixin is expected to provide it
+           * by using `this._setFocusElement(input)` Polymer API.
+           *
+           * @protected
+           * @type {!HTMLElement}
+           */
+          focusElement: {
+            type: Object,
+            readOnly: true,
+            observer: '_focusElementChanged'
+          }
+        };
+      }
+
+      constructor() {
+        super();
+
+        this._boundOnBlur = this._onBlur.bind(this);
+        this._boundOnFocus = this._onFocus.bind(this);
+      }
+
+      /** @protected */
+      ready() {
+        super.ready();
+
+        if (this.autofocus && !this.disabled) {
+          requestAnimationFrame(() => {
+            this.focus();
+            this.setAttribute('focus-ring', '');
+          });
+        }
+      }
+
+      /**
+       * @protected
+       * @override
+       */
+      focus() {
+        if (!this.focusElement || this.disabled) {
+          return;
+        }
+
+        this.focusElement.focus();
+        this._setFocused(true);
+      }
+
+      /**
+       * @protected
+       * @override
+       */
+      blur() {
+        if (!this.focusElement) {
+          return;
+        }
+        this.focusElement.blur();
+        this._setFocused(false);
+      }
+
+      /**
+       * @protected
+       * @override
+       */
+      click() {
+        if (this.focusElement && !this.disabled) {
+          this.focusElement.click();
+        }
+      }
+
+      /** @protected */
+      _focusElementChanged(element, oldElement) {
+        if (element) {
+          element.disabled = this.disabled;
+          this._addFocusListeners(element);
+        } else if (oldElement) {
+          this._removeFocusListeners(oldElement);
+        }
+      }
+
+      /**
+       * @param {HTMLElement} element
+       * @protected
+       */
+      _addFocusListeners(element) {
+        element.addEventListener('blur', this._boundOnBlur);
+        element.addEventListener('focus', this._boundOnFocus);
+      }
+
+      /**
+       * @param {HTMLElement} element
+       * @protected
+       */
+      _removeFocusListeners(element) {
+        element.removeEventListener('blur', this._boundOnBlur);
+        element.removeEventListener('focus', this._boundOnFocus);
+      }
+
+      /**
+       * Focus event does not bubble, so we dispatch it manually
+       * on the host element to support adding focus listeners
+       * when the focusable element is placed in light DOM.
+       * @param {FocusEvent} event
+       * @protected
+       */
+      _onFocus(event) {
+        event.stopPropagation();
+        this.dispatchEvent(new Event('focus'));
+      }
+
+      /**
+       * Blur event does not bubble, so we dispatch it manually
+       * on the host element to support adding blur listeners
+       * when the focusable element is placed in light DOM.
+       * @param {FocusEvent} event
+       * @protected
+       */
+      _onBlur(event) {
+        event.stopPropagation();
+        this.dispatchEvent(new Event('blur'));
+      }
+
+      /**
+       * @param {Event} event
+       * @return {boolean}
+       * @protected
+       * @override
+       */
+      _shouldSetFocus(event) {
+        return event.target === this.focusElement;
+      }
+
+      /**
+       * @param {boolean} disabled
+       * @protected
+       */
+      _disabledChanged(disabled) {
+        super._disabledChanged(disabled);
+
+        if (this.focusElement) {
+          this.focusElement.disabled = disabled;
+        }
+
+        if (disabled) {
+          this.blur();
+        }
+      }
+    }
+);

--- a/packages/field-base/src/delegate-state-mixin.js
+++ b/packages/field-base/src/delegate-state-mixin.js
@@ -5,119 +5,121 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
-const DelegateStateMixinImplementation = (superclass) =>
-  class DelegateStateMixinClass extends superclass {
-    static get properties() {
-      return {
-        /**
-         * A target element to which attributes and properties are delegated.
-         * @protected
-         */
-        stateTarget: {
-          type: Object,
-          observer: '_stateTargetChanged'
-        }
-      };
-    }
-
-    /**
-     * An array of the host attributes to delegate to the target element.
-     */
-    static get delegateAttrs() {
-      return [];
-    }
-
-    /**
-     * An array of the host properties to delegate to the target element.
-     */
-    static get delegateProps() {
-      return [];
-    }
-
-    /** @protected */
-    ready() {
-      super.ready();
-
-      this._createDelegateAttrsObserver();
-      this._createDelegatePropsObserver();
-    }
-
-    /** @protected */
-    _stateTargetChanged(target) {
-      if (target) {
-        this._ensureAttrsDelegated();
-        this._ensurePropsDelegated();
-      }
-    }
-
-    /** @protected */
-    _createDelegateAttrsObserver() {
-      this._createMethodObserver(`_delegateAttrsChanged(${this.constructor.delegateAttrs.join(', ')})`);
-    }
-
-    /** @protected */
-    _createDelegatePropsObserver() {
-      this._createMethodObserver(`_delegatePropsChanged(${this.constructor.delegateProps.join(', ')})`);
-    }
-
-    /** @protected */
-    _ensureAttrsDelegated() {
-      this.constructor.delegateAttrs.forEach((name) => {
-        this._delegateAttribute(name, this[name]);
-      });
-    }
-
-    /** @protected */
-    _ensurePropsDelegated() {
-      this.constructor.delegateProps.forEach((name) => {
-        this._delegateProperty(name, this[name]);
-      });
-    }
-
-    /** @protected */
-    _delegateAttrsChanged(...values) {
-      this.constructor.delegateAttrs.forEach((name, index) => {
-        this._delegateAttribute(name, values[index]);
-      });
-    }
-
-    /** @protected */
-    _delegatePropsChanged(...values) {
-      this.constructor.delegateProps.forEach((name, index) => {
-        this._delegateProperty(name, values[index]);
-      });
-    }
-
-    /** @protected */
-    _delegateAttribute(name, value) {
-      if (!this.stateTarget) {
-        return;
-      }
-
-      if (name === 'invalid') {
-        this._delegateAttribute('aria-invalid', value ? 'true' : false);
-      }
-
-      if (typeof value === 'boolean') {
-        this.stateTarget.toggleAttribute(name, value);
-      } else if (value) {
-        this.stateTarget.setAttribute(name, value);
-      } else {
-        this.stateTarget.removeAttribute(name);
-      }
-    }
-
-    /** @protected */
-    _delegateProperty(name, value) {
-      if (!this.stateTarget) {
-        return;
-      }
-
-      this.stateTarget[name] = value;
-    }
-  };
-
 /**
  * A mixin to delegate properties and attributes to a target element.
+ *
+ * @polymerMixin
  */
-export const DelegateStateMixin = dedupingMixin(DelegateStateMixinImplementation);
+export const DelegateStateMixin = dedupingMixin(
+  (superclass) =>
+    class DelegateStateMixinClass extends superclass {
+      static get properties() {
+        return {
+          /**
+           * A target element to which attributes and properties are delegated.
+           * @protected
+           */
+          stateTarget: {
+            type: Object,
+            observer: '_stateTargetChanged'
+          }
+        };
+      }
+
+      /**
+       * An array of the host attributes to delegate to the target element.
+       */
+      static get delegateAttrs() {
+        return [];
+      }
+
+      /**
+       * An array of the host properties to delegate to the target element.
+       */
+      static get delegateProps() {
+        return [];
+      }
+
+      /** @protected */
+      ready() {
+        super.ready();
+
+        this._createDelegateAttrsObserver();
+        this._createDelegatePropsObserver();
+      }
+
+      /** @protected */
+      _stateTargetChanged(target) {
+        if (target) {
+          this._ensureAttrsDelegated();
+          this._ensurePropsDelegated();
+        }
+      }
+
+      /** @protected */
+      _createDelegateAttrsObserver() {
+        this._createMethodObserver(`_delegateAttrsChanged(${this.constructor.delegateAttrs.join(', ')})`);
+      }
+
+      /** @protected */
+      _createDelegatePropsObserver() {
+        this._createMethodObserver(`_delegatePropsChanged(${this.constructor.delegateProps.join(', ')})`);
+      }
+
+      /** @protected */
+      _ensureAttrsDelegated() {
+        this.constructor.delegateAttrs.forEach((name) => {
+          this._delegateAttribute(name, this[name]);
+        });
+      }
+
+      /** @protected */
+      _ensurePropsDelegated() {
+        this.constructor.delegateProps.forEach((name) => {
+          this._delegateProperty(name, this[name]);
+        });
+      }
+
+      /** @protected */
+      _delegateAttrsChanged(...values) {
+        this.constructor.delegateAttrs.forEach((name, index) => {
+          this._delegateAttribute(name, values[index]);
+        });
+      }
+
+      /** @protected */
+      _delegatePropsChanged(...values) {
+        this.constructor.delegateProps.forEach((name, index) => {
+          this._delegateProperty(name, values[index]);
+        });
+      }
+
+      /** @protected */
+      _delegateAttribute(name, value) {
+        if (!this.stateTarget) {
+          return;
+        }
+
+        if (name === 'invalid') {
+          this._delegateAttribute('aria-invalid', value ? 'true' : false);
+        }
+
+        if (typeof value === 'boolean') {
+          this.stateTarget.toggleAttribute(name, value);
+        } else if (value) {
+          this.stateTarget.setAttribute(name, value);
+        } else {
+          this.stateTarget.removeAttribute(name);
+        }
+      }
+
+      /** @protected */
+      _delegateProperty(name, value) {
+        if (!this.stateTarget) {
+          return;
+        }
+
+        this.stateTarget[name] = value;
+      }
+    }
+);

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -11,6 +11,10 @@ import { ValidateMixin } from './validate-mixin.js';
 
 /**
  * A mixin to provide common field logic: label, error message and helper text.
+ *
+ * @polymerMixin
+ * @mixes LabelMixin
+ * @mixes ValidateMixin
  */
 export const FieldMixin = (superclass) =>
   class FieldMixinClass extends ValidateMixin(LabelMixin(superclass)) {
@@ -48,6 +52,7 @@ export const FieldMixin = (superclass) =>
       };
     }
 
+    /** @protected */
     get slots() {
       return {
         ...super.slots,

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -8,114 +8,119 @@ import { DelegateStateMixin } from './delegate-state-mixin.js';
 import { InputMixin } from './input-mixin.js';
 import { ValidateMixin } from './validate-mixin.js';
 
-const InputConstraintsMixinImplementation = (superclass) =>
-  class InputConstraintsMixinClass extends DelegateStateMixin(ValidateMixin(InputMixin(superclass))) {
-    /**
-     * An array of attributes which participate in the input validation.
-     * Changing these attributes will cause the input to re-validate.
-     *
-     * IMPORTANT: The attributes should be properly delegated to the input element
-     * from the host using `delegateAttrs` getter (see `DelegateStateMixin`).
-     * The `required` attribute is already delegated.
-     */
-    static get constraints() {
-      return ['required'];
-    }
-
-    static get delegateAttrs() {
-      return [...super.delegateAttrs, 'required'];
-    }
-
-    /** @protected */
-    ready() {
-      super.ready();
-
-      this._createConstraintsObserver();
-    }
-
-    /**
-     * Returns true if the current input value satisfies all constraints (if any).
-     * @return {boolean}
-     */
-    checkValidity() {
-      if (this.inputElement && this._hasValidConstraints(this.constructor.constraints.map((c) => this[c]))) {
-        return this.inputElement.checkValidity();
-      } else {
-        return !this.invalid;
-      }
-    }
-
-    /**
-     * Returns true if some of the provided set of constraints are valid.
-     * @param {Array} constraints
-     * @return {boolean}
-     * @protected
-     */
-    _hasValidConstraints(constraints) {
-      return constraints.some((c) => this.__isValidConstraint(c));
-    }
-
-    /**
-     * Override this method to customize setting up constraints observer.
-     * @protected
-     */
-    _createConstraintsObserver() {
-      // This complex observer needs to be added dynamically instead of using `static get observers()`
-      // to make it possible to tweak this behavior in classes that apply this mixin.
-      this._createMethodObserver(`_constraintsChanged(${this.constructor.constraints.join(', ')})`);
-    }
-
-    /**
-     * Override this method to implement custom validation constraints.
-     * @param {unknown[]} constraints
-     * @protected
-     */
-    _constraintsChanged(...constraints) {
-      // Prevent marking field as invalid when setting required state
-      // or any other constraint before a user has entered the value.
-      if (!this.invalid) {
-        return;
-      }
-
-      if (this._hasValidConstraints(constraints)) {
-        this.validate();
-      } else {
-        this.invalid = false;
-      }
-    }
-
-    /**
-     * Override an event listener inherited from `InputMixin`
-     * to capture native `change` event and make sure that
-     * a new one is dispatched after validation runs.
-     * @param {Event} event
-     * @protected
-     * @override
-     */
-    _onChange(event) {
-      event.stopPropagation();
-
-      this.validate();
-
-      this.dispatchEvent(
-        new CustomEvent('change', {
-          detail: {
-            sourceEvent: event
-          },
-          bubbles: event.bubbles,
-          cancelable: event.cancelable
-        })
-      );
-    }
-
-    /** @private */
-    __isValidConstraint(constraint) {
-      // 0 is valid for `minlength` and `maxlength`
-      return Boolean(constraint) || constraint === 0;
-    }
-  };
-
 /**
  * A mixin to combine multiple input validation constraints.
+ *
+ * @polymerMixin
+ * @mixes DelegateStateMixin
+ * @mixes InputMixin
+ * @mixes ValidateMixin
  */
-export const InputConstraintsMixin = dedupingMixin(InputConstraintsMixinImplementation);
+export const InputConstraintsMixin = dedupingMixin(
+  (superclass) =>
+    class InputConstraintsMixinClass extends DelegateStateMixin(ValidateMixin(InputMixin(superclass))) {
+      /**
+       * An array of attributes which participate in the input validation.
+       * Changing these attributes will cause the input to re-validate.
+       *
+       * IMPORTANT: The attributes should be properly delegated to the input element
+       * from the host using `delegateAttrs` getter (see `DelegateStateMixin`).
+       * The `required` attribute is already delegated.
+       */
+      static get constraints() {
+        return ['required'];
+      }
+
+      static get delegateAttrs() {
+        return [...super.delegateAttrs, 'required'];
+      }
+
+      /** @protected */
+      ready() {
+        super.ready();
+
+        this._createConstraintsObserver();
+      }
+
+      /**
+       * Returns true if the current input value satisfies all constraints (if any).
+       * @return {boolean}
+       */
+      checkValidity() {
+        if (this.inputElement && this._hasValidConstraints(this.constructor.constraints.map((c) => this[c]))) {
+          return this.inputElement.checkValidity();
+        } else {
+          return !this.invalid;
+        }
+      }
+
+      /**
+       * Returns true if some of the provided set of constraints are valid.
+       * @param {Array} constraints
+       * @return {boolean}
+       * @protected
+       */
+      _hasValidConstraints(constraints) {
+        return constraints.some((c) => this.__isValidConstraint(c));
+      }
+
+      /**
+       * Override this method to customize setting up constraints observer.
+       * @protected
+       */
+      _createConstraintsObserver() {
+        // This complex observer needs to be added dynamically instead of using `static get observers()`
+        // to make it possible to tweak this behavior in classes that apply this mixin.
+        this._createMethodObserver(`_constraintsChanged(${this.constructor.constraints.join(', ')})`);
+      }
+
+      /**
+       * Override this method to implement custom validation constraints.
+       * @param {unknown[]} constraints
+       * @protected
+       */
+      _constraintsChanged(...constraints) {
+        // Prevent marking field as invalid when setting required state
+        // or any other constraint before a user has entered the value.
+        if (!this.invalid) {
+          return;
+        }
+
+        if (this._hasValidConstraints(constraints)) {
+          this.validate();
+        } else {
+          this.invalid = false;
+        }
+      }
+
+      /**
+       * Override an event listener inherited from `InputMixin`
+       * to capture native `change` event and make sure that
+       * a new one is dispatched after validation runs.
+       * @param {Event} event
+       * @protected
+       * @override
+       */
+      _onChange(event) {
+        event.stopPropagation();
+
+        this.validate();
+
+        this.dispatchEvent(
+          new CustomEvent('change', {
+            detail: {
+              sourceEvent: event
+            },
+            bubbles: event.bubbles,
+            cancelable: event.cancelable
+          })
+        );
+      }
+
+      /** @private */
+      __isValidConstraint(constraint) {
+        // 0 is valid for `minlength` and `maxlength`
+        return Boolean(constraint) || constraint === 0;
+      }
+    }
+);

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -10,6 +10,12 @@ import { InputConstraintsMixin } from './input-constraints-mixin.js';
 
 /**
  * A mixin to provide shared logic for the editable form input controls.
+ *
+ * @polymerMixin
+ * @mixes DelegateFocusMixin
+ * @mixes FieldMixin
+ * @mixes InputConstraintsMixin
+ * @mixes KeyboardMixin
  */
 export const InputControlMixin = (superclass) =>
   class InputControlMixinClass extends DelegateFocusMixin(

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -7,6 +7,9 @@ import { InputControlMixin } from './input-control-mixin.js';
 
 /**
  * A mixin to provide logic for vaadin-text-field and related components.
+ *
+ * @polymerMixin
+ * @mixes InputControlMixin
  */
 export const InputFieldMixin = (superclass) =>
   class InputFieldMixinClass extends InputControlMixin(superclass) {

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -5,174 +5,176 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
-const InputMixinImplementation = (superclass) =>
-  class InputMixinClass extends superclass {
-    static get properties() {
-      return {
-        /**
-         * A reference to the input element controlled by the mixin.
-         * Any component implementing this mixin is expected to provide it
-         * by using `this._setInputElement(input)` Polymer API.
-         *
-         * A typical case is using `InputController` that does this automatically.
-         * However, the input element does not have to always be native <input>:
-         * as an example, <vaadin-combo-box-light> accepts other components.
-         *
-         * @protected
-         * @type {!HTMLElement}
-         */
-        inputElement: {
-          type: Object,
-          readOnly: true,
-          observer: '_inputElementChanged'
-        },
-
-        /**
-         * String used to define input type.
-         * @protected
-         */
-        type: {
-          type: String,
-          readOnly: true
-        },
-
-        /**
-         * The value of the field.
-         */
-        value: {
-          type: String,
-          value: '',
-          observer: '_valueChanged',
-          notify: true
-        }
-      };
-    }
-
-    constructor() {
-      super();
-
-      this._boundOnInput = this._onInput.bind(this);
-      this._boundOnChange = this._onChange.bind(this);
-    }
-
-    /**
-     * Clear the value of the field.
-     */
-    clear() {
-      this.value = '';
-    }
-
-    /**
-     * Add event listeners to the input element instance.
-     * Override this method to add custom listeners.
-     * @param {!HTMLElement} input
-     */
-    _addInputListeners(input) {
-      input.addEventListener('input', this._boundOnInput);
-      input.addEventListener('change', this._boundOnChange);
-    }
-
-    /**
-     * Remove event listeners from the input element instance.
-     * @param {!HTMLElement} input
-     */
-    _removeInputListeners(input) {
-      input.removeEventListener('input', this._boundOnInput);
-      input.removeEventListener('change', this._boundOnChange);
-    }
-
-    /**
-     * A method to forward the value property set on the field
-     * programmatically back to the input element value.
-     * Override this method to perform additional checks,
-     * for example to skip this in certain conditions.
-     * @param {string} value
-     * @protected
-     * @override
-     */
-    _forwardInputValue(value) {
-      // Value might be set before an input element is initialized.
-      // This case should be handled separately by a component that
-      // implements this mixin, for example in `connectedCallback`.
-      if (!this.inputElement) {
-        return;
-      }
-
-      if (value != undefined) {
-        this.inputElement.value = value;
-      } else {
-        this.inputElement.value = '';
-      }
-    }
-
-    /** @protected */
-    _inputElementChanged(input, oldInput) {
-      if (input) {
-        this._addInputListeners(input);
-      } else if (oldInput) {
-        this._removeInputListeners(oldInput);
-      }
-    }
-
-    /**
-     * An input event listener used to update the field value.
-     * Override this method with an actual implementation.
-     * @param {Event} _event
-     * @protected
-     * @override
-     */
-    _onInput(event) {
-      // Ignore fake input events e.g. used by clear button.
-      this.__userInput = event.isTrusted;
-      this.value = event.target.value;
-      this.__userInput = false;
-    }
-
-    /**
-     * A change event listener.
-     * Override this method with an actual implementation.
-     * @param {Event} _event
-     * @protected
-     * @override
-     */
-    _onChange(_event) {}
-
-    /**
-     * Toggle the has-value attribute based on the value property.
-     * @param {boolean} hasValue
-     * @protected
-     */
-    _toggleHasValue(hasValue) {
-      this.toggleAttribute('has-value', hasValue);
-    }
-
-    /**
-     * Observer called when a value property changes.
-     * @param {string | undefined} newVal
-     * @param {string | undefined} oldVal
-     * @protected
-     * @override
-     */
-    _valueChanged(newVal, oldVal) {
-      this._toggleHasValue(newVal !== '' && newVal != null);
-
-      // Setting initial value to empty string, do nothing.
-      if (newVal === '' && oldVal === undefined) {
-        return;
-      }
-
-      // Value is set by the user, no need to sync it back to input.
-      if (this.__userInput) {
-        return;
-      }
-
-      // Setting a value programmatically, sync it to input element.
-      this._forwardInputValue(newVal);
-    }
-  };
-
 /**
  * A mixin to store the reference to an input element
  * and add input and change event listeners to it.
+ *
+ * @polymerMixin
  */
-export const InputMixin = dedupingMixin(InputMixinImplementation);
+export const InputMixin = dedupingMixin(
+  (superclass) =>
+    class InputMixinClass extends superclass {
+      static get properties() {
+        return {
+          /**
+           * A reference to the input element controlled by the mixin.
+           * Any component implementing this mixin is expected to provide it
+           * by using `this._setInputElement(input)` Polymer API.
+           *
+           * A typical case is using `InputController` that does this automatically.
+           * However, the input element does not have to always be native <input>:
+           * as an example, <vaadin-combo-box-light> accepts other components.
+           *
+           * @protected
+           * @type {!HTMLElement}
+           */
+          inputElement: {
+            type: Object,
+            readOnly: true,
+            observer: '_inputElementChanged'
+          },
+
+          /**
+           * String used to define input type.
+           * @protected
+           */
+          type: {
+            type: String,
+            readOnly: true
+          },
+
+          /**
+           * The value of the field.
+           */
+          value: {
+            type: String,
+            value: '',
+            observer: '_valueChanged',
+            notify: true
+          }
+        };
+      }
+
+      constructor() {
+        super();
+
+        this._boundOnInput = this._onInput.bind(this);
+        this._boundOnChange = this._onChange.bind(this);
+      }
+
+      /**
+       * Clear the value of the field.
+       */
+      clear() {
+        this.value = '';
+      }
+
+      /**
+       * Add event listeners to the input element instance.
+       * Override this method to add custom listeners.
+       * @param {!HTMLElement} input
+       */
+      _addInputListeners(input) {
+        input.addEventListener('input', this._boundOnInput);
+        input.addEventListener('change', this._boundOnChange);
+      }
+
+      /**
+       * Remove event listeners from the input element instance.
+       * @param {!HTMLElement} input
+       */
+      _removeInputListeners(input) {
+        input.removeEventListener('input', this._boundOnInput);
+        input.removeEventListener('change', this._boundOnChange);
+      }
+
+      /**
+       * A method to forward the value property set on the field
+       * programmatically back to the input element value.
+       * Override this method to perform additional checks,
+       * for example to skip this in certain conditions.
+       * @param {string} value
+       * @protected
+       * @override
+       */
+      _forwardInputValue(value) {
+        // Value might be set before an input element is initialized.
+        // This case should be handled separately by a component that
+        // implements this mixin, for example in `connectedCallback`.
+        if (!this.inputElement) {
+          return;
+        }
+
+        if (value != undefined) {
+          this.inputElement.value = value;
+        } else {
+          this.inputElement.value = '';
+        }
+      }
+
+      /** @protected */
+      _inputElementChanged(input, oldInput) {
+        if (input) {
+          this._addInputListeners(input);
+        } else if (oldInput) {
+          this._removeInputListeners(oldInput);
+        }
+      }
+
+      /**
+       * An input event listener used to update the field value.
+       * Override this method with an actual implementation.
+       * @param {Event} _event
+       * @protected
+       * @override
+       */
+      _onInput(event) {
+        // Ignore fake input events e.g. used by clear button.
+        this.__userInput = event.isTrusted;
+        this.value = event.target.value;
+        this.__userInput = false;
+      }
+
+      /**
+       * A change event listener.
+       * Override this method with an actual implementation.
+       * @param {Event} _event
+       * @protected
+       * @override
+       */
+      _onChange(_event) {}
+
+      /**
+       * Toggle the has-value attribute based on the value property.
+       * @param {boolean} hasValue
+       * @protected
+       */
+      _toggleHasValue(hasValue) {
+        this.toggleAttribute('has-value', hasValue);
+      }
+
+      /**
+       * Observer called when a value property changes.
+       * @param {string | undefined} newVal
+       * @param {string | undefined} oldVal
+       * @protected
+       * @override
+       */
+      _valueChanged(newVal, oldVal) {
+        this._toggleHasValue(newVal !== '' && newVal != null);
+
+        // Setting initial value to empty string, do nothing.
+        if (newVal === '' && oldVal === undefined) {
+          return;
+        }
+
+        // Value is set by the user, no need to sync it back to input.
+        if (this.__userInput) {
+          return;
+        }
+
+        // Setting a value programmatically, sync it to input element.
+        this._forwardInputValue(newVal);
+      }
+    }
+);

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -6,84 +6,88 @@
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';
 
-const LabelMixinImplementation = (superclass) =>
-  class LabelMixinClass extends SlotMixin(superclass) {
-    static get properties() {
-      return {
-        /**
-         * The label text for the input node.
-         * When no light dom defined via [slot=label], this value will be used.
-         */
-        label: {
-          type: String,
-          observer: '_labelChanged'
-        }
-      };
-    }
-
-    get slots() {
-      return {
-        ...super.slots,
-        label: () => {
-          const label = document.createElement('label');
-          label.textContent = this.label;
-          return label;
-        }
-      };
-    }
-
-    /** @protected */
-    get _labelNode() {
-      return this._getDirectSlotChild('label');
-    }
-
-    constructor() {
-      super();
-
-      // Ensure every instance has unique ID
-      const uniqueId = (LabelMixinClass._uniqueLabelId = 1 + LabelMixinClass._uniqueLabelId || 0);
-      this._labelId = `label-${this.localName}-${uniqueId}`;
-
-      /**
-       * @type {MutationObserver}
-       * @private
-       */
-      this.__labelNodeObserver = new MutationObserver(() => {
-        this._toggleHasLabelAttribute();
-      });
-    }
-
-    /** @protected */
-    ready() {
-      super.ready();
-
-      if (this._labelNode) {
-        this._labelNode.id = this._labelId;
-        this._toggleHasLabelAttribute();
-
-        this.__labelNodeObserver.observe(this._labelNode, { childList: true });
-      }
-    }
-
-    /** @protected */
-    _labelChanged(label) {
-      if (this._labelNode) {
-        this._labelNode.textContent = label;
-        this._toggleHasLabelAttribute();
-      }
-    }
-
-    /** @protected */
-    _toggleHasLabelAttribute() {
-      if (this._labelNode) {
-        const hasLabel = this._labelNode.children.length > 0 || this._labelNode.textContent.trim() !== '';
-
-        this.toggleAttribute('has-label', hasLabel);
-      }
-    }
-  };
-
 /**
  * A mixin to provide label via corresponding property or named slot.
+ *
+ * @polymerMixin
+ * @mixes SlotMixin
  */
-export const LabelMixin = dedupingMixin(LabelMixinImplementation);
+export const LabelMixin = dedupingMixin(
+  (superclass) =>
+    class LabelMixinClass extends SlotMixin(superclass) {
+      static get properties() {
+        return {
+          /**
+           * The label text for the input node.
+           * When no light dom defined via [slot=label], this value will be used.
+           */
+          label: {
+            type: String,
+            observer: '_labelChanged'
+          }
+        };
+      }
+
+      /** @protected */
+      get slots() {
+        return {
+          ...super.slots,
+          label: () => {
+            const label = document.createElement('label');
+            label.textContent = this.label;
+            return label;
+          }
+        };
+      }
+
+      /** @protected */
+      get _labelNode() {
+        return this._getDirectSlotChild('label');
+      }
+
+      constructor() {
+        super();
+
+        // Ensure every instance has unique ID
+        const uniqueId = (LabelMixinClass._uniqueLabelId = 1 + LabelMixinClass._uniqueLabelId || 0);
+        this._labelId = `label-${this.localName}-${uniqueId}`;
+
+        /**
+         * @type {MutationObserver}
+         * @private
+         */
+        this.__labelNodeObserver = new MutationObserver(() => {
+          this._toggleHasLabelAttribute();
+        });
+      }
+
+      /** @protected */
+      ready() {
+        super.ready();
+
+        if (this._labelNode) {
+          this._labelNode.id = this._labelId;
+          this._toggleHasLabelAttribute();
+
+          this.__labelNodeObserver.observe(this._labelNode, { childList: true });
+        }
+      }
+
+      /** @protected */
+      _labelChanged(label) {
+        if (this._labelNode) {
+          this._labelNode.textContent = label;
+          this._toggleHasLabelAttribute();
+        }
+      }
+
+      /** @protected */
+      _toggleHasLabelAttribute() {
+        if (this._labelNode) {
+          const hasLabel = this._labelNode.children.length > 0 || this._labelNode.textContent.trim() !== '';
+
+          this.toggleAttribute('has-label', hasLabel);
+        }
+      }
+    }
+);

--- a/packages/field-base/src/pattern-mixin.js
+++ b/packages/field-base/src/pattern-mixin.js
@@ -9,6 +9,9 @@ import { InputConstraintsMixin } from './input-constraints-mixin.js';
 
 /**
  * A mixin to provide `pattern` and `preventInvalidInput` properties.
+ *
+ * @polymerMixin
+ * @mixes InputConstraintsMixin
  */
 export const PatternMixin = (superclass) =>
   class PatternMixinClass extends InputConstraintsMixin(superclass) {

--- a/packages/field-base/src/shadow-focus-mixin.js
+++ b/packages/field-base/src/shadow-focus-mixin.js
@@ -9,7 +9,11 @@ import { DelegateFocusMixin } from './delegate-focus-mixin.js';
 
 /**
  * A mixin to forward focus to an element in the shadow DOM.
+ *
  * @polymerMixin
+ * @mixes DelegateFocusMixin
+ * @mixes KeyboardMixin
+ * @mixes TabindexMixin
  */
 export const ShadowFocusMixin = (superClass) =>
   class ShadowFocusMixinClass extends TabindexMixin(DelegateFocusMixin(KeyboardMixin(superClass))) {

--- a/packages/field-base/src/slot-label-mixin.js
+++ b/packages/field-base/src/slot-label-mixin.js
@@ -7,28 +7,32 @@ import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { LabelMixin } from './label-mixin.js';
 import { SlotTargetMixin } from './slot-target-mixin.js';
 
-const SlotLabelMixinImplementation = (superclass) =>
-  class SlotLabelMixinClass extends SlotTargetMixin(LabelMixin(superclass)) {
-    /** @protected */
-    get _slotTarget() {
-      return this._labelNode;
-    }
-
-    /** @protected */
-    ready() {
-      super.ready();
-
-      if (this._labelNode) {
-        // The default slot's content is moved to the label node
-        // only after `LabelMixin` is initialized which means
-        // we should manually toggle the `has-label` attribute
-        // respecting the new label content.
-        this._toggleHasLabelAttribute();
-      }
-    }
-  };
-
 /**
  * A mixin to forward any content from the default slot to the label node.
+ *
+ * @polymerMixin
+ * @mixes LabelMixin
+ * @mixes SlotTargetMixin
  */
-export const SlotLabelMixin = dedupingMixin(SlotLabelMixinImplementation);
+export const SlotLabelMixin = dedupingMixin(
+  (superclass) =>
+    class SlotLabelMixinClass extends SlotTargetMixin(LabelMixin(superclass)) {
+      /** @protected */
+      get _slotTarget() {
+        return this._labelNode;
+      }
+
+      /** @protected */
+      ready() {
+        super.ready();
+
+        if (this._labelNode) {
+          // The default slot's content is moved to the label node
+          // only after `LabelMixin` is initialized which means
+          // we should manually toggle the `has-label` attribute
+          // respecting the new label content.
+          this._toggleHasLabelAttribute();
+        }
+      }
+    }
+);

--- a/packages/field-base/src/slot-styles-mixin.js
+++ b/packages/field-base/src/slot-styles-mixin.js
@@ -1,3 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
 const stylesMap = new WeakMap();
@@ -31,39 +36,41 @@ function insertStyles(styles, root) {
   }
 }
 
-const SlotStylesMixinImplementation = (superclass) =>
-  class SlotStylesMixinClass extends superclass {
-    /**
-     * List of styles to insert into root.
-     * @protected
-     */
-    get slotStyles() {
-      return {};
-    }
-
-    /** @protected */
-    connectedCallback() {
-      super.connectedCallback();
-
-      this.__applySlotStyles();
-    }
-
-    /** @private */
-    __applySlotStyles() {
-      const root = this.getRootNode();
-      const rootStyles = getRootStyles(root);
-
-      this.slotStyles.forEach((styles) => {
-        if (!rootStyles.has(styles)) {
-          insertStyles(styles, root);
-          rootStyles.add(styles);
-        }
-      });
-    }
-  };
-
 /**
  * Mixin to insert styles into the outer scope to handle slotted components.
  * This is useful e.g. to hide native `<input type="number">` controls.
+ *
+ * @polymerMixin
  */
-export const SlotStylesMixin = dedupingMixin(SlotStylesMixinImplementation);
+export const SlotStylesMixin = dedupingMixin(
+  (superclass) =>
+    class SlotStylesMixinClass extends superclass {
+      /**
+       * List of styles to insert into root.
+       * @protected
+       */
+      get slotStyles() {
+        return {};
+      }
+
+      /** @protected */
+      connectedCallback() {
+        super.connectedCallback();
+
+        this.__applySlotStyles();
+      }
+
+      /** @private */
+      __applySlotStyles() {
+        const root = this.getRootNode();
+        const rootStyles = getRootStyles(root);
+
+        this.slotStyles.forEach((styles) => {
+          if (!rootStyles.has(styles)) {
+            insertStyles(styles, root);
+            rootStyles.add(styles);
+          }
+        });
+      }
+    }
+);

--- a/packages/field-base/src/slot-target-mixin.js
+++ b/packages/field-base/src/slot-target-mixin.js
@@ -1,103 +1,110 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
-
-const SlotTargetMixinImplementation = (superclass) =>
-  class SlotTargetMixinClass extends superclass {
-    /** @protected */
-    ready() {
-      super.ready();
-
-      if (this._sourceSlot) {
-        this.__sourceSlotObserver = new MutationObserver(() => this.__checkAndCopyNodesToSlotTarget());
-
-        this.__checkAndCopyNodesToSlotTarget();
-
-        this._sourceSlot.addEventListener('slotchange', () => {
-          this.__checkAndCopyNodesToSlotTarget();
-        });
-      }
-    }
-
-    /**
-     * A reference to the source slot from which the nodes are copied to the target element.
-     *
-     * @type {HTMLSlotElement | null}
-     * @protected
-     */
-    get _sourceSlot() {
-      console.warn(`Please implement the '_sourceSlot' property in <${this.localName}>`);
-      return null;
-    }
-
-    /**
-     * A reference to the target element to which the nodes are copied from the source slot.
-     *
-     * @type {HTMLElement | null}
-     * @protected
-     */
-    get _slotTarget() {
-      console.warn(`Please implement the '_slotTarget' property in <${this.localName}>`);
-      return null;
-    }
-
-    /**
-     * Copies every node from the source slot to the target element
-     * once the source slot' content is changed.
-     *
-     * @private
-     */
-    __checkAndCopyNodesToSlotTarget() {
-      this.__sourceSlotObserver.disconnect();
-
-      if (!this._slotTarget) {
-        return;
-      }
-
-      // Remove any existing clones from the slot target
-      if (this.__slotTargetClones) {
-        this.__slotTargetClones.forEach((node) => {
-          if (node.parentElement === this._slotTarget) {
-            this._slotTarget.removeChild(node);
-          }
-        });
-        delete this.__slotTargetClones;
-      }
-
-      // Exclude whitespace text nodes
-      const nodes = this._sourceSlot
-        .assignedNodes({ flatten: true })
-        .filter((node) => !(node.nodeType == Node.TEXT_NODE && node.textContent.trim() === ''));
-
-      if (nodes.length > 0) {
-        this._slotTarget.innerHTML = '';
-        this.__copyNodesToSlotTarget(nodes);
-      }
-    }
-
-    /**
-     * Copies the nodes to the target element.
-     *
-     * @protected
-     * @param {!Array<!Node>} nodes
-     */
-    __copyNodesToSlotTarget(nodes) {
-      this.__slotTargetClones = this.__slotTargetClones || [];
-      nodes.forEach((node) => {
-        // Clone the nodes and append the clones to the target slot
-        const clone = node.cloneNode(true);
-        this.__slotTargetClones.push(clone);
-        this._slotTarget.appendChild(clone);
-        // Observe all changes to the source node to have the clones updated
-        this.__sourceSlotObserver.observe(node, {
-          attributes: true,
-          childList: true,
-          subtree: true,
-          characterData: true
-        });
-      });
-    }
-  };
 
 /**
  * A mixin to copy the content from a source slot to a target element.
+ *
+ * @polymerMixin
  */
-export const SlotTargetMixin = dedupingMixin(SlotTargetMixinImplementation);
+export const SlotTargetMixin = dedupingMixin(
+  (superclass) =>
+    class SlotTargetMixinClass extends superclass {
+      /** @protected */
+      ready() {
+        super.ready();
+
+        if (this._sourceSlot) {
+          this.__sourceSlotObserver = new MutationObserver(() => this.__checkAndCopyNodesToSlotTarget());
+
+          this.__checkAndCopyNodesToSlotTarget();
+
+          this._sourceSlot.addEventListener('slotchange', () => {
+            this.__checkAndCopyNodesToSlotTarget();
+          });
+        }
+      }
+
+      /**
+       * A reference to the source slot from which the nodes are copied to the target element.
+       *
+       * @type {HTMLSlotElement | null}
+       * @protected
+       */
+      get _sourceSlot() {
+        console.warn(`Please implement the '_sourceSlot' property in <${this.localName}>`);
+        return null;
+      }
+
+      /**
+       * A reference to the target element to which the nodes are copied from the source slot.
+       *
+       * @type {HTMLElement | null}
+       * @protected
+       */
+      get _slotTarget() {
+        console.warn(`Please implement the '_slotTarget' property in <${this.localName}>`);
+        return null;
+      }
+
+      /**
+       * Copies every node from the source slot to the target element
+       * once the source slot' content is changed.
+       *
+       * @private
+       */
+      __checkAndCopyNodesToSlotTarget() {
+        this.__sourceSlotObserver.disconnect();
+
+        if (!this._slotTarget) {
+          return;
+        }
+
+        // Remove any existing clones from the slot target
+        if (this.__slotTargetClones) {
+          this.__slotTargetClones.forEach((node) => {
+            if (node.parentElement === this._slotTarget) {
+              this._slotTarget.removeChild(node);
+            }
+          });
+          delete this.__slotTargetClones;
+        }
+
+        // Exclude whitespace text nodes
+        const nodes = this._sourceSlot
+          .assignedNodes({ flatten: true })
+          .filter((node) => !(node.nodeType == Node.TEXT_NODE && node.textContent.trim() === ''));
+
+        if (nodes.length > 0) {
+          this._slotTarget.innerHTML = '';
+          this.__copyNodesToSlotTarget(nodes);
+        }
+      }
+
+      /**
+       * Copies the nodes to the target element.
+       *
+       * @protected
+       * @param {!Array<!Node>} nodes
+       */
+      __copyNodesToSlotTarget(nodes) {
+        this.__slotTargetClones = this.__slotTargetClones || [];
+        nodes.forEach((node) => {
+          // Clone the nodes and append the clones to the target slot
+          const clone = node.cloneNode(true);
+          this.__slotTargetClones.push(clone);
+          this._slotTarget.appendChild(clone);
+          // Observe all changes to the source node to have the clones updated
+          this.__sourceSlotObserver.observe(node, {
+            attributes: true,
+            childList: true,
+            subtree: true,
+            characterData: true
+          });
+        });
+      }
+    }
+);

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -5,50 +5,52 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
-const ValidateMixinImplementation = (superclass) =>
-  class ValidateMixinClass extends superclass {
-    static get properties() {
-      return {
-        /**
-         * Set to true when the field is invalid.
-         */
-        invalid: {
-          type: Boolean,
-          reflectToAttribute: true,
-          notify: true,
-          value: false
-        },
-
-        /**
-         * Specifies that the user must fill in a value.
-         */
-        required: {
-          type: Boolean,
-          reflectToAttribute: true
-        }
-      };
-    }
-
-    /**
-     * Returns true if field is valid, and sets `invalid` based on the field validity.
-     *
-     * @return {boolean} True if the value is valid.
-     */
-    validate() {
-      return !(this.invalid = !this.checkValidity());
-    }
-
-    /**
-     * Returns true if the field value satisfies all constraints (if any).
-     *
-     * @return {boolean}
-     */
-    checkValidity() {
-      return !this.required || !!this.value;
-    }
-  };
-
 /**
  * A mixin to provide required state and validation logic.
+ *
+ * @polymerMixin
  */
-export const ValidateMixin = dedupingMixin(ValidateMixinImplementation);
+export const ValidateMixin = dedupingMixin(
+  (superclass) =>
+    class ValidateMixinClass extends superclass {
+      static get properties() {
+        return {
+          /**
+           * Set to true when the field is invalid.
+           */
+          invalid: {
+            type: Boolean,
+            reflectToAttribute: true,
+            notify: true,
+            value: false
+          },
+
+          /**
+           * Specifies that the user must fill in a value.
+           */
+          required: {
+            type: Boolean,
+            reflectToAttribute: true
+          }
+        };
+      }
+
+      /**
+       * Returns true if field is valid, and sets `invalid` based on the field validity.
+       *
+       * @return {boolean} True if the value is valid.
+       */
+      validate() {
+        return !(this.invalid = !this.checkValidity());
+      }
+
+      /**
+       * Returns true if the field value satisfies all constraints (if any).
+       *
+       * @return {boolean}
+       */
+      checkValidity() {
+        return !this.required || !!this.value;
+      }
+    }
+);

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -117,6 +117,7 @@ export class PasswordField extends TextField {
     return ['__i18nChanged(i18n.*)'];
   }
 
+  /** @protected */
   get slots() {
     return {
       ...super.slots,


### PR DESCRIPTION
## Description

1. Added `@polymerMixin` and `@mixes` JSDoc annotations to all new mixins.
2. Moved JSDoc comments to ensure the mixins appear in components API docs.

## Example

See the example for `vaadin-checkbox` component API docs:

### Before

Only own properties are in the API docs:

![checkbox-before](https://user-images.githubusercontent.com/10589913/136531091-5d21ca4c-633e-4915-bf38-ca8d53333d51.png)

### After

All the inherited properties are in the API docs:

![checkbox-after](https://user-images.githubusercontent.com/10589913/136531132-3379329c-96e2-4e0c-977e-337a2cd1bcce.png)

## Type of change

- Internal Change

## Note

Make sure you ignore whitespace changes when reviewing:

![whitespace](https://user-images.githubusercontent.com/10589913/136531387-bda84f94-a45e-495e-a343-3154c19182cb.png)