### PR TITLE
test: remove self-closing tags from tests

### DIFF
--- a/packages/polymer-legacy-adapter/test/fixtures/mock-grid-host.js
+++ b/packages/polymer-legacy-adapter/test/fixtures/mock-grid-host.js
@@ -13,9 +13,9 @@ export class MockGridHost extends PolymerElement {
           <template>
             <input class="parent-property" value="{{parentProperty::input}}" />
             <input class="title" value="{{item.title::input}}" />
-            <vaadin-checkbox class="selected" checked="{{selected}}" />
-            <vaadin-checkbox class="expanded" checked="{{expanded}}" />
-            <vaadin-checkbox class="details-opened" checked="{{detailsOpened}}" />
+            <vaadin-checkbox class="selected" checked="{{selected}}"></vaadin-checkbox>
+            <vaadin-checkbox class="expanded" checked="{{expanded}}"></vaadin-checkbox>
+            <vaadin-checkbox class="details-opened" checked="{{detailsOpened}}"></vaadin-checkbox>
           </template>
         </vaadin-grid-column>
 
@@ -35,9 +35,9 @@ export class MockGridHost extends PolymerElement {
         <template class="row-details">
           <div class="index">[[index]]</div>
           <input class="title" value="{{item.title::input}}" />
-          <vaadin-checkbox class="selected" checked="{{selected}}" />
-          <vaadin-checkbox class="expanded" checked="{{expanded}}" />
-          <vaadin-checkbox class="details-opened" checked="{{detailsOpened}}" />
+          <vaadin-checkbox class="selected" checked="{{selected}}"></vaadin-checkbox>
+          <vaadin-checkbox class="expanded" checked="{{expanded}}"></vaadin-checkbox>
+          <vaadin-checkbox class="details-opened" checked="{{detailsOpened}}"></vaadin-checkbox>
         </template>
       </vaadin-grid>
     `;


### PR DESCRIPTION
The use of self-closing tags (`<vaadin-checkbox />`) caused an infinite loop of
```
WARNING: Since Vaadin 22, placing the label as a direct child of a <vaadin-checkbox> is deprecated.
Please use <label slot="label"> wrapper or the label property instead.
```

in the tests. This PR fixes the tags.