### PR TITLE
fix: include model reference in declaratively bound events

### DIFF
--- a/packages/polymer-legacy-adapter/src/template-renderer-templatizer.js
+++ b/packages/polymer-legacy-adapter/src/template-renderer-templatizer.js
@@ -101,6 +101,10 @@ export class Templatizer extends PolymerElement {
     }, {});
 
     this.__TemplateClass = templatize(this.__template, this, {
+      // Events handled by declarative event listeners
+      // (`on-event="handler"`) will be decorated with a `model` property pointing
+      // to the template instance that stamped it.
+      parentModel: true,
       // This property prevents the template instance properties
       // from passing into the `forwardHostProp` callback
       instanceProps,

--- a/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
+++ b/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
@@ -119,6 +119,17 @@ describe('vaadin-template-renderer', () => {
     expect(spy.calledOnce).to.be.true;
   });
 
+  it('should include model in the event', () => {
+    const host = fixtureSync(`<mock-component-host></mock-component-host>`);
+    const component = host.$.component;
+    const button = component.$.content.querySelector('button');
+    const spy = sinon.spy(host, 'onClick');
+
+    click(button);
+
+    expect(spy.getCall(0).args[0].model).to.be.ok;
+  });
+
   it('should re-render the template instance when changing a parent property', async () => {
     const host = fixtureSync(`<mock-component-host></mock-component-host>`);
     const component = host.$.component;

--- a/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
+++ b/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
@@ -127,7 +127,7 @@ describe('vaadin-template-renderer', () => {
 
     click(button);
 
-    expect(spy.getCall(0).args[0].model).to.be.ok;
+    expect(spy.getCall(0).args[0].model).to.equal(component.$.content.__templateInstance);
   });
 
   it('should re-render the template instance when changing a parent property', async () => {


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/2355

The change includes `model` property (a reference to the template instance), in all events bound declaratively in a Polymer template. The property is being [accessed by the TemplateRenderer via RendererUtil](https://github.com/vaadin/flow-components/blob/e68fd61a0866957a4cc6ea6f09ae2783a3864e87/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/java/com/vaadin/flow/data/renderer/RendererUtil.java#L126) in flow-components.