### PR TITLE
docs: prefer label attribute for checkbox and radio-button

### DIFF
--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -32,9 +32,9 @@ export interface CheckboxGroupEventMap extends HTMLElementEventMap, CheckboxGrou
  *
  * ```html
  * <vaadin-checkbox-group label="Preferred language of contact:">
- *  <vaadin-checkbox value="en">English</vaadin-checkbox>
- *  <vaadin-checkbox value="fr">Français</vaadin-checkbox>
- *  <vaadin-checkbox value="de">Deutsch</vaadin-checkbox>
+ *   <vaadin-checkbox value="en" label="English"></vaadin-checkbox>
+ *   <vaadin-checkbox value="fr" label="Français"></vaadin-checkbox>
+ *   <vaadin-checkbox value="de" label="Deutsch"></vaadin-checkbox>
  * </vaadin-checkbox-group>
  * ```
  *

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -17,9 +17,9 @@ import { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
  *
  * ```html
  * <vaadin-checkbox-group label="Preferred language of contact:">
- *  <vaadin-checkbox value="en">English</vaadin-checkbox>
- *  <vaadin-checkbox value="fr">Français</vaadin-checkbox>
- *  <vaadin-checkbox value="de">Deutsch</vaadin-checkbox>
+ *   <vaadin-checkbox value="en" label="English"></vaadin-checkbox>
+ *   <vaadin-checkbox value="fr" label="Français"></vaadin-checkbox>
+ *   <vaadin-checkbox value="de" label="Deutsch"></vaadin-checkbox>
  * </vaadin-checkbox-group>
  * ```
  *

--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -32,7 +32,7 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEve
  * `<vaadin-checkbox>` is an input field representing a binary choice.
  *
  * ```html
- * <vaadin-checkbox>I accept the terms and conditions</vaadin-checkbox>
+ * <vaadin-checkbox label="I accept the terms and conditions"></vaadin-checkbox>
  * ```
  *
  * ### Styling

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -17,7 +17,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `<vaadin-checkbox>` is an input field representing a binary choice.
  *
  * ```html
- * <vaadin-checkbox>I accept the terms and conditions</vaadin-checkbox>
+ * <vaadin-checkbox label="I accept the terms and conditions"></vaadin-checkbox>
  * ```
  *
  * ### Styling

--- a/packages/radio-group/src/vaadin-radio-button.d.ts
+++ b/packages/radio-group/src/vaadin-radio-button.d.ts
@@ -27,9 +27,9 @@ export interface RadioButtonEventMap extends HTMLElementEventMap, RadioButtonCus
  *
  * ```html
  * <vaadin-radio-group label="Travel class">
- *  <vaadin-radio-button value="economy">Economy</vaadin-radio-button>
- *  <vaadin-radio-button value="business">Business</vaadin-radio-button>
- *  <vaadin-radio-button value="firstClass">First Class</vaadin-radio-button>
+ *   <vaadin-radio-button value="economy" label="Economy"></vaadin-radio-button>
+ *   <vaadin-radio-button value="business" label="Business"></vaadin-radio-button>
+ *   <vaadin-radio-button value="firstClass" label="First Class"></vaadin-radio-button>
  * </vaadin-radio-group>
  * ```
  *

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -19,9 +19,9 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * ```html
  * <vaadin-radio-group label="Travel class">
- *  <vaadin-radio-button value="economy">Economy</vaadin-radio-button>
- *  <vaadin-radio-button value="business">Business</vaadin-radio-button>
- *  <vaadin-radio-button value="firstClass">First Class</vaadin-radio-button>
+ *   <vaadin-radio-button value="economy" label="Economy"></vaadin-radio-button>
+ *   <vaadin-radio-button value="business" label="Business"></vaadin-radio-button>
+ *   <vaadin-radio-button value="firstClass" label="First Class"></vaadin-radio-button>
  * </vaadin-radio-group>
  * ```
  *

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -33,9 +33,9 @@ export interface RadioGroupEventMap extends HTMLElementEventMap, RadioGroupCusto
  *
  * ```html
  * <vaadin-radio-group label="Travel class">
- *   <vaadin-radio-button value="economy">Economy</vaadin-radio-button>
- *   <vaadin-radio-button value="business">Business</vaadin-radio-button>
- *   <vaadin-radio-button value="firstClass">First Class</vaadin-radio-button>
+ *   <vaadin-radio-button value="economy" label="Economy"></vaadin-radio-button>
+ *   <vaadin-radio-button value="business" label="Business"></vaadin-radio-button>
+ *   <vaadin-radio-button value="firstClass" label="First Class"></vaadin-radio-button>
  * </vaadin-radio-group>
  * ```
  *

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -18,9 +18,9 @@ import { RadioButton } from './vaadin-radio-button.js';
  *
  * ```html
  * <vaadin-radio-group label="Travel class">
- *   <vaadin-radio-button value="economy">Economy</vaadin-radio-button>
- *   <vaadin-radio-button value="business">Business</vaadin-radio-button>
- *   <vaadin-radio-button value="firstClass">First Class</vaadin-radio-button>
+ *   <vaadin-radio-button value="economy" label="Economy"></vaadin-radio-button>
+ *   <vaadin-radio-button value="business" label="Business"></vaadin-radio-button>
+ *   <vaadin-radio-button value="firstClass" label="First Class"></vaadin-radio-button>
  * </vaadin-radio-group>
  * ```
  *


### PR DESCRIPTION
Prefer `label` over the default slot in `<vaadin-checkbox>` and `<vaadin-radio-button>` JSDocs.