### PR TITLE
fix: add missing export to FocusTrapController

### DIFF
--- a/packages/component-base/src/focus-trap-controller.d.ts
+++ b/packages/component-base/src/focus-trap-controller.d.ts
@@ -8,7 +8,7 @@ import { ReactiveController } from 'lit';
 /**
  * A controller for trapping focus within a DOM node.
  */
-declare class FocusTrapController implements ReactiveController {
+export class FocusTrapController implements ReactiveController {
   constructor(node: HTMLElement);
 
   hostConnected(): void;


### PR DESCRIPTION
## Description

Added missing `export` for the controller `.d.ts` file.

## Type of change

- Bugfix