### PR TITLE
refactor!: use inputmode instead of number type

### DIFF
--- a/dev/number-field.html
+++ b/dev/number-field.html
@@ -12,6 +12,7 @@
   </head>
 
   <body>
-    <vaadin-number-field label="Required" required></vaadin-number-field>
+    <vaadin-number-field label="Amount" required placeholder="1 or more" min="1"></vaadin-number-field>
+    <vaadin-number-field label="Amount" required placeholder="5 or less" max="5" dir="rtl"></vaadin-number-field>
   </body>
 </html>

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -91,7 +91,6 @@ export class IntegerField extends NumberField {
         `Trying to set invalid step size "${newVal}", which is not a positive integer, to <vaadin-integer-field>. Resetting the default value 1.`
       );
       this.step = 1;
-      return;
     }
   }
 

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -59,6 +59,10 @@ export class IntegerField extends NumberField {
     };
   }
 
+  static get observers() {
+    return ['_stepChanged(step)'];
+  }
+
   /**
    * Override an observer from `InputMixin` to clear the value
    * when trying to type invalid characters.
@@ -77,14 +81,11 @@ export class IntegerField extends NumberField {
   }
 
   /**
-   * Override an observer from `NumberField` to reset the step
-   * property when an invalid step is set.
+   * Reset the step property when an invalid step is set.
    * @param {number} newVal
-   * @param {number | undefined} oldVal
-   * @protected
-   * @override
+   * @private
    */
-  _stepChanged(newVal, oldVal) {
+  _stepChanged(newVal) {
     if (!this.__hasOnlyDigits(newVal)) {
       console.warn(
         `Trying to set invalid step size "${newVal}", which is not a positive integer, to <vaadin-integer-field>. Resetting the default value 1.`
@@ -92,8 +93,6 @@ export class IntegerField extends NumberField {
       this.step = 1;
       return;
     }
-
-    super._stepChanged(newVal, oldVal);
   }
 
   /** @private */

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -347,11 +347,9 @@ snapshots["vaadin-integer-field slots default"] =
 <div slot="error-message">
 </div>
 <input
-  max="undefined"
-  min="undefined"
+  inputmode="numeric"
   slot="input"
-  step="any"
-  type="number"
+  type="text"
 >
 `;
 /* end snapshot vaadin-integer-field slots default */
@@ -362,11 +360,9 @@ snapshots["vaadin-integer-field slots helper"] =
 <div slot="error-message">
 </div>
 <input
-  max="undefined"
-  min="undefined"
+  inputmode="numeric"
   slot="input"
-  step="any"
-  type="number"
+  type="text"
 >
 <div slot="helper">
   Helper

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -193,11 +193,6 @@ describe('integer-field', () => {
       expect(integerField.step).to.eql(initialStep);
     });
 
-    it('should allow setting positive integer as string', () => {
-      integerField.step = '5';
-      expect(integerField.step).to.eql(5);
-    });
-
     describe('invalid step', () => {
       beforeEach(() => {
         sinon.stub(console, 'warn');

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -5,7 +5,6 @@
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
@@ -61,7 +60,7 @@ export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCus
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
+declare class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   /**
    * Set to true to display value increase/decrease controls.
    * @attr {boolean} has-controls

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -10,7 +10,6 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -51,11 +50,10 @@ const isNumUnset = (n) => !n && n !== 0;
  *
  * @extends HTMLElement
  * @mixes InputFieldMixin
- * @mixes SlotStylesMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
+export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-number-field';
   }
@@ -178,23 +176,6 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
     super();
     // TODO: extend text-field
     this._setType('text');
-  }
-
-  /** @protected */
-  get slotStyles() {
-    const tag = this.localName;
-    // TODO: check if placeholder styles are needed
-    return [
-      `
-        ${tag}[dir='rtl'] input::placeholder {
-          direction: rtl;
-        }
-
-        ${tag}[dir='rtl']:not([has-controls]) input::placeholder {
-          text-align: left;
-        }
-      `
-    ];
   }
 
   /**

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -5,7 +5,6 @@
  */
 import '@vaadin/input-container/src/vaadin-input-container.js';
 import { html, PolymerElement } from '@polymer/polymer';
-import { isAndroid, isIPhone } from '@vaadin/component-base/src/browser-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
@@ -15,14 +14,11 @@ import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaa
 
 registerStyles('vaadin-number-field', inputFieldShared, { moduleId: 'vaadin-number-field-styles' });
 
-const intlOptions = new Intl.NumberFormat().resolvedOptions();
-const hasDecimals = intlOptions.maximumFractionDigits > 0;
-
 const isNumUnset = (n) => !n && n !== 0;
 
 /**
  * Handle problematic values when calculating a remainder.
- * Source: Source: https://stackoverflow.com/a/31711034
+ * Source: https://stackoverflow.com/a/31711034
  */
 const floatSafeRemainder = (value, step) => {
   const valDecCount = (value.toString().split('.')[1] || '').length;
@@ -160,8 +156,7 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
        * The minimum value of the field.
        */
       min: {
-        type: Number,
-        observer: '_minChanged'
+        type: Number
       },
 
       /**
@@ -187,7 +182,7 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
 
   constructor() {
     super();
-    // TODO: extend text-field
+
     this._setType('text');
   }
 
@@ -197,15 +192,6 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
    */
   get clearElement() {
     return this.$.clearButton;
-  }
-
-  /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-
-    if (this.inputElement) {
-      this.__setInputMode(this.inputElement, this.min);
-    }
   }
 
   /** @protected */
@@ -222,41 +208,8 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
     );
     this.addController(new LabelledInputController(this.inputElement, this._labelNode));
 
+    this.inputElement.setAttribute('inputmode', 'numeric');
     this.inputElement.addEventListener('wheel', (e) => this._onWheel(e));
-  }
-
-  /**
-   * The `inputmode` attribute influences the software keyboard that is shown on touch devices.
-   * https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
-   * Browsers and operating systems are quite inconsistent about what keys are available.
-   * We choose between numeric and decimal based on whether negative numbers are allowed,
-   * and based on testing on various devices to determine what keys are available.
-   * @private
-   */
-  __setInputMode(input, min) {
-    const hasNegative = isNaN(min) || min < 0;
-    let inputMode = 'numeric';
-
-    if (isIPhone) {
-      // iPhone doesn't have a minus sign in either numeric or decimal.
-      // Note this is only for iPhone, not iPad, which always has both
-      // minus and decimal in numeric.
-      if (hasNegative) {
-        inputMode = 'text';
-      } else if (hasDecimals) {
-        inputMode = 'decimal';
-      }
-    } else if (isAndroid) {
-      // Android numeric has both a decimal point and minus key.
-      // decimal does not have a minus key.
-      if (hasNegative) {
-        inputMode = 'numeric';
-      } else if (hasDecimals) {
-        inputMode = 'decimal';
-      }
-    }
-
-    input.setAttribute('inputmode', inputMode);
   }
 
   /** @private */
@@ -428,13 +381,6 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
     const incr = sign * (this.step || 1);
     const value = parseFloat(this.value);
     return !this.value || (!this.disabled && this._incrementIsInsideTheLimits(incr, value));
-  }
-
-  /** @private */
-  _minChanged(min) {
-    if (this.inputElement) {
-      this.__setInputMode(this.inputElement, min);
-    }
   }
 
   /**

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -347,11 +347,9 @@ snapshots["vaadin-number-field slots default"] =
 <div slot="error-message">
 </div>
 <input
-  max="undefined"
-  min="undefined"
+  inputmode="numeric"
   slot="input"
-  step="any"
-  type="number"
+  type="text"
 >
 `;
 /* end snapshot vaadin-number-field slots default */
@@ -362,11 +360,9 @@ snapshots["vaadin-number-field slots helper"] =
 <div slot="error-message">
 </div>
 <input
-  max="undefined"
-  min="undefined"
+  inputmode="numeric"
   slot="input"
-  step="any"
-  type="number"
+  type="text"
 >
 <div slot="helper">
   Helper

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -14,16 +14,12 @@ describe('number-field', () => {
   });
 
   describe('native', () => {
-    it('should have [type=number]', () => {
-      expect(input.type).to.equal('number');
+    it('should set type attribute to text', () => {
+      expect(input.type).to.equal('text');
     });
 
-    ['min', 'max'].forEach(function (attr) {
-      it('should set numeric attribute ' + attr, () => {
-        const value = 5;
-        numberField[attr] = value;
-        expect(input.getAttribute(attr)).to.be.equal(String(value));
-      });
+    it('should set inputmode attribute to numeric', () => {
+      expect(input.getAttribute('inputmode')).to.equal('numeric');
     });
 
     it('should set value with correct decimal places regardless of step', () => {
@@ -669,13 +665,6 @@ describe('number-field', () => {
       numberField.value = 'foo';
       expect(numberField.value).to.be.empty;
       expect(numberField.validate()).to.be.true;
-    });
-
-    it('should align checkValidity with the native input element', () => {
-      numberField.value = -1;
-      numberField.min = 0;
-
-      expect(numberField.checkValidity()).to.equal(input.checkValidity());
     });
 
     it('should not validate when explicitly set to invalid', () => {

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { arrowDown, arrowUp, fixtureSync } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-number-field.js';
 
@@ -391,6 +392,58 @@ describe('number-field', () => {
           expect(numberField.validate()).to.be.true;
         }
       });
+    });
+  });
+
+  describe('wheel event', () => {
+    function wheel({ element = input, deltaX = 0, deltaY = 0 }) {
+      const e = new CustomEvent('wheel', { bubbles: true, cancelable: true });
+      e.deltaY = deltaY;
+      e.deltaX = deltaX;
+      element.dispatchEvent(e);
+    }
+
+    beforeEach(async () => {
+      numberField.value = 0;
+      await sendKeys({ press: 'Tab' });
+    });
+
+    it('should increase value on wheel with positive deltaY', () => {
+      wheel({ deltaY: 1 });
+      expect(numberField.value).to.be.equal('1');
+    });
+
+    it('should decrease value on wheel with negative deltaY', () => {
+      wheel({ deltaY: -1 });
+      expect(numberField.value).to.be.equal('-1');
+    });
+
+    it('should not change value on wheel with positive deltaX > deltaY', () => {
+      wheel({ deltaX: 2, deltaY: 1 });
+      expect(numberField.value).to.be.equal('0');
+    });
+
+    it('should not change value on wheel with negative deltaX < deltaY', () => {
+      wheel({ deltaX: -2, deltaY: -1 });
+      expect(numberField.value).to.be.equal('0');
+    });
+
+    it('should not change value on wheel when readonly', () => {
+      numberField.readonly = true;
+      wheel({ deltaY: 10 });
+      expect(numberField.value).to.be.equal('0');
+    });
+
+    it('should not change value on wheel when disabled', () => {
+      numberField.disabled = true;
+      wheel({ deltaY: 10 });
+      expect(numberField.value).to.be.equal('0');
+    });
+
+    it('should not change value on wheel when not focused', () => {
+      numberField.blur();
+      wheel({ deltaY: 10 });
+      expect(numberField.value).to.be.equal('0');
     });
   });
 

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -369,6 +369,7 @@ describe('number-field', () => {
           Object.assign(numberField, reset, props);
           increaseButton.click();
           expect(numberField.value).to.be.equal(expectedValue);
+          expect(numberField.validate()).to.be.true;
         }
       });
 
@@ -387,6 +388,7 @@ describe('number-field', () => {
           Object.assign(numberField, reset, props);
           decreaseButton.click();
           expect(numberField.value).to.be.equal(expectedValue);
+          expect(numberField.validate()).to.be.true;
         }
       });
     });

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -13,13 +13,9 @@ describe('number-field', () => {
     increaseButton = numberField.shadowRoot.querySelector('[part=increase-button]');
   });
 
-  describe('native', () => {
-    it('should set type attribute to text', () => {
-      expect(input.type).to.equal('text');
-    });
-
-    it('should set inputmode attribute to numeric', () => {
-      expect(input.getAttribute('inputmode')).to.equal('numeric');
+  describe('step', () => {
+    it('should not have initial value for step property', () => {
+      expect(numberField.step).to.be.undefined;
     });
 
     it('should set value with correct decimal places regardless of step', () => {
@@ -28,17 +24,9 @@ describe('number-field', () => {
 
       expect(numberField.value).equal('9.99');
     });
+  });
 
-    it('should increment value to next multiple of step offset by the min', () => {
-      numberField.step = 3;
-      numberField.min = 4;
-      numberField.value = 4;
-
-      increaseButton.click();
-
-      expect(numberField.value).equal('7');
-    });
-
+  describe('arrow keys', () => {
     it('should increment value on arrow up', () => {
       numberField.step = 3;
       arrowUp(input);
@@ -70,6 +58,16 @@ describe('number-field', () => {
       increaseButton.click();
 
       expect(numberField.value).to.be.equal('1');
+    });
+
+    it('should increase value to next multiple of step offset by the min', () => {
+      numberField.step = 3;
+      numberField.min = 4;
+      numberField.value = 4;
+
+      increaseButton.click();
+
+      expect(numberField.value).equal('7');
     });
 
     it('should dispatch change event on minus button click', () => {

--- a/packages/number-field/test/typings/number-field.types.ts
+++ b/packages/number-field/test/typings/number-field.types.ts
@@ -2,7 +2,6 @@ import '../../vaadin-number-field.js';
 import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
-import { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import {
   NumberField,
@@ -19,7 +18,6 @@ const field = document.createElement('vaadin-number-field');
 assertType<ControllerMixinClass>(field);
 assertType<ElementMixinClass>(field);
 assertType<InputFieldMixinClass>(field);
-assertType<SlotStylesMixinClass>(field);
 assertType<ThemableMixinClass>(field);
 
 // Events


### PR DESCRIPTION
## Description

1. Updated to use `<input type="text">` but not extend `vaadin-text-field` for now (IMO, that should be done separately, because it would also mean having to bring back `pattern` and `preventInvalidInput` properties and tests for them).
2. Implemented validation logic based on [`AbstractNumberField`](https://github.com/vaadin/flow-components/blob/e68fd61a0866957a4cc6ea6f09ae2783a3864e87/vaadin-text-field-flow-parent/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java#L390-L402) because we no longer use `<input type="number">` and can't rely on its built-in logic. Note, the Flow counterpart will still override client-side validation.

Fixes #1169
Fixes #1224

## Type of change

- Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.