### PR TITLE
feat: add disabled property to menu-bar

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -84,7 +84,7 @@ export const ButtonsMixin = (superClass) =>
     __restoreButtons(buttons) {
       for (let i = 0; i < buttons.length; i++) {
         const btn = buttons[i];
-        btn.disabled = btn.item && btn.item.disabled;
+        btn.disabled = (btn.item && btn.item.disabled) || this.disabled;
         btn.style.visibility = '';
         btn.style.position = '';
 

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ButtonsMixin } from './vaadin-menu-bar-buttons-mixin.js';
@@ -81,7 +82,7 @@ export interface MenuBarEventMap extends HTMLElementEventMap, MenuBarCustomEvent
  *
  * @fires {CustomEvent} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  */
-declare class MenuBar extends ButtonsMixin(InteractionsMixin(ElementMixin(ThemableMixin(HTMLElement)))) {
+declare class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(HTMLElement))))) {
   /**
    * Defines a hierarchical structure, where root level items represent menu bar buttons,
    * and `children` property configures a submenu with items to be opened below

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -6,6 +6,7 @@
 import './vaadin-menu-bar-submenu.js';
 import './vaadin-menu-bar-button.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ButtonsMixin } from './vaadin-menu-bar-buttons-mixin.js';
@@ -58,7 +59,7 @@ import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class MenuBar extends ButtonsMixin(InteractionsMixin(ElementMixin(ThemableMixin(PolymerElement)))) {
+class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(PolymerElement))))) {
   static get template() {
     return html`
       <style>
@@ -198,6 +199,30 @@ class MenuBar extends ButtonsMixin(InteractionsMixin(ElementMixin(ThemableMixin(
         }
       }
     };
+  }
+
+  /**
+   * Override method inherited from `DisabledMixin`
+   * to update the `disabled` property for the buttons
+   * whenever the property changes on the menu bar.
+   *
+   * @param {boolean} newValue the new disabled value
+   * @param {boolean} oldValue the previous disabled value
+   * @override
+   * @protected
+   */
+  _disabledChanged(newValue, oldValue) {
+    super._disabledChanged(newValue, oldValue);
+    if (oldValue !== newValue) {
+      this.__updateItemsDisabledProperty();
+    }
+  }
+
+  __updateItemsDisabledProperty() {
+    this._buttons.forEach((btn) => {
+      // disable the button if the entire menu-bar is disabled or the item alone is disabled
+      btn.disabled = this.disabled || (btn.item && btn.item.disabled);
+    });
   }
 
   /**

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -214,11 +214,12 @@ class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(
   _disabledChanged(newValue, oldValue) {
     super._disabledChanged(newValue, oldValue);
     if (oldValue !== newValue) {
-      this.__updateItemsDisabledProperty();
+      this.__updateButtonsDisabled();
     }
   }
 
-  __updateItemsDisabledProperty() {
+  /** @private */
+  __updateButtonsDisabled() {
     this._buttons.forEach((btn) => {
       // disable the button if the entire menu-bar is disabled or the item alone is disabled
       btn.disabled = this.disabled || (btn.item && btn.item.disabled);

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -214,15 +214,15 @@ class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(
   _disabledChanged(newValue, oldValue) {
     super._disabledChanged(newValue, oldValue);
     if (oldValue !== newValue) {
-      this.__updateButtonsDisabled();
+      this.__updateButtonsDisabled(newValue);
     }
   }
 
   /** @private */
-  __updateButtonsDisabled() {
+  __updateButtonsDisabled(disabled) {
     this._buttons.forEach((btn) => {
       // disable the button if the entire menu-bar is disabled or the item alone is disabled
-      btn.disabled = this.disabled || (btn.item && btn.item.disabled);
+      btn.disabled = disabled || (btn.item && btn.item.disabled);
     });
   }
 

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -97,6 +97,27 @@ describe('root menu layout', () => {
     });
   });
 
+  it('should disable all buttons in the menu-bar', () => {
+    menu.disabled = true;
+    buttons.forEach((btn) => {
+      expect(btn.disabled).to.be.true;
+    });
+  });
+
+  it('should keep previously disabled buttons disabled when re-enabling the menu-bar', () => {
+    expect(buttons[2].disabled).to.be.true;
+    menu.disabled = true;
+    expect(buttons[2].disabled).to.be.true;
+    menu.disabled = false;
+    expect(buttons[2].disabled).to.be.true;
+  });
+
+  it('should also disable the overflow button', () => {
+    menu.disabled = true;
+    const overflow = buttons[menu.items.length];
+    expect(overflow.disabled).to.be.true;
+  });
+
   it('should render disabled button if disabled property is true', () => {
     expect(buttons[2].disabled).to.be.true;
   });
@@ -486,6 +507,15 @@ describe('responsive behaviour in container', () => {
     expect(buttons[4].disabled).to.be.true;
     expect(overflow.hasAttribute('hidden')).to.be.true;
     expect(overflow.item.children.length).to.equal(0);
+  });
+
+  it('should keep buttons disabled when resizing', async () => {
+    menu.disabled = true;
+    container.style.width = '150px';
+    await onceResized(menu);
+    buttons.forEach((btn) => {
+      expect(btn.disabled).to.be.true;
+    });
   });
 });
 

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -97,7 +97,7 @@ describe('root menu layout', () => {
     });
   });
 
-  it('should disable all buttons in the menu-bar', () => {
+  it('should disable all buttons when menu-bar disabled is set to true', () => {
     menu.disabled = true;
     buttons.forEach((btn) => {
       expect(btn.disabled).to.be.true;
@@ -110,12 +110,6 @@ describe('root menu layout', () => {
     expect(buttons[2].disabled).to.be.true;
     menu.disabled = false;
     expect(buttons[2].disabled).to.be.true;
-  });
-
-  it('should also disable the overflow button', () => {
-    menu.disabled = true;
-    const overflow = buttons[menu.items.length];
-    expect(overflow.disabled).to.be.true;
   });
 
   it('should render disabled button if disabled property is true', () => {


### PR DESCRIPTION
## Description

Add logic to the `menu-bar` so if `disabled`, all buttons in the bar will be disabled. If not set, each item then will be `disabled` only if set on the item itself.

Related https://github.com/vaadin/web-components/issues/3202

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
