### PR TITLE
refactor: update time-picker theme files imports

### DIFF
--- a/packages/time-picker/theme/lumo/vaadin-time-picker.js
+++ b/packages/time-picker/theme/lumo/vaadin-time-picker.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/combo-box/theme/lumo/vaadin-combo-box-light.js';
+import '@vaadin/combo-box/theme/lumo/vaadin-combo-box-dropdown-styles.js';
+import '@vaadin/combo-box/theme/lumo/vaadin-combo-box-item-styles.js';
 import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import './vaadin-time-picker-styles.js';
 import '../../src/vaadin-time-picker.js';

--- a/packages/time-picker/theme/material/vaadin-time-picker.js
+++ b/packages/time-picker/theme/material/vaadin-time-picker.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/combo-box/theme/material/vaadin-combo-box-light.js';
+import '@vaadin/combo-box/theme/material/vaadin-combo-box-dropdown-styles.js';
+import '@vaadin/combo-box/theme/material/vaadin-combo-box-item-styles.js';
 import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import './vaadin-time-picker-styles.js';
 import '../../src/vaadin-time-picker.js';


### PR DESCRIPTION
## Description

Starting from Vaadin 22, we changed `vaadin-time-picker` to not use `vaadin-combo-box-light` but its own extension instead. So there is no need for importing the `-light` version, as it just brings some extra bytes to JS bundle.

## Type of change

- Internal change

## Type of change

- Refactor