### PR TITLE
fix: don't mention no longer existing CSS parts in JSDoc

### DIFF
--- a/packages/radio-group/src/vaadin-radio-button.d.ts
+++ b/packages/radio-group/src/vaadin-radio-button.d.ts
@@ -39,9 +39,7 @@ export interface RadioButtonEventMap extends HTMLElementEventMap, RadioButtonCus
  *
  * Part name   | Description
  * ------------|----------------
- * `container` | The container element.
  * `radio`     | The wrapper element which contains slotted `<input type="radio">`.
- * `label`     | The wrapper element which contains slotted `<label>`.
  *
  * The following state attributes are available for styling:
  *

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -31,9 +31,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * Part name   | Description
  * ------------|----------------
- * `container` | The container element.
  * `radio`     | The wrapper element that contains slotted `<input type="radio">`.
- * `label`     | The wrapper element that contains slotted `<label>`.
  *
  * The following state attributes are available for styling:
  *


### PR DESCRIPTION
## Description

The PR removes any mentions of no longer existing CSS parts from the JSDoc of the radio-button component. Removing these mentions has been missed when removing the CSS parts themself in #2754, #2773.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
