### PR TITLE
feat: allow easy customizing of required indicator's color 

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -44,7 +44,7 @@ const requiredField = css`
     content: var(--lumo-required-field-indicator, '•');
     transition: opacity 0.2s;
     opacity: 0;
-    color: var(--lumo-primary-text-color);
+    color: var(--lumo-required-field-indicator-color, --lumo-primary-text-color);
     position: absolute;
     right: 0;
     width: 1em;
@@ -56,7 +56,7 @@ const requiredField = css`
   }
 
   :host([invalid]) [part='required-indicator']::after {
-    color: var(--lumo-error-text-color);
+    color: var(--lumo-required-field-indicator-color, --lumo-error-text-color);
   }
 
   [part='error-message'] {


### PR DESCRIPTION
## Description

Allows easy customization of the default required indicator's color to allow for common use cases like red colored required indicator without overwriting the `part=required-indicator` for every component.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.

--> Half / Half .. it was dicussed with Jouni in the ticket; but there is not AC created.
