### PR TITLE
chore: use relative imports for virtualizer

### DIFF
--- a/packages/component-base/src/iron-list-core.js
+++ b/packages/component-base/src/iron-list-core.js
@@ -7,8 +7,8 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
-import { animationFrame, idlePeriod, microTask } from '@vaadin/component-base/src/async.js';
-import { Debouncer, enqueueDebouncer, flush } from '@vaadin/component-base/src/debounce.js';
+import { animationFrame, idlePeriod, microTask } from './async.js';
+import { Debouncer, enqueueDebouncer, flush } from './debounce.js';
 
 const IOS = navigator.userAgent.match(/iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/);
 const IOS_TOUCH_SCROLLING = IOS && IOS[1] >= 8;

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -1,5 +1,10 @@
-import { animationFrame, timeOut } from '@vaadin/component-base/src/async.js';
-import { Debouncer, flush } from '@vaadin/component-base/src/debounce.js';
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { animationFrame, timeOut } from './async.js';
+import { Debouncer, flush } from './debounce.js';
 import { ironList } from './iron-list-core.js';
 
 // iron-list can by default handle sizes up to around 100000.


### PR DESCRIPTION
## Description

Looks like we forgot to change imports when moving virtualizer code to `@vaadin/component-base`.

## Type of change

- Internal change