### PR TITLE
fix: prevent crash in Firefox when dragging disabled text area

### DIFF
--- a/packages/text-area/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area-styles.js
@@ -44,10 +44,12 @@ const textArea = css`
 
   /* Part of the workaround above: restore default cursor and prevent text 
      selection, same as when setting pointer-events: none */
+  :host([disabled]),
   :host([disabled]) [part='input-field'],
   :host([disabled]) ::slotted(textarea) {
     cursor: default;
     user-select: none;
+    -webkit-user-select: none;
   }
 
   :host(:hover:not([readonly]):not([focused]):not([invalid]):not([disabled])) [part='input-field'] {

--- a/packages/text-area/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area-styles.js
@@ -59,7 +59,7 @@ const textArea = css`
       background-color: var(--lumo-contrast-10pct);
     }
 
-    :host(:active:not([readonly]):not([focused])) [part='input-field'] {
+    :host(:active:not([readonly]):not([focused]):not([disabled])) [part='input-field'] {
       background-color: var(--lumo-contrast-20pct);
     }
   }

--- a/packages/text-area/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area-styles.js
@@ -36,12 +36,26 @@ const textArea = css`
     border: none;
   }
 
-  :host(:hover:not([readonly]):not([focused]):not([invalid])) [part='input-field'] {
+  /* Allow pointer events when disabled in order to work around crash in FF
+     See https://bugzilla.mozilla.org/show_bug.cgi?id=1739079 */
+  :host([disabled]) {
+    pointer-events: initial;
+  }
+
+  /* Part of the workaround above: restore default cursor and prevent text 
+     selection, same as when setting pointer-events: none */
+  :host([disabled]) [part='input-field'],
+  :host([disabled]) ::slotted(textarea) {
+    cursor: default;
+    user-select: none;
+  }
+
+  :host(:hover:not([readonly]):not([focused]):not([invalid]):not([disabled])) [part='input-field'] {
     background-color: var(--lumo-contrast-20pct);
   }
 
   @media (pointer: coarse) {
-    :host(:hover:not([readonly]):not([focused]):not([invalid])) [part='input-field'] {
+    :host(:hover:not([readonly]):not([focused]):not([invalid]):not([disabled])) [part='input-field'] {
       background-color: var(--lumo-contrast-10pct);
     }
 


### PR DESCRIPTION
## Description

Workaround for the Firefox bug, where dragging a disabled textarea crashes the tab. The issue is causes by two things: The textarea being wrapped in a shadow DOM, and a container element using `pointer-events: none`. Currently all input-based components apply `pointer-events: none` to the host element when they are disabled (through [`input-field-shared.js`](https://github.com/vaadin/web-components/blob/master/packages/vaadin-lumo-styles/mixins/input-field-shared.js#L91)), as far as I can see for styling purposes. 

Rather than changing the shared input field styles (which would affect 9 components), this solution overrides this style only for the `<vaadin-text-area>` by setting it to `pointer-events: initial`. This has a minimal impact to fix this issue quickly, rather than having to refactor multiple components. We can consider refactoring the remaining components later, if there is agreement that the `pointer-events: none` solution is not a good approach to cover disabled state styling.

Currently the workaround would apply to all browsers. We can invest more time, if we want to scope it to FF specifically, for example, by checking the user-agent when initializing the component, and then adding an attribute/class that can be checked in the styles.

Fixes https://github.com/vaadin/flow-components/issues/2296

Reproduction for testing:
```html
  <wrapper-component></wrapper-component>
  <p>Some other text to select, to check whether the tab is still alive</p>
  <script type="module">
    import '@vaadin/text-area';
    customElements.define('wrapper-component', class extends HTMLElement {
      constructor() {
        super();
        const shadowRoot = this.attachShadow({mode: 'open'});
        shadowRoot.innerHTML = `
          <vaadin-text-area disabled label="foobar" helper-text="Help me" value="Some text value"></vaadin-text-area>
        `;
      }
    });
  </script>
```

## Type of change

- [x] Bugfix

