### PR TITLE
fix: validate on input event when invalid

### DIFF
--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -121,6 +121,21 @@ export const InputFieldMixin = (superclass) =>
     }
 
     /**
+     * Override an event listener from `InputMixin`
+     * to mark as valid after user started typing.
+     * @param {Event} event
+     * @protected
+     * @override
+     */
+    _onInput(event) {
+      super._onInput(event);
+
+      if (this.invalid) {
+        this.validate();
+      }
+    }
+
+    /**
      * Override a method from `InputMixin` to validate the field
      * when a new value is set programmatically.
      * @param {string} value

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { InputController } from '../src/input-controller.js';
@@ -80,6 +81,16 @@ describe('input-field-mixin', () => {
       const spy = sinon.spy(element, 'validate');
       input.dispatchEvent(new Event('blur'));
       expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate on input event', async () => {
+      const spy = sinon.spy(element, 'validate');
+      element.required = true;
+      element.invalid = true;
+      input.focus();
+      await sendKeys({ type: 'f' });
+      expect(spy.calledOnce).to.be.true;
+      expect(element.invalid).to.be.false;
     });
 
     it('should validate on value change when field is invalid', () => {


### PR DESCRIPTION
## Description

The original issue is a regression introduced while adding slotted input support https://github.com/vaadin/vaadin-text-field/pull/283/commits/c56eff7d3fa8f8770573e07048e08bb345bbc458

In particular, [this block](https://github.com/vaadin/vaadin-text-field/pull/283/commits/c56eff7d3fa8f8770573e07048e08bb345bbc458#diff-4291a0d535966bc93fefcb9582856c416ff3d7924442b8b6e56e6d73bb450b6eR353-R360) added `return` for user input inside the observer so the `validate()` call could not be reached.
The logic has been changed, so overriding the `_onInput` listener seems like a correct place for this.

Fixes #2729

## Type of change

- Bugfix