### PR TITLE
refactor: use FocusMixin instead of custom logic

### DIFF
--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -404,10 +404,24 @@ describe('avatar-group', () => {
       overflow.click();
     });
 
-    it('should not restore focus-ring attribute on close if not set', (done) => {
+    it('should restore focus-ring attribute on close if closed with keyboard', (done) => {
       overlay.addEventListener('vaadin-overlay-open', () => {
         const list = overlay.content.querySelector('vaadin-avatar-group-list-box');
         escKeyDown(list);
+
+        afterNextRender(overlay, () => {
+          expect(overflow.hasAttribute('focus-ring')).to.be.true;
+          done();
+        });
+      });
+
+      overflow.click();
+    });
+
+    it('should not restore focus-ring attribute on close if not set', (done) => {
+      overlay.addEventListener('vaadin-overlay-open', () => {
+        const items = overlay.content.querySelectorAll('[theme="avatar-group-item"]');
+        items[0].click();
 
         afterNextRender(overlay, () => {
           expect(overflow.hasAttribute('focus-ring')).to.be.false;

--- a/packages/avatar/src/vaadin-avatar.d.ts
+++ b/packages/avatar/src/vaadin-avatar.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export interface AvatarI18n {
@@ -34,7 +35,7 @@ export interface AvatarI18n {
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  */
-declare class Avatar extends ElementMixin(ThemableMixin(HTMLElement)) {
+declare class Avatar extends FocusMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   /**
    * The path to the image
    */

--- a/packages/avatar/src/vaadin-avatar.d.ts
+++ b/packages/avatar/src/vaadin-avatar.d.ts
@@ -27,10 +27,12 @@ export interface AvatarI18n {
  * `abbr`    | The abbreviation element
  * `icon`    | The icon element
  *
- * The following attributes are exposed for styling:
+ * The following state attributes are available for styling:
  *
- * Attribute | Description
- * --------- | -----------
+ * Attribute         | Description
+ * ------------------|-------------
+ * `focus-ring`      | Set when the avatar is focused using the keyboard.
+ * `focused`         | Set when the avatar is focused.
  * `has-color-index` | Set when the avatar has `colorIndex` and the corresponding custom CSS property exists.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -5,30 +5,9 @@
  */
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import './vaadin-avatar-icons.js';
-
-// We consider the keyboard to be active if the window has received a keydown
-// event since the last mousedown event.
-let keyboardActive = false;
-
-// Listen for top-level Tab keydown and mousedown events.
-// Use capture phase so we detect events even if they're handled.
-window.addEventListener(
-  'keydown',
-  (e) => {
-    keyboardActive = e.keyCode === 9;
-  },
-  true
-);
-
-window.addEventListener(
-  'mousedown',
-  () => {
-    keyboardActive = false;
-  },
-  true
-);
 
 /**
  * `<vaadin-avatar>` is a Web Component providing avatar displaying functionality.
@@ -55,10 +34,11 @@ window.addEventListener(
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @extends HTMLElement
+ * @mixes FocusMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class Avatar extends ElementMixin(ThemableMixin(PolymerElement)) {
+class Avatar extends FocusMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   static get template() {
     return html`
       <style>
@@ -235,28 +215,6 @@ class Avatar extends ElementMixin(ThemableMixin(PolymerElement)) {
 
     if (!this.hasAttribute('tabindex')) {
       this.setAttribute('tabindex', '0');
-    }
-
-    this.addEventListener('focusin', () => {
-      this.__setFocused(true);
-    });
-
-    this.addEventListener('focusout', () => {
-      this.__setFocused(false);
-    });
-  }
-
-  /** @private */
-  __setFocused(focused) {
-    if (focused) {
-      this.setAttribute('focused', '');
-
-      if (keyboardActive) {
-        this.setAttribute('focus-ring', '');
-      }
-    } else {
-      this.removeAttribute('focused');
-      this.removeAttribute('focus-ring');
     }
   }
 

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -25,10 +25,12 @@ import './vaadin-avatar-icons.js';
  * `abbr`    | The abbreviation element
  * `icon`    | The icon element
  *
- * The following attributes are exposed for styling:
+ * The following state attributes are available for styling:
  *
- * Attribute | Description
- * --------- | -----------
+ * Attribute         | Description
+ * ------------------|-------------
+ * `focus-ring`      | Set when the avatar is focused using the keyboard.
+ * `focused`         | Set when the avatar is focused.
  * `has-color-index` | Set when the avatar has `colorIndex` and the corresponding custom CSS property exists.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.


### PR DESCRIPTION
## Description

The only reason for copy-paste in the original implementation was the lack of `FocusMixin` back then.
Note, we can change the tests separately to use `sendKeys` - for now current tests might be OK.

## Type of change

- Refactor