### PR TITLE
fix: hide upload drop files button from assistive technologies

### DIFF
--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -94,7 +94,7 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
             </vaadin-button>
           </slot>
         </div>
-        <div part="drop-label" hidden$="[[nodrop]]" id="dropLabelContainer">
+        <div part="drop-label" hidden$="[[nodrop]]" id="dropLabelContainer" aria-hidden="true">
           <slot name="drop-label-icon">
             <div part="drop-label-icon"></div>
           </slot>

--- a/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
@@ -16,6 +16,7 @@ snapshots["vaadin-upload shadow default"] =
     </slot>
   </div>
   <div
+    aria-hidden="true"
     id="dropLabelContainer"
     part="drop-label"
   >


### PR DESCRIPTION
Fixes #2864 

Confirmed that the change fixed the issue on NVDA = "Drop files here" no longer gets announced and it can't be navigated to with the reading cursor