### PR TITLE
test: add mouseenter event to reduce flakiness

### DIFF
--- a/packages/field-highlighter/test/visual/common.js
+++ b/packages/field-highlighter/test/visual/common.js
@@ -42,4 +42,6 @@ const users = [
 export const setUsers = (field) => {
   FieldHighlighter.init(field);
   FieldHighlighter.setUsers(field, users);
+  // Mimic focus to show highlight and badges
+  field.dispatchEvent(new CustomEvent('mouseenter'));
 };


### PR DESCRIPTION
## Description

Currently the field highlighter tests are very flaky: they expect user tags to be shown, but they are visible for 2 seconds.
This change adds `mouseenter` event which was missed during the visual tests conversion to show them permanently.

## Type of change

- Tests