### PR TITLE
feat: Distinct styling for anchors without href

### DIFF
--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -174,8 +174,11 @@ const color = css`
     color: var(--lumo-header-text-color);
   }
 
-  a {
+  a:any-link {
     color: var(--lumo-primary-text-color);
+  }
+  a:not(:any-link) {
+    color: var(--lumo-disabled-text-color);
   }
 
   blockquote {

--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -103,7 +103,7 @@ const typography = css`
     text-decoration: none;
   }
 
-  a:hover {
+  a:any-link:hover {
     text-decoration: underline;
   }
 


### PR DESCRIPTION
Flow intends to use (temporary) href attribute removal to disable anchors (as they lack a native disabled state), see https://github.com/vaadin/flow/issues/10924. This PR changes Lumo styling of anchors so that the regular styling is applied only to anchors with href (using the `:any-link` pseudoclass) and Lumo disabled text color is instead applied to those without.

Potential breaking change: if an app contains href-less anchors (and e.g. use click event to do stuff instead) they will now have a disabled text color. However, at least Flow apps are almost guaranteed to have an _empty_ href rather than missing one (unless developer has explicitly removed the empty href), so this is very unlikely to affect Flow-based apps.

Fixes #1594 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended **(not really testable until Flow fix is in)**
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
