### PR TITLE
fix: align footer border-radius with overlay container

### DIFF
--- a/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
+++ b/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
@@ -23,6 +23,8 @@ registerStyles(
       margin-top: var(--lumo-space-l);
       padding: 0 var(--lumo-space-l);
       background-color: var(--lumo-contrast-5pct);
+      border-bottom-left-radius: var(--lumo-border-radius-l);
+      border-bottom-right-radius: var(--lumo-border-radius-l);
     }
 
     [part='footer'] > * {


### PR DESCRIPTION
Use the same border radius on the footer as in the overlay container. Currently the footer corners are slightly overflowing

<img width="309" alt="Screen Shot 2022-01-31 at 13 06 03" src="https://user-images.githubusercontent.com/66382/151783102-6d9771c2-1e37-4704-b544-551578f268a5.png">
.