### PR TITLE
refactor: remove iron-resizable-behavior from split-layout

### DIFF
--- a/dev/split-layout.html
+++ b/dev/split-layout.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Split Layout</title>
+
+    <script type="module">
+      import '@vaadin/split-layout';
+
+      document.querySelector('#first').textContent = new Array(1000).fill('a').join(' ');
+      document.querySelector('#second').textContent = new Array(1000).fill('b').join(' ');
+    </script>
+  </head>
+
+  <body>
+    <vaadin-split-layout style="width: 400px; height: 200px">
+      <div id="first"></div>
+      <div id="second"></div>
+    </vaadin-split-layout>
+  </body>
+</html>

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -32,7 +32,6 @@
     "polymer"
   ],
   "dependencies": {
-    "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.0.0-alpha2",
     "@vaadin/vaadin-lumo-styles": "23.0.0-alpha2",

--- a/packages/split-layout/src/vaadin-split-layout.d.ts
+++ b/packages/split-layout/src/vaadin-split-layout.d.ts
@@ -137,13 +137,6 @@ export interface SplitLayoutEventMap extends HTMLElementEventMap, SplitLayoutCus
  * </vaadin-split-layout>
  * ```
  *
- * ### Resize Notification
- *
- * This element implements `IronResizableBehavior` to notify the nested resizables
- * when the splitter is dragged. In order to define a resizable and receive that
- * notification in a nested element, include `IronResizableBehavior` and listen
- * for the `iron-resize` event.
- *
  * ### Styling
  *
  * The following shadow DOM parts are available for styling:
@@ -164,8 +157,8 @@ declare class SplitLayout extends ElementMixin(ThemableMixin(HTMLElement)) {
   orientation: 'horizontal' | 'vertical';
 
   /**
-   * Can be called to manually notify a resizable and its descendant
-   * resizables of a resize change.
+   * @deprecated Since Vaadin 23, `notifyResize()` is deprecated. The component uses a
+   * ResizeObserver internally and doesn't need to be explicitly notified of resizes.
    */
   notifyResize(): void;
 

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -337,14 +337,6 @@ class SplitLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   /**
-   * Fired when the splitter is dragged. Non-bubbling. Fired for the splitter
-   * element and any nested elements with `IronResizableBehavior`.
-   *
-   * DEPRECATED: This event will be dropped in one of the future Vaadin versions. Use a ResizeObserver instead.
-   * @event iron-resize
-   */
-
-  /**
    * Fired after dragging the splitter have ended.
    *
    * @event splitter-dragend

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -246,11 +246,7 @@ class SplitLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   _processChildren() {
-    const effectiveChildren = FlattenedNodesObserver.getFlattenedNodes(this).filter(
-      (node) => node.nodeType === Node.ELEMENT_NODE
-    );
-
-    effectiveChildren.forEach((child, i) => {
+    [...this.children].forEach((child, i) => {
       if (i === 0) {
         this._primaryChild = child;
         child.setAttribute('slot', 'primary');

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -3,8 +3,6 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
@@ -153,7 +151,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class SplitLayout extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizableBehavior], PolymerElement))) {
+class SplitLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
   static get template() {
     return html`
       <style>
@@ -248,7 +246,11 @@ class SplitLayout extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizab
 
   /** @private */
   _processChildren() {
-    this.getEffectiveChildren().forEach((child, i) => {
+    const effectiveChildren = FlattenedNodesObserver.getFlattenedNodes(this).filter(
+      (node) => node.nodeType === Node.ELEMENT_NODE
+    );
+
+    effectiveChildren.forEach((child, i) => {
       if (i === 0) {
         this._primaryChild = child;
         child.setAttribute('slot', 'primary');
@@ -317,8 +319,6 @@ class SplitLayout extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizab
     this._setFlexBasis(this._primaryChild, this._startSize.primary + dirDistance, this._startSize.container);
     this._setFlexBasis(this._secondaryChild, this._startSize.secondary - dirDistance, this._startSize.container);
 
-    this.notifyResize();
-
     if (event.detail.state === 'end') {
       this.dispatchEvent(new CustomEvent('splitter-dragend'));
 
@@ -327,13 +327,13 @@ class SplitLayout extends ElementMixin(ThemableMixin(mixinBehaviors([IronResizab
   }
 
   /**
-   * Can be called to manually notify a resizable and its descendant
-   * resizables of a resize change.
+   * @deprecated Since Vaadin 23, `notifyResize()` is deprecated. The component uses a
+   * ResizeObserver internally and doesn't need to be explicitly notified of resizes.
    */
   notifyResize() {
-    // NOTE: we have this method here to include it to the API docs,
-    // as we do not use `IronResizableBehavior` in type definitions.
-    super.notifyResize();
+    console.warn(
+      `WARNING: Since Vaadin 23, notifyResize() is deprecated. The component uses a ResizeObserver internally and doesn't need to be explicitly notified of resizes.`
+    );
   }
 
   /**

--- a/packages/split-layout/test/split-layout.test.js
+++ b/packages/split-layout/test/split-layout.test.js
@@ -75,6 +75,15 @@ describe('split layout', () => {
       expect(getComputedStyle(second).pointerEvents).to.equal('visible');
     });
   });
+
+  it('should warn when calling deprecated notifyResize()', () => {
+    const stub = sinon.stub(console, 'warn');
+    splitLayout.notifyResize();
+    stub.restore();
+
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.args[0][0]).to.include('WARNING: Since Vaadin 23, notifyResize() is deprecated.');
+  });
 });
 
 function testDimensions(isVertical) {
@@ -218,12 +227,6 @@ function testDimensions(isVertical) {
         second.style[maxSize] = max + 'px';
         testCssLimits(second, 1);
       });
-    });
-
-    it('should notify resizables', () => {
-      const spy = sinon.spy(splitLayout, 'notifyResize');
-      dragHandle(initialSize / 2);
-      expect(spy.callCount).to.be.above(0);
     });
 
     it('should dispatch `splitter-dragend` event', () => {


### PR DESCRIPTION
Part of #331 

The video shows how the child components adapt to parent container size changes without split layout having to explicitly notify them.

https://user-images.githubusercontent.com/1222264/146634102-f7ccc4fd-9bac-4dc3-8da4-824da15876e9.mp4