### PR TITLE
test: simplify themable-mixin imports in tests

### DIFF
--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -5,7 +5,7 @@ import '../vaadin-chart.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import HttpUtilities from 'highcharts/es-modules/Core/HttpUtilities.js';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { chartDefaultTheme } from '../theme/vaadin-chart-default-theme.js';
 
 const chart = css`

--- a/packages/charts/test/styling.test.js
+++ b/packages/charts/test/styling.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { chartDefaultTheme } from '../theme/vaadin-chart-default-theme.js';
 
 registerStyles('vaadin-chart', [

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -6,7 +6,7 @@ import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 import '../vaadin-combo-box-light.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import {
   flushComboBox,

--- a/packages/combo-box/test/not-animated-styles.js
+++ b/packages/combo-box/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-combo-box-overlay',

--- a/packages/combo-box/test/visual/common.js
+++ b/packages/combo-box/test/visual/common.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/confirm-dialog/test/not-animated-styles.js
+++ b/packages/confirm-dialog/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-dialog-overlay',

--- a/packages/context-menu/test/not-animated-styles.js
+++ b/packages/context-menu/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-context-menu-overlay',

--- a/packages/date-picker/test/not-animated-styles.js
+++ b/packages/date-picker/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-date-picker-overlay',

--- a/packages/date-picker/test/visual/common.js
+++ b/packages/date-picker/test/visual/common.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -5,7 +5,7 @@ import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/text-area/vaadin-text-area.js';
 import '../src/vaadin-dialog.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-dialog-overlay',

--- a/packages/grid-pro/test/not-animated-styles.js
+++ b/packages/grid-pro/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-select-overlay',

--- a/packages/grid/test/data-provider.test.js
+++ b/packages/grid/test/data-provider.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import {
   flushGrid,
   getCellContent,

--- a/packages/grid/test/dynamic-item-size.test.js
+++ b/packages/grid/test/dynamic-item-size.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { flushGrid, getFirstVisibleItem, infiniteDataProvider } from './helpers.js';
 
 registerStyles(

--- a/packages/grid/test/physical-count.test.js
+++ b/packages/grid/test/physical-count.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import {
   flushGrid,
   getCellContent,

--- a/packages/grid/test/row-height.test.js
+++ b/packages/grid/test/row-height.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { flushGrid, getRowCells, getRows, infiniteDataProvider, scrollToEnd } from './helpers.js';
 
 registerStyles(

--- a/packages/login/test/login-form.test.js
+++ b/packages/login/test/login-form.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { enter, fixtureSync, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-login-form.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { fillUsernameAndPassword } from './helpers.js';
 
 registerStyles(

--- a/packages/login/test/visual/common.js
+++ b/packages/login/test/visual/common.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -3,7 +3,7 @@ import { arrowLeft, arrowRight, end, fixtureSync, focusin, home, nextRender } fr
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-menu-bar.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-menu-bar',

--- a/packages/menu-bar/test/not-animated-styles.js
+++ b/packages/menu-bar/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-context-menu-overlay',

--- a/packages/notification/test/animation.test.js
+++ b/packages/notification/test/animation.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-notification-card',

--- a/packages/notification/test/multiple.test.js
+++ b/packages/notification/test/multiple.test.js
@@ -3,7 +3,7 @@ import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-notification-card',

--- a/packages/number-field/test/visual/common.js
+++ b/packages/number-field/test/visual/common.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/polymer-legacy-adapter/test/style-modules-lazy-import.test.js
+++ b/packages/polymer-legacy-adapter/test/style-modules-lazy-import.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 function defineCustomElement(name) {

--- a/packages/select/test/not-animated-styles.js
+++ b/packages/select/test/not-animated-styles.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-select-overlay',

--- a/packages/text-field/test/visual/common.js
+++ b/packages/text-field/test/visual/common.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/time-picker/test/visual/common.js
+++ b/packages/time-picker/test/visual/common.js
@@ -1,4 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /* hide caret */
 registerStyles(

--- a/packages/vaadin-overlay/test/animations.test.js
+++ b/packages/vaadin-overlay/test/animations.test.js
@@ -3,7 +3,7 @@ import { escKeyDown, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-overlay.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-overlay',

--- a/packages/vaadin-overlay/test/styling.test.js
+++ b/packages/vaadin-overlay/test/styling.test.js
@@ -3,7 +3,7 @@ import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'overlay-local-styles',


### PR DESCRIPTION
## Description

Since #2594 `register-styles.js` is just a re-export so we can use the `themable-mixin.js` import instead.
Same as #3009 but for test folders, therefore the commit is `test:` and not `refactor:`

## Type of change

- Refactor