### PR TITLE
refactor: remove iron-resizable-behavior from avatar-group

### DIFF
--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -34,7 +34,6 @@
   ],
   "dependencies": {
     "@polymer/iron-a11y-announcer": "^3.0.0",
-    "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/avatar": "23.0.0-alpha1",
     "@vaadin/component-base": "23.0.0-alpha1",

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -594,7 +594,7 @@ class AvatarGroup extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
   }
 
-  /*
+  /**
    * @deprecated Since Vaadin 23, `notifyResize()` is deprecated. The component uses a
    * ResizeObserver internally and doesn't need to be explicitly notified of resizes.
    */

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -8,8 +8,6 @@ import '@vaadin/item/src/vaadin-item.js';
 import './vaadin-avatar-group-list-box.js';
 import './vaadin-avatar-group-overlay.js';
 import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announcer.js';
-import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { calculateSplices } from '@polymer/polymer/lib/utils/array-splice.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -61,7 +59,7 @@ const MINIMUM_DISPLAYED_AVATARS = 2;
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class AvatarGroup extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizableBehavior], PolymerElement))) {
+class AvatarGroup extends ElementMixin(ThemableMixin(PolymerElement)) {
   static get template() {
     return html`
       <style>
@@ -284,7 +282,8 @@ class AvatarGroup extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizab
 
     this.__boundSetPosition = this.__setPosition.bind(this);
 
-    this.addEventListener('iron-resize', this._onResize.bind(this));
+    this.__resizeObserver = new ResizeObserver(() => this._onResize());
+    this.__resizeObserver.observe(this);
 
     this._overlayElement = this.shadowRoot.querySelector('vaadin-avatar-group-overlay');
 
@@ -593,6 +592,16 @@ class AvatarGroup extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizab
       this._overlayElement.style.removeProperty('bottom');
       this._overlayElement.style.top = btnRect.bottom + 'px';
     }
+  }
+
+  /*
+   * @deprecated Since Vaadin 23, `notifyResize()` is deprecated. The component uses a
+   * ResizeObserver internally and doesn't need to be explicitly notified of resizes.
+   */
+  notifyResize() {
+    console.warn(
+      `WARNING: Since Vaadin 23, notifyResize() is deprecated. The component uses a ResizeObserver internally and doesn't need to be explicitly notified of resizes.`
+    );
   }
 }
 

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -10,7 +10,7 @@ const { visualRegressionPlugin } = require('@web/test-runner-visual-regression/p
 const HIDDEN_WARNINGS = [
   '<vaadin-crud> Unable to autoconfigure form because the data structure is unknown. Either specify `include` or ensure at least one item is available beforehand.',
   'The <vaadin-grid> needs the total number of items in order to display rows. Set the total number of items to the `size` property, or provide the total number of items in the second argument of the `dataProvider`’s `callback` call.',
-  /^WARNING: Since Vaadin 22, .* is deprecated.*/,
+  /^WARNING: Since Vaadin .* is deprecated.*/,
   /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/
 ];
 


### PR DESCRIPTION
Continue removing Polymer legacy dependencies.

This PR replaces the "iron-resize"/`notifyResize` mechanism in `<vaadin-avatar-group>` with a native `ResizeObserver`