### PR TITLE
fix: consider a value matching selected item label a known value

### DIFF
--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -241,6 +241,36 @@ describe('Properties', () => {
         input.blur();
         expect(spy.called).to.be.false;
       });
+
+      it('should not fire when the custom value equals the label of the selected item', () => {
+        const spy = sinon.spy();
+        comboBox.addEventListener('custom-value-set', spy);
+        comboBox.selectedItem = {
+          label: 'foo',
+          value: 'bar'
+        };
+
+        comboBox.open();
+        input.value = 'foo';
+        comboBox.close();
+
+        expect(spy.called).to.be.false;
+      });
+
+      it('should fire when the custom value equals the value of the selected item', () => {
+        const spy = sinon.spy();
+        comboBox.addEventListener('custom-value-set', spy);
+        comboBox.selectedItem = {
+          label: 'foo',
+          value: 'bar'
+        };
+
+        comboBox.open();
+        input.value = 'bar';
+        comboBox.close();
+
+        expect(spy.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/packages/combo-box/test/scrolling.test.js
+++ b/packages/combo-box/test/scrolling.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, focusout, isIOS } from '@vaadin/testing-helpers';
+import { fixtureSync, focusout, isIOS, nextFrame } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 import { getSelectedItem, onceScrolled } from './helpers.js';
@@ -95,13 +95,13 @@ describe('scrolling', () => {
 
     it('should make selected item visible after reopen', async () => {
       comboBox.open();
-      await aTimeout(0);
+      await nextFrame();
 
       comboBox.value = comboBox.items[50];
       comboBox.close();
 
       comboBox.open();
-      await aTimeout(0);
+      await nextFrame();
 
       expectSelectedItemPositionToBeVisible();
     });


### PR DESCRIPTION
Part of https://github.com/vaadin/flow-components/issues/2524

This change fixes the main issue in https://github.com/vaadin/flow-components/issues/2524:
The "custom-item-set" event was dispatched even when the value matched the label of `comboBox.selectedItem`.

There's still another issue related to https://github.com/vaadin/flow-components/issues/2524 (the dropdown doesn't populate on the first open after setting new items) but it will be fixed separately.