### PR TITLE
fix: hide the native reveal password icon on edge

### DIFF
--- a/packages/vaadin-text-field/src/vaadin-password-field.js
+++ b/packages/vaadin-text-field/src/vaadin-password-field.js
@@ -22,6 +22,10 @@ const $_documentContainer = html` <style>
         [part='reveal-button'][hidden] {
           display: none !important;
         }
+
+        input::-ms-reveal {
+          display: none;
+        }
       </style>
 
       <div


### PR DESCRIPTION
Part of #799