### PR TITLE
fix: set correct index when autoOpenDisabled

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -946,10 +946,14 @@ export const ComboBoxMixin = (subclass) =>
       if (e.path === 'filteredItems' || e.path === 'filteredItems.splices') {
         this._setOverlayItems(this.filteredItems);
 
-        this._focusedIndex =
-          this.opened || this.autoOpenDisabled
-            ? this.$.dropdown.indexOfLabel(this.filter)
-            : this._indexOfValue(this.value, this.filteredItems);
+        const filterIndex = this.$.dropdown.indexOfLabel(this.filter);
+        if (this.opened) {
+          this._focusedIndex = filterIndex;
+        } else {
+          // Pre-select item matching the filter to focus it later when overlay opens
+          const valueIndex = this._indexOfValue(this.value, this.filteredItems);
+          this._focusedIndex = filterIndex === -1 ? valueIndex : filterIndex;
+        }
 
         // see https://github.com/vaadin/web-components/issues/2615
         if (this.selectedItem === null && this._focusedIndex >= 0) {

--- a/packages/combo-box/test/filtering.test.js
+++ b/packages/combo-box/test/filtering.test.js
@@ -416,7 +416,7 @@ describe('autoOpenDisabled', () => {
     comboBox.filteredItems = ['foo', 'bar', 'baz'];
   });
 
-  it.only('should set correct focused index when opened', () => {
+  it('should set correct focused index when opened', () => {
     comboBox.open();
 
     expect(comboBox._focusedIndex).to.eql(1);

--- a/packages/combo-box/test/filtering.test.js
+++ b/packages/combo-box/test/filtering.test.js
@@ -416,9 +416,10 @@ describe('autoOpenDisabled', () => {
     comboBox.filteredItems = ['foo', 'bar', 'baz'];
   });
 
-  it('should set correct focused index when opened', () => {
+  it('should focus the correct item when opened', () => {
     comboBox.open();
 
-    expect(comboBox._focusedIndex).to.eql(1);
+    const items = getAllItems(comboBox);
+    expect(items[1].hasAttribute('focused')).to.be.true;
   });
 });

--- a/packages/combo-box/test/filtering.test.js
+++ b/packages/combo-box/test/filtering.test.js
@@ -407,3 +407,18 @@ describe('value attribute', () => {
     expect(comboBox.value).to.equal('');
   });
 });
+
+describe('autoOpenDisabled', () => {
+  let comboBox;
+
+  beforeEach(() => {
+    comboBox = fixtureSync(`<vaadin-combo-box auto-open-disabled value="bar"></vaadin-combo-box>`);
+    comboBox.filteredItems = ['foo', 'bar', 'baz'];
+  });
+
+  it.only('should set correct focused index when opened', () => {
+    comboBox.open();
+
+    expect(comboBox._focusedIndex).to.eql(1);
+  });
+});

--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -91,3 +91,18 @@ describe('combo-box', () => {
     expect(comboBox.autoOpenDisabled).to.be.true;
   });
 });
+
+describe('autoOpenDisabled', () => {
+  let timePicker, comboBox;
+
+  beforeEach(() => {
+    timePicker = fixtureSync(`<vaadin-time-picker auto-open-disabled value="05:00"></vaadin-time-picker>`);
+    comboBox = timePicker.$.comboBox;
+  });
+
+  it('should set correct focused index when opened', () => {
+    comboBox.open();
+
+    expect(comboBox._focusedIndex).to.eql(5);
+  });
+});

--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -100,9 +100,10 @@ describe('autoOpenDisabled', () => {
     comboBox = timePicker.$.comboBox;
   });
 
-  it('should set correct focused index when opened', () => {
+  it('should focus the correct item when opened', () => {
     comboBox.open();
 
-    expect(comboBox._focusedIndex).to.eql(5);
+    const items = document.querySelectorAll('vaadin-time-picker-item');
+    expect(items[5].hasAttribute('focused')).to.be.true;
   });
 });


### PR DESCRIPTION
## Description

The original issue was found in `vaadin-time-picker` but the actual problem was in combo-box with `filteredItems`.
It was caused by the fact that `autoOpenDisabled` was treated the same as `opened` which isn't always correct.

Fixes #507

## Type of change

- Bugfix