### PR TITLE
refactor: add FocusTrapController for trapping focus within a node

### DIFF
--- a/packages/component-base/index.d.ts
+++ b/packages/component-base/index.d.ts
@@ -4,6 +4,7 @@ export { DirMixin } from './src/dir-mixin.js';
 export { DisabledMixin } from './src/disabled-mixin.js';
 export { ElementMixin } from './src/element-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';
+export { FocusTrapController } from './src/focus-trap-controller.js';
 export { KeyboardMixin } from './src/keyboard-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
 export { TabindexMixin } from './src/tabindex-mixin.js';

--- a/packages/component-base/index.js
+++ b/packages/component-base/index.js
@@ -4,6 +4,7 @@ export { DirMixin } from './src/dir-mixin.js';
 export { DisabledMixin } from './src/disabled-mixin.js';
 export { ElementMixin } from './src/element-mixin.js';
 export { FocusMixin } from './src/focus-mixin.js';
+export { FocusTrapController } from './src/focus-trap-controller.js';
 export { KeyboardMixin } from './src/keyboard-mixin.js';
 export { SlotMixin } from './src/slot-mixin.js';
 export { TabindexMixin } from './src/tabindex-mixin.js';

--- a/packages/component-base/src/focus-trap-controller.d.ts
+++ b/packages/component-base/src/focus-trap-controller.d.ts
@@ -21,11 +21,6 @@ declare class FocusTrapController implements ReactiveController {
   host: HTMLElement;
 
   /**
-   * A node for trapping focus in.
-   */
-  trapNode: HTMLElement | null;
-
-  /**
    * Activates a focus trap for a DOM node that will prevent focus from escaping the node.
    * The trap can be deactivated with the `.releaseFocus()` method.
    *

--- a/packages/component-base/src/focus-trap-controller.d.ts
+++ b/packages/component-base/src/focus-trap-controller.d.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ReactiveController } from 'lit';
+
+/**
+ * A controller for trapping focus within a DOM node.
+ */
+declare class FocusTrapController implements ReactiveController {
+  constructor(node: HTMLElement);
+
+  hostConnected(): void;
+
+  hostDisconnected(): void;
+
+  /**
+   * The controller host element.
+   */
+  host: HTMLElement;
+
+  /**
+   * A node for trapping focus in.
+   */
+  trapNode: HTMLElement | null;
+
+  /**
+   * Activates a focus trap for a DOM node that will prevent focus from escaping the node.
+   * The trap can be deactivated with the `.releaseFocus()` method.
+   *
+   * If focus is initially outside the trap, the method will move focus inside,
+   * on the first focusable element of the trap in the tab order.
+   * The first focusable element can be the trap node itself if it is focusable
+   * and comes first in the tab order.
+   */
+  trapFocus(trapNode: HTMLElement): void;
+
+  /**
+   * Deactivates the focus trap set with the `.trapFocus()` method
+   * so that it becomes possible to tab outside the trap node.
+   */
+  releaseFocus(): void;
+}

--- a/packages/component-base/src/focus-trap-controller.js
+++ b/packages/component-base/src/focus-trap-controller.js
@@ -48,18 +48,26 @@ export class FocusTrapController {
    * The first focusable element can be the trap node itself if it is focusable
    * and comes first in the tab order.
    *
+   * If there are no focusable elements, the method will throw an exception
+   * and the trap will not be set.
+   *
    * @param {HTMLElement} trapNode
    */
   trapFocus(trapNode) {
     this.__trapNode = trapNode;
 
-    if (this.__focusedElementIndex === -1 && this.__focusableElements.length > 0) {
+    if (this.__focusableElements.length === 0) {
+      this.__trapNode = null;
+      throw new Error('The trap node should have at least one focusable descendant or be focusable itself.');
+    }
+
+    if (this.__focusedElementIndex === -1) {
       this.__focusableElements[0].focus();
     }
   }
 
   /**
-   * Deactivates the focus trap set up with the `.trapFocus()` method
+   * Deactivates the focus trap set with the `.trapFocus()` method
    * so that it becomes possible to tab outside the trap node.
    */
   releaseFocus() {
@@ -103,10 +111,6 @@ export class FocusTrapController {
    */
   __focusNextElement(backward = false) {
     const focusableElements = this.__focusableElements;
-    if (focusableElements.length === 0) {
-      return;
-    }
-
     const step = backward ? -1 : 1;
     const currentIndex = this.__focusedElementIndex;
     const nextIndex = (focusableElements.length + currentIndex + step) % focusableElements.length;

--- a/packages/component-base/src/focus-trap-controller.js
+++ b/packages/component-base/src/focus-trap-controller.js
@@ -24,8 +24,9 @@ export class FocusTrapController {
      * A node for trapping focus in.
      *
      * @type {HTMLElement | null}
+     * @private
      */
-    this.trapNode = null;
+    this.__trapNode = null;
 
     this.__onKeyDown = this.__onKeyDown.bind(this);
   }
@@ -50,7 +51,7 @@ export class FocusTrapController {
    * @param {HTMLElement} trapNode
    */
   trapFocus(trapNode) {
-    this.trapNode = trapNode;
+    this.__trapNode = trapNode;
 
     if (this.__focusedElementIndex === -1 && this.__focusableElements.length > 0) {
       this.__focusableElements[0].focus();
@@ -62,7 +63,7 @@ export class FocusTrapController {
    * so that it becomes possible to tab outside the trap node.
    */
   releaseFocus() {
-    this.trapNode = null;
+    this.__trapNode = null;
   }
 
   /**
@@ -77,7 +78,7 @@ export class FocusTrapController {
    * @private
    */
   __onKeyDown(event) {
-    if (!this.trapNode) {
+    if (!this.__trapNode) {
       return;
     }
 
@@ -119,7 +120,7 @@ export class FocusTrapController {
    * @private
    */
   get __focusableElements() {
-    return getFocusableElements(this.trapNode);
+    return getFocusableElements(this.__trapNode);
   }
 
   /**

--- a/packages/component-base/src/focus-trap-controller.js
+++ b/packages/component-base/src/focus-trap-controller.js
@@ -58,7 +58,7 @@ export class FocusTrapController {
   }
 
   /**
-   * Deactivates the focus trap set with the `.trapFocus()` method
+   * Deactivates the focus trap set up with the `.trapFocus()` method
    * so that it becomes possible to tab outside the trap node.
    */
   releaseFocus() {
@@ -66,11 +66,12 @@ export class FocusTrapController {
   }
 
   /**
-   * A `keydown` event handler that prevents tabbing from escaping the trap node
-   * when the trap is enabled.
+   * A `keydown` event handler that manages tabbing navigation when the trap is enabled.
    *
-   * When the trap is enabled, the tabbing will cycle to the first/last focusable element
-   * inside the trap node whenever focus moves away from the last/first focusable element.
+   * - Moves focus to the next focusable element of the trap on `Tab` press.
+   * When no next element to focus, the method moves focus to the first focusable element.
+   * - Moves focus to the prev focusable element of the trap on `Shift+Tab` press.
+   * When no prev element to focus, the method moves focus to the last focusable element.
    *
    * @param {KeyboardEvent} event
    * @private
@@ -90,7 +91,7 @@ export class FocusTrapController {
 
   /**
    * - Moves focus to the next focusable element if `backward === false`.
-   * When no next element to focus, the method moves focus to the last focusable element.
+   * When no next element to focus, the method moves focus to the first focusable element.
    * - Moves focus to the prev focusable element if `backward === true`.
    * When no prev element to focus the method moves focus to the last focusable element.
    *

--- a/packages/component-base/src/focus-trap-controller.js
+++ b/packages/component-base/src/focus-trap-controller.js
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { getFocusableElements, isElementFocused } from './focus-utils.js';
+
+/**
+ * A controller for trapping focus within a DOM node.
+ */
+export class FocusTrapController {
+  /**
+   * @param {HTMLElement} host
+   */
+  constructor(host) {
+    /**
+     * The controller host element.
+     *
+     * @type {HTMLElement}
+     */
+    this.host = host;
+
+    /**
+     * A node for trapping focus in.
+     *
+     * @type {HTMLElement | null}
+     */
+    this.trapNode = null;
+
+    this.__onKeyDown = this.__onKeyDown.bind(this);
+  }
+
+  hostConnected() {
+    document.addEventListener('keydown', this.__onKeyDown);
+  }
+
+  hostDisconnected() {
+    document.removeEventListener('keydown', this.__onKeyDown);
+  }
+
+  /**
+   * Activates a focus trap for a DOM node that will prevent focus from escaping the node.
+   * The trap can be deactivated with the `.releaseFocus()` method.
+   *
+   * If focus is initially outside the trap, the method will move focus inside,
+   * on the first focusable element of the trap in the tab order.
+   * The first focusable element can be the trap node itself if it is focusable
+   * and comes first in the tab order.
+   *
+   * @param {HTMLElement} trapNode
+   */
+  trapFocus(trapNode) {
+    this.trapNode = trapNode;
+
+    if (this.__focusedElementIndex === -1 && this.__focusableElements.length > 0) {
+      this.__focusableElements[0].focus();
+    }
+  }
+
+  /**
+   * Deactivates the focus trap set with the `.trapFocus()` method
+   * so that it becomes possible to tab outside the trap node.
+   */
+  releaseFocus() {
+    this.trapNode = null;
+  }
+
+  /**
+   * A `keydown` event handler that prevents tabbing from escaping the trap node
+   * when the trap is enabled.
+   *
+   * When the trap is enabled, the tabbing will cycle to the first/last focusable element
+   * inside the trap node whenever focus moves away from the last/first focusable element.
+   *
+   * @param {KeyboardEvent} event
+   * @private
+   */
+  __onKeyDown(event) {
+    if (!this.trapNode) {
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      event.preventDefault();
+
+      const backward = event.shiftKey;
+      this.__focusNextElement(backward);
+    }
+  }
+
+  /**
+   * - Moves focus to the next focusable element if `backward === false`.
+   * When no next element to focus, the method moves focus to the last focusable element.
+   * - Moves focus to the prev focusable element if `backward === true`.
+   * When no prev element to focus the method moves focus to the last focusable element.
+   *
+   * If no focusable elements, the method returns immediately.
+   *
+   * @param {boolean} backward
+   * @private
+   */
+  __focusNextElement(backward = false) {
+    const focusableElements = this.__focusableElements;
+    if (focusableElements.length === 0) {
+      return;
+    }
+
+    const step = backward ? -1 : 1;
+    const currentIndex = this.__focusedElementIndex;
+    const nextIndex = (focusableElements.length + currentIndex + step) % focusableElements.length;
+    focusableElements[nextIndex].focus();
+  }
+
+  /**
+   * An array of tab-ordered focusable elements inside the trap node.
+   *
+   * @return {HTMLElement[]}
+   * @private
+   */
+  get __focusableElements() {
+    return getFocusableElements(this.trapNode);
+  }
+
+  /**
+   * The index of the element inside the trap node that currently has focus.
+   *
+   * @return {HTMLElement | undefined}
+   * @private
+   */
+  get __focusedElementIndex() {
+    return this.__focusableElements.findIndex(isElementFocused);
+  }
+}

--- a/packages/component-base/test/focus-trap-controller.test.js
+++ b/packages/component-base/test/focus-trap-controller.test.js
@@ -1,0 +1,215 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '../src/controller-mixin.js';
+import { FocusTrapController } from '../src/focus-trap-controller.js';
+
+customElements.define(
+  'focus-trap-element',
+  class FocusTrapElement extends ControllerMixin(PolymerElement) {
+    static get template() {
+      return html`<slot></slot>`;
+    }
+
+    ready() {
+      super.ready();
+      this.innerHTML = `
+        <div id="outside">
+          <input id="outside-input-1" />
+
+          <div id="trap">
+            <input id="trap-input-1" />
+            <input id="trap-input-2" />
+            <input id="trap-input-3" />
+          </div>
+
+          <input id="outside-input-2" />
+        </div>
+      `;
+    }
+  }
+);
+
+describe('focus-trap-controller', () => {
+  let element, controller, trap;
+
+  describe('trapFocus', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<focus-trap-element></focus-trap-element>`);
+      controller = new FocusTrapController(element);
+      element.addController(controller);
+      trap = element.querySelector('#trap');
+      element.querySelector('#outside-input-1').focus();
+    });
+
+    it('should set focus on the first focusable element in the default tab order', () => {
+      controller.trapFocus(trap);
+      const input = trap.querySelector('#trap-input-1');
+      expect(document.activeElement).to.equal(input);
+    });
+
+    it('should set focus on the first focusable element in the custom tab order', () => {
+      const input = trap.querySelector('#trap-input-2');
+      input.tabIndex = 2;
+      controller.trapFocus(trap);
+      expect(document.activeElement).to.equal(input);
+    });
+
+    it('should set focus on the trap node when it is the first focusable element', () => {
+      trap.tabIndex = 0;
+      controller.trapFocus(trap);
+      expect(document.activeElement).to.equal(trap);
+    });
+
+    it('should keep focus outside when no focusable elements are in the trap node', () => {
+      trap.querySelectorAll('input').forEach((input) => {
+        input.tabIndex = -1;
+      });
+      controller.trapFocus(trap);
+      expect(trap.contains(document.activeElement)).to.be.false;
+    });
+
+    it('should keep focus on the element when the element is inside the trap node', () => {
+      const input = element.querySelector('#trap-input-1');
+      input.focus();
+      controller.trapFocus(trap);
+      expect(document.activeElement).to.equal(input);
+    });
+  });
+
+  describe('releaseFocus', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<focus-trap-element></focus-trap-element>`);
+      controller = new FocusTrapController(element);
+      element.addController(controller);
+      trap = element.querySelector('#trap');
+    });
+
+    it('should not throw when no trap node', () => {
+      expect(() => controller.releaseFocus(trap)).not.to.throw(Error);
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    let trapInput1, trapInput2, trapInput3;
+
+    async function tab() {
+      await sendKeys({ press: 'Tab' });
+      return document.activeElement;
+    }
+
+    async function shiftTab() {
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+      return document.activeElement;
+    }
+
+    beforeEach(() => {
+      element = fixtureSync(`<focus-trap-element></focus-trap-element>`);
+      controller = new FocusTrapController(element);
+      element.addController(controller);
+      trap = element.querySelector('#trap');
+      trapInput1 = trap.querySelector('#trap-input-1');
+      trapInput2 = trap.querySelector('#trap-input-2');
+      trapInput3 = trap.querySelector('#trap-input-3');
+    });
+
+    describe('trap is activated', () => {
+      describe('default tab order', () => {
+        beforeEach(() => {
+          controller.trapFocus(trap);
+        });
+
+        it('should have focus on the 1st input', () => {
+          expect(document.activeElement).to.equal(trapInput1);
+        });
+
+        it('should navigate cyclically within the trap node with Tab', async () => {
+          const activeElement1 = await tab();
+          const activeElement2 = await tab();
+          const activeElement3 = await tab();
+          expect([activeElement1.id, activeElement2.id, activeElement3.id]).to.deep.equal([
+            'trap-input-2',
+            'trap-input-3',
+            'trap-input-1'
+          ]);
+        });
+
+        it('should navigate cyclically within the trap node with Shift+Tab', async () => {
+          const activeElement1 = await shiftTab();
+          const activeElement2 = await shiftTab();
+          const activeElement3 = await shiftTab();
+          expect([activeElement1.id, activeElement2.id, activeElement3.id]).to.deep.equal([
+            'trap-input-3',
+            'trap-input-2',
+            'trap-input-1'
+          ]);
+        });
+      });
+
+      describe('custom tab order', () => {
+        beforeEach(() => {
+          trapInput1.tabIndex = 2;
+          trapInput2.tabIndex = 1;
+          trapInput3.tabIndex = -1;
+          controller.trapFocus(trap);
+        });
+
+        it('should have focus on the 2nd input', () => {
+          expect(document.activeElement).to.equal(trapInput2);
+        });
+
+        it('should navigate cyclically within the trap node with Tab', async () => {
+          const activeElement1 = await tab();
+          const activeElement2 = await tab();
+          const activeElement3 = await tab();
+          expect([activeElement1.id, activeElement2.id, activeElement3.id]).to.deep.equal([
+            'trap-input-1',
+            'trap-input-2',
+            'trap-input-1'
+          ]);
+        });
+
+        it('should navigate cyclically within the trap node with Shift+Tab', async () => {
+          const activeElement1 = await shiftTab();
+          const activeElement2 = await shiftTab();
+          const activeElement3 = await shiftTab();
+          expect([activeElement1.id, activeElement2.id, activeElement3.id]).to.deep.equal([
+            'trap-input-1',
+            'trap-input-2',
+            'trap-input-1'
+          ]);
+        });
+      });
+    });
+
+    describe('trap is deactivated', () => {
+      let outsideInput1, outsideInput2;
+
+      beforeEach(() => {
+        controller.trapFocus(trap);
+        controller.releaseFocus(trap);
+
+        outsideInput1 = element.querySelector('#outside-input-1');
+        outsideInput2 = element.querySelector('#outside-input-2');
+      });
+
+      it('should have focus on the 1st input', () => {
+        expect(document.activeElement).to.equal(trapInput1);
+      });
+
+      it('should move focus from the 1st input to outside the trap on Shift+Tab', async () => {
+        await shiftTab();
+        expect(document.activeElement).to.equal(outsideInput1);
+      });
+
+      it('should move focus from the 3rd input to outside the trap on Tab', async () => {
+        trapInput3.focus();
+        await tab();
+        expect(document.activeElement).to.equal(outsideInput2);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

The PR introduces a controller for trapping focus within a DOM node that is basically an extraction of the respective logic from the overlay component.

The controller supports two methods:

- `.trapFocus(node)` – activates a focus trap for a DOM node and sets focus on the first focusable element inside the node if focus is not inside already.
- `.releaseFocus()` – deactivates the focus trap

**Todo List:**

- [x] https://github.com/vaadin/web-components/pull/3141
- [x] Add a controller for trapping focus.
- [x] Add unit tests for the controller.
- [x] Add TS declarations for the controller.

Depends on #3141 

Part of #3134

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
