### PR TITLE
refactor: remove use of `constant()` as no longer required

### DIFF
--- a/packages/app-layout/src/safe-area-inset.js
+++ b/packages/app-layout/src/safe-area-inset.js
@@ -4,19 +4,10 @@ $_documentContainer.innerHTML = `
   <style>
     /* Use units so that the values can be used in calc() */
     html {
-      --safe-area-inset-top: constant(safe-area-inset-top, 0px);
-      --safe-area-inset-right: constant(safe-area-inset-right, 0px);
-      --safe-area-inset-bottom: constant(safe-area-inset-bottom, 0px);
-      --safe-area-inset-left: constant(safe-area-inset-left, 0px);
-    }
-
-    @supports (padding-left: env(safe-area-inset-left)) {
-      html {
-        --safe-area-inset-top: env(safe-area-inset-top, 0px);
-        --safe-area-inset-right: env(safe-area-inset-right, 0px);
-        --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
-        --safe-area-inset-left: env(safe-area-inset-left, 0px);
-      }
+      --safe-area-inset-top: env(safe-area-inset-top, 0px);
+      --safe-area-inset-right: env(safe-area-inset-right, 0px);
+      --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-area-inset-left: env(safe-area-inset-left, 0px);
     }
   </style>
 `;


### PR DESCRIPTION
`env()` is supported since iOS 11.3: https://caniuse.com/css-env-function