### PR TITLE
fix: don't update element for the same index more than once (#2910)

### DIFF
--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -157,11 +157,8 @@ class VirtualListElement extends ElementMixin(ThemableMixin(PolymerElement)) {
     const hasRenderedItems = this.childElementCount > 0;
 
     if ((renderer || hasRenderedItems) && virtualizer) {
-      if (items.length === virtualizer.size) {
-        virtualizer.update();
-      } else {
-        virtualizer.size = items.length;
-      }
+      virtualizer.size = items.length;
+      virtualizer.update();
     }
   }
 

--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -118,19 +118,20 @@ export class IronListAdapter {
   update(startIndex = 0, endIndex = this.size - 1) {
     this.__getVisibleElements().forEach((el) => {
       if (el.__virtualIndex >= startIndex && el.__virtualIndex <= endIndex) {
-        this.__updateElement(el, el.__virtualIndex);
+        this.__updateElement(el, el.__virtualIndex, true);
       }
     });
   }
 
-  __updateElement(el, index) {
+  __updateElement(el, index, forceSameIndexUpdates) {
     // Clean up temporary min height
     if (el.style.minHeight) {
       el.style.minHeight = '';
     }
 
-    if (!this.__preventElementUpdates) {
+    if (!this.__preventElementUpdates && (el.__lastUpdatedIndex !== index || forceSameIndexUpdates)) {
       this.updateElement(el, index);
+      el.__lastUpdatedIndex = index;
     }
 
     if (el.offsetHeight === 0) {


### PR DESCRIPTION
Cherry-pick #2910 to V21