### PR TITLE
fix: skip undefined LitElement styles

### DIFF
--- a/packages/vaadin-themable-mixin/test/lit-setup.js
+++ b/packages/vaadin-themable-mixin/test/lit-setup.js
@@ -14,7 +14,7 @@ window.defineCustomElementFunction = (name, parentName, content, styles) => {
     }
 
     static get styles() {
-      return unsafeCSS(styles);
+      return styles ? unsafeCSS(styles) : undefined;
     }
 
     render() {

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -216,7 +216,8 @@ export const ThemableMixin = (superClass) =>
       // The "styles" object originates from the "static get styles()" function of
       // a LitElement based component. The theme styles are added after it
       // so that they can override the component styles.
-      return [styles, ...this.getStylesForThis()];
+      const themeStyles = this.getStylesForThis();
+      return styles ? [styles, ...themeStyles] : themeStyles;
     }
 
     /**


### PR DESCRIPTION
The `styles` argument in `static finalizeStyles(styles) {` may be undefined in the case a LitElement based component doesn't implement `static get styles()`.

The undefined `styles` must be excluded from the array returned by `finalizeStyles`.