### PR TITLE
refactor: use a11y-announcer in date-picker

### DIFF
--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -32,7 +32,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/iron-a11y-announcer": "^3.0.0",
     "@polymer/iron-media-query": "^3.0.0",
     "@polymer/polymer": "^3.2.0",
     "@vaadin/button": "23.0.0-alpha2",

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -7,8 +7,8 @@ import '@polymer/iron-media-query/iron-media-query.js';
 import '@vaadin/button/src/vaadin-button.js';
 import './vaadin-month-calendar.js';
 import './vaadin-infinite-scroller.js';
-import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announcer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { announce } from '@vaadin/component-base/src/a11y-announcer.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
@@ -350,34 +350,25 @@ class DatePickerOverlayContent extends ThemableMixin(DirMixin(PolymerElement)) {
     this._closeYearScroller();
     this._toggleAnimateClass(true);
     setTouchAction(this.$.scrollers, 'pan-y');
-    IronA11yAnnouncer.requestAvailability();
   }
 
   announceFocusedDate() {
-    var focusedDate = this._currentlyFocusedDate();
-    var announce = [];
+    const focusedDate = this._currentlyFocusedDate();
+    let messages = [];
     if (dateEquals(focusedDate, new Date())) {
-      announce.push(this.i18n.today);
+      messages.push(this.i18n.today);
     }
-    announce = announce.concat([
+    messages = messages.concat([
       this.i18n.weekdays[focusedDate.getDay()],
       focusedDate.getDate(),
       this.i18n.monthNames[focusedDate.getMonth()],
       focusedDate.getFullYear()
     ]);
     if (this.showWeekNumbers && this.i18n.firstDayOfWeek === 1) {
-      announce.push(this.i18n.week);
-      announce.push(getISOWeekNumber(focusedDate));
+      messages.push(this.i18n.week);
+      messages.push(getISOWeekNumber(focusedDate));
     }
-    this.dispatchEvent(
-      new CustomEvent('iron-announce', {
-        bubbles: true,
-        composed: true,
-        detail: {
-          text: announce.join(' ')
-        }
-      })
-    );
+    announce(messages.join(' '));
   }
 
   /**


### PR DESCRIPTION
## Description

Updated `vaadin-date-picker-overlay-content` to use new `announce()` helper added in #3238

Note: using bigger delay `clock.tick(200)` here to ensure all the internal timeouts terminate.

## Type of change

- Refactor