### PR TITLE
test: rewrite date-picker keyboard tests to use sendKeys

### DIFF
--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -109,3 +109,30 @@ export function getOverlayContent(datepicker) {
   overlayContent.$.yearScroller.bufferSize = 0;
   return overlayContent;
 }
+
+export function getFocusedMonth(overlayContent) {
+  const months = Array.from(overlayContent.shadowRoot.querySelectorAll('vaadin-month-calendar'));
+  return months.find((month) => {
+    const focused = month.shadowRoot.querySelector('[part="date"][focused]');
+    return !!focused;
+  });
+}
+
+export function getFocusedCell(datepicker) {
+  const overlayContent = getOverlayContent(datepicker);
+
+  const months = Array.from(overlayContent.shadowRoot.querySelectorAll('vaadin-month-calendar'));
+
+  // Date that is currently focused
+  let focusedCell;
+
+  for (let i = 0; i < months.length; i++) {
+    focusedCell = months[i].shadowRoot.querySelector('[part="date"][focused]');
+
+    if (focusedCell) {
+      break;
+    }
+  }
+
+  return focusedCell;
+}

--- a/packages/date-picker/test/keyboard-input-old.test.js
+++ b/packages/date-picker/test/keyboard-input-old.test.js
@@ -1,0 +1,268 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  arrowDown,
+  arrowLeft,
+  arrowRight,
+  arrowUp,
+  aTimeout,
+  enter,
+  fixtureSync,
+  isIOS,
+  keyDownOn,
+  listenOnce,
+  tab,
+  tap
+} from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-date-picker.js';
+import { close, getOverlayContent, open } from './common.js';
+
+(isIOS ? describe.skip : describe)('keyboard input', () => {
+  let target;
+  let datepicker;
+
+  function inputChar(char) {
+    target.value += char;
+    keyDownOn(target, char.charCodeAt(0));
+    target.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
+  }
+
+  function inputText(text) {
+    for (var i = 0; i < text.length; i++) {
+      inputChar(text[i]);
+    }
+  }
+
+  function closeWithEnter() {
+    return new Promise((resolve) => {
+      listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', resolve);
+      enter(target);
+    });
+  }
+
+  function focusedDate() {
+    return getOverlayContent(datepicker).focusedDate;
+  }
+
+  beforeEach(() => {
+    datepicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
+    target = datepicker.inputElement;
+  });
+
+  it('should not focus with invalid date', () => {
+    inputChar('j');
+    expect(focusedDate()).not.to.be.ok;
+  });
+
+  it('should display focused date while overlay focused', () => {
+    inputText('1/2/2000');
+    arrowDown(target);
+    expect(target.value).not.to.equal('1/2/2000');
+  });
+
+  it('should not forward keys after close', async () => {
+    inputText('1/2/2000');
+    arrowDown(target);
+    await closeWithEnter();
+    const focused = focusedDate();
+    arrowRight(target);
+    expect(focusedDate()).to.eql(focused);
+  });
+
+  it('should not forward keys after reopen', (done) => {
+    inputText('1/2/2000');
+    arrowDown(target);
+
+    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
+      const focused = focusedDate();
+      arrowRight(target);
+      expect(focusedDate()).to.eql(focused);
+      done();
+    });
+
+    listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', () => {
+      inputText('0');
+    });
+    enter(target);
+  });
+
+  it('should not forward after user changes input', (done) => {
+    inputText('1/2/2000');
+    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
+      arrowDown(target);
+      // Forwarding keys to overlay
+      target.value = '';
+      inputText('foo');
+      // Keys shouldn't get forwarded anymore
+      const focused = focusedDate();
+      arrowRight(target);
+      expect(focusedDate()).to.eql(focused);
+      done();
+    });
+  });
+
+  it('should not forward after input tap', async () => {
+    await open(datepicker);
+    arrowDown(target);
+    const focused = focusedDate();
+    target.dispatchEvent(new CustomEvent('tap', { bubbles: true, composed: true }));
+    arrowLeft(target);
+    expect(focusedDate()).to.eql(focused);
+  });
+
+  it('should reflect focused date to input', (done) => {
+    datepicker.value = '2000-01-01';
+
+    arrowDown(target);
+    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
+      arrowDown(target);
+      expect(datepicker._inputValue).to.equal('1/8/2000');
+      done();
+    });
+  });
+
+  it('should not reflect focused date on open', (done) => {
+    arrowDown(target);
+    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
+      expect(datepicker._inputValue).to.equal('');
+      done();
+    });
+  });
+
+  it('should stop key event bubbles from overlay', (done) => {
+    datepicker.value = '2000-01-01';
+
+    arrowDown(target);
+    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
+      arrowDown(target);
+      target = getOverlayContent(datepicker);
+      arrowDown(target);
+      expect(datepicker._inputValue).to.equal('1/15/2000');
+      done();
+    });
+  });
+
+  it('should clear selection on close', async () => {
+    await open(datepicker);
+    arrowDown(target);
+    await close(datepicker);
+    expect(target.selectionStart).to.equal(target.selectionEnd);
+  });
+
+  it('should not throw on enter before opening overlay', () => {
+    expect(() => {
+      datepicker.focus();
+      enter(target);
+    }).not.to.throw(Error);
+  });
+
+  describe('no parseDate', () => {
+    beforeEach(() => {
+      datepicker.i18n = {
+        ...datepicker.i18n,
+        parseDate: null
+      };
+    });
+
+    it('should prevent key input', () => {
+      const e = new CustomEvent('keydown', {
+        bubbles: true,
+        composed: true
+      });
+
+      const spy = sinon.spy(e, 'preventDefault');
+      datepicker._nativeInput.dispatchEvent(e);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should select focused date on close', async () => {
+      await open(datepicker);
+      await close(datepicker);
+      expect(datepicker._selectedDate).to.equal(datepicker._focusedDate);
+    });
+  });
+
+  it('should not forward up/down to overlay when closed', (done) => {
+    arrowUp(target);
+    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
+      expect(datepicker._focusedDate.getDate()).to.eql(new Date().getDate());
+      done();
+    });
+  });
+
+  it('should forward up/down to overlay', async () => {
+    await open(datepicker);
+    arrowUp(target);
+    expect(datepicker._focusedDate.getDate()).not.to.eql(new Date().getDate());
+  });
+
+  describe('focus modes', () => {
+    let overlayContent;
+
+    beforeEach(async () => {
+      overlayContent = getOverlayContent(datepicker);
+      // As a side effect, getOverlayContent opens and closes the dropdown.
+      // Since closing the dropdown focuses the input, we need to blur explicilty
+      // to reset the state.
+      datepicker.blur();
+    });
+
+    it('should be tabbable', () => {
+      expect(parseInt(overlayContent.getAttribute('tabindex'), 10)).to.equal(0);
+      expect(datepicker.hasAttribute('focused')).to.be.false;
+    });
+
+    it('should focus cancel on input shift tab', async () => {
+      await open(datepicker);
+      datepicker.inputElement.focus();
+      tab(datepicker.inputElement, ['shift']);
+      expect(overlayContent.$.cancelButton.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should focus input in cancel tab', async () => {
+      await open(datepicker);
+      overlayContent.$.cancelButton.focus();
+
+      const spy = sinon.spy(datepicker, '_focus');
+      tab(overlayContent.$.cancelButton);
+      await aTimeout(1);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should not reveal the focused date on tap', async () => {
+      await open(datepicker);
+      const spy = sinon.spy(overlayContent, 'revealDate');
+      tap(overlayContent);
+      overlayContent.focus();
+      await aTimeout(1);
+      expect(spy.called).to.be.false;
+    });
+
+    it('should reveal the focused date on tab focus from input', async () => {
+      await open(datepicker);
+      const spy = sinon.spy(overlayContent, 'revealDate');
+      tab(datepicker.inputElement);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should reveal the focused date on shift-tab focus from today button', async () => {
+      await open(datepicker);
+      const spy = sinon.spy(overlayContent, 'revealDate');
+      tab(overlayContent.$.todayButton, ['shift']);
+      overlayContent.focus();
+      await aTimeout(1);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should not focus overlay on key-input', (done) => {
+      const spy = sinon.spy(datepicker.$.overlay, 'focus');
+
+      listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
+        expect(spy.called).to.be.false;
+        done();
+      });
+
+      inputText('1');
+    });
+  });
+});

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -1,48 +1,14 @@
 import { expect } from '@esm-bundle/chai';
-import {
-  arrowDown,
-  arrowLeft,
-  arrowRight,
-  arrowUp,
-  aTimeout,
-  click,
-  enter,
-  esc,
-  fixtureSync,
-  isIOS,
-  keyDownOn,
-  listenOnce,
-  nextRender,
-  tab,
-  tap
-} from '@vaadin/testing-helpers';
+import { fixtureSync, listenOnce, nextRender, tap } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../src/vaadin-date-picker.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-import { close, getOverlayContent, open } from './common.js';
+import './not-animated-styles.js';
+import '../vaadin-date-picker.js';
+import { close, getFocusedCell, getOverlayContent, open } from './common.js';
 
-(isIOS ? describe.skip : describe)('keyboard input', () => {
-  let target;
+describe('keyboard', () => {
   let datepicker;
-
-  function inputChar(char) {
-    target.value += char;
-    keyDownOn(target, char.charCodeAt(0));
-    target.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
-  }
-
-  function inputText(text) {
-    for (var i = 0; i < text.length; i++) {
-      inputChar(text[i]);
-    }
-  }
-
-  function closeWithEnter() {
-    return new Promise((resolve) => {
-      listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', resolve);
-      enter(target);
-    });
-  }
+  let input;
 
   function focusedDate() {
     return getOverlayContent(datepicker).focusedDate;
@@ -50,309 +16,270 @@ import { close, getOverlayContent, open } from './common.js';
 
   beforeEach(() => {
     datepicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
-    target = datepicker.inputElement;
+    input = datepicker.inputElement;
+    input.focus();
   });
 
-  it('should open overlay on input', () => {
-    inputChar('j');
-    expect(datepicker.opened).to.be.true;
-  });
+  describe('focused date', () => {
+    it('should focus parsed date', async () => {
+      await sendKeys({ type: '1/20/2000' });
 
-  it('should not focus with invalid date', () => {
-    inputChar('j');
-    expect(focusedDate()).not.to.be.ok;
-  });
+      expect(focusedDate().getMonth()).to.equal(0);
+      expect(focusedDate().getDate()).to.equal(20);
+    });
 
-  it('should focus parsed date', () => {
-    inputText('1/20/2000');
+    it('should change focused date on user input', async () => {
+      datepicker.value = '2000-01-01';
 
-    expect(focusedDate().getMonth()).to.equal(0);
-    expect(focusedDate().getDate()).to.equal(20);
-  });
-
-  it('should change focused date on input when closed', (done) => {
-    datepicker.value = '2000-01-01';
-
-    datepicker._inputValue = '1/30/2000';
-    target.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
-
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
+      input.select();
+      await sendKeys({ type: '1/30/2000' });
       expect(focusedDate().getDate()).to.equal(30);
-      done();
+    });
+
+    it('should update focus on input value change', async () => {
+      await sendKeys({ type: '1/20/20' });
+      await sendKeys({ type: '17' });
+
+      expect(focusedDate().getMonth()).to.equal(0);
+      expect(focusedDate().getFullYear()).to.equal(2017);
+    });
+
+    it('should select focused date on Enter', async () => {
+      await sendKeys({ type: '1/1/2001' });
+      await sendKeys({ press: 'Enter' });
+      expect(datepicker.value).to.equal('2001-01-01');
+    });
+
+    it('should update focused date on value change', () => {
+      datepicker.value = '2000-01-01';
+      expect(focusedDate().getMonth()).to.equal(0);
+      expect(focusedDate().getDate()).to.equal(1);
+      expect(focusedDate().getFullYear()).to.equal(2000);
     });
   });
 
-  it('should update focus on input change', () => {
-    inputText('1/20/20');
-    inputText('17');
-
-    expect(focusedDate().getMonth()).to.equal(0);
-    expect(focusedDate().getFullYear()).to.equal(2017);
-  });
-
-  it('should select focused date on enter', async () => {
-    inputText('1/1/2001');
-    await closeWithEnter();
-    expect(datepicker.value).to.equal('2001-01-01');
-  });
-
-  it('should not select a date on enter if input invalid', async () => {
-    await open(datepicker);
-    inputText('foo');
-    await closeWithEnter();
-    expect(datepicker.opened).to.be.false;
-    expect(datepicker.invalid).to.be.true;
-    expect(datepicker.value).to.equal('');
-    expect(target.value).to.equal('foo');
-  });
-
-  it('should display focused date while overlay focused', () => {
-    inputText('1/2/2000');
-    arrowDown(target);
-    expect(target.value).not.to.equal('1/2/2000');
-  });
-
-  it('should not forward keys after close', async () => {
-    inputText('1/2/2000');
-    arrowDown(target);
-    await closeWithEnter();
-    const focused = focusedDate();
-    arrowRight(target);
-    expect(focusedDate()).to.eql(focused);
-  });
-
-  it('should not open with wrong keys', () => {
-    arrowRight(target);
-    expect(datepicker.opened).not.to.be.ok;
-  });
-
-  it('should not forward keys after reopen', (done) => {
-    inputText('1/2/2000');
-    arrowDown(target);
-
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
-      const focused = focusedDate();
-      arrowRight(target);
-      expect(focusedDate()).to.eql(focused);
-      done();
-    });
-
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', () => {
-      inputText('0');
-    });
-    enter(target);
-  });
-
-  it('should not forward after user changes input', (done) => {
-    inputText('1/2/2000');
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
-      arrowDown(target);
-      // Forwarding keys to overlay
-      target.value = '';
-      inputText('foo');
-      // Keys shouldn't get forwarded anymore
-      const focused = focusedDate();
-      arrowRight(target);
-      expect(focusedDate()).to.eql(focused);
-      done();
-    });
-  });
-
-  it('should not forward after input tap', async () => {
-    await open(datepicker);
-    arrowDown(target);
-    const focused = focusedDate();
-    target.dispatchEvent(new CustomEvent('tap', { bubbles: true, composed: true }));
-    arrowLeft(target);
-    expect(focusedDate()).to.eql(focused);
-  });
-
-  it('should reflect focused date to input', (done) => {
-    datepicker.value = '2000-01-01';
-
-    arrowDown(target);
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
-      arrowDown(target);
-      expect(datepicker._inputValue).to.equal('1/8/2000');
-      done();
-    });
-  });
-
-  it('should not reflect focused date on open', (done) => {
-    arrowDown(target);
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
-      expect(datepicker._inputValue).to.equal('');
-      done();
-    });
-  });
-
-  it('should stop key event bubbles from overlay', (done) => {
-    datepicker.value = '2000-01-01';
-
-    arrowDown(target);
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
-      arrowDown(target);
-      target = getOverlayContent(datepicker);
-      arrowDown(target);
-      expect(datepicker._inputValue).to.equal('1/15/2000');
-      done();
-    });
-  });
-
-  it('should update focused date on select', () => {
-    datepicker.value = '2000-01-01';
-    expect(focusedDate().getMonth()).to.equal(0);
-    expect(focusedDate().getDate()).to.equal(1);
-    expect(focusedDate().getFullYear()).to.equal(2000);
-  });
-
-  it('should validate on close', async () => {
-    await open(datepicker);
-    const spy = sinon.spy(datepicker, 'validate');
-    await close(datepicker);
-    expect(spy.called).to.be.true;
-  });
-
-  it('should validate on blur when not opened', async () => {
-    inputText('foo');
-    await close(datepicker);
-    // wait for overlay to finish closing
-    await nextRender(datepicker);
-    target.value = '';
-    const spy = sinon.spy(datepicker, 'validate');
-    target.dispatchEvent(new Event('blur'));
-    expect(spy.callCount).to.equal(1);
-    expect(datepicker.invalid).to.be.false;
-  });
-
-  it('should validate on clear button', async () => {
-    datepicker.clearButtonVisible = true;
-    inputText('foo');
-    await close(datepicker);
-    // wait for overlay to finish closing. Without this, clear button click
-    // will trigger "close()" again, which will result in infinite loop.
-    await nextRender(datepicker);
-    const spy = sinon.spy(datepicker, 'validate');
-    click(datepicker.$.clearButton);
-    expect(spy.callCount).to.equal(1);
-    expect(datepicker.invalid).to.be.false;
-  });
-
-  it('should empty value with false input', async () => {
-    datepicker.value = '2000-01-01';
-    target.value = '';
-    inputText('foo');
-    await close(datepicker);
-    expect(datepicker.value).to.equal('');
-  });
-
-  it('should be invalid with false input', async () => {
-    datepicker.value = '2000-01-01';
-    target.value = '';
-    inputText('foo');
-    await close(datepicker);
-    expect(datepicker.invalid).to.be.true;
-  });
-
-  it('should clear selection on close', async () => {
-    await open(datepicker);
-    arrowDown(target);
-    await close(datepicker);
-    expect(target.selectionStart).to.equal(target.selectionEnd);
-  });
-
-  it('should not throw on enter before opening overlay', () => {
-    expect(() => {
-      datepicker.focus();
-      enter(target);
-    }).not.to.throw(Error);
-  });
-
-  describe('no parseDate', () => {
-    beforeEach(() => {
-      datepicker.i18n = {
-        ...datepicker.i18n,
-        parseDate: null
-      };
-    });
-
-    it('should prevent key input', () => {
-      const e = new CustomEvent('keydown', {
-        bubbles: true,
-        composed: true
-      });
-
-      const spy = sinon.spy(e, 'preventDefault');
-      datepicker._nativeInput.dispatchEvent(e);
+  describe('invalid date', () => {
+    it('should validate on close', async () => {
+      await open(datepicker);
+      const spy = sinon.spy(datepicker, 'validate');
+      await close(datepicker);
       expect(spy.called).to.be.true;
     });
 
-    it('should select focused date on close', async () => {
+    it('should not select date on Enter if input invalid', async () => {
       await open(datepicker);
+      await sendKeys({ type: 'foo' });
+      await sendKeys({ press: 'Enter' });
+      expect(datepicker.invalid).to.be.true;
+      expect(datepicker.value).to.equal('');
+      expect(input.value).to.equal('foo');
+    });
+
+    it('should validate on blur when not opened', async () => {
+      await sendKeys({ type: 'foo' });
       await close(datepicker);
-      expect(datepicker._selectedDate).to.equal(datepicker._focusedDate);
+      // Wait for overlay to finish closing
+      await nextRender(datepicker);
+      expect(datepicker.invalid).to.be.true;
+
+      // Clear the invalid input
+      input.select();
+      await sendKeys({ press: 'Backspace' });
+      const spy = sinon.spy(datepicker, 'validate');
+      await sendKeys({ press: 'Tab' });
+      expect(spy.callCount).to.equal(1);
+      expect(datepicker.invalid).to.be.false;
+    });
+
+    it('should validate on clear button', async () => {
+      datepicker.clearButtonVisible = true;
+      await sendKeys({ type: 'foo' });
+      await close(datepicker);
+      // wait for overlay to finish closing. Without this, clear button click
+      // will trigger "close()" again, which will result in infinite loop.
+      await nextRender(datepicker);
+      const spy = sinon.spy(datepicker, 'validate');
+      datepicker.$.clearButton.click();
+      expect(spy.callCount).to.equal(1);
+      expect(datepicker.invalid).to.be.false;
+    });
+
+    it('should empty value with invalid input', async () => {
+      datepicker.value = '2000-01-01';
+      input.select();
+      await sendKeys({ type: 'foo' });
+      await close(datepicker);
+      expect(datepicker.value).to.equal('');
+    });
+
+    it('should be invalid with false input', async () => {
+      datepicker.value = '2000-01-01';
+      input.select();
+      await sendKeys({ type: 'foo' });
+      await close(datepicker);
+      expect(datepicker.invalid).to.be.true;
     });
   });
 
-  it('should not forward up/down to overlay when closed', (done) => {
-    arrowUp(target);
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
-      expect(datepicker._focusedDate.getDate()).to.eql(new Date().getDate());
-      done();
+  describe('open overlay', () => {
+    it('should open the overlay on input', async () => {
+      await sendKeys({ type: 'j' });
+      expect(datepicker.opened).to.be.true;
+    });
+
+    it('should open the overlay on Arrow Down', async () => {
+      await sendKeys({ press: 'ArrowDown' });
+      expect(datepicker.opened).to.be.true;
+    });
+
+    it('should open the overlay on Arrow Up', async () => {
+      await sendKeys({ press: 'ArrowUp' });
+      expect(datepicker.opened).to.be.true;
+    });
+
+    it('should open on Arrow Down if autoOpenDisabled is true', async () => {
+      datepicker.autoOpenDisabled = true;
+      await sendKeys({ press: 'ArrowDown' });
+      expect(datepicker.opened).to.be.true;
+    });
+
+    it('should open on Arrow Up if autoOpenDisabled is true', async () => {
+      datepicker.autoOpenDisabled = true;
+      await sendKeys({ press: 'ArrowUp' });
+      expect(datepicker.opened).to.be.true;
+    });
+
+    it('should not open the overlay on Arrow Right', async () => {
+      await sendKeys({ press: 'ArrowRight' });
+      expect(datepicker.opened).to.be.not.ok;
+    });
+
+    it('should not open the overlay on Arrow Left', async () => {
+      await sendKeys({ press: 'ArrowLeft' });
+      expect(datepicker.opened).to.be.not.ok;
+    });
+
+    it('should not open the overlay on Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expect(datepicker.opened).to.be.not.ok;
     });
   });
 
-  it('should forward up/down to overlay', async () => {
-    await open(datepicker);
-    arrowUp(target);
-    expect(datepicker._focusedDate.getDate()).not.to.eql(new Date().getDate());
-  });
+  describe('overlay opened', () => {
+    let overlayContent;
 
-  describe('esc behavior', () => {
-    it('should close the overlay on esc', async () => {
+    beforeEach(async () => {
+      // Open the overlay
       await open(datepicker);
-      esc(target);
-      await aTimeout(1);
-      expect(datepicker.opened).to.be.false;
+      await nextRender(datepicker);
+      overlayContent = getOverlayContent(datepicker);
     });
 
+    it('should keep focused attribute when the focus moves to the overlay', async () => {
+      // Move focus to the calendar
+      await sendKeys({ press: 'Tab' });
+      await nextRender(datepicker);
+      expect(datepicker.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should move focus back to the input on Cancel button tap', async () => {
+      // Move focus to the calendar
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender(datepicker);
+      const spy = sinon.spy(input, 'focus');
+      tap(overlayContent.$.cancelButton);
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should move focus back to the input on Today button tap', async () => {
+      // Move focus to the calendar
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender(datepicker);
+      const spy = sinon.spy(input, 'focus');
+      tap(overlayContent.$.todayButton);
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should move focus back to the input on calendar date tap', async () => {
+      // Move focus to the calendar
+      await sendKeys({ press: 'Tab' });
+      const cell = getFocusedCell(datepicker);
+      const spy = sinon.spy(input, 'focus');
+      tap(cell);
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('Escape key', () => {
     describe('empty', () => {
       beforeEach(async () => {
-        datepicker.value = '';
+        // Open the overlay
         await open(datepicker);
+        await nextRender(datepicker);
       });
 
-      it('should revert input value on esc when empty', () => {
-        inputText('1/2/2000');
-        arrowDown(target);
-        arrowDown(target);
-        esc(target);
-        expect(target.value).to.equal('');
-      });
-
-      it('should cancel on overlay content esc', () => {
-        inputText('1/2/2000 ');
-        arrowDown(target);
-        arrowDown(target);
-        const overlayContent = datepicker.$.overlay.content.querySelector('vaadin-date-picker-overlay-content').$
-          .monthScroller;
-        target = overlayContent;
-        esc(target);
+      it('should close the overlay when input is focused', async () => {
+        await sendKeys({ press: 'Escape' });
         expect(datepicker.opened).to.be.false;
-        expect(datepicker.value).not.to.be.ok;
       });
 
-      it('should not change value on esc when empty', (done) => {
-        inputText('1/2/2000');
-        arrowDown(target);
-        arrowDown(target);
+      it('should close the overlay when calendar has focus', async () => {
+        // Move focus to the calendar
+        await sendKeys({ press: 'ArrowDown' });
+        await nextRender(datepicker);
 
-        listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', () => {
-          expect(datepicker.value).to.equal('');
-          done();
-        });
+        await sendKeys({ press: 'Escape' });
+        expect(datepicker.opened).to.be.false;
+      });
 
-        esc(target);
+      it('should move focus from the calendar back to input', async () => {
+        // Move focus to the calendar
+        await sendKeys({ press: 'ArrowDown' });
+        await nextRender(datepicker);
+        expect(document.activeElement).to.not.equal(input);
+
+        await sendKeys({ press: 'Escape' });
+        expect(document.activeElement).to.equal(input);
+      });
+
+      it('should revert input value on input Esc when empty', async () => {
+        await sendKeys({ type: '1/2/2000' });
+        await nextRender(datepicker);
+
+        await sendKeys({ press: 'Escape' });
+        expect(input.value).to.equal('');
+      });
+
+      it('should not change value on input Esc when empty', async () => {
+        await sendKeys({ type: '1/2/2000' });
+        await nextRender(datepicker);
+
+        await sendKeys({ press: 'Escape' });
+        expect(datepicker.value).to.equal('');
+      });
+
+      it('should revert input value on calendar Esc when empty', async () => {
+        await sendKeys({ type: '1/2/2000' });
+
+        // Move focus to the calendar
+        await sendKeys({ press: 'ArrowDown' });
+        await nextRender(datepicker);
+
+        await sendKeys({ press: 'Escape' });
+
+        expect(input.value).to.equal('');
+      });
+
+      it('should not change value on calendar Esc when empty', async () => {
+        await sendKeys({ type: '1/2/2000' });
+
+        // Move focus to the calendar
+        await sendKeys({ press: 'ArrowDown' });
+        await nextRender(datepicker);
+
+        await sendKeys({ press: 'Escape' });
+
+        expect(datepicker.value).to.equal('');
       });
     });
 
@@ -360,27 +287,47 @@ import { close, getOverlayContent, open } from './common.js';
       beforeEach(async () => {
         datepicker.value = '2000-01-01';
         await open(datepicker);
+        await nextRender(datepicker);
+        input.select();
       });
 
-      it('should revert input value on esc', () => {
-        inputText('1/2/2000');
-        arrowDown(target);
-        arrowDown(target);
-        esc(target);
-        expect(target.value).to.equal('1/1/2000');
+      it('should revert input value on input Esc when value is set', async () => {
+        // Replace input with a new one
+        await sendKeys({ type: '1/2/2000' });
+        await sendKeys({ press: 'Escape' });
+        expect(input.value).to.equal('1/1/2000');
       });
 
-      it('should not change value on esc', (done) => {
-        inputText('1/2/2000');
-        arrowDown(target);
-        arrowDown(target);
+      it('should not change value on input Esc when value is set', async () => {
+        // Replace input with a new one
+        await sendKeys({ type: '1/2/2000' });
 
-        listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', () => {
-          expect(datepicker.value).to.equal('2000-01-01');
-          done();
-        });
+        await sendKeys({ press: 'Escape' });
+        expect(datepicker.value).to.equal('2000-01-01');
+      });
 
-        esc(target);
+      it('should revert input value on calendar Esc when value is set', async () => {
+        // Replace input with a new one
+        await sendKeys({ type: '1/2/2000' });
+
+        // Move focus to the calendar
+        await sendKeys({ press: 'ArrowDown' });
+        await nextRender(datepicker);
+
+        await sendKeys({ press: 'Escape' });
+        expect(input.value).to.equal('1/1/2000');
+      });
+
+      it('should not change value on calendar Esc when value is set', async () => {
+        // Replace input with a new one
+        await sendKeys({ type: '1/2/2000' });
+
+        // Move focus to the calendar
+        await sendKeys({ press: 'ArrowDown' });
+        await nextRender(datepicker);
+
+        await sendKeys({ press: 'Escape' });
+        expect(datepicker.value).to.equal('2000-01-01');
       });
     });
   });
@@ -388,164 +335,66 @@ import { close, getOverlayContent, open } from './common.js';
   describe('default parser', () => {
     const today = new Date();
 
-    it('should parse a single digit', () => {
-      inputText('20');
+    it('should parse a single digit', async () => {
+      await sendKeys({ type: '20' });
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(today.getFullYear());
       expect(result.getMonth()).to.equal(today.getMonth());
       expect(result.getDate()).to.equal(20);
     });
 
-    it('should parse two digits', () => {
-      inputText('6/20');
+    it('should parse two digits', async () => {
+      await sendKeys({ type: '6/20' });
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(today.getFullYear());
       expect(result.getMonth()).to.equal(5);
       expect(result.getDate()).to.equal(20);
     });
 
-    it('should parse three digits', () => {
-      inputText('6/20/1999');
+    it('should parse three digits', async () => {
+      await sendKeys({ type: '6/20/1999' });
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(1999);
       expect(result.getMonth()).to.equal(5);
       expect(result.getDate()).to.equal(20);
     });
 
-    it('should parse three digits with small year', () => {
-      inputText('6/20/0099');
+    it('should parse three digits with small year', async () => {
+      await sendKeys({ type: '6/20/0099' });
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(99);
     });
 
-    it('should parse three digits with short year', () => {
-      inputText('6/20/99');
+    it('should parse three digits with short year', async () => {
+      await sendKeys({ type: '6/20/99' });
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(1999);
     });
 
-    it('should parse three digits with short year 2', () => {
-      inputText('6/20/20');
+    it('should parse three digits with short year 2', async () => {
+      await sendKeys({ type: '6/20/20' });
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(2020);
     });
 
-    it('should parse three digits with short year 3', () => {
-      inputText('6/20/1');
+    it('should parse three digits with short year 3', async () => {
+      await sendKeys({ type: '6/20/1' });
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(2001);
     });
 
-    it('should parse three digits with negative year', () => {
-      inputText('6/20/-1');
+    it('should parse three digits with negative year', async () => {
+      await sendKeys({ type: '6/20/-1' });
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(-1);
     });
 
-    it('should parse in base 10', () => {
-      inputText('09/09/09');
+    it('should parse in base 10', async () => {
+      await sendKeys({ type: '09/09/09' });
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(2009);
       expect(result.getMonth()).to.equal(8);
       expect(result.getDate()).to.equal(9);
-    });
-  });
-
-  describe('focus modes', () => {
-    let overlayContent;
-
-    beforeEach(async () => {
-      overlayContent = getOverlayContent(datepicker);
-      // As a side effect, getOverlayContent opens and closes the dropdown.
-      // Since closing the dropdown focuses the input, we need to blur explicilty
-      // to reset the state.
-      datepicker.blur();
-    });
-
-    it('should be tabbable', () => {
-      expect(parseInt(overlayContent.getAttribute('tabindex'), 10)).to.equal(0);
-      expect(datepicker.hasAttribute('focused')).to.be.false;
-    });
-
-    it('should focus the input on esc', () => {
-      arrowDown(target);
-      esc(target);
-      expect(datepicker.hasAttribute('focused')).to.be.true;
-    });
-
-    it('should focus the input on date tap', () => {
-      arrowDown(target);
-      overlayContent.dispatchEvent(new CustomEvent('date-tap', { bubbles: true, composed: true }));
-      expect(datepicker.hasAttribute('focused')).to.be.true;
-    });
-
-    it('should focus the input on date cancel', () => {
-      arrowDown(target);
-      tap(overlayContent.$.cancelButton);
-      expect(datepicker.hasAttribute('focused')).to.be.true;
-    });
-
-    it('should focus cancel on input shift tab', async () => {
-      await open(datepicker);
-      datepicker.inputElement.focus();
-      tab(datepicker.inputElement, ['shift']);
-      expect(overlayContent.$.cancelButton.hasAttribute('focused')).to.be.true;
-    });
-
-    it('should focus input in cancel tab', async () => {
-      await open(datepicker);
-      overlayContent.$.cancelButton.focus();
-
-      const spy = sinon.spy(datepicker, '_focus');
-      tab(overlayContent.$.cancelButton);
-      await aTimeout(1);
-      expect(spy.called).to.be.true;
-    });
-
-    it('should keep focused attribute when the focus moves to the overlay', async () => {
-      await open(datepicker);
-      tap(overlayContent);
-      datepicker.focusElement.blur();
-      expect(datepicker.hasAttribute('focused')).to.be.false;
-
-      overlayContent.focus();
-      expect(datepicker.hasAttribute('focused')).to.be.true;
-    });
-
-    it('should not reveal the focused date on tap', async () => {
-      await open(datepicker);
-      const spy = sinon.spy(overlayContent, 'revealDate');
-      tap(overlayContent);
-      overlayContent.focus();
-      await aTimeout(1);
-      expect(spy.called).to.be.false;
-    });
-
-    it('should reveal the focused date on tab focus from input', async () => {
-      await open(datepicker);
-      const spy = sinon.spy(overlayContent, 'revealDate');
-      tab(datepicker.inputElement);
-      expect(spy.called).to.be.true;
-    });
-
-    it('should reveal the focused date on shift-tab focus from today button', async () => {
-      await open(datepicker);
-      const spy = sinon.spy(overlayContent, 'revealDate');
-      tab(overlayContent.$.todayButton, ['shift']);
-      overlayContent.focus();
-      await aTimeout(1);
-      expect(spy.called).to.be.true;
-    });
-
-    it('should not focus overlay on key-input', (done) => {
-      const spy = sinon.spy(datepicker.$.overlay, 'focus');
-
-      listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', () => {
-        expect(spy.called).to.be.false;
-        done();
-      });
-
-      inputText('1');
     });
   });
 
@@ -557,29 +406,48 @@ import { close, getOverlayContent, open } from './common.js';
       datepicker.addEventListener('change', spy);
     });
 
-    it('should fire change on user text input commit', () => {
-      inputText('1/2/2000');
-      enter(target);
+    it('should not fire change on focused date change', async () => {
+      await sendKeys({ type: '1/2/2000' });
+      expect(spy.called).to.be.false;
+    });
+
+    it('should fire change on user text input commit', async () => {
+      await sendKeys({ type: '1/2/2000' });
+      await sendKeys({ press: 'Enter' });
+      expect(spy.called).to.be.true;
+    });
+
+    it('should fire change on selecting date with Enter', async () => {
+      // Open the overlay
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender(datepicker);
+
+      // Move focus to the calendar
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender(datepicker);
+
+      await sendKeys({ press: 'Enter' });
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should fire change on user arrow input commit', () => {
-      arrowDown(target);
-      arrowDown(target);
-      enter(target);
+    it('should fire change on selecting date with Space', async () => {
+      // Open the overlay
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender(datepicker);
+
+      // Move focus to the calendar
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender(datepicker);
+
+      await sendKeys({ press: 'Space' });
       expect(spy.calledOnce).to.be.true;
     });
 
     it('should fire change clear button click', () => {
       datepicker.clearButtonVisible = true;
       datepicker.value = '2000-01-01';
-      click(datepicker.$.clearButton);
+      datepicker.$.clearButton.click();
       expect(spy.calledOnce).to.be.true;
-    });
-
-    it('should not fire change on focused date change', () => {
-      inputText('1/2/2000');
-      expect(spy.called).to.be.false;
     });
 
     it('should not fire change on programmatic value change', () => {
@@ -587,30 +455,30 @@ import { close, getOverlayContent, open } from './common.js';
       expect(spy.called).to.be.false;
     });
 
-    it('should not fire change on programmatic value change when opened', () => {
-      datepicker.open();
+    it('should not fire change on programmatic value change when opened', async () => {
+      await open(datepicker);
       datepicker.value = '2000-01-01';
-      datepicker.close();
+      await close(datepicker);
       expect(spy.called).to.be.false;
     });
 
-    it('should not fire change on programmatic value change when text input changed', () => {
-      inputText('1/2/2000');
+    it('should not fire change on programmatic value change when text input changed', async () => {
+      await sendKeys({ type: '1/2/2000' });
       datepicker.value = '2000-01-01';
-      datepicker.close();
+      await close(datepicker);
       expect(spy.called).to.be.false;
     });
 
-    it('should not fire change if the value was not changed', () => {
+    it('should not fire change if the value was not changed', async () => {
       datepicker.value = '2000-01-01';
-      datepicker.open();
-      enter(target);
+      await open(datepicker);
+      await sendKeys({ press: 'Enter' });
       expect(spy.called).to.be.false;
     });
 
-    it('should not fire change on revert', () => {
-      datepicker.value = '2000-01-01';
-      esc(target);
+    it('should not fire change when reverting input with Escape', async () => {
+      await sendKeys({ type: '1/2/2000' });
+      await sendKeys({ press: 'Escape' });
       expect(spy.called).to.be.false;
     });
   });
@@ -620,72 +488,72 @@ import { close, getOverlayContent, open } from './common.js';
       datepicker.autoOpenDisabled = true;
     });
 
-    it('should not open overlay on input', () => {
-      inputChar('j');
+    it('should not open overlay on input', async () => {
+      await sendKeys({ type: 'j' });
       expect(datepicker.opened).not.to.be.true;
     });
 
-    it('should set datepicker value on blur', () => {
-      inputText('1/1/2000');
-      target.dispatchEvent(new Event('blur'));
+    it('should set datepicker value on blur', async () => {
+      await sendKeys({ type: '1/1/2000' });
+      await sendKeys({ press: 'Tab' });
       expect(datepicker.value).to.equal('2000-01-01');
     });
 
-    it('should not be invalid on blur if valid date is entered', () => {
-      inputText('1/1/2000');
-      target.dispatchEvent(new Event('blur'));
+    it('should not be invalid on blur if valid date is entered', async () => {
+      await sendKeys({ type: '1/1/2000' });
+      await sendKeys({ press: 'Tab' });
       expect(datepicker.invalid).not.to.be.true;
     });
 
-    it('should validate on blur only once', () => {
-      inputText('foo');
+    it('should validate on blur only once', async () => {
+      await sendKeys({ type: 'foo' });
       const spy = sinon.spy(datepicker, 'validate');
-      target.dispatchEvent(new Event('blur'));
+      await sendKeys({ press: 'Tab' });
       expect(spy.callCount).to.equal(1);
       expect(datepicker.invalid).to.be.true;
     });
 
-    it('should revert input value on esc when overlay not initialized', () => {
-      inputText('1/1/2000');
-      esc(target);
-      expect(datepicker._inputValue).to.equal('');
+    it('should revert input value on Esc when overlay not initialized', async () => {
+      await sendKeys({ type: '1/1/2000' });
+      await sendKeys({ press: 'Escape' });
+      expect(input.value).to.equal('');
       expect(datepicker.value).to.equal('');
     });
 
-    it('should revert input value on esc when overlay has been initialized', () => {
-      datepicker.open();
-      datepicker.close();
-      inputText('1/1/2000');
-      esc(target);
+    it('should revert input value on Esc when overlay has been initialized', async () => {
+      await open(datepicker);
+      await close(datepicker);
+      await sendKeys({ type: '1/1/2000' });
+      await sendKeys({ press: 'Escape' });
       expect(datepicker.value).to.equal('');
     });
 
-    it('should not revert input value on esc after selected value is removed', () => {
-      datepicker.open();
-      inputText('1/1/2000');
-      datepicker.close();
-      target.value = '';
-      esc(target);
+    it('should not revert input value on esc after selected value is removed', async () => {
+      await open(datepicker);
+      await sendKeys({ type: '1/1/2000' });
+      await close(datepicker);
+      input.value = '';
+      await sendKeys({ press: 'Escape' });
       expect(datepicker.value).to.equal('');
     });
 
-    it('should apply the input value on enter when overlay not initialized', () => {
-      inputText('1/1/2000');
-      enter(target);
+    it('should apply the input value on enter when overlay not initialized', async () => {
+      await sendKeys({ type: '1/1/2000' });
+      await sendKeys({ press: 'Enter' });
       expect(datepicker.value).to.equal('2000-01-01');
     });
 
-    it('should apply input value on enter when overlay has been initialized', () => {
-      datepicker.open();
-      datepicker.close();
-      inputText('1/1/2000');
-      enter(target);
+    it('should apply input value on enter when overlay has been initialized', async () => {
+      await open(datepicker);
+      await close(datepicker);
+      await sendKeys({ type: '1/1/2000' });
+      await sendKeys({ press: 'Enter' });
       expect(datepicker.value).to.equal('2000-01-01');
     });
 
-    it('should be invalid on enter with false input', () => {
-      inputText('foo');
-      enter(target);
+    it('should be invalid on enter with false input', async () => {
+      await sendKeys({ type: 'foo' });
+      await sendKeys({ press: 'Enter' });
       expect(datepicker.value).to.equal('');
       expect(datepicker.invalid).to.be.true;
     });
@@ -704,26 +572,24 @@ import { close, getOverlayContent, open } from './common.js';
     describe('overlay is open and value selected', () => {
       beforeEach(async () => {
         await open(datepicker);
-        inputText('01/02/20');
+        await sendKeys({ type: '01/02/20' });
+        await nextRender(datepicker);
       });
 
-      it('should validate without change on Esc', (done) => {
-        listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', () => {
-          // wait for overlay to finish closing
-          afterNextRender(datepicker, () => {
-            expect(validateSpy.calledOnce).to.be.true;
-            expect(changeSpy.called).to.be.false;
-            done();
-          });
-        });
+      it('should validate without change on Esc', async () => {
+        await sendKeys({ press: 'Escape' });
 
-        esc(target);
+        // Wait for overlay to finish closing
+        await nextRender(datepicker);
+
+        expect(validateSpy.calledOnce).to.be.true;
+        expect(changeSpy.called).to.be.false;
       });
 
       it('should change after validate on overlay close', (done) => {
         listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', () => {
           // wait for overlay to finish closing
-          afterNextRender(datepicker, () => {
+          nextRender(datepicker).then(() => {
             expect(validateSpy.calledOnce).to.be.true;
             expect(changeSpy.calledOnce).to.be.true;
             expect(changeSpy.calledAfter(validateSpy)).to.be.true;
@@ -734,25 +600,22 @@ import { close, getOverlayContent, open } from './common.js';
         datepicker.close();
       });
 
-      it('should change after validate on Enter', (done) => {
-        listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', () => {
-          // wait for overlay to finish closing
-          afterNextRender(datepicker, () => {
-            expect(validateSpy.calledOnce).to.be.true;
-            expect(changeSpy.calledOnce).to.be.true;
-            expect(changeSpy.calledAfter(validateSpy)).to.be.true;
-            done();
-          });
-        });
+      it('should change after validate on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
 
-        enter(target);
+        // Wait for overlay to finish closing
+        await nextRender(datepicker);
+
+        expect(validateSpy.calledOnce).to.be.true;
+        expect(changeSpy.calledOnce).to.be.true;
+        expect(changeSpy.calledAfter(validateSpy)).to.be.true;
       });
     });
 
     describe('overlay is closed, value is set', () => {
       beforeEach(async () => {
         await open(datepicker);
-        inputText('01/02/20');
+        await sendKeys({ type: '01/02/20' });
         await close(datepicker);
         validateSpy.resetHistory();
         changeSpy.resetHistory();
@@ -763,39 +626,39 @@ import { close, getOverlayContent, open } from './common.js';
 
       it('should change after validate on clear button click', () => {
         datepicker.clearButtonVisible = true;
-        click(datepicker.$.clearButton);
+        datepicker.$.clearButton.click();
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.calledOnce).to.be.true;
         expect(changeSpy.calledAfter(validateSpy)).to.be.true;
       });
 
-      it('should change after validate on Esc with clear button', () => {
+      it('should change after validate on Esc with clear button', async () => {
         datepicker.clearButtonVisible = true;
-        esc(target);
+        await sendKeys({ press: 'Escape' });
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.calledOnce).to.be.true;
         expect(changeSpy.calledAfter(validateSpy)).to.be.true;
       });
 
-      it('should neither change nor validate on Esc without clear button', () => {
-        esc(target);
+      it('should neither change nor validate on Esc without clear button', async () => {
+        await sendKeys({ press: 'Escape' });
         expect(validateSpy.called).to.be.false;
         expect(changeSpy.called).to.be.false;
       });
 
-      it('should change after validate on Backspace & Enter', () => {
-        target.value = '';
-        target.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
-        enter(target);
+      it('should change after validate on Backspace & Enter', async () => {
+        input.select();
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Enter' });
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.calledOnce).to.be.true;
         expect(changeSpy.calledAfter(validateSpy)).to.be.true;
       });
 
-      it('should change after validate on Backspace & Esc', () => {
-        target.value = '';
-        target.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
-        esc(target);
+      it('should change after validate on Backspace & Esc', async () => {
+        input.select();
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Escape' });
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.calledOnce).to.be.true;
         expect(changeSpy.calledAfter(validateSpy)).to.be.true;
@@ -807,85 +670,85 @@ import { close, getOverlayContent, open } from './common.js';
         datepicker.autoOpenDisabled = true;
       });
 
-      it('should change after validate on Enter', () => {
-        inputText('01/02/20');
-        enter(target);
+      it('should change after validate on Enter', async () => {
+        await sendKeys({ type: '01/02/20' });
+        await sendKeys({ press: 'Enter' });
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.calledOnce).to.be.true;
         expect(changeSpy.calledAfter(validateSpy)).to.be.true;
       });
 
-      it('should validate on Enter when value is the same', () => {
-        enter(target);
+      it('should validate on Enter when value is the same', async () => {
+        await sendKeys({ press: 'Enter' });
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.called).to.be.false;
       });
 
-      it('should validate on Enter when invalid', () => {
-        inputText('foo');
-        enter(target);
+      it('should validate on Enter when invalid', async () => {
+        await sendKeys({ type: 'foo' });
+        await sendKeys({ press: 'Enter' });
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.called).to.be.false;
       });
 
-      it('should validate on blur', () => {
-        target.dispatchEvent(new Event('blur'));
+      it('should validate on blur', async () => {
+        await sendKeys({ press: 'Tab' });
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.called).to.be.false;
       });
 
-      it('should neither change nor validate on Esc', () => {
-        inputText('01/02/20');
-        esc(target);
+      it('should neither change nor validate on Esc', async () => {
+        await sendKeys({ type: '01/02/20' });
+        await sendKeys({ press: 'Escape' });
         expect(validateSpy.called).to.be.false;
         expect(changeSpy.called).to.be.false;
       });
 
       describe('value is set', () => {
-        beforeEach(() => {
-          inputText('01/02/20');
-          enter(target);
+        beforeEach(async () => {
+          await sendKeys({ type: '01/02/20' });
+          await sendKeys({ press: 'Enter' });
           validateSpy.resetHistory();
           changeSpy.resetHistory();
           datepicker._focusAndSelect();
         });
 
-        it('should change after validate on Esc with clear button', () => {
+        it('should change after validate on Esc with clear button', async () => {
           datepicker.clearButtonVisible = true;
-          esc(target);
+          await sendKeys({ press: 'Escape' });
           expect(validateSpy.calledOnce).to.be.true;
           expect(changeSpy.calledOnce).to.be.true;
           expect(changeSpy.calledAfter(validateSpy)).to.be.true;
         });
 
-        it('should neither change nor validate on Esc without clear button', () => {
-          esc(target);
+        it('should neither change nor validate on Esc without clear button', async () => {
+          await sendKeys({ press: 'Escape' });
           expect(validateSpy.called).to.be.false;
           expect(changeSpy.called).to.be.false;
         });
 
-        it('should change after validate on Backspace & Enter', () => {
-          target.value = '';
-          target.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
-          enter(target);
+        it('should change after validate on Backspace & Enter', async () => {
+          input.select();
+          await sendKeys({ press: 'Backspace' });
+          await sendKeys({ press: 'Enter' });
           expect(validateSpy.calledOnce).to.be.true;
           expect(changeSpy.calledOnce).to.be.true;
           expect(changeSpy.calledAfter(validateSpy)).to.be.true;
         });
 
-        it('should change after validate on Backspace & Esc', () => {
-          target.value = '';
-          target.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
-          esc(target);
+        it('should change after validate on Backspace & Esc', async () => {
+          input.select();
+          await sendKeys({ press: 'Backspace' });
+          await sendKeys({ press: 'Escape' });
           expect(validateSpy.calledOnce).to.be.true;
           expect(changeSpy.calledOnce).to.be.true;
           expect(changeSpy.calledAfter(validateSpy)).to.be.true;
         });
 
-        it('should change after validate on Backspace & blur', () => {
-          target.value = '';
-          target.dispatchEvent(new CustomEvent('change', { bubbles: true }));
-          target.dispatchEvent(new Event('blur'));
+        it('should change after validate on Backspace & blur', async () => {
+          input.select();
+          await sendKeys({ press: 'Backspace' });
+          await sendKeys({ press: 'Tab' });
           expect(validateSpy.calledOnce).to.be.true;
           expect(changeSpy.calledOnce).to.be.true;
           expect(changeSpy.calledAfter(validateSpy)).to.be.true;

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -7,7 +7,6 @@ import {
   aTimeout,
   end,
   enter,
-  esc,
   fixtureSync,
   home,
   isIOS,
@@ -33,40 +32,6 @@ import { getDefaultI18n, getOverlayContent, open } from './common.js';
 
     beforeEach(() => {
       datepicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
-    });
-
-    it('should open overlay on down', () => {
-      target = datepicker.inputElement;
-      arrowDown(target);
-      expect(datepicker.opened).to.be.true;
-    });
-
-    it('should open overlay on down if autoOpenDisabled is true', () => {
-      datepicker.autoOpenDisabled = true;
-      target = datepicker.inputElement;
-      arrowDown(target);
-      expect(datepicker.opened).to.be.true;
-    });
-
-    it('should open overlay on up', () => {
-      target = datepicker.inputElement;
-      arrowUp(target);
-      expect(datepicker.opened).to.be.true;
-    });
-
-    it('should open overlay on up even if autoOpenDisabled is true', () => {
-      datepicker.autoOpenDisabled = true;
-      target = datepicker.inputElement;
-      arrowUp(target);
-      expect(datepicker.opened).to.be.true;
-    });
-
-    it('should close overlay on esc', async () => {
-      datepicker.open();
-      target = datepicker.$.overlay;
-      await aTimeout(1);
-      esc(target);
-      expect(datepicker.opened).to.be.false;
     });
 
     it('should be focused on selected value when overlay is opened', () => {


### PR DESCRIPTION
## Description

Before re-implementing the date-picker keyboard navigation, I decided to update existing tests:

1. Updated `keyboard-input.test.js` to use `sendKeys()` instead of the fake input helpers e.g. `inputText`
2. Moved some tests to `keyboard-input-old.test.js` - some of these will be no longer relevant after the refactor
3. Grouped some tests into suites e.g. those related to focused date, invalid input, opening the overlay etc.

There will be another PR with the actual keyboard navigation changes based on this one.

## Type of change

- Tests