### PR TITLE
fix: make themable-mixin a runtime dependency

### DIFF
--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -31,12 +31,12 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
+    "@vaadin/vaadin-themable-mixin": "22.0.0-alpha7",
     "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.3.0",
-    "@vaadin/vaadin-themable-mixin": "22.0.0-alpha7",
     "sinon": "^9.2.4"
   }
 }


### PR DESCRIPTION
## Description

The adapter uses code from themable-mixin package so it needs to be a dependency.

## Type of change

- Bugfix