### PR TITLE
chore: bump Playwright to 1.17.0-next-alpha-nov-5-2021

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "resolutions": {
+    "playwright": "1.17.0-next-alpha-nov-5-2021"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9110,10 +9110,10 @@ pkg-dir@4.2.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@=1.16.3:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.16.3.tgz#f466be9acaffb698654adfb0a17a4906ba936895"
-  integrity sha512-16hF27IvQheJee+DbhC941AUZLjbJgfZFWi9YPS4LKEk/lKFhZI+9TiFD0sboYqb9eaEWvul47uR5xxTVbE4iw==
+playwright-core@=1.17.0-next-alpha-nov-5-2021:
+  version "1.17.0-next-alpha-nov-5-2021"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.17.0-next-alpha-nov-5-2021.tgz#1cf666ba769f6e44161c73dccf516ceb3be9e78e"
+  integrity sha512-kWfzHUfD1jRWvLQ+PBuSb5qsnJQ78AADcCJS4Vgt5GnrF2Gp+4jLPdJMY+oWhB/6fETTzABidY0OQeyjq34UWA==
   dependencies:
     commander "^8.2.0"
     debug "^4.1.1"
@@ -9132,12 +9132,12 @@ playwright-core@=1.16.3:
     yauzl "^2.10.0"
     yazl "^2.5.1"
 
-playwright@^1.14.0:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.16.3.tgz#27a292d9fa54fbac923998d3af58cd2b691f5ebe"
-  integrity sha512-nfJx/OpIb/8OexL3rYGxNN687hGyaM3XNpfuMzoPlrekURItyuiHHsNhC9oQCx3JDmCn5O3EyyyFCnrZjH6MpA==
+playwright@1.17.0-next-alpha-nov-5-2021, playwright@^1.14.0:
+  version "1.17.0-next-alpha-nov-5-2021"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.17.0-next-alpha-nov-5-2021.tgz#728c911b64255288086353581880462473779126"
+  integrity sha512-M3rURKXd+8otyz1lEt0qmYBFq06Rh+l+WnMQHD3kBAYoCONawVthtRFzmqRcvd/3uAPx1bQigqnLTyYgcmaYXw==
   dependencies:
-    playwright-core "=1.16.3"
+    playwright-core "=1.17.0-next-alpha-nov-5-2021"
 
 plexer@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

The PR bumps Playwright to 1.17.0-next-alpha-nov-5-2021 to get the most recent fix of the issue (https://github.com/microsoft/playwright/issues/9811) where Webkit falls on Mac OS Monterey with the following error:

> browser.newContext: Target closed

## Type of change

- [x] Internal change

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
