### PR TITLE
fix!: prevent virtual keyboard open on combo-box/date-picker close

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -294,6 +294,9 @@ export const ComboBoxMixin = (subclass) =>
       this.addEventListener('mousedown', bringToFrontListener);
       this.addEventListener('touchstart', bringToFrontListener);
 
+      // Re-enable the virtual keyboard whenever the field is touched
+      this.addEventListener('touchstart', () => this.__setVirtualKeyboardEnabled(true));
+
       processTemplates(this);
     }
 
@@ -430,6 +433,11 @@ export const ComboBoxMixin = (subclass) =>
       }
 
       this._closeOnBlurIsPrevented = false;
+    }
+
+    /** @private */
+    __setVirtualKeyboardEnabled(value) {
+      this.inputElement.inputMode = value ? '' : 'none';
     }
 
     /**
@@ -670,6 +678,9 @@ export const ComboBoxMixin = (subclass) =>
       if (!this.loading || this.allowCustomValue) {
         this._commitValue();
       }
+
+      // Avoid opening the virtual keyboard when the input gets re-focused on dropdown close
+      this.__setVirtualKeyboardEnabled(false);
     }
 
     /** @private */
@@ -1047,6 +1058,9 @@ export const ComboBoxMixin = (subclass) =>
       if (!this.readonly && !this._closeOnBlurIsPrevented) {
         this._closeOrCommit();
       }
+
+      // Re-enable virtual keyboard for when the field gets the focus back
+      this.__setVirtualKeyboardEnabled(true);
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -4,17 +4,20 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
+import { VirtualKeyboardController } from '@vaadin/field-base/src/virtual-keyboard-controller.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
 
 /**
  * @polymerMixin
+ * @param {function(new:HTMLElement)} subclass
  */
 export const ComboBoxMixin = (subclass) =>
-  class VaadinComboBoxMixinElement extends KeyboardMixin(InputMixin(DisabledMixin(subclass))) {
+  class VaadinComboBoxMixinElement extends ControllerMixin(KeyboardMixin(InputMixin(DisabledMixin(subclass)))) {
     static get properties() {
       return {
         /**
@@ -264,6 +267,8 @@ export const ComboBoxMixin = (subclass) =>
         if (this.clearElement) {
           this.clearElement.addEventListener('mousedown', this._boundOnClearButtonMouseDown);
         }
+
+        this.addController(new VirtualKeyboardController(this, input));
       }
     }
 
@@ -293,9 +298,6 @@ export const ComboBoxMixin = (subclass) =>
 
       this.addEventListener('mousedown', bringToFrontListener);
       this.addEventListener('touchstart', bringToFrontListener);
-
-      // Re-enable the virtual keyboard whenever the field is touched
-      this.addEventListener('touchstart', () => this.__setVirtualKeyboardEnabled(true));
 
       processTemplates(this);
     }
@@ -433,11 +435,6 @@ export const ComboBoxMixin = (subclass) =>
       }
 
       this._closeOnBlurIsPrevented = false;
-    }
-
-    /** @private */
-    __setVirtualKeyboardEnabled(value) {
-      this.inputElement.inputMode = value ? '' : 'none';
     }
 
     /**
@@ -678,9 +675,6 @@ export const ComboBoxMixin = (subclass) =>
       if (!this.loading || this.allowCustomValue) {
         this._commitValue();
       }
-
-      // Avoid opening the virtual keyboard when the input gets re-focused on dropdown close
-      this.__setVirtualKeyboardEnabled(false);
     }
 
     /** @private */
@@ -1058,9 +1052,6 @@ export const ComboBoxMixin = (subclass) =>
       if (!this.readonly && !this._closeOnBlurIsPrevented) {
         this._closeOrCommit();
       }
-
-      // Re-enable virtual keyboard for when the field gets the focus back
-      this.__setVirtualKeyboardEnabled(true);
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -267,8 +267,6 @@ export const ComboBoxMixin = (subclass) =>
         if (this.clearElement) {
           this.clearElement.addEventListener('mousedown', this._boundOnClearButtonMouseDown);
         }
-
-        this.addController(new VirtualKeyboardController(this, input));
       }
     }
 
@@ -300,6 +298,8 @@ export const ComboBoxMixin = (subclass) =>
       this.addEventListener('touchstart', bringToFrontListener);
 
       processTemplates(this);
+
+      this.addController(new VirtualKeyboardController(this));
     }
 
     /**

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -238,6 +238,7 @@ describe('toggling dropdown', () => {
       it('should re-enable virtual keyboard on blur', async () => {
         comboBox.open();
         comboBox.close();
+        await aTimeout(0);
         await sendKeys({ press: 'Tab' });
         expect(input.inputMode).to.equal('');
       });

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -228,7 +228,7 @@ describe('toggling dropdown', () => {
         expect(input.inputMode).to.equal('none');
       });
 
-      it('should re-enable virtual keyboard on touchstart', async () => {
+      it('should re-enable virtual keyboard on touchstart', () => {
         comboBox.open();
         comboBox.close();
         touchstart(comboBox);

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -241,13 +241,6 @@ describe('toggling dropdown', () => {
         await sendKeys({ press: 'Tab' });
         expect(input.inputMode).to.equal('');
       });
-
-      it('should re-enable virtual keyboard on outside-click close', async () => {
-        comboBox.open();
-        outsideClick();
-        await aTimeout(0);
-        expect(input.inputMode).to.equal('');
-      });
     });
 
     describe('filtered items are empty', () => {

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -222,7 +222,7 @@ describe('toggling dropdown', () => {
     });
 
     describe('virtual keyboard', () => {
-      it('should disable virtual keyboard on close', async () => {
+      it('should disable virtual keyboard on close', () => {
         comboBox.open();
         comboBox.close();
         expect(input.inputMode).to.equal('none');

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, click, fixtureSync, focusout, isIOS, tap } from '@vaadin/testing-helpers';
+import { aTimeout, click, fixtureSync, focusout, isIOS, tap, touchstart } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
@@ -218,6 +219,35 @@ describe('toggling dropdown', () => {
       outsideClick();
       await aTimeout(0);
       expect(document.activeElement).to.equal(input);
+    });
+
+    describe('virtual keyboard', () => {
+      it('should disable virtual keyboard on close', async () => {
+        comboBox.open();
+        comboBox.close();
+        expect(input.inputMode).to.equal('none');
+      });
+
+      it('should re-enable virtual keyboard on touchstart', async () => {
+        comboBox.open();
+        comboBox.close();
+        touchstart(comboBox);
+        expect(input.inputMode).to.equal('');
+      });
+
+      it('should re-enable virtual keyboard on blur', async () => {
+        comboBox.open();
+        comboBox.close();
+        await sendKeys({ press: 'Tab' });
+        expect(input.inputMode).to.equal('');
+      });
+
+      it('should re-enable virtual keyboard on outside-click close', async () => {
+        comboBox.open();
+        outsideClick();
+        await aTimeout(0);
+        expect(input.inputMode).to.equal('');
+      });
     });
 
     describe('filtered items are empty', () => {

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -422,6 +422,8 @@ export const DatePickerMixin = (subclass) =>
           this.open();
         }
       });
+
+      this.addController(new VirtualKeyboardController(this));
     }
 
     /** @protected */
@@ -583,8 +585,6 @@ export const DatePickerMixin = (subclass) =>
         input.setAttribute('role', 'combobox');
         input.setAttribute('aria-expanded', !!this.opened);
         this._applyInputValue(this._selectedDate);
-
-        this.addController(new VirtualKeyboardController(this, input));
       }
     }
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -408,6 +408,9 @@ export const DatePickerMixin = (subclass) =>
           this.validate();
         }
       }
+
+      // Re-enable virtual keyboard for when the field gets the focus back
+      this.__setVirtualKeyboardEnabled(true);
     }
 
     /** @protected */
@@ -443,6 +446,9 @@ export const DatePickerMixin = (subclass) =>
     close() {
       if (this._overlayInitialized || this.autoOpenDisabled) {
         this.$.overlay.close();
+
+        // Avoid opening the virtual keyboard when the input gets re-focused on dropdown close
+        this.__setVirtualKeyboardEnabled(false);
       }
     }
 
@@ -465,6 +471,9 @@ export const DatePickerMixin = (subclass) =>
 
       this.addEventListener('mousedown', () => this.__bringToFront());
       this.addEventListener('touchstart', () => this.__bringToFront());
+
+      // Re-enable the virtual keyboard whenever the field is touched
+      this.addEventListener('touchstart', () => this.__setVirtualKeyboardEnabled(true));
     }
 
     /**
@@ -516,6 +525,11 @@ export const DatePickerMixin = (subclass) =>
       requestAnimationFrame(() => {
         this.$.overlay.bringToFront();
       });
+    }
+
+    /** @private */
+    __setVirtualKeyboardEnabled(value) {
+      this.inputElement.inputMode = value ? '' : 'none';
     }
 
     /** @private */

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -58,7 +58,7 @@ describe('dropdown', () => {
   });
 
   describe('virtual keyboard', () => {
-    it('should disable virtual keyboard on close', async () => {
+    it('should disable virtual keyboard on close', () => {
       await open(datepicker);
       datepicker.close();
       expect(input.inputMode).to.equal('none');

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -64,7 +64,7 @@ describe('dropdown', () => {
       expect(input.inputMode).to.equal('none');
     });
 
-    it('should re-enable virtual keyboard on touchstart', async () => {
+    it('should re-enable virtual keyboard on touchstart', () => {
       await open(datepicker);
       datepicker.close();
       touchstart(datepicker);

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -59,29 +59,22 @@ describe('dropdown', () => {
 
   describe('virtual keyboard', () => {
     it('should disable virtual keyboard on close', async () => {
-      datepicker.open();
+      await open(datepicker);
       datepicker.close();
       expect(input.inputMode).to.equal('none');
     });
 
     it('should re-enable virtual keyboard on touchstart', async () => {
-      datepicker.open();
+      await open(datepicker);
       datepicker.close();
       touchstart(datepicker);
       expect(input.inputMode).to.equal('');
     });
 
     it('should re-enable virtual keyboard on blur', async () => {
-      datepicker.open();
+      await open(datepicker);
       datepicker.close();
       await sendKeys({ press: 'Tab' });
-      expect(input.inputMode).to.equal('');
-    });
-
-    it('should re-enable virtual keyboard on outside-click close', async () => {
-      datepicker.open();
-      outsideClick();
-      await aTimeout(0);
       expect(input.inputMode).to.equal('');
     });
   });

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -58,13 +58,13 @@ describe('dropdown', () => {
   });
 
   describe('virtual keyboard', () => {
-    it('should disable virtual keyboard on close', () => {
+    it('should disable virtual keyboard on close', async () => {
       await open(datepicker);
       datepicker.close();
       expect(input.inputMode).to.equal('none');
     });
 
-    it('should re-enable virtual keyboard on touchstart', () => {
+    it('should re-enable virtual keyboard on touchstart', async () => {
       await open(datepicker);
       datepicker.close();
       touchstart(datepicker);

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, click, down, fixtureSync, isIOS } from '@vaadin/testing-helpers';
+import { aTimeout, click, down, fixtureSync, isIOS, touchstart } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import '../src/vaadin-date-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { open, outsideClick } from './common.js';
@@ -54,6 +55,35 @@ describe('dropdown', () => {
     outsideClick();
     await aTimeout(0);
     expect(document.activeElement).to.equal(input);
+  });
+
+  describe('virtual keyboard', () => {
+    it('should disable virtual keyboard on close', async () => {
+      datepicker.open();
+      datepicker.close();
+      expect(input.inputMode).to.equal('none');
+    });
+
+    it('should re-enable virtual keyboard on touchstart', async () => {
+      datepicker.open();
+      datepicker.close();
+      touchstart(datepicker);
+      expect(input.inputMode).to.equal('');
+    });
+
+    it('should re-enable virtual keyboard on blur', async () => {
+      datepicker.open();
+      datepicker.close();
+      await sendKeys({ press: 'Tab' });
+      expect(input.inputMode).to.equal('');
+    });
+
+    it('should re-enable virtual keyboard on outside-click close', async () => {
+      datepicker.open();
+      outsideClick();
+      await aTimeout(0);
+      expect(input.inputMode).to.equal('');
+    });
   });
 
   describe('sizing', () => {

--- a/packages/field-base/src/virtual-keyboard-controller.d.ts
+++ b/packages/field-base/src/virtual-keyboard-controller.d.ts
@@ -10,5 +10,5 @@ import { ReactiveController } from 'lit';
  * when the field's overlay is closed.
  */
 export class VirtualKeyboardController implements ReactiveController {
-  constructor(host: { inputElement: HTMLElement; opened: boolean } & HTMLElement);
+  constructor(host: { inputElement?: HTMLElement; opened: boolean } & HTMLElement);
 }

--- a/packages/field-base/src/virtual-keyboard-controller.d.ts
+++ b/packages/field-base/src/virtual-keyboard-controller.d.ts
@@ -10,5 +10,5 @@ import { ReactiveController } from 'lit';
  * when the field's overlay is closed.
  */
 export class VirtualKeyboardController implements ReactiveController {
-  constructor(host: { inputElement: HTMLElement } & HTMLElement);
+  constructor(host: { inputElement: HTMLElement; opened: boolean } & HTMLElement);
 }

--- a/packages/field-base/src/virtual-keyboard-controller.d.ts
+++ b/packages/field-base/src/virtual-keyboard-controller.d.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ReactiveController } from 'lit';
+
+/**
+ * A controller which prevents the virtual keyboard from showing up on mobile devices
+ * when the field's overlay is closed.
+ */
+export class VirtualKeyboardController implements ReactiveController {
+  constructor(host: HTMLElement, input: HTMLInputElement);
+}

--- a/packages/field-base/src/virtual-keyboard-controller.d.ts
+++ b/packages/field-base/src/virtual-keyboard-controller.d.ts
@@ -10,5 +10,5 @@ import { ReactiveController } from 'lit';
  * when the field's overlay is closed.
  */
 export class VirtualKeyboardController implements ReactiveController {
-  constructor(host: HTMLElement, input: HTMLInputElement);
+  constructor(host: { inputElement: HTMLElement } & HTMLElement);
 }

--- a/packages/field-base/src/virtual-keyboard-controller.js
+++ b/packages/field-base/src/virtual-keyboard-controller.js
@@ -10,7 +10,7 @@
  */
 export class VirtualKeyboardController {
   /**
-   * @param {{ inputElement: HTMLElement; opened: boolean } & HTMLElement} host
+   * @param {{ inputElement?: HTMLElement; opened: boolean } & HTMLElement} host
    */
   constructor(host) {
     this.host = host;

--- a/packages/field-base/src/virtual-keyboard-controller.js
+++ b/packages/field-base/src/virtual-keyboard-controller.js
@@ -10,11 +10,10 @@
  */
 export class VirtualKeyboardController {
   /**
-   * @param {HTMLElement} host
-   * @param {HTMLInputElement} input
+   * @param {{ inputElement: HTMLElement } & HTMLElement} host
    */
-  constructor(host, input) {
-    this.input = input;
+  constructor(host) {
+    this.host = host;
 
     host.addEventListener('opened-changed', (event) => {
       if (event instanceof CustomEvent && !event.detail.value) {
@@ -32,6 +31,8 @@ export class VirtualKeyboardController {
 
   /** @private */
   __setVirtualKeyboardEnabled(value) {
-    this.input.inputMode = value ? '' : 'none';
+    if (this.host.inputElement) {
+      this.host.inputElement.inputMode = value ? '' : 'none';
+    }
   }
 }

--- a/packages/field-base/src/virtual-keyboard-controller.js
+++ b/packages/field-base/src/virtual-keyboard-controller.js
@@ -10,14 +10,14 @@
  */
 export class VirtualKeyboardController {
   /**
-   * @param {{ inputElement: HTMLElement } & HTMLElement} host
+   * @param {{ inputElement: HTMLElement; opened: boolean } & HTMLElement} host
    */
   constructor(host) {
     this.host = host;
 
-    host.addEventListener('opened-changed', (event) => {
-      if (event instanceof CustomEvent && !event.detail.value) {
-        // Avoid opening the virtual keyboard when the input gets re-focused on dropdown close
+    host.addEventListener('opened-changed', () => {
+      if (!host.opened) {
+        // Prevent opening the virtual keyboard when the input gets re-focused on dropdown close
         this.__setVirtualKeyboardEnabled(false);
       }
     });

--- a/packages/field-base/src/virtual-keyboard-controller.js
+++ b/packages/field-base/src/virtual-keyboard-controller.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A controller which prevents the virtual keyboard from showing up on mobile devices
+ * when the field's overlay is closed.
+ */
+export class VirtualKeyboardController {
+  /**
+   * @param {HTMLElement} host
+   * @param {HTMLInputElement} input
+   */
+  constructor(host, input) {
+    this.input = input;
+
+    host.addEventListener('opened-changed', (event) => {
+      if (event instanceof CustomEvent && !event.detail.value) {
+        // Avoid opening the virtual keyboard when the input gets re-focused on dropdown close
+        this.__setVirtualKeyboardEnabled(false);
+      }
+    });
+
+    // Re-enable virtual keyboard on blur, so it gets opened when the field is focused again
+    host.addEventListener('blur', () => this.__setVirtualKeyboardEnabled(true));
+
+    // Re-enable the virtual keyboard whenever the field is touched
+    host.addEventListener('touchstart', () => this.__setVirtualKeyboardEnabled(true));
+  }
+
+  /** @private */
+  __setVirtualKeyboardEnabled(value) {
+    this.input.inputMode = value ? '' : 'none';
+  }
+}

--- a/packages/field-base/test/virtual-keyboard-controller.test.js
+++ b/packages/field-base/test/virtual-keyboard-controller.test.js
@@ -1,0 +1,58 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, touchstart } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { VirtualKeyboardController } from '../src/virtual-keyboard-controller.js';
+
+customElements.define(
+  'virtual-keyboard-controller-element',
+  class extends ControllerMixin(PolymerElement) {
+    static get template() {
+      return html`<input id="input" />`;
+    }
+
+    ready() {
+      super.ready();
+      this.addController(new VirtualKeyboardController(this, this.$.input));
+    }
+
+    open() {
+      this.dispatchEvent(new CustomEvent('opened-changed', { detail: { value: true } }));
+    }
+
+    close() {
+      this.dispatchEvent(new CustomEvent('opened-changed', { detail: { value: false } }));
+    }
+  }
+);
+
+describe('virtual-keyboard-controller-element', () => {
+  let element, input;
+
+  beforeEach(() => {
+    element = fixtureSync('<virtual-keyboard-controller-element></virtual-keyboard-controller-element>');
+    input = element.$.input;
+  });
+
+  it('should disable virtual keyboard on close', async () => {
+    element.open();
+    element.close();
+    expect(input.inputMode).to.equal('none');
+  });
+
+  it('should re-enable virtual keyboard on touchstart', async () => {
+    element.open();
+    element.close();
+    touchstart(element);
+    expect(input.inputMode).to.equal('');
+  });
+
+  it('should re-enable virtual keyboard on blur', async () => {
+    element.open();
+    element.close();
+    input.focus();
+    await sendKeys({ press: 'Tab' });
+    expect(input.inputMode).to.equal('');
+  });
+});

--- a/packages/field-base/test/virtual-keyboard-controller.test.js
+++ b/packages/field-base/test/virtual-keyboard-controller.test.js
@@ -9,12 +9,18 @@ customElements.define(
   'virtual-keyboard-controller-element',
   class extends ControllerMixin(PolymerElement) {
     static get template() {
-      return html`<input id="input" />`;
+      return html`<slot></slot>`;
+    }
+
+    constructor() {
+      super();
+      this.inputElement = document.createElement('input');
+      this.appendChild(this.inputElement);
     }
 
     ready() {
       super.ready();
-      this.addController(new VirtualKeyboardController(this, this.$.input));
+      this.addController(new VirtualKeyboardController(this));
     }
 
     open() {
@@ -27,12 +33,12 @@ customElements.define(
   }
 );
 
-describe('virtual-keyboard-controller-element', () => {
+describe('virtual-keyboard-controller', () => {
   let element, input;
 
   beforeEach(() => {
     element = fixtureSync('<virtual-keyboard-controller-element></virtual-keyboard-controller-element>');
-    input = element.$.input;
+    input = element.inputElement;
   });
 
   it('should disable virtual keyboard on close', async () => {
@@ -51,7 +57,8 @@ describe('virtual-keyboard-controller-element', () => {
   it('should re-enable virtual keyboard on blur', async () => {
     element.open();
     element.close();
-    input.focus();
+    element.tabIndex = 1;
+    element.focus();
     await sendKeys({ press: 'Tab' });
     expect(input.inputMode).to.equal('');
   });


### PR DESCRIPTION
Fixes #3191 

This PR sets the `inputMode` property of the `<input>` element in date-picker/combo-box to "none" whenever the dropdown gets closed, effectively preventing the virtual keyboard from opening automatically.


https://user-images.githubusercontent.com/1222264/148064485-ee3c685c-249f-4e91-98ab-b0ac03f8cb8e.mp4


The `inputMode` property is reset back to its default value in two cases:
- **on blur:** a user might tab to the next input while the `inputMode` is "none". Tabbing back to the field should open the virtual keyboard (default behavior).
- **on touchstart:** a user can tap the field to get the virtual keyboard opened

