### PR TITLE
fix: do not override custom helper on attach

### DIFF
--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -66,8 +66,9 @@ export class HelperController extends SlotController {
   setHelperText(helperText) {
     this.helperText = helperText;
 
-    if (!this.node || this.node === this.defaultNode) {
-      this.__applyDefaultHelper(helperText, this.defaultNode);
+    const helperNode = this.getSlotChild();
+    if (!helperNode || helperNode === this.defaultNode) {
+      this.__applyDefaultHelper(helperText, helperNode);
     }
   }
 

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -487,6 +487,20 @@ describe('field-mixin', () => {
           expect(element._helperNode).to.equal(defaultHelper);
         });
 
+        it('should restore the default helper when helperText property is restored', async () => {
+          element.appendChild(helper);
+          await nextFrame();
+
+          element.helperText = '';
+
+          element.removeChild(helper);
+          await nextFrame();
+
+          element.helperText = 'Helper';
+          await nextFrame();
+          expect(element._helperNode).to.equal(defaultHelper);
+        });
+
         it('should keep has-helper attribute when the default helper is restored', async () => {
           element.appendChild(helper);
           await nextFrame();

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -358,6 +358,22 @@ describe('field-mixin', () => {
       });
     });
 
+    describe('slotted with property', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`
+          <field-mixin-element helper-text="Default">
+            <div slot="helper">Custom</div>
+          </field-mixin-element>
+        `);
+        await nextFrame();
+        helper = element.querySelector('[slot=helper]');
+      });
+
+      it('should not override slotted helper with property on attach', () => {
+        expect(helper.textContent).to.equal('Custom');
+      });
+    });
+
     describe('slotted empty', () => {
       beforeEach(() => {
         element = fixtureSync(`


### PR DESCRIPTION
## Description

The problem was caused by improper timings: by the time when the `helperText` property observer runs when attached, the `FlattenedNodesObserver` is not yet triggered. This is due to the fact that Polymer observers run before `ready()`. As a result, `this.node` does not exist yet. Changed to get the actual slot child every time to ensure it's up to date. 

## Type of change

-  Bugfix