### PR TITLE
test: update testing helpers, use browser utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@polymer/iron-component-page": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",
-    "@vaadin/testing-helpers": "^0.3.1",
+    "@vaadin/testing-helpers": "^0.3.2",
     "@web/dev-server": "^0.1.28",
     "@web/rollup-plugin-html": "^1.10.1",
     "@web/test-runner": "^0.13.22",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/tabs": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.4"
   }
 }

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.4"
   }
 }

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.0"
   }
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.0"
   }
 }

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -47,7 +47,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/dialog": "^23.0.0-alpha0",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "@vaadin/text-field": "^23.0.0-alpha0",
     "lit": "^2.0.0",
     "sinon": "^9.2.0"

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.4"
   }
 }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -8,6 +8,7 @@ import {
   escKeyDown,
   fire,
   fixtureSync,
+  isChrome,
   isIOS,
   nextFrame,
   nextRender,
@@ -431,7 +432,6 @@ describe('items', () => {
       expect(menuComponents()[0].getAttribute('aria-expanded')).to.equal('false');
     });
 
-    const isChrome = window.chrome || /HeadlessChrome/.test(navigator.userAgent);
     (isChrome ? describe : describe.skip)('scrolling', () => {
       let rootOverlay, subOverlay1, subOverlay2, scrollElm;
 

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0"
+    "@vaadin/testing-helpers": "^0.3.2"
   }
 }

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -49,7 +49,7 @@
     "@vaadin/password-field": "^23.0.0-alpha0",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
     "@vaadin/select": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "@vaadin/text-area": "^23.0.0-alpha0",
     "@vaadin/text-field": "^23.0.0-alpha0",
     "@vaadin/time-picker": "^23.0.0-alpha0",

--- a/packages/custom-field/test/keyboard.test.js
+++ b/packages/custom-field/test/keyboard.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, tabKeyDown } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, isChrome, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-custom-field.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -94,7 +94,6 @@ describe('keyboard navigation', () => {
         customField = wrapper.$.field;
       });
 
-      const isChrome = window.chrome || /HeadlessChrome/.test(window.navigator.userAgent);
       // Skip this test on any platform apart from Chrome
       (isChrome ? it : it.skip)('should properly set tabindex on Shift Tab for wrapping slots', async () => {
         for (let i = 2; i > -1; i--) {

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -48,7 +48,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/dialog": "^23.0.0-alpha0",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.0"
   }
 }

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "@vaadin/text-area": "^23.0.0-alpha0",
     "sinon": "^9.2.1"
   }

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "@vaadin/text-field": "^23.0.0-alpha0",
     "sinon": "^9.2.1"
   }

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -51,7 +51,7 @@
     "@vaadin/date-picker": "^23.0.0-alpha0",
     "@vaadin/dialog": "^23.0.0-alpha0",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "lit": "^2.0.0",
     "sinon": "^9.2.1"
   }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "lit": "^2.0.0",
     "sinon": "^9.2.0"
   }

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -40,6 +40,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0"
+    "@vaadin/testing-helpers": "^0.3.2"
   }
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -38,6 +38,6 @@
     "lit": "^2.0.0"
   },
   "devDependencies": {
-    "@vaadin/testing-helpers": "^0.3.0"
+    "@vaadin/testing-helpers": "^0.3.2"
   }
 }

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -40,6 +40,6 @@
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/icon": "^23.0.0-alpha0",
     "@vaadin/icons": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0"
+    "@vaadin/testing-helpers": "^0.3.2"
   }
 }

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/icon": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.4"
   }
 }

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.4"
   }
 }

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -43,7 +43,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/button": "^23.0.0-alpha0",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -39,7 +39,7 @@
     "@vaadin/checkbox": "^23.0.0-alpha0",
     "@vaadin/grid": "^23.0.0-alpha0",
     "@vaadin/grid-pro": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.4"
   }
 }

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -42,6 +42,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0"
+    "@vaadin/testing-helpers": "^0.3.2"
   }
 }

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
     "gulp-iconfont": "^11.0.0",

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -40,6 +40,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0"
+    "@vaadin/testing-helpers": "^0.3.2"
   }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "lit": "^2.0.0",
     "sinon": "^9.2.0"
   }

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.0"
   }
 }

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/form-layout": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.0"
   }
 }

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, isFirefox } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-upload.js';
 import { createFile, createFiles, touchDevice, xhrCreator } from './common.js';
@@ -34,7 +34,6 @@ describe('file list', () => {
     });
   });
 
-  const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
   (isFirefox ? describe.skip : describe)('with add button', () => {
     it('should open file dialog by click', () => {
       // This test checks if the 'click' event is synchronously dispatched

--- a/packages/vaadin-avatar/package.json
+++ b/packages/vaadin-avatar/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/vaadin-list-mixin/package.json
+++ b/packages/vaadin-list-mixin/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.4"
   }
 }

--- a/packages/vaadin-messages/package.json
+++ b/packages/vaadin-messages/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.4"
   }
 }

--- a/packages/vaadin-ordered-layout/package.json
+++ b/packages/vaadin-ordered-layout/package.json
@@ -40,6 +40,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0"
+    "@vaadin/testing-helpers": "^0.3.2"
   }
 }

--- a/packages/vaadin-overlay/package.json
+++ b/packages/vaadin-overlay/package.json
@@ -44,7 +44,7 @@
     "@polymer/iron-overlay-behavior": "^3.0.0",
     "@vaadin/button": "^23.0.0-alpha0",
     "@vaadin/radio-group": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "@vaadin/text-field": "^23.0.0-alpha0",
     "lit": "^2.0.0",
     "sinon": "^9.2.1"

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@polymer/polymer": "^3.0.0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.4"
   }
 }

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -40,6 +40,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.3.0"
+    "@vaadin/testing-helpers": "^0.3.2"
   }
 }

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/polymer-legacy-adapter": "^23.0.0-alpha0",
-    "@vaadin/testing-helpers": "^0.3.0",
+    "@vaadin/testing-helpers": "^0.3.2",
     "lit": "^2.0.0",
     "sinon": "^9.2.4"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,10 +2019,10 @@
     "@typescript-eslint/types" "5.3.1"
     eslint-visitor-keys "^3.0.0"
 
-"@vaadin/testing-helpers@^0.3.0", "@vaadin/testing-helpers@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.3.1.tgz#785368988a05a5b354b089e72291775087b68708"
-  integrity sha512-dtSnQcQ2guLWRODOOhI5QF452Mu/3XzZC068EW8sw3kmFutcSCQCeHGszbOniWyIF+3IEn/H2OTpOFQGNLoHsw==
+"@vaadin/testing-helpers@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.3.2.tgz#f1a5c35ccaaa3012be419b27823386593927a1d8"
+  integrity sha512-oteeq6wjcnPVfU7IGUXym+/Y0F0wLEhQJmaXsdEqVkX1uPEBQpV4VqaMosFYLmsPd7DYqZYtl3N7tKJHoIdC8g==
   dependencies:
     "@esm-bundle/chai" "^4.3.1"
     "@open-wc/semantic-dom-diff" "^0.19.5-next.1"


### PR DESCRIPTION
## Description

1. Changed to use `isChrome` added in `@vaadin/testing-helpers` 0.3.2,
2. Updated one of the test files to import `isFirefox` from testing helpers.

## Type of change

- Tests