### PR TITLE
fix: change grid table role to treegrid

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -279,7 +279,7 @@ class Grid extends ElementMixin(
         loading$="[[loading]]"
         column-reordering-allowed$="[[columnReorderingAllowed]]"
       >
-        <table id="table" role="grid" aria-multiselectable="true" tabindex="0">
+        <table id="table" role="treegrid" aria-multiselectable="true" tabindex="0">
           <caption id="sizer" part="row"></caption>
           <thead id="header" role="rowgroup"></thead>
           <tbody id="items" role="rowgroup"></tbody>

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -111,8 +111,8 @@ describe('accessibility', () => {
     });
 
     describe('structural roles', () => {
-      it('should have role grid on table', () => {
-        expect(grid.$.table.getAttribute('role')).to.equal('grid');
+      it('should have role treegrid on table', () => {
+        expect(grid.$.table.getAttribute('role')).to.equal('treegrid');
       });
 
       it('should have role rowgroup on row groups', () => {


### PR DESCRIPTION
Fixes #3180 

This PR changes the `role` of the `<table>` element inside `<vaadin-grid>`'s shadow root from "grid" to "treegrid", which supports the `aria-level` attribute as desribed [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level#within_treegrid_role). Changing the role to "treegrid" has been [discussed](https://github.com/vaadin/web-components/issues/97#issuecomment-818603600) earlier also.

The current `role="grid"` originates from times before hierarchy support was added to `<vaadin-grid>`. The [feature PR](https://github.com/vaadin/vaadin-grid/pull/1057) missed the necessary update to the `<table>` element's role.