### PR TITLE
refactor: remove obsolete IE11 workaround

### DIFF
--- a/packages/vaadin-material-styles/color.js
+++ b/packages/vaadin-material-styles/color.js
@@ -7,8 +7,7 @@ import './version.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const colorLight = css`
-  :host,
-  #host-fix {
+  :host {
     /* Text colors */
     --material-body-text-color: var(--light-theme-text-color, rgba(0, 0, 0, 0.87));
     --material-secondary-text-color: var(--light-theme-secondary-color, rgba(0, 0, 0, 0.54));
@@ -106,8 +105,7 @@ const colorLight = css`
 registerStyles('', colorLight, { moduleId: 'material-color-light' });
 
 const colorDark = css`
-  :host,
-  #host-fix {
+  :host {
     /* Text colors */
     --material-body-text-color: var(--dark-theme-text-color, rgba(255, 255, 255, 1));
     --material-secondary-text-color: var(--dark-theme-secondary-color, rgba(255, 255, 255, 0.7));


### PR DESCRIPTION
## Description

This essentially reverts https://github.com/vaadin/vaadin-material-styles/commit/5fe9f9ebbf2aeaf3532ad25b7b226af5911683ca
The workaround was needed for polyfilled browsers that we no longer support.

## Type of change

- Refactor