### PR TITLE
fix: include model reference in declaratively bound events (#3078)

### DIFF
--- a/packages/vaadin-template-renderer/src/vaadin-template-renderer-templatizer.js
+++ b/packages/vaadin-template-renderer/src/vaadin-template-renderer-templatizer.js
@@ -101,6 +101,10 @@ export class Templatizer extends PolymerElement {
     }, {});
 
     this.__TemplateClass = templatize(this.__template, this, {
+      // Events handled by declarative event listeners
+      // (`on-event="handler"`) will be decorated with a `model` property pointing
+      // to the template instance that stamped it.
+      parentModel: true,
       // This property prevents the template instance properties
       // from passing into the `forwardHostProp` callback
       instanceProps,

--- a/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
+++ b/packages/vaadin-template-renderer/test/vaadin-template-renderer.test.js
@@ -121,6 +121,17 @@ describe('vaadin-template-renderer', () => {
     expect(spy.calledOnce).to.be.true;
   });
 
+  it('should include model in the event', () => {
+    const host = fixtureSync(`<mock-component-host></mock-component-host>`);
+    const component = host.$.component;
+    const button = component.$.content.querySelector('button');
+    const spy = sinon.spy(host, 'onClick');
+
+    click(button);
+
+    expect(spy.getCall(0).args[0].model).to.equal(component.$.content.__templateInstance);
+  });
+
   it('should re-render the template instance when changing a parent property', async () => {
     const host = fixtureSync(`<mock-component-host></mock-component-host>`);
     const component = host.$.component;


### PR DESCRIPTION
Backport https://github.com/vaadin/web-components/pull/3078 for V21