### PR TITLE
fix: open select overlay on label click

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -123,7 +123,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       </style>
 
       <div class="vaadin-select-container">
-        <div part="label">
+        <div part="label" on-click="_onClick">
           <slot name="label"></slot>
           <span part="required-indicator" aria-hidden="true" on-click="focus"></span>
         </div>
@@ -397,12 +397,13 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
     this.validate();
   }
 
-  /** @private */
-  _onClick(e) {
-    const isHelperClick = Array.from(e.composedPath()).some((node) => {
-      return node.nodeType === Node.ELEMENT_NODE && node.getAttribute('slot') === 'helper';
-    });
-    this.opened = !this.readonly && !isHelperClick;
+  /**
+   * Opens the overlay if the field is not read-only.
+   *
+   * @private
+   */
+  _onClick() {
+    this.opened = !this.readonly;
   }
 
   /**

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -261,6 +261,16 @@ describe('vaadin-select', () => {
         expect(select._overlayElement.opened).to.be.true;
       });
 
+      it('should open overlay on label click', () => {
+        select.querySelector('[slot=label]').click();
+        expect(select._overlayElement.opened).to.be.true;
+      });
+
+      it('should open overlay on required indicator click', () => {
+        select.shadowRoot.querySelector('[part=required-indicator]').click();
+        expect(select._overlayElement.opened).to.be.true;
+      });
+
       it('should open overlay on ArrowUp', () => {
         arrowUp(valueButton);
         expect(select._overlayElement.opened).to.be.true;
@@ -284,6 +294,18 @@ describe('vaadin-select', () => {
       it('should close overlay on Escape', () => {
         select.opened = true;
         escKeyDown(valueButton);
+        expect(select._overlayElement.opened).to.be.false;
+      });
+
+      it('should not open overlay on helper click', () => {
+        select.helperText = 'Helper Text';
+        select.querySelector('[slot=helper]').click();
+        expect(select._overlayElement.opened).to.be.false;
+      });
+
+      it('should not open overlay on error message click', () => {
+        select.errorMessage = 'Error Message';
+        select.querySelector('[slot=error-message]').click();
         expect(select._overlayElement.opened).to.be.false;
       });
 


### PR DESCRIPTION
## Description

The PR fixes the regression where the select component doesn't open the overlay on the label click.

Fixes #2899

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
