### PR TITLE
fix: add aria-required attribute when checkbox-group is required

### DIFF
--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -131,7 +131,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(DirMixin(Themabl
   }
 
   static get observers() {
-    return ['__valueChanged(value, value.splices)'];
+    return ['__valueChanged(value, value.splices)', '__requiredChanged(required)'];
   }
 
   constructor() {
@@ -311,6 +311,11 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(DirMixin(Themabl
   }
 
   /**
+   * A callback method for the `value` property observer.
+   * Whenever the observed property changes, the method toggles the `has-value` attribute,
+   * makes checked only those checkboxes which are included in the new value,
+   * and then runs the validation.
+   *
    * @param {string | null | undefined} value
    * @private
    */
@@ -329,6 +334,21 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(DirMixin(Themabl
     });
 
     this.validate();
+  }
+
+  /**
+   * A callback method for the `required` property observer.
+   * Whenever the observed property changes, the method toggles the `aria-required` attribute.
+   *
+   * @param {boolean} required
+   * @private
+   */
+  __requiredChanged(required) {
+    if (required) {
+      this.setAttribute('aria-required', 'true');
+    } else {
+      this.removeAttribute('aria-required');
+    }
   }
 
   /**

--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -93,6 +93,24 @@ describe('vaadin-checkbox-group', () => {
     });
   });
 
+  describe('aria-required attribute', () => {
+    beforeEach(async () => {
+      group = fixtureSync(`<vaadin-checkbox-group></vaadin-checkbox-group>`);
+      await nextFrame();
+    });
+
+    it('should not set aria-required attribute by default', () => {
+      expect(group.hasAttribute('aria-required')).to.be.false;
+    });
+
+    it('should toggle aria-required attribute on required property change', () => {
+      group.required = true;
+      expect(group.getAttribute('aria-required')).to.equal('true');
+      group.required = false;
+      expect(group.hasAttribute('aria-required')).to.false;
+    });
+  });
+
   describe('value', () => {
     beforeEach(async () => {
       group = fixtureSync(`


### PR DESCRIPTION
## Description

The PR fixes the bug where the checkbox-group isn't announced by screen readers as required when the `required` attribute is present. The bug is fixed by adding the additional `[aria-required=true]` attribute to the checkbox-group element when the  `required` attribute is present.

Part of #2938

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
