### PR TITLE
fix: disable new buttons in readonly radio group

### DIFF
--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -295,7 +295,7 @@ class RadioGroup extends FieldMixin(
     radioButton.name = this._fieldName;
     radioButton.addEventListener('checked-changed', this.__onRadioButtonCheckedChange);
 
-    if (this.disabled) {
+    if (this.disabled || this.readonly) {
       radioButton.disabled = true;
     }
 

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -159,6 +159,31 @@ describe('radio-group', () => {
       group.readonly = true;
       expect(group.hasAttribute('readonly')).to.be.true;
     });
+
+    it('should disable a new button when added to a readonly group', async () => {
+      group.readonly = true;
+
+      const newRadioButton = document.createElement('vaadin-radio-button');
+      newRadioButton.label = 'Button 3';
+      newRadioButton.value = '3';
+      group.appendChild(newRadioButton);
+      await nextFrame();
+
+      expect(newRadioButton.disabled).to.be.true;
+    });
+
+    it('should not disable a checked button when added to a readonly group', async () => {
+      group.readonly = true;
+
+      const newRadioButton = document.createElement('vaadin-radio-button');
+      newRadioButton.label = 'Button 3';
+      newRadioButton.value = '3';
+      newRadioButton.checked = true;
+      group.appendChild(newRadioButton);
+      await nextFrame();
+
+      expect(newRadioButton.disabled).to.be.false;
+    });
   });
 
   describe('label property', () => {


### PR DESCRIPTION
FIxes an issue where a new `<vaadin-radio-button>` would not get marked `disabled` when added to a `readonly` `<vaadin-radio-group readonly>`:

![Screenshot 2022-01-17 at 15 43 48](https://user-images.githubusercontent.com/1222264/149779768-c2e2ac90-e44c-451a-8b62-2360dfa887a2.png)

