### PR TITLE
fix: stop Escape keydown propagation if the event was handled

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -570,6 +570,7 @@ export const ComboBoxMixin = (subclass) =>
       if (this.autoOpenDisabled) {
         // Auto-open is disabled
         if (this.opened || (this.value !== this._inputElementValue && this._inputElementValue.length > 0)) {
+          // The overlay is open or
           // The input value has changed but the change hasn't been committed, so cancel it.
           e.stopPropagation();
           this._focusedIndex = -1;

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -569,11 +569,13 @@ export const ComboBoxMixin = (subclass) =>
     _onEscape(e) {
       if (this.autoOpenDisabled) {
         // Auto-open is disabled
-        if (this.value !== this._inputElementValue) {
+        if (this.opened || (this.value !== this._inputElementValue && this._inputElementValue.length > 0)) {
           // The input value has changed but the change hasn't been committed, so cancel it.
+          e.stopPropagation();
           this._focusedIndex = -1;
           this.cancel();
-        } else if (this.clearButtonVisible && !this.opened) {
+        } else if (this.clearButtonVisible && !this.opened && !!this.value) {
+          e.stopPropagation();
           // The clear button is visible and the overlay is closed, so clear the value.
           this._clear();
         }
@@ -591,7 +593,8 @@ export const ComboBoxMixin = (subclass) =>
             // No item is focused, cancel the change and close the overlay
             this.cancel();
           }
-        } else if (this.clearButtonVisible) {
+        } else if (this.clearButtonVisible && !!this.value) {
+          e.stopPropagation();
           // The clear button is visible and the overlay is closed, so clear the value.
           this._clear();
         }

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -8,6 +8,7 @@ import {
   fire,
   fixtureSync,
   focusout,
+  keyboardEventFor,
   keyDownOn,
   nextFrame
 } from '@vaadin/testing-helpers';
@@ -71,22 +72,20 @@ describe('keyboard', () => {
     });
 
     it('should propagate escape key event if dropdown is closed', () => {
-      const keyDownSpy = sinon.spy();
-      document.body.addEventListener('keydown', keyDownSpy);
-      escKeyDown(input);
-      document.body.removeEventListener('keydown', keyDownSpy);
-      expect(keyDownSpy.called).to.be.true;
+      const event = keyboardEventFor('keydown', 27, [], 'Escape');
+      const keyDownSpy = sinon.spy(event, 'stopPropagation');
+      input.dispatchEvent(event);
+      expect(keyDownSpy.called).to.be.false;
     });
 
     it('should not propagate esc keydown event when overlay is closed, clear button is visible and value is not empty', () => {
       comboBox.value = 'bar';
       comboBox.clearButtonVisible = true;
 
-      const keyDownSpy = sinon.spy();
-      document.body.addEventListener('keydown', keyDownSpy);
-      escKeyDown(input);
-      document.body.removeEventListener('keydown', keyDownSpy);
-      expect(keyDownSpy.called).to.be.false;
+      const event = keyboardEventFor('keydown', 27, [], 'Escape');
+      const keyDownSpy = sinon.spy(event, 'stopPropagation');
+      input.dispatchEvent(event);
+      expect(keyDownSpy.called).to.be.true;
     });
   });
 
@@ -580,11 +579,10 @@ describe('keyboard', () => {
     it('should not propagate when input value is not empty', () => {
       inputText('foo');
 
-      const keyDownSpy = sinon.spy();
-      document.body.addEventListener('keydown', keyDownSpy);
-      escKeyDown(input);
-      document.body.removeEventListener('keydown', keyDownSpy);
-      expect(keyDownSpy.called).to.be.false;
+      const event = keyboardEventFor('keydown', 27, [], 'Escape');
+      const keyDownSpy = sinon.spy(event, 'stopPropagation');
+      input.dispatchEvent(event);
+      expect(keyDownSpy.called).to.be.true;
     });
   });
 });

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -69,6 +69,25 @@ describe('keyboard', () => {
 
       expect(getFocusedIndex()).to.equal(0);
     });
+
+    it('should propagate escape key event if dropdown is closed', () => {
+      const keyDownSpy = sinon.spy();
+      document.body.addEventListener('keydown', keyDownSpy);
+      escKeyDown(input);
+      document.body.removeEventListener('keydown', keyDownSpy);
+      expect(keyDownSpy.called).to.be.true;
+    });
+
+    it('should not propagate esc keydown event when overlay is closed, clear button is visible and value is not empty', () => {
+      comboBox.value = 'bar';
+      comboBox.clearButtonVisible = true;
+
+      const keyDownSpy = sinon.spy();
+      document.body.addEventListener('keydown', keyDownSpy);
+      escKeyDown(input);
+      document.body.removeEventListener('keydown', keyDownSpy);
+      expect(keyDownSpy.called).to.be.false;
+    });
   });
 
   describe('navigating after overlay opened', () => {
@@ -556,6 +575,16 @@ describe('keyboard', () => {
       comboBox.opened = true;
       escKeyDown(input);
       expect(comboBox.value).to.equal('bar');
+    });
+
+    it('should not propagate when input value is not empty', () => {
+      inputText('foo');
+
+      const keyDownSpy = sinon.spy();
+      document.body.addEventListener('keydown', keyDownSpy);
+      escKeyDown(input);
+      document.body.removeEventListener('keydown', keyDownSpy);
+      expect(keyDownSpy.called).to.be.false;
     });
   });
 });

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -231,7 +231,7 @@ describe('keyboard', () => {
       expect(input.value).to.equal('foobar');
     });
 
-    it('should revert to the custom value after keyboar navigation', () => {
+    it('should revert to the custom value after keyboard navigation', () => {
       comboBox.allowCustomValue = true;
       comboBox.value = 'foobar';
       arrowDownKeyDown(input);


### PR DESCRIPTION
## Description

In the event of pressing the <kbd>Esc</kbd> key, if the event is "consumed" by the combo-box, it must stop its propagation. If no action is performed by the combo-box, then the event must be propagated so other components can act accordingly.

Some conditions were missing to cover all cases.

Related: #984

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
