### PR TITLE
fix: prevent double error message announcement when using NVDA

### DIFF
--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-bind.js';
@@ -461,8 +461,9 @@ describe('vaadin-checkbox-group', () => {
       expect(aria).to.include(label.id);
     });
 
-    it('should add error message to aria-labelledby when field is invalid', () => {
+    it('should add error message to aria-labelledby when field is invalid', async () => {
       group.invalid = true;
+      await aTimeout(0);
       const aria = group.getAttribute('aria-labelledby');
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);

--- a/packages/combo-box/test/aria.test.js
+++ b/packages/combo-box/test/aria.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDownKeyDown, escKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { arrowDownKeyDown, aTimeout, escKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 import { getAllItems } from './helpers.js';
@@ -39,8 +39,9 @@ describe('ARIA', () => {
       expect(aria).to.not.include(error.id);
     });
 
-    it('should add error message ID to aria-describedby when invalid', () => {
+    it('should add error message ID to aria-describedby when invalid', async () => {
       comboBox.invalid = true;
+      await aTimeout(0);
       const aria = input.getAttribute('aria-describedby');
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);

--- a/packages/custom-field/test/custom-field.test.js
+++ b/packages/custom-field/test/custom-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, focusin, focusout } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, focusin, focusout } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-custom-field.js';
 import { dispatchChange } from './common.js';
@@ -205,8 +205,9 @@ describe('custom field', () => {
       expect(aria).to.include(label.id);
     });
 
-    it('should add error message to aria-labelledby when field is invalid', () => {
+    it('should add error message to aria-labelledby when field is invalid', async () => {
       customField.invalid = true;
+      await aTimeout(0);
       const aria = customField.getAttribute('aria-labelledby');
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -28,8 +28,9 @@ describe('WAI-ARIA', () => {
       expect(aria).to.not.include(error.id);
     });
 
-    it('should add error message ID to aria-describedby when invalid', () => {
+    it('should add error message ID to aria-describedby when invalid', async () => {
       datepicker.invalid = true;
+      await aTimeout(0);
       const aria = input.getAttribute('aria-describedby');
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);

--- a/packages/date-time-picker/test/aria.test.js
+++ b/packages/date-time-picker/test/aria.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-date-time-picker.js';
 
 describe('ARIA', () => {
@@ -25,8 +25,9 @@ describe('ARIA', () => {
     expect(aria).to.include(label.id);
   });
 
-  it('should add error message to aria-labelledby when field is invalid', () => {
+  it('should add error message to aria-labelledby when field is invalid', async () => {
     dateTimePicker.invalid = true;
+    await aTimeout(0);
     const aria = dateTimePicker.getAttribute('aria-labelledby');
     expect(aria).to.include(helper.id);
     expect(aria).to.include(error.id);

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -369,12 +369,18 @@ export const FieldMixin = (superclass) =>
      * @protected
      */
     _invalidChanged(invalid) {
-      // Error message ID needs to be dynamically added / removed based on the validity
-      // Otherwise assistive technologies would announce the error, even if we hide it.
-      if (invalid) {
-        this._fieldAriaController.setErrorId(this._errorId);
-      } else {
-        this._fieldAriaController.setErrorId(null);
-      }
+      // This timeout is needed to prevent NVDA from announcing the error message twice:
+      // 1. Once adding the `[role=alert]` attribute by the `_updateErrorMessage` method (OK).
+      // 2. Once linking the error ID with the ARIA target here (unwanted).
+      // Related issue: https://github.com/vaadin/web-components/issues/3061.
+      setTimeout(() => {
+        // Error message ID needs to be dynamically added / removed based on the validity
+        // Otherwise assistive technologies would announce the error, even if we hide it.
+        if (invalid) {
+          this._fieldAriaController.setErrorId(this._errorId);
+        } else {
+          this._fieldAriaController.setErrorId(null);
+        }
+      });
     }
   };

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { FieldMixin } from '../src/field-mixin.js';
@@ -578,8 +578,9 @@ describe('field-mixin', () => {
           expect(aria).to.equal(helper.id);
         });
 
-        it('should contain error id when the field is invalid', () => {
+        it('should add error id asynchronously after the field becomes invalid', async () => {
           element.invalid = true;
+          await aTimeout(0);
           const aria = input.getAttribute('aria-describedby');
           expect(aria).to.include(helper.id);
           expect(aria).to.include(error.id);
@@ -606,8 +607,9 @@ describe('field-mixin', () => {
           expect(aria).to.not.include(error.id);
         });
 
-        it('should contain error id when the field is invalid', () => {
+        it('should add error id asynchronously after the field becomes invalid', async () => {
           element.invalid = true;
+          await aTimeout(0);
           const aria = element.getAttribute('aria-labelledby');
           expect(aria).to.include(label.id);
           expect(aria).to.include(helper.id);

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-radio-group.js';
@@ -546,8 +546,9 @@ describe('radio-group', () => {
       expect(aria).to.include(label.id);
     });
 
-    it('should add error message to aria-labelledby when field is invalid', () => {
+    it('should add error message to aria-labelledby when field is invalid', async () => {
       group.invalid = true;
+      await aTimeout(0);
       const aria = group.getAttribute('aria-labelledby');
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);

--- a/packages/time-picker/test/aria.test.js
+++ b/packages/time-picker/test/aria.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDownKeyDown, escKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { arrowDownKeyDown, aTimeout, escKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../src/vaadin-time-picker.js';
 
 describe('ARIA', () => {
@@ -45,8 +45,9 @@ describe('ARIA', () => {
       expect(aria).to.not.include(error.id);
     });
 
-    it('should add error message ID to aria-describedby when invalid', () => {
+    it('should add error message ID to aria-describedby when invalid', async () => {
       timePicker.invalid = true;
+      await aTimeout(0);
       const aria = input.getAttribute('aria-describedby');
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);


### PR DESCRIPTION
## Description

The PR introduces a workaround for `FieldMixin` that prevents double error message announcement when using NVDA, occurring as a side-effect of linking the error id to the ARIA target element. From now on, the error message is announced once and only when the `[role=alert]` attribute is added to the slotted error element.

The workaround is to add a `setTimeout` delay before linking the error id to the ARIA target element. This is the only workaround I was able to find. For the record, I tried `requestAnimationFrame` and `new Promise((resolve) => resolve())`, but they didn't work.

Fixes #3061

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
