### PR TITLE
refactor: remove no longer needed CSS property

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -148,7 +148,6 @@ class AppLayout extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizable
 
         :host(:not([no-scroll])) [content] {
           overflow: auto;
-          -webkit-overflow-scrolling: touch;
         }
 
         [content] {


### PR DESCRIPTION
No longer needed with the iOS support we promise.