### PR TITLE
test: use sendKeys for keyboard navigation tests

### DIFF
--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -118,9 +118,7 @@ export function getFocusedMonth(overlayContent) {
   });
 }
 
-export function getFocusedCell(datepicker) {
-  const overlayContent = getOverlayContent(datepicker);
-
+export function getFocusedCell(overlayContent) {
   const months = Array.from(overlayContent.shadowRoot.querySelectorAll('vaadin-month-calendar'));
 
   // Date that is currently focused

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -203,7 +203,7 @@ describe('keyboard', () => {
     it('should move focus back to the input on calendar date tap', async () => {
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
-      const cell = getFocusedCell(datepicker);
+      const cell = getFocusedCell(overlayContent);
       const spy = sinon.spy(input, 'focus');
       tap(cell);
       expect(spy.calledOnce).to.be.true;


### PR DESCRIPTION
## Description

Follow up on #3371, this is a second batch of date-picker keyboard tests converted to use `sendKeys`.
Again, it was extracted from #3372 - see https://github.com/vaadin/web-components/pull/3372/commits/8602303f6b8c362793df25c626607a4d48437df6

## Type of change

- Tests