### PR TITLE
test: prevent opening add file dialog in tests

### DIFF
--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -823,7 +823,7 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
     // cancelling the following synthetic click. See also:
     // https://github.com/Polymer/polymer/issues/5289
     this.__resetMouseCanceller();
-    this._onAddFilesClick();
+    this._onAddFilesClick(e);
   }
 
   /** @private */
@@ -832,11 +832,12 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @private */
-  _onAddFilesClick() {
+  _onAddFilesClick(e) {
     if (this.maxFilesReached) {
       return;
     }
 
+    e.stopPropagation();
     this.$.fileInput.value = '';
     this.$.fileInput.click();
   }

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -41,13 +41,10 @@ describe('file list', () => {
     beforeEach(() => {
       addFiles = upload.$.addFiles;
       input = upload.$.fileInput;
-      // This test suite checks if the 'click' event is synchronously dispatched
-      // on the hidden file input when user clicks Add Files button. The
-      // file dialog is actually not getting opened during testing.
-
-      // While the mock Add Files button click event fired by this test is not
-      // trusted and therefore it should generate a non-trusted click event on
-      // the hidden file input, some browsers (Firefox) can still open dialog.
+      // While the synthetic "Add Files" button click event is not trusted and
+      // it should generate a non-trusted click event on the hidden file input,
+      // at the time of writing Chrome and Firefox still open the file dialog.
+      // Use stub calling `preventDefault` to prevent dialog from opening.
       clickSpy = sinon.stub().callsFake((e) => e.preventDefault());
       input.addEventListener('click', clickSpy);
     });

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { click, fixtureSync, makeSoloTouchEvent, touchend } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-upload.js';
 import { createFile, createFiles, touchDevice, xhrCreator } from './common.js';
@@ -36,7 +36,7 @@ describe('file list', () => {
   describe('with add button', () => {
     let input;
     let addFiles;
-    let clickSpy;
+    let inputClickSpy;
 
     beforeEach(() => {
       addFiles = upload.$.addFiles;
@@ -45,20 +45,19 @@ describe('file list', () => {
       // it should generate a non-trusted click event on the hidden file input,
       // at the time of writing Chrome and Firefox still open the file dialog.
       // Use stub calling `preventDefault` to prevent dialog from opening.
-      clickSpy = sinon.stub().callsFake((e) => e.preventDefault());
-      input.addEventListener('click', clickSpy);
+      inputClickSpy = sinon.stub().callsFake((e) => e.preventDefault());
+      input.addEventListener('click', inputClickSpy);
     });
 
     it('should open file dialog by click', () => {
-      addFiles.dispatchEvent(new MouseEvent('click'));
-      expect(clickSpy.calledOnce).to.be.true;
+      click(addFiles);
+      expect(inputClickSpy.calledOnce).to.be.true;
     });
 
     it('should open file dialog by touchend', () => {
-      const e = new CustomEvent('touchend', { cancelable: true });
-      addFiles.dispatchEvent(e);
-      expect(clickSpy.calledOnce).to.be.true;
-      expect(e.defaultPrevented).to.be.true;
+      const event = makeSoloTouchEvent('touchend', null, addFiles);
+      expect(inputClickSpy.calledOnce).to.be.true;
+      expect(event.defaultPrevented).to.be.true;
     });
 
     it('should invoke Polymer.Gestures.resetMouseCanceller before open file dialog', () => {
@@ -66,9 +65,7 @@ describe('file list', () => {
       // Polymer.Gestures.resetMouseCanceller. Have to use a separate
       // wrapper method for testing.
       const spy = sinon.spy(upload, '__resetMouseCanceller');
-
-      const e = new CustomEvent('touchend', { cancelable: true });
-      addFiles.dispatchEvent(e);
+      touchend(addFiles);
       expect(spy.calledOnce).to.be.true;
     });
 
@@ -112,7 +109,7 @@ describe('file list', () => {
     it('should not open upload dialog when max files added', () => {
       upload.maxFiles = 0;
       addFiles.dispatchEvent(new MouseEvent('click'));
-      expect(clickSpy.called).to.be.false;
+      expect(inputClickSpy.called).to.be.false;
     });
 
     it('should set max-files-reached style attribute when max files added', () => {

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { click, fixtureSync, makeSoloTouchEvent, touchend } from '@vaadin/testing-helpers';
+import { change, click, fixtureSync, makeSoloTouchEvent, touchend } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-upload.js';
 import { createFile, createFiles, touchDevice, xhrCreator } from './common.js';
@@ -76,7 +76,7 @@ describe('file list', () => {
       delete input.value;
       input.value = 'foo';
 
-      addFiles.dispatchEvent(new MouseEvent('click'));
+      click(addFiles);
       expect(input.value).to.be.empty;
     });
 
@@ -86,8 +86,7 @@ describe('file list', () => {
       input.__proto__ = HTMLElement.prototype;
       input.files = files;
 
-      const e = new Event('change', { cancelable: true });
-      input.dispatchEvent(e);
+      change(input);
 
       expect(upload.files[0]).to.equal(files[1]);
       expect(upload.files[1]).to.equal(files[0]);
@@ -108,7 +107,7 @@ describe('file list', () => {
 
     it('should not open upload dialog when max files added', () => {
       upload.maxFiles = 0;
-      addFiles.dispatchEvent(new MouseEvent('click'));
+      click(addFiles);
       expect(inputClickSpy.called).to.be.false;
     });
 


### PR DESCRIPTION
## Description

It turns out that Firefox on Playwright, and Chrome (in manual mode) opened native file upload on synthetic click.
Updated the tests to add spy that calls `event.preventDefault()` in `beforeEach` to prevent this behavior.

## Type of change

- Tests