### PR TITLE
refactor: use attribute utils in FieldAriaController

### DIFF
--- a/packages/field-base/src/field-aria-controller.js
+++ b/packages/field-base/src/field-aria-controller.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { addValueToAttribute, removeValueFromAttribute } from './utils.js';
 
 /**
  * A controller for managing ARIA attributes for a field element:
@@ -160,16 +161,12 @@ export class FieldAriaController {
       return;
     }
 
-    const value = this.__target.getAttribute(attr);
-    const ids = value ? new Set(value.split(' ')) : new Set();
-
     if (oldId) {
-      ids.delete(oldId);
-    }
-    if (newId) {
-      ids.add(newId);
+      removeValueFromAttribute(this.__target, attr, oldId);
     }
 
-    this.__target.setAttribute(attr, [...ids].join(' '));
+    if (newId) {
+      addValueToAttribute(this.__target, attr, newId);
+    }
   }
 }


### PR DESCRIPTION
## Description

The PR makes `FieldAriaController` use attribute utils instead of its own implementation of adding and removing values from ARIA attributes.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
