### PR TITLE
chore: set `type` to `module` in package.json

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-accordion.js",
+  "type": "module",
   "module": "vaadin-accordion.js",
   "files": [
     "src",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-accordion.js",
-  "type": "module",
   "module": "vaadin-accordion.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-app-layout.js",
-  "type": "module",
   "module": "vaadin-app-layout.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-app-layout.js",
+  "type": "module",
   "module": "vaadin-app-layout.js",
   "files": [
     "src",

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-avatar/issues"
   },
   "main": "vaadin-avatar-group.js",
+  "type": "module",
   "module": "vaadin-avatar-group.js",
   "files": [
     "src",

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-avatar/issues"
   },
   "main": "vaadin-avatar-group.js",
-  "type": "module",
   "module": "vaadin-avatar-group.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-avatar.js",
-  "type": "module",
   "module": "vaadin-avatar.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-avatar.js",
+  "type": "module",
   "module": "vaadin-avatar.js",
   "files": [
     "src",

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-board.js",
+  "type": "module",
   "module": "vaadin-board.js",
   "files": [
     "src",

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-board.js",
-  "type": "module",
   "module": "vaadin-board.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-button/issues"
   },
   "main": "vaadin-button.js",
-  "type": "module",
   "module": "vaadin-button.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-button/issues"
   },
   "main": "vaadin-button.js",
+  "type": "module",
   "module": "vaadin-button.js",
   "files": [
     "src",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-chart.js",
-  "type": "module",
   "module": "vaadin-chart.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-chart.js",
+  "type": "module",
   "module": "vaadin-chart.js",
   "files": [
     "src",

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-checkbox-group.js",
-  "type": "module",
   "module": "vaadin-checkbox-group.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-checkbox-group.js",
+  "type": "module",
   "module": "vaadin-checkbox-group.js",
   "files": [
     "src",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-checkbox.js",
+  "type": "module",
   "module": "vaadin-checkbox.js",
   "files": [
     "src",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-checkbox.js",
-  "type": "module",
   "module": "vaadin-checkbox.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-combo-box.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components"
   },
   "main": "index.js",
-  "type": "module",
   "module": "index.js",
+  "type": "module",
   "files": [
     "custom_typings",
     "index.d.ts",

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components"
   },
   "main": "index.js",
+  "type": "module",
   "module": "index.js",
   "files": [
     "custom_typings",

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-confirm-dialog.js",
+  "type": "module",
   "module": "vaadin-confirm-dialog.js",
   "files": [
     "src",

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-confirm-dialog.js",
-  "type": "module",
   "module": "vaadin-confirm-dialog.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-context-menu.js",
-  "type": "module",
   "module": "vaadin-context-menu.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-context-menu.js",
+  "type": "module",
   "module": "vaadin-context-menu.js",
   "files": [
     "src",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-cookie-consent.js",
-  "type": "module",
   "module": "vaadin-cookie-consent.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-cookie-consent.js",
+  "type": "module",
   "module": "vaadin-cookie-consent.js",
   "files": [
     "src",

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-crud.js",
-  "type": "module",
   "module": "vaadin-crud.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-crud.js",
+  "type": "module",
   "module": "vaadin-crud.js",
   "files": [
     "src",

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-custom-field.js",
-  "type": "module",
   "module": "vaadin-custom-field.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-custom-field.js",
+  "type": "module",
   "module": "vaadin-custom-field.js",
   "files": [
     "src",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-date-picker.js",
-  "type": "module",
   "module": "vaadin-date-picker.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-date-picker.js",
+  "type": "module",
   "module": "vaadin-date-picker.js",
   "files": [
     "src",

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-date-time-picker.js",
+  "type": "module",
   "module": "vaadin-date-time-picker.js",
   "files": [
     "src",

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-date-time-picker.js",
-  "type": "module",
   "module": "vaadin-date-time-picker.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-details.js",
-  "type": "module",
   "module": "vaadin-details.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-details.js",
+  "type": "module",
   "module": "vaadin-details.js",
   "files": [
     "src",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-dialog.js",
+  "type": "module",
   "module": "vaadin-dialog.js",
   "files": [
     "src",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-dialog.js",
-  "type": "module",
   "module": "vaadin-dialog.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-email-field.js",
+  "type": "module",
   "module": "vaadin-email-field.js",
   "files": [
     "src",

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-email-field.js",
-  "type": "module",
   "module": "vaadin-email-field.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components"
   },
   "main": "index.js",
+  "type": "module",
   "module": "index.js",
   "files": [
     "index.d.ts",

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components"
   },
   "main": "index.js",
-  "type": "module",
   "module": "index.js",
+  "type": "module",
   "files": [
     "index.d.ts",
     "index.js",

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-field-highlighter.js",
-  "type": "module",
   "module": "vaadin-field-highlighter.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-field-highlighter.js",
+  "type": "module",
   "module": "vaadin-field-highlighter.js",
   "files": [
     "src",

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-form-layout.js",
+  "type": "module",
   "module": "vaadin-form-layout.js",
   "files": [
     "src",

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-form-layout.js",
-  "type": "module",
   "module": "vaadin-form-layout.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-grid-pro.js",
-  "type": "module",
   "module": "vaadin-grid-pro.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-grid-pro.js",
+  "type": "module",
   "module": "vaadin-grid-pro.js",
   "files": [
     "src",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-grid.js",
+  "type": "module",
   "module": "vaadin-grid.js",
   "files": [
     "all-imports.js",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-grid.js",
-  "type": "module",
   "module": "vaadin-grid.js",
+  "type": "module",
   "files": [
     "all-imports.js",
     "src",

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-horizontal-layout.js",
+  "type": "module",
   "module": "vaadin-horizontal-layout.js",
   "files": [
     "src",

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-horizontal-layout.js",
-  "type": "module",
   "module": "vaadin-horizontal-layout.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-icon.js",
-  "type": "module",
   "module": "vaadin-icon.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-icon.js",
+  "type": "module",
   "module": "vaadin-icon.js",
   "files": [
     "src",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-iconset.js",
-  "type": "module",
   "module": "vaadin-iconset.js",
+  "type": "module",
   "scripts": {
     "icons": "gulp icons"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-iconset.js",
+  "type": "module",
   "module": "vaadin-iconset.js",
   "scripts": {
     "icons": "gulp icons"

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-input-container.js",
+  "type": "module",
   "module": "vaadin-input-container.js",
   "files": [
     "src",

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-input-container.js",
-  "type": "module",
   "module": "vaadin-input-container.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-integer-field.js",
+  "type": "module",
   "module": "vaadin-integer-field.js",
   "files": [
     "src",

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-integer-field.js",
-  "type": "module",
   "module": "vaadin-integer-field.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-item.js",
+  "type": "module",
   "module": "vaadin-item.js",
   "files": [
     "src",

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-item.js",
-  "type": "module",
   "module": "vaadin-item.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-list-box.js",
-  "type": "module",
   "module": "vaadin-list-box.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-list-box.js",
+  "type": "module",
   "module": "vaadin-list-box.js",
   "files": [
     "src",

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-login-overlay.js",
-  "type": "module",
   "module": "vaadin-login-overlay.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-login-overlay.js",
+  "type": "module",
   "module": "vaadin-login-overlay.js",
   "files": [
     "src",

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-menu-bar.js",
+  "type": "module",
   "module": "vaadin-menu-bar.js",
   "files": [
     "src",

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-menu-bar.js",
-  "type": "module",
   "module": "vaadin-menu-bar.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-message-input.js",
+  "type": "module",
   "module": "vaadin-message-input.js",
   "files": [
     "src",

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-message-input.js",
-  "type": "module",
   "module": "vaadin-message-input.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-message-list.js",
+  "type": "module",
   "module": "vaadin-message-list.js",
   "files": [
     "src",

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-message-list.js",
-  "type": "module",
   "module": "vaadin-message-list.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-notification.js",
+  "type": "module",
   "module": "vaadin-notification.js",
   "files": [
     "src",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-notification.js",
-  "type": "module",
   "module": "vaadin-notification.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-number-field.js",
+  "type": "module",
   "module": "vaadin-number-field.js",
   "files": [
     "src",

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-number-field.js",
-  "type": "module",
   "module": "vaadin-number-field.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-password-field.js",
+  "type": "module",
   "module": "vaadin-password-field.js",
   "files": [
     "src",

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-password-field.js",
-  "type": "module",
   "module": "vaadin-password-field.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "index.js",
+  "type": "module",
   "module": "index.js",
   "files": [
     "*.d.ts",

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "index.js",
-  "type": "module",
   "module": "index.js",
+  "type": "module",
   "files": [
     "*.d.ts",
     "*.js",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-progress-bar.js",
-  "type": "module",
   "module": "vaadin-progress-bar.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-progress-bar.js",
+  "type": "module",
   "module": "vaadin-progress-bar.js",
   "files": [
     "src",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-radio-group.js",
-  "type": "module",
   "module": "vaadin-radio-group.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-radio-group.js",
+  "type": "module",
   "module": "vaadin-radio-group.js",
   "files": [
     "src",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-rich-text-editor.js",
-  "type": "module",
   "module": "vaadin-rich-text-editor.js",
+  "type": "module",
   "scripts": {
     "icons": "gulp icons"
   },

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-rich-text-editor.js",
+  "type": "module",
   "module": "vaadin-rich-text-editor.js",
   "scripts": {
     "icons": "gulp icons"

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-scroller.js",
+  "type": "module",
   "module": "vaadin-scroller.js",
   "files": [
     "src",

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-scroller.js",
-  "type": "module",
   "module": "vaadin-scroller.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-select/issues"
   },
   "main": "vaadin-select.js",
+  "type": "module",
   "module": "vaadin-select.js",
   "files": [
     "src",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-select/issues"
   },
   "main": "vaadin-select.js",
-  "type": "module",
   "module": "vaadin-select.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-split-layout.js",
-  "type": "module",
   "module": "vaadin-split-layout.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-split-layout.js",
+  "type": "module",
   "module": "vaadin-split-layout.js",
   "files": [
     "src",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-tabs.js",
-  "type": "module",
   "module": "vaadin-tabs.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-tabs.js",
+  "type": "module",
   "module": "vaadin-tabs.js",
   "files": [
     "src",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-text-area.js",
-  "type": "module",
   "module": "vaadin-text-area.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-text-area.js",
+  "type": "module",
   "module": "vaadin-text-area.js",
   "files": [
     "src",

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-text-field.js",
-  "type": "module",
   "module": "vaadin-text-field.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-text-field.js",
+  "type": "module",
   "module": "vaadin-text-field.js",
   "files": [
     "src",

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-time-picker.js",
+  "type": "module",
   "module": "vaadin-time-picker.js",
   "files": [
     "src",

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-time-picker.js",
-  "type": "module",
   "module": "vaadin-time-picker.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-upload.js",
-  "type": "module",
   "module": "vaadin-upload.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-upload.js",
+  "type": "module",
   "module": "vaadin-upload.js",
   "files": [
     "src",

--- a/packages/vaadin-accordion/package.json
+++ b/packages/vaadin-accordion/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-accordion/issues"
   },
   "main": "vaadin-accordion.js",
+  "type": "module",
   "module": "vaadin-accordion.js",
   "files": [
     "src",

--- a/packages/vaadin-accordion/package.json
+++ b/packages/vaadin-accordion/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-accordion/issues"
   },
   "main": "vaadin-accordion.js",
-  "type": "module",
   "module": "vaadin-accordion.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-app-layout/package.json
+++ b/packages/vaadin-app-layout/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-app-layout/issues"
   },
   "main": "vaadin-app-layout.js",
-  "type": "module",
   "module": "vaadin-app-layout.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-app-layout/package.json
+++ b/packages/vaadin-app-layout/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-app-layout/issues"
   },
   "main": "vaadin-app-layout.js",
+  "type": "module",
   "module": "vaadin-app-layout.js",
   "files": [
     "src",

--- a/packages/vaadin-avatar/package.json
+++ b/packages/vaadin-avatar/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-avatar/issues"
   },
   "main": "vaadin-avatar-group.js",
+  "type": "module",
   "module": "vaadin-avatar-group.js",
   "files": [
     "src",

--- a/packages/vaadin-avatar/package.json
+++ b/packages/vaadin-avatar/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-avatar/issues"
   },
   "main": "vaadin-avatar-group.js",
-  "type": "module",
   "module": "vaadin-avatar-group.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-board/package.json
+++ b/packages/vaadin-board/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-board/issues"
   },
   "main": "vaadin-board.js",
-  "type": "module",
   "module": "vaadin-board.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-board/package.json
+++ b/packages/vaadin-board/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-board/issues"
   },
   "main": "vaadin-board.js",
+  "type": "module",
   "module": "vaadin-board.js",
   "files": [
     "src",

--- a/packages/vaadin-button/package.json
+++ b/packages/vaadin-button/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-button/issues"
   },
   "main": "vaadin-button.js",
-  "type": "module",
   "module": "vaadin-button.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-button/package.json
+++ b/packages/vaadin-button/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-button/issues"
   },
   "main": "vaadin-button.js",
+  "type": "module",
   "module": "vaadin-button.js",
   "files": [
     "src",

--- a/packages/vaadin-charts/package.json
+++ b/packages/vaadin-charts/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-charts/issues"
   },
   "main": "vaadin-chart.js",
+  "type": "module",
   "module": "vaadin-chart.js",
   "files": [
     "src",

--- a/packages/vaadin-charts/package.json
+++ b/packages/vaadin-charts/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-charts/issues"
   },
   "main": "vaadin-chart.js",
-  "type": "module",
   "module": "vaadin-chart.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-checkbox/package.json
+++ b/packages/vaadin-checkbox/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-checkbox/issues"
   },
   "main": "vaadin-checkbox.js",
+  "type": "module",
   "module": "vaadin-checkbox.js",
   "files": [
     "src",

--- a/packages/vaadin-checkbox/package.json
+++ b/packages/vaadin-checkbox/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-checkbox/issues"
   },
   "main": "vaadin-checkbox.js",
-  "type": "module",
   "module": "vaadin-checkbox.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-combo-box/package.json
+++ b/packages/vaadin-combo-box/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-combo-box/issues"
   },
   "main": "vaadin-combo-box.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-confirm-dialog/package.json
+++ b/packages/vaadin-confirm-dialog/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-confirm-dialog/issues"
   },
   "main": "vaadin-confirm-dialog.js",
-  "type": "module",
   "module": "vaadin-confirm-dialog.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-confirm-dialog/package.json
+++ b/packages/vaadin-confirm-dialog/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-confirm-dialog/issues"
   },
   "main": "vaadin-confirm-dialog.js",
+  "type": "module",
   "module": "vaadin-confirm-dialog.js",
   "files": [
     "src",

--- a/packages/vaadin-context-menu/package.json
+++ b/packages/vaadin-context-menu/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-context-menu/issues"
   },
   "main": "vaadin-context-menu.js",
+  "type": "module",
   "module": "vaadin-context-menu.js",
   "files": [
     "src",

--- a/packages/vaadin-context-menu/package.json
+++ b/packages/vaadin-context-menu/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-context-menu/issues"
   },
   "main": "vaadin-context-menu.js",
-  "type": "module",
   "module": "vaadin-context-menu.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-cookie-consent/package.json
+++ b/packages/vaadin-cookie-consent/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-cookie-consent/issues"
   },
   "main": "vaadin-cookie-consent.js",
+  "type": "module",
   "module": "vaadin-cookie-consent.js",
   "files": [
     "src",

--- a/packages/vaadin-cookie-consent/package.json
+++ b/packages/vaadin-cookie-consent/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-cookie-consent/issues"
   },
   "main": "vaadin-cookie-consent.js",
-  "type": "module",
   "module": "vaadin-cookie-consent.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-crud/package.json
+++ b/packages/vaadin-crud/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-crud.js",
-  "type": "module",
   "module": "vaadin-crud.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-crud/package.json
+++ b/packages/vaadin-crud/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-crud.js",
+  "type": "module",
   "module": "vaadin-crud.js",
   "files": [
     "src",

--- a/packages/vaadin-custom-field/package.json
+++ b/packages/vaadin-custom-field/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-custom-field.js",
-  "type": "module",
   "module": "vaadin-custom-field.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-custom-field/package.json
+++ b/packages/vaadin-custom-field/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-custom-field.js",
+  "type": "module",
   "module": "vaadin-custom-field.js",
   "files": [
     "src",

--- a/packages/vaadin-date-picker/package.json
+++ b/packages/vaadin-date-picker/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-date-picker/issues"
   },
   "main": "vaadin-date-picker.js",
-  "type": "module",
   "module": "vaadin-date-picker.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-date-picker/package.json
+++ b/packages/vaadin-date-picker/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-date-picker/issues"
   },
   "main": "vaadin-date-picker.js",
+  "type": "module",
   "module": "vaadin-date-picker.js",
   "files": [
     "src",

--- a/packages/vaadin-date-time-picker/package.json
+++ b/packages/vaadin-date-time-picker/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-date-time-picker/issues"
   },
   "main": "vaadin-date-time-picker.js",
-  "type": "module",
   "module": "vaadin-date-time-picker.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-date-time-picker/package.json
+++ b/packages/vaadin-date-time-picker/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-date-time-picker/issues"
   },
   "main": "vaadin-date-time-picker.js",
+  "type": "module",
   "module": "vaadin-date-time-picker.js",
   "files": [
     "src",

--- a/packages/vaadin-details/package.json
+++ b/packages/vaadin-details/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-details/issues"
   },
   "main": "vaadin-details.js",
+  "type": "module",
   "module": "vaadin-details.js",
   "files": [
     "src",

--- a/packages/vaadin-details/package.json
+++ b/packages/vaadin-details/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-details/issues"
   },
   "main": "vaadin-details.js",
-  "type": "module",
   "module": "vaadin-details.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-dialog/package.json
+++ b/packages/vaadin-dialog/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-dialog/issues"
   },
   "main": "vaadin-dialog.js",
-  "type": "module",
   "module": "vaadin-dialog.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-dialog/package.json
+++ b/packages/vaadin-dialog/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-dialog/issues"
   },
   "main": "vaadin-dialog.js",
+  "type": "module",
   "module": "vaadin-dialog.js",
   "files": [
     "src",

--- a/packages/vaadin-form-layout/package.json
+++ b/packages/vaadin-form-layout/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-form-layout/issues"
   },
   "main": "vaadin-form-layout.js",
-  "type": "module",
   "module": "vaadin-form-layout.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-form-layout/package.json
+++ b/packages/vaadin-form-layout/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-form-layout/issues"
   },
   "main": "vaadin-form-layout.js",
+  "type": "module",
   "module": "vaadin-form-layout.js",
   "files": [
     "src",

--- a/packages/vaadin-grid-pro/package.json
+++ b/packages/vaadin-grid-pro/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-grid-pro/issues"
   },
   "main": "vaadin-grid-pro.js",
-  "type": "module",
   "module": "vaadin-grid-pro.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-grid-pro/package.json
+++ b/packages/vaadin-grid-pro/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-grid-pro/issues"
   },
   "main": "vaadin-grid-pro.js",
+  "type": "module",
   "module": "vaadin-grid-pro.js",
   "files": [
     "src",

--- a/packages/vaadin-grid/package.json
+++ b/packages/vaadin-grid/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-grid/issues"
   },
   "main": "vaadin-grid.js",
-  "type": "module",
   "module": "vaadin-grid.js",
+  "type": "module",
   "files": [
     "all-imports.js",
     "src",

--- a/packages/vaadin-grid/package.json
+++ b/packages/vaadin-grid/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-grid/issues"
   },
   "main": "vaadin-grid.js",
+  "type": "module",
   "module": "vaadin-grid.js",
   "files": [
     "all-imports.js",

--- a/packages/vaadin-icon/package.json
+++ b/packages/vaadin-icon/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-icon.js",
-  "type": "module",
   "module": "vaadin-icon.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-icon/package.json
+++ b/packages/vaadin-icon/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-icon.js",
+  "type": "module",
   "module": "vaadin-icon.js",
   "files": [
     "src",

--- a/packages/vaadin-icons/package.json
+++ b/packages/vaadin-icons/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-icons/issues"
   },
   "main": "vaadin-icons.js",
+  "type": "module",
   "module": "vaadin-icons.js",
   "files": [
     "iconset.js",

--- a/packages/vaadin-icons/package.json
+++ b/packages/vaadin-icons/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-icons/issues"
   },
   "main": "vaadin-icons.js",
-  "type": "module",
   "module": "vaadin-icons.js",
+  "type": "module",
   "files": [
     "iconset.js",
     "vaadin-icons.js",

--- a/packages/vaadin-item/package.json
+++ b/packages/vaadin-item/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-item/issues"
   },
   "main": "vaadin-item.js",
-  "type": "module",
   "module": "vaadin-item.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-item/package.json
+++ b/packages/vaadin-item/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-item/issues"
   },
   "main": "vaadin-item.js",
+  "type": "module",
   "module": "vaadin-item.js",
   "files": [
     "src",

--- a/packages/vaadin-list-box/package.json
+++ b/packages/vaadin-list-box/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-list-box/issues"
   },
   "main": "vaadin-list-box.js",
-  "type": "module",
   "module": "vaadin-list-box.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-list-box/package.json
+++ b/packages/vaadin-list-box/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-list-box/issues"
   },
   "main": "vaadin-list-box.js",
+  "type": "module",
   "module": "vaadin-list-box.js",
   "files": [
     "src",

--- a/packages/vaadin-list-mixin/package.json
+++ b/packages/vaadin-list-mixin/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-list-mixin/issues"
   },
   "main": "vaadin-list-mixin.js",
+  "type": "module",
   "module": "vaadin-list-mixin.js",
   "files": [
     "*.d.ts",

--- a/packages/vaadin-list-mixin/package.json
+++ b/packages/vaadin-list-mixin/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-list-mixin/issues"
   },
   "main": "vaadin-list-mixin.js",
-  "type": "module",
   "module": "vaadin-list-mixin.js",
+  "type": "module",
   "files": [
     "*.d.ts",
     "vaadin-*.js"

--- a/packages/vaadin-login/package.json
+++ b/packages/vaadin-login/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-login/issues"
   },
   "main": "vaadin-login-overlay.js",
-  "type": "module",
   "module": "vaadin-login-overlay.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-login/package.json
+++ b/packages/vaadin-login/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-login/issues"
   },
   "main": "vaadin-login-overlay.js",
+  "type": "module",
   "module": "vaadin-login-overlay.js",
   "files": [
     "src",

--- a/packages/vaadin-lumo-styles/package.json
+++ b/packages/vaadin-lumo-styles/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-lumo-styles/issues"
   },
   "main": "all-imports.js",
-  "type": "module",
   "module": "all-imports.js",
+  "type": "module",
   "scripts": {
     "icons": "gulp icons"
   },

--- a/packages/vaadin-lumo-styles/package.json
+++ b/packages/vaadin-lumo-styles/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-lumo-styles/issues"
   },
   "main": "all-imports.js",
+  "type": "module",
   "module": "all-imports.js",
   "scripts": {
     "icons": "gulp icons"

--- a/packages/vaadin-material-styles/package.json
+++ b/packages/vaadin-material-styles/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-material-styles/issues"
   },
   "main": "all-imports.js",
+  "type": "module",
   "module": "all-imports.js",
   "scripts": {
     "icons": "gulp icons"

--- a/packages/vaadin-material-styles/package.json
+++ b/packages/vaadin-material-styles/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-material-styles/issues"
   },
   "main": "all-imports.js",
-  "type": "module",
   "module": "all-imports.js",
+  "type": "module",
   "scripts": {
     "icons": "gulp icons"
   },

--- a/packages/vaadin-menu-bar/package.json
+++ b/packages/vaadin-menu-bar/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-menu-bar.js",
+  "type": "module",
   "module": "vaadin-menu-bar.js",
   "files": [
     "src",

--- a/packages/vaadin-menu-bar/package.json
+++ b/packages/vaadin-menu-bar/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-menu-bar.js",
-  "type": "module",
   "module": "vaadin-menu-bar.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-messages/package.json
+++ b/packages/vaadin-messages/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-messages/issues"
   },
   "main": "all-imports.js",
-  "type": "module",
   "module": "all-imports.js",
+  "type": "module",
   "files": [
     "all-imports.d.ts",
     "all-imports.js",

--- a/packages/vaadin-messages/package.json
+++ b/packages/vaadin-messages/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-messages/issues"
   },
   "main": "all-imports.js",
+  "type": "module",
   "module": "all-imports.js",
   "files": [
     "all-imports.d.ts",

--- a/packages/vaadin-notification/package.json
+++ b/packages/vaadin-notification/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-notification/issues"
   },
   "main": "vaadin-notification.js",
+  "type": "module",
   "module": "vaadin-notification.js",
   "files": [
     "src",

--- a/packages/vaadin-notification/package.json
+++ b/packages/vaadin-notification/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-notification/issues"
   },
   "main": "vaadin-notification.js",
-  "type": "module",
   "module": "vaadin-notification.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-ordered-layout/package.json
+++ b/packages/vaadin-ordered-layout/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-ordered-layout/issues"
   },
   "main": "imports.js",
+  "type": "module",
   "module": "imports.js",
   "files": [
     "imports.d.ts",

--- a/packages/vaadin-ordered-layout/package.json
+++ b/packages/vaadin-ordered-layout/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-ordered-layout/issues"
   },
   "main": "imports.js",
-  "type": "module",
   "module": "imports.js",
+  "type": "module",
   "files": [
     "imports.d.ts",
     "imports.js",

--- a/packages/vaadin-overlay/package.json
+++ b/packages/vaadin-overlay/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-overlay/issues"
   },
   "main": "vaadin-overlay.js",
+  "type": "module",
   "module": "vaadin-overlay.js",
   "files": [
     "src",

--- a/packages/vaadin-overlay/package.json
+++ b/packages/vaadin-overlay/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-overlay/issues"
   },
   "main": "vaadin-overlay.js",
-  "type": "module",
   "module": "vaadin-overlay.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-progress-bar/package.json
+++ b/packages/vaadin-progress-bar/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-progress-bar.js",
-  "type": "module",
   "module": "vaadin-progress-bar.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-progress-bar/package.json
+++ b/packages/vaadin-progress-bar/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-progress-bar.js",
+  "type": "module",
   "module": "vaadin-progress-bar.js",
   "files": [
     "src",

--- a/packages/vaadin-radio-button/package.json
+++ b/packages/vaadin-radio-button/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-radio-button/issues"
   },
   "main": "vaadin-radio-button.js",
+  "type": "module",
   "module": "vaadin-radio-button.js",
   "files": [
     "src",

--- a/packages/vaadin-radio-button/package.json
+++ b/packages/vaadin-radio-button/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-radio-button/issues"
   },
   "main": "vaadin-radio-button.js",
-  "type": "module",
   "module": "vaadin-radio-button.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-rich-text-editor/package.json
+++ b/packages/vaadin-rich-text-editor/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-rich-text-editor/issues"
   },
   "main": "vaadin-rich-text-editor.js",
+  "type": "module",
   "module": "vaadin-rich-text-editor.js",
   "files": [
     "src",

--- a/packages/vaadin-rich-text-editor/package.json
+++ b/packages/vaadin-rich-text-editor/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-rich-text-editor/issues"
   },
   "main": "vaadin-rich-text-editor.js",
-  "type": "module",
   "module": "vaadin-rich-text-editor.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-select/package.json
+++ b/packages/vaadin-select/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-select/issues"
   },
   "main": "vaadin-select.js",
+  "type": "module",
   "module": "vaadin-select.js",
   "files": [
     "src",

--- a/packages/vaadin-select/package.json
+++ b/packages/vaadin-select/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-select/issues"
   },
   "main": "vaadin-select.js",
-  "type": "module",
   "module": "vaadin-select.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-split-layout/package.json
+++ b/packages/vaadin-split-layout/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-split-layout.js",
-  "type": "module",
   "module": "vaadin-split-layout.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-split-layout/package.json
+++ b/packages/vaadin-split-layout/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-split-layout.js",
+  "type": "module",
   "module": "vaadin-split-layout.js",
   "files": [
     "src",

--- a/packages/vaadin-tabs/package.json
+++ b/packages/vaadin-tabs/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-tabs/issues"
   },
   "main": "vaadin-tabs.js",
+  "type": "module",
   "module": "vaadin-tabs.js",
   "files": [
     "src",

--- a/packages/vaadin-tabs/package.json
+++ b/packages/vaadin-tabs/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-tabs/issues"
   },
   "main": "vaadin-tabs.js",
-  "type": "module",
   "module": "vaadin-tabs.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-template-renderer/package.json
+++ b/packages/vaadin-template-renderer/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-template-renderer.js",
-  "type": "module",
   "module": "vaadin-template-renderer.js",
+  "type": "module",
   "files": [
     "vaadin-*.js"
   ],

--- a/packages/vaadin-template-renderer/package.json
+++ b/packages/vaadin-template-renderer/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-template-renderer.js",
+  "type": "module",
   "module": "vaadin-template-renderer.js",
   "files": [
     "vaadin-*.js"

--- a/packages/vaadin-text-field/package.json
+++ b/packages/vaadin-text-field/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-text-field/issues"
   },
   "main": "vaadin-text-field.js",
-  "type": "module",
   "module": "vaadin-text-field.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-text-field/package.json
+++ b/packages/vaadin-text-field/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-text-field/issues"
   },
   "main": "vaadin-text-field.js",
+  "type": "module",
   "module": "vaadin-text-field.js",
   "files": [
     "src",

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-themable-mixin/issues"
   },
   "main": "vaadin-themable-mixin.js",
-  "type": "module",
   "module": "vaadin-themable-mixin.js",
+  "type": "module",
   "files": [
     "*.d.ts",
     "register-styles.js",

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-themable-mixin/issues"
   },
   "main": "vaadin-themable-mixin.js",
+  "type": "module",
   "module": "vaadin-themable-mixin.js",
   "files": [
     "*.d.ts",

--- a/packages/vaadin-time-picker/package.json
+++ b/packages/vaadin-time-picker/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-time-picker/issues"
   },
   "main": "vaadin-time-picker.js",
-  "type": "module",
   "module": "vaadin-time-picker.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-time-picker/package.json
+++ b/packages/vaadin-time-picker/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-time-picker/issues"
   },
   "main": "vaadin-time-picker.js",
+  "type": "module",
   "module": "vaadin-time-picker.js",
   "files": [
     "src",

--- a/packages/vaadin-upload/package.json
+++ b/packages/vaadin-upload/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/vaadin-upload/issues"
   },
   "main": "vaadin-upload.js",
+  "type": "module",
   "module": "vaadin-upload.js",
   "files": [
     "src",

--- a/packages/vaadin-upload/package.json
+++ b/packages/vaadin-upload/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/vaadin-upload/issues"
   },
   "main": "vaadin-upload.js",
-  "type": "module",
   "module": "vaadin-upload.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-virtual-list/package.json
+++ b/packages/vaadin-virtual-list/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-virtual-list.js",
-  "type": "module",
   "module": "vaadin-virtual-list.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vaadin-virtual-list/package.json
+++ b/packages/vaadin-virtual-list/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-virtual-list.js",
+  "type": "module",
   "module": "vaadin-virtual-list.js",
   "files": [
     "src",

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-vertical-layout.js",
-  "type": "module",
   "module": "vaadin-vertical-layout.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-vertical-layout.js",
+  "type": "module",
   "module": "vaadin-vertical-layout.js",
   "files": [
     "src",

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-virtual-list.js",
-  "type": "module",
   "module": "vaadin-virtual-list.js",
+  "type": "module",
   "files": [
     "src",
     "theme",

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/vaadin/web-components/issues"
   },
   "main": "vaadin-virtual-list.js",
+  "type": "module",
   "module": "vaadin-virtual-list.js",
   "files": [
     "src",


### PR DESCRIPTION
## Description

The `type` property is commonly used by frontend tooling for detecting whether the entry point of a package is a CJS or ES module. If no property is specified, the entry point may be treated as a CJS module which is absolutely not correct in the case of Vaadin web components. To illustrate the problem, here is a warning that Vite shows when you import a Vaadin web component:

> @vaadin/vaadin-time-picker doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix. 

This PR explicitly sets the `type` property to `module` to avoid such confusion.

Related to https://github.com/vaadin/flow/issues/12574

## Type of change

- [x] Internal
