### PR TITLE
test: do not use font-size for hiding blinking caret

### DIFF
--- a/packages/combo-box/test/visual/common.js
+++ b/packages/combo-box/test/visual/common.js
@@ -6,7 +6,7 @@ registerStyles(
   css`
     :host([focus-ring]) ::slotted(input),
     :host([opened]) ::slotted(input) {
-      font-size: 0 !important;
+      caret-color: transparent;
     }
   `
 );

--- a/packages/login/test/visual/common.js
+++ b/packages/login/test/visual/common.js
@@ -5,7 +5,7 @@ registerStyles(
   'vaadin-text-field',
   css`
     ::slotted(input) {
-      font-size: 0 !important;
+      caret-color: transparent;
     }
   `
 );

--- a/packages/number-field/test/visual/common.js
+++ b/packages/number-field/test/visual/common.js
@@ -5,7 +5,7 @@ registerStyles(
   'vaadin-number-field',
   css`
     :host([focus-ring]) ::slotted(input) {
-      font-size: 0 !important;
+      caret-color: transparent;
     }
   `
 );


### PR DESCRIPTION
## Description

Updated a few components to use `caret-color` CSS property instead of setting `font-size: 0` for consistency.

## Type of change

- Tests