### PR TITLE
fix: workaround to fix date picker overlay positioning

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -72,8 +72,6 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
         id="overlay"
         fullscreen$="[[_fullscreen]]"
         opened="{{opened}}"
-        position-target="[[inputElement]]"
-        no-vertical-overlap
         on-vaadin-overlay-open="_onOverlayOpened"
         on-vaadin-overlay-close="_onOverlayClosed"
         theme$="[[__getOverlayTheme(theme, _overlayInitialized)]]"
@@ -148,6 +146,15 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
   /** @return {string | undefined} */
   get _inputValue() {
     return this.inputElement && this.inputElement[dashToCamelCase(this.attrForValue)];
+  }
+
+  // Workaround https://github.com/vaadin/web-components/issues/2855
+  /** @protected */
+  _openedChanged(opened) {
+    super._openedChanged(opened);
+
+    this.$.overlay.positionTarget = this.inputElement;
+    this.$.overlay.noVerticalOverlap = true;
   }
 }
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -581,7 +581,7 @@ export const DatePickerMixin = (subclass) =>
       }
     }
 
-    /** @private */
+    /** @protected */
     _openedChanged(opened) {
       if (opened && !this._overlayInitialized) {
         this._initOverlay();

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -156,7 +156,6 @@ class DatePicker extends DatePickerMixin(
         id="overlay"
         fullscreen$="[[_fullscreen]]"
         theme$="[[__getOverlayTheme(theme, _overlayInitialized)]]"
-        no-vertical-overlap
         on-vaadin-overlay-open="_onOverlayOpened"
         on-vaadin-overlay-close="_onOverlayClosed"
         disable-upgrade
@@ -207,7 +206,6 @@ class DatePicker extends DatePickerMixin(
       })
     );
     this.addController(new AriaLabelController(this, this.inputElement, this._labelNode));
-    this.$.overlay.positionTarget = this.shadowRoot.querySelector('[part="input-field"]');
   }
 
   /** @private */
@@ -226,6 +224,15 @@ class DatePicker extends DatePickerMixin(
   _toggle(e) {
     e.stopPropagation();
     this[this._overlayInitialized && this.$.overlay.opened ? 'close' : 'open']();
+  }
+
+  // Workaround https://github.com/vaadin/web-components/issues/2855
+  /** @protected */
+  _openedChanged(opened) {
+    super._openedChanged(opened);
+
+    this.$.overlay.positionTarget = this.shadowRoot.querySelector('[part="input-field"]');
+    this.$.overlay.noVerticalOverlap = true;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/2855

The issue is caused by a bug in the Polymer version used in the Vaadin platform (`@polymer/polymer@3.2.0`). With version `3.4.1`, the issue doesn't manifest. This PR is a workaround for the issue.