### PR TITLE
fix: don't throw when requesting content update before attaching to DOM

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -344,6 +344,10 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
   requestContentUpdate() {
+    if (!this._overlayElement) {
+      return;
+    }
+
     this._overlayElement.requestContentUpdate();
 
     // Ensure menu element is set

--- a/packages/select/test/renderer.test.js
+++ b/packages/select/test/renderer.test.js
@@ -50,6 +50,11 @@ describe('renderer', () => {
     };
   });
 
+  it('should not throw when requesting content update before attaching to the DOM', () => {
+    const select = document.createElement('vaadin-select');
+    expect(() => select.requestContentUpdate()).not.to.throw(Error);
+  });
+
   it('should run renderers when requesting content update', () => {
     select.renderer = sinon.spy();
     select.opened = true;


### PR DESCRIPTION
## Description

This PR prevents throwing an exception in the select component when requesting the content update before the component is attached to the DOM.

Extracted from #2990.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
