### PR TITLE
fix: update date picker observer to mind the new structure

### DIFF
--- a/packages/field-highlighter/src/fields/vaadin-date-picker-observer.js
+++ b/packages/field-highlighter/src/fields/vaadin-date-picker-observer.js
@@ -72,7 +72,7 @@ export class DatePickerObserver extends ComponentObserver {
   }
 
   onOverlayFocusOut(event) {
-    if (event.relatedTarget !== this.datePicker) {
+    if (!this.datePicker.contains(event.relatedTarget)) {
       // Mark as blurred to wait for opened-changed.
       this.blurWhileOpened = true;
     }

--- a/packages/field-highlighter/test/field-components.test.js
+++ b/packages/field-highlighter/test/field-components.test.js
@@ -98,6 +98,17 @@ describe('field components', () => {
         });
       });
 
+      it('should not dispatch vaadin-highlight-hide event on close with focus moved to the field', (done) => {
+        open(field, async () => {
+          listenOnce(field, 'opened-changed', () => {
+            expect(hideSpy.callCount).to.equal(0);
+            done();
+          });
+          field.focus();
+          field.close();
+        });
+      });
+
       it('should not dispatch vaadin-highlight-hide event on re-focusing field', (done) => {
         field.focus();
         open(field, () => {


### PR DESCRIPTION
A fix derived from https://github.com/vaadin/web-components/pull/3138

This makes the date picker observer in the field highlighter mind the new component structure; the date picker's focusable node is the `input` in the light DOM