### PR TITLE
fix: add a better workaround for iron-list scrollToIndex issue

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -97,9 +97,10 @@ export class IronListAdapter {
 
     this.__skipNextVirtualIndexAdjust = true;
     super.scrollToIndex(targetVirtualIndex);
-    if (this.firstVisibleIndex !== index - this._vidxOffset && this._scrollTop < this._maxScrollTop && !this.grid) {
-      // Second invocation to scrollToIndex may be needed to workaround an issue in iron-list
-      super.scrollToIndex(targetVirtualIndex);
+
+    if (this.adjustedFirstVisibleIndex !== index && this._scrollTop < this._maxScrollTop && !this.grid) {
+      // Workaround an iron-list issue by manually adjusting the scroll position
+      this._scrollTop -= this.__getIndexScrollOffset(index) || 0;
     }
     this._scrollHandler();
   }
@@ -162,7 +163,7 @@ export class IronListAdapter {
     let fvi; // first visible index
     let fviOffsetBefore; // scroll offset of the first visible index
     if (size > 0) {
-      fvi = this.firstVisibleIndex + this._vidxOffset;
+      fvi = this.adjustedFirstVisibleIndex;
       fviOffsetBefore = this.__getIndexScrollOffset(fvi);
     }
 

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -162,6 +162,14 @@ describe('virtualizer', () => {
     expect(item.getBoundingClientRect().top).to.equal(scrollTarget.getBoundingClientRect().top);
   });
 
+  it('should scroll to an arbitrary index 2', async () => {
+    // Wait for a possible resize observer flush
+    await aTimeout(100);
+    virtualizer.scrollToIndex(6);
+    const item = elementsContainer.querySelector(`#item-6`);
+    expect(item.getBoundingClientRect().top).to.equal(scrollTarget.getBoundingClientRect().top);
+  });
+
   it('should restore scroll position on size change', async () => {
     // Scroll to item 50 and an additional 10 pixels
     virtualizer.scrollToIndex(50);


### PR DESCRIPTION
[A change in a previous PR](https://github.com/vaadin/web-components/pull/2916/files#diff-5f471994c5bb4ba62dbd8dd477ecd39a5a9d6b7c771c7ddb7f42dc9ec140422aR21) affected how the iron-list issue mentioned [here](https://github.com/vaadin/web-components/blob/3eaa3aa37c6e861bef3a49faadf72076e9a617e4/packages/component-base/src/virtualizer-iron-list-adapter.js#L101) manifests. Needed to improve the workaround to mitigate the issue with the changed setup. The regression was caught by a GridPro Flow-component integration test.