### PR TITLE
refactor: remove iron-resizable-behavior from combo-box

### DIFF
--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -32,7 +32,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.0.0-alpha1",
     "@vaadin/field-base": "23.0.0-alpha1",

--- a/packages/combo-box/src/vaadin-combo-box-dropdown.js
+++ b/packages/combo-box/src/vaadin-combo-box-dropdown.js
@@ -6,8 +6,6 @@
 import './vaadin-combo-box-item.js';
 import './vaadin-combo-box-overlay.js';
 import './vaadin-combo-box-scroller.js';
-import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 /**
@@ -16,7 +14,7 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
  * @extends HTMLElement
  * @private
  */
-export class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, PolymerElement) {
+export class ComboBoxDropdown extends PolymerElement {
   static get is() {
     return 'vaadin-combo-box-dropdown';
   }
@@ -171,14 +169,6 @@ export class ComboBoxDropdown extends mixinBehaviors(IronResizableBehavior, Poly
 
     // Making sure the overlay is closed and removed from DOM after detaching the dropdown.
     this._overlayOpened = false;
-  }
-
-  notifyResize() {
-    super.notifyResize();
-
-    if (this.positionTarget && this.opened) {
-      this._setOverlayWidth();
-    }
   }
 
   _fireTouchAction(sourceEvent) {

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -648,8 +648,6 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _onOpened() {
-      setTimeout(() => this._resizeDropdown(), 1);
-
       // Defer scroll position adjustment to improve performance.
       requestAnimationFrame(() => {
         this.$.dropdown.adjustScrollPosition();
@@ -823,11 +821,6 @@ export const ComboBoxMixin = (subclass) =>
       } else {
         this._inputElementValue = this._getItemLabel(this.selectedItem);
       }
-    }
-
-    /** @private */
-    _resizeDropdown() {
-      this.$.dropdown.notifyResize();
     }
 
     /** @private */

--- a/packages/combo-box/test/combo-box-light.test.js
+++ b/packages/combo-box/test/combo-box-light.test.js
@@ -16,11 +16,9 @@ import '@vaadin/text-field/vaadin-text-field.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box-light.js';
-import * as settings from '@polymer/polymer/lib/utils/settings.js';
+import '@polymer/polymer/lib/elements/dom-repeat.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { createEventSpy, getFirstItem } from './helpers.js';
-
-settings.setCancelSyntheticClickEvents(false);
 
 class MyInput extends PolymerElement {
   static get template() {

--- a/packages/combo-box/test/filtering.test.js
+++ b/packages/combo-box/test/filtering.test.js
@@ -350,13 +350,6 @@ describe('filtering items', () => {
       expect(overlay.hasAttribute('loading')).to.be.false;
     });
 
-    it('should not notify resize the dropdown if not opened', () => {
-      const resizeSpy = sinon.spy(comboBox.$.dropdown, 'notifyResize');
-      comboBox.filteredItems = ['foo', 'bar', 'baz'];
-
-      expect(resizeSpy.called).to.be.false;
-    });
-
     it('should not perform measurements when loading changes if not opened', () => {
       const measureSpy = sinon.spy(comboBox.inputElement, 'getBoundingClientRect');
       comboBox.loading = true;


### PR DESCRIPTION
`IronResizableBehavior` hasn't been necessary for `<vaadin-combo-box>` [since](https://github.com/vaadin/web-components/pull/2497) replacing the internal overlay positioning logic with `vaadin-overlay-position-mixin`

Part of https://github.com/vaadin/web-components/issues/331