### PR TITLE
refactor!: drop update() method support

### DIFF
--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -601,45 +601,6 @@ declare class Chart extends ThemableMixin(ElementMixin(HTMLElement)) {
    */
   updateConfiguration(jsonConfiguration: Options, resetConfiguration?: boolean): void;
 
-  /**
-   * Update the chart configuration.
-   * This JSON API provides a simple single-argument alternative to the configuration property.
-   *
-   * Styling properties specified in this configuration will be ignored. To learn about chart styling
-   * please see the CSS Styling section above.
-   *
-   * @param {!Options} jsonConfiguration Object chart configuration. Most important properties are:
-   *
-   * - chart `Object` with options regarding the chart area and plot area as well as general chart options.
-   *    Detailed API for chart object is available in [API Site](http://api.highcharts.com/highcharts/chart)
-   * - credits `Object` with options regarding the chart area and plot area as well as general chart options.
-   *    Detailed API for credits object is available in [API Site](http://api.highcharts.com/highcharts/credits)
-   * - labels `Object[]` with HTML labels that can be positioned anywhere in the chart area
-   *    Detailed API for labels object is available in [API Site](http://api.highcharts.com/highcharts/labels)
-   * - plotOptions `Object` wrapper for config objects for each series type.
-   *    Detailed API for plotOptions object is available in [API Site](http://api.highcharts.com/highcharts/plotOptions)
-   * - series `Object[]` the actual series to append to the chart.
-   *    Detailed API for series object is available in [API Site](http://api.highcharts.com/highcharts/series)
-   * - subtitle `Object` the chart's subtitle.
-   *    Detailed API for subtitle object is available in [API Site](http://api.highcharts.com/highcharts/subtitle)
-   * - title `Object` the chart's main title.
-   *    Detailed API for title object is available in [API Site](http://api.highcharts.com/highcharts/title)
-   * - tooltip `Object` Options for the tooltip that appears when the user hovers over a series or point.
-   *    Detailed API for tooltip object is available in [API Site](http://api.highcharts.com/highcharts/tooltip)
-   * - xAxis `Object[]` The X axis or category axis. Normally this is the horizontal axis.
-   *    Detailed API for xAxis object is available in [API Site](http://api.highcharts.com/highcharts/xAxis)
-   * - yAxis `Object[]` The Y axis or value axis. Normally this is the vertical axis.
-   *    Detailed API for yAxis object is available in [API Site](http://api.highcharts.com/highcharts/yAxis)
-   * - zAxis `Object[]` The Z axis or depth axis for 3D plots.
-   *    Detailed API for zAxis object is available in [API Site](http://api.highcharts.com/highcharts/zAxis)
-   *
-   * @param {boolean=} resetConfiguration Optional boolean that should be set to true if no other chart configuration was set before or
-   *    if existing configuration should be discarded.
-   *
-   * @deprecated Since Vaadin 21, `update()` is deprecated. Please use `updateConfiguration()` instead.
-   */
-  update(jsonConfiguration: Options, resetConfiguration?: boolean): void;
-
   addEventListener<K extends keyof ChartEventMap>(
     type: K,
     listener: (this: Chart, ev: ChartEventMap[K]) => void,

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1173,49 +1173,6 @@ class Chart extends ElementMixin(ThemableMixin(PolymerElement)) {
     });
   }
 
-  /**
-   * Update the chart configuration.
-   * This JSON API provides a simple single-argument alternative to the configuration property.
-   *
-   * Styling properties specified in this configuration will be ignored. To learn about chart styling
-   * please see the CSS Styling section above.
-   *
-   * @param {!Options} jsonConfiguration Object chart configuration. Most important properties are:
-   *
-   * - chart `Object` with options regarding the chart area and plot area as well as general chart options.
-   *    Detailed API for chart object is available in [API Site](http://api.highcharts.com/highcharts/chart)
-   * - credits `Object` with options regarding the chart area and plot area as well as general chart options.
-   *    Detailed API for credits object is available in [API Site](http://api.highcharts.com/highcharts/credits)
-   * - labels `Object[]` with HTML labels that can be positioned anywhere in the chart area
-   *    Detailed API for labels object is available in [API Site](http://api.highcharts.com/highcharts/labels)
-   * - plotOptions `Object` wrapper for config objects for each series type.
-   *    Detailed API for plotOptions object is available in [API Site](http://api.highcharts.com/highcharts/plotOptions)
-   * - series `Object[]` the actual series to append to the chart.
-   *    Detailed API for series object is available in [API Site](http://api.highcharts.com/highcharts/series)
-   * - subtitle `Object` the chart's subtitle.
-   *    Detailed API for subtitle object is available in [API Site](http://api.highcharts.com/highcharts/subtitle)
-   * - title `Object` the chart's main title.
-   *    Detailed API for title object is available in [API Site](http://api.highcharts.com/highcharts/title)
-   * - tooltip `Object` Options for the tooltip that appears when the user hovers over a series or point.
-   *    Detailed API for tooltip object is available in [API Site](http://api.highcharts.com/highcharts/tooltip)
-   * - xAxis `Object[]` The X axis or category axis. Normally this is the horizontal axis.
-   *    Detailed API for xAxis object is available in [API Site](http://api.highcharts.com/highcharts/xAxis)
-   * - yAxis `Object[]` The Y axis or value axis. Normally this is the vertical axis.
-   *    Detailed API for yAxis object is available in [API Site](http://api.highcharts.com/highcharts/yAxis)
-   * - zAxis `Object[]` The Z axis or depth axis for 3D plots.
-   *    Detailed API for zAxis object is available in [API Site](http://api.highcharts.com/highcharts/zAxis)
-   *
-   * @param {boolean=} resetConfiguration Optional boolean that should be set to true if no other chart configuration was set before or
-   *    if existing configuration should be discarded.
-   *
-   * @deprecated Since Vaadin 21, `update()` is deprecated. Please use `updateConfiguration()` instead.
-   */
-  update(jsonConfiguration, resetConfiguration) {
-    console.warn('WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.');
-
-    this.updateConfiguration(jsonConfiguration, resetConfiguration);
-  }
-
   /** @private */
   __makeConfigurationBuffer(target, source) {
     const _source = Highcharts.merge(source);

--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -174,27 +174,6 @@ describe('vaadin-chart', () => {
       expect(title).to.be.ok;
       expect(title.textContent).to.be.empty;
     });
-
-    it('should call updateConfiguration() when calling deprecated update()', () => {
-      const stub = sinon.stub(chart, 'updateConfiguration');
-      chart.update({}, true);
-      stub.restore();
-
-      expect(stub.calledOnce).to.be.true;
-      expect(stub.args[0][0]).to.be.an('object');
-      expect(stub.args[0][1]).to.be.true;
-    });
-
-    it('should warn when calling deprecated update()', () => {
-      const stub = sinon.stub(console, 'warn');
-      chart.update({}, true);
-      stub.restore();
-
-      expect(stub.calledOnce).to.be.true;
-      expect(stub.args[0][0]).to.equal(
-        'WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.'
-      );
-    });
   });
 
   describe('series', () => {

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -10,7 +10,6 @@ const { visualRegressionPlugin } = require('@web/test-runner-visual-regression/p
 const HIDDEN_WARNINGS = [
   '<vaadin-crud> Unable to autoconfigure form because the data structure is unknown. Either specify `include` or ensure at least one item is available beforehand.',
   'The <vaadin-grid> needs the total number of items in order to display rows. Set the total number of items to the `size` property, or provide the total number of items in the second argument of the `dataProvider`’s `callback` call.',
-  'WARNING: Since Vaadin 21, update() is deprecated. Please use updateConfiguration() instead.',
   /^WARNING: Since Vaadin 22, .* is deprecated.*/,
   /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/
 ];


### PR DESCRIPTION
## Description

The PR drops support for the `update()` method that has been deprecated since Vaadin 21.

Fixes #2779

## Type of change

- [x] Breaking-change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
