### PR TITLE
fix!: use correct variable name for button styles

### DIFF
--- a/packages/button/theme/lumo/vaadin-button-styles.js
+++ b/packages/button/theme/lumo/vaadin-button-styles.js
@@ -18,8 +18,8 @@ const button = css`
     font-family: var(--lumo-font-family);
     font-size: var(--lumo-font-size-m);
     font-weight: 500;
-    color: var(--_lumo-button-color, var(--lumo-primary-text-color));
-    background-color: var(--_lumo-button-background-color, var(--lumo-contrast-5pct));
+    color: var(--lumo-button-color, var(--lumo-primary-text-color));
+    background-color: var(--lumo-button-background-color, var(--lumo-contrast-5pct));
     border-radius: var(--lumo-border-radius-m);
     cursor: var(--lumo-clickable-cursor);
     -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
## Description

The variables for the custom styling for buttons aren't aligned with all other properties. 
This PR fixes this by removing the "_" after "--". 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
