### PR TITLE
fix: disable autocomplete for date-picker

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -582,6 +582,7 @@ export const DatePickerMixin = (subclass) =>
     _inputElementChanged(input) {
       super._inputElementChanged(input);
       if (input) {
+        input.autocomplete = 'off';
         input.setAttribute('role', 'combobox');
         input.setAttribute('aria-expanded', !!this.opened);
         this._applyInputValue(this._selectedDate);

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -18,6 +18,14 @@ describe('WAI-ARIA', () => {
       helper = datepicker.querySelector('[slot=helper]');
     });
 
+    it('should set role attribute on the native input', () => {
+      expect(input.getAttribute('role')).to.equal('combobox');
+    });
+
+    it('should disable browser autocomplete on the native input', () => {
+      expect(input.getAttribute('autocomplete')).to.equal('off');
+    });
+
     it('should set aria-labelledby attribute on the native input', () => {
       expect(input.getAttribute('aria-labelledby')).to.equal(label.id);
     });


### PR DESCRIPTION
## Description

Currently `autocomplete="off"` is set by combo-box and time-picker, but not by the date-picker. This PR fixes that.
 
Fixes https://github.com/vaadin/flow-components/issues/2510

## Type of change

- Bugfix