### PR TITLE
fix: ensure virtualizer re-renders unhidden items (#3081)

### DIFF
--- a/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
+++ b/packages/vaadin-virtual-list/src/virtualizer-iron-list-adapter.js
@@ -268,6 +268,8 @@ export class IronListAdapter {
       if (!el.hidden) {
         el.__virtualIndex = vidx + (this._vidxOffset || 0);
         this.__updateElement(el, el.__virtualIndex);
+      } else {
+        delete el.__lastUpdatedIndex;
       }
     }, itemSet);
   }

--- a/packages/vaadin-virtual-list/test/virtualizer.test.js
+++ b/packages/vaadin-virtual-list/test/virtualizer.test.js
@@ -224,6 +224,28 @@ describe('virtualizer', () => {
     expect(firstIndexUpdatesCount).to.equal(1);
   });
 
+  it('should re-render an unhidden item', async () => {
+    // Create a virtualizer with just one item (rendered content "foo-0")
+    let prefix = 'foo-';
+    const updateElement = (el, index) => (el.textContent = `${prefix}${index}`);
+    init({ size: 1, updateElement });
+
+    // Wait for a possible resize observer flush
+    await aTimeout(100);
+
+    // Reduce the size to 0 (the item gets hidden)
+    virtualizer.size = 0;
+
+    // Update the prefix used by the renderer to "bar-"
+    prefix = 'bar-';
+
+    // Increase the size back to 1
+    virtualizer.size = 1;
+
+    // Expect the unhidden item to be re-rendered with the new prefix even though its index hasn't changed
+    expect(elementsContainer.firstElementChild.textContent).to.equal('bar-0');
+  });
+
   it('should have physical items once visible', async () => {
     init({ size: 0 });
     // Wait for possibly active resize observers to flush


### PR DESCRIPTION
Backport https://github.com/vaadin/web-components/pull/3081 for V21