### PR TITLE
fix: use correct 1-based index for aria-posinset

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -287,7 +287,7 @@ export class ComboBoxScroller extends PolymerElement {
     el.id = `${this.__hostTagName}-item-${index}`;
     el.setAttribute('role', this.__getAriaRole(index));
     el.setAttribute('aria-selected', this.__getAriaSelected(focusedIndex, index));
-    el.setAttribute('aria-posinset', index);
+    el.setAttribute('aria-posinset', index + 1);
 
     if (this.theme) {
       el.setAttribute('theme', this.theme);

--- a/packages/combo-box/test/aria.test.js
+++ b/packages/combo-box/test/aria.test.js
@@ -108,7 +108,7 @@ describe('ARIA', () => {
 
     it('should set aria-posinset attribute on the dropdown items', () => {
       items.forEach((item, idx) => {
-        expect(item.getAttribute('aria-posinset')).to.equal(idx.toString());
+        expect(item.getAttribute('aria-posinset')).to.equal((idx + 1).toString());
       });
     });
 

--- a/packages/time-picker/test/aria.test.js
+++ b/packages/time-picker/test/aria.test.js
@@ -106,7 +106,7 @@ describe('ARIA', () => {
 
     it('should set aria-posinset attribute on the dropdown items', () => {
       items.forEach((item, idx) => {
-        expect(item.getAttribute('aria-posinset')).to.equal(idx.toString());
+        expect(item.getAttribute('aria-posinset')).to.equal((idx + 1).toString());
       });
     });
 


### PR DESCRIPTION
## Description

Tested with NVDA and now the last item is properly announced. 
Not sure why I missed to handle it in https://github.com/vaadin/web-components/pull/2745#discussion_r722261384 🤷‍♂️ 

Fixes #2747

## Type of change

- Bugfix