### PR TITLE
test: add CSS to hide caret when focused

### DIFF
--- a/packages/date-time-picker/test/visual/common.js
+++ b/packages/date-time-picker/test/visual/common.js
@@ -1,0 +1,11 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/* hide caret */
+registerStyles(
+  'vaadin-date-picker',
+  css`
+    :host([focused]) ::slotted(input) {
+      caret-color: transparent;
+    }
+  `
+);

--- a/packages/date-time-picker/test/visual/lumo/date-time-picker.test.js
+++ b/packages/date-time-picker/test/visual/lumo/date-time-picker.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/lumo/vaadin-date-time-picker.js';
+import '../common.js';
 
 describe('date-time-picker', () => {
   let div, element;

--- a/packages/date-time-picker/test/visual/material/date-time-picker.test.js
+++ b/packages/date-time-picker/test/visual/material/date-time-picker.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/material/vaadin-date-time-picker.js';
+import '../common.js';
 
 describe('date-time-picker', () => {
   let div, element;


### PR DESCRIPTION
## Description

Follow-up from #3310. This is needed to make visual test reliable (it failed when cherry-picking).
The same commit is already applied to the cherry-pick PR manually.

## Type of change

- Tests