### PR TITLE
fix: don't mention no longer existing CSS parts in JSDoc

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -41,9 +41,7 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEve
  *
  * Part name   | Description
  * ------------|----------------
- * `container` | The container element
  * `checkbox`  | The wrapper element that contains slotted `<input type="checkbox">`
- * `label`     | The wrapper element that contains slotted `<label>`
  *
  * The following state attributes are available for styling:
  *

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -26,9 +26,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * Part name   | Description
  * ------------|----------------
- * `container` | The container element.
  * `checkbox`  | The wrapper element that contains slotted <input type="checkbox">.
- * `label`     | The wrapper element that contains slotted <label>.
  *
  * The following state attributes are available for styling:
  *


### PR DESCRIPTION
## Description

The PR removes any mentions of no longer existing CSS parts from the JSDoc of the checkbox component. Removing these mentions has been missed when removing the CSS parts themself in #2754, #2739.

Note, the same will be done for the radio-button component in a separate PR.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
