### PR TITLE
chore: sort import statements in visual tests (WIP)

### DIFF
--- a/packages/button/test/visual/lumo/button.test.js
+++ b/packages/button/test/visual/lumo/button.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync, mousedown } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/icon/theme/lumo/vaadin-icon.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import '../../../theme/lumo/vaadin-button.js';

--- a/packages/button/test/visual/material/button.test.js
+++ b/packages/button/test/visual/material/button.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/icon/theme/material/vaadin-icon.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import '../../../theme/material/vaadin-button.js';

--- a/packages/checkbox/test/visual/lumo/checkbox.test.js
+++ b/packages/checkbox/test/visual/lumo/checkbox.test.js
@@ -1,6 +1,6 @@
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../../theme/lumo/vaadin-checkbox.js';
 
 describe('checkbox', () => {

--- a/packages/checkbox/test/visual/material/checkbox.test.js
+++ b/packages/checkbox/test/visual/material/checkbox.test.js
@@ -1,6 +1,6 @@
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../../theme/material/vaadin-checkbox.js';
 
 describe('checkbox', () => {

--- a/packages/combo-box/test/visual/common.js
+++ b/packages/combo-box/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/combo-box/test/visual/lumo/combo-box.test.js
+++ b/packages/combo-box/test/visual/lumo/combo-box.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/lumo/vaadin-combo-box.js';
 import '../../not-animated-styles.js';

--- a/packages/combo-box/test/visual/material/combo-box.test.js
+++ b/packages/combo-box/test/visual/material/combo-box.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/material/vaadin-combo-box.js';
 import '../../not-animated-styles.js';

--- a/packages/context-menu/test/visual/lumo/context-menu.test.js
+++ b/packages/context-menu/test/visual/lumo/context-menu.test.js
@@ -1,7 +1,7 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import { openSubMenus } from '../common.js';
+import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../../../theme/lumo/vaadin-context-menu.js';
 import '../../not-animated-styles.js';
 

--- a/packages/context-menu/test/visual/material/context-menu.test.js
+++ b/packages/context-menu/test/visual/material/context-menu.test.js
@@ -1,7 +1,7 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import { openSubMenus } from '../common.js';
+import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../../../theme/material/vaadin-context-menu.js';
 import '../../not-animated-styles.js';
 

--- a/packages/date-picker/test/visual/common.js
+++ b/packages/date-picker/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/grid-pro/test/visual/lumo/grid-pro.test.js
+++ b/packages/grid-pro/test/visual/lumo/grid-pro.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import { getContainerCell } from '../../helpers.js';
 import { users } from '../users.js';
 import '../../../theme/lumo/vaadin-grid-pro.js';

--- a/packages/grid-pro/test/visual/material/grid-pro.test.js
+++ b/packages/grid-pro/test/visual/material/grid-pro.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import { getContainerCell } from '../../helpers.js';
 import { users } from '../users.js';
 import '../../../theme/material/vaadin-grid-pro.js';

--- a/packages/grid/test/visual/lumo/grid.test.js
+++ b/packages/grid/test/visual/lumo/grid.test.js
@@ -1,9 +1,9 @@
 import { click, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers/dist/index-no-side-effects.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import { flushGrid, nextResize } from '../../helpers.js';
 import { users } from '../users.js';
+import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../../../theme/lumo/vaadin-grid.js';
 import '../../../theme/lumo/vaadin-grid-column-group.js';
 import '../../../theme/lumo/vaadin-grid-sorter.js';

--- a/packages/grid/test/visual/material/grid.test.js
+++ b/packages/grid/test/visual/material/grid.test.js
@@ -1,9 +1,9 @@
 import { click, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers/dist/index-no-side-effects.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import { flushGrid, nextResize } from '../../helpers.js';
 import { users } from '../users.js';
+import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../../../theme/material/vaadin-grid.js';
 import '../../../theme/material/vaadin-grid-column-group.js';
 import '../../../theme/material/vaadin-grid-sorter.js';

--- a/packages/login/test/visual/common.js
+++ b/packages/login/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/number-field/test/visual/common.js
+++ b/packages/number-field/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/radio-group/test/visual/lumo/radio-button.test.js
+++ b/packages/radio-group/test/visual/lumo/radio-button.test.js
@@ -1,6 +1,6 @@
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../../theme/lumo/vaadin-radio-button.js';
 
 describe('radio-button', () => {

--- a/packages/radio-group/test/visual/lumo/radio-group.test.js
+++ b/packages/radio-group/test/visual/lumo/radio-group.test.js
@@ -1,5 +1,5 @@
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/lumo/vaadin-radio-group.js';
 

--- a/packages/radio-group/test/visual/material/radio-button.test.js
+++ b/packages/radio-group/test/visual/material/radio-button.test.js
@@ -1,6 +1,6 @@
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../../theme/material/vaadin-radio-button.js';
 
 describe('radio-button', () => {

--- a/packages/radio-group/test/visual/material/radio-group.test.js
+++ b/packages/radio-group/test/visual/material/radio-group.test.js
@@ -1,5 +1,5 @@
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/material/vaadin-radio-group.js';
 

--- a/packages/select/test/visual/lumo/select.test.js
+++ b/packages/select/test/visual/lumo/select.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/item/theme/lumo/vaadin-item.js';
 import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
 import '../../not-animated-styles.js';

--- a/packages/select/test/visual/material/select.test.js
+++ b/packages/select/test/visual/material/select.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/item/theme/material/vaadin-item.js';
 import '@vaadin/list-box/theme/material/vaadin-list-box.js';
 import '../../not-animated-styles.js';

--- a/packages/text-field/test/visual/common.js
+++ b/packages/text-field/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/text-field/test/visual/lumo/text-field.test.js
+++ b/packages/text-field/test/visual/lumo/text-field.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/lumo/vaadin-text-field.js';
 

--- a/packages/text-field/test/visual/material/text-field.test.js
+++ b/packages/text-field/test/visual/material/text-field.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/material/vaadin-text-field.js';
 

--- a/packages/time-picker/test/visual/common.js
+++ b/packages/time-picker/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/time-picker/test/visual/lumo/time-picker.test.js
+++ b/packages/time-picker/test/visual/lumo/time-picker.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/lumo/vaadin-time-picker.js';
 

--- a/packages/time-picker/test/visual/material/time-picker.test.js
+++ b/packages/time-picker/test/visual/material/time-picker.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/material/vaadin-time-picker.js';
 


### PR DESCRIPTION
## Description

The PR is the result of running the `eslint-plugin-simple-import-sort` ESLint plugin for the files matching the `packages/**/visual` glob.

The following configuration is used:
```js
"simple-import-sort/imports": ["error", {
  "groups": [
    [
      "^@esm-bundle",
      "^sinon",
      "^@vaadin/testing-helpers",
      "^@web",
      "^@polymer",
      "^lit",
      "^@vaadin\/component-base",
      "^@vaadin\/field-base",
      "^@vaadin\/vaadin-themable-mixin",
      "^@vaadin",
      "^highcharts",
      // Parent imports.
      "^\\.\\.",
      // Sibling imports.
      "^\\.",
      // Side effect imports.
      "^\\u0000"
    ]
  ]
}]
```

Note, the plugin itself will be added to the ESLint configuration in a separate PR after all the statements across the project are in the correct order, to avoid build failures reporting some files not being in order yet.

Part of #2537

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
