### PR TITLE
fix: prevent memory leaks by cleaning up FlattenedNodeObserver instances

### DIFF
--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -152,6 +152,20 @@ class Accordion extends ThemableMixin(ElementMixin(PolymerElement)) {
     });
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    if (this._observer) {
+      this._observer.connect();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._observer) {
+      this._observer.disconnect();
+    }
+  }
+
   /**
    * @param {!Array<!Element>} array
    * @return {!Array<!AccordionPanel>}

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -161,6 +161,20 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
     });
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    if (this._observer) {
+      this._observer.connect();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._observer) {
+      this._observer.disconnect();
+    }
+  }
+
   /**
    * Override method inherited from `ValidateMixin`
    * to validate the value array.

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -347,6 +347,20 @@ class ConfirmDialog extends SlotMixin(ElementMixin(ThemePropertyMixin(PolymerEle
     }
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    if (this._observer) {
+      this._observer.connect();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._observer) {
+      this._observer.disconnect();
+    }
+  }
+
   /** @private */
   __onDialogOpened() {
     const overlay = this._overlayElement;

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -687,6 +687,20 @@ class Crud extends SlotMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     this.__propagateHostAttributes();
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    if (this._observer) {
+      this._observer.connect();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._observer) {
+      this._observer.disconnect();
+    }
+  }
+
   /** @private */
   __isSaveBtnDisabled(isDirty) {
     // Used instead of isDirty property binding in order to enable overriding of the behavior

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -425,6 +425,20 @@ class DateTimePicker extends FieldMixin(SlotMixin(DisabledMixin(ThemableMixin(El
     this.ariaTarget = this;
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    if (this._observer) {
+      this._observer.connect();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._observer) {
+      this._observer.disconnect();
+    }
+  }
+
   /** @private */
   __filterElements(node) {
     return node.nodeType === Node.ELEMENT_NODE;

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -169,6 +169,20 @@ export const FieldMixin = (superclass) =>
       this.addController(this._fieldAriaController);
     }
 
+    connectedCallback() {
+      super.connectedCallback();
+      if (this.__helperIdObserver) {
+        this.__helperIdObserver.connect();
+      }
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      if (this.__helperIdObserver) {
+        this.__helperIdObserver.disconnect();
+      }
+    }
+
     /** @private */
     __applyCustomError() {
       const error = this.__errorMessage;

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -186,6 +186,20 @@ class RadioGroup extends FieldMixin(
     });
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    if (this._observer) {
+      this._observer.connect();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._observer) {
+      this._observer.disconnect();
+    }
+  }
+
   /**
    * @param {!Array<!Node>} nodes
    * @return {!Array<!RadioButton>}

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -246,6 +246,20 @@ class SplitLayout extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizab
     addListener(splitter, 'up', this._restorePointerEvents.bind(this));
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.__observer) {
+      this.__observer.connect();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this.__observer) {
+      this.__observer.disconnect();
+    }
+  }
+
   /** @private */
   _processChildren() {
     this.getEffectiveChildren().forEach((child, i) => {

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.js
@@ -91,6 +91,20 @@ export const ListMixin = (superClass) =>
       });
     }
 
+    connectedCallback() {
+      super.connectedCallback();
+      if (this._observer) {
+        this._observer.connect();
+      }
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      if (this._observer) {
+        this._observer.disconnect();
+      }
+    }
+
     /** @private */
     _enhanceItems(items, orientation, selected, disabled) {
       if (!disabled) {

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -417,6 +417,10 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
       this._detectIosNavbar();
       window.addEventListener('resize', this._boundIosResizeListener);
     }
+
+    if (this._observer) {
+      this._observer.connect();
+    }
   }
 
   /** @protected */
@@ -426,6 +430,10 @@ class OverlayElement extends ThemableMixin(DirMixin(PolymerElement)) {
     /* c8 ignore next 3 */
     if (this._boundIosResizeListener) {
       window.removeEventListener('resize', this._boundIosResizeListener);
+    }
+
+    if (this._observer) {
+      this._observer.disconnect();
     }
   }
 


### PR DESCRIPTION
## Description

There are several instances where a component uses a `FlattenedNodeObserver`, but doesn't disconnect the observer when it is removed from the DOM. I'm assuming that this can result in memory leaks, and we have other components that explicitly clean up the observer in the disconnected callback. This change aligns all remaining components to clean up the observer.

## Type of change

- [x] Bugfix
