### PR TITLE
feat: prevent focusing drawer by keyboard when it is closed 

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -204,16 +204,20 @@ class AppLayout extends ElementMixin(
           right: auto;
           bottom: var(--vaadin-app-layout-navbar-offset-bottom, var(--vaadin-viewport-offset-bottom, 0));
           left: var(--vaadin-app-layout-navbar-offset-left, 0);
-          transition: transform var(--vaadin-app-layout-transition);
+          transition: transform var(--vaadin-app-layout-transition), visibility var(--vaadin-app-layout-transition);
           transform: translateX(-100%);
           max-width: 90%;
           width: 16em;
           box-sizing: border-box;
           padding: var(--safe-area-inset-top) 0 var(--safe-area-inset-bottom) var(--safe-area-inset-left);
           outline: none;
+          /* The drawer should be inaccessible by the tabbing navigation when it is closed. */
+          visibility: hidden;
         }
 
         :host([drawer-opened]) [part='drawer'] {
+          /* The drawer should be accessible by the tabbing navigation when it is opened. */
+          visibility: visible;
           transform: translateX(0%);
           touch-action: manipulation;
         }

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -564,7 +564,7 @@ class AppLayout extends ElementMixin(
   }
 
   /**
-   * Returns a promise that resolves when the drawer opening/closing CSS transition ends.
+   * Returns a promise that resolves when the drawer opening/closing CSS animation completes.
    *
    * The method relies on the `--vaadin-app-layout-transition` CSS variable to detect whether
    * the drawer has a CSS transition that needs to be awaited. If the CSS variable equals `none`,
@@ -573,7 +573,7 @@ class AppLayout extends ElementMixin(
    * @return {Promise}
    * @private
    */
-  __drawerTransitionComplete() {
+  __drawerAnimationComplete() {
     return new Promise((resolve) => {
       if (this._getCustomPropertyValue('--vaadin-app-layout-transition') === 'none') {
         resolve();
@@ -590,6 +590,11 @@ class AppLayout extends ElementMixin(
     // in order for VoiceOver to have a proper outline.
     await this.__drawerTransitionComplete();
 
+    if (!this.drawerOpened) {
+      // The drawer has been closed during the animation.
+      return;
+    }
+
     this.$.drawer.setAttribute('tabindex', '0');
     this.__focusTrapController.trapFocus(this.$.drawer);
   }
@@ -599,6 +604,11 @@ class AppLayout extends ElementMixin(
     // Wait for the drawer CSS transition in order to restore focus to the toggle
     // only after `visibility` becomes `hidden`, that is, the drawer becomes inaccessible by the tabbing navigation.
     await this.__drawerTransitionComplete();
+
+    if (this.drawerOpened) {
+      // The drawer has been opened during the animation.
+      return;
+    }
 
     this.__focusTrapController.releaseFocus();
     this.$.drawer.removeAttribute('tabindex');

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -564,7 +564,7 @@ class AppLayout extends ElementMixin(
   }
 
   /**
-   * Returns a promise that resolves when the drawer opening/closing CSS animation completes.
+   * Returns a promise that resolves when the drawer opening/closing CSS transition ends.
    *
    * The method relies on the `--vaadin-app-layout-transition` CSS variable to detect whether
    * the drawer has a CSS transition that needs to be awaited. If the CSS variable equals `none`,
@@ -573,7 +573,7 @@ class AppLayout extends ElementMixin(
    * @return {Promise}
    * @private
    */
-  __drawerAnimationComplete() {
+  __drawerTransitionComplete() {
     return new Promise((resolve) => {
       if (this._getCustomPropertyValue('--vaadin-app-layout-transition') === 'none') {
         resolve();
@@ -591,7 +591,7 @@ class AppLayout extends ElementMixin(
     await this.__drawerTransitionComplete();
 
     if (!this.drawerOpened) {
-      // The drawer has been closed during the animation.
+      // The drawer has been closed during the CSS transition.
       return;
     }
 
@@ -606,7 +606,7 @@ class AppLayout extends ElementMixin(
     await this.__drawerTransitionComplete();
 
     if (this.drawerOpened) {
-      // The drawer has been opened during the animation.
+      // The drawer has been opened during the CSS transition.
       return;
     }
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -213,6 +213,15 @@ describe('vaadin-app-layout', () => {
         expect(getComputedStyle(drawer).visibility).to.equal('hidden');
       });
 
+      it(`should not change the drawer's tabindex attribute on sequential drawer open/close`, async () => {
+        const spy = sinon.spy();
+        new MutationObserver(spy).observe(drawer, { attributes: true, attributeFilter: ['tabindex'] });
+        layout.drawerOpened = true;
+        layout.drawerOpened = false;
+        await nextFrame();
+        expect(spy.called).to.be.false;
+      });
+
       it('should reflect scrollHeight to a custom CSS property when the drawer has overflow', () => {
         const drawer = layout.shadowRoot.querySelector('[part=drawer]');
         drawer.style.height = '50px';
@@ -300,6 +309,14 @@ describe('vaadin-app-layout', () => {
           expect(layout.shadowRoot.activeElement).to.equal(drawer);
           await oneEvent(drawer, 'transitionend');
           expect(document.activeElement).to.equal(toggle);
+        });
+
+        it(`should not call focus() on the drawer toggle on sequential drawer close/open`, async () => {
+          const spy = sinon.spy(toggle, 'focus');
+          layout.drawerOpened = false;
+          layout.drawerOpened = true;
+          await nextFrame();
+          expect(spy.called).to.be.false;
         });
       });
     });

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -141,11 +141,11 @@ describe('vaadin-app-layout', () => {
         expect(layout.drawerOpened).to.be.true;
       });
 
-      it('should have visibility: visible by default', () => {
+      it('should have the CSS visibility set to visible by default', () => {
         expect(getComputedStyle(drawer).visibility).to.equal('visible');
       });
 
-      it(`should toggle the drawer's CSS visibility on drawerOpened property toggle`, () => {
+      it('should toggle the CSS visibility on drawerOpened property toggle', () => {
         layout.drawerOpened = false;
         expect(getComputedStyle(drawer).visibility).to.equal('hidden');
         layout.drawerOpened = true;
@@ -202,18 +202,18 @@ describe('vaadin-app-layout', () => {
         expect(layout.drawerOpened).to.be.false;
       });
 
-      it('should have visibility: hidden by default', () => {
+      it('should have the CSS visibility set to hidden by default', () => {
         expect(getComputedStyle(drawer).visibility).to.equal('hidden');
       });
 
-      it(`should toggle the drawer's CSS visibility on drawerOpened property toggle`, () => {
+      it('should toggle the CSS visibility on drawerOpened property toggle', () => {
         layout.drawerOpened = true;
         expect(getComputedStyle(drawer).visibility).to.equal('visible');
         layout.drawerOpened = false;
         expect(getComputedStyle(drawer).visibility).to.equal('hidden');
       });
 
-      it(`should not change the drawer's tabindex attribute on sequential drawer open/close`, async () => {
+      it('should not change tabindex attribute on consecutive drawer open/close', async () => {
         const spy = sinon.spy();
         new MutationObserver(spy).observe(drawer, { attributes: true, attributeFilter: ['tabindex'] });
         layout.drawerOpened = true;
@@ -311,7 +311,7 @@ describe('vaadin-app-layout', () => {
           expect(document.activeElement).to.equal(toggle);
         });
 
-        it(`should not call focus() on the drawer toggle on sequential drawer close/open`, async () => {
+        it('should not call focus() on the drawer toggle on consecutive drawer close/open', async () => {
           const spy = sinon.spy(toggle, 'focus');
           layout.drawerOpened = false;
           layout.drawerOpened = true;

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -141,6 +141,17 @@ describe('vaadin-app-layout', () => {
         expect(layout.drawerOpened).to.be.true;
       });
 
+      it('should have visibility: visible by default', () => {
+        expect(getComputedStyle(drawer).visibility).to.equal('visible');
+      });
+
+      it(`should toggle the drawer's CSS visibility on drawerOpened property toggle`, () => {
+        layout.drawerOpened = false;
+        expect(getComputedStyle(drawer).visibility).to.equal('hidden');
+        layout.drawerOpened = true;
+        expect(getComputedStyle(drawer).visibility).to.equal('visible');
+      });
+
       it('should reflect drawerOpened property to the attribute', () => {
         layout.drawerOpened = false;
         expect(layout.hasAttribute('drawer-opened')).to.be.false;
@@ -155,7 +166,7 @@ describe('vaadin-app-layout', () => {
         expect(layout.drawerOpened).to.be.true;
       });
 
-      it('should fire "drawer-opened-changed" event on drawer opened toggle', () => {
+      it('should fire "drawer-opened-changed" event on drawerOpened property toggle', () => {
         const spy = sinon.spy();
         layout.addEventListener('drawer-opened-changed', spy);
         layout.drawerOpened = false;
@@ -189,6 +200,17 @@ describe('vaadin-app-layout', () => {
 
       it('should be closed by default', () => {
         expect(layout.drawerOpened).to.be.false;
+      });
+
+      it('should have visibility: hidden by default', () => {
+        expect(getComputedStyle(drawer).visibility).to.equal('hidden');
+      });
+
+      it(`should toggle the drawer's CSS visibility on drawerOpened property toggle`, () => {
+        layout.drawerOpened = true;
+        expect(getComputedStyle(drawer).visibility).to.equal('visible');
+        layout.drawerOpened = false;
+        expect(getComputedStyle(drawer).visibility).to.equal('hidden');
       });
 
       it('should reflect scrollHeight to a custom CSS property when the drawer has overflow', () => {


### PR DESCRIPTION
## Description

When the app-layout drawer is closed, it should be inaccessible by the keyboard tabbing navigation. The PR solves this by adding `visibility: hidden` to the drawer when it is closed.

**WARNING: Do not merge this PR before #2395 is merged.**

Depends on #2395

Related to #95, #466, #2888

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
