### PR TITLE
feat: add focus-ring attribute to vaadin-upload-file

### DIFF
--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -106,7 +106,7 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
         <ul id="fileList" part="file-list">
           <template is="dom-repeat" items="[[files]]" as="file">
             <li>
-              <vaadin-upload-file tabindex="0" file="[[file]]" i18n="[[i18n]]"></vaadin-upload-file>
+              <vaadin-upload-file file="[[file]]" i18n="[[i18n]]"></vaadin-upload-file>
             </li>
           </template>
         </ul>

--- a/packages/upload/test/file.test.js
+++ b/packages/upload/test/file.test.js
@@ -87,5 +87,18 @@ describe('<vaadin-upload-file> element', () => {
 
       expect(fileElement.hasAttribute('focus-ring')).to.be.true;
     });
+
+    it('should not set focus-ring on Shift Tab to button', async () => {
+      const button = fileElement.shadowRoot.querySelector('[part="remove-button"]');
+      button.focus();
+      await sendKeys({ press: 'Tab' });
+
+      // Move focus back to the button.
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+
+      expect(fileElement.hasAttribute('focus-ring')).to.be.false;
+    });
   });
 });

--- a/packages/upload/test/file.test.js
+++ b/packages/upload/test/file.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import '../vaadin-upload.js';
 import { createFile } from './common.js';
 
@@ -47,6 +48,44 @@ describe('<vaadin-upload-file> element', () => {
     it('should reflect error', () => {
       fileElement.set('file.error', true);
       expect(fileElement.hasAttribute('error')).to.be.true;
+    });
+  });
+
+  describe('focus', () => {
+    beforeEach(() => {
+      // Show the "Start" button
+      fileElement.set('file.held', true);
+    });
+
+    it('should not add focus-ring to the host on programmatic focus', () => {
+      fileElement.focus();
+      expect(fileElement.hasAttribute('focus-ring')).to.be.false;
+    });
+
+    it('should add focus-ring to the host on keyboard focus', async () => {
+      await sendKeys({ press: 'Tab' });
+      expect(fileElement.hasAttribute('focus-ring')).to.be.true;
+    });
+
+    it('should remove focus-ring when a button is focused', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      // Focus the button
+      await sendKeys({ press: 'Tab' });
+
+      expect(fileElement.hasAttribute('focus-ring')).to.be.false;
+    });
+
+    it('should restore focus-ring when focus moves back', async () => {
+      const button = fileElement.shadowRoot.querySelector('button');
+      button.focus();
+
+      // Move focus back to the upload file.
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+
+      expect(fileElement.hasAttribute('focus-ring')).to.be.true;
     });
   });
 });

--- a/packages/upload/theme/lumo/vaadin-upload-styles.js
+++ b/packages/upload/theme/lumo/vaadin-upload-styles.js
@@ -73,13 +73,10 @@ registerStyles(
 const uploadFile = css`
   :host {
     padding: var(--lumo-space-s) 0;
-  }
-
-  :host(:focus) {
     outline: none;
   }
 
-  :host(:focus) [part='row'] {
+  :host([focus-ring]) [part='row'] {
     border-radius: var(--lumo-border-radius-s);
     box-shadow: 0 0 0 2px var(--lumo-primary-color-50pct);
   }

--- a/packages/upload/theme/material/vaadin-upload-styles.js
+++ b/packages/upload/theme/material/vaadin-upload-styles.js
@@ -99,6 +99,10 @@ registerStyles(
 registerStyles(
   'vaadin-upload-file',
   css`
+    :host {
+      outline: none;
+    }
+
     [part='row'] {
       display: flex;
       align-items: flex-start;
@@ -106,11 +110,7 @@ registerStyles(
       padding: 8px;
     }
 
-    :host(:focus) {
-      outline: none;
-    }
-
-    :host(:focus) [part='row'] {
+    :host([focus-ring]) [part='row'] {
       background-color: var(--material-divider-color);
     }
 


### PR DESCRIPTION
## Description

1. Added `FocusMixin` and changed to use `focus-ring` styles, similarly as we did for `vaadin-scroller`,
2. Implemented custom `focusin` and `focusout` listeners to hanle focusing buttons in Shadow DOM.

Fixes #3117

## Type of change

- Internal feature