### PR TITLE
fix: remove tabindex from combo-box overlay (#2948) (CP: 21.0)

### DIFF
--- a/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-dropdown.js
@@ -22,6 +22,8 @@ registerStyles(
 
 const ONE_THIRD = 0.3;
 
+let memoizedTemplate;
+
 /**
  * An element used internally by `<vaadin-combo-box>`. Not intended to be used separately.
  *
@@ -31,6 +33,15 @@ const ONE_THIRD = 0.3;
 class ComboBoxOverlayElement extends OverlayElement {
   static get is() {
     return 'vaadin-combo-box-overlay';
+  }
+
+  static get template() {
+    if (!memoizedTemplate) {
+      memoizedTemplate = super.template.cloneNode(true);
+      memoizedTemplate.content.querySelector('[part~="overlay"]').removeAttribute('tabindex');
+    }
+
+    return memoizedTemplate;
   }
 
   connectedCallback() {

--- a/packages/vaadin-combo-box/test/keyboard.test.js
+++ b/packages/vaadin-combo-box/test/keyboard.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@esm-bundle/chai';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import {
   aTimeout,
@@ -74,6 +75,7 @@ describe('keyboard', () => {
     beforeEach((done) =>
       setTimeout(() => {
         arrowDownKeyDown(comboBox.inputElement);
+        comboBox.inputElement.focus();
         done();
       })
     );
@@ -128,6 +130,38 @@ describe('keyboard', () => {
       arrowDownKeyDown(comboBox.inputElement);
 
       expect(getFocusedIndex()).to.equal(0);
+    });
+
+    it('should tab to the next focusable', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      expect(document.activeElement).to.equal(document.body);
+    });
+
+    describe('focusable items content', () => {
+      let button;
+
+      beforeEach(() => {
+        button = document.createElement('button');
+        button.textContent = 'Button';
+      });
+
+      afterEach(() => {
+        button.remove();
+      });
+
+      it('should tab to the next focusable when items have focusable content', async () => {
+        comboBox.renderer = (root) => (root.innerHTML = '<input>');
+        document.body.appendChild(button);
+
+        // Workaround Firefox sendKeys bug
+        button.focus();
+        comboBox.inputElement.focus();
+        arrowDownKeyDown(comboBox.inputElement);
+
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement).to.equal(button);
+      });
     });
   });
 


### PR DESCRIPTION
Backport #2948 to V21