### PR TITLE
refactor: use new mixins, simplify keyboard handling logic

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
@@ -44,9 +44,6 @@ class GridProEditSelect extends Select {
     super.ready();
 
     this.setAttribute('theme', 'grid-pro-editor');
-
-    this.__boundOnKeyDown = this.__onOverlayKeyDown.bind(this);
-    this._overlayElement.addEventListener('keydown', this.__boundOnKeyDown);
   }
 
   _onKeyDown(e) {
@@ -61,10 +58,25 @@ class GridProEditSelect extends Select {
     }
   }
 
-  __onOverlayKeyDown(e) {
-    if (e.keyCode === 9) {
-      !this._grid.singleCellEdit && this._grid._switchEditCell(e);
+  /**
+   * Override list-box event listener inherited from `Select`:
+   * - Enter: set flag for moving to next row on value change,
+   * - Tab: switch to next cell when "singleCellEdit" is false.
+   * @param {!KeyboardEvent} event
+   * @protected
+   * @override
+   */
+  _onKeyDownInside(event) {
+    if (event.keyCode === 13) {
+      this._enterKeydown = event;
     }
+
+    if (event.keyCode === 9) {
+      !this._grid.singleCellEdit && this._grid._switchEditCell(event);
+    }
+
+    // Call `super` to close overlay on Tab.
+    super._onKeyDownInside(event);
   }
 
   _valueChanged(value, oldValue) {
@@ -99,18 +111,6 @@ class GridProEditSelect extends Select {
           item.textContent = option;
           listBox.appendChild(item);
         });
-
-        // Save the "keydown" event for Enter to handle it on value change.
-        // Use capture phase because the item calls `preventDefault()`.
-        listBox.addEventListener(
-          'keydown',
-          (e) => {
-            if (e.keyCode === 13) {
-              this._enterKeydown = e;
-            }
-          },
-          true
-        );
 
         root.appendChild(listBox);
       };

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
@@ -100,12 +100,17 @@ class GridProEditSelect extends Select {
           listBox.appendChild(item);
         });
 
-        // save the "keydown" event for Enter
-        listBox.addEventListener('keydown', (e) => {
-          if (e.keyCode === 13) {
-            this._enterKeydown = e;
-          }
-        });
+        // Save the "keydown" event for Enter to handle it on value change.
+        // Use capture phase because the item calls `preventDefault()`.
+        listBox.addEventListener(
+          'keydown',
+          (e) => {
+            if (e.keyCode === 13) {
+              this._enterKeydown = e;
+            }
+          },
+          true
+        );
 
         root.appendChild(listBox);
       };

--- a/packages/grid-pro/test/edit-column-type.test.js
+++ b/packages/grid-pro/test/edit-column-type.test.js
@@ -214,7 +214,6 @@ describe('edit column editor type', () => {
         grid.enterNextRow = true;
         const item = editor._overlayElement.querySelector('vaadin-item');
         enter(item);
-        item.click();
         expect(column._getEditorComponent(cell)).to.not.be.ok;
         const secondCell = getContainerCell(grid.$.items, 1, 1);
         expect(getCellEditor(secondCell)).to.be.ok;

--- a/packages/grid-pro/test/edit-column.test.js
+++ b/packages/grid-pro/test/edit-column.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { enter, esc, fixtureSync, focusin, focusout, isIOS, tab } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import {
   createItems,
@@ -320,7 +321,7 @@ describe('edit column', () => {
   });
 
   (isIOS ? describe.skip : describe)('select column', () => {
-    let grid, input, textCell, selectCell, selectOverlay, checkboxCell;
+    let grid, textCell, selectCell, checkboxCell;
 
     beforeEach(() => {
       grid = fixtureSync(`
@@ -339,32 +340,34 @@ describe('edit column', () => {
       checkboxCell = getContainerCell(grid.$.items, 1, 2);
     });
 
-    it('should focus cell next available for editing in edit mode on Tab', (done) => {
+    it('should focus cell next available for editing in edit mode on Tab', async () => {
       dblclick(textCell._content);
-      input = getCellEditor(textCell);
-      tab(input);
+      expect(getCellEditor(textCell)).to.be.ok;
 
-      selectOverlay = getCellEditor(selectCell)._overlayElement;
-      selectOverlay.addEventListener('vaadin-overlay-open', () => {
-        tab(selectOverlay);
-        input = getCellEditor(checkboxCell);
-        expect(input).to.be.ok;
-        done();
-      });
+      // Press Tab to edit the select cell
+      await sendKeys({ press: 'Tab' });
+      expect(getCellEditor(selectCell)).to.be.ok;
+
+      // Press Tab to edit the checkbox cell
+      await sendKeys({ press: 'Tab' });
+      expect(getCellEditor(checkboxCell)).to.be.ok;
     });
 
-    it('should focus previous cell available for editing in edit mode on Shift Tab', (done) => {
+    it('should focus previous cell available for editing in edit mode on Shift Tab', async () => {
       dblclick(checkboxCell._content);
-      input = getCellEditor(checkboxCell);
-      tab(input, ['shift']);
+      expect(getCellEditor(checkboxCell)).to.be.ok;
 
-      selectOverlay = getCellEditor(selectCell)._overlayElement;
-      selectOverlay.addEventListener('vaadin-overlay-open', () => {
-        tab(selectOverlay, ['shift']);
-        input = getCellEditor(textCell);
-        expect(input).to.be.ok;
-        done();
-      });
+      // Press Shift + Tab to edit the select cell
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+      expect(getCellEditor(selectCell)).to.be.ok;
+
+      // Press Shift + Tab to edit the text cell
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+      expect(getCellEditor(textCell)).to.be.ok;
     });
   });
 

--- a/packages/item/src/vaadin-item-mixin.d.ts
+++ b/packages/item/src/vaadin-item-mixin.d.ts
@@ -5,6 +5,7 @@
  */
 import { Constructor } from '@open-wc/dedupe-mixin';
 import { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 
 /**
@@ -14,7 +15,11 @@ import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
  */
 export declare function ItemMixin<T extends Constructor<HTMLElement>>(
   base: T
-): T & Constructor<ItemMixinClass> & Constructor<ActiveMixinClass> & Constructor<FocusMixinClass>;
+): T &
+  Constructor<ItemMixinClass> &
+  Constructor<ActiveMixinClass> &
+  Constructor<DisabledMixinClass> &
+  Constructor<FocusMixinClass>;
 
 export declare class ItemMixinClass {
   value: string;

--- a/packages/item/src/vaadin-item-mixin.d.ts
+++ b/packages/item/src/vaadin-item-mixin.d.ts
@@ -4,13 +4,17 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { Constructor } from '@open-wc/dedupe-mixin';
+import { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 
 /**
  * A mixin providing `focused`, `focus-ring`, `active`, `disabled` and `selected`.
  *
  * `focused`, `active` and `focus-ring` are set as only as attributes.
  */
-export declare function ItemMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ItemMixinClass>;
+export declare function ItemMixin<T extends Constructor<HTMLElement>>(
+  base: T
+): T & Constructor<ItemMixinClass> & Constructor<ActiveMixinClass> & Constructor<FocusMixinClass>;
 
 export declare class ItemMixinClass {
   value: string;
@@ -23,20 +27,7 @@ export declare class ItemMixinClass {
   protected _hasVaadinItemMixin: boolean;
 
   /**
-   * If true, the user cannot interact with this element.
-   */
-  disabled: boolean;
-
-  /**
    * If true, the item is in selected state.
    */
   selected: boolean;
-
-  protected _setFocused(focused: boolean): void;
-
-  protected _setActive(active: boolean): void;
-
-  protected _onKeydown(event: KeyboardEvent): void;
-
-  protected _onKeyup(event: KeyboardEvent): void;
 }

--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -99,7 +99,7 @@ export const ItemMixin = (superClass) =>
      * @override
      */
     _shouldSetActive(event) {
-      return !this.disabled && !event.defaultPrevented;
+      return !this.disabled && !(event.type === 'keydown' && event.defaultPrevented);
     }
 
     /** @private */

--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -79,8 +79,8 @@ export const ItemMixin = (superClass) =>
     }
 
     /**
-     * Override native `focus` to set focus-ring attribute
-     * in a backwards compatible way when opened using keyboard.
+     * Override native `focus` to set focused attribute
+     * when focusing the item programmatically.
      * @protected
      * @override
      */

--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
+import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 
 /**
  * A mixin providing `focused`, `focus-ring`, `active`, `disabled` and `selected`.
@@ -11,7 +13,7 @@
  * @polymerMixin
  */
 export const ItemMixin = (superClass) =>
-  class VaadinItemMixin extends superClass {
+  class VaadinItemMixin extends ActiveMixin(FocusMixin(superClass)) {
     static get properties() {
       return {
         /**
@@ -22,17 +24,6 @@ export const ItemMixin = (superClass) =>
          */
         _hasVaadinItemMixin: {
           value: true
-        },
-
-        /**
-         * If true, the user cannot interact with this element.
-         * @type {boolean}
-         */
-        disabled: {
-          type: Boolean,
-          value: false,
-          observer: '_disabledChanged',
-          reflectToAttribute: true
         },
 
         /**
@@ -49,6 +40,18 @@ export const ItemMixin = (superClass) =>
         /** @private */
         _value: String
       };
+    }
+
+    /**
+     * By default, `Space` is the only possible activation key for a focusable HTML element.
+     * Nonetheless, the item is an exception as it can be also activated by pressing `Enter`.
+     * See the "Keyboard Support" section in https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-1/menubar-1.html.
+     *
+     * @protected
+     * @override
+     */
+    get _activeKeys() {
+      return ['Enter', ' '];
     }
 
     /**
@@ -73,31 +76,30 @@ export const ItemMixin = (superClass) =>
       if (attrValue !== null) {
         this.value = attrValue;
       }
-
-      this.addEventListener('focus', () => this._setFocused(true), true);
-      this.addEventListener('blur', () => this._setFocused(false), true);
-      this.addEventListener('mousedown', () => {
-        this._setActive((this._mousedown = true));
-        const mouseUpListener = () => {
-          this._setActive((this._mousedown = false));
-          document.removeEventListener('mouseup', mouseUpListener);
-        };
-        document.addEventListener('mouseup', mouseUpListener);
-      });
-      this.addEventListener('keydown', (e) => this._onKeydown(e));
-      this.addEventListener('keyup', (e) => this._onKeyup(e));
     }
 
-    /** @protected */
-    disconnectedCallback() {
-      super.disconnectedCallback();
-
-      // in Firefox and Safari, blur does not fire on the element when it is removed,
-      // especially between keydown and keyup events, being active at the same time.
-      // reproducible in `<vaadin-select>` when closing overlay on select.
-      if (this.hasAttribute('active')) {
-        this._setFocused(false);
+    /**
+     * Override native `focus` to set focus-ring attribute
+     * in a backwards compatible way when opened using keyboard.
+     * @protected
+     * @override
+     */
+    focus() {
+      if (this.disabled) {
+        return;
       }
+
+      super.focus();
+      this._setFocused(true);
+    }
+
+    /**
+     * @param {KeyboardEvent | MouseEvent} _event
+     * @protected
+     * @override
+     */
+    _shouldSetActive(event) {
+      return !this.disabled && !event.defaultPrevented;
     }
 
     /** @private */
@@ -105,64 +107,40 @@ export const ItemMixin = (superClass) =>
       this.setAttribute('aria-selected', selected);
     }
 
-    /** @private */
+    /**
+     * Override an observer from `DisabledMixin`.
+     * @protected
+     * @override
+     */
     _disabledChanged(disabled) {
+      super._disabledChanged(disabled);
+
       if (disabled) {
         this.selected = false;
-        this.setAttribute('aria-disabled', 'true');
         this.blur();
-      } else {
-        this.removeAttribute('aria-disabled');
       }
     }
 
     /**
-     * @param {boolean} focused
+     * In order to be fully accessible from the keyboard, the item should
+     * manually fire the `click` event once an activation key is pressed.
+     *
+     * According to the UI Events specifications,
+     * the `click` event should be fired exactly on `keydown`:
+     * https://www.w3.org/TR/uievents/#event-type-keydown
+     *
+     * @param {KeyboardEvent} event
      * @protected
+     * @override
      */
-    _setFocused(focused) {
-      if (focused) {
-        this.setAttribute('focused', '');
-        if (!this._mousedown) {
-          this.setAttribute('focus-ring', '');
-        }
-      } else {
-        this.removeAttribute('focused');
-        this.removeAttribute('focus-ring');
-        this._setActive(false);
-      }
-    }
+    _onKeyDown(event) {
+      super._onKeyDown(event);
 
-    /**
-     * @param {boolean} active
-     * @protected
-     */
-    _setActive(active) {
-      if (active) {
-        this.setAttribute('active', '');
-      } else {
-        this.removeAttribute('active');
-      }
-    }
-
-    /**
-     * @param {!KeyboardEvent} event
-     * @protected
-     */
-    _onKeydown(event) {
-      if (/^( |SpaceBar|Enter)$/.test(event.key) && !event.defaultPrevented) {
+      if (this._activeKeys.includes(event.key) && !event.defaultPrevented) {
         event.preventDefault();
-        this._setActive(true);
-      }
-    }
 
-    /**
-     * @param {!KeyboardEvent} event
-     * @protected
-     */
-    _onKeyup() {
-      if (this.hasAttribute('active')) {
-        this._setActive(false);
+        // `DisabledMixin` overrides the standard `click()` method
+        // so that it doesn't fire the `click` event when the element is disabled.
         this.click();
       }
     }

--- a/packages/item/test/item-mixin.test.js
+++ b/packages/item/test/item-mixin.test.js
@@ -1,6 +1,17 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { enter, fire, fixtureSync, spaceKeyDown, spaceKeyUp, space } from '@vaadin/testing-helpers';
+import {
+  enterKeyDown,
+  fixtureSync,
+  focusin,
+  focusout,
+  mousedown,
+  mouseup,
+  spaceKeyDown,
+  spaceKeyUp,
+  space,
+  tabKeyDown
+} from '@vaadin/testing-helpers';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import { ItemMixin } from '../src/vaadin-item-mixin.js';
 
@@ -70,30 +81,45 @@ describe('vaadin-item-mixin', () => {
         expect(item.hasAttribute('focused')).to.be.false;
       });
 
-      it('should have focused attribute when focused', () => {
-        fire(item, 'focus');
+      it('should have focused attribute on focusin', () => {
+        focusin(item);
         expect(item.hasAttribute('focused')).to.be.true;
       });
 
-      it('should not have focused attribute when blurred', () => {
-        fire(item, 'focus');
-        fire(item, 'blur');
+      it('should not have focused attribute on focusout', () => {
+        focusin(item);
+        focusout(item);
+        expect(item.hasAttribute('focused')).to.be.false;
+      });
+
+      it('should set focused attribute on programmatic focus', () => {
+        item.focus();
+        expect(item.hasAttribute('focused')).to.be.true;
+      });
+
+      it('should not set focused on programmatic focus when disabled', () => {
+        item.disabled = true;
+        item.focus();
         expect(item.hasAttribute('focused')).to.be.false;
       });
     });
 
     describe('active', () => {
-      it('should have active attribute on mousedown', () => {
-        fire(item, 'mousedown');
+      it('should set active attribute on mousedown', () => {
+        mousedown(item);
         expect(item.hasAttribute('active')).to.be.true;
-        expect(item._mousedown).to.be.true;
       });
 
-      it('should not have active attribute after mouseup', () => {
-        fire(item, 'mousedown');
-        fire(item, 'mouseup');
+      it('should remove active attribute on mouseup', () => {
+        mousedown(item);
+        mouseup(item);
         expect(item.hasAttribute('active')).to.be.false;
-        expect(item._mousedown).to.be.false;
+      });
+
+      it('should not set active attribute on mousedown when disabled', () => {
+        item.disabled = true;
+        mousedown(item);
+        expect(item.hasAttribute('active')).to.be.false;
       });
 
       it('should have active attribute on space down', () => {
@@ -125,37 +151,44 @@ describe('vaadin-item-mixin', () => {
       });
 
       it('should have focus-ring attribute when focused with keyboard', () => {
-        fire(item, 'focus');
+        tabKeyDown(item);
+        focusin(item);
         expect(item.hasAttribute('focus-ring')).to.be.true;
       });
 
-      it('should not have focus-ring after blur', () => {
-        fire(item, 'focus');
-        fire(item, 'blur');
+      it('should not have focus-ring after focusout', () => {
+        tabKeyDown(item);
+        focusin(item);
+        focusout(item);
+        expect(item.hasAttribute('focus-ring')).to.be.false;
+      });
+
+      it('should set focus-ring on programmatic focus after keydown', () => {
+        tabKeyDown(item);
+        item.focus();
+        expect(item.hasAttribute('focus-ring')).to.be.true;
+      });
+
+      it('should not set focus-ring on programmatic focus after mousedown', () => {
+        mousedown(item);
+        item.focus();
         expect(item.hasAttribute('focus-ring')).to.be.false;
       });
     });
 
-    describe('interaction', () => {
-      it('set this._mousedown to false if mouseup was outside', () => {
-        fire(item, 'mousedown');
-        expect(item._mousedown).to.be.true;
-        fire(document, 'mouseup');
-        expect(item._mousedown).to.be.false;
-      });
-
-      it('should fire click event when activated with Enter', () => {
+    describe('click', () => {
+      it('should fire click event on Enter keydown', () => {
         const clickSpy = sinon.spy();
         item.addEventListener('click', clickSpy);
-        enter(item);
+        enterKeyDown(item);
         expect(clickSpy.calledOnce).to.be.true;
       });
 
-      it('should not fire click event if keyup does not happen after a keydown in the element', () => {
+      it('should fire click event on Space keydown', () => {
         const clickSpy = sinon.spy();
         item.addEventListener('click', clickSpy);
-        spaceKeyUp(item);
-        expect(clickSpy.called).to.be.false;
+        spaceKeyDown(item);
+        expect(clickSpy.calledOnce).to.be.true;
       });
     });
 
@@ -202,6 +235,16 @@ describe('vaadin-item-mixin', () => {
       });
       spaceKeyDown(button);
       expect(item.hasAttribute('active')).to.be.false;
+    });
+
+    it('should not call click method if keydown was prevented', () => {
+      const button = item.querySelector('button');
+      button.addEventListener('keydown', (e) => {
+        e.preventDefault();
+      });
+      const spy = sinon.spy(item, 'click');
+      spaceKeyDown(button);
+      expect(spy.called).to.be.false;
     });
   });
 });

--- a/packages/item/test/item-mixin.test.js
+++ b/packages/item/test/item-mixin.test.js
@@ -170,6 +170,7 @@ describe('vaadin-item-mixin', () => {
       });
 
       it('should not set focus-ring on programmatic focus after mousedown', () => {
+        tabKeyDown(item);
         mousedown(item);
         item.focus();
         expect(item.hasAttribute('focus-ring')).to.be.false;

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -380,7 +380,9 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
         this._items.forEach((item) => item.setAttribute('role', 'option'));
       });
       menuElement.addEventListener('selected-changed', () => this.__updateValueButton());
-      menuElement.addEventListener('keydown', (e) => this._onKeyDownInside(e));
+      // Use capture phase to make it possible for `<vaadin-grid-pro-edit-select>`
+      // to override and handle the keydown event before the value change happens.
+      menuElement.addEventListener('keydown', (e) => this._onKeyDownInside(e), true);
       menuElement.addEventListener(
         'click',
         () => {

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -51,13 +51,16 @@ class Tab extends ElementMixin(ThemableMixin(ItemMixin(PolymerElement))) {
   }
 
   /**
+   * Override an event listener from `KeyboardMixin`
+   * to handle clicking anchors inside the tabs.
    * @param {!KeyboardEvent} event
    * @protected
+   * @override
    */
-  _onKeyup(event) {
+  _onKeyUp(event) {
     const willClick = this.hasAttribute('active');
 
-    super._onKeyup(event);
+    super._onKeyUp(event);
 
     if (willClick) {
       const anchor = this.querySelector('a');

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.js
@@ -284,14 +284,27 @@ export const ListMixin = (superClass) =>
       this.items.forEach((e) => (e.focused = e === item));
       this._setFocusable(idx);
       this._scrollToItem(idx);
-      item.focus();
+      this._focusItem(item);
+    }
+
+    /**
+     * Always set focus-ring on the item managed by the list-box
+     * for backwards compatibility with the old implementation.
+     * @param {HTMLElement} item
+     * @protected
+     */
+    _focusItem(item) {
+      if (item) {
+        item.focus();
+        item.setAttribute('focus-ring', '');
+      }
     }
 
     focus() {
       // In initialisation (e.g vaadin-select) observer might not been run yet.
       this._observer && this._observer.flush();
       const firstItem = this.querySelector('[tabindex="0"]') || (this.items ? this.items[0] : null);
-      firstItem && firstItem.focus();
+      this._focusItem(firstItem);
     }
 
     /**


### PR DESCRIPTION
## Description

- Changed to use `ActiveMixin` and `FocusMixin` so that we handle these consistently for all components.
- Added some necessary tweaks to preserve setting `focus-ring` when focusing an item inside a list-box
  - Previously, the `focus-ring` was always set **unless** there was a `mousedown` event before `focusin`,
  - Now, the `focus-ring` is set **only** if there was a `keydown` (same as in button, input fields etc),
  - But we still need to have `focus-ring` set by `vaadin-select`, `vaadin-list-box`, `vaadin-menu-bar`.

## Type of change

- Refactor