### PR TITLE
chore: remove private and protected API from ts definitions

### DIFF
--- a/packages/board/src/vaadin-board.d.ts
+++ b/packages/board/src/vaadin-board.d.ts
@@ -25,8 +25,6 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
  * ```
  */
 declare class Board extends ElementMixin(HTMLElement) {
-  static _finalizeClass(): void;
-
   /**
    * Redraws the board and all rows inside it, if necessary.
    *

--- a/packages/charts/src/vaadin-chart-series.d.ts
+++ b/packages/charts/src/vaadin-chart-series.d.ts
@@ -160,8 +160,6 @@ declare class ChartSeries extends HTMLElement {
    */
   additionalOptions: SeriesOptionsType | null | undefined;
 
-  _series: Series | undefined;
-
   /**
    * Method to attach a series object of type `Highcharts.Series`.
    *

--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -542,29 +542,6 @@ declare class Chart extends ThemableMixin(ElementMixin(HTMLElement)) {
   polar: boolean | null | undefined;
 
   /**
-   * Search for axis with given `id`.
-   *
-   * @param id contains the id that will be searched
-   * @param isXAxis indicates if it will remove x or y axes. Defaults to `false`.
-   */
-  __getAxis(id: string, isXAxis: boolean): Axis | null;
-
-  /**
-   * Add an axis with given options
-   *
-   * @param options axis options
-   * @param isXAxis indicates if axis is X (`true`) or Y (`false`). Defaults to `false`.
-   */
-  __addAxis(options: object | null, isXAxis: boolean): Axis;
-
-  /**
-   * Iterates over axes (y or x) and removes whenever it doesn't contain any series and was created for unit
-   *
-   * @param isXAxis indicates if it will remove x or y axes. Defaults to `false`.
-   */
-  __removeAxisIfEmpty(isXAxis: boolean): void;
-
-  /**
    * Update the chart configuration.
    * This JSON API provides a simple single-argument alternative to the configuration property.
    *

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -30,8 +30,6 @@ interface ComboBoxMixinConstructor<TItem> {
 }
 
 interface ComboBoxMixin<TItem> extends DisabledMixin, InputMixin, KeyboardMixin {
-  readonly _propertyForValue: string;
-
   /**
    * True if the dropdown is open, false otherwise.
    */

--- a/packages/component-base/src/dir-mixin.d.ts
+++ b/packages/component-base/src/dir-mixin.d.ts
@@ -15,10 +15,6 @@ interface DirMixinConstructor {
   finalize(): void;
 }
 
-interface DirMixin {
-  __getNormalizedScrollLeft(element: Element | null): number;
-
-  __setNormalizedScrollLeft(element: Element | null, scrollLeft: number): void;
-}
+interface DirMixin {}
 
 export { DirMixin, DirMixinConstructor };

--- a/packages/component-base/src/disabled-mixin.d.ts
+++ b/packages/component-base/src/disabled-mixin.d.ts
@@ -7,17 +7,17 @@
 /**
  * A mixin to provide disabled property for field components.
  */
-declare function DisabledMixin<T extends new (...args: any[]) => {}>(base: T): T & DisabledMixinConstructor;
+declare const DisabledMixin: <T>(superClass: T) => Constructor<DisabledMixinInterface> & T;
 
-interface DisabledMixinConstructor {
-  new (...args: any[]): DisabledMixin;
-}
+declare type Constructor<T> = new (...args: any[]) => T;
 
-interface DisabledMixin {
+declare class DisabledMixinClass {
   /**
    * If true, the user cannot interact with this element.
    */
   disabled: boolean;
 }
 
-export { DisabledMixinConstructor, DisabledMixin };
+type DisabledMixinInterface = DisabledMixinClass;
+
+export { DisabledMixin, DisabledMixinInterface };

--- a/packages/component-base/src/disabled-mixin.d.ts
+++ b/packages/component-base/src/disabled-mixin.d.ts
@@ -11,13 +11,11 @@ declare const DisabledMixin: <T>(superClass: T) => Constructor<DisabledMixinInte
 
 declare type Constructor<T> = new (...args: any[]) => T;
 
-declare class DisabledMixinClass {
+declare class DisabledMixinInterface {
   /**
    * If true, the user cannot interact with this element.
    */
   disabled: boolean;
 }
 
-type DisabledMixinInterface = DisabledMixinClass;
-
-export { DisabledMixin, DisabledMixinInterface };
+export { DisabledMixin };

--- a/packages/component-base/src/focus-mixin.d.ts
+++ b/packages/component-base/src/focus-mixin.d.ts
@@ -7,12 +7,25 @@
 /**
  * A mixin to handle `focused` and `focus-ring` attributes based on focus.
  */
-declare function FocusMixin<T extends new (...args: any[]) => {}>(base: T): T & FocusMixinConstructor;
+declare const FocusMixin: <T>(superClass: T) => Constructor<FocusMixinInterface> & T;
 
-interface FocusMixinConstructor {
-  new (...args: any[]): FocusMixin;
+declare type Constructor<T> = new (...args: any[]) => T;
+
+declare class FocusMixinInterface {
+  /**
+   * Override to change how focused and focus-ring attributes are set.
+   */
+  protected _setFocused(focused: boolean): void;
+
+  /**
+   * Override to define if the field receives focus based on the event.
+   */
+  protected _shouldSetFocus(event: FocusEvent): boolean;
+
+  /**
+   * Override to define if the field loses focus based on the event.
+   */
+  protected _shouldRemoveFocus(event: FocusEvent): boolean;
 }
 
-interface FocusMixin {}
-
-export { FocusMixinConstructor, FocusMixin };
+export { FocusMixin };

--- a/packages/component-base/src/focus-mixin.d.ts
+++ b/packages/component-base/src/focus-mixin.d.ts
@@ -11,7 +11,7 @@ declare const FocusMixin: <T>(superClass: T) => Constructor<FocusMixinInterface>
 
 declare type Constructor<T> = new (...args: any[]) => T;
 
-declare class FocusMixinInterface {
+declare class FocusMixinClass {
   /**
    * Override to change how focused and focus-ring attributes are set.
    */
@@ -28,4 +28,6 @@ declare class FocusMixinInterface {
   protected _shouldRemoveFocus(event: FocusEvent): boolean;
 }
 
-export { FocusMixin };
+type FocusMixinInterface = FocusMixinClass;
+
+export { FocusMixin, FocusMixinInterface };

--- a/packages/component-base/src/focus-mixin.d.ts
+++ b/packages/component-base/src/focus-mixin.d.ts
@@ -13,21 +13,6 @@ interface FocusMixinConstructor {
   new (...args: any[]): FocusMixin;
 }
 
-interface FocusMixin {
-  /**
-   * Override to change how focused and focus-ring attributes are set.
-   */
-  _setFocused(focused: boolean): void;
-
-  /**
-   * Override to define if the field receives focus based on the event.
-   */
-  _shouldSetFocus(event: FocusEvent): boolean;
-
-  /**
-   * Override to define if the field loses focus based on the event.
-   */
-  _shouldRemoveFocus(event: FocusEvent): boolean;
-}
+interface FocusMixin {}
 
 export { FocusMixinConstructor, FocusMixin };

--- a/packages/component-base/src/focus-mixin.d.ts
+++ b/packages/component-base/src/focus-mixin.d.ts
@@ -11,7 +11,7 @@ declare const FocusMixin: <T>(superClass: T) => Constructor<FocusMixinInterface>
 
 declare type Constructor<T> = new (...args: any[]) => T;
 
-declare class FocusMixinClass {
+declare class FocusMixinInterface {
   /**
    * Override to change how focused and focus-ring attributes are set.
    */
@@ -28,6 +28,4 @@ declare class FocusMixinClass {
   protected _shouldRemoveFocus(event: FocusEvent): boolean;
 }
 
-type FocusMixinInterface = FocusMixinClass;
-
-export { FocusMixin, FocusMixinInterface };
+export { FocusMixin };

--- a/packages/component-base/src/focus-mixin.js
+++ b/packages/component-base/src/focus-mixin.js
@@ -84,7 +84,7 @@ export const FocusMixin = dedupingMixin(
       /**
        * Override to define if the field receives focus based on the event.
        *
-       * @param {FocusEvent} event
+       * @param {FocusEvent} _event
        * @return {boolean}
        * @protected
        */
@@ -95,7 +95,7 @@ export const FocusMixin = dedupingMixin(
       /**
        * Override to define if the field loses focus based on the event.
        *
-       * @param {FocusEvent} event
+       * @param {FocusEvent} _event
        * @return {boolean}
        * @protected
        */

--- a/packages/component-base/src/keyboard-mixin.d.ts
+++ b/packages/component-base/src/keyboard-mixin.d.ts
@@ -15,18 +15,6 @@ interface KeyboardMixinConstructor {
   new (...args: any[]): KeyboardMixin;
 }
 
-interface KeyboardMixin {
-  /**
-   * A handler for the `keydown` event. By default, it does nothing.
-   * Override the method to implement your own behavior.
-   */
-  _onKeyDown(event: KeyboardEvent): void;
-
-  /**
-   * A handler for the `keyup` event. By default, it does nothing.
-   * Override the method to implement your own behavior.
-   */
-  _onKeyUp(event: KeyboardEvent): void;
-}
+interface KeyboardMixin {}
 
 export { KeyboardMixinConstructor, KeyboardMixin };

--- a/packages/component-base/test/typings/focus-mixin.types.ts
+++ b/packages/component-base/test/typings/focus-mixin.types.ts
@@ -1,0 +1,16 @@
+import { FocusMixin } from '../../src/focus-mixin.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+class Base {
+  foo = 'foo';
+}
+
+class SubClass extends FocusMixin(Base) {
+  protected _setFocused(focused: boolean) {
+    super._setFocused(focused);
+  }
+}
+
+const instance = new SubClass();
+assertType<string>(instance.foo);

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -43,8 +43,6 @@ interface ItemsMixinConstructor {
 }
 
 interface ItemsMixin {
-  readonly __isRTL: boolean;
-
   /**
    * Defines a (hierarchical) menu structure for the component.
    * If a menu item has a non-empty `children` set, a sub-menu with the child items is opened

--- a/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
@@ -70,11 +70,6 @@ declare class CookieConsent extends ElementMixin(HTMLElement) {
    * @attr {string} cookie-name
    */
   cookieName: string;
-
-  /**
-   * Shows the popup even if the user has seen it before.
-   */
-  _show(): void;
 }
 
 declare global {

--- a/packages/crud/src/vaadin-crud-form.d.ts
+++ b/packages/crud/src/vaadin-crud-form.d.ts
@@ -14,13 +14,6 @@ declare class CrudForm<Item> extends IncludedMixin(FormLayout) {
    * The item being edited.
    */
   item: Item | null | undefined;
-
-  /**
-   * Auto-generate form fields based on the JSON structure of the object provided.
-   *
-   * If not called, the method will be executed the first time an item is assigned.
-   */
-  _configure(object: Item): void;
 }
 
 declare global {

--- a/packages/field-base/src/delegate-focus-mixin.d.ts
+++ b/packages/field-base/src/delegate-focus-mixin.d.ts
@@ -15,7 +15,7 @@ interface DelegateFocusMixinConstructor {
   new (...args: any[]): DelegateFocusMixin;
 }
 
-interface DelegateFocusMixin extends DisabledMixin, FocusMixin {
+declare class DelegateFocusMixin extends FocusMixin(DisabledMixin) {
   /**
    * Specify that this control should have input focus when the page loads.
    */

--- a/packages/field-base/src/delegate-focus-mixin.d.ts
+++ b/packages/field-base/src/delegate-focus-mixin.d.ts
@@ -3,19 +3,17 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
-import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
+import { DisabledMixinInterface } from '@vaadin/component-base/src/disabled-mixin.js';
+import { FocusMixinInterface } from '@vaadin/component-base/src/focus-mixin.js';
 
 /**
  * A mixin to forward focus to an element in the light DOM.
  */
-declare function DelegateFocusMixin<T extends new (...args: any[]) => {}>(base: T): T & DelegateFocusMixinConstructor;
+declare const DelegateFocusMixin: <T>(superClass: T) => Constructor<DelegateFocusMixinInterface> & T;
 
-interface DelegateFocusMixinConstructor {
-  new (...args: any[]): DelegateFocusMixin;
-}
+declare type Constructor<T> = new (...args: any[]) => T;
 
-declare class DelegateFocusMixin extends FocusMixin(DisabledMixin) {
+declare class DelegateFocusMixinClass {
   /**
    * Specify that this control should have input focus when the page loads.
    */
@@ -31,4 +29,6 @@ declare class DelegateFocusMixin extends FocusMixin(DisabledMixin) {
   readonly focusElement: Element | null | undefined;
 }
 
-export { DelegateFocusMixinConstructor, DelegateFocusMixin };
+type DelegateFocusMixinInterface = DisabledMixinInterface & FocusMixinInterface & DelegateFocusMixinClass;
+
+export { DelegateFocusMixin, DelegateFocusMixinInterface };

--- a/packages/field-base/src/delegate-focus-mixin.d.ts
+++ b/packages/field-base/src/delegate-focus-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DisabledMixinInterface } from '@vaadin/component-base/src/disabled-mixin.js';
-import { FocusMixinInterface } from '@vaadin/component-base/src/focus-mixin.js';
+import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
+import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 
 /**
  * A mixin to forward focus to an element in the light DOM.
@@ -13,7 +13,7 @@ declare const DelegateFocusMixin: <T>(superClass: T) => Constructor<DelegateFocu
 
 declare type Constructor<T> = new (...args: any[]) => T;
 
-declare class DelegateFocusMixinClass {
+declare class DelegateFocusMixinInterface extends DisabledMixin(FocusMixin({})) {
   /**
    * Specify that this control should have input focus when the page loads.
    */
@@ -29,6 +29,4 @@ declare class DelegateFocusMixinClass {
   readonly focusElement: Element | null | undefined;
 }
 
-type DelegateFocusMixinInterface = DisabledMixinInterface & FocusMixinInterface & DelegateFocusMixinClass;
-
-export { DelegateFocusMixin, DelegateFocusMixinInterface };
+export { DelegateFocusMixin };

--- a/packages/field-base/src/slot-target-mixin.d.ts
+++ b/packages/field-base/src/slot-target-mixin.d.ts
@@ -13,20 +13,6 @@ interface SlotTargetMixinConstructor {
   new (...args: any[]): SlotTargetMixin;
 }
 
-interface SlotTargetMixin {
-  /**
-   * A reference to the source slot from which the content is copied to the target element.
-   *
-   * @protected
-   */
-  _sourceSlot: HTMLSlotElement;
-
-  /**
-   * A reference to the target element to which the content is copied from the source slot.
-   *
-   * @protected
-   */
-  _slotTarget: HTMLElement;
-}
+interface SlotTargetMixin {}
 
 export { SlotTargetMixinConstructor, SlotTargetMixin };

--- a/packages/field-base/test/typings/delegate-focus-mixin.types.ts
+++ b/packages/field-base/test/typings/delegate-focus-mixin.types.ts
@@ -1,0 +1,18 @@
+import { DelegateFocusMixin } from '../../src/delegate-focus-mixin.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+class Base {
+  foo = 'foo';
+}
+
+class SubClass extends DelegateFocusMixin(Base) {
+  protected _setFocused(focused: boolean) {
+    super._setFocused(focused);
+  }
+}
+
+const instance = new SubClass();
+assertType<string>(instance.foo);
+assertType<boolean>(instance.disabled);
+assertType<Element | null | undefined>(instance.focusElement);

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -5,7 +5,7 @@
  * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
-import { GridDefaultItem, GridBodyRenderer, GridItemModel } from '@vaadin/grid/src/vaadin-grid.js';
+import { GridDefaultItem, GridBodyRenderer } from '@vaadin/grid/src/vaadin-grid.js';
 
 export type GridProEditorType = 'text' | 'checkbox' | 'select' | 'custom';
 
@@ -69,16 +69,6 @@ declare class GridProEditColumn<TItem = GridDefaultItem> extends GridColumn<TIte
    * @attr {string} editor-value-path
    */
   editorValuePath: string;
-
-  _getEditorTagName(cell: HTMLElement): string;
-
-  _getEditorComponent(cell: HTMLElement): HTMLElement | null;
-
-  _getEditorValue(editor: HTMLElement): unknown | null;
-
-  _startCellEdit(cell: HTMLElement, model: GridItemModel<TItem>): void;
-
-  _stopCellEdit(cell: HTMLElement, model: GridItemModel<TItem>): void;
 }
 
 declare global {

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
@@ -36,12 +36,6 @@ interface InlineEditingMixin {
    * @attr {boolean} edit-on-click
    */
   editOnClick: boolean | null | undefined;
-
-  _checkImports(): void;
-
-  _stopEdit(shouldCancel?: boolean, shouldRestoreFocus?: boolean): void;
-
-  _switchEditCell(e: KeyboardEvent): void;
 }
 
 export { InlineEditingMixin, InlineEditingMixinConstructor };

--- a/packages/grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro.d.ts
@@ -76,8 +76,6 @@ export interface GridProEventMap<TItem>
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  */
 declare class GridPro<TItem = GridDefaultItem> extends Grid<TItem> {
-  static _finalizeClass(): void;
-
   addEventListener<K extends keyof GridProEventMap<TItem>>(
     type: K,
     listener: (this: GridPro<TItem>, ev: GridProEventMap<TItem>[K]) => void,

--- a/packages/item/src/vaadin-item-mixin.d.ts
+++ b/packages/item/src/vaadin-item-mixin.d.ts
@@ -19,13 +19,6 @@ interface ItemMixin {
   value: string;
 
   /**
-   * Used for mixin detection because `instanceof` does not work with mixins.
-   * e.g. in VaadinListMixin it filters items by using the
-   * `element._hasVaadinItemMixin` condition.
-   */
-  _hasVaadinItemMixin: boolean;
-
-  /**
    * If true, the user cannot interact with this element.
    */
   disabled: boolean;
@@ -34,14 +27,6 @@ interface ItemMixin {
    * If true, the item is in selected state.
    */
   selected: boolean;
-
-  _setFocused(focused: boolean): void;
-
-  _setActive(active: boolean): void;
-
-  _onKeydown(event: KeyboardEvent): void;
-
-  _onKeyup(event: KeyboardEvent): void;
 }
 
 export { ItemMixin, ItemMixinConstructor };

--- a/packages/list-box/src/vaadin-list-box.d.ts
+++ b/packages/list-box/src/vaadin-list-box.d.ts
@@ -61,8 +61,6 @@ export interface ListBoxEventMap extends HTMLElementEventMap, ListBoxCustomEvent
 declare class ListBox extends MultiSelectListMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   focused: Element | null;
 
-  readonly _scrollerElement: HTMLElement;
-
   addEventListener<K extends keyof ListBoxEventMap>(
     type: K,
     listener: (this: ListBox, ev: ListBoxEventMap[K]) => void,

--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -90,8 +90,6 @@ interface LoginMixin {
    *         }
    */
   i18n: LoginI18n;
-
-  _retargetEvent(e: Event): void;
 }
 
 export { LoginMixin, LoginMixinConstructor };

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.d.ts
@@ -10,14 +10,6 @@ interface ButtonsMixinConstructor {
   new (...args: any[]): ButtonsMixin;
 }
 
-interface ButtonsMixin {
-  readonly _buttons: HTMLElement[];
-
-  readonly _container: HTMLElement;
-
-  readonly _overflow: HTMLElement;
-
-  _hasOverflow: boolean;
-}
+interface ButtonsMixin {}
 
 export { ButtonsMixin, ButtonsMixinConstructor };

--- a/packages/tabs/src/vaadin-tab.d.ts
+++ b/packages/tabs/src/vaadin-tab.d.ts
@@ -29,9 +29,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  */
-declare class Tab extends ElementMixin(ThemableMixin(ItemMixin(HTMLElement))) {
-  _onKeyup(event: KeyboardEvent): void;
-}
+declare class Tab extends ElementMixin(ThemableMixin(ItemMixin(HTMLElement))) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/tabs/src/vaadin-tabs.d.ts
+++ b/packages/tabs/src/vaadin-tabs.d.ts
@@ -62,8 +62,6 @@ export interface TabsEventMap extends HTMLElementEventMap, TabsCustomEventMap {}
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  */
 declare class Tabs extends ElementMixin(ListMixin(ThemableMixin(HTMLElement))) {
-  readonly _scrollerElement: HTMLElement;
-
   /**
    * The index of the selected tab.
    */
@@ -73,8 +71,6 @@ declare class Tabs extends ElementMixin(ListMixin(ThemableMixin(HTMLElement))) {
    * Set tabs disposition. Possible values are `horizontal|vertical`
    */
   orientation: TabsOrientation;
-
-  readonly _scrollOffset: number;
 
   addEventListener<K extends keyof TabsEventMap>(
     type: K,

--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -398,20 +398,6 @@ declare class Upload extends ThemableMixin(ElementMixin(HTMLElement)) {
    */
   uploadFiles(files?: UploadFile | UploadFile[]): void;
 
-  /**
-   * Add the file for uploading. Called internally for each file after picking files from dialog or dropping files.
-   *
-   * @param file File being added
-   */
-  _addFile(file: UploadFile): void;
-
-  /**
-   * Remove file from upload list. Called internally if file upload was canceled.
-   *
-   * @param file File to remove
-   */
-  _removeFile(file: UploadFile): void;
-
   addEventListener<K extends keyof UploadEventMap>(
     type: K,
     listener: (this: Upload, ev: UploadEventMap[K]) => void,

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.d.ts
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.d.ts
@@ -16,13 +16,6 @@ interface ListMixinConstructor {
 interface ListMixin {
   readonly focused: Element | null;
 
-  readonly _scrollerElement: HTMLElement;
-
-  /**
-   * Used for mixin detection because `instanceof` does not work with mixins.
-   */
-  _hasVaadinListMixin: boolean;
-
   /**
    * The index of the item selected in the items array.
    * Note: Not updated when used in `multiple` selection mode.

--- a/packages/vaadin-overlay/src/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay.d.ts
@@ -112,11 +112,6 @@ export type OverlayEventMap = HTMLElementEventMap & OverlayElementEventMap;
  */
 declare class OverlayElement extends ThemableMixin(DirMixin(HTMLElement)) {
   /**
-   * returns true if this is the last one in the opened overlays stack
-   */
-  readonly _last: boolean;
-
-  /**
    * When true, the overlay is visible and attached to body.
    */
   opened: boolean | null | undefined;
@@ -184,37 +179,7 @@ declare class OverlayElement extends ThemableMixin(DirMixin(HTMLElement)) {
    */
   restoreFocusOnClose: boolean;
 
-  _setTemplateFromNodes(nodes: Element[]): void;
-
   close(sourceEvent?: Event | null): void;
-
-  _ensureTemplatized(): void;
-
-  _shouldAnimate(): boolean;
-
-  _enqueueAnimation(type: string, callback: Function | null): void;
-
-  _flushAnimation(type: string): void;
-
-  _animatedOpening(): void;
-
-  _attachOverlay(): void;
-
-  _animatedClosing(): void;
-
-  _detachOverlay(): void;
-
-  _addGlobalListeners(): void;
-
-  _enterModalState(): void;
-
-  _removeGlobalListeners(): void;
-
-  _exitModalState(): void;
-
-  _removeOldContent(): void;
-
-  _stampOverlayTemplate(template: HTMLTemplateElement, instanceProps: object | null): void;
 
   /**
    * Requests an update for the content of the overlay.
@@ -223,18 +188,6 @@ declare class OverlayElement extends ThemableMixin(DirMixin(HTMLElement)) {
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
   requestContentUpdate(): void;
-
-  _isFocused(element: Element | null): boolean;
-
-  _focusedIndex(elements: Array<Element | null> | null): number;
-
-  _cycleTab(increment: number, index: number | undefined): void;
-
-  _getFocusableElements(): HTMLElement[];
-
-  _getActiveElement(): Element;
-
-  _deepContains(node: Node): boolean;
 
   /**
    * Brings the overlay as visually the frontmost one


### PR DESCRIPTION
All API defined in interfaces/types end up as public. Remove.

<img width="632" alt="Screenshot 2021-10-18 at 15 37 04" src="https://user-images.githubusercontent.com/1222264/137731840-fee91e06-babb-426c-ac69-159d0207151e.png">

