### PR TITLE
refactor: drop support for setting instanceProps

### DIFF
--- a/packages/vaadin-overlay/src/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay.d.ts
@@ -61,18 +61,13 @@ export type OverlayEventMap = HTMLElementEventMap & OverlayElementEventMap;
  *
  * The overlay provides `forwardHostProp` when calling
  * `Polymer.Templatize.templatize` for the template, so that the bindings
- * from the parent scope propagate to the content.  You can also pass
- * custom `instanceProps` object using the `instanceProps` property.
+ * from the parent scope propagate to the content.
  *
  * ```html
  * <vaadin-overlay>
  *   <template>Overlay content</template>
  * </vaadin-overlay>
  * ```
- *
- * **NOTE:** when using `instanceProps`: because of the Polymer limitation,
- * every template can only be templatized once, so it is important
- * to set `instanceProps` before the `template` is assigned to the overlay.
  *
  * ### Styling
  *
@@ -135,11 +130,6 @@ declare class OverlayElement extends ThemableMixin(DirMixin(HTMLElement)) {
    * The template of the overlay content.
    */
   template: HTMLTemplateElement | null | undefined;
-
-  /**
-   * Optional argument for `Polymer.Templatize.templatize`.
-   */
-  instanceProps: object | null | undefined;
 
   /**
    * References the content container after the template is stamped.

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -54,18 +54,7 @@ import { FocusablesHelper } from './vaadin-focusables-helper.js';
  *
  * The overlay provides `forwardHostProp` when calling
  * `Polymer.Templatize.templatize` for the template, so that the bindings
- * from the parent scope propagate to the content.  You can also pass
- * custom `instanceProps` object using the `instanceProps` property.
- *
- * ```html
- * <vaadin-overlay>
- *   <template>Overlay content</template>
- * </vaadin-overlay>
- * ```
- *
- * **NOTE:** when using `instanceProps`: because of the Polymer limitation,
- * every template can only be templatized once, so it is important
- * to set `instanceProps` before the `template` is assigned to the overlay.
+ * from the parent scope propagate to the content.
  *
  * ### Styling
  *
@@ -227,13 +216,6 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
       },
 
       /**
-       * Optional argument for `Polymer.Templatize.templatize`.
-       */
-      instanceProps: {
-        type: Object
-      },
-
-      /**
        * References the content container after the template is stamped.
        * @type {!HTMLElement | undefined}
        */
@@ -330,9 +312,6 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
       _oldTemplate: Object,
 
       /** @private */
-      _oldInstanceProps: Object,
-
-      /** @private */
       _oldRenderer: Object,
 
       /** @private */
@@ -341,7 +320,7 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   static get observers() {
-    return ['_templateOrRendererChanged(template, renderer, owner, model, instanceProps, opened)'];
+    return ['_templateOrRendererChanged(template, renderer, owner, model, opened)'];
   }
 
   constructor() {
@@ -824,15 +803,13 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
 
   /**
    * @param {!HTMLTemplateElement} template
-   * @param {object} instanceProps
    * @protected
    */
-  _stampOverlayTemplate(template, instanceProps) {
+  _stampOverlayTemplate(template) {
     this._removeOldContent();
 
     if (!template._Templatizer) {
       template._Templatizer = templatize(template, this, {
-        instanceProps: instanceProps,
         forwardHostProp: function (prop, value) {
           if (this._instance) {
             this._instance.forwardHostProp(prop, value);
@@ -885,7 +862,7 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   /** @private */
-  _templateOrRendererChanged(template, renderer, owner, model, instanceProps, opened) {
+  _templateOrRendererChanged(template, renderer, owner, model, opened) {
     if (template && renderer) {
       this._removeNewRendererOrTemplate(template, this._oldTemplate, renderer, this._oldRenderer);
       throw new Error('You should only use either a renderer or a template for overlay content');
@@ -895,8 +872,7 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
     this._oldModel = model;
     this._oldOwner = owner;
 
-    const templateOrInstancePropsChanged = this._oldInstanceProps !== instanceProps || this._oldTemplate !== template;
-    this._oldInstanceProps = instanceProps;
+    const templateChanged = this._oldTemplate !== template;
     this._oldTemplate = template;
 
     const rendererChanged = this._oldRenderer !== renderer;
@@ -914,8 +890,8 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
       delete this.content._$litPart$;
     }
 
-    if (template && templateOrInstancePropsChanged) {
-      this._stampOverlayTemplate(template, instanceProps);
+    if (template && templateChanged) {
+      this._stampOverlayTemplate(template);
     } else if (renderer && (rendererChanged || openedChanged || ownerOrModelChanged)) {
       if (opened) {
         this.requestContentUpdate();

--- a/packages/vaadin-overlay/test/renderer.test.js
+++ b/packages/vaadin-overlay/test/renderer.test.js
@@ -67,15 +67,6 @@ describe('renderer', () => {
       };
     });
 
-    it('should not call renderer on instanceProps change', () => {
-      const spy = sinon.spy();
-      overlay.opened = true;
-      overlay.renderer = () => spy();
-      spy.resetHistory();
-      overlay.instanceProps = {};
-      expect(spy.called).to.be.false;
-    });
-
     it('should not call renderer on template change', () => {
       const spy = sinon.spy();
       overlay.opened = true;
@@ -160,13 +151,6 @@ describe('renderer', () => {
 
     it('should throw an error when setting a renderer if there is already a template', () => {
       expect(() => (overlay.renderer = () => {})).to.throw(Error);
-    });
-
-    it('should restamp the template on instanceProps change', () => {
-      const lastInstance = overlay._instance;
-      expect(lastInstance).to.be.ok;
-      overlay.instanceProps = {};
-      expect(overlay._instance).to.not.equal(lastInstance);
     });
 
     it('should not restamp the template on model change', () => {


### PR DESCRIPTION
## Description

Some cleanup for `vaadin-overlay` that I'd like to get done for V23 before trying to convert it to Lit.

## Type of change

- Breaking change (internal API)