### PR TITLE
fix: prevent closing overlays when interacting with notifications

### DIFF
--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, listenOnce } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
@@ -55,6 +55,34 @@ describe('vaadin-notification', () => {
     it('should be visible after opening', () => {
       var isVisible = (elem) => !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
       expect(isVisible(document.body.querySelector('vaadin-notification-container'))).to.be.true;
+    });
+
+    it('should cancel vaadin-overlay-close events when the source event occurred within the container', (done) => {
+      listenOnce(document, 'click', (clickEvent) => {
+        const overlayCloseEvent = new CustomEvent('vaadin-overlay-close', {
+          cancelable: true,
+          detail: { sourceEvent: clickEvent }
+        });
+        document.dispatchEvent(overlayCloseEvent);
+
+        expect(overlayCloseEvent.defaultPrevented).to.be.true;
+        done();
+      });
+      notification._card.click();
+    });
+
+    it('should not cancel vaadin-overlay-close events when the source event occurred outside of the container', (done) => {
+      listenOnce(document, 'click', (clickEvent) => {
+        const overlayCloseEvent = new CustomEvent('vaadin-overlay-close', {
+          cancelable: true,
+          detail: { sourceEvent: clickEvent }
+        });
+        document.dispatchEvent(overlayCloseEvent);
+
+        expect(overlayCloseEvent.defaultPrevented).to.be.false;
+        done();
+      });
+      document.body.click();
     });
 
     const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent);


### PR DESCRIPTION
## Description

Currently interacting with a notification (clicking in it, pressing Escape while focusing a control within it), will also close the top-most vaadin-overlay. Notification does not use / integrate with vaadin-overlay, which means that those interactions are registered as outside interactions from the overlay.

This change makes the notification container listen for `vaadin-overlay-close` events, and cancels them if they occured in the notification. 

I think a better solution would be to stop propagation of click / keyboard events from the notification container, however vaadin-overlay uses a [capture event listener](https://github.com/vaadin/web-components/blob/master/packages/vaadin-overlay/src/vaadin-overlay.js#L755) for outside clicks. In order to support stopping propagation, we would have to change this, which would result in a significant refactoring (~21 test failures in all sorts of components). 

Given that we have a limited amount of overlay mechanisms, making the notification container aware of overlays might be a reasonable short-term fix, and we can keep a ticket to refactor the overlay mechanism later.

Fixes https://github.com/vaadin/flow-components/issues/2184
Related to #844

## Type of change

- [x] Bugfix
