### PR TITLE
refactor: use ElementMixin instead of DirMixin

### DIFF
--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
@@ -70,7 +70,7 @@ export interface RadioGroupEventMap extends HTMLElementEventMap, RadioGroupCusto
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 declare class RadioGroup extends FieldMixin(
-  FocusMixin(DisabledMixin(KeyboardMixin(DirMixin(ThemableMixin(HTMLElement)))))
+  FocusMixin(DisabledMixin(KeyboardMixin(ElementMixin(ThemableMixin(HTMLElement)))))
 ) {
   /**
    * The value of the radio group.

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -5,8 +5,8 @@
  */
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
@@ -56,13 +56,15 @@ import { RadioButton } from './vaadin-radio-button.js';
  *
  * @extends HTMLElement
  * @mixes ThemableMixin
- * @mixes DirMixin
- * @mixes KeyboardMixin
  * @mixes DisabledMixin
+ * @mixes ElementMixin
  * @mixes FocusMixin
  * @mixes FieldMixin
+ * @mixes KeyboardMixin
  */
-class RadioGroup extends FieldMixin(FocusMixin(DisabledMixin(KeyboardMixin(DirMixin(ThemableMixin(PolymerElement)))))) {
+class RadioGroup extends FieldMixin(
+  FocusMixin(DisabledMixin(KeyboardMixin(ElementMixin(ThemableMixin(PolymerElement)))))
+) {
   static get is() {
     return 'vaadin-radio-group';
   }


### PR DESCRIPTION
## Description

This enables adding reactive controllers to `vaadin-radio-group`, like `FieldHighlighter` - see #3031

## Type of change

- Refactor