### PR TITLE
feat: add default slot support to SlotMixin

### DIFF
--- a/packages/component-base/src/slot-mixin.js
+++ b/packages/component-base/src/slot-mixin.js
@@ -51,8 +51,8 @@ export const SlotMixin = dedupingMixin(
         return Array.from(this.childNodes).find((node) => {
           // Either an element (any slot) or a text node (only un-named slot).
           return (
-            (node.nodeType == Node.ELEMENT_NODE && node.slot === slotName) ||
-            (slotName === '' && node.nodeType == Node.TEXT_NODE && node.textContent.trim() !== '')
+            (node.nodeType === Node.ELEMENT_NODE && node.slot === slotName) ||
+            (node.nodeType === Node.TEXT_NODE && node.textContent.trim() && slotName === '')
           );
         });
       }

--- a/packages/component-base/src/slot-mixin.js
+++ b/packages/component-base/src/slot-mixin.js
@@ -37,7 +37,9 @@ export const SlotMixin = dedupingMixin(
             const slotFactory = this.slots[slotName];
             const slotContent = slotFactory();
             if (slotContent instanceof Element) {
-              slotContent.setAttribute('slot', slotName);
+              if (slotName !== '') {
+                slotContent.setAttribute('slot', slotName);
+              }
               this.appendChild(slotContent);
             }
           }
@@ -46,7 +48,13 @@ export const SlotMixin = dedupingMixin(
 
       /** @protected */
       _getDirectSlotChild(slotName) {
-        return Array.from(this.children).find((el) => el.slot === slotName);
+        return Array.from(this.childNodes).find((node) => {
+          // Either an element (any slot) or a text node (only un-named slot).
+          return (
+            (node.nodeType == Node.ELEMENT_NODE && node.slot === slotName) ||
+            (slotName === '' && node.nodeType == Node.TEXT_NODE && node.textContent.trim() !== '')
+          );
+        });
       }
     }
 );

--- a/packages/component-base/test/slot-mixin.test.js
+++ b/packages/component-base/test/slot-mixin.test.js
@@ -7,7 +7,10 @@ customElements.define(
   'slot-mixin-element',
   class extends SlotMixin(PolymerElement) {
     static get template() {
-      return html`<slot name="foo"></slot>`;
+      return html`
+        <slot name="foo"></slot>
+        <slot></slot>
+      `;
     }
 
     get slots() {
@@ -16,6 +19,11 @@ customElements.define(
           const div = document.createElement('div');
           div.textContent = 'foo';
           return div;
+        },
+        '': () => {
+          const div = document.createElement('div');
+          div.textContent = 'bar';
+          return div;
         }
       };
     }
@@ -23,45 +31,118 @@ customElements.define(
     get fooChild() {
       return this._getDirectSlotChild('foo');
     }
+
+    get barChild() {
+      return this._getDirectSlotChild('');
+    }
   }
 );
 
 describe('slot-mixin', () => {
   let element, child;
 
-  describe('default', () => {
-    beforeEach(() => {
-      element = fixtureSync('<slot-mixin-element></slot-mixin-element>');
-      child = element.querySelector('[slot="foo"]');
+  describe('named slot', () => {
+    describe('default content', () => {
+      beforeEach(() => {
+        element = fixtureSync('<slot-mixin-element></slot-mixin-element>');
+        child = element.querySelector('[slot="foo"]');
+      });
+
+      it('should append an element to named slot', () => {
+        expect(child).to.be.ok;
+        expect(child.textContent).to.equal('foo');
+      });
+
+      it('should store a reference to named slot child', () => {
+        expect(element.fooChild).to.equal(child);
+      });
     });
 
-    it('should append an element to named slot', () => {
-      expect(child).to.be.ok;
-      expect(child.textContent).to.equal('foo');
-    });
+    describe('custom content', () => {
+      beforeEach(() => {
+        element = fixtureSync(`
+          <slot-mixin-element>
+            <div slot="foo">bar</div>
+          </slot-mixin-element>
+        `);
+        child = element.querySelector('[slot="foo"]');
+      });
 
-    it('should store a reference to the slot child', () => {
-      expect(element.fooChild).to.equal(child);
+      it('should not override an element passed to named slot', () => {
+        expect(child).to.be.ok;
+        expect(child.textContent).to.equal('bar');
+      });
+
+      it('should store a reference to the custom slot child', () => {
+        expect(element.fooChild).to.equal(child);
+      });
     });
   });
 
-  describe('custom', () => {
-    beforeEach(() => {
-      element = fixtureSync(`
-        <slot-mixin-element>
-          <div slot="foo">bar</div>
-        </slot-mixin-element>
-      `);
-      child = element.querySelector('[slot="foo"]');
+  describe('un-named slot', () => {
+    describe('default content', () => {
+      beforeEach(() => {
+        element = fixtureSync('<slot-mixin-element></slot-mixin-element>');
+        child = element.querySelector(':not([slot])');
+      });
+
+      it('should append an element to un-named slot', () => {
+        expect(child).to.be.ok;
+        expect(child.textContent).to.equal('bar');
+      });
+
+      it('should store a reference to un-named slot child', () => {
+        expect(element.barChild).to.equal(child);
+      });
     });
 
-    it('should not override an element passed to named slot', () => {
-      expect(child).to.be.ok;
-      expect(child.textContent).to.equal('bar');
+    describe('custom element', () => {
+      beforeEach(() => {
+        element = fixtureSync(`
+          <slot-mixin-element>
+            <div>baz</div>
+          </slot-mixin-element>
+        `);
+        child = element.querySelector(':not([slot])');
+      });
+
+      it('should not override an element passed to un-named slot', () => {
+        expect(child).to.be.ok;
+        expect(child.textContent).to.equal('baz');
+      });
+
+      it('should store a reference to the slotted element', () => {
+        expect(element.barChild).to.equal(child);
+      });
     });
 
-    it('should store a reference to the custom slot child', () => {
-      expect(element.fooChild).to.equal(child);
+    describe('custom text node', () => {
+      beforeEach(() => {
+        element = fixtureSync('<slot-mixin-element>baz</slot-mixin-element>');
+        // Custom text node comes first, before the "foo" content is appended.
+        child = element.firstChild;
+      });
+
+      it('should not override a text node passed to un-named slot', () => {
+        expect(child).to.be.ok;
+        expect(child.textContent).to.equal('baz');
+      });
+
+      it('should store a reference to the slotted text node', () => {
+        expect(element.barChild).to.equal(child);
+      });
+    });
+
+    describe('empty text node', () => {
+      beforeEach(() => {
+        element = fixtureSync('<slot-mixin-element> </slot-mixin-element>');
+        // Default text node comes last, after the "foo" content is appended.
+        child = element.lastChild;
+      });
+
+      it('should override an empty text node passed to un-named slot', () => {
+        expect(child.textContent).to.equal('bar');
+      });
     });
   });
 });


### PR DESCRIPTION
## Motivation

This is a pre-requisite for creating `vaadin-confirm-dialog-overlay-content` that is planned to use `SlotMixin`.
Based on https://github.com/ing-bank/lion/pull/1496

## Type of change

- Internal feature