### PR TITLE
fix: reset background for menu-bar item in button

### DIFF
--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-button-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-button-styles.js
@@ -15,6 +15,7 @@ const menuBarButton = css`
   /* NOTE(web-padawan): avoid using shorthand padding property for IE11 */
   [part='label'] ::slotted(vaadin-context-menu-item) {
     justify-content: center;
+    background-color: transparent;
     height: var(--lumo-button-size);
     margin: 0 calc((var(--lumo-size-m) / 3 + var(--lumo-border-radius-m) / 2) * -1);
     padding-left: calc(var(--lumo-size-m) / 3 + var(--lumo-border-radius-m) / 2);

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-button-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-button-styles.js
@@ -8,6 +8,7 @@ const menuBarButton = css`
 
   [part='label'] ::slotted(vaadin-context-menu-item) {
     line-height: 20px;
+    background-color: transparent;
     margin: -8px;
     padding: 8px;
     justify-content: center;


### PR DESCRIPTION
## Description

As reported by @jouni at https://github.com/vaadin/web-components/pull/2955#issuecomment-957436657, moving styles caused a regression in Menu Bar styles. 
This is what happens on hover when `item.component` is used e.g. to provide custom icon:

<img width="93" alt="Screen Shot 2021-11-02 at 14 21 21" src="https://user-images.githubusercontent.com/66382/139845036-2df564fd-805b-49b7-88e3-c7e54562cf93.png">

Caused by the following style (same also happens in Material theme):

https://github.com/vaadin/web-components/blob/c2d88fd6d8402311306647915f162ac60610f7f3/packages/item/theme/lumo/vaadin-item-styles.js#L67-L69

## Type of change

- Bugfix