### PR TITLE
refactor: add more rules to ESLint config, fix warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -67,7 +67,12 @@
     "prefer-spread": "error",
     "space-in-parens": ["error", "never"],
     "func-style": ["error", "declaration", { "allowArrowFunctions": true }],
-    "grouped-accessor-pairs": ["error", "getBeforeSet"]
+    "grouped-accessor-pairs": ["error", "getBeforeSet"],
+    "lines-between-class-members": [
+      "error",
+      "always",
+      { "exceptAfterSingleLine": true }
+    ]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,7 +73,8 @@
       "always",
       { "exceptAfterSingleLine": true }
     ],
-    "spaced-comment": ["error", "always"]
+    "spaced-comment": ["error", "always"],
+    "default-case": ["error", { "commentPattern": "^no\\sdefault" }]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,7 +66,8 @@
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "space-in-parens": ["error", "never"],
-    "func-style": ["error", "declaration", { "allowArrowFunctions": true }]
+    "func-style": ["error", "declaration", { "allowArrowFunctions": true }],
+    "grouped-accessor-pairs": ["error", "getBeforeSet"]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,8 +49,12 @@
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "accessor-pairs": "error",
     "array-callback-return": "error",
+    "default-case": ["error", { "commentPattern": "^no\\sdefault" }],
     "default-param-last": "error",
     "dot-notation": ["error", { "allowPattern": "^[a-zA-Z]+([_-][a-zA-Z]+)+$" }],
+    "func-style": ["error", "declaration", { "allowArrowFunctions": true }],
+    "grouped-accessor-pairs": ["error", "getBeforeSet"],
+    "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
     "max-classes-per-file": ["error", 3],
     "max-params": ["error", 4],
     "no-eval": "error",
@@ -66,15 +70,7 @@
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "space-in-parens": ["error", "never"],
-    "func-style": ["error", "declaration", { "allowArrowFunctions": true }],
-    "grouped-accessor-pairs": ["error", "getBeforeSet"],
-    "lines-between-class-members": [
-      "error",
-      "always",
-      { "exceptAfterSingleLine": true }
-    ],
-    "spaced-comment": ["error", "always"],
-    "default-case": ["error", { "commentPattern": "^no\\sdefault" }]
+    "spaced-comment": ["error", "always"]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -72,7 +72,8 @@
       "error",
       "always",
       { "exceptAfterSingleLine": true }
-    ]
+    ],
+    "spaced-comment": ["error", "always"]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,8 @@
     "prefer-exponentiation-operator": "error",
     "prefer-rest-params": "error",
     "prefer-spread": "error",
-    "space-in-parens": ["error", "never"]
+    "space-in-parens": ["error", "never"],
+    "func-style": ["error", "declaration", { "allowArrowFunctions": true }]
   },
   "overrides": [
     {

--- a/packages/app-layout/src/detect-ios-navbar.js
+++ b/packages/app-layout/src/detect-ios-navbar.js
@@ -5,7 +5,7 @@
  */
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 
-export const _detectIosNavbar = function () {
+export function _detectIosNavbar() {
   /* c8 ignore next 11 */
   if (isIOS) {
     const innerHeight = window.innerHeight;
@@ -18,7 +18,7 @@ export const _detectIosNavbar = function () {
       document.documentElement.style.setProperty('--vaadin-viewport-offset-bottom', '');
     }
   }
-};
+}
 
 _detectIosNavbar();
 window.addEventListener('resize', _detectIosNavbar);

--- a/packages/board/src/vaadin-board-row.js
+++ b/packages/board/src/vaadin-board-row.js
@@ -245,7 +245,7 @@ class BoardRow extends ElementMixin(mixinBehaviors([IronResizableBehavior], Poly
       breakpoints.mediumSize != this._oldBreakpoints.mediumSize
     ) {
       const nodes = this.$.insertionPoint.assignedNodes({ flatten: true });
-      const isElementNode = function (node) {
+      const isElementNode = (node) => {
         return !(node.nodeType === node.TEXT_NODE || node instanceof DomRepeat || node instanceof DomIf);
       };
       const filteredNodes = nodes.filter(isElementNode);

--- a/packages/board/src/vaadin-board-row.js
+++ b/packages/board/src/vaadin-board-row.js
@@ -94,7 +94,7 @@ class BoardRow extends ElementMixin(mixinBehaviors([IronResizableBehavior], Poly
     this.addEventListener('iron-resize', this._onIronResize, true);
     this.$.insertionPoint.addEventListener('slotchange', this.redraw.bind(this));
     afterNextRender(this, function () {
-      //force this as an interested resizable of parent
+      // force this as an interested resizable of parent
       this.dispatchEvent(
         new CustomEvent('iron-request-resize-notifications', {
           node: this,

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -30,7 +30,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { ChartSeries } from './vaadin-chart-series.js';
 
 /** @private */
-export const deepMerge = function deepMerge(target, source) {
+export function deepMerge(target, source) {
   const isObject = (item) => item && typeof item === 'object' && !Array.isArray(item);
 
   if (isObject(source) && isObject(target)) {
@@ -48,7 +48,7 @@ export const deepMerge = function deepMerge(target, source) {
   }
 
   return target;
-};
+}
 
 ['exportChart', 'exportChartLocal', 'getSVG'].forEach((methodName) => {
   Highcharts.wrap(Highcharts.Chart.prototype, methodName, function (proceed, ...args) {

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1700,6 +1700,8 @@ class Chart extends ElementMixin(ThemableMixin(PolymerElement)) {
         case 3:
           axes = this.configuration.colorAxis;
           break;
+        default:
+          break;
       }
       if (axes && axes[axisIndex]) {
         const axis = axes[axisIndex];

--- a/packages/component-base/src/debounce.js
+++ b/packages/component-base/src/debounce.js
@@ -135,16 +135,16 @@ let debouncerQueue = new Set();
  * @param {!Debouncer} debouncer Debouncer to enqueue
  * @return {void}
  */
-export const enqueueDebouncer = function (debouncer) {
+export function enqueueDebouncer(debouncer) {
   debouncerQueue.add(debouncer);
-};
+}
 
 /**
  * Flushes any enqueued debouncers
  *
  * @return {boolean} Returns whether any debouncers were flushed
  */
-export const flushDebouncers = function () {
+export function flushDebouncers() {
   const didFlush = Boolean(debouncerQueue.size);
   // If new debouncers are added while flushing, Set.forEach will ensure
   // newly added ones are also flushed
@@ -158,7 +158,7 @@ export const flushDebouncers = function () {
     }
   });
   return didFlush;
-};
+}
 
 export const flush = () => {
   let debouncers;

--- a/packages/component-base/src/debounce.js
+++ b/packages/component-base/src/debounce.js
@@ -17,6 +17,7 @@ export class Debouncer {
     this._callback = null;
     this._timer = null;
   }
+
   /**
    * Sets the scheduler; that is, a module with the Async interface,
    * a callback and optional arguments to be passed to the run function
@@ -35,6 +36,7 @@ export class Debouncer {
       this._callback();
     });
   }
+
   /**
    * Cancels an active debouncer and returns a reference to itself.
    *
@@ -50,6 +52,7 @@ export class Debouncer {
       debouncerQueue.delete(this);
     }
   }
+
   /**
    * Cancels a debouncer's async callback.
    *
@@ -61,6 +64,7 @@ export class Debouncer {
       this._timer = null;
     }
   }
+
   /**
    * Flushes an active debouncer and returns a reference to itself.
    *
@@ -72,6 +76,7 @@ export class Debouncer {
       this._callback();
     }
   }
+
   /**
    * Returns true if the debouncer is active.
    *
@@ -80,6 +85,7 @@ export class Debouncer {
   isActive() {
     return this._timer != null;
   }
+
   /**
    * Creates a debouncer if no debouncer is passed as a parameter
    * or it cancels an active debouncer otherwise. The following

--- a/packages/component-base/src/dir-helper.js
+++ b/packages/component-base/src/dir-helper.js
@@ -57,8 +57,9 @@ class DirHelper {
         return element.scrollWidth - element.clientWidth + scrollLeft;
       case 'reverse':
         return element.scrollWidth - element.clientWidth - scrollLeft;
+      default:
+        return scrollLeft;
     }
-    return scrollLeft;
   }
 
   /**

--- a/packages/component-base/src/dir-mixin.js
+++ b/packages/component-base/src/dir-mixin.js
@@ -9,29 +9,29 @@ import { DirHelper } from './dir-helper.js';
  * Array of Vaadin custom element classes that have been subscribed to the dir changes.
  */
 const directionSubscribers = [];
-const directionUpdater = function () {
+function directionUpdater() {
   const documentDir = getDocumentDir();
   directionSubscribers.forEach((element) => {
     alignDirs(element, documentDir);
   });
-};
+}
 
 let scrollType;
 
 const directionObserver = new MutationObserver(directionUpdater);
 directionObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['dir'] });
 
-const alignDirs = function (element, documentDir, elementDir = element.getAttribute('dir')) {
+function alignDirs(element, documentDir, elementDir = element.getAttribute('dir')) {
   if (documentDir) {
     element.setAttribute('dir', documentDir);
   } else if (elementDir != null) {
     element.removeAttribute('dir');
   }
-};
+}
 
-const getDocumentDir = function () {
+function getDocumentDir() {
   return document.documentElement.getAttribute('dir');
-};
+}
 
 /**
  * A mixin to handle `dir` attribute based on the one set on the `<html>` element.

--- a/packages/component-base/src/gestures.js
+++ b/packages/component-base/src/gestures.js
@@ -163,7 +163,7 @@ function matchingLabels(el) {
 // but this breaks `<input>` focus and link clicks
 // disable mouse handlers for MOUSE_TIMEOUT ms after
 // a touchend to ignore synthetic mouse events
-let mouseCanceller = function (mouseEvent) {
+function mouseCanceller(mouseEvent) {
   // Check for sourceCapabilities, used to distinguish synthetic events
   // if mouseEvent did not come from a device that fires touch events,
   // it was made by a real mouse and should be counted
@@ -202,7 +202,7 @@ let mouseCanceller = function (mouseEvent) {
     mouseEvent.preventDefault();
     mouseEvent.stopPropagation();
   }
-};
+}
 
 /**
  * @param {boolean=} setup True to add, false to remove.
@@ -229,7 +229,7 @@ function ignoreMouse(e) {
   if (!POINTERSTATE.mouse.mouseIgnoreJob) {
     setupTeardownMouseCanceller(true);
   }
-  let unset = function () {
+  let unset = () => {
     setupTeardownMouseCanceller();
     POINTERSTATE.mouse.target = null;
     POINTERSTATE.mouse.mouseIgnoreJob = null;
@@ -743,13 +743,13 @@ register({
     let t = _findOriginalTarget(e);
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let self = this;
-    let movefn = function movefn(e) {
+    let movefn = (e) => {
       if (!hasLeftMouseButton(e)) {
         downupFire('up', t, e);
         untrackDocument(self.info);
       }
     };
-    let upfn = function upfn(e) {
+    let upfn = (e) => {
       if (hasLeftMouseButton(e)) {
         downupFire('up', t, e);
       }
@@ -854,7 +854,7 @@ register({
     let t = _findOriginalTarget(e);
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let self = this;
-    let movefn = function movefn(e) {
+    let movefn = (e) => {
       let x = e.clientX,
         y = e.clientY;
       if (trackHasMovedEnough(self.info, x, y)) {
@@ -876,7 +876,7 @@ register({
         self.info.started = true;
       }
     };
-    let upfn = function upfn(e) {
+    let upfn = (e) => {
       if (self.info.started) {
         movefn(e);
       }

--- a/packages/component-base/src/iron-list-core.js
+++ b/packages/component-base/src/iron-list-core.js
@@ -186,6 +186,10 @@ export const ironList = {
     return Math.max(0, virtualCount - this._physicalCount);
   },
 
+  get _virtualStart() {
+    return this._virtualStartVal || 0;
+  },
+
   set _virtualStart(val) {
     val = this._clamp(val, 0, this._maxVirtualStart);
     if (this.grid) {
@@ -194,8 +198,8 @@ export const ironList = {
     this._virtualStartVal = val;
   },
 
-  get _virtualStart() {
-    return this._virtualStartVal || 0;
+  get _physicalStart() {
+    return this._physicalStartVal || 0;
   },
 
   /**
@@ -212,10 +216,6 @@ export const ironList = {
     this._physicalStartVal = val;
   },
 
-  get _physicalStart() {
-    return this._physicalStartVal || 0;
-  },
-
   /**
    * The k-th tile that is at the bottom of the scrolling list.
    */
@@ -223,12 +223,12 @@ export const ironList = {
     return (this._physicalStart + this._physicalCount - 1) % this._physicalCount;
   },
 
-  set _physicalCount(val) {
-    this._physicalCountVal = val;
-  },
-
   get _physicalCount() {
     return this._physicalCountVal || 0;
+  },
+
+  set _physicalCount(val) {
+    this._physicalCountVal = val;
   },
 
   /**

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -155,6 +155,10 @@ export class IronListAdapter {
     return element ? this.scrollTarget.getBoundingClientRect().top - element.getBoundingClientRect().top : undefined;
   }
 
+  get size() {
+    return this.__size;
+  }
+
   set size(size) {
     if (size === this.size) {
       return;
@@ -202,10 +206,6 @@ export class IronListAdapter {
     // Schedule and flush a resize handler
     this._resizeHandler();
     flush();
-  }
-
-  get size() {
-    return this.__size;
   }
 
   /** @private */

--- a/packages/component-base/src/virtualizer.js
+++ b/packages/component-base/src/virtualizer.js
@@ -17,18 +17,18 @@ export class Virtualizer {
 
   /**
    * The size of the virtualizer
-   * @param {number} size The size of the virtualizer
-   */
-  set size(size) {
-    this.__adapter.size = size;
-  }
-
-  /**
-   * The size of the virtualizer
    * @return {number | undefined} The size of the virtualizer
    */
   get size() {
     return this.__adapter.size;
+  }
+
+  /**
+   * The size of the virtualizer
+   * @param {number} size The size of the virtualizer
+   */
+  set size(size) {
+    this.__adapter.size = size;
   }
 
   /**

--- a/packages/custom-field/test/common.js
+++ b/packages/custom-field/test/common.js
@@ -1,4 +1,4 @@
-export const dispatchChange = function (el) {
+export function dispatchChange(el) {
   const evt = new CustomEvent('change', { bubbles: true });
   el.dispatchEvent(evt);
-};
+}

--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -138,15 +138,15 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
     this._setFocusElement(this.inputElement);
   }
 
+  /** @return {string | undefined} */
+  get _inputValue() {
+    return this.inputElement && this.inputElement[dashToCamelCase(this.attrForValue)];
+  }
+
   set _inputValue(value) {
     if (this.inputElement) {
       this.inputElement[dashToCamelCase(this.attrForValue)] = value;
     }
-  }
-
-  /** @return {string | undefined} */
-  get _inputValue() {
-    return this.inputElement && this.inputElement[dashToCamelCase(this.attrForValue)];
   }
 
   // Workaround https://github.com/vaadin/web-components/issues/2855

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -921,7 +921,7 @@ export const DatePickerMixin = (subclass) =>
           } else if (this.clearButtonVisible) {
             this._onClearButtonClick();
           } else if (this.autoOpenDisabled) {
-            //Do not restore selected date if Esc was pressed after clearing input field
+            // Do not restore selected date if Esc was pressed after clearing input field
             if (this.inputElement.value === '') {
               this._selectedDate = null;
             }
@@ -934,7 +934,7 @@ export const DatePickerMixin = (subclass) =>
         case 'Tab':
           if (this.opened) {
             e.preventDefault();
-            //Clear the selection range (remains visible on IE)
+            // Clear the selection range (remains visible on IE)
             this._setSelectionRange(0, 0);
             if (e.shiftKey) {
               this._overlayContent.focusCancel();

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -350,15 +350,15 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /** @protected */
+    get _inputValue() {
+      return this.inputElement ? this.inputElement.value : undefined;
+    }
+
+    /** @protected */
     set _inputValue(value) {
       if (this.inputElement) {
         this.inputElement.value = value;
       }
-    }
-
-    /** @protected */
-    get _inputValue() {
-      return this.inputElement ? this.inputElement.value : undefined;
     }
 
     /** @private */

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -944,6 +944,8 @@ export const DatePickerMixin = (subclass) =>
             }
           }
           break;
+        default:
+          break;
       }
     }
 

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -610,11 +610,9 @@ class DatePickerOverlayContent extends ThemableMixin(DirMixin(PolymerElement)) {
       case 'start':
         this._toggleAnimateClass(false);
         break;
-
       case 'track':
         this._handleTrack(e);
         break;
-
       case 'end':
         this._toggleAnimateClass(true);
         if (this._translateX >= this._yearScrollerWidth / 2) {
@@ -622,6 +620,8 @@ class DatePickerOverlayContent extends ThemableMixin(DirMixin(PolymerElement)) {
         } else {
           this._openYearScroller();
         }
+        break;
+      default:
         break;
     }
   }
@@ -815,6 +815,8 @@ class DatePickerOverlayContent extends ThemableMixin(DirMixin(PolymerElement)) {
           break;
         case 'Escape':
           this._cancel();
+          break;
+        default:
           break;
       }
     }

--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -210,6 +210,13 @@ class InfiniteScroller extends PolymerElement {
   }
 
   /**
+   * @private
+   */
+  get position() {
+    return (this.$.scroller.scrollTop - this._buffers[0].translateY) / this.itemHeight + this._firstIndex;
+  }
+
+  /**
    * Current scroller position as index. Can be a fractional number.
    *
    * @type {Number}
@@ -236,13 +243,6 @@ class InfiniteScroller extends PolymerElement {
         this.$.scroller.classList.remove('notouchscroll');
       }, 10);
     }
-  }
-
-  /**
-   * @private
-   */
-  get position() {
-    return (this.$.scroller.scrollTop - this._buffers[0].translateY) / this.itemHeight + this._firstIndex;
   }
 
   get itemHeight() {

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -25,14 +25,14 @@ registerStyles('vaadin-date-time-picker', inputFieldShared, { moduleId: 'vaadin-
  */
 
 // Find a property definition from the prototype chain of a Polymer element class
-const getPropertyFromPrototype = function (clazz, prop) {
+function getPropertyFromPrototype(clazz, prop) {
   while (clazz) {
     if (clazz.properties && clazz.properties[prop]) {
       return clazz.properties[prop];
     }
     clazz = Object.getPrototypeOf(clazz);
   }
-};
+}
 
 const datePickerClass = customElements.get('vaadin-date-time-picker-date-picker');
 const timePickerClass = customElements.get('vaadin-date-time-picker-time-picker');

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -211,6 +211,8 @@ export const DialogResizableMixin = (superClass) =>
               }
               break;
             }
+            default:
+              break;
           }
         });
 

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -30,6 +30,7 @@ customElements.define(
         </vaadin-form-layout>
       `;
     }
+
     static get properties() {
       return {
         items: {

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -160,6 +160,8 @@ export const KeyboardNavigationMixin = (superClass) =>
         case ' ':
           keyGroup = 'Space';
           break;
+        default:
+          break;
       }
 
       this._detectInteracting(e);
@@ -275,6 +277,8 @@ export const KeyboardNavigationMixin = (superClass) =>
           break;
         case 'PageUp':
           dy = -visibleItemsCount;
+          break;
+        default:
           break;
       }
 
@@ -528,6 +532,8 @@ export const KeyboardNavigationMixin = (superClass) =>
           break;
         case 'F2':
           wantInteracting = !this.interacting;
+          break;
+        default:
           break;
       }
 

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -31,17 +31,17 @@ export const ScrollMixin = (superClass) =>
       };
     }
 
+    /** @private */
+    get _scrollTop() {
+      return this.$.table.scrollTop;
+    }
+
     /**
      * Override (from iron-scroll-target-behavior) to avoid document scroll
      * @private
      */
     set _scrollTop(top) {
       this.$.table.scrollTop = top;
-    }
-
-    /** @private */
-    get _scrollTop() {
-      return this.$.table.scrollTop;
     }
 
     /** @private */

--- a/packages/notification/test/statichelper.test.js
+++ b/packages/notification/test/statichelper.test.js
@@ -16,8 +16,8 @@ describe('static helpers', () => {
   it('show should show a Lit template notification', () => {
     const notification = Notification.show(html`Hello world`);
 
-    //const notificationDom = document.body.querySelector('vaadin-notification');
-    //FIXME This causes 'TypeError: Converting circular structure to JSON'
+    // const notificationDom = document.body.querySelector('vaadin-notification');
+    // FIXME This causes 'TypeError: Converting circular structure to JSON'
     // expect(notification).to.equal(notificationDom);
 
     expect(notification._card.innerText.trim()).to.equal('Hello world');

--- a/packages/polymer-legacy-adapter/test/fixtures/mock-component.js
+++ b/packages/polymer-legacy-adapter/test/fixtures/mock-component.js
@@ -15,13 +15,13 @@ export class MockComponent extends HTMLElement {
     };
   }
 
+  get renderer() {
+    return this.__renderer;
+  }
+
   set renderer(renderer) {
     this.__renderer = renderer;
     this.render();
-  }
-
-  get renderer() {
-    return this.__renderer;
   }
 
   render() {

--- a/packages/upload/test/mock-http-request.js
+++ b/packages/upload/test/mock-http-request.js
@@ -98,7 +98,6 @@ MockHttpRequest.prototype = {
       case 'TRACE':
       case 'TRACK':
         throw new Error('SECURITY_ERR');
-
       case 'DELETE':
       case 'GET':
       case 'HEAD':
@@ -106,6 +105,9 @@ MockHttpRequest.prototype = {
       case 'POST':
       case 'PUT':
         method = method.toUpperCase();
+        break;
+      default:
+        break;
     }
     this.method = method;
 
@@ -149,6 +151,8 @@ MockHttpRequest.prototype = {
       case 'user-agent':
       case 'via':
         return;
+      default:
+        break;
     }
     if (header.substr(0, 6) === 'proxy-' || header.substr(0, 4) === 'sec-') {
       return;

--- a/packages/upload/test/mock-http-request.js
+++ b/packages/upload/test/mock-http-request.js
@@ -77,7 +77,7 @@ MockHttpRequest.prototype = {
     507: 'Insufficient Storage'
   },
 
-  /*** State ***/
+  /* State */
 
   UNSENT: 0,
   OPENED: 1,
@@ -86,7 +86,7 @@ MockHttpRequest.prototype = {
   DONE: 4,
   readyState: 0,
 
-  /*** Request ***/
+  /* Request */
 
   // eslint-disable-next-line max-params
   open: function (method, url, async, user, password) {
@@ -191,7 +191,7 @@ MockHttpRequest.prototype = {
     this.readyState = this.UNSENT;
   },
 
-  /*** Response ***/
+  /* Response */
 
   status: 0,
   statusText: '',
@@ -217,7 +217,7 @@ MockHttpRequest.prototype = {
   responseText: '',
   responseXML: undefined,
 
-  /*** See http://www.w3.org/TR/progress-events/ ***/
+  /* See http://www.w3.org/TR/progress-events/ */
 
   onload: function () {
     // Instances should override this.
@@ -239,7 +239,7 @@ MockHttpRequest.prototype = {
     // Instances should override this.
   },
 
-  /*** Properties and methods for test interaction ***/
+  /* Properties and methods for test interaction */
 
   onsend: function () {
     // Instances should override this.

--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -76,6 +76,7 @@ export const PositionMixin = (superClass) =>
         }
       };
     }
+
     static get observers() {
       return [
         '__positionSettingsChanged(positionTarget, horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap)',

--- a/packages/vaadin-overlay/test/overlay.test.js
+++ b/packages/vaadin-overlay/test/overlay.test.js
@@ -15,6 +15,7 @@ customElements.define(
         </vaadin-overlay>
       `;
     }
+
     static get properties() {
       return {
         opened: Boolean

--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -45,6 +45,8 @@ async function getReleases() {
       case '--compact':
         compact = true;
         break;
+      default:
+        break;
     }
   }
 


### PR DESCRIPTION
## Description

The PR adds more ESLint rules as proposed in #2987.

- [x] func-style
- [x] grouped-accessor-pairs
- [x] lines-between-class-members
- [x] spaced-comment
- [x] default-case

Part of #2987

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
