### PR TITLE
fix: add missing combo-box mixin classes

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -3,6 +3,9 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
 import { ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
@@ -136,6 +139,9 @@ declare class ComboBoxLight<TItem = ComboBoxDefaultItem> extends HTMLElement {
 interface ComboBoxLight<TItem = ComboBoxDefaultItem>
   extends ComboBoxDataProviderMixinClass<TItem>,
     ComboBoxMixinClass<TItem>,
+    KeyboardMixinClass,
+    InputMixinClass,
+    DisabledMixinClass,
     ThemableMixinClass {}
 
 declare global {

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -4,9 +4,19 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
+import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
+import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
+import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
 import { ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
@@ -215,8 +225,18 @@ declare class ComboBox<TItem = ComboBoxDefaultItem> extends HTMLElement {
 interface ComboBox<TItem = ComboBoxDefaultItem>
   extends ComboBoxDataProviderMixinClass<TItem>,
     ComboBoxMixinClass<TItem>,
+    ValidateMixinClass,
     PatternMixinClass,
+    LabelMixinClass,
+    KeyboardMixinClass,
+    InputMixinClass,
     InputControlMixinClass,
+    InputConstraintsMixinClass,
+    FocusMixinClass,
+    FieldMixinClass,
+    DisabledMixinClass,
+    DelegateStateMixinClass,
+    DelegateFocusMixinClass,
     ThemableMixinClass,
     ElementMixinClass,
     ControllerMixinClass {}

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -22,6 +22,7 @@ import {
   ComboBoxFilterChangedEvent,
   ComboBoxInvalidChangedEvent,
   ComboBoxOpenedChangedEvent,
+  ComboBoxRenderer,
   ComboBoxSelectedItemChangedEvent,
   ComboBoxValueChangedEvent
 } from '../../vaadin-combo-box';
@@ -88,6 +89,7 @@ assertType<() => boolean>(narrowedComboBox.checkValidity);
 assertType<() => boolean>(narrowedComboBox.validate);
 assertType<() => void>(narrowedComboBox.close);
 assertType<() => void>(narrowedComboBox.open);
+assertType<() => void>(narrowedComboBox.requestContentUpdate);
 assertType<boolean>(narrowedComboBox.allowCustomValue);
 assertType<boolean>(narrowedComboBox.autofocus);
 assertType<boolean>(narrowedComboBox.autoselect);
@@ -100,6 +102,7 @@ assertType<string | null | undefined>(narrowedComboBox.itemIdPath);
 assertType<string>(narrowedComboBox.itemLabelPath);
 assertType<string>(narrowedComboBox.itemValuePath);
 assertType<boolean>(narrowedComboBox.loading);
+assertType<ComboBoxRenderer<TestComboBoxItem> | null | undefined>(narrowedComboBox.renderer);
 assertType<TestComboBoxItem | null | undefined>(narrowedComboBox.selectedItem);
 assertType<boolean>(narrowedComboBox.invalid);
 assertType<HTMLElement | null | undefined>(narrowedComboBox.focusElement);

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -1,5 +1,17 @@
 import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
+import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
+import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
+import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
+import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
 import { ComboBoxDataProviderMixinClass } from '../../src/vaadin-combo-box-data-provider-mixin';
 import { ComboBoxMixinClass } from '../../src/vaadin-combo-box-mixin';
@@ -30,7 +42,7 @@ interface TestComboBoxItem {
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-/* ComboBoxElement */
+/* ComboBox */
 const genericComboBox = document.createElement('vaadin-combo-box');
 
 const narrowedComboBox = genericComboBox as ComboBox<TestComboBoxItem>;
@@ -76,7 +88,44 @@ narrowedComboBox.addEventListener('selected-item-changed', (event) => {
   assertType<TestComboBoxItem | null | undefined>(event.detail.value);
 });
 
-/* ComboBoxLightElement */
+// ComboBox properties
+assertType<() => boolean>(narrowedComboBox.checkValidity);
+assertType<() => boolean>(narrowedComboBox.validate);
+assertType<() => void>(narrowedComboBox.close);
+assertType<() => void>(narrowedComboBox.open);
+assertType<boolean | null | undefined>(narrowedComboBox.autoOpenDisabled);
+assertType<boolean | null | undefined>(narrowedComboBox.opened);
+assertType<boolean>(narrowedComboBox.invalid);
+assertType<HTMLElement | null | undefined>(narrowedComboBox.focusElement);
+assertType<boolean>(narrowedComboBox.disabled);
+assertType<boolean>(narrowedComboBox.clearButtonVisible);
+assertType<string | null | undefined>(narrowedComboBox.errorMessage);
+assertType<string>(narrowedComboBox.placeholder);
+assertType<string | null | undefined>(narrowedComboBox.helperText);
+assertType<boolean>(narrowedComboBox.readonly);
+assertType<string | null | undefined>(narrowedComboBox.label);
+assertType<string>(narrowedComboBox.value);
+assertType<boolean>(narrowedComboBox.required);
+assertType<string>(narrowedComboBox.name);
+
+// ComboBox mixins
+assertType<ControllerMixinClass>(narrowedComboBox);
+assertType<ElementMixinClass>(narrowedComboBox);
+assertType<DelegateFocusMixinClass>(narrowedComboBox);
+assertType<DelegateStateMixinClass>(narrowedComboBox);
+assertType<DisabledMixinClass>(narrowedComboBox);
+assertType<FieldMixinClass>(narrowedComboBox);
+assertType<FocusMixinClass>(narrowedComboBox);
+assertType<InputConstraintsMixinClass>(narrowedComboBox);
+assertType<InputControlMixinClass>(narrowedComboBox);
+assertType<InputMixinClass>(narrowedComboBox);
+assertType<KeyboardMixinClass>(narrowedComboBox);
+assertType<LabelMixinClass>(narrowedComboBox);
+assertType<PatternMixinClass>(narrowedComboBox);
+assertType<ValidateMixinClass>(narrowedComboBox);
+assertType<ThemableMixinClass>(narrowedComboBox);
+
+/* ComboBoxLight */
 const genericComboBoxLight = document.createElement('vaadin-combo-box-light');
 assertType<ComboBoxLight>(genericComboBoxLight);
 
@@ -119,3 +168,23 @@ narrowedComboBoxLight.addEventListener('selected-item-changed', (event) => {
   assertType<ComboBoxLightSelectedItemChangedEvent<TestComboBoxItem>>(event);
   assertType<TestComboBoxItem | null | undefined>(event.detail.value);
 });
+
+// ComboBoxLight properties
+assertType<() => boolean>(narrowedComboBoxLight.checkValidity);
+assertType<() => boolean>(narrowedComboBoxLight.validate);
+assertType<() => void>(narrowedComboBoxLight.close);
+assertType<() => void>(narrowedComboBoxLight.open);
+assertType<boolean | null | undefined>(narrowedComboBoxLight.autoOpenDisabled);
+assertType<boolean | null | undefined>(narrowedComboBoxLight.opened);
+assertType<boolean>(narrowedComboBoxLight.invalid);
+assertType<boolean>(narrowedComboBoxLight.disabled);
+assertType<boolean>(narrowedComboBoxLight.readonly);
+assertType<string>(narrowedComboBoxLight.value);
+
+// ComboBoxLight mixins
+assertType<ElementMixinClass>(narrowedComboBoxLight);
+assertType<DisabledMixinClass>(narrowedComboBoxLight);
+assertType<InputConstraintsMixinClass>(narrowedComboBoxLight);
+assertType<InputMixinClass>(narrowedComboBoxLight);
+assertType<KeyboardMixinClass>(narrowedComboBoxLight);
+assertType<ThemableMixinClass>(narrowedComboBoxLight);

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -44,14 +44,9 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 
 /* ComboBox */
 const genericComboBox = document.createElement('vaadin-combo-box');
+assertType<ComboBox>(genericComboBox);
 
 const narrowedComboBox = genericComboBox as ComboBox<TestComboBoxItem>;
-assertType<ComboBox>(narrowedComboBox);
-assertType<ControllerMixinClass>(narrowedComboBox);
-assertType<ElementMixinClass>(narrowedComboBox);
-assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBox);
-assertType<ComboBoxMixinClass<TestComboBoxItem>>(narrowedComboBox);
-assertType<ThemableMixinClass>(narrowedComboBox);
 
 narrowedComboBox.addEventListener('change', (event) => {
   assertType<ComboBoxChangeEvent<TestComboBoxItem>>(event);
@@ -93,8 +88,19 @@ assertType<() => boolean>(narrowedComboBox.checkValidity);
 assertType<() => boolean>(narrowedComboBox.validate);
 assertType<() => void>(narrowedComboBox.close);
 assertType<() => void>(narrowedComboBox.open);
+assertType<boolean>(narrowedComboBox.allowCustomValue);
+assertType<boolean>(narrowedComboBox.autofocus);
+assertType<boolean>(narrowedComboBox.autoselect);
 assertType<boolean | null | undefined>(narrowedComboBox.autoOpenDisabled);
-assertType<boolean | null | undefined>(narrowedComboBox.opened);
+assertType<boolean>(narrowedComboBox.opened);
+assertType<string>(narrowedComboBox.filter);
+assertType<TestComboBoxItem[] | undefined>(narrowedComboBox.filteredItems);
+assertType<TestComboBoxItem[] | undefined>(narrowedComboBox.items);
+assertType<string | null | undefined>(narrowedComboBox.itemIdPath);
+assertType<string>(narrowedComboBox.itemLabelPath);
+assertType<string>(narrowedComboBox.itemValuePath);
+assertType<boolean>(narrowedComboBox.loading);
+assertType<TestComboBoxItem | null | undefined>(narrowedComboBox.selectedItem);
 assertType<boolean>(narrowedComboBox.invalid);
 assertType<HTMLElement | null | undefined>(narrowedComboBox.focusElement);
 assertType<boolean>(narrowedComboBox.disabled);
@@ -102,6 +108,8 @@ assertType<boolean>(narrowedComboBox.clearButtonVisible);
 assertType<string | null | undefined>(narrowedComboBox.errorMessage);
 assertType<string>(narrowedComboBox.placeholder);
 assertType<string | null | undefined>(narrowedComboBox.helperText);
+assertType<string>(narrowedComboBox.pattern);
+assertType<boolean | null | undefined>(narrowedComboBox.preventInvalidInput);
 assertType<boolean>(narrowedComboBox.readonly);
 assertType<string | null | undefined>(narrowedComboBox.label);
 assertType<string>(narrowedComboBox.value);
@@ -109,6 +117,8 @@ assertType<boolean>(narrowedComboBox.required);
 assertType<string>(narrowedComboBox.name);
 
 // ComboBox mixins
+assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBox);
+assertType<ComboBoxMixinClass<TestComboBoxItem>>(narrowedComboBox);
 assertType<ControllerMixinClass>(narrowedComboBox);
 assertType<ElementMixinClass>(narrowedComboBox);
 assertType<DelegateFocusMixinClass>(narrowedComboBox);
@@ -130,9 +140,6 @@ const genericComboBoxLight = document.createElement('vaadin-combo-box-light');
 assertType<ComboBoxLight>(genericComboBoxLight);
 
 const narrowedComboBoxLight = genericComboBoxLight as ComboBoxLight<TestComboBoxItem>;
-assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);
-assertType<ComboBoxMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);
-assertType<ThemableMixinClass>(narrowedComboBoxLight);
 
 narrowedComboBoxLight.addEventListener('change', (event) => {
   assertType<ComboBoxLightChangeEvent<TestComboBoxItem>>(event);
@@ -175,16 +182,16 @@ assertType<() => boolean>(narrowedComboBoxLight.validate);
 assertType<() => void>(narrowedComboBoxLight.close);
 assertType<() => void>(narrowedComboBoxLight.open);
 assertType<boolean | null | undefined>(narrowedComboBoxLight.autoOpenDisabled);
-assertType<boolean | null | undefined>(narrowedComboBoxLight.opened);
+assertType<boolean>(narrowedComboBoxLight.opened);
 assertType<boolean>(narrowedComboBoxLight.invalid);
 assertType<boolean>(narrowedComboBoxLight.disabled);
 assertType<boolean>(narrowedComboBoxLight.readonly);
 assertType<string>(narrowedComboBoxLight.value);
 
 // ComboBoxLight mixins
-assertType<ElementMixinClass>(narrowedComboBoxLight);
+assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);
+assertType<ComboBoxMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);
 assertType<DisabledMixinClass>(narrowedComboBoxLight);
-assertType<InputConstraintsMixinClass>(narrowedComboBoxLight);
 assertType<InputMixinClass>(narrowedComboBoxLight);
 assertType<KeyboardMixinClass>(narrowedComboBoxLight);
 assertType<ThemableMixinClass>(narrowedComboBoxLight);


### PR DESCRIPTION
## Description

Unlike other field components, `vaadin-combo-box` does not use mixin functions (which apply these classes internally).
This is due to using generics (mixins can't accept generic type parameters). So we have to list all the mixin classes.

## Type of change

- Bugfix