### PR TITLE
fix: decrease link selectors specificity using `:where()`

### DIFF
--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -174,9 +174,10 @@ const color = css`
     color: var(--lumo-header-text-color);
   }
 
-  a:any-link {
+  a:where(:any-link) {
     color: var(--lumo-primary-text-color);
   }
+
   a:not(:any-link) {
     color: var(--lumo-disabled-text-color);
   }

--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -103,7 +103,7 @@ const typography = css`
     text-decoration: none;
   }
 
-  a:any-link:hover {
+  a:where(:any-link):hover {
     text-decoration: underline;
   }
 


### PR DESCRIPTION
## Description

It turns out the selector `a:any-link` has higher specificity than `.link` which causes users styles to break.
We can fix this by using `a:where(:any-link)`: https://codepen.io/webpadawan/pen/OJOLgdp

See also https://css-tricks.com/using-the-specificity-of-where-as-a-css-reset/

Closes https://github.com/vaadin/start/issues/1730

## Type of change

- Bugfix