### PR TITLE
fix: link form-item label to field via aria-labelledby

### DIFF
--- a/packages/field-base/src/utils.d.ts
+++ b/packages/field-base/src/utils.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Adds a value to an attribute containing space-delimited values.
+ */
+export declare function addValueToAttribute(element: HTMLElement, attr: string, value: string): void;
+
+/**
+ * Removes a value from an attribute containing space-delimited values.
+ */
+export declare function removeValueFromAttribute(element: HTMLElement, attr: string, value: string): void;

--- a/packages/field-base/src/utils.d.ts
+++ b/packages/field-base/src/utils.d.ts
@@ -1,9 +1,16 @@
 /**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
  * Adds a value to an attribute containing space-delimited values.
  */
 export declare function addValueToAttribute(element: HTMLElement, attr: string, value: string): void;
 
 /**
  * Removes a value from an attribute containing space-delimited values.
+ * If the value is the last one, the whole attribute is removed.
  */
 export declare function removeValueFromAttribute(element: HTMLElement, attr: string, value: string): void;

--- a/packages/field-base/src/utils.js
+++ b/packages/field-base/src/utils.js
@@ -1,4 +1,10 @@
 /**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
  * @param {string} value
  * @return {Set<string>}
  */
@@ -33,6 +39,7 @@ export function addValueToAttribute(element, attr, value) {
 
 /**
  * Removes a value from an attribute containing space-delimited values.
+ * If the value is the last one, the whole attribute is removed.
  *
  * @param {HTMLElement} element
  * @param {string} attr

--- a/packages/field-base/src/utils.js
+++ b/packages/field-base/src/utils.js
@@ -1,0 +1,49 @@
+/**
+ * @param {string} value
+ * @return {Set<string>}
+ */
+function deserializeAttributeValue(value) {
+  if (!value) {
+    return new Set();
+  }
+
+  return new Set(value.split(' '));
+}
+
+/**
+ * @param {Set<string>} values
+ * @return {string}
+ */
+function serializeAttributeValue(values) {
+  return [...values].join(' ');
+}
+
+/**
+ * Adds a value to an attribute containing space-delimited values.
+ *
+ * @param {HTMLElement} element
+ * @param {string} attr
+ * @param {string} value
+ */
+export function addValueToAttribute(element, attr, value) {
+  const values = deserializeAttributeValue(element.getAttribute(attr));
+  values.add(value);
+  element.setAttribute(attr, serializeAttributeValue(values));
+}
+
+/**
+ * Removes a value from an attribute containing space-delimited values.
+ *
+ * @param {HTMLElement} element
+ * @param {string} attr
+ * @param {string} value
+ */
+export function removeValueFromAttribute(element, attr, value) {
+  const values = deserializeAttributeValue(element.getAttribute(attr));
+  values.delete(value);
+  if (values.size === 0) {
+    element.removeAttribute(attr);
+    return;
+  }
+  element.setAttribute(attr, serializeAttributeValue(values));
+}

--- a/packages/field-base/test/utils.test.js
+++ b/packages/field-base/test/utils.test.js
@@ -1,0 +1,43 @@
+import { expect } from '@esm-bundle/chai';
+import { addValueToAttribute, removeValueFromAttribute } from '../src/utils.js';
+
+describe('utils', () => {
+  describe('addValueToAttribute', () => {
+    let element;
+
+    beforeEach(() => {
+      element = document.createElement('div');
+    });
+
+    it('should add a value to an attribute', () => {
+      addValueToAttribute(element, 'aria-labelledby', 'label-id');
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id');
+
+      addValueToAttribute(element, 'aria-labelledby', 'error-id');
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id error-id');
+    });
+
+    it('should not duplicate values in the attribute', () => {
+      addValueToAttribute(element, 'aria-labelledby', 'label-id');
+      addValueToAttribute(element, 'aria-labelledby', 'label-id');
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id');
+    });
+  });
+
+  describe('removeValueFromAttribute', () => {
+    let element;
+
+    beforeEach(() => {
+      element = document.createElement('div');
+      element.setAttribute('aria-labelledby', 'label-id error-id');
+    });
+
+    it('should remove a value from an attribute', () => {
+      removeValueFromAttribute(element, 'aria-labelledby', 'error-id');
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id');
+
+      removeValueFromAttribute(element, 'aria-labelledby', 'label-id');
+      expect(element.hasAttribute('aria-labelledby')).to.be.false;
+    });
+  });
+});

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/custom-field": "23.0.0-alpha1",
     "@vaadin/testing-helpers": "^0.3.2",
     "@vaadin/text-field": "23.0.0-alpha1",
-    "@vaadin/custom-field": "23.0.0-alpha1",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -43,6 +43,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.3.2",
     "@vaadin/text-field": "23.0.0-alpha1",
+    "@vaadin/custom-field": "23.0.0-alpha1",
     "sinon": "^9.2.1"
   }
 }

--- a/packages/form-layout/src/vaadin-form-item.d.ts
+++ b/packages/form-layout/src/vaadin-form-item.d.ts
@@ -97,7 +97,16 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  */
-declare class FormItem extends ThemableMixin(HTMLElement) {}
+declare class FormItem extends ThemableMixin(HTMLElement) {
+  /**
+   * Returns a target element to add ARIA attributes to for a field.
+   *
+   * - For Vaadin field components, the method returns an element
+   * obtained through the `ariaTarget` property defined in `FieldMixin`.
+   * - In other cases, the method returns the field element itself.
+   */
+  protected _getFieldAriaTarget(field: HTMLElement): HTMLElement;
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -202,27 +202,38 @@ class FormItem extends ThemableMixin(PolymerElement) {
   }
 
   /**
-   * Links the label to a field by adding the label's id to
-   * the `aria-labelledby` attribute of the field.
+   * Returns a target element to add ARIA attributes to for a field.
+   *
+   * - For Vaadin field components, the method returns an element
+   * obtained through the `ariaTarget` property defined in `FieldMixin`.
+   * - In other cases, the method returns the field element itself.
+   *
+   * @protected
+   */
+  _getFieldAriaTarget(field) {
+    return field.ariaTarget || field;
+  }
+
+  /**
+   * Links the label to a field by adding the label id to
+   * the `aria-labelledby` attribute of the field's ARIA target element.
    *
    * @param {HTMLElement} field
    * @private
    */
   __linkLabelToField(field) {
-    const ariaTarget = field.ariaTarget || field;
-    addValueToAttribute(ariaTarget, 'aria-labelledby', this.__labelId);
+    addValueToAttribute(this._getFieldAriaTarget(field), 'aria-labelledby', this.__labelId);
   }
 
   /**
-   * Unlinks the label from a field by removing the label's id from
-   * the `aria-labelledby` attribute of the field.
+   * Unlinks the label from a field by removing the label id from
+   * the `aria-labelledby` attribute of the field's ARIA target element.
    *
    * @param {HTMLElement} field
    * @private
    */
   __unlinkLabelFromField(field) {
-    const ariaTarget = field.ariaTarget || field;
-    removeValueFromAttribute(ariaTarget, 'aria-labelledby', this.__labelId);
+    removeValueFromAttribute(this._getFieldAriaTarget(field), 'aria-labelledby', this.__labelId);
   }
 
   /** @private */

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -208,6 +208,7 @@ class FormItem extends ThemableMixin(PolymerElement) {
    * obtained through the `ariaTarget` property defined in `FieldMixin`.
    * - In other cases, the method returns the field element itself.
    *
+   * @param {HTMLElement} field
    * @protected
    */
   _getFieldAriaTarget(field) {

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -5,6 +5,7 @@
  */
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/field-base/src/utils.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
@@ -226,11 +227,7 @@ class FormItem extends ThemableMixin(PolymerElement) {
    */
   __linkLabelToField(field) {
     const ariaTarget = field.ariaTarget || field;
-
-    // TODO: Consider creating a helper like `addValueToAttribute`.
-    let ariaIds = new Set((ariaTarget.getAttribute('aria-labelledby') || '').split(' '));
-    ariaIds.add(this.__labelId);
-    ariaTarget.setAttribute('aria-labelledby', [...ariaIds].filter(Boolean).join(' '));
+    addValueToAttribute(ariaTarget, 'aria-labelledby', this.__labelId);
   }
 
   /**
@@ -242,16 +239,7 @@ class FormItem extends ThemableMixin(PolymerElement) {
    */
   __unlinkLabelFromField(field) {
     const ariaTarget = field.ariaTarget || field;
-
-    // TODO: Consider creating a helper like `removeValueFromAttribute`.
-    let ariaIds = new Set((ariaTarget.getAttribute('aria-labelledby') || '').split(' '));
-    ariaIds.delete('');
-    ariaIds.delete(this.__labelId);
-    if (ariaIds.size > 0) {
-      ariaTarget.setAttribute('aria-labelledby', [...ariaIds].filter(Boolean).join(' '));
-    } else {
-      ariaTarget.removeAttribute('aria-labelledby');
-    }
+    removeValueFromAttribute(ariaTarget, 'aria-labelledby', this.__labelId);
   }
 
   /** @private */

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -179,14 +179,26 @@ class FormItem extends ThemableMixin(PolymerElement) {
     }
   }
 
+  /**
+   * @return {HTMLElement}
+   * @private
+   */
   get __labelNode() {
     return this.querySelector('[slot=label]');
   }
 
+  /**
+   * @return {HTMLElement[]}
+   * @private
+   */
   get __fieldNodes() {
     return [...this.querySelectorAll(':not([slot])')];
   }
 
+  /**
+   * @return {HTMLElement | undefined}
+   * @private
+   */
   get __fieldAriaTarget() {
     const fieldNode = this.__fieldNodes[0];
     if (fieldNode && fieldNode.ariaTarget) {
@@ -195,15 +207,18 @@ class FormItem extends ThemableMixin(PolymerElement) {
     return fieldNode;
   }
 
-  /** @private */
+  /**
+   * @param {HTMLElement} labelNode
+   * @private
+   */
   __linkLabelToField(labelNode) {
     const fieldAriaTarget = this.__fieldAriaTarget;
     if (!fieldAriaTarget) {
       return;
     }
 
-    const ariaLabelledBy = fieldAriaTarget.getAttribute('aria-labelledby');
-    fieldAriaTarget.setAttribute('aria-labelledby', `${ariaLabelledBy} ${labelNode.id}`);
+    const aria = fieldAriaTarget.getAttribute('aria-labelledby');
+    fieldAriaTarget.setAttribute('aria-labelledby', `${aria} ${labelNode.id}`);
   }
 
   /** @private */
@@ -222,6 +237,10 @@ class FormItem extends ThemableMixin(PolymerElement) {
 
   /** @private */
   __onContentSlotChange() {
+    if (this.__labelNode) {
+      this.__linkLabelToField(this.__labelNode);
+    }
+
     if (this.__contentField) {
       // Discard the old field
       this.__updateRequiredState(false);

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -166,6 +166,7 @@ class FormItem extends ThemableMixin(PolymerElement) {
     this.__contentFieldObserver = new MutationObserver(() => this.__updateRequiredState(this.__contentField.required));
   }
 
+  /** @protected */
   ready() {
     super.ready();
 

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -217,8 +217,11 @@ class FormItem extends ThemableMixin(PolymerElement) {
       return;
     }
 
-    const aria = fieldAriaTarget.getAttribute('aria-labelledby');
-    fieldAriaTarget.setAttribute('aria-labelledby', `${aria} ${labelNode.id}`);
+    const ariaIds = (fieldAriaTarget.getAttribute('aria-labelledby') || '').split(' ');
+    if (!ariaIds.includes(labelNode.id)) {
+      ariaIds.push(labelNode.id);
+    }
+    fieldAriaTarget.setAttribute('aria-labelledby', ariaIds.filter(Boolean).join(' '));
   }
 
   /** @private */

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -120,17 +120,16 @@ describe('form-item', () => {
       newLabel.slot = 'label';
       item.replaceChild(newLabel, label);
       await nextFrame();
-      expect(label.id).to.be.empty;
       expect(newLabel.id).to.equal(labelId);
     });
 
-    it('should set id to the new label element when using appendChild', async () => {
+    it('should not set id to the new label element when using appendChild', async () => {
       const newLabel = document.createElement('label');
       newLabel.slot = 'label';
       item.appendChild(newLabel);
       await nextFrame();
-      expect(label.id).to.be.empty;
-      expect(newLabel.id).to.equal(labelId);
+      expect(label.id).to.equal(labelId);
+      expect(newLabel.id).to.be.empty;
     });
 
     it('should set id to the new label element when using insertBefore', async () => {
@@ -138,7 +137,6 @@ describe('form-item', () => {
       newLabel.slot = 'label';
       item.insertBefore(newLabel, label);
       await nextFrame();
-      expect(label.id).to.be.empty;
       expect(newLabel.id).to.equal(labelId);
     });
   });
@@ -165,7 +163,6 @@ describe('form-item', () => {
         const newInput = document.createElement('input');
         item.replaceChild(newInput, input);
         await nextFrame();
-        expect(input.getAttribute('aria-labelledby')).to.equal('custom-id');
         expect(newInput.getAttribute('aria-labelledby')).to.equal(label.id);
       });
 

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -2,8 +2,8 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/custom-style.js';
-import '@vaadin/text-field';
 import '@vaadin/custom-field';
+import '@vaadin/text-field';
 import '../vaadin-form-item.js';
 
 describe('form-item', () => {

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -45,6 +45,18 @@ describe('form-item', () => {
       expect(id).to.match(ID_REGEX);
       expect(id.endsWith(item.constructor._uniqueLabelId)).to.be.true;
     });
+
+    it('should focus input on label click', () => {
+      const spy = sinon.spy(input, 'focus');
+      label.click();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should click input on label click', () => {
+      const spy = sinon.spy(input, 'click');
+      label.click();
+      expect(spy.calledOnce).to.be.true;
+    });
   });
 
   describe('label positioning', () => {
@@ -88,9 +100,9 @@ describe('form-item', () => {
     });
   });
 
-  describe.only('label', () => {
+  describe('aria-labelledby', () => {
     describe('input', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         item = fixtureSync(`
           <vaadin-form-item>
             <label slot="label">Label</label>
@@ -99,31 +111,33 @@ describe('form-item', () => {
         `);
         label = item.querySelector('label');
         input = item.querySelector('input');
+        await nextFrame();
       });
 
-      it('should focus input on label click', () => {
-        const spy = sinon.spy(input, 'focus');
-        label.click();
-        expect(spy.calledOnce).to.be.true;
+      it('should link the label to the input', () => {
+        expect(input.getAttribute('aria-labelledby')).to.equal(`custom-id ${label.id}`);
       });
 
-      it('should click input on label click', () => {
-        const spy = sinon.spy(input, 'click');
-        label.click();
-        expect(spy.calledOnce).to.be.true;
+      it('should link the label only to the first input', async () => {
+        const newInput = document.createElement('input');
+        item.appendChild(newInput);
+        await nextFrame();
+        expect(input.getAttribute('aria-labelledby')).to.equal(`custom-id ${label.id}`);
+        expect(newInput.hasAttribute('aria-labelledby')).to.be.false;
       });
 
-      it('should link the label to the input via aria-labelledby', () => {
-        const aria = input.getAttribute('aria-labelledby');
-        expect(aria).to.include('custom-id');
-        expect(aria).to.include(label.id);
+      it('should link the label to the new input when replacing the input', async () => {
+        const newInput = document.createElement('input');
+        item.replaceChild(newInput, input);
+        await nextFrame();
+        expect(newInput.getAttribute('aria-labelledby')).to.equal(label.id);
       });
     });
 
     describe('field', () => {
       let field, fieldInput;
 
-      beforeEach(() => {
+      beforeEach(async () => {
         item = fixtureSync(`
           <vaadin-form-item>
             <label slot="label">Label</label>
@@ -135,21 +149,19 @@ describe('form-item', () => {
         label = item.querySelector('label');
         field = item.querySelector('vaadin-text-field');
         fieldInput = field.querySelector('input');
+        await nextFrame();
       });
 
-      it('should link the label to the field input via aria-labelledby', () => {
-        console.log(field, fieldInput);
-        console.log(label.id);
-        const aria = fieldInput.getAttribute('aria-labelledby');
-        expect(aria).to.include('custom-id');
-        expect(aria).to.include(label.id);
+      it('should link the label to the field input', () => {
+        expect(fieldInput.getAttribute('aria-labelledby')).to.include('custom-id');
+        expect(fieldInput.getAttribute('aria-labelledby')).to.include(label.id);
       });
     });
 
     describe('field group', () => {
-      let fieldGroup;
+      let field;
 
-      beforeEach(() => {
+      beforeEach(async () => {
         item = fixtureSync(`
           <vaadin-form-item>
             <label slot="label">Label</label>
@@ -157,13 +169,13 @@ describe('form-item', () => {
           </vaadin-form-item>
         `);
         label = item.querySelector('label');
-        fieldGroup = item.querySelector('vaadin-custom-field');
+        field = item.querySelector('vaadin-custom-field');
+        await nextFrame();
       });
 
-      it('should link the label to the field group via aria-labelledby', () => {
-        const aria = fieldGroup.getAttribute('aria-labelledby');
-        expect(aria).to.include('custom-id');
-        expect(aria).to.include(label.id);
+      it('should link the label to the field group', () => {
+        expect(field.getAttribute('aria-labelledby')).to.include('custom-id');
+        expect(field.getAttribute('aria-labelledby')).to.include(label.id);
       });
     });
   });
@@ -181,6 +193,14 @@ describe('form-item', () => {
     });
 
     beforeEach(() => {
+      item = fixtureSync(`
+        <vaadin-form-item>
+          <label slot="label">Label</label>
+          <input>
+        </vaadin-form-item>
+      `);
+      label = item.querySelector('label');
+      input = item.querySelector('input');
       item.style.width = '100%';
     });
 
@@ -205,6 +225,14 @@ describe('form-item', () => {
 
   describe('required input', () => {
     beforeEach(async () => {
+      item = fixtureSync(`
+        <vaadin-form-item>
+          <label slot="label">Label</label>
+          <input>
+        </vaadin-form-item>
+      `);
+      label = item.querySelector('label');
+      input = item.querySelector('input');
       input.required = true;
       await nextFrame();
     });

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -2,26 +2,27 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/custom-style.js';
+import '@vaadin/text-field';
+import '@vaadin/custom-field';
 import '../vaadin-form-item.js';
 
 describe('form-item', () => {
   let item, label, input;
 
-  beforeEach(() => {
-    item = fixtureSync(`
-      <vaadin-form-item>
-        <label slot="label">Label</label>
-        <input>
-      </vaadin-form-item>
-    `);
-    label = item.querySelector('label');
-    input = item.querySelector('input');
-  });
-
   describe('basic features', () => {
     let labelSlot, inputSlot;
 
+    const ID_REGEX = /^label-vaadin-form-item-\d+$/;
+
     beforeEach(() => {
+      item = fixtureSync(`
+        <vaadin-form-item>
+          <label slot="label">Label</label>
+          <input>
+        </vaadin-form-item>
+      `);
+      label = item.querySelector('label');
+      input = item.querySelector('input');
       labelSlot = item.shadowRoot.querySelector('slot[name="label"]');
       inputSlot = item.shadowRoot.querySelector('slot:not([name])');
     });
@@ -38,9 +39,26 @@ describe('form-item', () => {
     it('should distribute input', () => {
       expect(inputSlot.assignedNodes()).to.contain(input);
     });
+
+    it('should set id on the label element', () => {
+      const id = label.getAttribute('id');
+      expect(id).to.match(ID_REGEX);
+      expect(id.endsWith(item.constructor._uniqueLabelId)).to.be.true;
+    });
   });
 
   describe('label positioning', () => {
+    beforeEach(() => {
+      item = fixtureSync(`
+        <vaadin-form-item>
+          <label slot="label">Label</label>
+          <input>
+        </vaadin-form-item>
+      `);
+      label = item.querySelector('label');
+      input = item.querySelector('input');
+    });
+
     it('should be aside by default', () => {
       const labelRect = label.getBoundingClientRect();
       const inputRect = input.getBoundingClientRect();
@@ -70,17 +88,83 @@ describe('form-item', () => {
     });
   });
 
-  describe('label click', () => {
-    it('should focus input', () => {
-      const spy = sinon.spy(input, 'focus');
-      label.click();
-      expect(spy.called).to.be.true;
+  describe.only('label', () => {
+    describe('input', () => {
+      beforeEach(() => {
+        item = fixtureSync(`
+          <vaadin-form-item>
+            <label slot="label">Label</label>
+            <input aria-labelledby="custom-id">
+          </vaadin-form-item>
+        `);
+        label = item.querySelector('label');
+        input = item.querySelector('input');
+      });
+
+      it('should focus input on label click', () => {
+        const spy = sinon.spy(input, 'focus');
+        label.click();
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should click input on label click', () => {
+        const spy = sinon.spy(input, 'click');
+        label.click();
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should link the label to the input via aria-labelledby', () => {
+        const aria = input.getAttribute('aria-labelledby');
+        expect(aria).to.include('custom-id');
+        expect(aria).to.include(label.id);
+      });
     });
 
-    it('should click input', () => {
-      const spy = sinon.spy(input, 'click');
-      label.click();
-      expect(spy.called).to.be.true;
+    describe('field', () => {
+      let field, fieldInput;
+
+      beforeEach(() => {
+        item = fixtureSync(`
+          <vaadin-form-item>
+            <label slot="label">Label</label>
+            <vaadin-text-field>
+              <input slot="input" aria-labelledby="custom-id">
+            </vaadin-text-field>
+          </vaadin-form-item>
+        `);
+        label = item.querySelector('label');
+        field = item.querySelector('vaadin-text-field');
+        fieldInput = field.querySelector('input');
+      });
+
+      it('should link the label to the field input via aria-labelledby', () => {
+        console.log(field, fieldInput);
+        console.log(label.id);
+        const aria = fieldInput.getAttribute('aria-labelledby');
+        expect(aria).to.include('custom-id');
+        expect(aria).to.include(label.id);
+      });
+    });
+
+    describe('field group', () => {
+      let fieldGroup;
+
+      beforeEach(() => {
+        item = fixtureSync(`
+          <vaadin-form-item>
+            <label slot="label">Label</label>
+            <vaadin-custom-field aria-labelledby="custom-id"></vaadin-custom-field>
+          </vaadin-form-item>
+        `);
+        label = item.querySelector('label');
+        fieldGroup = item.querySelector('vaadin-custom-field');
+      });
+
+      it('should link the label to the field group via aria-labelledby', () => {
+        const aria = fieldGroup.getAttribute('aria-labelledby');
+        expect(aria).to.include('custom-id');
+        expect(aria).to.include(label.id);
+      });
     });
   });
 

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -161,14 +161,6 @@ describe('form-item', () => {
         expect(input.getAttribute('aria-labelledby')).to.equal(`custom-id ${label.id}`);
       });
 
-      it('should not link the label to the new input when using appendChild', async () => {
-        const newInput = document.createElement('input');
-        item.appendChild(newInput);
-        await nextFrame();
-        expect(input.getAttribute('aria-labelledby')).to.equal(`custom-id ${label.id}`);
-        expect(newInput.hasAttribute('aria-labelledby')).to.be.false;
-      });
-
       it('should link the label to the new input when using replaceChild', async () => {
         const newInput = document.createElement('input');
         item.replaceChild(newInput, input);
@@ -183,6 +175,14 @@ describe('form-item', () => {
         await nextFrame();
         expect(input.getAttribute('aria-labelledby')).to.equal('custom-id');
         expect(newInput.getAttribute('aria-labelledby')).to.equal(label.id);
+      });
+
+      it('should not link the label to the new input when using appendChild', async () => {
+        const newInput = document.createElement('input');
+        item.appendChild(newInput);
+        await nextFrame();
+        expect(input.getAttribute('aria-labelledby')).to.equal(`custom-id ${label.id}`);
+        expect(newInput.hasAttribute('aria-labelledby')).to.be.false;
       });
     });
 
@@ -201,7 +201,7 @@ describe('form-item', () => {
         expect(input.getAttribute('aria-labelledby')).to.equal('custom-id');
       });
 
-      it('should link the label to the input once the label element is added', async () => {
+      it('should link the label to the input once a label element is added', async () => {
         const label = document.createElement('label');
         label.slot = 'label';
         item.appendChild(label);


### PR DESCRIPTION
## Description

The PR makes screen readers announce the form-item label when tabbing to the first field inside the item. This is achieved by linking the label with the field via the `aria-labelledby` attribute on:

- the ARIA target element when the field specifies the `ariaTarget` property (that typically refers to a slotted input)
- the field element itself otherwise

Fixes #1145

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
