### PR TITLE
test: sort import statements in test files

### DIFF
--- a/packages/accordion/test/accordion.test.js
+++ b/packages/accordion/test/accordion.test.js
@@ -1,16 +1,15 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
-  isIOS,
-  fixtureSync,
   arrowDownKeyDown,
   arrowUpKeyDown,
-  keyboardEventFor,
-  homeKeyDown,
   endKeyDown,
+  fixtureSync,
+  homeKeyDown,
+  isIOS,
+  keyboardEventFor,
   nextFrame
 } from '@vaadin/testing-helpers';
-
+import sinon from 'sinon';
 import '../vaadin-accordion.js';
 
 describe('vaadin-accordion', () => {

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-app-layout.js';
+import '../vaadin-drawer-toggle.js';
 import { IronResizableBehavior } from '@polymer/iron-resizable-behavior';
 import { PolymerElement } from '@polymer/polymer';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
-import '../vaadin-app-layout.js';
-import '../vaadin-drawer-toggle.js';
 
 describe('vaadin-app-layout', () => {
   let layout;

--- a/packages/app-layout/test/drawer-toggle.test.js
+++ b/packages/app-layout/test/drawer-toggle.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
+import { enter, fixtureSync, space } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { fixtureSync, enter, space } from '@vaadin/testing-helpers';
-
 import '../vaadin-drawer-toggle.js';
 
 describe('drawer-toggle', () => {

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { enterKeyDown, escKeyDown, fixtureSync, nextRender, spaceKeyDown, tabKeyDown } from '@vaadin/testing-helpers';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import sinon from 'sinon';
 import '../vaadin-avatar-group.js';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 describe('avatar-group', () => {
   let group;

--- a/packages/avatar/test/avatar.test.js
+++ b/packages/avatar/test/avatar.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, focusin, focusout, mousedown, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
-
+import sinon from 'sinon';
 import '../vaadin-avatar.js';
 
 describe('vaadin-avatar', () => {

--- a/packages/board/test/board-cols.test.js
+++ b/packages/board/test/board-cols.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-board-row.js';
 
 describe('board-cols', () => {

--- a/packages/board/test/template.test.js
+++ b/packages/board/test/template.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-bind.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
 import '@polymer/polymer/lib/elements/dom-repeat.js';

--- a/packages/button/test/button.test.js
+++ b/packages/button/test/button.test.js
@@ -1,7 +1,7 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '../vaadin-button.js';
 
 describe('vaadin-button', () => {

--- a/packages/button/test/visual/lumo/button.test.js
+++ b/packages/button/test/visual/lumo/button.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync, mousedown } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/icon/theme/lumo/vaadin-icon.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import '../../../theme/lumo/vaadin-button.js';

--- a/packages/button/test/visual/material/button.test.js
+++ b/packages/button/test/visual/material/button.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/icon/theme/material/vaadin-icon.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 import '../../../theme/material/vaadin-button.js';

--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -1,6 +1,6 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextRender, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart', () => {

--- a/packages/charts/test/chart-properties.test.js
+++ b/packages/charts/test/chart-properties.test.js
@@ -1,6 +1,6 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart properties', () => {

--- a/packages/charts/test/chart-series.test.js
+++ b/packages/charts/test/chart-series.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
+import { aTimeout, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync, oneEvent, nextRender } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart-series', () => {

--- a/packages/charts/test/dom-repeat.test.js
+++ b/packages/charts/test/dom-repeat.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, oneEvent, nextRender } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
 import '../vaadin-chart.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 customElements.define(
   'chart-series-dom-repeat',

--- a/packages/charts/test/events.test.js
+++ b/packages/charts/test/events.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-chart.js';
 
 describe('vaadin-chart events', () => {

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -1,13 +1,12 @@
 import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { fixtureSync, oneEvent, nextRender } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
-import HttpUtilities from 'highcharts/es-modules/Core/HttpUtilities.js';
-import { chartDefaultTheme } from '../theme/vaadin-chart-default-theme.js';
-
 import '../vaadin-chart.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import HttpUtilities from 'highcharts/es-modules/Core/HttpUtilities.js';
+import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { chartDefaultTheme } from '../theme/vaadin-chart-default-theme.js';
 
 const chart = css`
   /* Ensure exporting works with complex selectors */

--- a/packages/charts/test/styling.test.js
+++ b/packages/charts/test/styling.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-import { chartDefaultTheme } from '../theme/vaadin-chart-default-theme.js';
 import '../vaadin-chart.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { chartDefaultTheme } from '../theme/vaadin-chart-default-theme.js';
 
 registerStyles('vaadin-chart', [
   chartDefaultTheme,

--- a/packages/charts/test/typings/chart.types.ts
+++ b/packages/charts/test/typings/chart.types.ts
@@ -1,5 +1,5 @@
-import { Axis, Chart as HighchartsChart, Point, Series } from 'highcharts';
 import '../../vaadin-chart.js';
+import { Axis, Chart as HighchartsChart, Point, Series } from 'highcharts';
 import {
   ChartAddSeriesEvent,
   ChartAfterExportEvent,
@@ -8,9 +8,17 @@ import {
   ChartBeforePrintEvent,
   ChartClickEvent,
   ChartDrilldownEvent,
-  ChartDrillupEvent,
   ChartDrillupallEvent,
+  ChartDrillupEvent,
   ChartLoadEvent,
+  ChartPointClickEvent,
+  ChartPointLegendItemClickEvent,
+  ChartPointMouseOutEvent,
+  ChartPointMouseOverEvent,
+  ChartPointRemoveEvent,
+  ChartPointSelectEvent,
+  ChartPointUnselectEvent,
+  ChartPointUpdateEvent,
   ChartRedrawEvent,
   ChartSelectionEvent,
   ChartSeriesAfterAnimateEvent,
@@ -21,14 +29,6 @@ import {
   ChartSeriesMouseOutEvent,
   ChartSeriesMouseOverEvent,
   ChartSeriesShowEvent,
-  ChartPointClickEvent,
-  ChartPointLegendItemClickEvent,
-  ChartPointMouseOutEvent,
-  ChartPointMouseOverEvent,
-  ChartPointRemoveEvent,
-  ChartPointSelectEvent,
-  ChartPointUnselectEvent,
-  ChartPointUpdateEvent,
   ChartXaxesExtremesSetEvent,
   ChartYaxesExtremesSetEvent
 } from '../../vaadin-chart.js';

--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -1,7 +1,7 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-bind.js';
 import '../vaadin-checkbox-group.js';
 

--- a/packages/checkbox/test/checkbox.test.js
+++ b/packages/checkbox/test/checkbox.test.js
@@ -1,7 +1,7 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync, mousedown, mouseup, nextFrame } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '../vaadin-checkbox.js';
 
 describe('checkbox', () => {

--- a/packages/checkbox/test/typings/checkbox.types.ts
+++ b/packages/checkbox/test/typings/checkbox.types.ts
@@ -1,13 +1,13 @@
+import '../../vaadin-checkbox.js';
 import { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { CheckedMixinClass } from '@vaadin/field-base/src/checked-mixin.js';
 import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
 import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import '../../vaadin-checkbox.js';
 import { CheckboxCheckedChangedEvent, CheckboxIndeterminateChangedEvent } from '../../vaadin-checkbox.js';
 
 const assertType = <TExpected>(value: TExpected) => value;

--- a/packages/checkbox/test/visual/lumo/checkbox.test.js
+++ b/packages/checkbox/test/visual/lumo/checkbox.test.js
@@ -1,6 +1,6 @@
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../../theme/lumo/vaadin-checkbox.js';
 
 describe('checkbox', () => {

--- a/packages/checkbox/test/visual/material/checkbox.test.js
+++ b/packages/checkbox/test/visual/material/checkbox.test.js
@@ -1,6 +1,6 @@
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../../theme/material/vaadin-checkbox.js';
 
 describe('checkbox', () => {

--- a/packages/combo-box/test/aria.test.js
+++ b/packages/combo-box/test/aria.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, arrowDownKeyDown, escKeyDown, nextFrame } from '@vaadin/testing-helpers';
-import { getAllItems } from './helpers.js';
+import { arrowDownKeyDown, escKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { getAllItems } from './helpers.js';
 
 describe('ARIA', () => {
   let comboBox, input, label, helper, error;

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, focusout } from '@vaadin/testing-helpers';
-import { getFirstItem, getViewportItems } from './helpers.js';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { getFirstItem, getViewportItems } from './helpers.js';
 
 describe('Properties', () => {
   let comboBox, overlay, input;

--- a/packages/combo-box/test/combo-box-light.test.js
+++ b/packages/combo-box/test/combo-box-light.test.js
@@ -1,24 +1,24 @@
 import { expect } from '@esm-bundle/chai';
-import { sendKeys } from '@web/test-runner-commands';
-import sinon from 'sinon';
 import {
   click,
   fixtureSync,
+  isDesktopSafari,
   isIOS,
   mousedown,
   mouseup,
+  nextFrame,
   touchend,
-  touchstart,
-  isDesktopSafari,
-  nextFrame
+  touchstart
 } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { resetMouseCanceller } from '@polymer/polymer/lib/utils/gestures.js';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { createEventSpy, getFirstItem } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box-light.js';
+import { resetMouseCanceller } from '@polymer/polymer/lib/utils/gestures.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { createEventSpy, getFirstItem } from './helpers.js';
 
 class MyInput extends PolymerElement {
   static get template() {

--- a/packages/combo-box/test/dialog.test.js
+++ b/packages/combo-box/test/dialog.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, mousedown, touchstart, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, nextFrame, touchstart } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/dialog/src/vaadin-dialog.js';
 import '../src/vaadin-combo-box.js';

--- a/packages/combo-box/test/dynamic-size.test.js
+++ b/packages/combo-box/test/dynamic-size.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { flushComboBox, getViewportItems, scrollToIndex } from './helpers.js';
 import '../src/vaadin-combo-box.js';
+import { flushComboBox, getViewportItems, scrollToIndex } from './helpers.js';
 
 describe('dynamic size change', () => {
   describe('reduce size once scrolled to end', () => {

--- a/packages/combo-box/test/filtering.test.js
+++ b/packages/combo-box/test/filtering.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
-import { getAllItems, onceOpened } from './helpers.js';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import { getAllItems, onceOpened } from './helpers.js';
 
 describe('filtering items', () => {
   let comboBox, overlay;

--- a/packages/combo-box/test/fixtures/mock-combo-box-light-template-wrapper.js
+++ b/packages/combo-box/test/fixtures/mock-combo-box-light-template-wrapper.js
@@ -1,5 +1,5 @@
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '../../vaadin-combo-box-light.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class MockComboBoxLightTemplateWrapper extends PolymerElement {
   static get template() {

--- a/packages/combo-box/test/fixtures/mock-combo-box-template-wrapper.js
+++ b/packages/combo-box/test/fixtures/mock-combo-box-template-wrapper.js
@@ -1,5 +1,5 @@
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '../../vaadin-combo-box.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class MockComboBoxTemplateWrapper extends PolymerElement {
   static get template() {

--- a/packages/combo-box/test/form-input.test.js
+++ b/packages/combo-box/test/form-input.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { createEventSpy } from './helpers.js';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { createEventSpy } from './helpers.js';
 
 describe('form field', () => {
   let comboBox, input;

--- a/packages/combo-box/test/item-renderer.test.js
+++ b/packages/combo-box/test/item-renderer.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { getFirstItem } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { getFirstItem } from './helpers.js';
 
 describe('item renderer', () => {
   let comboBox;

--- a/packages/combo-box/test/item-template.test.js
+++ b/packages/combo-box/test/item-template.test.js
@@ -1,12 +1,12 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
-import { getFirstItem } from './helpers.js';
 import './fixtures/mock-combo-box-template-wrapper.js';
 import './fixtures/mock-combo-box-light-template-wrapper.js';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import { getFirstItem } from './helpers.js';
 
 describe('item template', () => {
   let wrapper, comboBox, firstItem;

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -1,20 +1,20 @@
 import { expect } from '@esm-bundle/chai';
-import { sendKeys } from '@web/test-runner-commands';
-import sinon from 'sinon';
 import {
-  aTimeout,
-  fixtureSync,
-  focusout,
-  keyDownOn,
   arrowDownKeyDown,
   arrowUpKeyDown,
+  aTimeout,
   enterKeyDown,
   escKeyDown,
   fire,
+  fixtureSync,
+  focusout,
+  keyDownOn,
   nextFrame
 } from '@vaadin/testing-helpers';
-import { getViewportItems, getVisibleItemsCount, onceScrolled, scrollToIndex } from './helpers.js';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '../src/vaadin-combo-box.js';
+import { getViewportItems, getVisibleItemsCount, onceScrolled, scrollToIndex } from './helpers.js';
 
 describe('keyboard', () => {
   let comboBox, input;

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -1,9 +1,12 @@
 import { expect } from '@esm-bundle/chai';
+import { aTimeout, enterKeyDown, fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { fixtureSync, nextFrame, aTimeout, enterKeyDown, fire } from '@vaadin/testing-helpers';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '@vaadin/text-field/vaadin-text-field.js';
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import '../vaadin-combo-box-light.js';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import {
   flushComboBox,
@@ -14,9 +17,6 @@ import {
   getVisibleItemsCount,
   makeItems
 } from './helpers.js';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
-import '../vaadin-combo-box-light.js';
 
 registerStyles(
   'vaadin-combo-box*',

--- a/packages/combo-box/test/lit.test.js
+++ b/packages/combo-box/test/lit.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { html, render } from 'lit';
-import { getViewportItems } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { html, render } from 'lit';
+import { getViewportItems } from './helpers.js';
 
 describe('lit', () => {
   describe('renderer', () => {

--- a/packages/combo-box/test/not-animated-styles.js
+++ b/packages/combo-box/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-combo-box-overlay',

--- a/packages/combo-box/test/object-values.test.js
+++ b/packages/combo-box/test/object-values.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
-import { getFirstItem, getViewportItems, selectItem } from './helpers.js';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { getFirstItem, getViewportItems, selectItem } from './helpers.js';
 
 describe('object values', () => {
   let comboBox, input;

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, isIOS, fire } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { makeItems } from './helpers.js';
+import { aTimeout, fire, fixtureSync, isIOS } from '@vaadin/testing-helpers';
 import '../src/vaadin-combo-box.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { makeItems } from './helpers.js';
 
 class XFixed extends PolymerElement {
   static get template() {

--- a/packages/combo-box/test/scrolling.test.js
+++ b/packages/combo-box/test/scrolling.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, focusout, isIOS, aTimeout } from '@vaadin/testing-helpers';
-import { getSelectedItem, onceScrolled } from './helpers.js';
+import { aTimeout, fixtureSync, focusout, isIOS } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { getSelectedItem, onceScrolled } from './helpers.js';
 
 describe('scrolling', () => {
   let comboBox, overlay, scroller, input;

--- a/packages/combo-box/test/selecting-items.test.js
+++ b/packages/combo-box/test/selecting-items.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
+import { aTimeout, fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { aTimeout, fixtureSync, fire } from '@vaadin/testing-helpers';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
-import { getAllItems, getFirstItem, onceScrolled, scrollToIndex, selectItem } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import { getAllItems, getFirstItem, onceScrolled, scrollToIndex, selectItem } from './helpers.js';
 
 describe('selecting items', () => {
   let comboBox;

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, click, fixtureSync, focusout, isIOS, tap } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { createEventSpy } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
+import { createEventSpy } from './helpers.js';
 
 describe('toggling dropdown', () => {
   let comboBox, overlay, input;

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -3,22 +3,22 @@ import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
 import { ComboBoxDataProviderMixinClass } from '../../src/vaadin-combo-box-data-provider-mixin';
 import { ComboBoxMixinClass } from '../../src/vaadin-combo-box-mixin';
 import {
+  ComboBox,
+  ComboBoxCustomValueSetEvent,
   ComboBoxFilterChangedEvent,
   ComboBoxInvalidChangedEvent,
   ComboBoxOpenedChangedEvent,
-  ComboBoxValueChangedEvent,
-  ComboBoxCustomValueSetEvent,
   ComboBoxSelectedItemChangedEvent,
-  ComboBox
+  ComboBoxValueChangedEvent
 } from '../../vaadin-combo-box';
 import {
+  ComboBoxLight,
+  ComboBoxLightCustomValueSetEvent,
   ComboBoxLightFilterChangedEvent,
   ComboBoxLightInvalidChangedEvent,
   ComboBoxLightOpenedChangedEvent,
-  ComboBoxLightValueChangedEvent,
-  ComboBoxLightCustomValueSetEvent,
   ComboBoxLightSelectedItemChangedEvent,
-  ComboBoxLight
+  ComboBoxLightValueChangedEvent
 } from '../../vaadin-combo-box-light';
 
 interface TestComboBoxItem {

--- a/packages/combo-box/test/visual/common.js
+++ b/packages/combo-box/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/combo-box/test/visual/lumo/combo-box.test.js
+++ b/packages/combo-box/test/visual/lumo/combo-box.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/lumo/vaadin-combo-box.js';
 import '../../not-animated-styles.js';

--- a/packages/combo-box/test/visual/material/combo-box.test.js
+++ b/packages/combo-box/test/visual/material/combo-box.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/material/vaadin-combo-box.js';
 import '../../not-animated-styles.js';

--- a/packages/component-base/test/active-mixin.test.js
+++ b/packages/component-base/test/active-mixin.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync, isIOS, mousedown, mouseup, touchend, touchstart } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { sendKeys } from '@web/test-runner-commands';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ActiveMixin } from '../src/active-mixin.js';
 
 customElements.define(

--- a/packages/component-base/test/disabled-mixin.test.js
+++ b/packages/component-base/test/disabled-mixin.test.js
@@ -1,7 +1,7 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DisabledMixin } from '../src/disabled-mixin.js';
 
 customElements.define(

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { ElementMixin } from '../src/element-mixin.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { flush } from '../src/debounce.js';
+import { ElementMixin } from '../src/element-mixin.js';
 
 describe('ElementMixin', () => {
   const defineCE = (tagName) => {

--- a/packages/component-base/test/focus-mixin.test.js
+++ b/packages/component-base/test/focus-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, focusin, focusout, keyDownOn, mousedown } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { FocusMixin } from '../src/focus-mixin.js';
 
 customElements.define(

--- a/packages/component-base/test/keyboard-mixin.test.js
+++ b/packages/component-base/test/keyboard-mixin.test.js
@@ -1,8 +1,8 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { KeyboardMixin } from '../src/keyboard-mixin.js';
 
 describe('keyboard-mixin', () => {

--- a/packages/component-base/test/slot-mixin.test.js
+++ b/packages/component-base/test/slot-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { SlotMixin } from '../src/slot-mixin.js';
 
 customElements.define(

--- a/packages/component-base/test/tabindex-mixin.test.js
+++ b/packages/component-base/test/tabindex-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { TabindexMixin } from '../src/tabindex-mixin.js';
 
 customElements.define(

--- a/packages/component-base/test/templates.test.js
+++ b/packages/component-base/test/templates.test.js
@@ -1,8 +1,7 @@
-import sinon from 'sinon';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-
 import { processTemplates } from '../src/templates.js';
 
 class ComponentElement extends PolymerElement {

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
+import { esc, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { fixtureSync, esc, nextFrame } from '@vaadin/testing-helpers';
-import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import './not-animated-styles.js';
 import '../vaadin-confirm-dialog.js';
+import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 
 describe('vaadin-confirm-dialog', () => {
   describe('custom element definition', () => {

--- a/packages/confirm-dialog/test/not-animated-styles.js
+++ b/packages/confirm-dialog/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-dialog-overlay',

--- a/packages/context-menu/test/context.test.js
+++ b/packages/context-menu/test/context.test.js
@@ -1,12 +1,12 @@
 import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { fixtureSync, fire } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class XFoo extends PolymerElement {
   static get template() {

--- a/packages/context-menu/test/integration.test.js
+++ b/packages/context-menu/test/integration.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, click, fixtureSync, isIOS, makeSoloTouchEvent } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class MenuWrapper extends PolymerElement {
   static get template() {

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   arrowDownKeyDown,
   arrowLeftKeyDown,
@@ -14,6 +13,7 @@ import {
   nextRender,
   spaceKeyDown
 } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
 import './not-animated-styles.js';

--- a/packages/context-menu/test/not-animated-styles.js
+++ b/packages/context-menu/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-context-menu-overlay',

--- a/packages/context-menu/test/renderer.test.js
+++ b/packages/context-menu/test/renderer.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 

--- a/packages/context-menu/test/selection.test.js
+++ b/packages/context-menu/test/selection.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { click, enter, fire, fixtureSync, isIOS, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';

--- a/packages/context-menu/test/touch.test.js
+++ b/packages/context-menu/test/touch.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   fire,
   fixtureSync,
@@ -7,14 +6,15 @@ import {
   listenOnce,
   makeSoloTouchEvent,
   middleOfNode,
-  touchstart,
-  touchend
+  touchend,
+  touchstart
 } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { gestures } from '@polymer/polymer/lib/utils/gestures.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
+import { gestures } from '@polymer/polymer/lib/utils/gestures.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class MenuTouchWrapper extends PolymerElement {
   static get template() {

--- a/packages/context-menu/test/typings/context-menu.types.ts
+++ b/packages/context-menu/test/typings/context-menu.types.ts
@@ -1,8 +1,8 @@
 import '../../vaadin-context-menu.js';
 import {
   ContextMenuItem,
-  ContextMenuOpenedChangedEvent,
-  ContextMenuItemSelectedEvent
+  ContextMenuItemSelectedEvent,
+  ContextMenuOpenedChangedEvent
 } from '../../vaadin-context-menu.js';
 
 const menu = document.createElement('vaadin-context-menu');

--- a/packages/context-menu/test/visual/lumo/context-menu.test.js
+++ b/packages/context-menu/test/visual/lumo/context-menu.test.js
@@ -1,9 +1,9 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { openSubMenus } from '../common.js';
 import '../../../theme/lumo/vaadin-context-menu.js';
 import '../../not-animated-styles.js';
+import { openSubMenus } from '../common.js';
 
 describe('context-menu', () => {
   let element;

--- a/packages/context-menu/test/visual/material/context-menu.test.js
+++ b/packages/context-menu/test/visual/material/context-menu.test.js
@@ -1,9 +1,9 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { openSubMenus } from '../common.js';
 import '../../../theme/material/vaadin-context-menu.js';
 import '../../not-animated-styles.js';
+import { openSubMenus } from '../common.js';
 
 describe('context-menu', () => {
   let element;

--- a/packages/crud/test/crud-editor.test.js
+++ b/packages/crud/test/crud-editor.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { flushGrid } from './helpers.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-crud.js';
+import { flushGrid } from './helpers.js';
 
 describe('vaadin-crud editor', () => {
   ['default', 'custom'].forEach((type) => {

--- a/packages/crud/test/crud-grid.test.js
+++ b/packages/crud/test/crud-grid.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, listenOnce, nextRender } from '@vaadin/testing-helpers';
-import { flushGrid, getBodyCellContent, getHeaderCellContent } from './helpers.js';
 import '../src/vaadin-crud-grid.js';
+import { flushGrid, getBodyCellContent, getHeaderCellContent } from './helpers.js';
 
 describe('crud grid', () => {
   let grid;

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, isIOS, listenOnce, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, getBodyCellContent } from './helpers.js';
 import '../src/vaadin-crud.js';
+import { flushGrid, getBodyCellContent } from './helpers.js';
 
 describe('crud', () => {
   let crud;

--- a/packages/crud/test/typings/crud.types.ts
+++ b/packages/crud/test/typings/crud.types.ts
@@ -1,11 +1,11 @@
 import '../../vaadin-crud.js';
 import {
   Crud,
-  CrudEditedItemChangedEvent,
-  CrudEditorOpenedChangedEvent,
   CrudCancelEvent,
   CrudDeleteEvent,
+  CrudEditedItemChangedEvent,
   CrudEditEvent,
+  CrudEditorOpenedChangedEvent,
   CrudItemsChangedEvent,
   CrudNewEvent,
   CrudSaveEvent,

--- a/packages/custom-field/test/custom-field.test.js
+++ b/packages/custom-field/test/custom-field.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, focusin, focusout } from '@vaadin/testing-helpers';
-import { dispatchChange } from './common.js';
+import sinon from 'sinon';
 import '../src/vaadin-custom-field.js';
+import { dispatchChange } from './common.js';
 
 describe('custom field', () => {
   let customField;

--- a/packages/custom-field/test/keyboard.test.js
+++ b/packages/custom-field/test/keyboard.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
+import { aTimeout, fixtureSync, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { fixtureSync, aTimeout, tabKeyDown } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '../src/vaadin-custom-field.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class XWrapper extends PolymerElement {
   static get template() {

--- a/packages/custom-field/test/slot-wrapper.test.js
+++ b/packages/custom-field/test/slot-wrapper.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { dispatchChange } from './common.js';
 import '../src/vaadin-custom-field.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { dispatchChange } from './common.js';
 
 class XField extends PolymerElement {
   static get template() {

--- a/packages/custom-field/test/typings/custom-field.types.ts
+++ b/packages/custom-field/test/typings/custom-field.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-custom-field.js';
-import { CustomFieldValueChangedEvent, CustomFieldInvalidChangedEvent } from '../../vaadin-custom-field.js';
+import { CustomFieldInvalidChangedEvent, CustomFieldValueChangedEvent } from '../../vaadin-custom-field.js';
 
 const customField = document.createElement('vaadin-custom-field');
 

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
-import { sendKeys } from '@web/test-runner-commands';
 import { aTimeout, click, fixtureSync, oneEvent, tap } from '@vaadin/testing-helpers';
-import { close, getOverlayContent, monthsEqual, open } from './common.js';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
+import { close, getOverlayContent, monthsEqual, open } from './common.js';
 
 describe('basic features', () => {
   let datepicker, input, toggleButton;

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { click, down, fixtureSync, isIOS } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { isFullscreen } from './common.js';
 import '../src/vaadin-date-picker.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { isFullscreen } from './common.js';
 
 describe('dropdown', () => {
   let datepicker, input;

--- a/packages/date-picker/test/form-input.test.js
+++ b/packages/date-picker/test/form-input.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import { DatePicker } from '../vaadin-date-picker.js';
 import { close, open } from './common.js';

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   arrowDown,
   arrowLeft,
@@ -17,9 +16,10 @@ import {
   tab,
   tap
 } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-date-picker.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { close, getOverlayContent, open } from './common.js';
-import '../src/vaadin-date-picker.js';
 
 (isIOS ? describe.skip : describe)('keyboard input', () => {
   let target;

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   arrowDown,
   arrowLeft,
@@ -18,8 +17,9 @@ import {
   pageUp,
   space
 } from '@vaadin/testing-helpers';
-import { getDefaultI18n, getOverlayContent, open } from './common.js';
+import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
+import { getDefaultI18n, getOverlayContent, open } from './common.js';
 
 (isIOS ? describe.skip : describe)('keyboard navigation', () => {
   let target;

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, tap } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../src/vaadin-month-calendar.js';
 import { getDefaultI18n } from './common.js';
 

--- a/packages/date-picker/test/not-animated-styles.js
+++ b/packages/date-picker/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-date-picker-overlay',

--- a/packages/date-picker/test/overlay.test.js
+++ b/packages/date-picker/test/overlay.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { click, fixtureSync, listenOnce, tap } from '@vaadin/testing-helpers';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import sinon from 'sinon';
 import '../src/vaadin-date-picker-overlay-content.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { getDefaultI18n, getFirstVisibleItem, monthsEqual } from './common.js';
 
 function waitUntilScrolledTo(overlay, date, callback) {

--- a/packages/date-picker/test/scroller.test.js
+++ b/packages/date-picker/test/scroller.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, listenOnce } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../src/vaadin-infinite-scroller.js';
 import { activateScroller, getFirstVisibleItem } from './common.js';
 

--- a/packages/date-picker/test/theme-propagation.test.js
+++ b/packages/date-picker/test/theme-propagation.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { open } from './common.js';
 import '../src/vaadin-date-picker.js';
+import { open } from './common.js';
 
 describe('theme attribute', () => {
   let datepicker;

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -1,15 +1,16 @@
+import '../../vaadin-date-picker.js';
+import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import '../../vaadin-date-picker.js';
+import { DatePickerMixinClass } from '../../src/vaadin-date-picker-mixin.js';
 import {
   DatePicker,
   DatePickerInvalidChangedEvent,
@@ -22,7 +23,6 @@ import {
   DatePickerLightOpenedChangedEvent,
   DatePickerLightValueChangedEvent
 } from '../../vaadin-date-picker-light.js';
-import { DatePickerMixinClass } from '../../src/vaadin-date-picker-mixin.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/date-picker/test/visual/common.js
+++ b/packages/date-picker/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, isIOS, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-date-picker.js';
 import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announcer.js';
 import { activateScroller, getDefaultI18n, open } from './common.js';
-import '../src/vaadin-date-picker.js';
 
 describe('WAI-ARIA', () => {
   describe('date picker', () => {

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { changeInputValue } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';
+import { changeInputValue } from './helpers.js';
 
 const fixtures = {
   'default-inputs': `

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '../vaadin-date-time-picker.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 const formatTime = (...args) =>
   customElements

--- a/packages/date-time-picker/test/properties.test.js
+++ b/packages/date-time-picker/test/properties.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { dispatchChange } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';
+import { dispatchChange } from './helpers.js';
 
 const fixtures = {
   default: '<vaadin-date-time-picker></vaadin-date-time-picker>',

--- a/packages/date-time-picker/test/typings/date-time-picker.types.ts
+++ b/packages/date-time-picker/test/typings/date-time-picker.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-date-time-picker.js';
-import { DateTimePickerValueChangedEvent, DateTimePickerInvalidChangedEvent } from '../../vaadin-date-time-picker.js';
+import { DateTimePickerInvalidChangedEvent, DateTimePickerValueChangedEvent } from '../../vaadin-date-time-picker.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';
 
 class DateTimePicker2020Element extends customElements.get('vaadin-date-time-picker') {

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, keyboardEventFor, keyDownOn } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-details.js';
 
 describe('vaadin-details', () => {

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { esc, fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-dialog.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 customElements.define(
   'x-dialog',

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/text-area/vaadin-text-area.js';
 import '../src/vaadin-dialog.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-dialog-overlay',

--- a/packages/dialog/test/renderer.test.js
+++ b/packages/dialog/test/renderer.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-dialog.js';
 

--- a/packages/dialog/test/typings/dialog.types.ts
+++ b/packages/dialog/test/typings/dialog.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-dialog.js';
-import { DialogResizeEvent, DialogOpenedChangedEvent, DialogResizeDimensions } from '../../vaadin-dialog.js';
+import { DialogOpenedChangedEvent, DialogResizeDimensions, DialogResizeEvent } from '../../vaadin-dialog.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/email-field/test/typings/email-field.types.ts
+++ b/packages/email-field/test/typings/email-field.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-email-field.js';
-
 import { EmailFieldInvalidChangedEvent, EmailFieldValueChangedEvent } from '../../vaadin-email-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;

--- a/packages/field-base/test/aria-label-controller.test.js
+++ b/packages/field-base/test/aria-label-controller.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { AriaLabelController } from '../src/aria-label-controller.js';
 import { InputMixin } from '../src/input-mixin.js';

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, fire } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { fire, fixtureSync } from '@vaadin/testing-helpers';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { CheckedMixin } from '../src/checked-mixin.js';
 import { DelegateFocusMixin } from '../src/delegate-focus-mixin.js';

--- a/packages/field-base/test/delegate-focus-mixin.test.js
+++ b/packages/field-base/test/delegate-focus-mixin.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { DelegateFocusMixin } from '../src/delegate-focus-mixin.js';
 import { InputController } from '../src/input-controller.js';

--- a/packages/field-base/test/delegate-state-mixin.test.js
+++ b/packages/field-base/test/delegate-state-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DelegateStateMixin } from '../src/delegate-state-mixin.js';
 
 customElements.define(

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { FieldMixin } from '../src/field-mixin.js';
-import { InputMixin } from '../src/input-mixin.js';
 import { InputController } from '../src/input-controller.js';
+import { InputMixin } from '../src/input-mixin.js';
 
 customElements.define(
   'field-mixin-element',

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputConstraintsMixin } from '../src/input-constraints-mixin.js';
 import { InputController } from '../src/input-controller.js';

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
+import { escKeyDown, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { fixtureSync, escKeyDown } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { InputController } from '../src/input-controller.js';
 import { InputControlMixin } from '../src/input-control-mixin.js';
+import { InputController } from '../src/input-controller.js';
 
 customElements.define(
   'input-control-mixin-element',

--- a/packages/field-base/test/input-controller.test.js
+++ b/packages/field-base/test/input-controller.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { InputMixin } from '../src/input-mixin.js';

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { InputFieldMixin } from '../src/input-field-mixin.js';

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { InputMixin } from '../src/input-mixin.js';
 
 customElements.define(

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { LabelMixin } from '../src/label-mixin.js';
 
 customElements.define(

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { PatternMixin } from '../src/pattern-mixin.js';

--- a/packages/field-base/test/shadow-focus-mixin.test.js
+++ b/packages/field-base/test/shadow-focus-mixin.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, focusin, focusout, keyboardEventFor, keyDownOn } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ShadowFocusMixin } from '../src/shadow-focus-mixin.js';
 
 customElements.define(

--- a/packages/field-base/test/slot-label-mixin.test.js
+++ b/packages/field-base/test/slot-label-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { SlotLabelMixin } from '../src/slot-label-mixin.js';
 
 customElements.define(

--- a/packages/field-base/test/slot-styles-mixin.test.js
+++ b/packages/field-base/test/slot-styles-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';
 import { SlotStylesMixin } from '../src/slot-styles-mixin.js';
 

--- a/packages/field-base/test/slot-target-mixin.test.js
+++ b/packages/field-base/test/slot-target-mixin.test.js
@@ -1,7 +1,7 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { SlotTargetMixin } from '../src/slot-target-mixin.js';
 
 customElements.define(

--- a/packages/field-base/test/text-area-controller.test.js
+++ b/packages/field-base/test/text-area-controller.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { TextAreaController } from '../src/text-area-controller.js';
 import { InputMixin } from '../src/input-mixin.js';
+import { TextAreaController } from '../src/text-area-controller.js';
 
 customElements.define(
   'textarea-controller-element',

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ValidateMixin } from '../src/validate-mixin.js';
 
 customElements.define(

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/custom-style.js';
 import '../vaadin-form-item.js';
 

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
 import '@vaadin/text-field/vaadin-text-field.js';
 import '../vaadin-form-layout.js';
 import '../vaadin-form-item.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 customElements.define(
   'mutable-layout',

--- a/packages/grid-pro/test/edit-column-overlay.test.js
+++ b/packages/grid-pro/test/edit-column-overlay.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, focusin, focusout, enter, nextFrame } from '@vaadin/testing-helpers';
+import { enter, fixtureSync, focusin, focusout, nextFrame } from '@vaadin/testing-helpers';
 import '@vaadin/date-picker/vaadin-date-picker.js';
 import '@vaadin/dialog/vaadin-dialog.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { createItems, flushGrid, getCellEditor, getContainerCell } from './helpers.js';
 import '../vaadin-grid-pro.js';
 import '../vaadin-grid-pro-edit-column.js';
+import { createItems, flushGrid, getCellEditor, getContainerCell } from './helpers.js';
 
 async function clickOverlay(element) {
   focusout(element);

--- a/packages/grid-pro/test/edit-column-renderer.test.js
+++ b/packages/grid-pro/test/edit-column-renderer.test.js
@@ -1,8 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { enter, esc, fixtureSync, focusout, space } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid-pro.js';
+import '../vaadin-grid-pro-edit-column.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   createItems,
   dblclick,
@@ -11,8 +13,6 @@ import {
   getContainerCell,
   getContainerCellContent
 } from './helpers.js';
-import '../vaadin-grid-pro.js';
-import '../vaadin-grid-pro-edit-column.js';
 
 customElements.define(
   'user-editor',

--- a/packages/grid-pro/test/edit-column-template.test.js
+++ b/packages/grid-pro/test/edit-column-template.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { enter, esc, fixtureSync, space } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { createItems, dblclick, flushGrid, getCellEditor, getContainerCell } from './helpers.js';
 import '../vaadin-grid-pro.js';
 import '../vaadin-grid-pro-edit-column.js';
+import { createItems, dblclick, flushGrid, getCellEditor, getContainerCell } from './helpers.js';
 
 describe('edit column template', () => {
   describe('default', () => {

--- a/packages/grid-pro/test/edit-column-type.test.js
+++ b/packages/grid-pro/test/edit-column-type.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   arrowDown,
   arrowUp,
@@ -11,14 +10,15 @@ import {
   nextRender,
   space
 } from '@vaadin/testing-helpers';
-import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
-import { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
-import { Select } from '@vaadin/select/src/vaadin-select.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { createItems, dblclick, flushGrid, getCellEditor, getContainerCell, onceOpened } from './helpers.js';
 import './not-animated-styles.js';
 import '../vaadin-grid-pro.js';
 import '../vaadin-grid-pro-edit-column.js';
+import { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
+import { Select } from '@vaadin/select/src/vaadin-select.js';
+import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
+import { createItems, dblclick, flushGrid, getCellEditor, getContainerCell, onceOpened } from './helpers.js';
 
 describe('edit column editor type', () => {
   describe('with representation template', () => {

--- a/packages/grid-pro/test/edit-column.test.js
+++ b/packages/grid-pro/test/edit-column.test.js
@@ -1,8 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { enter, esc, fixtureSync, focusin, focusout, isIOS, tab } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid-pro.js';
+import '../vaadin-grid-pro-edit-column.js';
 import {
   createItems,
   dblclick,
@@ -15,8 +16,6 @@ import {
   getRows,
   infiniteDataProvider
 } from './helpers.js';
-import '../vaadin-grid-pro.js';
-import '../vaadin-grid-pro-edit-column.js';
 
 describe('edit column', () => {
   (isIOS ? describe.skip : describe)('keyboard navigation', () => {

--- a/packages/grid-pro/test/edit-column.test.js
+++ b/packages/grid-pro/test/edit-column.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { enter, esc, fixtureSync, focusin, focusout, isIOS, tab } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid-pro.js';
 import '../vaadin-grid-pro-edit-column.js';

--- a/packages/grid-pro/test/grid-pro.test.js
+++ b/packages/grid-pro/test/grid-pro.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid-pro.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import { flushGrid, infiniteDataProvider } from './helpers.js';
-import '../vaadin-grid-pro.js';
 
 describe('custom element definition', () => {
   let grid, tagName;

--- a/packages/grid-pro/test/lit.test.js
+++ b/packages/grid-pro/test/lit.test.js
@@ -1,9 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { enter, fixtureSync } from '@vaadin/testing-helpers';
-import { html, render } from 'lit';
-
 import '../vaadin-grid-pro.js';
 import '../vaadin-grid-pro-edit-column.js';
+import { html, render } from 'lit';
 import { flushGrid } from './helpers.js';
 
 describe('lit', () => {

--- a/packages/grid-pro/test/not-animated-styles.js
+++ b/packages/grid-pro/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-select-overlay',

--- a/packages/grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/grid-pro/test/typings/grid-pro.types.ts
@@ -1,4 +1,5 @@
 import {
+  Grid,
   GridActiveItemChangedEvent,
   GridCellActivateEvent,
   GridColumnReorderEvent,
@@ -6,7 +7,6 @@ import {
   GridDragStartEvent,
   GridDropEvent,
   GridDropLocation,
-  Grid,
   GridExpandedItemsChangedEvent,
   GridItemModel,
   GridLoadingChangedEvent,

--- a/packages/grid-pro/test/visual/lumo/grid-pro.test.js
+++ b/packages/grid-pro/test/visual/lumo/grid-pro.test.js
@@ -1,11 +1,11 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
-import { getContainerCell } from '../../helpers.js';
-import { users } from '../users.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/lumo/vaadin-grid-pro.js';
 import '../../../theme/lumo/vaadin-grid-pro-edit-column.js';
 import '../../not-animated-styles.js';
+import { getContainerCell } from '../../helpers.js';
+import { users } from '../users.js';
 
 describe('grid-pro', () => {
   let div, element;

--- a/packages/grid-pro/test/visual/material/grid-pro.test.js
+++ b/packages/grid-pro/test/visual/material/grid-pro.test.js
@@ -1,11 +1,11 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
-import { getContainerCell } from '../../helpers.js';
-import { users } from '../users.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/material/vaadin-grid-pro.js';
 import '../../../theme/material/vaadin-grid-pro-edit-column.js';
 import '../../not-animated-styles.js';
+import { getContainerCell } from '../../helpers.js';
+import { users } from '../users.js';
 
 describe('grid-pro', () => {
   let div, element;

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid } from './helpers.js';
 import '../all-imports.js';
+import { flushGrid } from './helpers.js';
 
 const fixtures = {
   default: `

--- a/packages/grid/test/array-data-provider.test.js
+++ b/packages/grid/test/array-data-provider.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, getCellContent, getRows, getRowCells, getBodyCellContent } from './helpers.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-filter.js';
 import '../vaadin-grid-sorter.js';
+import { flushGrid, getBodyCellContent, getCellContent, getRowCells, getRows } from './helpers.js';
 
 describe('array data provider', () => {
   let grid, body;

--- a/packages/grid/test/basic.test.js
+++ b/packages/grid/test/basic.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
 import {
   flushGrid,
   getBodyCellContent,
@@ -15,7 +16,6 @@ import {
   scrollGrid,
   scrollToEnd
 } from './helpers.js';
-import '../vaadin-grid.js';
 
 describe('basic features', () => {
   let grid;

--- a/packages/grid/test/class-name-generator.test.js
+++ b/packages/grid/test/class-name-generator.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { flushGrid, getContainerCell, getRows, infiniteDataProvider, scrollToEnd } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-grid.js';
+import { flushGrid, getContainerCell, getRows, infiniteDataProvider, scrollToEnd } from './helpers.js';
 
 describe('class name generator', () => {
   let grid, firstCell, initialCellClasses;

--- a/packages/grid/test/column-auto-width.test.js
+++ b/packages/grid/test/column-auto-width.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import { flushGrid } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
+import { flushGrid } from './helpers.js';
 
 describe('column auto-width', function () {
   let grid;

--- a/packages/grid/test/column-group.test.js
+++ b/packages/grid/test/column-group.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { flushGrid, getContainerCell } from './helpers.js';
 
 describe('column group', () => {

--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -1,18 +1,18 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
+import '../vaadin-grid-column-group.js';
 import {
   flushGrid,
   getCellContent,
   getContainerCellContent,
-  getRows,
   getRowCells,
+  getRows,
   infiniteDataProvider,
-  scrollToEnd,
-  nextResize
+  nextResize,
+  scrollToEnd
 } from './helpers.js';
-import '../vaadin-grid.js';
-import '../vaadin-grid-column-group.js';
 
 const createColumn = () => {
   const column = document.createElement('vaadin-grid-column');

--- a/packages/grid/test/column-reordering.test.js
+++ b/packages/grid/test/column-reordering.test.js
@@ -1,7 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
+import '../vaadin-grid-column-group.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import {
   dragAndDropOver,
@@ -9,13 +11,11 @@ import {
   dragStart,
   flushGrid,
   getContainerCell,
-  getRows,
   getRowCells,
+  getRows,
   infiniteDataProvider,
   makeSoloTouchEvent
 } from './helpers.js';
-import '../vaadin-grid.js';
-import '../vaadin-grid-column-group.js';
 
 function getVisualCellContent(section, row, col) {
   let cell = Array.from(section.querySelectorAll('[part~="cell"]:not([part~="details-cell"])')).pop();

--- a/packages/grid/test/column-resizing.test.js
+++ b/packages/grid/test/column-resizing.test.js
@@ -1,19 +1,19 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, listenOnce, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
+import '../vaadin-grid-column-group.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import {
   dragAndDropOver,
   fire,
   flushGrid,
   getHeaderCellContent,
-  getRows,
   getRowCells,
+  getRows,
   infiniteDataProvider
 } from './helpers.js';
-import '../vaadin-grid.js';
-import '../vaadin-grid-column-group.js';
 
 function getElementFromPoint(context, x, y) {
   return context.shadowRoot.elementFromPoint(x, y);

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -1,8 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
+import '../vaadin-grid-column-group.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   flushGrid,
   getBodyCellContent,
@@ -13,8 +15,6 @@ import {
   getPhysicalItems,
   infiniteDataProvider
 } from './helpers.js';
-import '../vaadin-grid.js';
-import '../vaadin-grid-column-group.js';
 
 class GridContainer extends PolymerElement {
   static get template() {

--- a/packages/grid/test/data-provider.test.js
+++ b/packages/grid/test/data-provider.test.js
@@ -1,23 +1,23 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import {
   flushGrid,
   getCellContent,
   getContainerCell,
   getFirstCell,
   getFirstVisibleItem,
-  getRows,
-  getRowCells,
-  infiniteDataProvider,
-  scrollToEnd,
   getLastVisibleItem,
-  getPhysicalAverage
+  getPhysicalAverage,
+  getRowCells,
+  getRows,
+  infiniteDataProvider,
+  scrollToEnd
 } from './helpers.js';
-import '../vaadin-grid.js';
 
 registerStyles(
   'vaadin-grid',

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
+import { aTimeout, fixtureSync, listenOnce, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { fixtureSync, listenOnce, nextFrame, oneEvent, aTimeout } from '@vaadin/testing-helpers';
-import { flushGrid, getBodyCellContent, getFirstCell, getRows } from './helpers.js';
 import '../vaadin-grid.js';
+import { flushGrid, getBodyCellContent, getFirstCell, getRows } from './helpers.js';
 
 describe('drag and drop', () => {
   let grid, dragData;

--- a/packages/grid/test/dynamic-item-size.test.js
+++ b/packages/grid/test/dynamic-item-size.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, getFirstVisibleItem, infiniteDataProvider } from './helpers.js';
 import '../vaadin-grid.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { flushGrid, getFirstVisibleItem, infiniteDataProvider } from './helpers.js';
 
 registerStyles(
   'vaadin-grid',

--- a/packages/grid/test/event-context.test.js
+++ b/packages/grid/test/event-context.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { click, fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, getContainerCell } from './helpers.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
+import { flushGrid, getContainerCell } from './helpers.js';
 
 describe('event context', () => {
   let grid, column, columnGroup;

--- a/packages/grid/test/filtering.test.js
+++ b/packages/grid/test/filtering.test.js
@@ -1,14 +1,14 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, listenOnce } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, getBodyCellContent, getHeaderCellContent, scrollToEnd, getVisibleItems } from './helpers.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-filter.js';
 import '../vaadin-grid-filter-column.js';
 import '../vaadin-grid-sorter.js';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { flushGrid, getBodyCellContent, getHeaderCellContent, getVisibleItems, scrollToEnd } from './helpers.js';
 
 class FilterWrapper extends PolymerElement {
   static get template() {

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, listenOnce } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, getRows, getRowCells, infiniteDataProvider, isWithinParentConstraints, wheel } from './helpers.js';
 import '../vaadin-grid.js';
+import { flushGrid, getRowCells, getRows, infiniteDataProvider, isWithinParentConstraints, wheel } from './helpers.js';
 
 // Returns true if the element's computed transform style matches with the
 // computed transform style of a div element with the given transform applied

--- a/packages/grid/test/hidden-grid.test.js
+++ b/packages/grid/test/hidden-grid.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import { flushGrid, getBodyCellContent, infiniteDataProvider } from './helpers.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
+import { flushGrid, getBodyCellContent, infiniteDataProvider } from './helpers.js';
 
 describe('hidden grid', () => {
   let grid;

--- a/packages/grid/test/keyboard-navigation-row-focus.test.js
+++ b/packages/grid/test/keyboard-navigation-row-focus.test.js
@@ -3,12 +3,12 @@ import {
   down as mouseDown,
   fixtureSync,
   keyDownOn,
-  nextRender,
   listenOnce,
+  nextRender,
   up as mouseUp
 } from '@vaadin/testing-helpers';
-import { getCellContent } from './helpers.js';
 import '../src/all-imports.js';
+import { getCellContent } from './helpers.js';
 
 let grid, header, footer, body;
 

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1,33 +1,33 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   aTimeout,
   down as mouseDown,
   fixtureSync,
   focusin,
+  keyboardEventFor,
   keyDownOn,
   keyUpOn,
-  keyboardEventFor,
   listenOnce,
   nextFrame,
   up as mouseUp
 } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
+import '../vaadin-grid-column-group.js';
+import '../vaadin-grid-selection-column.js';
 import {
   flushGrid,
   getCell,
   getCellContent,
   getContainerCell,
-  getRows,
+  getLastVisibleItem,
   getRowCells,
+  getRows,
   infiniteDataProvider,
-  scrollToEnd,
-  getLastVisibleItem
+  scrollToEnd
 } from './helpers.js';
-import '../vaadin-grid.js';
-import '../vaadin-grid-column-group.js';
-import '../vaadin-grid-selection-column.js';
 
 let grid, focusable, scroller, header, footer, body;
 

--- a/packages/grid/test/light-dom-observing.test.js
+++ b/packages/grid/test/light-dom-observing.test.js
@@ -1,22 +1,22 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@polymer/polymer/lib/elements/dom-bind.js';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
+import '../vaadin-grid.js';
+import '../vaadin-grid-column-group.js';
+import '../vaadin-grid-selection-column.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   flushGrid,
   getCellContent,
   getHeaderCellContent,
-  getRows,
   getRowCells,
+  getRows,
   infiniteDataProvider,
   scrollToEnd
 } from './helpers.js';
-import '../vaadin-grid.js';
-import '../vaadin-grid-column-group.js';
-import '../vaadin-grid-selection-column.js';
 
 class XBooleanToggle extends PolymerElement {
   static get template() {

--- a/packages/grid/test/lit-renderers.test.js
+++ b/packages/grid/test/lit-renderers.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { render, html } from 'lit';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column.js';
+import { html, render } from 'lit';
 import { flushGrid } from './helpers.js';
 
 describe('lit renderers', () => {

--- a/packages/grid/test/lit.test.js
+++ b/packages/grid/test/lit.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
-import { render, html } from 'lit';
 import '../vaadin-grid.js';
+import { html, render } from 'lit';
 import { getPhysicalItems } from './helpers.js';
 
 describe('lit', () => {

--- a/packages/grid/test/missing-imports.test.js
+++ b/packages/grid/test/missing-imports.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { flushGrid, infiniteDataProvider } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-grid.js';
+import { flushGrid, infiniteDataProvider } from './helpers.js';
 
 describe('missing imports', () => {
   let grid;

--- a/packages/grid/test/physical-count.test.js
+++ b/packages/grid/test/physical-count.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import {
   flushGrid,
   getCellContent,
@@ -10,7 +11,6 @@ import {
   getPhysicalItems,
   infiniteDataProvider
 } from './helpers.js';
-import '../vaadin-grid.js';
 
 registerStyles(
   'vaadin-grid',

--- a/packages/grid/test/renderers.test.js
+++ b/packages/grid/test/renderers.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, isIOS, keyDownOn } from '@vaadin/testing-helpers';
-import { flushGrid, getBodyCellContent, getCell, getContainerCell } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-grid.js';
+import { flushGrid, getBodyCellContent, getCell, getContainerCell } from './helpers.js';
 
 function getHeaderCell(grid, index = 0) {
   return grid.$.header.querySelectorAll('[part~="cell"]')[index];

--- a/packages/grid/test/resizing-material.test.js
+++ b/packages/grid/test/resizing-material.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { flushGrid, infiniteDataProvider } from './helpers.js';
 import '../theme/material/vaadin-grid.js';
+import { flushGrid, infiniteDataProvider } from './helpers.js';
 
 describe('resizing material grid', () => {
   let grid;

--- a/packages/grid/test/resizing.test.js
+++ b/packages/grid/test/resizing.test.js
@@ -1,21 +1,21 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
+import '../vaadin-grid-column-group.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   flushGrid,
   getContainerCellContent,
   getHeaderCellContent,
-  getRows,
+  getPhysicalItems,
   getRowCells,
+  getRows,
   infiniteDataProvider,
-  scrollToEnd,
   nextResize,
-  getPhysicalItems
+  scrollToEnd
 } from './helpers.js';
-import '../vaadin-grid.js';
-import '../vaadin-grid-column-group.js';
-import sinon from 'sinon';
 
 class TestComponent extends PolymerElement {
   static get template() {

--- a/packages/grid/test/row-details.test.js
+++ b/packages/grid/test/row-details.test.js
@@ -1,9 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, click, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
+import '../vaadin-grid.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   buildDataSet,
   flushGrid,
@@ -14,7 +15,6 @@ import {
   infiniteDataProvider,
   scrollToEnd
 } from './helpers.js';
-import '../vaadin-grid.js';
 
 class GridDetailsWrapper extends PolymerElement {
   static get template() {

--- a/packages/grid/test/row-height.test.js
+++ b/packages/grid/test/row-height.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, getRows, getRowCells, infiniteDataProvider, scrollToEnd } from './helpers.js';
 import '../vaadin-grid.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { flushGrid, getRowCells, getRows, infiniteDataProvider, scrollToEnd } from './helpers.js';
 
 registerStyles(
   'vaadin-grid',

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -1,6 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, listenOnce, nextFrame } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '../vaadin-grid.js';
+import '../vaadin-grid-tree-column.js';
 import {
   flushGrid,
   getFirstVisibleItem,
@@ -9,8 +11,6 @@ import {
   getPhysicalItems,
   infiniteDataProvider
 } from './helpers.js';
-import '../vaadin-grid.js';
-import '../vaadin-grid-tree-column.js';
 
 const fixtures = {
   small: `

--- a/packages/grid/test/scrolling-mode.test.js
+++ b/packages/grid/test/scrolling-mode.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, listenOnce } from '@vaadin/testing-helpers';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, infiniteDataProvider, scrollToEnd } from './helpers.js';
 import '../vaadin-grid.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import { flushGrid, infiniteDataProvider, scrollToEnd } from './helpers.js';
 
 describe('scrolling mode', () => {
   let grid;

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -1,19 +1,19 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, listenOnce } from '@vaadin/testing-helpers';
-import {
-  flushGrid,
-  getBodyCellContent,
-  getCellContent,
-  getRows,
-  getRowCells,
-  infiniteDataProvider
-} from './helpers.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-selection-column.js';
 import '../vaadin-grid-filter.js';
 import '../vaadin-grid-column-group.js';
+import {
+  flushGrid,
+  getBodyCellContent,
+  getCellContent,
+  getRowCells,
+  getRows,
+  infiniteDataProvider
+} from './helpers.js';
 
 const fixtures = {
   renderer: `

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { buildDataSet, flushGrid, getBodyCellContent, getHeaderCellContent, getRows, getRowCells } from './helpers.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-sorter.js';
 import '../vaadin-grid-sort-column.js';
+import { buildDataSet, flushGrid, getBodyCellContent, getHeaderCellContent, getRowCells, getRows } from './helpers.js';
 
 describe('sorting', () => {
   describe('sorter', () => {

--- a/packages/grid/test/templates.test.js
+++ b/packages/grid/test/templates.test.js
@@ -1,10 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-bind.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/text-field/vaadin-text-field.js';
+import '../vaadin-grid.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   flushGrid,
   getBodyCellContent,
@@ -14,7 +15,6 @@ import {
   getFirstCell,
   infiniteDataProvider
 } from './helpers.js';
-import '../vaadin-grid.js';
 
 class GridWithSlots extends PolymerElement {
   static get template() {

--- a/packages/grid/test/tree-toggle.test.js
+++ b/packages/grid/test/tree-toggle.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { click, fixtureSync } from '@vaadin/testing-helpers';
-import { flushGrid, getBodyCellContent } from './helpers.js';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-tree-toggle.js';
 import '../vaadin-grid-tree-column.js';
+import { flushGrid, getBodyCellContent } from './helpers.js';
 
 describe('tree toggle', () => {
   let toggle;

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -11,19 +11,12 @@ import { ScrollMixinClass } from '../../src/vaadin-grid-scroll-mixin';
 import { SelectionMixinClass } from '../../src/vaadin-grid-selection-mixin';
 import { SortMixinClass } from '../../src/vaadin-grid-sort-mixin';
 import { StylingMixinClass } from '../../src/vaadin-grid-styling-mixin';
-import { GridColumnGroup } from '../../vaadin-grid-column-group';
-import { GridFilterColumn } from '../../vaadin-grid-filter-column';
-import { GridFilter, GridFilterValueChangedEvent } from '../../vaadin-grid-filter.js';
-import { GridSelectionColumn, GridSelectionColumnSelectAllChangedEvent } from '../../vaadin-grid-selection-column.js';
-import { GridSortColumnDirectionChangedEvent, GridSortColumn } from '../../vaadin-grid-sort-column.js';
-import { GridSorterDirectionChangedEvent, GridSorter } from '../../vaadin-grid-sorter.js';
-import { GridTreeColumn } from '../../vaadin-grid-tree-column';
-import { GridTreeToggle, GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
 import {
   ColumnBaseMixinClass,
+  Grid,
   GridActiveItemChangedEvent,
-  GridCellActivateEvent,
   GridBodyRenderer,
+  GridCellActivateEvent,
   GridCellClassNameGenerator,
   GridCellFocusEvent,
   GridColumn,
@@ -36,7 +29,6 @@ import {
   GridDropEvent,
   GridDropLocation,
   GridDropMode,
-  Grid,
   GridEventContext,
   GridExpandedItemsChangedEvent,
   GridFilterDefinition,
@@ -47,6 +39,14 @@ import {
   GridSorterDefinition,
   GridSorterDirection
 } from '../../vaadin-grid.js';
+import { GridColumnGroup } from '../../vaadin-grid-column-group';
+import { GridFilter, GridFilterValueChangedEvent } from '../../vaadin-grid-filter.js';
+import { GridFilterColumn } from '../../vaadin-grid-filter-column';
+import { GridSelectionColumn, GridSelectionColumnSelectAllChangedEvent } from '../../vaadin-grid-selection-column.js';
+import { GridSortColumn, GridSortColumnDirectionChangedEvent } from '../../vaadin-grid-sort-column.js';
+import { GridSorter, GridSorterDirectionChangedEvent } from '../../vaadin-grid-sorter.js';
+import { GridTreeColumn } from '../../vaadin-grid-tree-column';
+import { GridTreeToggle, GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
 
 interface TestGridItem {
   testProperty: string;

--- a/packages/grid/test/visual/lumo/grid.test.js
+++ b/packages/grid/test/visual/lumo/grid.test.js
@@ -1,12 +1,12 @@
 import { click, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers/dist/index-no-side-effects.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, nextResize } from '../../helpers.js';
-import { users } from '../users.js';
 import '../../../theme/lumo/vaadin-grid.js';
 import '../../../theme/lumo/vaadin-grid-column-group.js';
 import '../../../theme/lumo/vaadin-grid-sorter.js';
+import { flushGrid, nextResize } from '../../helpers.js';
+import { users } from '../users.js';
 
 describe('grid', () => {
   let element;

--- a/packages/grid/test/visual/material/grid.test.js
+++ b/packages/grid/test/visual/material/grid.test.js
@@ -1,12 +1,12 @@
 import { click, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers/dist/index-no-side-effects.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import { flushGrid, nextResize } from '../../helpers.js';
-import { users } from '../users.js';
 import '../../../theme/material/vaadin-grid.js';
 import '../../../theme/material/vaadin-grid-column-group.js';
 import '../../../theme/material/vaadin-grid-sorter.js';
+import { flushGrid, nextResize } from '../../helpers.js';
+import { users } from '../users.js';
 
 describe('grid', () => {
   let element;

--- a/packages/horizontal-layout/test/horizontal-layout.test.js
+++ b/packages/horizontal-layout/test/horizontal-layout.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { getComputedCSSPropertyValue } from './common.js';
 import '../vaadin-horizontal-layout.js';
+import { getComputedCSSPropertyValue } from './common.js';
 
 describe('vaadin-horizontal-layout', () => {
   describe('basic features', () => {

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { unsafeSvgLiteral } from '../src/vaadin-icon-svg.js';
+import sinon from 'sinon';
 import '../vaadin-icon.js';
+import { unsafeSvgLiteral } from '../src/vaadin-icon-svg.js';
 
 const ANGLE_DOWN = '<path d="M13 4v2l-5 5-5-5v-2l5 5z"></path>';
 const ANGLE_UP = '<path d="M3 12v-2l5-5 5 5v2l-5-5z"></path>';

--- a/packages/icon/test/iconset.test.js
+++ b/packages/icon/test/iconset.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { Iconset } from '../vaadin-iconset.js';
 import { isValidSvg } from '../src/vaadin-icon-svg.js';
+import { Iconset } from '../vaadin-iconset.js';
 
 describe('vaadin-iconset', () => {
   let iconset;

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../src/vaadin-integer-field.js';
 
 describe('integer-field', () => {

--- a/packages/integer-field/test/typings/integer-field.types.ts
+++ b/packages/integer-field/test/typings/integer-field.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-integer-field.js';
-
 import { IntegerFieldInvalidChangedEvent, IntegerFieldValueChangedEvent } from '../../vaadin-integer-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;

--- a/packages/item/test/item-mixin.test.js
+++ b/packages/item/test/item-mixin.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   enterKeyDown,
   fixtureSync,
@@ -7,12 +6,13 @@ import {
   focusout,
   mousedown,
   mouseup,
+  space,
   spaceKeyDown,
   spaceKeyUp,
-  space,
   tabKeyDown
 } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ItemMixin } from '../src/vaadin-item-mixin.js';
 
 class TestItem extends ItemMixin(PolymerElement) {

--- a/packages/list-box/test/missing-import.test.js
+++ b/packages/list-box/test/missing-import.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-list-box.js';
 
 describe('missing import', () => {

--- a/packages/login/test/login-form.test.js
+++ b/packages/login/test/login-form.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { enter, fixtureSync, tap } from '@vaadin/testing-helpers';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-import { fillUsernameAndPassword } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-login-form.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { fillUsernameAndPassword } from './helpers.js';
 
 registerStyles(
   'vaadin-login-form-wrapper',

--- a/packages/login/test/login-overlay.test.js
+++ b/packages/login/test/login-overlay.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { enter, esc, fixtureSync, tap } from '@vaadin/testing-helpers';
-import { fillUsernameAndPassword } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-login-overlay.js';
+import { fillUsernameAndPassword } from './helpers.js';
 
 describe('login overlay', () => {
   let overlay;

--- a/packages/login/test/login-submit.test.js
+++ b/packages/login/test/login-submit.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, tabKeyUp } from '@vaadin/testing-helpers';
-import { fillUsernameAndPassword } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-login-overlay.js';
 import '../vaadin-login-form.js';
+import { fillUsernameAndPassword } from './helpers.js';
 
 describe('login form submit', () => {
   let login, iframe;

--- a/packages/login/test/visual/common.js
+++ b/packages/login/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { arrowLeft, arrowRight, end, fixtureSync, focusin, home, nextRender } from '@vaadin/testing-helpers';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-menu-bar.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-menu-bar',

--- a/packages/menu-bar/test/not-animated-styles.js
+++ b/packages/menu-bar/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-context-menu-overlay',

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   arrowDown,
   arrowLeft,
@@ -11,12 +10,13 @@ import {
   isDesktopSafari as isSafari,
   isIOS,
   nextRender,
-  touchstart,
-  touchend
+  touchend,
+  touchstart
 } from '@vaadin/testing-helpers';
-import { onceOpened } from './helpers.js';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-menu-bar.js';
+import { onceOpened } from './helpers.js';
 
 describe('sub-menu', () => {
   let menu, buttons, subMenu, item;

--- a/packages/menu-bar/test/typings/menu-bar.types.ts
+++ b/packages/menu-bar/test/typings/menu-bar.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-menu-bar';
-
 import { MenuBarItem, MenuBarItemSelectedEvent } from '../../vaadin-menu-bar';
 
 const menu = document.createElement('vaadin-menu-bar');

--- a/packages/message-input/test/message-input.test.js
+++ b/packages/message-input/test/message-input.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { enterKeyDown, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-message-input.js';
 
 describe('message-input', () => {

--- a/packages/message-input/test/typings/message-input.types.ts
+++ b/packages/message-input/test/typings/message-input.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-message-input.js';
-
 import { MessageInputSubmitEvent } from '../../vaadin-message-input.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;

--- a/packages/notification/test/animation.test.js
+++ b/packages/notification/test/animation.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-notification-card',

--- a/packages/notification/test/lit.test.js
+++ b/packages/notification/test/lit.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { html, render } from 'lit';
-
 import '../vaadin-notification.js';
+import { html, render } from 'lit';
 
 describe('lit', () => {
   describe('renderer', () => {

--- a/packages/notification/test/multiple.test.js
+++ b/packages/notification/test/multiple.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-notification-card',

--- a/packages/notification/test/statichelper.test.js
+++ b/packages/notification/test/statichelper.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout } from '@vaadin/testing-helpers';
+import '../vaadin-notification.js';
 import { html } from 'lit';
 import { Notification } from '../src/vaadin-notification.js';
-import '../vaadin-notification.js';
 
 describe('static helpers', () => {
   it('show should show a text notification', () => {

--- a/packages/notification/test/template.test.js
+++ b/packages/notification/test/template.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class XNotification extends PolymerElement {
   static get template() {

--- a/packages/notification/test/typings/notification.types.ts
+++ b/packages/notification/test/typings/notification.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-notification.js';
-
 import { Notification, NotificationOpenedChangedEvent } from '../../vaadin-notification.js';
 
 const assertType = <TExpected>(value: TExpected) => value;

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { arrowDown, arrowUp, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../src/vaadin-number-field.js';
 
 describe('number-field', () => {

--- a/packages/number-field/test/typings/number-field.types.ts
+++ b/packages/number-field/test/typings/number-field.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-number-field.js';
-
 import { NumberFieldInvalidChangedEvent, NumberFieldValueChangedEvent } from '../../vaadin-number-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;

--- a/packages/number-field/test/visual/common.js
+++ b/packages/number-field/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
+import { fixtureSync, focusout, mousedown } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { fixtureSync, focusout, mousedown } from '@vaadin/testing-helpers';
 import '../src/vaadin-password-field.js';
 
 describe('password-field', () => {

--- a/packages/password-field/test/typings/password-field.types.ts
+++ b/packages/password-field/test/typings/password-field.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-password-field.js';
-
 import { PasswordFieldInvalidChangedEvent, PasswordFieldValueChangedEvent } from '../../vaadin-password-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;

--- a/packages/polymer-legacy-adapter/test/fixtures/mock-component-host.js
+++ b/packages/polymer-legacy-adapter/test/fixtures/mock-component-host.js
@@ -1,6 +1,5 @@
-import { PolymerElement, html } from '@polymer/polymer';
-
 import './mock-component.js';
+import { html, PolymerElement } from '@polymer/polymer';
 
 export class MockComponentHost extends PolymerElement {
   static get template() {

--- a/packages/polymer-legacy-adapter/test/fixtures/mock-component-slotted-host.js
+++ b/packages/polymer-legacy-adapter/test/fixtures/mock-component-slotted-host.js
@@ -1,6 +1,5 @@
-import { PolymerElement, html } from '@polymer/polymer';
-
 import './mock-component.js';
+import { html, PolymerElement } from '@polymer/polymer';
 
 export class MockComponentSlottedHost extends PolymerElement {
   static get template() {

--- a/packages/polymer-legacy-adapter/test/fixtures/mock-grid-host.js
+++ b/packages/polymer-legacy-adapter/test/fixtures/mock-grid-host.js
@@ -1,9 +1,8 @@
-import { PolymerElement, html } from '@polymer/polymer';
-
 import '@vaadin/grid';
 import '@vaadin/checkbox';
 import '@vaadin/grid/vaadin-grid-column';
 import '@vaadin/grid/vaadin-grid-tree-column';
+import { html, PolymerElement } from '@polymer/polymer';
 
 export class MockGridHost extends PolymerElement {
   static get template() {

--- a/packages/polymer-legacy-adapter/test/fixtures/mock-grid-pro-host.js
+++ b/packages/polymer-legacy-adapter/test/fixtures/mock-grid-pro-host.js
@@ -1,7 +1,6 @@
-import { PolymerElement, html } from '@polymer/polymer';
-
 import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column';
+import { html, PolymerElement } from '@polymer/polymer';
 
 export class MockGridProHost extends PolymerElement {
   static get template() {

--- a/packages/polymer-legacy-adapter/test/fixtures/mock-list-host.js
+++ b/packages/polymer-legacy-adapter/test/fixtures/mock-list-host.js
@@ -1,6 +1,5 @@
-import { PolymerElement, html } from '@polymer/polymer';
-
 import './mock-list.js';
+import { html, PolymerElement } from '@polymer/polymer';
 
 export class MockListHost extends PolymerElement {
   static get template() {

--- a/packages/polymer-legacy-adapter/test/grid-body.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-body.test.js
@@ -1,12 +1,10 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/grid';
-import { GridTemplatizer } from '../src/template-renderer-grid-templatizer.js';
-
 import '../template-renderer.js';
-
 import './fixtures/mock-grid-host.js';
+import { GridTemplatizer } from '../src/template-renderer-grid-templatizer.js';
 
 describe('grid body template', () => {
   function fixtureGrid() {

--- a/packages/polymer-legacy-adapter/test/grid-editor.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-editor.test.js
@@ -1,12 +1,10 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
+import { enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/grid-pro';
-import { fixtureSync, nextRender, enter } from '@vaadin/testing-helpers';
-import { GridTemplatizer } from '../src/template-renderer-grid-templatizer.js';
-
 import '../template-renderer.js';
-
 import './fixtures/mock-grid-pro-host.js';
+import { GridTemplatizer } from '../src/template-renderer-grid-templatizer.js';
 
 describe('grid editor template', () => {
   function fixtureGrid() {

--- a/packages/polymer-legacy-adapter/test/grid-footer.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-footer.test.js
@@ -1,12 +1,10 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/grid';
-import { Templatizer } from '../src/template-renderer-templatizer.js';
-
 import '../template-renderer.js';
-
 import './fixtures/mock-grid-host.js';
+import { Templatizer } from '../src/template-renderer-templatizer.js';
 
 describe('grid footer template', () => {
   function fixtureGrid() {

--- a/packages/polymer-legacy-adapter/test/grid-header.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-header.test.js
@@ -1,12 +1,10 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/grid';
-import { Templatizer } from '../src/template-renderer-templatizer.js';
-
 import '../template-renderer.js';
-
 import './fixtures/mock-grid-host.js';
+import { Templatizer } from '../src/template-renderer-templatizer.js';
 
 describe('grid header template', () => {
   function fixtureGrid() {

--- a/packages/polymer-legacy-adapter/test/grid-row-details.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-row-details.test.js
@@ -1,12 +1,10 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import '@vaadin/grid';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { GridTemplatizer } from '../src/template-renderer-grid-templatizer.js';
-
+import sinon from 'sinon';
+import '@vaadin/grid';
 import '../template-renderer.js';
-
 import './fixtures/mock-grid-host.js';
+import { GridTemplatizer } from '../src/template-renderer-grid-templatizer.js';
 
 describe('row details template', () => {
   function fixtureGrid() {

--- a/packages/polymer-legacy-adapter/test/list.test.js
+++ b/packages/polymer-legacy-adapter/test/list.test.js
@@ -1,9 +1,7 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, fire, click } from '@vaadin/testing-helpers';
-
+import { click, fire, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../template-renderer.js';
-
 import './fixtures/mock-list-host.js';
 import './fixtures/mock-list.js';
 

--- a/packages/polymer-legacy-adapter/test/observer.test.js
+++ b/packages/polymer-legacy-adapter/test/observer.test.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-
 import '../template-renderer.js';
-
 import './fixtures/mock-component.js';
 import './fixtures/mock-component-slotted-host.js';
 

--- a/packages/polymer-legacy-adapter/test/style-modules-lazy-import.test.js
+++ b/packages/polymer-legacy-adapter/test/style-modules-lazy-import.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 function defineCustomElement(name) {
   customElements.define(

--- a/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
+++ b/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
@@ -1,13 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { click, fire, fixtureSync } from '@vaadin/testing-helpers';
-
+import sinon from 'sinon';
 import '../template-renderer.js';
-import { Templatizer } from '../src/template-renderer-templatizer.js';
-
 import './fixtures/mock-component.js';
 import './fixtures/mock-component-host.js';
 import './fixtures/mock-component-slotted-host.js';
+import { Templatizer } from '../src/template-renderer-templatizer.js';
 
 describe('vaadin-template-renderer', () => {
   describe('basic', () => {

--- a/packages/polymer-legacy-adapter/test/warning.test.js
+++ b/packages/polymer-legacy-adapter/test/warning.test.js
@@ -1,9 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-
+import sinon from 'sinon';
 import '../template-renderer.js';
-
 import './fixtures/mock-component.js';
 
 describe('warning', () => {

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -1,7 +1,7 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, mousedown, mouseup, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
-import { fixtureSync, nextFrame, fire, mousedown, mouseup } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-radio-button.js';
 
 describe('radio-button', () => {

--- a/packages/radio-group/test/radio-group-keyboard-navigation.test.js
+++ b/packages/radio-group/test/radio-group-keyboard-navigation.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
+import { fixtureSync, isFirefox, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
-import { fixtureSync, nextFrame, isFirefox } from '@vaadin/testing-helpers';
 import '../vaadin-radio-group.js';
 
 describe('keyboard navigation', () => {

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -1,7 +1,7 @@
-import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '../vaadin-radio-group.js';
 
 describe('radio-group', () => {

--- a/packages/radio-group/test/typings/radio-button.types.ts
+++ b/packages/radio-group/test/typings/radio-button.types.ts
@@ -1,14 +1,14 @@
+import '../../vaadin-radio-button.js';
+import '../../vaadin-radio-group.js';
 import { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { CheckedMixinClass } from '@vaadin/field-base/src/checked-mixin.js';
 import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
 import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import '../../vaadin-radio-button.js';
-import '../../vaadin-radio-group.js';
 import { RadioButtonCheckedChangedEvent } from '../../vaadin-radio-button.js';
 import { RadioGroupInvalidChangedEvent, RadioGroupValueChangedEvent } from '../../vaadin-radio-group.js';
 

--- a/packages/radio-group/test/visual/lumo/radio-button.test.js
+++ b/packages/radio-group/test/visual/lumo/radio-button.test.js
@@ -1,6 +1,6 @@
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../../theme/lumo/vaadin-radio-button.js';
 
 describe('radio-button', () => {

--- a/packages/radio-group/test/visual/lumo/radio-group.test.js
+++ b/packages/radio-group/test/visual/lumo/radio-group.test.js
@@ -1,5 +1,5 @@
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/lumo/vaadin-radio-group.js';
 

--- a/packages/radio-group/test/visual/material/radio-button.test.js
+++ b/packages/radio-group/test/visual/material/radio-button.test.js
@@ -1,6 +1,6 @@
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../../theme/material/vaadin-radio-button.js';
 
 describe('radio-button', () => {

--- a/packages/radio-group/test/visual/material/radio-group.test.js
+++ b/packages/radio-group/test/visual/material/radio-group.test.js
@@ -1,5 +1,5 @@
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/material/vaadin-radio-group.js';
 

--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { down, fixtureSync, focusin, isFirefox, keyboardEventFor } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-rich-text-editor.js';
 
 describe('accessibility', () => {

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, focusout, isDesktopSafari, isFirefox, nextRender } from '@vaadin/testing-helpers';
-import { createImage } from './helpers.js';
+import sinon from 'sinon';
 import '../vaadin-rich-text-editor.js';
+import { createImage } from './helpers.js';
 
 describe('rich text editor', () => {
   'use strict';

--- a/packages/rich-text-editor/test/typings/rich-text-editor.types.ts
+++ b/packages/rich-text-editor/test/typings/rich-text-editor.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-rich-text-editor.js';
-
 import { RichTextEditorHtmlValueChangedEvent, RichTextEditorValueChangedEvent } from '../../vaadin-rich-text-editor.js';
 
 const customField = document.createElement('vaadin-rich-text-editor');

--- a/packages/select/test/accessibility.test.js
+++ b/packages/select/test/accessibility.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { html, render } from 'lit';
 import { sendKeys } from '@web/test-runner-commands';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
 import './not-animated-styles.js';
 import '../vaadin-select.js';
+import { html, render } from 'lit';
 
 describe('accessibility', () => {
   let select, valueButton;

--- a/packages/select/test/not-animated-styles.js
+++ b/packages/select/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-select-overlay',

--- a/packages/select/test/renderer.test.js
+++ b/packages/select/test/renderer.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
 import './not-animated-styles.js';

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   arrowDown,
   arrowUp,
@@ -8,17 +7,18 @@ import {
   enterKeyUp,
   escKeyDown,
   fixtureSync,
-  nextFrame,
-  tab,
   keyboardEventFor,
   keyDownChar,
-  spaceKeyDown
+  nextFrame,
+  spaceKeyDown,
+  tab
 } from '@vaadin/testing-helpers';
-import { html, render } from 'lit';
+import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
 import './not-animated-styles.js';
 import '../vaadin-select.js';
+import { html, render } from 'lit';
 
 describe('vaadin-select', () => {
   let select, valueButton;

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-select.js';
-
 import {
   Select,
   SelectInvalidChangedEvent,

--- a/packages/select/test/visual/lumo/select.test.js
+++ b/packages/select/test/visual/lumo/select.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/item/theme/lumo/vaadin-item.js';
 import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
 import '../../not-animated-styles.js';

--- a/packages/select/test/visual/material/select.test.js
+++ b/packages/select/test/visual/material/select.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/item/theme/material/vaadin-item.js';
 import '@vaadin/list-box/theme/material/vaadin-list-box.js';
 import '../../not-animated-styles.js';

--- a/packages/split-layout/test/split-layout.test.js
+++ b/packages/split-layout/test/split-layout.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, aTimeout, track } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, track } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-split-layout.js';
 

--- a/packages/tabs/test/tabs.test.js
+++ b/packages/tabs/test/tabs.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { arrowRight, enter, fixtureSync, listenOnce, nextRender, space } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-tabs.js';
 
 describe('tabs', () => {

--- a/packages/tabs/test/typings/tabs.types.ts
+++ b/packages/tabs/test/typings/tabs.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-tabs.js';
-
 import { TabsItemsChangedEvent, TabsSelectedChangedEvent } from '../../vaadin-tabs.js';
 
 const tabs = document.createElement('vaadin-tabs');

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../src/vaadin-text-area.js';
 
 describe('text-area', () => {

--- a/packages/text-field/test/text-field.test.js
+++ b/packages/text-field/test/text-field.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../src/vaadin-text-field.js';
 
 describe('text-field', () => {

--- a/packages/text-field/test/typings/text-field.types.ts
+++ b/packages/text-field/test/typings/text-field.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-text-field.js';
-
 import { TextFieldInvalidChangedEvent, TextFieldValueChangedEvent } from '../../vaadin-text-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;

--- a/packages/text-field/test/visual/common.js
+++ b/packages/text-field/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/text-field/test/visual/lumo/text-field.test.js
+++ b/packages/text-field/test/visual/lumo/text-field.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/lumo/vaadin-text-field.js';
 

--- a/packages/text-field/test/visual/material/text-field.test.js
+++ b/packages/text-field/test/visual/material/text-field.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/material/vaadin-text-field.js';
 

--- a/packages/time-picker/test/aria.test.js
+++ b/packages/time-picker/test/aria.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, arrowDownKeyDown, escKeyDown, nextFrame } from '@vaadin/testing-helpers';
+import { arrowDownKeyDown, escKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../src/vaadin-time-picker.js';
 
 describe('ARIA', () => {

--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { arrowDown, arrowUp, aTimeout, esc, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-time-picker.js';
 
 describe('keyboard navigation', () => {

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
+import { arrowDown, arrowUp, enter, esc, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { arrowDown, arrowUp, enter, esc, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-time-picker.js';
 
 describe('time-picker', () => {

--- a/packages/time-picker/test/typings/time-picker.types.ts
+++ b/packages/time-picker/test/typings/time-picker.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-time-picker.js';
-
 import { TimePickerInvalidChangedEvent, TimePickerValueChangedEvent } from '../../vaadin-time-picker.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;

--- a/packages/time-picker/test/visual/common.js
+++ b/packages/time-picker/test/visual/common.js
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/time-picker/test/visual/lumo/time-picker.test.js
+++ b/packages/time-picker/test/visual/lumo/time-picker.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/lumo/vaadin-time-picker.js';
 

--- a/packages/time-picker/test/visual/material/time-picker.test.js
+++ b/packages/time-picker/test/visual/material/time-picker.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
-import { visualDiff } from '@web/test-runner-visual-regression';
 import { sendKeys } from '@web/test-runner-commands';
+import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
 import '../../../theme/material/vaadin-time-picker.js';
 

--- a/packages/upload/test/a11y.test.js
+++ b/packages/upload/test/a11y.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { createFile } from './common.js';
 import '../vaadin-upload.js';
+import { createFile } from './common.js';
 
 const FAKE_FILE = createFile(100000, 'application/uknown');
 

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { createFile, createFiles, touchDevice, xhrCreator } from './common.js';
+import sinon from 'sinon';
 import '../vaadin-upload.js';
+import { createFile, createFiles, touchDevice, xhrCreator } from './common.js';
 
 describe('file list', () => {
   let upload, file, files;

--- a/packages/upload/test/file-list.test.js
+++ b/packages/upload/test/file-list.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import { createFiles, xhrCreator } from './common.js';
 import '../vaadin-upload.js';
+import { createFiles, xhrCreator } from './common.js';
 
 describe('file list', () => {
   let upload;

--- a/packages/upload/test/file.test.js
+++ b/packages/upload/test/file.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { createFile } from './common.js';
 import '../vaadin-upload.js';
+import { createFile } from './common.js';
 
 describe('<vaadin-upload-file> element', () => {
   let fileElement, fileObject;

--- a/packages/upload/test/keyboard-navigation.test.js
+++ b/packages/upload/test/keyboard-navigation.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { sendKeys } from '@web/test-runner-commands';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { createFile } from './common.js';
+import { sendKeys } from '@web/test-runner-commands';
 import '../vaadin-upload.js';
+import { createFile } from './common.js';
 
 const FAKE_FILE = createFile(100000, 'application/uknown');
 

--- a/packages/upload/test/typings/upload.types.ts
+++ b/packages/upload/test/typings/upload.types.ts
@@ -1,10 +1,9 @@
 import '../../vaadin-upload.js';
-
 import {
-  UploadFile,
   UploadAbortEvent,
   UploadBeforeEvent,
   UploadErrorEvent,
+  UploadFile,
   UploadFileRejectEvent,
   UploadFilesChangedEvent,
   UploadMaxFilesReachedChangedEvent,

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-upload.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { createFile, createFiles, xhrCreator } from './common.js';
-import '../vaadin-upload.js';
 
 describe('upload', () => {
   let upload, file;

--- a/packages/vaadin-list-mixin/test/list-mixin.test.js
+++ b/packages/vaadin-list-mixin/test/list-mixin.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import {
   arrowDown,
   arrowLeft,
@@ -11,9 +10,10 @@ import {
   keyDownChar,
   nextFrame
 } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { MultiSelectListMixin } from '../vaadin-multi-select-list-mixin.js';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ListMixin } from '../vaadin-list-mixin.js';
+import { MultiSelectListMixin } from '../vaadin-multi-select-list-mixin.js';
 
 customElements.define(
   'test-list-element',

--- a/packages/vaadin-overlay/test/animations.test.js
+++ b/packages/vaadin-overlay/test/animations.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { escKeyDown, fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '../vaadin-overlay.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-overlay',

--- a/packages/vaadin-overlay/test/focus-trap.test.js
+++ b/packages/vaadin-overlay/test/focus-trap.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, oneEvent, tabKeyDown, nextRender } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import '@vaadin/button/vaadin-button.js';
 import '@vaadin/text-field/vaadin-text-field.js';
 import '@vaadin/radio-group/vaadin-radio-group.js';
 import '@vaadin/radio-group/vaadin-radio-button.js';
 import '../vaadin-overlay.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 const shadowTemplate = document.createElement('template');
 shadowTemplate.innerHTML = `

--- a/packages/vaadin-overlay/test/legacy.test.js
+++ b/packages/vaadin-overlay/test/legacy.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { escKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
+import sinon from 'sinon';
 import { IronOverlayBehavior } from '@polymer/iron-overlay-behavior/iron-overlay-behavior.js';
+import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { OverlayElement } from '../src/vaadin-overlay.js';
 
 Polymer({

--- a/packages/vaadin-overlay/test/lit.test.js
+++ b/packages/vaadin-overlay/test/lit.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { html, render } from 'lit';
-
 import '../vaadin-overlay.js';
+import { html, render } from 'lit';
 
 describe('lit', () => {
   describe('renderer', () => {

--- a/packages/vaadin-overlay/test/multiple.test.js
+++ b/packages/vaadin-overlay/test/multiple.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { click, escKeyDown, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-overlay.js';
 
 describe('multiple overlays', () => {

--- a/packages/vaadin-overlay/test/overlay.test.js
+++ b/packages/vaadin-overlay/test/overlay.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { click, enterKeyDown, escKeyDown, fixtureSync, mousedown, mouseup, oneEvent } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
 import '../vaadin-overlay.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 customElements.define(
   'overlay-wrapper',

--- a/packages/vaadin-overlay/test/position-target.test.js
+++ b/packages/vaadin-overlay/test/position-target.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-overlay.js';
 import { css } from 'lit';
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
-import { PositionMixin } from '../src/vaadin-overlay-position-mixin.js';
 import { OverlayElement } from '../src/vaadin-overlay.js';
-import '../vaadin-overlay.js';
+import { PositionMixin } from '../src/vaadin-overlay-position-mixin.js';
 
 class PositionedOverlay extends PositionMixin(OverlayElement) {
   static get is() {

--- a/packages/vaadin-overlay/test/renderer.test.js
+++ b/packages/vaadin-overlay/test/renderer.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-overlay.js';
 
 describe('renderer', () => {

--- a/packages/vaadin-overlay/test/restore-focus.test.js
+++ b/packages/vaadin-overlay/test/restore-focus.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '@vaadin/text-field/vaadin-text-field.js';
-import { open, close } from './helpers.js';
 import '../src/vaadin-overlay.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { close, open } from './helpers.js';
 
 customElements.define(
   'overlay-field-wrapper',

--- a/packages/vaadin-overlay/test/styling.test.js
+++ b/packages/vaadin-overlay/test/styling.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import '../vaadin-overlay.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'overlay-local-styles',

--- a/packages/vaadin-overlay/test/template.test.js
+++ b/packages/vaadin-overlay/test/template.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import '../vaadin-overlay.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 customElements.define(
   'overlay-opened-wrapper',

--- a/packages/vaadin-overlay/test/typings/overlay.types.ts
+++ b/packages/vaadin-overlay/test/typings/overlay.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-overlay.js';
-
 import { OverlayOpenedChangedEvent } from '../../vaadin-overlay.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;

--- a/packages/vaadin-themable-mixin/test/register-styles.test.js
+++ b/packages/vaadin-themable-mixin/test/register-styles.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { registerStyles, css, unsafeCSS } from '../register-styles.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { css, registerStyles, unsafeCSS } from '../register-styles.js';
 import { ThemableMixin } from '../vaadin-themable-mixin.js';
 
 let attachedInstances = [];

--- a/packages/vaadin-themable-mixin/test/themable-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/themable-mixin.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { ThemableMixin, registerStyles, css } from '../vaadin-themable-mixin.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { css, registerStyles, ThemableMixin } from '../vaadin-themable-mixin.js';
 
 let createStyles =
   window.createStylesFunction ||

--- a/packages/vaadin-themable-mixin/test/theme-property-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/theme-property-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ThemePropertyMixin } from '../vaadin-theme-property-mixin.js';
 
 class ThemeHostElement extends ThemePropertyMixin(PolymerElement) {

--- a/packages/vaadin-themable-mixin/test/typings/register-styles.types.ts
+++ b/packages/vaadin-themable-mixin/test/typings/register-styles.types.ts
@@ -1,4 +1,4 @@
-import { registerStyles, css } from '../../register-styles.js';
+import { css, registerStyles } from '../../register-styles.js';
 
 registerStyles(
   'vaadin-grid',

--- a/packages/vertical-layout/test/vertical-layout.test.js
+++ b/packages/vertical-layout/test/vertical-layout.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { getComputedCSSPropertyValue } from './common.js';
 import '../vaadin-vertical-layout.js';
+import { getComputedCSSPropertyValue } from './common.js';
 
 describe('vaadin-vertical-layout', () => {
   describe('basic features', () => {

--- a/packages/virtual-list/test/lit.test.js
+++ b/packages/virtual-list/test/lit.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { html, render } from 'lit';
 import '../vaadin-virtual-list.js';
+import { html, render } from 'lit';
 
 describe('lit', () => {
   describe('renderer', () => {

--- a/packages/virtual-list/test/typings/virtual-list.types.ts
+++ b/packages/virtual-list/test/typings/virtual-list.types.ts
@@ -1,5 +1,4 @@
 import '../../vaadin-virtual-list.js';
-
 import { VirtualList, VirtualListItemModel, VirtualListRenderer } from '../../vaadin-virtual-list.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;


### PR DESCRIPTION
## Description

The PR sorts import statements in the unit and visual tests with the `simple-import-sort` ESLint plugin.

The following configuration is used:

```js
"overrides": [
  {
    "files": ["packages/**/test/**"],
    "rules": {
      "simple-import-sort/imports": [
        "error",
        {
          "groups": [
            [
              // Testing tools group
              "^(@esm-bundle|@web|@vaadin/testing-helpers|sinon)",
              // Side-effects group
              "^\\u0000",
              // External group
              "^",
              // Vaadin group
              "^@vaadin",
              // Parent group
              "^\\.\\.",
              // Sibling group
              "^\\."
            ]
          ]
        }
      ]
    }
  }
]
```

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
