### PR TITLE
fix: prevent combo box closing other overlays (v21)

### DIFF
--- a/packages/vaadin-combo-box/test/dialog.test.js
+++ b/packages/vaadin-combo-box/test/dialog.test.js
@@ -46,9 +46,7 @@ describe('dialog', () => {
       dialog = fixtureSync(`
       <vaadin-dialog>
         <template>
-          <div id="content">
-            <vaadin-combo-box items="[1,2,3]"></vaadin-combo-box>
-          </div>
+          <vaadin-combo-box items="[1,2,3]"></vaadin-combo-box>
         </template>
       </vaadin-dialog>
     `);

--- a/packages/vaadin-combo-box/test/dialog.test.js
+++ b/packages/vaadin-combo-box/test/dialog.test.js
@@ -7,33 +7,65 @@ import '../src/vaadin-combo-box.js';
 describe('dialog', () => {
   let dialog, comboBox;
 
-  beforeEach(async () => {
-    dialog = fixtureSync(`
+  describe('modeless', () => {
+    beforeEach(async () => {
+      dialog = fixtureSync(`
       <vaadin-dialog modeless>
         <template>
           <vaadin-combo-box items="[1,2,3]"></vaadin-combo-box>
         </template>
       </vaadin-dialog>
     `);
-    dialog.opened = true;
-    await nextFrame();
-    comboBox = dialog.$.overlay.querySelector('vaadin-combo-box');
+      dialog.opened = true;
+      await nextFrame();
+      comboBox = dialog.$.overlay.querySelector('vaadin-combo-box');
+    });
+
+    it('should not end up behind the dialog overlay on mousedown', async () => {
+      comboBox.open();
+      mousedown(comboBox);
+      await nextFrame();
+      expect(comboBox.$.overlay.$.dropdown.$.overlay._last).to.be.true;
+    });
+
+    it('should not end up behind the dialog overlay on touchstart', async () => {
+      comboBox.open();
+
+      const { left: x, top: y } = comboBox.getBoundingClientRect();
+      touchstart(comboBox, { x, y });
+
+      await nextFrame();
+      expect(comboBox.$.overlay.$.dropdown.$.overlay._last).to.be.true;
+    });
   });
 
-  it('should not end up behind the dialog overlay on mousedown', async () => {
-    comboBox.open();
-    mousedown(comboBox);
-    await nextFrame();
-    expect(comboBox.$.overlay.$.dropdown.$.overlay._last).to.be.true;
-  });
+  describe('modal', () => {
+    let backdrop;
 
-  it('should not end up behind the dialog overlay on touchstart', async () => {
-    comboBox.open();
+    beforeEach(async () => {
+      dialog = fixtureSync(`
+      <vaadin-dialog>
+        <template>
+          <div id="content">
+            <vaadin-combo-box items="[1,2,3]"></vaadin-combo-box>
+          </div>
+        </template>
+      </vaadin-dialog>
+    `);
+      dialog.opened = true;
+      await nextFrame();
+      comboBox = dialog.$.overlay.querySelector('vaadin-combo-box');
+      backdrop = dialog.$.overlay.$.backdrop;
+    });
 
-    const { left: x, top: y } = comboBox.getBoundingClientRect();
-    touchstart(comboBox, { x, y });
+    it('should not close the dialog on outside click', async () => {
+      comboBox.open();
+      await nextFrame();
 
-    await nextFrame();
-    expect(comboBox.$.overlay.$.dropdown.$.overlay._last).to.be.true;
+      // Clicking on backdrop should close the combo box overlay, but not the dialog overlay
+      backdrop.click();
+      expect(comboBox.opened).to.be.false;
+      expect(dialog.opened).to.be.true;
+    });
   });
 });

--- a/packages/vaadin-combo-box/test/dropdown.test.js
+++ b/packages/vaadin-combo-box/test/dropdown.test.js
@@ -7,6 +7,7 @@ describe('dropdown', () => {
 
   beforeEach(() => {
     dropdown = fixtureSync(`<vaadin-combo-box-dropdown></vaadin-combo-box-dropdown>`);
+    dropdown.positionTarget = document.createElement('button');
     overlay = dropdown.$.overlay;
   });
 


### PR DESCRIPTION
## Description

Fixes combo box closing lower-layer overlays, when closing the combo box dropdown. The original issue was about the time picker, but the root cause was the outside click handler logic in the combo box dropdown. I moved the outside click handler logic into the overlay itself, inspired by the recent refactoring here https://github.com/vaadin/web-components/pull/2497. That allows to reuse the regular overlay closing logic, which makes sure that only the uppermost overlay is closed.

The issue is already fixed in v22 and v23 due to https://github.com/vaadin/web-components/pull/2497, this fix is for v21. Will check v14 after merging the fix.

Fixes #2978 

## Type of change

- [x] Bugfix
