### PR TITLE
fix: workaround Safari/VoiceOver menu navigation

### DIFF
--- a/packages/context-menu/theme/lumo/vaadin-context-menu-styles.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu-styles.js
@@ -93,6 +93,10 @@ registerStyles(
     :host {
       user-select: none;
       -ms-user-select: none;
+    }
+
+    /* Workaround https://github.com/vaadin/web-components/issues/3133 */
+    :host(:hover) {
       -webkit-user-select: none;
     }
 

--- a/packages/context-menu/theme/lumo/vaadin-context-menu-styles.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu-styles.js
@@ -90,13 +90,10 @@ registerStyles(
 registerStyles(
   'vaadin-context-menu-item',
   css`
-    :host {
+    /* :hover needed to workaround https://github.com/vaadin/web-components/issues/3133 */
+    :host(:hover) {
       user-select: none;
       -ms-user-select: none;
-    }
-
-    /* Workaround https://github.com/vaadin/web-components/issues/3133 */
-    :host(:hover) {
       -webkit-user-select: none;
     }
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/3133

Seems that having `-webkit-user-select: none;` always enabled for the menu-item causes the glitch on Safari. Worked around the issue by only having the rule enabled on hover.