### PR TITLE
fix: regenerate cell class names after column tree update

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -864,6 +864,7 @@ class Grid extends ElementMixin(
     this._a11yUpdateHeaderRows();
     this._a11yUpdateFooterRows();
     this.__updateFooterPositioning();
+    this.generateCellClassNames();
   }
 
   __updateFooterPositioning() {

--- a/packages/grid/test/class-name-generator.test.js
+++ b/packages/grid/test/class-name-generator.test.js
@@ -114,4 +114,15 @@ describe('class name generator', () => {
     expect(() => (grid.cellClassNameGenerator = () => ' foo  bar ')).not.to.throw(Error);
     assertClassList(firstCell, ['foo', 'bar']);
   });
+
+  it('should have the right class names after toggling column visibility', async () => {
+    grid.cellClassNameGenerator = (_column, { index }) => (index % 2 === 0 ? 'even' : 'odd');
+    const column = grid.querySelector('vaadin-grid-column');
+    column.hidden = true;
+    await nextFrame();
+    column.hidden = false;
+    await nextFrame();
+    assertClassList(getContainerCell(grid.$.items, 1, 0), ['odd']);
+    assertClassList(getContainerCell(grid.$.items, 1, 1), ['odd']);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/2988