### PR TITLE
refactor: update LabelMixin to use SlotController (#3181) (CP: 22.0)

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -166,17 +166,19 @@ class Checkbox extends SlotLabelMixin(
   }
 
   /** @protected */
-  ready() {
-    super.ready();
+  connectedCallback() {
+    super.connectedCallback();
 
-    this.addController(
-      new InputController(this, (input) => {
+    if (!this._inputController) {
+      this._inputController = new InputController(this, (input) => {
         this._setInputElement(input);
         this._setFocusElement(input);
         this.stateTarget = input;
-      })
-    );
-    this.addController(new LabelledInputController(this.inputElement, this._labelNode));
+        this.ariaTarget = input;
+      });
+      this.addController(this._inputController);
+      this.addController(new LabelledInputController(this.inputElement, this._labelController));
+    }
   }
 
   /**

--- a/packages/checkbox/test/checkbox.test.js
+++ b/packages/checkbox/test/checkbox.test.js
@@ -25,8 +25,10 @@ describe('checkbox', () => {
   });
 
   describe('default', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       checkbox = fixtureSync('<vaadin-checkbox>I accept <a href="#">the terms and conditions</a></vaadin-checkbox>');
+      // Wait for MutationObserver.
+      await nextFrame();
       input = checkbox.inputElement;
       label = checkbox._labelNode;
       link = label.children[0];
@@ -291,8 +293,9 @@ describe('checkbox', () => {
       console.warn.restore();
     });
 
-    it('should warn about using default slot label', () => {
+    it('should warn about using default slot label', async () => {
       fixtureSync('<vaadin-checkbox>label</vaadin-checkbox>');
+      await nextFrame();
 
       expect(console.warn.calledOnce).to.be.true;
       expect(console.warn.args[0][0]).to.include(

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -242,7 +242,7 @@ class ComboBox extends ComboBoxDataProviderMixin(
         this.ariaTarget = input;
       })
     );
-    this.addController(new LabelledInputController(this.inputElement, this._labelNode));
+    this.addController(new LabelledInputController(this.inputElement, this._labelController));
     this._positionTarget = this.shadowRoot.querySelector('[part="input-field"]');
     this._toggleElement = this.$.toggleButton;
   }

--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -5,7 +5,7 @@
  */
 import { ReactiveController } from 'lit';
 
-export class SlotController implements ReactiveController {
+export class SlotController extends EventTarget implements ReactiveController {
   constructor(
     host: HTMLElement,
     slotName: string,
@@ -33,6 +33,12 @@ export class SlotController implements ReactiveController {
   protected initialized: boolean;
 
   protected defaultNode: Node;
+
+  protected defaultId: string;
+
+  protected attachDefaultNode(): Node | undefined;
+
+  protected initNode(node: Node): void;
 
   /**
    * Override to initialize the newly added custom node.

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -213,7 +213,7 @@ class DatePicker extends DatePickerMixin(
         this.ariaTarget = input;
       })
     );
-    this.addController(new LabelledInputController(this.inputElement, this._labelNode));
+    this.addController(new LabelledInputController(this.inputElement, this._labelController));
   }
 
   /** @private */

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -229,9 +229,7 @@ snapshots["vaadin-email-field shadow theme"] =
 /* end snapshot vaadin-email-field shadow theme */
 
 snapshots["vaadin-email-field slots default"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -241,13 +239,13 @@ snapshots["vaadin-email-field slots default"] =
   slot="input"
   type="email"
 >
+<label slot="label">
+</label>
 `;
 /* end snapshot vaadin-email-field slots default */
 
 snapshots["vaadin-email-field slots helper"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -257,6 +255,8 @@ snapshots["vaadin-email-field slots helper"] =
   slot="input"
   type="email"
 >
+<label slot="label">
+</label>
 <div slot="helper">
   Helper
 </div>

--- a/packages/field-base/src/field-mixin.d.ts
+++ b/packages/field-base/src/field-mixin.d.ts
@@ -5,6 +5,7 @@
  */
 import { Constructor } from '@open-wc/dedupe-mixin';
 import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import { SlotMixinClass } from '@vaadin/component-base/src/slot-mixin.js';
 import { LabelMixinClass } from './label-mixin.js';
 import { ValidateMixinClass } from './validate-mixin.js';
 
@@ -17,6 +18,7 @@ export declare function FieldMixin<T extends Constructor<HTMLElement>>(
   Constructor<ControllerMixinClass> &
   Constructor<FieldMixinClass> &
   Constructor<LabelMixinClass> &
+  Constructor<SlotMixinClass> &
   Constructor<ValidateMixinClass>;
 
 export declare class FieldMixinClass {

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -7,6 +7,7 @@ import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nod
 import { animationFrame } from '@vaadin/component-base/src/async.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';
 import { FieldAriaController } from './field-aria-controller.js';
 import { LabelMixin } from './label-mixin.js';
 import { ValidateMixin } from './validate-mixin.js';
@@ -17,10 +18,11 @@ import { ValidateMixin } from './validate-mixin.js';
  * @polymerMixin
  * @mixes ControllerMixin
  * @mixes LabelMixin
+ * @mixes SlotMixin
  * @mixes ValidateMixin
  */
 export const FieldMixin = (superclass) =>
-  class FieldMixinClass extends ValidateMixin(LabelMixin(ControllerMixin(superclass))) {
+  class FieldMixinClass extends ValidateMixin(LabelMixin(ControllerMixin(SlotMixin(superclass)))) {
     static get properties() {
       return {
         /**
@@ -105,6 +107,11 @@ export const FieldMixin = (superclass) =>
       this.__savedHelperId = this._helperId;
 
       this._fieldAriaController = new FieldAriaController(this);
+
+      this._labelController.addEventListener('label-changed', (event) => {
+        const { hasLabel, node } = event.detail;
+        this.__labelChanged(hasLabel, node);
+      });
     }
 
     /** @protected */
@@ -268,17 +275,12 @@ export const FieldMixin = (superclass) =>
       );
     }
 
-    /**
-     * @protected
-     * @override
-     */
-    _toggleHasLabelAttribute() {
-      super._toggleHasLabelAttribute();
-
+    /** @private */
+    __labelChanged(hasLabel, labelNode) {
       // Label ID should be only added when the label content is present.
       // Otherwise, it may conflict with an `aria-label` attribute possibly added by the user.
-      if (this.hasAttribute('has-label')) {
-        this._fieldAriaController.setLabelId(this._labelId);
+      if (hasLabel) {
+        this._fieldAriaController.setLabelId(labelNode.id);
       } else {
         this._fieldAriaController.setLabelId(null);
       }

--- a/packages/field-base/src/label-controller.d.ts
+++ b/packages/field-base/src/label-controller.d.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+/**
+ * A controller to manage the label element.
+ */
+export class LabelController extends SlotController {
+  /**
+   * String used for the label.
+   */
+  protected label: string | null | undefined;
+
+  /**
+   * Set label based on corresponding host property.
+   */
+  setLabel(label: string | null | undefined): void;
+
+  /**
+   * ID attribute value set on the label element.
+   */
+  labelId: string;
+}

--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright (c) 2021 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+/**
+ * A controller to manage the label element.
+ */
+export class LabelController extends SlotController {
+  constructor(host) {
+    super(
+      host,
+      'label',
+      () => document.createElement('label'),
+      (_host, node) => {
+        // Set ID attribute or use the existing one.
+        this.__updateLabelId(node);
+
+        // Set text content for the default label.
+        this.__updateDefaultLabel(this.label);
+
+        this.__observeLabel(node);
+      }
+    );
+  }
+
+  /**
+   * @return {string}
+   */
+  get labelId() {
+    return this.node.id;
+  }
+
+  /**
+   * Override to initialize the newly added custom label.
+   *
+   * @param {Node} labelNode
+   * @protected
+   * @override
+   */
+  initCustomNode(labelNode) {
+    const hasLabel = this.__hasLabel(labelNode);
+    this.__toggleHasLabel(hasLabel);
+  }
+
+  /**
+   * Override to cleanup label node when it's removed.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  teardownNode(node) {
+    if (this.__labelObserver) {
+      this.__labelObserver.disconnect();
+    }
+
+    let labelNode = this.getSlotChild();
+
+    // If custom label was removed, restore the default one.
+    if (!labelNode && node !== this.defaultNode) {
+      labelNode = this.attachDefaultNode();
+
+      // Run initializer to update default label and ID.
+      this.initNode(labelNode);
+    }
+
+    const hasLabel = this.__hasLabel(labelNode);
+    this.__toggleHasLabel(hasLabel);
+  }
+
+  /**
+   * Set label based on corresponding host property.
+   *
+   * @param {string} label
+   */
+  setLabel(label) {
+    this.label = label;
+
+    this.__updateDefaultLabel(label);
+  }
+
+  /**
+   * @param {HTMLElement} labelNode
+   * @return {boolean}
+   * @private
+   */
+  __hasLabel(labelNode) {
+    if (!labelNode) {
+      return false;
+    }
+
+    return labelNode.children.length > 0 || this.__isNotEmpty(labelNode.textContent);
+  }
+
+  /**
+   * @param {string} label
+   * @private
+   */
+  __isNotEmpty(label) {
+    return Boolean(label && label.trim() !== '');
+  }
+
+  /**
+   * @param {HTMLElement} labelNode
+   * @private
+   */
+  __observeLabel(labelNode) {
+    this.__labelObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        const target = mutation.target;
+
+        // Ensure the mutation target is the currently connected label
+        // to ignore async mutations dispatched for removed element.
+        const isLabelMutation = target === this.node;
+
+        if (mutation.type === 'attributes') {
+          // We use attributeFilter to only observe ID mutation,
+          // no need to check for attribute name separately.
+          if (isLabelMutation && target.id !== this.defaultId) {
+            this.__updateLabelId(target);
+          }
+        } else if (isLabelMutation || target.parentElement === this.node) {
+          // Update has-label when textContent changes
+          const hasLabel = this.__hasLabel(this.node);
+          this.__toggleHasLabel(hasLabel);
+        }
+      });
+    });
+
+    // Observe changes to label ID attribute, text content and children.
+    this.__labelObserver.observe(labelNode, {
+      attributes: true,
+      attributeFilter: ['id'],
+      childList: true,
+      subtree: true,
+      characterData: true
+    });
+  }
+
+  /**
+   * @param {boolean} hasLabel
+   * @private
+   */
+  __toggleHasLabel(hasLabel) {
+    this.host.toggleAttribute('has-label', hasLabel);
+
+    // Make it possible for other mixins to observe change
+    this.dispatchEvent(
+      new CustomEvent('label-changed', {
+        detail: {
+          hasLabel,
+          node: this.node
+        }
+      })
+    );
+  }
+
+  /**
+   * @param {string} label
+   * @private
+   */
+  __updateDefaultLabel(label) {
+    if (this.defaultNode) {
+      this.defaultNode.textContent = label;
+
+      // Update has-label if default label is used
+      if (this.defaultNode === this.node) {
+        const hasLabel = this.__isNotEmpty(label);
+        this.__toggleHasLabel(hasLabel);
+      }
+    }
+  }
+
+  /**
+   * @param {HTMLElement} labelNode
+   * @private
+   */
+  __updateLabelId(labelNode) {
+    if (!labelNode.id) {
+      labelNode.id = this.defaultId;
+    }
+  }
+}

--- a/packages/field-base/src/label-mixin.d.ts
+++ b/packages/field-base/src/label-mixin.d.ts
@@ -5,6 +5,7 @@
  */
 import { Constructor } from '@open-wc/dedupe-mixin';
 import { SlotMixinClass } from '@vaadin/component-base/src/slot-mixin.js';
+import { LabelController } from './label-controller.js';
 
 /**
  * A mixin to provide label via corresponding property or named slot.
@@ -21,7 +22,7 @@ export declare class LabelMixinClass {
 
   protected readonly _labelNode: HTMLLabelElement;
 
-  protected _labelChanged(label: string | null | undefined): void;
+  protected _labelController: LabelController;
 
-  protected _toggleHasLabelAttribute(): void;
+  protected _labelChanged(label: string | null | undefined): void;
 }

--- a/packages/field-base/src/labelled-input-controller.js
+++ b/packages/field-base/src/labelled-input-controller.js
@@ -8,15 +8,28 @@
  * A controller for linking a `<label>` element with an `<input>` element.
  */
 export class LabelledInputController {
-  constructor(input, label) {
+  constructor(input, labelController) {
     this.input = input;
     this.__preventDuplicateLabelClick = this.__preventDuplicateLabelClick.bind(this);
 
+    labelController.addEventListener('label-changed', (event) => {
+      this.__initLabel(event.detail.node);
+    });
+
+    // Initialize the default label element
+    this.__initLabel(labelController.node);
+  }
+
+  /**
+   * @param {HTMLElement} label
+   * @private
+   */
+  __initLabel(label) {
     if (label) {
       label.addEventListener('click', this.__preventDuplicateLabelClick);
 
-      if (input) {
-        label.setAttribute('for', input.id);
+      if (this.input) {
+        label.setAttribute('for', this.input.id);
       }
     }
   }

--- a/packages/field-base/src/slot-label-mixin.js
+++ b/packages/field-base/src/slot-label-mixin.js
@@ -21,18 +21,5 @@ export const SlotLabelMixin = dedupingMixin(
       get _slotTarget() {
         return this._labelNode;
       }
-
-      /** @protected */
-      ready() {
-        super.ready();
-
-        if (this._labelNode) {
-          // The default slot's content is moved to the label node
-          // only after `LabelMixin` is initialized which means
-          // we should manually toggle the `has-label` attribute
-          // respecting the new label content.
-          this._toggleHasLabelAttribute();
-        }
-      }
     }
 );

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { LabelMixin } from '../src/label-mixin.js';
 
 customElements.define(
@@ -34,7 +35,7 @@ describe('label-mixin', () => {
     it('should set id on the label element', () => {
       const id = label.getAttribute('id');
       expect(id).to.match(ID_REGEX);
-      expect(id.endsWith(element.constructor._uniqueLabelId)).to.be.true;
+      expect(id.endsWith(SlotController.labelId)).to.be.true;
     });
 
     describe('label property', () => {
@@ -83,24 +84,25 @@ describe('label-mixin', () => {
 
   describe('slotted', () => {
     describe('basic', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         element = fixtureSync(`
           <label-mixin-element>
             <label slot="label">Custom</label>
           </label-mixin-element>
         `);
         label = element.querySelector('label');
+        await nextFrame();
       });
 
       it('should set id on the slotted label element', () => {
         const id = label.getAttribute('id');
         expect(id).to.match(ID_REGEX);
-        expect(id.endsWith(element.constructor._uniqueLabelId)).to.be.true;
+        expect(id.endsWith(SlotController.labelId)).to.be.true;
       });
 
-      it('should update slotted label content on property change', () => {
+      it('should not update slotted label content on property change', () => {
         element.label = 'Email';
-        expect(label.textContent).to.equal('Email');
+        expect(label.textContent).to.equal('Custom');
       });
 
       it('should add has-label attribute', () => {
@@ -117,6 +119,13 @@ describe('label-mixin', () => {
         label.textContent = '';
         await nextFrame();
         expect(element.hasAttribute('has-label')).to.be.false;
+      });
+
+      it('should attach default label when removing the custom label', async () => {
+        element.label = 'Fallback';
+        element.removeChild(label);
+        await nextFrame();
+        expect(element._labelNode.textContent).to.equal('Fallback');
       });
     });
 
@@ -174,6 +183,131 @@ describe('label-mixin', () => {
 
       it('should add has-label attribute', () => {
         expect(element.hasAttribute('has-label')).to.be.true;
+      });
+    });
+  });
+
+  describe('lazy', () => {
+    describe('DOM manipulations', () => {
+      let lazyLabel;
+
+      beforeEach(async () => {
+        element = fixtureSync('<label-mixin-element></label-mixin-element>');
+        element.label = 'Default label';
+        await nextFrame();
+        label = element._labelNode;
+        lazyLabel = document.createElement('label');
+        lazyLabel.setAttribute('slot', 'label');
+        lazyLabel.textContent = 'Lazy';
+      });
+
+      it('should handle lazy label added using appendChild', async () => {
+        element.appendChild(lazyLabel);
+        await nextFrame();
+        expect(element._labelNode).to.equal(lazyLabel);
+      });
+
+      it('should handle lazy label added using insertBefore', async () => {
+        element.insertBefore(lazyLabel, label);
+        await nextFrame();
+        expect(element._labelNode).to.equal(lazyLabel);
+      });
+
+      it('should handle lazy label added using replaceChild', async () => {
+        element.replaceChild(lazyLabel, label);
+        await nextFrame();
+        expect(element._labelNode).to.equal(lazyLabel);
+      });
+
+      it('should remove the default label from the element when using appendChild', async () => {
+        element.appendChild(lazyLabel);
+        await nextFrame();
+        expect(label.parentNode).to.be.null;
+      });
+
+      it('should remove the default label from the element when using insertBefore', async () => {
+        element.insertBefore(lazyLabel, label);
+        await nextFrame();
+        expect(label.parentNode).to.be.null;
+      });
+
+      it('should support replacing lazy label with a new one using appendChild', async () => {
+        element.appendChild(lazyLabel);
+        await nextFrame();
+
+        const newLabel = document.createElement('label');
+        newLabel.setAttribute('slot', 'label');
+        newLabel.textContent = 'New';
+        element.appendChild(newLabel);
+
+        await nextFrame();
+        expect(element._labelNode).to.equal(newLabel);
+      });
+
+      it('should support replacing lazy label with a new one using insertBefore', async () => {
+        element.appendChild(lazyLabel);
+        await nextFrame();
+
+        const newLabel = document.createElement('label');
+        newLabel.setAttribute('slot', 'label');
+        newLabel.textContent = 'New';
+        element.insertBefore(newLabel, lazyLabel);
+
+        await nextFrame();
+        expect(element._labelNode).to.equal(newLabel);
+      });
+
+      it('should support replacing lazy label with a new one using replaceChild', async () => {
+        element.appendChild(lazyLabel);
+        await nextFrame();
+
+        const newLabel = document.createElement('label');
+        newLabel.setAttribute('slot', 'label');
+        newLabel.textContent = 'New';
+        element.replaceChild(newLabel, lazyLabel);
+
+        await nextFrame();
+        expect(element._labelNode).to.equal(newLabel);
+      });
+
+      it('should support adding lazy label after removing the default one', async () => {
+        element.removeChild(label);
+        await nextFrame();
+
+        element.appendChild(lazyLabel);
+        await nextFrame();
+
+        expect(element._labelNode).to.equal(lazyLabel);
+      });
+
+      it('should restore the default label when removing the lazy label', async () => {
+        element.appendChild(lazyLabel);
+        await nextFrame();
+
+        element.removeChild(lazyLabel);
+        await nextFrame();
+        expect(element._labelNode).to.equal(label);
+      });
+
+      it('should keep has-label attribute when the default label is restored', async () => {
+        element.appendChild(lazyLabel);
+        await nextFrame();
+
+        element.removeChild(lazyLabel);
+        await nextFrame();
+        expect(element.hasAttribute('has-label')).to.be.true;
+      });
+
+      it('should remove has-label attribute when label is set to empty', async () => {
+        element.appendChild(lazyLabel);
+        await nextFrame();
+
+        element.label = '';
+
+        element.removeChild(lazyLabel);
+        await nextFrame();
+
+        expect(element.hasAttribute('has-label')).to.be.false;
       });
     });
   });

--- a/packages/field-base/test/labelled-input-controller.test.js
+++ b/packages/field-base/test/labelled-input-controller.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
@@ -37,7 +37,7 @@ describe('labelled-input-controller', () => {
         target.setAttribute('slot', el);
         element.appendChild(target);
         element._setInputElement(target);
-        element.addController(new LabelledInputController(target, label));
+        element.addController(new LabelledInputController(target, element._labelController));
       });
 
       it('should set for attribute on the label', () => {
@@ -49,6 +49,29 @@ describe('labelled-input-controller', () => {
         element.addEventListener('click', spy);
         label.click();
         expect(spy.calledOnce).to.be.true;
+      });
+
+      describe('lazy label', () => {
+        let lazyLabel;
+
+        beforeEach(async () => {
+          lazyLabel = document.createElement('label');
+          lazyLabel.setAttribute('slot', 'label');
+          lazyLabel.textContent = 'Lazy';
+          element.appendChild(lazyLabel);
+          await nextFrame();
+        });
+
+        it('should set for attribute on the lazily added label', () => {
+          expect(lazyLabel.getAttribute('for')).to.equal(target.id);
+        });
+
+        it('should only run click handler once on lazy label click', () => {
+          const spy = sinon.spy();
+          element.addEventListener('click', spy);
+          lazyLabel.click();
+          expect(spy.calledOnce).to.be.true;
+        });
       });
     });
   });

--- a/packages/field-base/test/slot-label-mixin.test.js
+++ b/packages/field-base/test/slot-label-mixin.test.js
@@ -26,8 +26,10 @@ describe('slot-label-mixin', () => {
   let element;
 
   describe('slot label', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       element = fixtureSync(`<slot-label-mixin-element>Slot Label</slot-label-mixin-element>`);
+      // Wait for MutationObserver.
+      await nextFrame();
     });
 
     it('should display the slot label', () => {
@@ -62,8 +64,10 @@ describe('slot-label-mixin', () => {
   });
 
   describe('label property and slot label', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       element = fixtureSync(`<slot-label-mixin-element label="Label Property">Slot Label</slot-label-mixin-element>`);
+      // Wait for MutationObserver.
+      await nextFrame();
     });
 
     it('should display the slot label', () => {

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -342,9 +342,7 @@ snapshots["vaadin-integer-field shadow theme"] =
 /* end snapshot vaadin-integer-field shadow theme */
 
 snapshots["vaadin-integer-field slots default"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -356,13 +354,13 @@ snapshots["vaadin-integer-field slots default"] =
   step="any"
   type="number"
 >
+<label slot="label">
+</label>
 `;
 /* end snapshot vaadin-integer-field slots default */
 
 snapshots["vaadin-integer-field slots helper"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -374,6 +372,8 @@ snapshots["vaadin-integer-field slots helper"] =
   step="any"
   type="number"
 >
+<label slot="label">
+</label>
 <div slot="helper">
   Helper
 </div>

--- a/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
+++ b/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
@@ -3,8 +3,6 @@ export const snapshots = {};
 
 snapshots["vaadin-message-input default"] = 
 `<vaadin-message-input-text-area placeholder="Message">
-  <label slot="label">
-  </label>
   <div
     hidden=""
     slot="error-message"
@@ -18,6 +16,8 @@ snapshots["vaadin-message-input default"] =
     style="min-height: 0px;"
   >
   </textarea>
+  <label slot="label">
+  </label>
 </vaadin-message-input-text-area>
 <vaadin-message-input-button
   role="button"
@@ -35,8 +35,6 @@ snapshots["vaadin-message-input disabled"] =
   disabled=""
   placeholder="Message"
 >
-  <label slot="label">
-  </label>
   <div
     hidden=""
     slot="error-message"
@@ -51,6 +49,8 @@ snapshots["vaadin-message-input disabled"] =
     style="min-height: 0px;"
   >
   </textarea>
+  <label slot="label">
+  </label>
 </vaadin-message-input-text-area>
 <vaadin-message-input-button
   aria-disabled="true"

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -233,7 +233,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
         this.ariaTarget = input;
       })
     );
-    this.addController(new LabelledInputController(this.inputElement, this._labelNode));
+    this.addController(new LabelledInputController(this.inputElement, this._labelController));
   }
 
   /** @private */

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -342,9 +342,7 @@ snapshots["vaadin-number-field shadow theme"] =
 /* end snapshot vaadin-number-field shadow theme */
 
 snapshots["vaadin-number-field slots default"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -356,13 +354,13 @@ snapshots["vaadin-number-field slots default"] =
   step="any"
   type="number"
 >
+<label slot="label">
+</label>
 `;
 /* end snapshot vaadin-number-field slots default */
 
 snapshots["vaadin-number-field slots helper"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -374,6 +372,8 @@ snapshots["vaadin-number-field slots helper"] =
   step="any"
   type="number"
 >
+<label slot="label">
+</label>
 <div slot="helper">
   Helper
 </div>

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -264,9 +264,7 @@ snapshots["vaadin-password-field shadow theme"] =
 /* end snapshot vaadin-password-field shadow theme */
 
 snapshots["vaadin-password-field slots default"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -284,13 +282,13 @@ snapshots["vaadin-password-field slots default"] =
   slot="input"
   type="password"
 >
+<label slot="label">
+</label>
 `;
 /* end snapshot vaadin-password-field slots default */
 
 snapshots["vaadin-password-field slots helper"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -308,6 +306,8 @@ snapshots["vaadin-password-field slots helper"] =
   slot="input"
   type="password"
 >
+<label slot="label">
+</label>
 <div slot="helper">
   Helper
 </div>

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -173,18 +173,19 @@ class RadioButton extends SlotLabelMixin(
   }
 
   /** @protected */
-  ready() {
-    super.ready();
+  connectedCallback() {
+    super.connectedCallback();
 
-    this.addController(
-      new InputController(this, (input) => {
+    if (!this._inputController) {
+      this._inputController = new InputController(this, (input) => {
         this._setInputElement(input);
         this._setFocusElement(input);
         this.stateTarget = input;
         this.ariaTarget = input;
-      })
-    );
-    this.addController(new LabelledInputController(this.inputElement, this._labelNode));
+      });
+      this.addController(this._inputController);
+      this.addController(new LabelledInputController(this.inputElement, this._labelController));
+    }
   }
 }
 

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -26,8 +26,10 @@ describe('radio-button', () => {
 
   // TODO: A legacy suit. Replace with snapshot tests when possible.
   describe('default', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       radio = fixtureSync('<vaadin-radio-button>Label</vaadin-radio-button>');
+      // Wait for MutationObserver
+      await nextFrame();
       label = radio.querySelector('[slot=label]');
     });
 
@@ -286,8 +288,10 @@ describe('radio-button', () => {
       console.warn.restore();
     });
 
-    it('should warn about using default slot label', () => {
+    it('should warn about using default slot label', async () => {
       fixtureSync('<vaadin-radio-button>label</vaadin-radio-button>');
+      // Wait for MutationObserver
+      await nextFrame();
 
       expect(console.warn.calledOnce).to.be.true;
       expect(console.warn.args[0][0]).to.include(

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -219,9 +219,7 @@ snapshots["vaadin-select shadow theme"] =
 /* end snapshot vaadin-select shadow theme */
 
 snapshots["vaadin-select slots default"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -235,13 +233,13 @@ snapshots["vaadin-select slots default"] =
   tabindex="0"
 >
 </vaadin-select-value-button>
+<label slot="label">
+</label>
 `;
 /* end snapshot vaadin-select slots default */
 
 snapshots["vaadin-select slots helper"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -255,6 +253,8 @@ snapshots["vaadin-select slots helper"] =
   tabindex="0"
 >
 </vaadin-select-value-button>
+<label slot="label">
+</label>
 <div slot="helper">
   Helper
 </div>

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -210,7 +210,7 @@ export class TextArea extends InputFieldMixin(ThemableMixin(ElementMixin(Polymer
         this.ariaTarget = input;
       })
     );
-    this.addController(new LabelledInputController(this.inputElement, this._labelNode));
+    this.addController(new LabelledInputController(this.inputElement, this._labelController));
     this.addEventListener('animationend', this._onAnimationEnd);
   }
 

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -229,28 +229,28 @@ snapshots["vaadin-text-area shadow theme"] =
 /* end snapshot vaadin-text-area shadow theme */
 
 snapshots["vaadin-text-area slots default"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
 </div>
 <textarea slot="textarea">
 </textarea>
+<label slot="label">
+</label>
 `;
 /* end snapshot vaadin-text-area slots default */
 
 snapshots["vaadin-text-area slots helper"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
 </div>
 <textarea slot="textarea">
 </textarea>
+<label slot="label">
+</label>
 <div slot="helper">
   Helper
 </div>

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -174,7 +174,7 @@ export class TextField extends PatternMixin(InputFieldMixin(ThemableMixin(Elemen
         this.ariaTarget = input;
       })
     );
-    this.addController(new LabelledInputController(this.inputElement, this._labelNode));
+    this.addController(new LabelledInputController(this.inputElement, this._labelController));
   }
 }
 

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -229,9 +229,7 @@ snapshots["vaadin-text-field shadow theme"] =
 /* end snapshot vaadin-text-field shadow theme */
 
 snapshots["vaadin-text-field slots default"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -240,13 +238,13 @@ snapshots["vaadin-text-field slots default"] =
   slot="input"
   type="text"
 >
+<label slot="label">
+</label>
 `;
 /* end snapshot vaadin-text-field slots default */
 
 snapshots["vaadin-text-field slots helper"] = 
-`<label slot="label">
-</label>
-<div
+`<div
   hidden=""
   slot="error-message"
 >
@@ -255,6 +253,8 @@ snapshots["vaadin-text-field slots helper"] =
   slot="input"
   type="text"
 >
+<label slot="label">
+</label>
 <div slot="helper">
   Helper
 </div>

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -320,7 +320,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
         this.ariaTarget = input;
       })
     );
-    this.addController(new LabelledInputController(this.inputElement, this._labelNode));
+    this.addController(new LabelledInputController(this.inputElement, this._labelController));
     this._inputContainer = this.shadowRoot.querySelector('[part~="input-field"]');
   }
 


### PR DESCRIPTION
## Description

Manual cherry-pick of #3181 to `22.0` branch (there was a conflict due to `iron-resize` removal from `FieldMixin`).

## Type of change

- Cherry-pick