### PR TITLE
feat: add i18n property to app-layout

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -7,6 +7,10 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
+export interface AppLayoutI18n {
+  drawer: string;
+}
+
 /**
  * Fired when the `drawerOpened` property changes.
  */
@@ -120,6 +124,28 @@ export type AppLayoutEventMap = HTMLElementEventMap & AppLayoutCustomEventMap;
  * @fires {CustomEvent} primary-section-changed - Fired when the `primarySection` property changes.
  */
 declare class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(HTMLElement))) {
+  /**
+   * The object used to localize this component.
+   * To change the default localization, replace the entire
+   * `i18n` object with a custom one.
+   *
+   * To update individual properties, extend the existing i18n object as follows:
+   * ```js
+   * appLayout.i18n = {
+   *   ...appLayout.i18n,
+   *   drawer: 'Drawer'
+   * }
+   * ```
+   *
+   * The object has the following structure and default values:
+   * ```
+   * {
+   *   drawer: 'Drawer'
+   * }
+   * ```
+   */
+  i18n: AppLayoutI18n;
+
   /**
    * Defines whether navbar or drawer will come first visually.
    * - By default (`primary-section="navbar"`), the navbar takes the full available width and moves the drawer down.

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -524,15 +524,13 @@ class AppLayout extends ElementMixin(
   /**
    * A callback for the `i18n` property observer.
    *
-   * The method ensures the drawer has the `aria-label` attribute updated
+   * The method ensures the drawer has ARIA attributes updated
    * once the `i18n` property changes.
    *
    * @private
    */
   __i18nChanged() {
-    if (this.overlay) {
-      this._updateOverlayMode();
-    }
+    this.__updateDrawerAriaAttributes();
   }
 
   /** @protected */
@@ -603,7 +601,6 @@ class AppLayout extends ElementMixin(
   /** @protected */
   _updateOverlayMode() {
     const overlay = this._getCustomPropertyValue('--vaadin-app-layout-drawer-overlay') === 'true';
-    const drawer = this.$.drawer;
 
     if (!this.overlay && overlay) {
       // Changed from not overlay to overlay
@@ -613,28 +610,38 @@ class AppLayout extends ElementMixin(
 
     this._setOverlay(overlay);
 
-    if (this.overlay) {
-      drawer.setAttribute('role', 'dialog');
-      drawer.setAttribute('aria-modal', 'true');
-      drawer.setAttribute('aria-label', this.i18n.drawer);
-    } else {
-      if (this._drawerStateSaved) {
-        this.drawerOpened = this._drawerStateSaved;
-        this._drawerStateSaved = null;
-      }
-
-      drawer.removeAttribute('role');
-      drawer.removeAttribute('aria-modal');
-      drawer.removeAttribute('aria-label');
+    if (!this.overlay && this._drawerStateSaved) {
+      this.drawerOpened = this._drawerStateSaved;
+      this._drawerStateSaved = null;
     }
 
     this._updateDrawerHeight();
+    this.__updateDrawerAriaAttributes();
 
     if (this.overlay !== overlay) {
       this.notifyResize();
     }
 
     // TODO(jouni): ARIA attributes. The drawer should act similar to a modal dialog when in ”overlay” mode
+  }
+
+  /**
+   * Updates ARIA attributes on the drawer depending on
+   * whether the drawer is in the overlay mode or not.
+   *
+   * @private
+   */
+  __updateDrawerAriaAttributes() {
+    const drawer = this.$.drawer;
+    if (this.overlay) {
+      drawer.setAttribute('role', 'dialog');
+      drawer.setAttribute('aria-modal', 'true');
+      drawer.setAttribute('aria-label', this.i18n.drawer);
+    } else {
+      drawer.removeAttribute('role');
+      drawer.removeAttribute('aria-modal');
+      drawer.removeAttribute('aria-label');
+    }
   }
 
   /**

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -626,8 +626,11 @@ class AppLayout extends ElementMixin(
   }
 
   /**
-   * Updates ARIA attributes on the drawer depending on
-   * whether the drawer is in the overlay mode or not.
+   * Updates ARIA attributes on the drawer depending on the drawer mode.
+   *
+   * - In the overlay mode, the method marks the drawer with ARIA attributes as a dialog
+   * labelled with the `i18n.drawer` property.
+   * - In the normal mode, the method removes the ARIA attributes that has been set for the overlay mode.
    *
    * @private
    */

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -484,7 +484,7 @@ class AppLayout extends ElementMixin(
    * A callback for the `primarySection` property observer.
    *
    * Ensures the property is set to its default value `navbar`
-   * if the new value is neither of the valid values: `navbar`, `drawer`.
+   * whenever the new value is not one of the valid values: `navbar`, `drawer`.
    *
    * @param {string} value
    * @private
@@ -502,7 +502,7 @@ class AppLayout extends ElementMixin(
    * When the drawer opens, the method ensures the drawer has a proper height and sets focus on it.
    * As long as the drawer is open, the focus is trapped within the drawer.
    *
-   * When the drawer closes, the method releases focus from the drawer setting focus on the drawer toggle.
+   * When the drawer closes, the method releases focus from the drawer, setting focus on the drawer toggle.
    *
    * @param {boolean} drawerOpened
    * @param {boolean} oldDrawerOpened

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -411,10 +411,6 @@ class AppLayout extends ElementMixin(
 
   constructor() {
     super();
-
-    /** @type {AppLayoutI18n} */
-    this.i18n;
-
     // TODO(jouni): might want to debounce
     this.__boundResizeListener = this._resize.bind(this);
     this.__drawerToggleClickListener = this._drawerToggleClick.bind(this);

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -617,8 +617,6 @@ class AppLayout extends ElementMixin(
     if (this.overlay !== overlay) {
       this.notifyResize();
     }
-
-    // TODO(jouni): ARIA attributes. The drawer should act similar to a modal dialog when in ”overlay” mode
   }
 
   /**

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -265,7 +265,7 @@ describe('vaadin-app-layout', () => {
         expect(layout.shadowRoot.activeElement).to.equal(drawer);
       });
 
-      it('should update aria-label attribute on the drawer when changing i18n.drawer property', () => {
+      it('should update aria-label attribute on the drawer on i18n.drawer property change', () => {
         layout.i18n = { ...layout.i18n, drawer: 'New Value' };
         expect(drawer.getAttribute('aria-label')).to.equal('New Value');
       });

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -265,6 +265,11 @@ describe('vaadin-app-layout', () => {
         expect(layout.shadowRoot.activeElement).to.equal(drawer);
       });
 
+      it('should update aria-label attribute on the drawer when changing i18n.drawer property', () => {
+        layout.i18n = { ...layout.i18n, drawer: 'New Value' };
+        expect(drawer.getAttribute('aria-label')).to.equal('New Value');
+      });
+
       describe('opened', () => {
         beforeEach(async () => {
           layout.drawerOpened = true;

--- a/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
+++ b/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
@@ -98,7 +98,7 @@ snapshots["vaadin-app-layout mobile layout shadow default"] =
 <div part="backdrop">
 </div>
 <div
-  aria-label="drawer"
+  aria-label="Drawer"
   aria-modal="true"
   id="drawer"
   part="drawer"
@@ -144,7 +144,7 @@ snapshots["vaadin-app-layout mobile layout shadow drawer opened"] =
 <div part="backdrop">
 </div>
 <div
-  aria-label="drawer"
+  aria-label="Drawer"
   aria-modal="true"
   id="drawer"
   part="drawer"

--- a/packages/app-layout/test/typings/app-layout.types.ts
+++ b/packages/app-layout/test/typings/app-layout.types.ts
@@ -4,6 +4,7 @@ import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import {
   AppLayoutDrawerOpenedChangedEvent,
+  AppLayoutI18n,
   AppLayoutOverlayChangedEvent,
   AppLayoutPrimarySectionChangedEvent
 } from '../../vaadin-app-layout.js';
@@ -22,6 +23,7 @@ assertType<'navbar' | 'drawer'>(layout.primarySection);
 assertType<boolean>(layout.drawerOpened);
 assertType<boolean>(layout.overlay);
 assertType<string>(layout.closeDrawerOn);
+assertType<AppLayoutI18n>(layout.i18n);
 
 // Events
 layout.addEventListener('drawer-opened-changed', (event) => {


### PR DESCRIPTION
## Description

This PR adds an `i18n` property for localizing the app-layout. The property has the following structure:

```js
{
  drawer: 'Drawer'
}
```

The `i18n.drawer` property can be used to customize the drawer's announcement when the drawer is opening in the overlay. In more specific terms, this i18n property affects the `aria-label` attribute that appears on the drawer element when it switches to the overlay mode.

Part of #466

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
