### PR TITLE
refactor: add overlay.restoreFocusNode and vaadin-overlay-closing event

### DIFF
--- a/packages/vaadin-overlay/src/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay.d.ts
@@ -25,6 +25,11 @@ export type OverlayOpenEvent = CustomEvent;
 export type OverlayCloseEvent = CustomEvent;
 
 /**
+ * Fired when the overlay will be closed.
+ */
+export type OverlayClosingEvent = CustomEvent;
+
+/**
  * Fired before the overlay will be closed on outside click.
  * If canceled the closing of the overlay is canceled as well.
  */
@@ -40,6 +45,7 @@ export interface OverlayElementEventMap {
   'opened-changed': OverlayOpenedChangedEvent;
   'vaadin-overlay-open': OverlayOpenEvent;
   'vaadin-overlay-close': OverlayCloseEvent;
+  'vaadin-overlay-closing': OverlayClosingEvent;
   'vaadin-overlay-outside-click': OverlayOutsideClickEvent;
   'vaadin-overlay-escape-press': OverlayEscapePressEvent;
 }
@@ -133,6 +139,7 @@ export type OverlayEventMap = HTMLElementEventMap & OverlayElementEventMap;
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} vaadin-overlay-open - Fired after the overlay is opened.
  * @fires {CustomEvent} vaadin-overlay-close - Fired before the overlay will be closed. If canceled the closing of the overlay is canceled as well.
+ * @fires {CustomEvent} vaadin-overlay-closing - Fired when the overlay will be closed.
  * @fires {CustomEvent} vaadin-overlay-outside-click - Fired before the overlay will be closed on outside click. If canceled the closing of the overlay is canceled as well.
  * @fires {CustomEvent} vaadin-overlay-escape-press - Fired before the overlay will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.
  */
@@ -199,6 +206,12 @@ declare class OverlayElement extends ThemableMixin(DirMixin(HTMLElement)) {
    * Set to true to enable restoring of focus when overlay is closed.
    */
   restoreFocusOnClose: boolean;
+
+  /**
+   * Set to specify the element which should be focused on overlay close,
+   * if `restoreFocusOnClose` is set to true.
+   */
+  restoreFocusNode?: HTMLElement;
 
   close(sourceEvent?: Event | null): void;
 

--- a/packages/vaadin-overlay/test/overlay.test.js
+++ b/packages/vaadin-overlay/test/overlay.test.js
@@ -301,7 +301,7 @@ describe('vaadin-overlay', () => {
     });
 
     describe('vaadin-overlay-closing event', () => {
-      it('should dispatch vaadin-overlay-closing the overlay will be closed', () => {
+      it('should dispatch vaadin-overlay-closing when the overlay is closing', () => {
         const spy = sinon.spy();
         overlay.addEventListener('vaadin-overlay-closing', spy);
         click(parent);

--- a/packages/vaadin-overlay/test/overlay.test.js
+++ b/packages/vaadin-overlay/test/overlay.test.js
@@ -300,6 +300,23 @@ describe('vaadin-overlay', () => {
       });
     });
 
+    describe('vaadin-overlay-closing event', () => {
+      it('should dispatch vaadin-overlay-closing the overlay will be closed', () => {
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-closing', spy);
+        click(parent);
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should not dispatch vaadin-overlay-closing when preventing vaadin-overlay-close', () => {
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-closing', spy);
+        overlay.addEventListener('vaadin-overlay-close', (e) => e.preventDefault());
+        click(parent);
+        expect(spy.called).to.be.false;
+      });
+    });
+
     describe('moving mouse pointer during click', () => {
       it('should close if both mousedown and mouseup outside', () => {
         mousedown(parent);

--- a/packages/vaadin-overlay/test/restore-focus.test.js
+++ b/packages/vaadin-overlay/test/restore-focus.test.js
@@ -104,7 +104,7 @@ describe('restore focus', () => {
       overlay.restoreFocusOnClose = true;
       focusable.focus();
       await open(overlay);
-      document.activeElement.blur();
+      focusable.blur();
       await close(overlay);
       expect(overlay._getActiveElement() === focusInput).to.be.true;
     });

--- a/packages/vaadin-overlay/test/restore-focus.test.js
+++ b/packages/vaadin-overlay/test/restore-focus.test.js
@@ -106,7 +106,7 @@ describe('restore focus', () => {
       await open(overlay);
       focusable.blur();
       await close(overlay);
-      expect(overlay._getActiveElement() === focusInput).to.be.true;
+      expect(overlay._getActiveElement()).to.equal(focusInput);
     });
   });
 });

--- a/packages/vaadin-overlay/test/restore-focus.test.js
+++ b/packages/vaadin-overlay/test/restore-focus.test.js
@@ -83,4 +83,30 @@ describe('restore focus', () => {
     await close(overlay);
     expect(overlay._getActiveElement()).to.equal(focusable);
   });
+
+  describe('restoreFocusNode', () => {
+    beforeEach(() => {
+      overlay.restoreFocusNode = focusInput;
+    });
+
+    it('should not restore focus on close by default (restore-focus-on-close=false)', async () => {
+      overlay.restoreFocusOnClose = false;
+      focusInput.focus();
+      await open(overlay);
+      // emulate focus leaving the input
+      focusInput.blur();
+      document.body.focus();
+      await close(overlay);
+      expect(overlay._getActiveElement()).to.not.equal(focusInput);
+    });
+
+    it('should restore focus to the restoreFocusNode', async () => {
+      overlay.restoreFocusOnClose = true;
+      focusable.focus();
+      await open(overlay);
+      document.activeElement.blur();
+      await close(overlay);
+      expect(overlay._getActiveElement() === focusInput).to.be.true;
+    });
+  });
 });

--- a/packages/vaadin-overlay/test/typings/overlay.types.ts
+++ b/packages/vaadin-overlay/test/typings/overlay.types.ts
@@ -1,6 +1,7 @@
 import '../../vaadin-overlay.js';
 import {
   OverlayCloseEvent,
+  OverlayClosingEvent,
   OverlayEscapePressEvent,
   OverlayOpenedChangedEvent,
   OverlayOpenEvent,
@@ -10,6 +11,9 @@ import {
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const overlay = document.createElement('vaadin-overlay');
+
+assertType<boolean>(overlay.restoreFocusOnClose);
+assertType<HTMLElement | undefined>(overlay.restoreFocusNode);
 
 overlay.addEventListener('opened-changed', (event) => {
   assertType<OverlayOpenedChangedEvent>(event);
@@ -22,6 +26,10 @@ overlay.addEventListener('vaadin-overlay-open', (event) => {
 
 overlay.addEventListener('vaadin-overlay-close', (event) => {
   assertType<OverlayCloseEvent>(event);
+});
+
+overlay.addEventListener('vaadin-overlay-closing', (event) => {
+  assertType<OverlayClosingEvent>(event);
 });
 
 overlay.addEventListener('vaadin-overlay-escape-press', (event) => {


### PR DESCRIPTION
Needed by https://github.com/vaadin/web-components/issues/3104

Changes derived as a separate PR from https://github.com/vaadin/web-components/pull/3138

Add new API to `<vaadin-overlay>`:

- `restoreFocusNode`: If set, the overlay will focus `restoreFocusNode` on close instead of the automatically obtained reference to the last focused element before the overlay got opened.
- "vaadin-overlay-closing" -event: Dispatched when the overlay will be closed. The existing "vaadin-overlay-close" doesn't guarantee the overlay will be closed, because canceling the event also cancels the overlay closing.