### PR TITLE
fix: remove unnecessary [has-label] selectors

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -121,11 +121,11 @@ const inputField = css`
     --lumo-text-field-size: var(--lumo-size-s);
   }
 
-  :host([theme~='small'][has-label]) [part='label'] {
+  :host([theme~='small']) [part='label'] {
     font-size: var(--lumo-font-size-xs);
   }
 
-  :host([theme~='small'][has-label]) [part='error-message'] {
+  :host([theme~='small']) [part='error-message'] {
     font-size: var(--lumo-font-size-xxs);
   }
 


### PR DESCRIPTION
There’s no need to scope those styles to only apply when the field has a label. Also, scoping the error message styling to be based on the presence of the label is incorrect.

I traced this “bug” back to 4 years ago: https://github.com/vaadin/vaadin-text-field/commit/494cfbce406fe16b3c68e27892ec440fc338535f