### PR TITLE
fix: only accept a focusable child element as a focus target

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -531,7 +531,11 @@ export const KeyboardNavigationMixin = (superClass) =>
 
       if (this.interacting !== wantInteracting && cell !== null) {
         if (wantInteracting) {
-          const focusTarget = cell._content.querySelector('[focus-target]') || cell._content.firstElementChild;
+          const focusTarget =
+            cell._content.querySelector('[focus-target]') ||
+            // If a child element hasn't been explicitly marked as a focus target,
+            // fall back to any focusable element inside the cell.
+            [...cell._content.querySelectorAll('*')].find((node) => this._isFocusable(node));
           if (focusTarget) {
             e.preventDefault();
             focusTarget.focus();

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -348,6 +348,17 @@ describe('keyboard navigation', () => {
 
       expect(grid.hasAttribute('navigating')).to.be.true;
     });
+
+    it('should not leave navigation mode on enter in a cell with only non-focusable elements', async () => {
+      // Focus a cell with only non-focusable elements
+      focusItem(0);
+      await sendKeys({ press: 'ArrowRight' });
+      await sendKeys({ press: 'ArrowRight' });
+      // Press Enter
+      await sendKeys({ press: 'Enter' });
+      // Since the element (span) in the cell isn't focusable, the grid should stay in navigation mode
+      expect(grid.hasAttribute('navigating')).to.be.true;
+    });
   });
 
   describe('navigating with tab', () => {


### PR DESCRIPTION
Fixes #3216 