### PR TITLE
chore: update GitHub Actions to use Node 16

### DIFF
--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Setup Node 14.x
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Setup Node 14.x
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Setup Node 14.x
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Node 14.x
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/lumo.yml
+++ b/.github/workflows/lumo.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Setup Node 14.x
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/material.yml
+++ b/.github/workflows/material.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Setup Node 14.x
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Setup Node 14.x
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Setup Node 14.x
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/.github/workflows/webkit.yml
+++ b/.github/workflows/webkit.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Setup Node 14.x
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'yarn'
 
       - name: Install Dependencies


### PR DESCRIPTION
## Description

Node.js 16.13.0 is now LTS: https://nodejs.org/en/blog/release/v16.13.0/

## Type of change

- Internal change