### PR TITLE
chore: remove unnecessary ghost-click prevention mechanism

### DIFF
--- a/packages/combo-box/test/combo-box-light.test.js
+++ b/packages/combo-box/test/combo-box-light.test.js
@@ -16,9 +16,11 @@ import '@vaadin/text-field/vaadin-text-field.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box-light.js';
-import { resetMouseCanceller } from '@polymer/polymer/lib/utils/gestures.js';
+import * as settings from '@polymer/polymer/lib/utils/settings.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { createEventSpy, getFirstItem } from './helpers.js';
+
+settings.setCancelSyntheticClickEvents(false);
 
 class MyInput extends PolymerElement {
   static get template() {
@@ -85,13 +87,6 @@ describe('vaadin-combo-box-light', () => {
   });
 
   describe('toggling', () => {
-    // NOTE(platosha): because we use emulate touch events in these
-    // tests, we need to reset mouseCanceller in Gestures. Otherwise
-    // it might interfere and cancel clicks in totally unrelated tests.
-    afterEach(() => {
-      resetMouseCanceller();
-    });
-
     it('should toggle overlay on input click', () => {
       inputElement.click();
       expect(comboBox.opened).to.be.true;

--- a/packages/component-base/src/gestures.d.ts
+++ b/packages/component-base/src/gestures.d.ts
@@ -64,17 +64,6 @@ export { prevent };
  */
 declare function prevent(evName: string): void;
 
-export { resetMouseCanceller };
-
-/**
- * Reset the 2500ms timeout on processing mouse input after detecting touch input.
- *
- * Touch inputs create synthesized mouse inputs anywhere from 0 to 2000ms after the touch.
- * This method should only be called during testing with simulated touch inputs.
- * Calling this method in production may cause duplicate taps or other Gestures.
- */
-declare function resetMouseCanceller(): void;
-
 export interface GestureRecognizer {
   reset: () => void;
   mousedown?: (e: MouseEvent) => void;

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -3,7 +3,6 @@ import { fixtureSync, focusout, makeSoloTouchEvent, mousedown } from '@vaadin/te
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-password-field.js';
-import { resetMouseCanceller } from '@vaadin/component-base/src/gestures.js';
 
 describe('password-field', () => {
   let passwordField, input, revealButton;
@@ -12,13 +11,6 @@ describe('password-field', () => {
     passwordField = fixtureSync('<vaadin-password-field></vaadin-password-field>');
     input = passwordField.inputElement;
     revealButton = passwordField.querySelector('[slot=reveal]');
-  });
-
-  // NOTE: because we use emulate touch events in some of the tests,
-  // we need to reset mouseCanceller in Gestures. Otherwise it might
-  // interfere and cancel clicks in totally unrelated tests.
-  afterEach(() => {
-    resetMouseCanceller();
   });
 
   it('should set default accessible label to reveal button', () => {

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -14,7 +14,6 @@ import { timeOut } from '@vaadin/component-base/src/async.js';
 import { isFirefox } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { resetMouseCanceller } from '@vaadin/component-base/src/gestures.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { richTextEditorStyles } from './vaadin-rich-text-editor-styles.js';
 
@@ -994,16 +993,7 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
   _onImageTouchEnd(e) {
     // Cancel the event to avoid the following click event
     e.preventDefault();
-    // FIXME(platosha): workaround for Polymer Gestures mouseCanceller
-    // cancelling the following synthetic click. See also:
-    // https://github.com/Polymer/polymer/issues/5289
-    this.__resetMouseCanceller();
     this._onImageClick();
-  }
-
-  /** @private */
-  __resetMouseCanceller() {
-    resetMouseCanceller();
   }
 
   /** @private */

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -220,15 +220,6 @@ describe('rich text editor', () => {
         expect(e.defaultPrevented).to.be.true;
       });
 
-      it('should invoke Polymer.Gestures.resetMouseCanceller before open file dialog', () => {
-        // NOTE(web-padawan): With ES modules we can’t put a spy on the actual
-        // Polymer.Gestures.resetMouseCanceller. Have to use a separate
-        // wrapper method for testing.
-        const spy = sinon.spy(rte, '__resetMouseCanceller');
-        btn.dispatchEvent(new CustomEvent('touchend', { cancelable: true }));
-        expect(spy.calledOnce).to.be.true;
-      });
-
       (isDesktopSafari ? it.skip : it)(
         'should insert image from the file dialog on file input change event',
         (done) => {

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -10,7 +10,6 @@ import './vaadin-upload-file.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { resetMouseCanceller } from '@vaadin/component-base/src/gestures.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
@@ -819,16 +818,7 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
   _onAddFilesTouchEnd(e) {
     // Cancel the event to avoid the following click event
     e.preventDefault();
-    // FIXME(platosha): workaround for Polymer Gestures mouseCanceller
-    // cancelling the following synthetic click. See also:
-    // https://github.com/Polymer/polymer/issues/5289
-    this.__resetMouseCanceller();
     this._onAddFilesClick(e);
-  }
-
-  /** @private */
-  __resetMouseCanceller() {
-    resetMouseCanceller();
   }
 
   /** @private */

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { change, click, fixtureSync, makeSoloTouchEvent, touchend } from '@vaadin/testing-helpers';
+import { change, click, fixtureSync, makeSoloTouchEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-upload.js';
 import { createFile, createFiles, touchDevice, xhrCreator } from './common.js';
@@ -58,15 +58,6 @@ describe('file list', () => {
       const event = makeSoloTouchEvent('touchend', null, addFiles);
       expect(inputClickSpy.calledOnce).to.be.true;
       expect(event.defaultPrevented).to.be.true;
-    });
-
-    it('should invoke Polymer.Gestures.resetMouseCanceller before open file dialog', () => {
-      // NOTE(platosha): With ES modules we can’t put a spy on the actual
-      // Polymer.Gestures.resetMouseCanceller. Have to use a separate
-      // wrapper method for testing.
-      const spy = sinon.spy(upload, '__resetMouseCanceller');
-      touchend(addFiles);
-      expect(spy.calledOnce).to.be.true;
     });
 
     it('should reset input.value before dialog', () => {


### PR DESCRIPTION
The ghost-click prevention mechanism in gestures is no longer necessary in modern browsers. Remove.