### PR TITLE
feat: add type definitions for change event

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -15,6 +15,13 @@ export {
 export { ComboBoxDefaultItem, ComboBoxItemModel, ComboBoxRenderer } from './vaadin-combo-box-mixin.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type ComboBoxLightChangeEvent<TItem> = Event & {
+  target: ComboBoxLight<TItem>;
+};
+
+/**
  * Fired when the user sets a custom value.
  */
 export type ComboBoxLightCustomValueSetEvent = CustomEvent<string>;
@@ -45,6 +52,8 @@ export type ComboBoxLightFilterChangedEvent = CustomEvent<{ value: string }>;
 export type ComboBoxLightSelectedItemChangedEvent<TItem> = CustomEvent<{ value: TItem | null | undefined }>;
 
 export interface ComboBoxLightEventMap<TItem> extends HTMLElementEventMap {
+  change: ComboBoxLightChangeEvent<TItem>;
+
   'custom-value-set': ComboBoxLightCustomValueSetEvent;
 
   'opened-changed': ComboBoxLightOpenedChangedEvent;

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -19,6 +19,13 @@ export {
 export { ComboBoxDefaultItem, ComboBoxItemModel, ComboBoxRenderer } from './vaadin-combo-box-mixin.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type ComboBoxChangeEvent<TItem> = Event & {
+  target: ComboBox<TItem>;
+};
+
+/**
  * Fired when the user sets a custom value.
  */
 export type ComboBoxCustomValueSetEvent = CustomEvent<string>;
@@ -49,6 +56,8 @@ export type ComboBoxFilterChangedEvent = CustomEvent<{ value: string }>;
 export type ComboBoxSelectedItemChangedEvent<TItem> = CustomEvent<{ value: TItem | null | undefined }>;
 
 export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
+  change: ComboBoxChangeEvent<TItem>;
+
   'custom-value-set': ComboBoxCustomValueSetEvent;
 
   'opened-changed': ComboBoxOpenedChangedEvent;

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -5,6 +5,7 @@ import { ComboBoxDataProviderMixinClass } from '../../src/vaadin-combo-box-data-
 import { ComboBoxMixinClass } from '../../src/vaadin-combo-box-mixin';
 import {
   ComboBox,
+  ComboBoxChangeEvent,
   ComboBoxCustomValueSetEvent,
   ComboBoxFilterChangedEvent,
   ComboBoxInvalidChangedEvent,
@@ -14,6 +15,7 @@ import {
 } from '../../vaadin-combo-box';
 import {
   ComboBoxLight,
+  ComboBoxLightChangeEvent,
   ComboBoxLightCustomValueSetEvent,
   ComboBoxLightFilterChangedEvent,
   ComboBoxLightInvalidChangedEvent,
@@ -38,6 +40,11 @@ assertType<ElementMixinClass>(narrowedComboBox);
 assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBox);
 assertType<ComboBoxMixinClass<TestComboBoxItem>>(narrowedComboBox);
 assertType<ThemableMixinClass>(narrowedComboBox);
+
+narrowedComboBox.addEventListener('change', (event) => {
+  assertType<ComboBoxChangeEvent<TestComboBoxItem>>(event);
+  assertType<ComboBox<TestComboBoxItem>>(event.target);
+});
 
 narrowedComboBox.addEventListener('custom-value-set', (event) => {
   assertType<ComboBoxCustomValueSetEvent>(event);
@@ -70,40 +77,45 @@ narrowedComboBox.addEventListener('selected-item-changed', (event) => {
 });
 
 /* ComboBoxLightElement */
-const genericComboBoxLightElement = document.createElement('vaadin-combo-box-light');
-assertType<ComboBoxLight>(genericComboBoxLightElement);
+const genericComboBoxLight = document.createElement('vaadin-combo-box-light');
+assertType<ComboBoxLight>(genericComboBoxLight);
 
-const narrowedComboBoxLightElement = genericComboBoxLightElement as ComboBoxLight<TestComboBoxItem>;
-assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBoxLightElement);
-assertType<ComboBoxMixinClass<TestComboBoxItem>>(narrowedComboBoxLightElement);
-assertType<ThemableMixinClass>(narrowedComboBoxLightElement);
+const narrowedComboBoxLight = genericComboBoxLight as ComboBoxLight<TestComboBoxItem>;
+assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);
+assertType<ComboBoxMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);
+assertType<ThemableMixinClass>(narrowedComboBoxLight);
 
-narrowedComboBoxLightElement.addEventListener('custom-value-set', (event) => {
+narrowedComboBoxLight.addEventListener('change', (event) => {
+  assertType<ComboBoxLightChangeEvent<TestComboBoxItem>>(event);
+  assertType<ComboBoxLight<TestComboBoxItem>>(event.target);
+});
+
+narrowedComboBoxLight.addEventListener('custom-value-set', (event) => {
   assertType<ComboBoxLightCustomValueSetEvent>(event);
   assertType<string>(event.detail);
 });
 
-narrowedComboBoxLightElement.addEventListener('opened-changed', (event) => {
+narrowedComboBoxLight.addEventListener('opened-changed', (event) => {
   assertType<ComboBoxLightOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
-narrowedComboBoxLightElement.addEventListener('invalid-changed', (event) => {
+narrowedComboBoxLight.addEventListener('invalid-changed', (event) => {
   assertType<ComboBoxLightInvalidChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
-narrowedComboBoxLightElement.addEventListener('value-changed', (event) => {
+narrowedComboBoxLight.addEventListener('value-changed', (event) => {
   assertType<ComboBoxLightValueChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
 
-narrowedComboBoxLightElement.addEventListener('filter-changed', (event) => {
+narrowedComboBoxLight.addEventListener('filter-changed', (event) => {
   assertType<ComboBoxLightFilterChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
 
-narrowedComboBoxLightElement.addEventListener('selected-item-changed', (event) => {
+narrowedComboBoxLight.addEventListener('selected-item-changed', (event) => {
   assertType<ComboBoxLightSelectedItemChangedEvent<TestComboBoxItem>>(event);
   assertType<TestComboBoxItem | null | undefined>(event.detail.value);
 });

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -19,6 +19,13 @@ export interface CustomFieldI18n {
 }
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type CustomFieldChangeEvent = Event & {
+  target: CustomField;
+};
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type CustomFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -34,7 +41,9 @@ export interface CustomFieldCustomEventMap {
   'value-changed': CustomFieldValueChangedEvent;
 }
 
-export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCustomEventMap {}
+export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCustomEventMap {
+  change: CustomFieldChangeEvent;
+}
 
 /**
  * `<vaadin-custom-field>` is a web component for wrapping multiple components as a single field.

--- a/packages/custom-field/test/typings/custom-field.types.ts
+++ b/packages/custom-field/test/typings/custom-field.types.ts
@@ -1,9 +1,19 @@
 import '../../vaadin-custom-field.js';
-import { CustomFieldInvalidChangedEvent, CustomFieldValueChangedEvent } from '../../vaadin-custom-field.js';
+import {
+  CustomField,
+  CustomFieldChangeEvent,
+  CustomFieldInvalidChangedEvent,
+  CustomFieldValueChangedEvent
+} from '../../vaadin-custom-field.js';
 
 const customField = document.createElement('vaadin-custom-field');
 
 const assertType = <TExpected>(actual: TExpected) => actual;
+
+customField.addEventListener('change', (event) => {
+  assertType<CustomFieldChangeEvent>(event);
+  assertType<CustomField>(event.target);
+});
 
 customField.addEventListener('invalid-changed', (event) => {
   assertType<CustomFieldInvalidChangedEvent>(event);

--- a/packages/date-picker/src/vaadin-date-picker-light.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-light.d.ts
@@ -8,6 +8,13 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
 export { DatePickerDate, DatePickerI18n } from './vaadin-date-picker-mixin.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type DatePickerLightChangeEvent = Event & {
+  target: DatePickerLight;
+};
+
+/**
  * Fired when the `opened` property changes.
  */
 export type DatePickerLightOpenedChangedEvent = CustomEvent<{ value: boolean }>;
@@ -30,7 +37,9 @@ export interface DatePickerLightCustomEventMap {
   'value-changed': DatePickerLightValueChangedEvent;
 }
 
-export interface DatePickerLightEventMap extends HTMLElementEventMap, DatePickerLightCustomEventMap {}
+export interface DatePickerLightEventMap extends HTMLElementEventMap, DatePickerLightCustomEventMap {
+  change: DatePickerLightChangeEvent;
+}
 
 /**
  * `<vaadin-date-picker-light>` is a customizable version of the `<vaadin-date-picker>` providing

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -10,6 +10,13 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
 export { DatePickerDate, DatePickerI18n } from './vaadin-date-picker-mixin.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type DatePickerChangeEvent = Event & {
+  target: DatePicker;
+};
+
+/**
  * Fired when the `opened` property changes.
  */
 export type DatePickerOpenedChangedEvent = CustomEvent<{ value: boolean }>;
@@ -32,7 +39,9 @@ export interface DatePickerCustomEventMap {
   'value-changed': DatePickerValueChangedEvent;
 }
 
-export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCustomEventMap {}
+export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCustomEventMap {
+  change: DatePickerChangeEvent;
+}
 
 /**
  * `<vaadin-date-picker>` is an input field that allows to enter a date by typing or by selecting from a calendar overlay.

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -14,12 +14,14 @@ import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themabl
 import { DatePickerMixinClass } from '../../src/vaadin-date-picker-mixin.js';
 import {
   DatePicker,
+  DatePickerChangeEvent,
   DatePickerInvalidChangedEvent,
   DatePickerOpenedChangedEvent,
   DatePickerValueChangedEvent
 } from '../../vaadin-date-picker.js';
 import {
   DatePickerLight,
+  DatePickerLightChangeEvent,
   DatePickerLightInvalidChangedEvent,
   DatePickerLightOpenedChangedEvent,
   DatePickerLightValueChangedEvent
@@ -44,6 +46,11 @@ datePicker.addEventListener('invalid-changed', (event) => {
 datePicker.addEventListener('value-changed', (event) => {
   assertType<DatePickerValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+datePicker.addEventListener('change', (event) => {
+  assertType<DatePickerChangeEvent>(event);
+  assertType<DatePicker>(event.target);
 });
 
 // DatePicker properties
@@ -103,6 +110,11 @@ datePickerLight.addEventListener('invalid-changed', (event) => {
 datePickerLight.addEventListener('value-changed', (event) => {
   assertType<DatePickerLightValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+datePickerLight.addEventListener('change', (event) => {
+  assertType<DatePickerLightChangeEvent>(event);
+  assertType<DatePickerLight>(event.target);
 });
 
 // DatePickerLight properties

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -14,6 +14,13 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 export interface DateTimePickerI18n extends DatePickerI18n, TimePickerI18n {}
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type DateTimePickerChangeEvent = Event & {
+  target: DateTimePicker;
+};
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type DateTimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -29,7 +36,9 @@ export interface DateTimePickerCustomEventMap {
   'value-changed': DateTimePickerValueChangedEvent;
 }
 
-export interface DateTimePickerEventMap extends DateTimePickerCustomEventMap, HTMLElementEventMap {}
+export interface DateTimePickerEventMap extends DateTimePickerCustomEventMap, HTMLElementEventMap {
+  change: DateTimePickerChangeEvent;
+}
 
 /**
  * `<vaadin-date-time-picker>` is a Web Component providing a date time selection field.

--- a/packages/date-time-picker/test/typings/date-time-picker.types.ts
+++ b/packages/date-time-picker/test/typings/date-time-picker.types.ts
@@ -1,9 +1,19 @@
 import '../../vaadin-date-time-picker.js';
-import { DateTimePickerInvalidChangedEvent, DateTimePickerValueChangedEvent } from '../../vaadin-date-time-picker.js';
+import {
+  DateTimePicker,
+  DateTimePickerChangeEvent,
+  DateTimePickerInvalidChangedEvent,
+  DateTimePickerValueChangedEvent
+} from '../../vaadin-date-time-picker.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const picker = document.createElement('vaadin-date-time-picker');
+
+picker.addEventListener('change', (event) => {
+  assertType<DateTimePickerChangeEvent>(event);
+  assertType<DateTimePicker>(event.target);
+});
 
 picker.addEventListener('invalid-changed', (event) => {
   assertType<DateTimePickerInvalidChangedEvent>(event);

--- a/packages/email-field/src/vaadin-email-field.d.ts
+++ b/packages/email-field/src/vaadin-email-field.d.ts
@@ -6,6 +6,13 @@
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type EmailFieldChangeEvent = Event & {
+  target: EmailField;
+};
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type EmailFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -21,7 +28,9 @@ export interface EmailFieldCustomEventMap {
   'value-changed': EmailFieldValueChangedEvent;
 }
 
-export interface EmailFieldEventMap extends HTMLElementEventMap, EmailFieldCustomEventMap {}
+export interface EmailFieldEventMap extends HTMLElementEventMap, EmailFieldCustomEventMap {
+  change: EmailFieldChangeEvent;
+}
 
 /**
  * `<vaadin-email-field>` is a Web Component for email field control in forms.

--- a/packages/email-field/test/typings/email-field.types.ts
+++ b/packages/email-field/test/typings/email-field.types.ts
@@ -1,9 +1,19 @@
 import '../../vaadin-email-field.js';
-import { EmailFieldInvalidChangedEvent, EmailFieldValueChangedEvent } from '../../vaadin-email-field.js';
+import {
+  EmailField,
+  EmailFieldChangeEvent,
+  EmailFieldInvalidChangedEvent,
+  EmailFieldValueChangedEvent
+} from '../../vaadin-email-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const field = document.createElement('vaadin-email-field');
+
+field.addEventListener('change', (event) => {
+  assertType<EmailFieldChangeEvent>(event);
+  assertType<EmailField>(event.target);
+});
 
 field.addEventListener('invalid-changed', (event) => {
   assertType<EmailFieldInvalidChangedEvent>(event);

--- a/packages/integer-field/src/vaadin-integer-field.d.ts
+++ b/packages/integer-field/src/vaadin-integer-field.d.ts
@@ -6,6 +6,13 @@
 import { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type IntegerFieldChangeEvent = Event & {
+  target: IntegerField;
+};
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type IntegerFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -21,7 +28,9 @@ export interface IntegerFieldCustomEventMap {
   'value-changed': IntegerFieldValueChangedEvent;
 }
 
-export interface IntegerFieldEventMap extends HTMLElementEventMap, IntegerFieldCustomEventMap {}
+export interface IntegerFieldEventMap extends HTMLElementEventMap, IntegerFieldCustomEventMap {
+  change: IntegerFieldChangeEvent;
+}
 
 /**
  * `<vaadin-integer-field>` is an input field web component that only accepts entering integer numbers.

--- a/packages/integer-field/test/typings/integer-field.types.ts
+++ b/packages/integer-field/test/typings/integer-field.types.ts
@@ -1,9 +1,19 @@
 import '../../vaadin-integer-field.js';
-import { IntegerFieldInvalidChangedEvent, IntegerFieldValueChangedEvent } from '../../vaadin-integer-field.js';
+import {
+  IntegerField,
+  IntegerFieldChangeEvent,
+  IntegerFieldInvalidChangedEvent,
+  IntegerFieldValueChangedEvent
+} from '../../vaadin-integer-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const field = document.createElement('vaadin-integer-field');
+
+field.addEventListener('change', (event) => {
+  assertType<IntegerFieldChangeEvent>(event);
+  assertType<IntegerField>(event.target);
+});
 
 field.addEventListener('invalid-changed', (event) => {
   assertType<IntegerFieldInvalidChangedEvent>(event);

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -9,6 +9,13 @@ import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type NumberFieldChangeEvent = Event & {
+  target: NumberField;
+};
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type NumberFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -24,7 +31,9 @@ export interface NumberFieldCustomEventMap {
   'value-changed': NumberFieldValueChangedEvent;
 }
 
-export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCustomEventMap {}
+export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCustomEventMap {
+  change: NumberFieldChangeEvent;
+}
 
 /**
  * `<vaadin-number-field>` is an input field web component that only accepts numeric input.

--- a/packages/number-field/test/typings/number-field.types.ts
+++ b/packages/number-field/test/typings/number-field.types.ts
@@ -4,7 +4,12 @@ import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
 import { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { NumberFieldInvalidChangedEvent, NumberFieldValueChangedEvent } from '../../vaadin-number-field.js';
+import {
+  NumberField,
+  NumberFieldChangeEvent,
+  NumberFieldInvalidChangedEvent,
+  NumberFieldValueChangedEvent
+} from '../../vaadin-number-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -18,6 +23,11 @@ assertType<SlotStylesMixinClass>(field);
 assertType<ThemableMixinClass>(field);
 
 // Events
+field.addEventListener('change', (event) => {
+  assertType<NumberFieldChangeEvent>(event);
+  assertType<NumberField>(event.target);
+});
+
 field.addEventListener('invalid-changed', (event) => {
   assertType<NumberFieldInvalidChangedEvent>(event);
   assertType<boolean>(event.detail.value);

--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -7,6 +7,13 @@ import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type PasswordFieldChangeEvent = Event & {
+  target: PasswordField;
+};
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type PasswordFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -22,7 +29,9 @@ export interface PasswordFieldCustomEventMap {
   'value-changed': PasswordFieldValueChangedEvent;
 }
 
-export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFieldCustomEventMap {}
+export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFieldCustomEventMap {
+  change: PasswordFieldChangeEvent;
+}
 
 /**
  * `<vaadin-password-field>` is an extension of `<vaadin-text-field>` component for entering passwords.

--- a/packages/password-field/test/typings/password-field.types.ts
+++ b/packages/password-field/test/typings/password-field.types.ts
@@ -1,9 +1,19 @@
 import '../../vaadin-password-field.js';
-import { PasswordFieldInvalidChangedEvent, PasswordFieldValueChangedEvent } from '../../vaadin-password-field.js';
+import {
+  PasswordField,
+  PasswordFieldChangeEvent,
+  PasswordFieldInvalidChangedEvent,
+  PasswordFieldValueChangedEvent
+} from '../../vaadin-password-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const field = document.createElement('vaadin-password-field');
+
+field.addEventListener('change', (event) => {
+  assertType<PasswordFieldChangeEvent>(event);
+  assertType<PasswordField>(event.target);
+});
 
 field.addEventListener('invalid-changed', (event) => {
   assertType<PasswordFieldInvalidChangedEvent>(event);

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
@@ -35,6 +35,13 @@ export interface RichTextEditorI18n {
 }
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type RichTextEditorChangeEvent = Event & {
+  target: RichTextEditor;
+};
+
+/**
  * Fired when the `htmlValue` property changes.
  */
 export type RichTextEditorHtmlValueChangedEvent = CustomEvent<{ value: string }>;
@@ -50,7 +57,9 @@ export interface RichTextEditorCustomEventMap {
   'value-changed': RichTextEditorValueChangedEvent;
 }
 
-export interface RichTextEditorEventMap extends HTMLElementEventMap, RichTextEditorCustomEventMap {}
+export interface RichTextEditorEventMap extends HTMLElementEventMap, RichTextEditorCustomEventMap {
+  change: RichTextEditorChangeEvent;
+}
 
 /**
  * `<vaadin-rich-text-editor>` is a Web Component for rich text editing.

--- a/packages/rich-text-editor/test/typings/rich-text-editor.types.ts
+++ b/packages/rich-text-editor/test/typings/rich-text-editor.types.ts
@@ -1,16 +1,27 @@
 import '../../vaadin-rich-text-editor.js';
-import { RichTextEditorHtmlValueChangedEvent, RichTextEditorValueChangedEvent } from '../../vaadin-rich-text-editor.js';
+import {
+  RichTextEditor,
+  RichTextEditorChangeEvent,
+  RichTextEditorHtmlValueChangedEvent,
+  RichTextEditorValueChangedEvent
+} from '../../vaadin-rich-text-editor.js';
 
-const customField = document.createElement('vaadin-rich-text-editor');
+const richTextEditor = document.createElement('vaadin-rich-text-editor');
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-customField.addEventListener('html-value-changed', (event) => {
+// Events
+richTextEditor.addEventListener('change', (event) => {
+  assertType<RichTextEditorChangeEvent>(event);
+  assertType<RichTextEditor>(event.target);
+});
+
+richTextEditor.addEventListener('html-value-changed', (event) => {
   assertType<RichTextEditorHtmlValueChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
 
-customField.addEventListener('value-changed', (event) => {
+richTextEditor.addEventListener('value-changed', (event) => {
   assertType<RichTextEditorValueChangedEvent>(event);
   assertType<string>(event.detail.value);
 });

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -16,6 +16,13 @@ export interface SelectItem {
 }
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type SelectChangeEvent = Event & {
+  target: Select;
+};
+
+/**
  * Function for rendering the content of the `<vaadin-select>`.
  * Receives two arguments:
  *
@@ -48,7 +55,9 @@ export interface SelectCustomEventMap {
   'value-changed': SelectValueChangedEvent;
 }
 
-export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMap {}
+export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMap {
+  change: SelectChangeEvent;
+}
 
 /**
  * `<vaadin-select>` is a Web Component for selecting values from a list of items.

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -1,6 +1,7 @@
 import '../../vaadin-select.js';
 import {
   Select,
+  SelectChangeEvent,
   SelectInvalidChangedEvent,
   SelectItem,
   SelectOpenedChangedEvent,
@@ -23,6 +24,11 @@ assertType<() => void>(select.requestContentUpdate);
 assertType<() => boolean>(select.validate);
 
 // Events
+select.addEventListener('change', (event) => {
+  assertType<SelectChangeEvent>(event);
+  assertType<Select>(event.target);
+});
+
 select.addEventListener('opened-changed', (event) => {
   assertType<SelectOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -8,6 +8,13 @@ import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type TextAreaChangeEvent = Event & {
+  target: TextArea;
+};
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type TextAreaInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -23,7 +30,9 @@ export interface TextAreaCustomEventMap {
   'value-changed': TextAreaValueChangedEvent;
 }
 
-export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEventMap {}
+export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEventMap {
+  change: TextAreaChangeEvent;
+}
 
 /**
  * `<vaadin-text-area>` is a web component for multi-line text input.

--- a/packages/text-area/test/typings/text-area.types.ts
+++ b/packages/text-area/test/typings/text-area.types.ts
@@ -3,7 +3,12 @@ import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixi
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { TextAreaInvalidChangedEvent, TextAreaValueChangedEvent } from '../../vaadin-text-area.js';
+import {
+  TextArea,
+  TextAreaChangeEvent,
+  TextAreaInvalidChangedEvent,
+  TextAreaValueChangedEvent
+} from '../../vaadin-text-area.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -16,6 +21,11 @@ assertType<InputFieldMixinClass>(area);
 assertType<ThemableMixinClass>(area);
 
 // Events
+area.addEventListener('change', (event) => {
+  assertType<TextAreaChangeEvent>(event);
+  assertType<TextArea>(event.target);
+});
+
 area.addEventListener('invalid-changed', (event) => {
   assertType<TextAreaInvalidChangedEvent>(event);
   assertType<boolean>(event.detail.value);

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -9,6 +9,13 @@ import { PatternMixin } from '@vaadin/field-base/src/pattern-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type TextFieldChangeEvent = Event & {
+  target: TextField;
+};
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type TextFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -24,7 +31,9 @@ export interface TextFieldCustomEventMap {
   'value-changed': TextFieldValueChangedEvent;
 }
 
-export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomEventMap {}
+export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomEventMap {
+  change: TextFieldChangeEvent;
+}
 
 /**
  * `<vaadin-text-field>` is a web component that allows the user to input and edit text.

--- a/packages/text-field/test/typings/text-field.types.ts
+++ b/packages/text-field/test/typings/text-field.types.ts
@@ -4,7 +4,12 @@ import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
 import { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { TextFieldInvalidChangedEvent, TextFieldValueChangedEvent } from '../../vaadin-text-field.js';
+import {
+  TextField,
+  TextFieldChangeEvent,
+  TextFieldInvalidChangedEvent,
+  TextFieldValueChangedEvent
+} from '../../vaadin-text-field.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -18,6 +23,11 @@ assertType<PatternMixinClass>(field);
 assertType<ThemableMixinClass>(field);
 
 // Events
+field.addEventListener('change', (event) => {
+  assertType<TextFieldChangeEvent>(event);
+  assertType<TextField>(event.target);
+});
+
 field.addEventListener('invalid-changed', (event) => {
   assertType<TextFieldInvalidChangedEvent>(event);
   assertType<boolean>(event.detail.value);

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -23,6 +23,13 @@ export interface TimePickerI18n {
 }
 
 /**
+ * Fired when the user commits a value change.
+ */
+export type TimePickerChangeEvent = Event & {
+  target: TimePicker;
+};
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type TimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -38,7 +45,9 @@ export interface TimePickerCustomEventMap {
   'value-changed': TimePickerValueChangedEvent;
 }
 
-export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCustomEventMap {}
+export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCustomEventMap {
+  change: TimePickerChangeEvent;
+}
 
 /**
  * `<vaadin-time-picker>` is a Web Component providing a time-selection field.

--- a/packages/time-picker/test/typings/time-picker.types.ts
+++ b/packages/time-picker/test/typings/time-picker.types.ts
@@ -4,7 +4,12 @@ import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { TimePickerInvalidChangedEvent, TimePickerValueChangedEvent } from '../../vaadin-time-picker.js';
+import {
+  TimePicker,
+  TimePickerChangeEvent,
+  TimePickerInvalidChangedEvent,
+  TimePickerValueChangedEvent
+} from '../../vaadin-time-picker.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -18,6 +23,11 @@ assertType<PatternMixinClass>(timePicker);
 assertType<ThemableMixinClass>(timePicker);
 
 // Events
+timePicker.addEventListener('change', (event) => {
+  assertType<TimePickerChangeEvent>(event);
+  assertType<TimePicker>(event.target);
+});
+
 timePicker.addEventListener('invalid-changed', (event) => {
   assertType<TimePickerInvalidChangedEvent>(event);
   assertType<boolean>(event.detail.value);


### PR DESCRIPTION
## Description

The main idea behind this improvement is providing a type for `target` property of the `change` event object.
This is especially important because typically inside a change event listener users check `event.target.value`.

We might consider updating all the other custom events to have type for `target` separately later.

Fixes #3040 

## Type of change

- Feature