### PR TITLE
feat: deprecate placing multiple fields directly to a form-item

### DIFF
--- a/packages/form-layout/src/vaadin-form-item.d.ts
+++ b/packages/form-layout/src/vaadin-form-item.d.ts
@@ -9,26 +9,13 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `<vaadin-form-item>` is a Web Component providing labelled form item wrapper
  * for using inside `<vaadin-form-layout>`.
  *
- * `<vaadin-form-item>` accepts any number of children as the input content,
+ * `<vaadin-form-item>` accepts a single child as the input content,
  * and also has a separate named `label` slot:
  *
  * ```html
  * <vaadin-form-item>
  *   <label slot="label">Label aside</label>
  *   <input>
- * </vaadin-form-item>
- * ```
- *
- * Any content can be used. For instance, you can have multiple input elements
- * with surrounding text. The label can be an element of any type:
- *
- * ```html
- * <vaadin-form-item>
- *   <span slot="label">Date of Birth</span>
- *   <input placeholder="YYYY" size="4"> -
- *   <input placeholder="MM" size="2"> -
- *   <input placeholder="DD" size="2"><br>
- *   <em>Example: 1900-01-01</em>
  * </vaadin-form-item>
  * ```
  *
@@ -58,7 +45,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * ### Input Width
  *
  * By default, `<vaadin-form-item>` does not manipulate the width of the slotted
- * input elements. Optionally you can stretch the child input element to fill
+ * input element. Optionally you can stretch the child input element to fill
  * the available width for the input content by adding the `full-width` class:
  *
  * ```html

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -11,26 +11,13 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `<vaadin-form-item>` is a Web Component providing labelled form item wrapper
  * for using inside `<vaadin-form-layout>`.
  *
- * `<vaadin-form-item>` accepts any number of children as the input content,
+ * `<vaadin-form-item>` accepts a single child as the input content,
  * and also has a separate named `label` slot:
  *
  * ```html
  * <vaadin-form-item>
  *   <label slot="label">Label aside</label>
  *   <input>
- * </vaadin-form-item>
- * ```
- *
- * Any content can be used. For instance, you can have multiple input elements
- * with surrounding text. The label can be an element of any type:
- *
- * ```html
- * <vaadin-form-item>
- *   <span slot="label">Date of Birth</span>
- *   <input placeholder="YYYY" size="4"> -
- *   <input placeholder="MM" size="2"> -
- *   <input placeholder="DD" size="2"><br>
- *   <em>Example: 1900-01-01</em>
  * </vaadin-form-item>
  * ```
  *
@@ -60,7 +47,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * ### Input Width
  *
  * By default, `<vaadin-form-item>` does not manipulate the width of the slotted
- * input elements. Optionally you can stretch the child input element to fill
+ * input element. Optionally you can stretch the child input element to fill
  * the available width for the input content by adding the `full-width` class:
  *
  * ```html
@@ -295,7 +282,15 @@ class FormItem extends ThemableMixin(PolymerElement) {
       this.__fieldNode = null;
     }
 
-    const newFieldNode = this.$.contentSlot.assignedElements().find((field) => {
+    const fieldNodes = this.$.contentSlot.assignedElements();
+    if (fieldNodes.length > 1) {
+      console.warn(
+        `WARNING: Since Vaadin 23, placing multiple fields directly to a <vaadin-form-item> is deprecated.
+Please wrap fields with a <vaadin-custom-field> instead.`
+      );
+    }
+
+    const newFieldNode = fieldNodes.find((field) => {
       return !!this.__getValidateFunction(field);
     });
     if (newFieldNode) {

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -431,4 +431,60 @@ describe('form-item', () => {
       });
     });
   });
+
+  describe('warnings', () => {
+    let stub;
+
+    beforeEach(() => {
+      stub = sinon.stub(console, 'warn');
+    });
+
+    afterEach(() => {
+      stub.restore();
+    });
+
+    it('should not warn when a single field is placed to an item', async () => {
+      fixtureSync(`
+        <vaadin-form-item>
+          <input />
+        </vaadin-form-item>
+      `);
+      await nextFrame();
+
+      expect(stub.calledOnce).to.be.false;
+    });
+
+    it('should warn when multiple fields are placed to an item initially', async () => {
+      fixtureSync(`
+        <vaadin-form-item>
+          <input />
+          <input />
+        </vaadin-form-item>
+      `);
+      await nextFrame();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.args[0][0]).to.include(
+        'WARNING: Since Vaadin 23, placing multiple fields directly to a <vaadin-form-item> is deprecated.'
+      );
+    });
+
+    it('should warn when multiple fields are placed to an item dynamically', async () => {
+      const item = fixtureSync(`
+        <vaadin-form-item>
+          <input />
+        </vaadin-form-item>
+      `);
+      await nextFrame();
+
+      const input = document.createElement('input');
+      item.appendChild(input);
+      await nextFrame();
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.args[0][0]).to.include(
+        'WARNING: Since Vaadin 23, placing multiple fields directly to a <vaadin-form-item> is deprecated.'
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Description

Added a deprecation warning that since Vaadin 23, the user has to wrap multiple fields with a `<vaadin-custom-field>` instead of placing them directly to a form-item element. 

👎 **Deprecated:**
```html
<vaadin-form-item>
  <label slot="label">Label</label>
  <input />
  <input />
</vaadin-form-item>
```

👍 **Recommended:**
```html
<vaadin-form-item>
  <label slot="label">Label</label>
  <vaadin-custom-field>
    <input />
    <input />
  </vaadin-custom-field>
</vaadin-form-item>
```


Fixes #3065 

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
