### PR TITLE
feat: add support for items property in select

### DIFF
--- a/packages/select/src/vaadin-select-item.js
+++ b/packages/select/src/vaadin-select-item.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Item } from '@vaadin/item/src/vaadin-item.js';
+
+/**
+ * An element used internally by `<vaadin-select>`. Not intended to be used separately.
+ *
+ * @extends Item
+ * @protected
+ */
+class SelectItem extends Item {
+  static get is() {
+    return 'vaadin-select-item';
+  }
+}
+
+customElements.define(SelectItem.is, SelectItem);

--- a/packages/select/src/vaadin-select-list-box.js
+++ b/packages/select/src/vaadin-select-list-box.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
+
+/**
+ * An element used internally by `<vaadin-select>`. Not intended to be used separately.
+ *
+ * @extends ListBox
+ * @protected
+ */
+class SelectListBox extends ListBox {
+  static get is() {
+    return 'vaadin-select-list-box';
+  }
+}
+
+customElements.define(SelectListBox.is, SelectListBox);

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -14,14 +14,14 @@ registerStyles(
       min-width: 0;
     }
 
-    ::slotted(vaadin-item) {
+    ::slotted(:not([slot])) {
       padding-left: 0;
       padding-right: 0;
       flex: auto;
     }
 
     /* placeholder styles */
-    ::slotted(:not([selected])) {
+    ::slotted(:not([slot]):not([selected])) {
       line-height: normal;
     }
 

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -53,17 +53,34 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
 /**
  * `<vaadin-select>` is a Web Component for selecting values from a list of items.
  *
+ * ### Items
+ *
+ * Use the `items` property to define possible options for the select:
+ *
+ * ```html
+ * <vaadin-select id="select"></vaadin-select>
+ * ```
+ * ```js
+ * const select = document.querySelector('#select');
+ * select.items = [
+ *   { label: 'Most recent first', value: 'recent' },
+ *   { component: 'hr' },
+ *   { label: 'Rating: low to high', value: 'rating-asc' },
+ *   { label: 'Rating: high to low', value: 'rating-desc' },
+ *   { component: 'hr' },
+ *   { label: 'Price: low to high', value: 'price-asc', disabled: true },
+ *   { label: 'Price: high to low', value: 'price-desc', disabled: true }
+ * ];
+ * ```
+ *
  * ### Rendering
  *
- * The content of the select can be populated by using the renderer callback function.
+ * Alternatively, the content of the select can be populated by using the renderer callback function.
  *
  * The renderer function provides `root`, `select` arguments.
  * Generate DOM content, append it to the `root` element and control the state
  * of the host element by accessing `select`.
  *
- * ```html
- * <vaadin-select id="select"></vaadin-select>
- * ```
  * ```js
  * const select = document.querySelector('#select');
  * select.renderer = function(root, select) {
@@ -139,17 +156,25 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  */
 declare class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(ThemableMixin(HTMLElement))))) {
   /**
-   * An array containing items that will be rendered as the select's options.
+   * An array containing items that will be rendered as the options of the select.
    *
    * #### Example
    * ```js
    * select.items = [
-   *   { label: 'Jose', value: 'jose' },
+   *   { label: 'Most recent first', value: 'recent' },
    *   { component: 'hr' },
-   *   { label: 'Pedro', value: 'pedro' },
-   *   { label: 'Manolo', value: 'manolo', disabled: true }
+   *   { label: 'Rating: low to high', value: 'rating-asc' },
+   *   { label: 'Rating: high to low', value: 'rating-desc' },
+   *   { component: 'hr' },
+   *   { label: 'Price: low to high', value: 'price-asc', disabled: true },
+   *   { label: 'Price: high to low', value: 'price-desc', disabled: true }
    * ];
    * ```
+   *
+   * Note: each item is rendered by default as the internal `<vaadin-select-item>` that is an extension of `<vaadin-item>`.
+   * To render the item with a custom component, provide a tag name by the `component` property.
+   *
+   * @type {!Array<!SelectItem>}
    */
   items: SelectItem[] | null | undefined;
 

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -11,7 +11,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 
 export interface SelectItem {
   label?: string;
-  component?: string | HTMLElement;
+  component?: string;
   disabled?: boolean;
 }
 
@@ -140,9 +140,6 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
 declare class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(ThemableMixin(HTMLElement))))) {
   /**
    * An array containing items that will be rendered as the select's options.
-   *
-   * The item is rendered with a custom component if a tag name or an element reference
-   * is passed by the `component` property.
    *
    * #### Example
    ```js

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -142,15 +142,15 @@ declare class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixi
    * An array containing items that will be rendered as the select's options.
    *
    * #### Example
-   ```js
-    * select.items = [
-    *   { label: 'Jose', value: 'jose' },
-    *   { component: 'hr' },
-    *   { label: 'Pedro', value: 'pedro' },
-    *   { label: 'Manolo', value: 'manolo', disabled: true }
-    * ];
-    * ```
-    */
+   * ```js
+   * select.items = [
+   *   { label: 'Jose', value: 'jose' },
+   *   { component: 'hr' },
+   *   { label: 'Pedro', value: 'pedro' },
+   *   { label: 'Manolo', value: 'manolo', disabled: true }
+   * ];
+   * ```
+   */
   items: SelectItem[];
 
   /**

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -9,6 +9,12 @@ import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
+export interface SelectItem {
+  label?: string;
+  component?: string | HTMLElement;
+  disabled?: boolean;
+}
+
 /**
  * Function for rendering the content of the `<vaadin-select>`.
  * Receives two arguments:
@@ -132,6 +138,11 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 declare class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(ThemableMixin(HTMLElement))))) {
+  /**
+   * An array of items.
+   */
+  items: SelectItem[];
+
   /**
    * Set when the select is open
    */

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -139,8 +139,21 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  */
 declare class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(ThemableMixin(HTMLElement))))) {
   /**
-   * An array of items.
-   */
+   * An array containing items that will be rendered as the select's options.
+   *
+   * The item is rendered with a custom component if a tag name or an element reference
+   * is passed by the `component` property.
+   *
+   * #### Example
+   ```js
+    * select.items = [
+    *   { label: 'Jose', value: 'jose' },
+    *   { component: 'hr' },
+    *   { label: 'Pedro', value: 'pedro' },
+    *   { label: 'Manolo', value: 'manolo', disabled: true }
+    * ];
+    * ```
+    */
   items: SelectItem[];
 
   /**

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -151,7 +151,7 @@ declare class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixi
    * ];
    * ```
    */
-  items: SelectItem[];
+  items: SelectItem[] | null | undefined;
 
   /**
    * Set when the select is open

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -173,7 +173,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
        * An array containing items that will be rendered as the select's options.
        *
        * #### Example
-       ```js
+       * ```js
        * select.items = [
        *   { label: 'Jose', value: 'jose' },
        *   { component: 'hr' },

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -5,6 +5,8 @@
  */
 import '@polymer/iron-media-query/iron-media-query.js';
 import '@vaadin/input-container/src/vaadin-input-container.js';
+import './vaadin-select-item.js';
+import './vaadin-select-list-box.js';
 import './vaadin-select-overlay.js';
 import './vaadin-select-value-button.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -561,7 +563,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
 
     const label = selected.getAttribute('label');
     if (label) {
-      labelItem = this.__createItemElement({ label });
+      labelItem = this.__createItemElement({ label, component: 'vaadin-item' });
     } else {
       labelItem = selected.cloneNode(true);
     }
@@ -580,7 +582,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    * @private
    */
   __createItemElement(item) {
-    const itemElement = document.createElement(item.component || 'vaadin-item');
+    const itemElement = document.createElement(item.component || 'vaadin-select-item');
     if (item.label) {
       itemElement.textContent = item.label;
     }
@@ -701,7 +703,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
 
     let listBox = root.firstElementChild;
     if (!listBox) {
-      listBox = document.createElement('vaadin-list-box');
+      listBox = document.createElement('vaadin-select-list-box');
       root.appendChild(listBox);
     }
 

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -183,9 +183,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       /**
        * An array containing items that will be rendered as the select's options.
        *
-       * The item is rendered with a custom component if a tag name or an element reference
-       * is passed by the `component` property.
-       *
        * #### Example
        ```js
        * select.items = [
@@ -427,9 +424,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    * @private
    */
   __itemsChanged() {
-    if (this.__renderer === this.__defaultRenderer) {
-      this.requestContentUpdate();
-    }
+    this.requestContentUpdate();
   }
 
   /** @private */

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -175,10 +175,10 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
        * @type {boolean}
        * @private
        */
-      __initialized: {
-        type: Boolean,
-        value: true
-      },
+      // __initialized: {
+      //   type: Boolean,
+      //   value: true
+      // },
 
       /**
        * An array containing items that will be rendered as the select's options.
@@ -229,9 +229,9 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
        * @type {!SelectRenderer}
        * @private
        */
-      __renderer: {
+      __computedRenderer: {
         type: Function,
-        computed: '__computeRenderer(renderer, __initialized)'
+        computed: '__computeRenderer(renderer, __defaultRenderer)'
       },
 
       /**
@@ -310,7 +310,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       '_updateAriaExpanded(opened)',
       '_updateAriaRequired(required)',
       '_updateSelectedItem(value, _items, placeholder)',
-      '__rendererChanged(__renderer, _overlayElement)'
+      '__computedRendererChanged(__computedRenderer, _overlayElement)'
     ];
   }
 
@@ -404,7 +404,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    * @param {SelectOverlay} overlay
    * @private
    */
-  __rendererChanged(renderer, overlay) {
+  __computedRendererChanged(renderer, overlay) {
     if (!overlay) {
       return;
     }
@@ -721,16 +721,18 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
   }
 
   /**
-   * Computes the final renderer for the `__renderer` property.
+   * Computes the final renderer for the `__computedRenderer` property.
+   * @param {SelectRenderer | undefined} renderer
+   * @param {!SelectRenderer} defaultRenderer
    * @return {!SelectRenderer}
    * @private
    */
-  __computeRenderer(renderer) {
+  __computeRenderer(renderer, defaultRenderer) {
     if (renderer) {
       return renderer;
     }
 
-    return this.__defaultRenderer;
+    return defaultRenderer;
   }
 
   /**

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -170,17 +170,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
   static get properties() {
     return {
       /**
-       * Polymer doesn't invoke observer during initialization when all of its dependencies are `undefined`.
-       * This internal property can be used to force Polymer to invoke such an observer during initialization.
-       * @type {boolean}
-       * @private
-       */
-      // __initialized: {
-      //   type: Boolean,
-      //   value: true
-      // },
-
-      /**
        * An array containing items that will be rendered as the select's options.
        *
        * #### Example
@@ -222,17 +211,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
        * @type {!SelectRenderer | undefined}
        */
       renderer: Function,
-
-      /**
-       * Represents the final renderer computed on the set of observable arguments.
-       * It is supposed to be used internally when rendering the select's content.
-       * @type {!SelectRenderer}
-       * @private
-       */
-      __computedRenderer: {
-        type: Function,
-        computed: '__computeRenderer(renderer, __defaultRenderer)'
-      },
 
       /**
        * It stores the the `value` property of the selected item, providing the
@@ -310,7 +288,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       '_updateAriaExpanded(opened)',
       '_updateAriaRequired(required)',
       '_updateSelectedItem(value, _items, placeholder)',
-      '__computedRendererChanged(__computedRenderer, _overlayElement)'
+      '_rendererChanged(renderer, _overlayElement)'
     ];
   }
 
@@ -404,12 +382,12 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    * @param {SelectOverlay} overlay
    * @private
    */
-  __computedRendererChanged(renderer, overlay) {
+  _rendererChanged(renderer, overlay) {
     if (!overlay) {
       return;
     }
 
-    overlay.setProperties({ owner: this, renderer });
+    overlay.setProperties({ owner: this, renderer: renderer || this.__defaultRenderer });
 
     this.requestContentUpdate();
 
@@ -418,11 +396,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
     }
   }
 
-  /**
-   * @param {Array<!SelectItem> | undefined} newItems
-   * @param {Array<!SelectItem> | undefined} oldItems
-   * @private
-   */
+  /** @private */
   __itemsChanged() {
     this.requestContentUpdate();
   }
@@ -711,21 +685,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    */
   validate() {
     return !(this.invalid = !(this.disabled || !this.required || this.value));
-  }
-
-  /**
-   * Computes the final renderer for the `__computedRenderer` property.
-   * @param {SelectRenderer | undefined} renderer
-   * @param {!SelectRenderer} defaultRenderer
-   * @return {!SelectRenderer}
-   * @private
-   */
-  __computeRenderer(renderer, defaultRenderer) {
-    if (renderer) {
-      return renderer;
-    }
-
-    return defaultRenderer;
   }
 
   /**

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -422,8 +422,8 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
   }
 
   /**
-   * @param {SelectItem[]} newItems
-   * @param {SelectItem[] | undefined} oldItems
+   * @param {SelectItem[] | undefined | null} newItems
+   * @param {SelectItem[] | undefined | null} oldItems
    * @private
    */
   __itemsChanged(newItems, oldItems) {

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -24,17 +24,34 @@ registerStyles('vaadin-select', [fieldShared, inputFieldContainer], { moduleId: 
 /**
  * `<vaadin-select>` is a Web Component for selecting values from a list of items.
  *
+ * ### Items
+ *
+ * Use the `items` property to define possible options for the select:
+ *
+ * ```html
+ * <vaadin-select id="select"></vaadin-select>
+ * ```
+ * ```js
+ * const select = document.querySelector('#select');
+ * select.items = [
+ *   { label: 'Most recent first', value: 'recent' },
+ *   { component: 'hr' },
+ *   { label: 'Rating: low to high', value: 'rating-asc' },
+ *   { label: 'Rating: high to low', value: 'rating-desc' },
+ *   { component: 'hr' },
+ *   { label: 'Price: low to high', value: 'price-asc', disabled: true },
+ *   { label: 'Price: high to low', value: 'price-desc', disabled: true }
+ * ];
+ * ```
+ *
  * ### Rendering
  *
- * The content of the select can be populated by using the renderer callback function.
+ * Alternatively, the content of the select can be populated by using the renderer callback function.
  *
  * The renderer function provides `root`, `select` arguments.
  * Generate DOM content, append it to the `root` element and control the state
  * of the host element by accessing `select`.
  *
- * ```html
- * <vaadin-select id="select"></vaadin-select>
- * ```
  * ```js
  * const select = document.querySelector('#select');
  * select.renderer = function(root, select) {
@@ -172,17 +189,24 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
   static get properties() {
     return {
       /**
-       * An array containing items that will be rendered as the select's options.
+       * An array containing items that will be rendered as the options of the select.
        *
        * #### Example
        * ```js
        * select.items = [
-       *   { label: 'Jose', value: 'jose' },
+       *   { label: 'Most recent first', value: 'recent' },
        *   { component: 'hr' },
-       *   { label: 'Pedro', value: 'pedro' },
-       *   { label: 'Manolo', value: 'manolo', disabled: true }
+       *   { label: 'Rating: low to high', value: 'rating-asc' },
+       *   { label: 'Rating: high to low', value: 'rating-desc' },
+       *   { component: 'hr' },
+       *   { label: 'Price: low to high', value: 'price-asc', disabled: true },
+       *   { label: 'Price: high to low', value: 'price-desc', disabled: true }
        * ];
        * ```
+       *
+       * Note: each item is rendered by default as the internal `<vaadin-select-item>` that is an extension of `<vaadin-item>`.
+       * To render the item with a custom component, provide a tag name by the `component` property.
+       *
        * @type {!Array<!SelectItem>}
        */
       items: {

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -688,7 +688,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
   }
 
   /**
-   * Renders items provided by the `items` property.
+   * Renders items when they are provided by the `items` property and clears the content otherwise.
    * @param {HTMLElement} root
    * @param {Select} _select
    * @private

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -181,7 +181,10 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       },
 
       /**
-       * An array containing the items, which will be rendered as the select options.
+       * An array containing items that will be rendered as the select's options.
+       *
+       * The item is rendered with a custom component if a tag name or an element reference
+       * is passed by the `component` property.
        *
        * #### Example
        ```js
@@ -196,7 +199,8 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
        */
       items: {
         type: Array,
-        value: () => []
+        value: () => [],
+        observer: '__itemsChanged'
       },
 
       /**
@@ -417,6 +421,17 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
     }
   }
 
+  /**
+   * @param {Array<!SelectItem> | undefined} newItems
+   * @param {Array<!SelectItem> | undefined} oldItems
+   * @private
+   */
+  __itemsChanged() {
+    if (this.__renderer === this.__defaultRenderer) {
+      this.requestContentUpdate();
+    }
+  }
+
   /** @private */
   _assignMenuElement() {
     const menuElement = this.__getMenuElement();
@@ -617,22 +632,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
   }
 
   /**
-   * @param {Array<!SelectItem> | undefined} newItems
-   * @param {Array<!SelectItem> | undefined} oldItems
-   * @private
-   */
-  __itemsChanged(newItems, oldItems) {
-    // Skip at initialization.
-    if (!newItems && !oldItems) {
-      return;
-    }
-
-    if (this.__renderer === this.__defaultRenderer) {
-      this.requestContentUpdate();
-    }
-  }
-
-  /**
    * @param {!HTMLElement} itemElement
    * @private
    */
@@ -746,21 +745,21 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    * @private
    */
   __defaultRenderer(root, _select) {
+    if (this.items.length === 0) {
+      root.textContent = '';
+      return;
+    }
+
     let listBox = root.firstElementChild;
     if (!listBox) {
       listBox = document.createElement('vaadin-list-box');
       root.appendChild(listBox);
     }
 
-    if (this.items) {
-      listBox.textContent = '';
-      this.items.forEach((item) => {
-        listBox.appendChild(this.__createItemElement(item));
-      });
-    } else {
-      // TODO: Is this necessary to do?
-      listBox.remove();
-    }
+    listBox.textContent = '';
+    this.items.forEach((item) => {
+      listBox.appendChild(this.__createItemElement(item));
+    });
   }
 
   /**

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -398,9 +398,15 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
     }
   }
 
-  /** @private */
-  __itemsChanged() {
-    this.requestContentUpdate();
+  /**
+   * @param {SelectItem[]} newItems
+   * @param {SelectItem[] | undefined} oldItems
+   * @private
+   */
+  __itemsChanged(newItems, oldItems) {
+    if (newItems || oldItems) {
+      this.requestContentUpdate();
+    }
   }
 
   /** @private */

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -606,13 +606,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    * @private
    */
   __createItemElement(item) {
-    let itemElement;
-    if (item.component instanceof HTMLElement) {
-      itemElement = item.component;
-    } else {
-      itemElement = document.createElement(item.component || 'vaadin-item');
-    }
-
+    const itemElement = document.createElement(item.component || 'vaadin-item');
     if (item.label) {
       itemElement.textContent = item.label;
     }
@@ -622,7 +616,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
     if (item.disabled) {
       itemElement.disabled = item.disabled;
     }
-
     return itemElement;
   }
 

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -187,7 +187,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
        */
       items: {
         type: Array,
-        value: () => [],
         observer: '__itemsChanged'
       },
 
@@ -702,7 +701,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    * @private
    */
   __defaultRenderer(root, _select) {
-    if (this.items.length === 0) {
+    if (!this.items || this.items.length === 0) {
       root.textContent = '';
       return;
     }

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -379,8 +379,8 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
   }
 
   /**
-   * @param {!SelectRenderer} renderer
-   * @param {SelectOverlay} overlay
+   * @param {SelectRenderer | undefined | null} renderer
+   * @param {SelectOverlay | undefined} overlay
    * @private
    */
   _rendererChanged(renderer, overlay) {
@@ -696,8 +696,8 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
 
   /**
    * Renders items when they are provided by the `items` property and clears the content otherwise.
-   * @param {HTMLElement} root
-   * @param {Select} _select
+   * @param {!HTMLElement} root
+   * @param {!Select} _select
    * @private
    */
   __defaultRenderer(root, _select) {

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -568,7 +568,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
 
     const label = selected.getAttribute('label');
     if (label) {
-      labelItem = this.__createItemElement({ label, component: 'vaadin-item' });
+      labelItem = this.__createItemElement({ label });
     } else {
       labelItem = selected.cloneNode(true);
     }

--- a/packages/select/test/items.test.js
+++ b/packages/select/test/items.test.js
@@ -1,0 +1,83 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
+import '../vaadin-select.js';
+
+describe('items', () => {
+  let select, overlay, listBox;
+
+  beforeEach(() => {
+    select = fixtureSync(`<vaadin-select></vaadin-select>`);
+    select.items = [{ label: 'Option 1', value: 'value-1' }];
+    select.opened = true;
+    overlay = select._overlayElement;
+    listBox = overlay.querySelector('vaadin-list-box');
+  });
+
+  it('should render items', () => {
+    expect(listBox).to.be.ok;
+    expect(listBox.childNodes).to.have.lengthOf(1);
+    expect(listBox.childNodes[0].localName).to.equal('vaadin-item');
+    expect(listBox.childNodes[0].textContent).to.equal('Option 1');
+    expect(listBox.childNodes[0].value).to.equal('value-1');
+    expect(listBox.childNodes[0].disabled).to.be.false;
+  });
+
+  it('should re-render items on items property change', () => {
+    select.items = [{ label: 'New Option', value: 'new-value' }];
+    expect(listBox.childNodes).to.have.lengthOf(1);
+    expect(listBox.childNodes[0].textContent).to.equal('New Option');
+    expect(listBox.childNodes[0].value).to.equal('new-value');
+  });
+
+  it('should re-render items on content update request', () => {
+    select.items[0].value = 'new-value';
+    select.requestContentUpdate();
+    expect(listBox.childNodes).to.have.lengthOf(1);
+    expect(listBox.childNodes[0].value).to.equal('new-value');
+  });
+
+  it('should clear the content when clearing items', () => {
+    select.items = [];
+    expect(overlay.childNodes).to.be.empty;
+  });
+
+  it('should render item with a custom component passed as string', () => {
+    select.items = [{ component: 'hr' }];
+    expect(listBox.childNodes).to.have.lengthOf(1);
+    expect(listBox.childNodes[0].localName).to.equal('hr');
+  });
+
+  it('should render item with a custom component passed as an element reference', () => {
+    const div = document.createElement('div');
+    select.items = [{ component: div }];
+    expect(listBox.childNodes).to.have.lengthOf(1);
+    expect(listBox.childNodes[0]).to.equal(div);
+  });
+
+  it('should render disabled item', () => {
+    select.items = [{ label: 'Option 1', value: 'value-1', disabled: true }];
+    expect(listBox.childNodes).to.have.lengthOf(1);
+    expect(listBox.childNodes[0].disabled).to.be.true;
+  });
+
+  describe('renderer', () => {
+    beforeEach(() => {
+      select.renderer = (root) => {
+        root.textContent = 'Renderer';
+      };
+    });
+
+    it('should override content with the renderer', () => {
+      expect(overlay.textContent).to.equal('Renderer');
+    });
+
+    it('should render items when removing the renderer', () => {
+      select.renderer = null;
+      const newListBox = overlay.querySelector('vaadin-list-box');
+      expect(newListBox).to.be.ok;
+      expect(newListBox.childNodes).to.have.lengthOf(1);
+      expect(newListBox.childNodes[0].textContent).to.equal('Option 1');
+    });
+  });
+});

--- a/packages/select/test/items.test.js
+++ b/packages/select/test/items.test.js
@@ -42,17 +42,10 @@ describe('items', () => {
     expect(overlay.childNodes).to.be.empty;
   });
 
-  it('should render item with a custom component passed as string', () => {
+  it('should render item with a custom component', () => {
     select.items = [{ component: 'hr' }];
     expect(listBox.childNodes).to.have.lengthOf(1);
     expect(listBox.childNodes[0].localName).to.equal('hr');
-  });
-
-  it('should render item with a custom component passed as an element reference', () => {
-    const div = document.createElement('div');
-    select.items = [{ component: div }];
-    expect(listBox.childNodes).to.have.lengthOf(1);
-    expect(listBox.childNodes[0]).to.equal(div);
   });
 
   it('should render disabled item', () => {

--- a/packages/select/test/items.test.js
+++ b/packages/select/test/items.test.js
@@ -9,9 +9,9 @@ describe('items', () => {
   beforeEach(() => {
     select = fixtureSync(`<vaadin-select></vaadin-select>`);
     select.items = [{ label: 'Option 1', value: 'value-1' }];
+    overlay = select.shadowRoot.querySelector('vaadin-select-overlay');
+    listBox = overlay.content.querySelector('vaadin-list-box');
     select.opened = true;
-    overlay = select._overlayElement;
-    listBox = overlay.querySelector('vaadin-list-box');
   });
 
   it('should render items', () => {
@@ -39,7 +39,7 @@ describe('items', () => {
 
   it('should clear the content when clearing items', () => {
     select.items = [];
-    expect(overlay.childNodes).to.be.empty;
+    expect(overlay.content.childNodes).to.be.empty;
   });
 
   it('should render item with a custom component', () => {
@@ -62,12 +62,12 @@ describe('items', () => {
     });
 
     it('should override content with the renderer', () => {
-      expect(overlay.textContent).to.equal('Renderer');
+      expect(overlay.content.textContent).to.equal('Renderer');
     });
 
     it('should render items when removing the renderer', () => {
       select.renderer = null;
-      const newListBox = overlay.querySelector('vaadin-list-box');
+      const newListBox = overlay.content.querySelector('vaadin-list-box');
       expect(newListBox).to.be.ok;
       expect(newListBox.childNodes).to.have.lengthOf(1);
       expect(newListBox.childNodes[0].textContent).to.equal('Option 1');

--- a/packages/select/test/items.test.js
+++ b/packages/select/test/items.test.js
@@ -10,14 +10,14 @@ describe('items', () => {
     select = fixtureSync(`<vaadin-select></vaadin-select>`);
     select.items = [{ label: 'Option 1', value: 'value-1' }];
     overlay = select.shadowRoot.querySelector('vaadin-select-overlay');
-    listBox = overlay.content.querySelector('vaadin-list-box');
+    listBox = overlay.content.querySelector('vaadin-select-list-box');
     select.opened = true;
   });
 
   it('should render items', () => {
     expect(listBox).to.be.ok;
     expect(listBox.childNodes).to.have.lengthOf(1);
-    expect(listBox.childNodes[0].localName).to.equal('vaadin-item');
+    expect(listBox.childNodes[0].localName).to.equal('vaadin-select-item');
     expect(listBox.childNodes[0].textContent).to.equal('Option 1');
     expect(listBox.childNodes[0].value).to.equal('value-1');
     expect(listBox.childNodes[0].disabled).to.be.false;
@@ -67,7 +67,7 @@ describe('items', () => {
 
     it('should render items when removing the renderer', () => {
       select.renderer = null;
-      const newListBox = overlay.content.querySelector('vaadin-list-box');
+      const newListBox = overlay.content.querySelector('vaadin-select-list-box');
       expect(newListBox).to.be.ok;
       expect(newListBox.childNodes).to.have.lengthOf(1);
       expect(newListBox.childNodes[0].textContent).to.equal('Option 1');

--- a/packages/select/test/items.test.js
+++ b/packages/select/test/items.test.js
@@ -37,8 +37,18 @@ describe('items', () => {
     expect(listBox.childNodes[0].value).to.equal('new-value');
   });
 
-  it('should clear the content when clearing items', () => {
+  it('should clear the content when setting items property to an empty array', () => {
     select.items = [];
+    expect(overlay.content.childNodes).to.be.empty;
+  });
+
+  it('should clear the content when setting items property to null', () => {
+    select.items = null;
+    expect(overlay.content.childNodes).to.be.empty;
+  });
+
+  it('should clear the content when setting items property to undefined', () => {
+    select.items = undefined;
     expect(overlay.content.childNodes).to.be.empty;
   });
 

--- a/packages/select/test/renderer.test.js
+++ b/packages/select/test/renderer.test.js
@@ -54,7 +54,7 @@ describe('renderer', () => {
 
     it('should clear the content when removing the renderer', () => {
       select.renderer = null;
-      expect(overlay.content.childNodes).to.have.lengthOf(0);
+      expect(overlay.content.childNodes).to.be.empty;
     });
 
     it('should not override the content on items property change', () => {

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -159,7 +159,7 @@ describe('vaadin-select', () => {
       it('should wrap the selected item `label` string in selected vaadin item', () => {
         menu.selected = 1;
         const item = valueButton.firstElementChild;
-        expect(item.localName).to.equal('vaadin-item');
+        expect(item.localName).to.equal('vaadin-select-item');
         expect(item.textContent).to.equal('o2');
         expect(item.selected).to.be.true;
         expect(item.getAttribute('tabindex')).to.be.null;

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -16,7 +16,7 @@ const select: Select = document.createElement('vaadin-select');
 assertType<SelectItem[] | null | undefined>(select.items);
 assertType<boolean>(select.opened);
 assertType<SelectRenderer | undefined>(select.renderer);
-assertType<string | boolean>(select.value);
+assertType<string>(select.value);
 assertType<string | null | undefined>(select.placeholder);
 assertType<boolean | null | undefined>(select.readonly);
 assertType<() => void>(select.requestContentUpdate);

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -18,7 +18,7 @@ assertType<boolean>(select.opened);
 assertType<SelectRenderer | undefined>(select.renderer);
 assertType<string>(select.value);
 assertType<string | null | undefined>(select.placeholder);
-assertType<boolean | null | undefined>(select.readonly);
+assertType<boolean>(select.readonly);
 assertType<() => void>(select.requestContentUpdate);
 assertType<() => boolean>(select.validate);
 

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -2,7 +2,9 @@ import '../../vaadin-select.js';
 import {
   Select,
   SelectInvalidChangedEvent,
+  SelectItem,
   SelectOpenedChangedEvent,
+  SelectRenderer,
   SelectValueChangedEvent
 } from '../../vaadin-select.js';
 
@@ -10,6 +12,17 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 
 const select: Select = document.createElement('vaadin-select');
 
+// Properties
+assertType<SelectItem[] | null | undefined>(select.items);
+assertType<boolean>(select.opened);
+assertType<SelectRenderer | undefined>(select.renderer);
+assertType<string | boolean>(select.value);
+assertType<string | null | undefined>(select.placeholder);
+assertType<boolean | null | undefined>(select.readonly);
+assertType<() => void>(select.requestContentUpdate);
+assertType<() => boolean>(select.validate);
+
+// Events
 select.addEventListener('opened-changed', (event) => {
   assertType<SelectOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);

--- a/packages/select/theme/lumo/vaadin-select-styles.js
+++ b/packages/select/theme/lumo/vaadin-select-styles.js
@@ -67,7 +67,7 @@ registerStyles(
       box-shadow: none;
     }
 
-    ::slotted(vaadin-item:hover) {
+    ::slotted(:not([slot]):hover) {
       background-color: transparent;
     }
   `,

--- a/packages/select/theme/material/vaadin-select-styles.js
+++ b/packages/select/theme/material/vaadin-select-styles.js
@@ -54,12 +54,12 @@ registerStyles(
       display: none;
     }
 
-    ::slotted(vaadin-item) {
+    ::slotted(:not([slot])) {
       font: inherit;
       padding: 4px 0;
     }
 
-    ::slotted(vaadin-item:hover) {
+    ::slotted(:not([slot]):hover) {
       background-color: transparent;
     }
   `,


### PR DESCRIPTION
## Description

The PR adds support for the `items` property in the select component by adding the default renderer that renders items when they are provided by the property and clears the select's content otherwise.

```html
<vaadin-select></vaadin-select>

<script>
  import '@vaadin/select';
  
  const select = document.querySelector('vaadin-select');
  select.items = [
    { label: 'Jose', value: 'jose' },
    { component: 'hr' },
    { label: 'Pedro', value: 'pedro' },
    { label: 'Manolo', value: 'manolo', disabled: true }
  ];
</script>
```

Fixes #501

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
