### PR TITLE
fix: set correct color for required-indicator

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -44,7 +44,7 @@ const requiredField = css`
     content: var(--lumo-required-field-indicator, '•');
     transition: opacity 0.2s;
     opacity: 0;
-    color: var(--lumo-required-field-indicator-color, --lumo-primary-text-color);
+    color: var(--lumo-required-field-indicator-color, var(--lumo-primary-text-color));
     position: absolute;
     right: 0;
     width: 1em;
@@ -56,7 +56,7 @@ const requiredField = css`
   }
 
   :host([invalid]) [part='required-indicator']::after {
-    color: var(--lumo-required-field-indicator-color, --lumo-error-text-color);
+    color: var(--lumo-required-field-indicator-color, var(--lumo-error-text-color));
   }
 
   [part='error-message'] {


### PR DESCRIPTION
## Description

The PR fixes the required-indicator's color that was accidentally broken because of using an incorrect notation when defining CSS variables in #2810.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
