### PR TITLE
test: import root entrypoints in typings tests

### DIFF
--- a/packages/confirm-dialog/test/typings/confirm-dialog.types.ts
+++ b/packages/confirm-dialog/test/typings/confirm-dialog.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-confirm-dialog.js';
-import { ConfirmDialogOpenedChangedEvent } from '../../src/vaadin-confirm-dialog.js';
+import { ConfirmDialogOpenedChangedEvent } from '../../vaadin-confirm-dialog.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/split-layout/test/typings/split-layout.types.ts
+++ b/packages/split-layout/test/typings/split-layout.types.ts
@@ -1,4 +1,4 @@
-import '../../src/vaadin-split-layout';
+import '../../vaadin-split-layout';
 
 const assert = <T>(value: T) => value;
 


### PR DESCRIPTION
## Description

Updated remaining files in `test/typings` to import from `../../vaadin-*` and not `../../src/vaadin-*` 

Closes #181

## Type of change

- Tests