### PR TITLE
refactor: simplify themable-mixin imports in themes

### DIFF
--- a/packages/accordion/theme/lumo/vaadin-accordion-panel-styles.js
+++ b/packages/accordion/theme/lumo/vaadin-accordion-panel-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import { details } from '@vaadin/details/theme/lumo/vaadin-details-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const accordionPanel = css`
   :host {

--- a/packages/accordion/theme/material/vaadin-accordion-panel-styles.js
+++ b/packages/accordion/theme/material/vaadin-accordion-panel-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import { details } from '@vaadin/details/theme/material/vaadin-details-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const accordionPanel = css`
   :host(:not([opened])) [part='summary']::after {

--- a/packages/app-layout/theme/lumo/vaadin-app-layout-styles.js
+++ b/packages/app-layout/theme/lumo/vaadin-app-layout-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-app-layout',

--- a/packages/app-layout/theme/lumo/vaadin-drawer-toggle-styles.js
+++ b/packages/app-layout/theme/lumo/vaadin-drawer-toggle-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { button } from '@vaadin/button/theme/lumo/vaadin-button-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const drawerToggle = css`
   :host {

--- a/packages/app-layout/theme/material/vaadin-app-layout-styles.js
+++ b/packages/app-layout/theme/material/vaadin-app-layout-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-app-layout',

--- a/packages/app-layout/theme/material/vaadin-drawer-toggle-styles.js
+++ b/packages/app-layout/theme/material/vaadin-drawer-toggle-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import { button } from '@vaadin/button/theme/material/vaadin-button-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const drawerToggle = css`
   :host {

--- a/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js
+++ b/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import { menuOverlayCore } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
 import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-avatar-group',

--- a/packages/avatar-group/theme/material/vaadin-avatar-group-styles.js
+++ b/packages/avatar-group/theme/material/vaadin-avatar-group-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const avatarGroupOverlay = css`
   [part='overlay'] {

--- a/packages/avatar/theme/lumo/vaadin-avatar-styles.js
+++ b/packages/avatar/theme/lumo/vaadin-avatar-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-avatar',

--- a/packages/avatar/theme/material/vaadin-avatar-styles.js
+++ b/packages/avatar/theme/material/vaadin-avatar-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-avatar',

--- a/packages/button/theme/lumo/vaadin-button-styles.js
+++ b/packages/button/theme/lumo/vaadin-button-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const button = css`
   :host {

--- a/packages/button/theme/material/vaadin-button-styles.js
+++ b/packages/button/theme/material/vaadin-button-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const button = css`
   :host {

--- a/packages/charts/theme/vaadin-chart-default-theme.js
+++ b/packages/charts/theme/vaadin-chart-default-theme.js
@@ -11,7 +11,7 @@
  *
  * License: www.highcharts.com/license
  */
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /* When updating this file do not override vaadin-charts custom properties section */
 

--- a/packages/checkbox-group/theme/lumo/vaadin-checkbox-group-styles.js
+++ b/packages/checkbox-group/theme/lumo/vaadin-checkbox-group-styles.js
@@ -5,7 +5,7 @@ import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import { helper } from '@vaadin/vaadin-lumo-styles/mixins/helper.js';
 import { requiredField } from '@vaadin/vaadin-lumo-styles/mixins/required-field.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const checkboxGroup = css`
   :host {

--- a/packages/checkbox-group/theme/material/vaadin-checkbox-group-styles.js
+++ b/packages/checkbox-group/theme/material/vaadin-checkbox-group-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import { helper } from '@vaadin/vaadin-material-styles/mixins/helper.js';
 import { requiredField } from '@vaadin/vaadin-material-styles/mixins/required-field.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const checkboxGroup = css`
   :host {

--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-checkbox',

--- a/packages/checkbox/theme/material/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/material/vaadin-checkbox-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-material-styles/color.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-checkbox',

--- a/packages/combo-box/theme/lumo/vaadin-combo-box-dropdown-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-dropdown-styles.js
@@ -4,7 +4,7 @@ import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-overlay/theme/lumo/vaadin-overlay.js';
 import { menuOverlayCore } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
 import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const comboBoxOverlay = css`
   [part='content'] {

--- a/packages/combo-box/theme/lumo/vaadin-combo-box-item-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-item-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const comboBoxItem = css`
   :host {

--- a/packages/combo-box/theme/lumo/vaadin-combo-box-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const comboBox = css`
   :host {

--- a/packages/combo-box/theme/material/vaadin-combo-box-dropdown-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-dropdown-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const comboBoxOverlay = css`
   :host {

--- a/packages/combo-box/theme/material/vaadin-combo-box-item-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-item-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import { item } from '@vaadin/item/theme/material/vaadin-item-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const comboBoxItem = css`
   :host {

--- a/packages/combo-box/theme/material/vaadin-combo-box-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const comboBox = css`
   :host {

--- a/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
+++ b/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-dialog-overlay',

--- a/packages/confirm-dialog/theme/material/vaadin-confirm-dialog-styles.js
+++ b/packages/confirm-dialog/theme/material/vaadin-confirm-dialog-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-dialog-overlay',

--- a/packages/context-menu/theme/lumo/vaadin-context-menu-styles.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu-styles.js
@@ -5,7 +5,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import { menuOverlay } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const contextMenuOverlay = css`
   :host([phone]) {

--- a/packages/context-menu/theme/material/vaadin-context-menu-styles.js
+++ b/packages/context-menu/theme/material/vaadin-context-menu-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const contextMenuOverlay = css`
   [part='overlay'] {

--- a/packages/crud/theme/lumo/vaadin-crud-styles.js
+++ b/packages/crud/theme/lumo/vaadin-crud-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '../vaadin-dialog-layout-overlay-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-crud-edit',

--- a/packages/crud/theme/material/vaadin-crud-styles.js
+++ b/packages/crud/theme/material/vaadin-crud-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-material-styles/color.js';
 import '../vaadin-dialog-layout-overlay-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-crud-edit',

--- a/packages/crud/theme/vaadin-dialog-layout-overlay-styles.js
+++ b/packages/crud/theme/vaadin-dialog-layout-overlay-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /*
   DISCLAIMER: These are the styles of an internal implementation of a web

--- a/packages/custom-field/theme/lumo/vaadin-custom-field-styles.js
+++ b/packages/custom-field/theme/lumo/vaadin-custom-field-styles.js
@@ -9,7 +9,7 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import { helper } from '@vaadin/vaadin-lumo-styles/mixins/helper.js';
 import { requiredField } from '@vaadin/vaadin-lumo-styles/mixins/required-field.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const customField = css`
   :host {

--- a/packages/custom-field/theme/material/vaadin-custom-field-styles.js
+++ b/packages/custom-field/theme/material/vaadin-custom-field-styles.js
@@ -7,7 +7,7 @@ import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import { helper } from '@vaadin/vaadin-material-styles/mixins/helper.js';
 import { requiredField } from '@vaadin/vaadin-material-styles/mixins/required-field.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const customField = css`
   :host {

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -4,7 +4,7 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import '@vaadin/button/theme/lumo/vaadin-button.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-date-picker-overlay-content',

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import { menuOverlay } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const datePickerOverlay = css`
   [part='overlay'] {

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const datePicker = css`
   :host {

--- a/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-month-calendar',

--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
 import '@vaadin/button/theme/material/vaadin-button.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-date-picker-overlay-content',

--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-styles.js
@@ -1,5 +1,5 @@
 import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const datePickerOverlay = css`
   :host([fullscreen]) {

--- a/packages/date-picker/theme/material/vaadin-date-picker-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const datePicker = css`
   :host {

--- a/packages/date-picker/theme/material/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/material/vaadin-month-calendar-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-month-calendar',

--- a/packages/date-time-picker/theme/lumo/vaadin-date-time-picker-styles.js
+++ b/packages/date-time-picker/theme/lumo/vaadin-date-time-picker-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/time-picker/theme/lumo/vaadin-time-picker.js';
 import { customField } from '@vaadin/custom-field/theme/lumo/vaadin-custom-field-styles.js';
 import { helper } from '@vaadin/vaadin-lumo-styles/mixins/helper.js';
 import { requiredField } from '@vaadin/vaadin-lumo-styles/mixins/required-field.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles('vaadin-date-time-picker', [requiredField, helper, customField], {
   moduleId: 'lumo-date-time-picker'

--- a/packages/details/theme/lumo/vaadin-details-styles.js
+++ b/packages/details/theme/lumo/vaadin-details-styles.js
@@ -4,7 +4,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const details = css`
   :host {

--- a/packages/details/theme/material/vaadin-details-styles.js
+++ b/packages/details/theme/material/vaadin-details-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const details = css`
   :host {

--- a/packages/dialog/theme/lumo/vaadin-dialog-styles.js
+++ b/packages/dialog/theme/lumo/vaadin-dialog-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const dialogOverlay = css`
   /* Optical centering */

--- a/packages/dialog/theme/material/vaadin-dialog-styles.js
+++ b/packages/dialog/theme/material/vaadin-dialog-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/shadow.js';
 import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const dialogOverlay = css`
   [part='overlay'] {

--- a/packages/email-field/theme/lumo/vaadin-email-field-styles.js
+++ b/packages/email-field/theme/lumo/vaadin-email-field-styles.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const emailField = css`
   :host([dir='rtl']) [part='input-field'] ::slotted(input) {

--- a/packages/form-layout/theme/lumo/vaadin-form-item-styles.js
+++ b/packages/form-layout/theme/lumo/vaadin-form-item-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-form-item',

--- a/packages/form-layout/theme/lumo/vaadin-form-layout-styles.js
+++ b/packages/form-layout/theme/lumo/vaadin-form-layout-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/spacing.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-form-layout',

--- a/packages/form-layout/theme/material/vaadin-form-item-styles.js
+++ b/packages/form-layout/theme/material/vaadin-form-item-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-form-item',

--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-edit-select-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-edit-select-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { gridProEditor } from './vaadin-grid-pro-editor-styles.js';
 
 const gridProEditSelect = css`

--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-editor-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-editor-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const gridProEditor = css`
   :host([theme~='grid-pro-editor']) {

--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-grid-pro',

--- a/packages/grid-pro/theme/material/vaadin-grid-pro-edit-select-styles.js
+++ b/packages/grid-pro/theme/material/vaadin-grid-pro-edit-select-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { gridProEditor } from './vaadin-grid-pro-editor-styles.js';
 
 const gridProEditSelect = css`

--- a/packages/grid-pro/theme/material/vaadin-grid-pro-editor-styles.js
+++ b/packages/grid-pro/theme/material/vaadin-grid-pro-editor-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const gridProEditor = css`
   :host([theme~='grid-pro-editor']) {

--- a/packages/grid-pro/theme/material/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/material/vaadin-grid-pro-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/grid/theme/material/vaadin-grid-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-grid-pro',

--- a/packages/grid/theme/lumo/vaadin-grid-sorter-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-sorter-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-grid-sorter',

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -5,7 +5,7 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import '@vaadin/checkbox/theme/lumo/vaadin-checkbox.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-grid',

--- a/packages/grid/theme/lumo/vaadin-grid-tree-toggle-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-tree-toggle-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-grid-tree-toggle',

--- a/packages/grid/theme/material/vaadin-grid-sorter-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-sorter-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-grid-sorter',

--- a/packages/grid/theme/material/vaadin-grid-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-grid',

--- a/packages/grid/theme/material/vaadin-grid-tree-toggle-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-tree-toggle-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-grid-tree-toggle',

--- a/packages/horizontal-layout/theme/lumo/vaadin-horizontal-layout-styles.js
+++ b/packages/horizontal-layout/theme/lumo/vaadin-horizontal-layout-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/spacing.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const horizontalLayout = css`
   :host([theme~='margin']) {

--- a/packages/horizontal-layout/theme/material/vaadin-horizontal-layout-styles.js
+++ b/packages/horizontal-layout/theme/material/vaadin-horizontal-layout-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const horizontalLayout = css`
   [theme~='margin'] {

--- a/packages/icon/theme/lumo/vaadin-icon-styles.js
+++ b/packages/icon/theme/lumo/vaadin-icon-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/sizing.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-icon',

--- a/packages/icon/theme/material/vaadin-icon-styles.js
+++ b/packages/icon/theme/material/vaadin-icon-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-icon',

--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-input-container',

--- a/packages/input-container/theme/material/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/material/vaadin-input-container-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-material-styles/color.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-input-container',

--- a/packages/item/theme/lumo/vaadin-item-styles.js
+++ b/packages/item/theme/lumo/vaadin-item-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const item = css`
   :host {

--- a/packages/item/theme/material/vaadin-item-styles.js
+++ b/packages/item/theme/material/vaadin-item-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const item = css`
   :host {

--- a/packages/list-box/theme/lumo/vaadin-list-box-styles.js
+++ b/packages/list-box/theme/lumo/vaadin-list-box-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-list-box',

--- a/packages/list-box/theme/material/vaadin-list-box-styles.js
+++ b/packages/list-box/theme/material/vaadin-list-box-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/color.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-list-box',

--- a/packages/login/theme/lumo/vaadin-login-form-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-form-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/spacing.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-login-form',

--- a/packages/login/theme/lumo/vaadin-login-form-wrapper-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-form-wrapper-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import { color } from '@vaadin/vaadin-lumo-styles/color.js';
 import { typography } from '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const loginFormWrapper = css`
   :host {

--- a/packages/login/theme/lumo/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-overlay-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import './vaadin-login-form-wrapper-styles.js';
 import { color } from '@vaadin/vaadin-lumo-styles/color.js';
 import { typography } from '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const loginOverlayWrapper = css`
   :host {

--- a/packages/login/theme/material/vaadin-login-form-styles.js
+++ b/packages/login/theme/material/vaadin-login-form-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-login-form',

--- a/packages/login/theme/material/vaadin-login-form-wrapper-styles.js
+++ b/packages/login/theme/material/vaadin-login-form-wrapper-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import { typography } from '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const loginFormWrapper = css`
   :host {

--- a/packages/login/theme/material/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/material/vaadin-login-overlay-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-material-styles/color.js';
 import './vaadin-login-form-styles.js';
 import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { typography } from '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const loginOverlayWrapper = css`
   :host {

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-button-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-button-styles.js
@@ -1,5 +1,5 @@
 import { button } from '@vaadin/button/theme/lumo/vaadin-button-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const menuBarButton = css`
   :host {

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-item-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-item-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-context-menu-item',

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-overlay-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-overlay-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-context-menu-overlay',

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-button-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-button-styles.js
@@ -1,5 +1,5 @@
 import { button } from '@vaadin/button/theme/material/vaadin-button-styles';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const menuBarButton = css`
   [part='label'] {

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-item-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-item-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-context-menu-item',

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-overlay-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-overlay-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-context-menu-overlay',

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-menu-bar',

--- a/packages/message-input/theme/lumo/vaadin-message-input-styles.js
+++ b/packages/message-input/theme/lumo/vaadin-message-input-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-message-input',

--- a/packages/message-input/theme/lumo/vaadin-message-input-text-area-styles.js
+++ b/packages/message-input/theme/lumo/vaadin-message-input-text-area-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-message-input-text-area',

--- a/packages/message-input/theme/material/vaadin-message-input-styles.js
+++ b/packages/message-input/theme/material/vaadin-message-input-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-message-input',

--- a/packages/message-input/theme/material/vaadin-message-input-text-area-styles.js
+++ b/packages/message-input/theme/material/vaadin-message-input-text-area-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-message-input-text-area',

--- a/packages/message-list/theme/lumo/vaadin-message-avatar-styles.js
+++ b/packages/message-list/theme/lumo/vaadin-message-avatar-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/avatar/theme/lumo/vaadin-avatar-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-message-avatar',

--- a/packages/message-list/theme/lumo/vaadin-message-list-styles.js
+++ b/packages/message-list/theme/lumo/vaadin-message-list-styles.js
@@ -3,6 +3,6 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import './vaadin-message-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles('vaadin-message-list', css``, { moduleId: 'lumo-message-list' });

--- a/packages/message-list/theme/lumo/vaadin-message-styles.js
+++ b/packages/message-list/theme/lumo/vaadin-message-styles.js
@@ -4,7 +4,7 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import './vaadin-message-avatar-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-message',

--- a/packages/message-list/theme/material/vaadin-message-avatar-styles.js
+++ b/packages/message-list/theme/material/vaadin-message-avatar-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/avatar/theme/material/vaadin-avatar-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-message-avatar',

--- a/packages/message-list/theme/material/vaadin-message-list-styles.js
+++ b/packages/message-list/theme/material/vaadin-message-list-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import './vaadin-message-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-message-list',

--- a/packages/message-list/theme/material/vaadin-message-styles.js
+++ b/packages/message-list/theme/material/vaadin-message-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import './vaadin-message-avatar-styles.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-message',

--- a/packages/notification/theme/lumo/vaadin-notification-styles.js
+++ b/packages/notification/theme/lumo/vaadin-notification-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-notification-card',

--- a/packages/notification/theme/material/vaadin-notification-styles.js
+++ b/packages/notification/theme/material/vaadin-notification-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
 import { colorDark } from '@vaadin/vaadin-material-styles/color.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-notification-container',

--- a/packages/number-field/theme/lumo/vaadin-number-field-styles.js
+++ b/packages/number-field/theme/lumo/vaadin-number-field-styles.js
@@ -6,7 +6,7 @@
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import { fieldButton } from '@vaadin/vaadin-lumo-styles/mixins/field-button.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const numberField = css`
   :host {

--- a/packages/number-field/theme/material/vaadin-number-field-styles.js
+++ b/packages/number-field/theme/material/vaadin-number-field-styles.js
@@ -5,7 +5,7 @@
  */
 import { fieldButton } from '@vaadin/vaadin-material-styles/mixins/field-button.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const numberField = css`
   :host {

--- a/packages/password-field/theme/lumo/vaadin-password-field-styles.js
+++ b/packages/password-field/theme/lumo/vaadin-password-field-styles.js
@@ -7,7 +7,7 @@ import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const passwordField = css`
   [part='reveal-button']::before {

--- a/packages/password-field/theme/material/vaadin-password-field-styles.js
+++ b/packages/password-field/theme/material/vaadin-password-field-styles.js
@@ -6,7 +6,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const passwordField = css`
   [part='reveal-button']::before {

--- a/packages/progress-bar/theme/lumo/vaadin-progress-bar-styles.js
+++ b/packages/progress-bar/theme/lumo/vaadin-progress-bar-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-progress-bar',

--- a/packages/progress-bar/theme/material/vaadin-progress-bar-styles.js
+++ b/packages/progress-bar/theme/material/vaadin-progress-bar-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-material-styles/color.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-progress-bar',

--- a/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-radio-button',

--- a/packages/radio-group/theme/lumo/vaadin-radio-group-styles.js
+++ b/packages/radio-group/theme/lumo/vaadin-radio-group-styles.js
@@ -5,7 +5,7 @@ import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import { helper } from '@vaadin/vaadin-lumo-styles/mixins/helper.js';
 import { requiredField } from '@vaadin/vaadin-lumo-styles/mixins/required-field.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const radioGroup = css`
   :host {

--- a/packages/radio-group/theme/material/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/material/vaadin-radio-button-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-material-styles/color.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-radio-button',

--- a/packages/radio-group/theme/material/vaadin-radio-group-styles.js
+++ b/packages/radio-group/theme/material/vaadin-radio-group-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import { helper } from '@vaadin/vaadin-material-styles/mixins/helper.js';
 import { requiredField } from '@vaadin/vaadin-material-styles/mixins/required-field.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const radioGroup = css`
   :host {

--- a/packages/rich-text-editor/theme/lumo/vaadin-rich-text-editor-styles.js
+++ b/packages/rich-text-editor/theme/lumo/vaadin-rich-text-editor-styles.js
@@ -4,7 +4,7 @@ import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import { color } from '@vaadin/vaadin-lumo-styles/color.js';
 import { typography } from '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const richTextEditor = css`
   :host {

--- a/packages/rich-text-editor/theme/material/vaadin-rich-text-editor-styles.js
+++ b/packages/rich-text-editor/theme/material/vaadin-rich-text-editor-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import { typography } from '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const richTextEditor = css`
   :host {

--- a/packages/select/theme/lumo/vaadin-select-styles.js
+++ b/packages/select/theme/lumo/vaadin-select-styles.js
@@ -8,7 +8,7 @@ import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
 import { menuOverlay } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const select = css`
   :host(:not([theme*='align'])) ::slotted([slot='value']) {

--- a/packages/select/theme/material/vaadin-select-styles.js
+++ b/packages/select/theme/material/vaadin-select-styles.js
@@ -6,7 +6,7 @@
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
 import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const select = css`
   :host {

--- a/packages/split-layout/theme/lumo/vaadin-split-layout-styles.js
+++ b/packages/split-layout/theme/lumo/vaadin-split-layout-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-split-layout',

--- a/packages/split-layout/theme/material/vaadin-split-layout-styles.js
+++ b/packages/split-layout/theme/material/vaadin-split-layout-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-material-styles/color.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-split-layout',

--- a/packages/tabs/theme/lumo/vaadin-tab-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tab-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-tab',

--- a/packages/tabs/theme/lumo/vaadin-tabs-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tabs-styles.js
@@ -4,7 +4,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-tabs',

--- a/packages/tabs/theme/material/vaadin-tab-styles.js
+++ b/packages/tabs/theme/material/vaadin-tab-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-tab',

--- a/packages/tabs/theme/material/vaadin-tabs-styles.js
+++ b/packages/tabs/theme/material/vaadin-tabs-styles.js
@@ -1,6 +1,6 @@
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/color.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-tabs',

--- a/packages/text-area/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area-styles.js
@@ -7,7 +7,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const textArea = css`
   [part='input-field'],

--- a/packages/text-area/theme/material/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/material/vaadin-text-area-styles.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const textArea = css`
   [part='input-field'] {

--- a/packages/time-picker/theme/lumo/vaadin-time-picker-styles.js
+++ b/packages/time-picker/theme/lumo/vaadin-time-picker-styles.js
@@ -5,7 +5,7 @@
  */
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const timePicker = css`
   [part~='toggle-button']::before {

--- a/packages/time-picker/theme/material/vaadin-time-picker-styles.js
+++ b/packages/time-picker/theme/material/vaadin-time-picker-styles.js
@@ -5,7 +5,7 @@
  */
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const timePicker = css`
   [part~='toggle-button']::before {

--- a/packages/upload/theme/lumo/vaadin-upload-styles.js
+++ b/packages/upload/theme/lumo/vaadin-upload-styles.js
@@ -7,7 +7,7 @@ import '@vaadin/vaadin-lumo-styles/typography.js';
 import '@vaadin/button/theme/lumo/vaadin-button.js';
 import '@vaadin/progress-bar/theme/lumo/vaadin-progress-bar.js';
 import { fieldButton } from '@vaadin/vaadin-lumo-styles/mixins/field-button.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-upload',

--- a/packages/upload/theme/material/vaadin-upload-styles.js
+++ b/packages/upload/theme/material/vaadin-upload-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/button/theme/material/vaadin-button.js';
 import '@vaadin/progress-bar/theme/material/vaadin-progress-bar.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-upload',

--- a/packages/vaadin-lumo-styles/badge.js
+++ b/packages/vaadin-lumo-styles/badge.js
@@ -6,7 +6,7 @@
 import './style.js';
 import './color.js';
 import './typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const badge = css`
   [theme~='badge'] {

--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './version.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const colorBase = css`
   :host {

--- a/packages/vaadin-lumo-styles/mixins/field-button.js
+++ b/packages/vaadin-lumo-styles/mixins/field-button.js
@@ -7,7 +7,7 @@ import '../color.js';
 import '../font-icons.js';
 import '../sizing.js';
 import '../style.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const fieldButton = css`
   [part$='button'] {

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -9,7 +9,7 @@ import '../sizing.js';
 import '../spacing.js';
 import '../style.js';
 import '../typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { fieldButton } from './field-button.js';
 import { helper } from './helper.js';
 import { requiredField } from './required-field.js';

--- a/packages/vaadin-lumo-styles/mixins/menu-overlay.js
+++ b/packages/vaadin-lumo-styles/mixins/menu-overlay.js
@@ -5,7 +5,7 @@
  */
 import '../spacing.js';
 import '../style.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { overlay } from './overlay.js';
 
 const menuOverlayCore = css`

--- a/packages/vaadin-lumo-styles/mixins/overlay.js
+++ b/packages/vaadin-lumo-styles/mixins/overlay.js
@@ -7,7 +7,7 @@ import '../color.js';
 import '../spacing.js';
 import '../style.js';
 import '../typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const overlay = css`
   :host {

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -7,7 +7,7 @@ import '../color.js';
 import '../spacing.js';
 import '../style.js';
 import '../typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const requiredField = css`
   [part='label'] {

--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './version.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const font = css`
   :host {

--- a/packages/vaadin-material-styles/color.js
+++ b/packages/vaadin-material-styles/color.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './version.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const colorLight = css`
   :host,

--- a/packages/vaadin-material-styles/mixins/field-button.js
+++ b/packages/vaadin-material-styles/mixins/field-button.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '../font-icons.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const fieldButton = css`
   [part$='button'] {

--- a/packages/vaadin-material-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-material-styles/mixins/input-field-shared.js
@@ -6,7 +6,7 @@
 import '../color.js';
 import '../font-icons.js';
 import '../typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { fieldButton } from './field-button.js';
 import { helper } from './helper.js';
 import { requiredField } from './required-field.js';

--- a/packages/vaadin-material-styles/mixins/overlay.js
+++ b/packages/vaadin-material-styles/mixins/overlay.js
@@ -6,7 +6,7 @@
 import '../color.js';
 import '../typography.js';
 import '../shadow.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const overlay = css`
   :host {

--- a/packages/vaadin-material-styles/mixins/required-field.js
+++ b/packages/vaadin-material-styles/mixins/required-field.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '../color.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const requiredField = css`
   [part='label'] {

--- a/packages/vaadin-material-styles/typography.js
+++ b/packages/vaadin-material-styles/typography.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './version.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const font = css`
   :host {

--- a/packages/vertical-layout/theme/lumo/vaadin-vertical-layout-styles.js
+++ b/packages/vertical-layout/theme/lumo/vaadin-vertical-layout-styles.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/spacing.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const verticalLayout = css`
   :host([theme~='margin']) {

--- a/packages/vertical-layout/theme/material/vaadin-vertical-layout-styles.js
+++ b/packages/vertical-layout/theme/material/vaadin-vertical-layout-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const verticalLayout = css`
   [theme~='margin'] {


### PR DESCRIPTION
## Description

Since #2594 `register-styles.js` is just a re-export so we can use the `themable-mixin.js` import instead.
Same as #3009 but for themes folders and Lumo / Material styles packages.

## Type of change

- Refactor