### PR TITLE
docs: remove incorrectly documented stylable part

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -72,7 +72,6 @@ export type AppLayoutEventMap = HTMLElementEventMap & AppLayoutCustomEventMap;
  * --------------|---------------------------------------------------------|
  * `navbar`      | Container for the navigation bar
  * `drawer`      | Container for the drawer area
- * `content`     | Container for page content.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -54,7 +54,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * --------------|---------------------------------------------------------|
  * `navbar`      | Container for the navigation bar
  * `drawer`      | Container for the drawer area
- * `content`     | Container for page content.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *


### PR DESCRIPTION
No `part="content"` in the shadow DOM.