### PR TITLE
fix: don't call forEach on HTMLCollection

### DIFF
--- a/packages/component-base/src/focus-utils.js
+++ b/packages/component-base/src/focus-utils.js
@@ -135,7 +135,7 @@ function collectFocusableNodes(node, result) {
     // Use shadow root if possible, will check for distributed nodes.
     children = (element.shadowRoot || element).children;
   }
-  children.forEach((child) => {
+  [...children].forEach((child) => {
     // Ensure method is always invoked to collect focusable children.
     needsSort = collectFocusableNodes(child, result) || needsSort;
   });


### PR DESCRIPTION
## Description

The PR fixes the `getFocusableElements` utility to not call `forEach` on `HTMLCollection` as it causes an exception because `HTMLCollection` doesn't support such a method and needs to be converted to an array first.

The existing unit tests haven't been able to catch this bug because of a known issue with Mocha 8 extending `HTMLCollection` and some other classes with a `forEach` method globally (#3154).

Related to #3154 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
