### PR TITLE
refactor: cleanup duplicate combo-box item styles

### DIFF
--- a/packages/combo-box/theme/lumo/vaadin-combo-box-item-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-item-styles.js
@@ -4,41 +4,17 @@ import '@vaadin/vaadin-lumo-styles/style.js';
 import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
-/* TODO partly duplicated from vaadin-list-box styles. Should find a way to make it DRY */
 const comboBoxItem = css`
   :host {
-    cursor: default;
-    -webkit-tap-highlight-color: var(--lumo-primary-color-10pct);
-    padding-left: calc(var(--lumo-border-radius-m) / 4);
-    padding-right: calc(var(--lumo-space-l) + var(--lumo-border-radius-m) / 4);
     transition: background-color 100ms;
-    border-radius: var(--lumo-border-radius-m);
     overflow: hidden;
     --_lumo-item-selected-icon-display: block;
   }
 
-  :host(:hover) {
-    background-color: var(--lumo-primary-color-10pct);
-  }
-
-  :host([focused]:not([disabled])) {
-    box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
-  }
-
-  @media (pointer: coarse) {
-    :host(:hover) {
-      background-color: transparent;
-    }
-
+  @media (any-hover: hover) {
     :host([focused]:not([disabled])) {
-      box-shadow: none;
+      box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
     }
-  }
-
-  /* RTL specific styles */
-  :host([dir='rtl']) {
-    padding-right: calc(var(--lumo-border-radius-m) / 4);
-    padding-left: calc(var(--lumo-space-l) + var(--lumo-border-radius-m) / 4);
   }
 `;
 

--- a/packages/combo-box/theme/material/vaadin-combo-box-item-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-item-styles.js
@@ -9,24 +9,7 @@ const comboBoxItem = css`
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
     padding: 4px 10px;
-    min-height: 36px;
-    font-size: var(--material-small-font-size);
     --_material-item-selected-icon-display: block;
-  }
-
-  :host(:hover) {
-    background-color: var(--material-secondary-background-color);
-  }
-
-  :host([focused]) {
-    background-color: var(--material-divider-color);
-  }
-
-  @media (pointer: coarse) {
-    :host(:hover),
-    :host([focused]) {
-      background-color: transparent;
-    }
   }
 `;
 


### PR DESCRIPTION
## Description

Folow-up from #2955 - some CSS rules are now duplicates and can be removed.
I had to keep `focused` styles for Lumo because the item uses `focus-ring`.

## Type of change

- Refactor