### PR TITLE
feat: add autocomplete attribute to login form

### DIFF
--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -91,6 +91,7 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
             required
             on-keydown="_handleInputKeydown"
             spellcheck="false"
+            autocomplete="current-password"
           >
             <input type="password" slot="input" on-keyup="_handleInputKeyup" />
           </vaadin-password-field>

--- a/packages/login/test/login-form.test.js
+++ b/packages/login/test/login-form.test.js
@@ -257,6 +257,11 @@ describe('login form', () => {
     const usernameElement = login.$.vaadinLoginUsername;
     expect(document.activeElement).to.equal(usernameElement.inputElement);
   });
+
+  it('should have autocomplete attribute set', () => {
+    const passwordField = login.$.vaadinLoginPassword;
+    expect(passwordField.getAttribute('autocomplete')).to.be.equal('current-password');
+  });
 });
 
 describe('no forgot password', () => {


### PR DESCRIPTION
## Description
By utilising `autocomplete=current-password`, we are helping browsers to fill user's saved password for the current site. This PR simply adds the mentioned attribute to password field in `vaadin-login-form`

Fixes #2126 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
