### PR TITLE
chore: remove an unused dependency

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -34,7 +34,6 @@
   ],
   "dependencies": {
     "@polymer/iron-a11y-announcer": "^3.0.0",
-    "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.0.0-alpha2",
     "@vaadin/item": "23.0.0-alpha2",


### PR DESCRIPTION
Avatar has never actually used `iron-resizable-behavior` so there are no other changes in this PR.