### PR TITLE
refactor!: remove transition from hover state

### DIFF
--- a/packages/button/theme/lumo/vaadin-button-styles.js
+++ b/packages/button/theme/lumo/vaadin-button-styles.js
@@ -62,7 +62,6 @@ const button = css`
     background-color: currentColor;
     border-radius: inherit;
     opacity: 0;
-    transition: opacity 0.2s;
     pointer-events: none;
   }
 


### PR DESCRIPTION
Make the hover state more apparent when there is no transition. Currently the 0.2s duration makes it more difficult to notice the visual change when hovering over the button.

Considered technically as a (small) breaking change because some custom theme might rely on this property. Doesn't not break an app, but can some could consider it as a degradation of user experience.

I want to highlight this change in the release notes, that’s the main reason I marked this as "breaking", but I’m okay without marking it such.