### PR TITLE
fix: add label id to aria-labelledby attribute

### DIFF
--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -161,6 +161,15 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(DirMixin(Themabl
   }
 
   /**
+   * @return {string}
+   * @override
+   * @protected
+   */
+  get _ariaAttr() {
+    return 'aria-labelledby';
+  }
+
+  /**
    * Override method inherited from `ValidateMixin`
    * to validate the value array.
    *

--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -427,6 +427,32 @@ describe('vaadin-checkbox-group', () => {
     });
   });
 
+  describe('aria-labelledby', () => {
+    let error, helper, label;
+
+    beforeEach(() => {
+      group = fixtureSync('<vaadin-checkbox-group helper-text="Choose one"></vaadin-checkbox-group>');
+      error = group.querySelector('[slot=error-message]');
+      helper = group.querySelector('[slot=helper]');
+      label = group.querySelector('[slot=label]');
+    });
+
+    it('should add label and helper text to aria-labelledby when field is valid', () => {
+      const aria = group.getAttribute('aria-labelledby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.not.include(error.id);
+      expect(aria).to.include(label.id);
+    });
+
+    it('should add error message to aria-labelledby when field is invalid', () => {
+      group.invalid = true;
+      const aria = group.getAttribute('aria-labelledby');
+      expect(aria).to.include(helper.id);
+      expect(aria).to.include(error.id);
+      expect(aria).to.include(label.id);
+    });
+  });
+
   describe('validation', () => {
     beforeEach(async () => {
       group = fixtureSync(`


### PR DESCRIPTION
## Description

The PR overrides the `_ariaAttr` getter for the checkbox-group the same way it is done for the radio-group to fix the label's announcement. 

Fixes #2828

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
