### PR TITLE
feat: add autoload imports to Lumo and Material

### DIFF
--- a/dev/confirm-dialog.html
+++ b/dev/confirm-dialog.html
@@ -7,12 +7,7 @@
     <title>Confirm dialog</title>
     <script type="module">
       import '@vaadin/confirm-dialog';
-      import { color, typography } from '@vaadin/vaadin-lumo-styles';
-
-      // Global color and typography styles affect the contents of the dialog
-      const style = document.createElement('style');
-      style.innerHTML = `${color.toString()} ${typography.toString()}`;
-      document.head.appendChild(style);
+      import '@vaadin/vaadin-lumo-styles/autoload.js';
     </script>
   </head>
   <body>

--- a/dev/crud.html
+++ b/dev/crud.html
@@ -11,12 +11,7 @@
     <script type="module">
       import '@vaadin/crud';
       import '@vaadin/radio-group';
-      import { color, typography } from '@vaadin/vaadin-lumo-styles';
-
-      // Global color and typography styles affect the contents of the dialog
-      const style = document.createElement('style');
-      style.innerHTML = `${color.toString()} ${typography.toString()}`;
-      document.head.appendChild(style);
+      import '@vaadin/vaadin-lumo-styles/autoload.js';
 
       const crud = document.querySelector('vaadin-crud');
       crud.items = [

--- a/packages/vaadin-lumo-styles/autoload.d.ts
+++ b/packages/vaadin-lumo-styles/autoload.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from './all-imports.js';

--- a/packages/vaadin-lumo-styles/autoload.js
+++ b/packages/vaadin-lumo-styles/autoload.js
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { color, typography } from './all-imports.js';
+
+const style = document.createElement('style');
+style.innerHTML = `${color.toString()} ${typography.toString()}`;
+document.head.appendChild(style);
+
+export * from './all-imports.js';

--- a/packages/vaadin-material-styles/autoload.d.ts
+++ b/packages/vaadin-material-styles/autoload.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from './all-imports.js';

--- a/packages/vaadin-material-styles/autoload.js
+++ b/packages/vaadin-material-styles/autoload.js
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { colorDark, colorLight, typography } from './all-imports.js';
+
+const color = document.documentElement.getAttribute('theme') === 'dark' ? colorDark : colorLight;
+
+const style = document.createElement('style');
+style.innerHTML = `${color.toString().replace(':host', 'html')} ${typography.toString()}`;
+document.head.appendChild(style);
+
+export * from './all-imports.js';


### PR DESCRIPTION
## Description

Added `autoload` files to inject typography and color style modules globally.

Fixes #3234

## Type of change

- Feature 

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
