### PR TITLE
refactor: move click listener from label to required indicator

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -188,9 +188,9 @@ class ComboBox extends ComboBoxDataProviderMixin(
       </style>
 
       <div class="vaadin-combo-box-container">
-        <div part="label" on-click="focus">
+        <div part="label">
           <slot name="label"></slot>
-          <span part="required-indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true" on-click="focus"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -345,6 +345,13 @@ describe('Properties', () => {
       expect(comboBox.hasAttribute('focused')).to.be.false;
     });
 
+    it('should focus on required indicator click', () => {
+      comboBox.required = true;
+      comboBox.autoOpenDisabled = true;
+      comboBox.shadowRoot.querySelector('[part="required-indicator"]').click();
+      expect(comboBox.hasAttribute('focused')).to.be.true;
+    });
+
     describe('touch devices', () => {
       it('should blur the input on touchend', () => {
         comboBox.focus();

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -125,9 +125,9 @@ class DatePicker extends DatePickerMixin(
       </style>
 
       <div class="vaadin-date-picker-container">
-        <div part="label" on-click="focus">
+        <div part="label">
           <slot name="label"></slot>
-          <span part="required-indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true" on-click="focus"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/date-picker/test/form-input.test.js
+++ b/packages/date-picker/test/form-input.test.js
@@ -164,6 +164,11 @@ describe('form input', () => {
       datepicker.validate();
       expect(datepicker.invalid).to.be.true;
     });
+
+    it('should focus on required indicator click', () => {
+      datepicker.shadowRoot.querySelector('[part="required-indicator"]').click();
+      expect(datepicker.hasAttribute('focused')).to.be.true;
+    });
   });
 
   describe('custom validator', () => {

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -94,9 +94,9 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
       </style>
 
       <div class="vaadin-field-container">
-        <div part="label" on-click="focus">
+        <div part="label">
           <slot name="label"></slot>
-          <span part="required-indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true" on-click="focus"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -898,3 +898,16 @@ describe('invalid with value', () => {
     expect(numberField.invalid).to.be.true;
   });
 });
+
+describe('required', () => {
+  let numberField;
+
+  beforeEach(() => {
+    numberField = fixtureSync('<vaadin-number-field required></vaadin-number-field>');
+  });
+
+  it('should focus on required indicator click', () => {
+    numberField.shadowRoot.querySelector('[part="required-indicator"]').click();
+    expect(numberField.hasAttribute('focused')).to.be.true;
+  });
+});

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -123,9 +123,9 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       </style>
 
       <div class="vaadin-select-container">
-        <div part="label" on-click="focus">
+        <div part="label">
           <slot name="label"></slot>
-          <span part="required-indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true" on-click="focus"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -426,6 +426,11 @@ describe('vaadin-select', () => {
         valueButton.dispatchEvent(ev);
         expect(ev.defaultPrevented).to.be.false;
       });
+
+      it('should focus on required indicator click', () => {
+        select.shadowRoot.querySelector('[part="required-indicator"]').click();
+        expect(select.hasAttribute('focused')).to.be.true;
+      });
     });
 
     describe('focus when overlay opened', () => {

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -95,9 +95,9 @@ export class TextField extends PatternMixin(InputFieldMixin(ThemableMixin(Elemen
       </style>
 
       <div class="vaadin-field-container">
-        <div part="label" on-click="focus">
+        <div part="label">
           <slot name="label"></slot>
-          <span part="required-indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true" on-click="focus"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/text-field/test/text-field.test.js
+++ b/packages/text-field/test/text-field.test.js
@@ -218,22 +218,14 @@ describe('text-field', () => {
       });
     });
 
-    describe('label', () => {
-      let label;
-
+    describe('required', () => {
       beforeEach(() => {
-        label = textField.shadowRoot.querySelector('[part="label"]');
+        textField.required = true;
       });
 
-      it('should update focused property on label click', () => {
-        label.click();
+      it('should focus on required indicator click', () => {
+        textField.shadowRoot.querySelector('[part="required-indicator"]').click();
         expect(textField.hasAttribute('focused')).to.be.true;
-      });
-
-      it('should not update focused property on click if disabled', () => {
-        textField.disabled = true;
-        label.click();
-        expect(textField.hasAttribute('focused')).to.be.false;
       });
     });
 

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -105,9 +105,9 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       </style>
 
       <div class="vaadin-time-picker-container">
-        <div part="label" on-click="focus">
+        <div part="label">
           <slot name="label"></slot>
-          <span part="required-indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true" on-click="focus"></span>
         </div>
 
         <vaadin-time-picker-combo-box

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -582,4 +582,15 @@ describe('time-picker', () => {
       expect(timePicker.$.comboBox.getAttribute('theme')).to.equal('foo');
     });
   });
+
+  describe('required', () => {
+    beforeEach(() => {
+      timePicker.required = true;
+    });
+
+    it('should focus on required indicator click', () => {
+      timePicker.shadowRoot.querySelector('[part="required-indicator"]').click();
+      expect(timePicker.hasAttribute('focused')).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/2793

In the case of `<vaadin-date-time-picker>` and `<vaadin-custom-field>`, the click listener was not changed because these two components can wrap multiple inputs, and thus the native `<label>` isn't connected to any specific one.