### PR TITLE
chore: add standard lumo style sheets on dev pages

### DIFF
--- a/dev/accordion.html
+++ b/dev/accordion.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Accordion</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/accordion';

--- a/dev/app-layout.html
+++ b/dev/app-layout.html
@@ -5,23 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>App Layout</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
-    <script type="module">
-      import { color } from '@vaadin/vaadin-lumo-styles';
-      import { typography } from '@vaadin/vaadin-lumo-styles';
-
-      const tpl = document.createElement('template');
-      tpl.innerHTML = `<style>
-        ${color.cssText}
-        ${typography.cssText}
-
-        h1 {
-          font-size: var(--lumo-font-size-l);
-          margin: 0;
-        }
-      </style>`;
-      document.head.appendChild(tpl.content);
-    </script>
+    <style>
+      h1 {
+        font-size: var(--lumo-font-size-l);
+        margin: 0;
+      }
+    </style>
 
     <script type="module">
       import '@vaadin/app-layout';

--- a/dev/avatar-group.html
+++ b/dev/avatar-group.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Avatar group</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/avatar-group';

--- a/dev/button.html
+++ b/dev/button.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/button';

--- a/dev/charts/lumo/area.html
+++ b/dev/charts/lumo/area.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | area</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/arearange.html
+++ b/dev/charts/lumo/arearange.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | area range</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script defer>

--- a/dev/charts/lumo/areaspline.html
+++ b/dev/charts/lumo/areaspline.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | area spline</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/areasplinerange.html
+++ b/dev/charts/lumo/areasplinerange.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | area spline range</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/bar.html
+++ b/dev/charts/lumo/bar.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | bar</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/boxplot.html
+++ b/dev/charts/lumo/boxplot.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | box plot</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/bubble.html
+++ b/dev/charts/lumo/bubble.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | bubble</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/bullet.html
+++ b/dev/charts/lumo/bullet.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | bullet</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/candlestick.html
+++ b/dev/charts/lumo/candlestick.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | candle stick</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/column.html
+++ b/dev/charts/lumo/column.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | column</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/columnrange.html
+++ b/dev/charts/lumo/columnrange.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | column range</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/errorbar.html
+++ b/dev/charts/lumo/errorbar.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | error bar</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/funnel.html
+++ b/dev/charts/lumo/funnel.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | funnel</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/gauge.html
+++ b/dev/charts/lumo/gauge.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | gauge</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/gaugedual.html
+++ b/dev/charts/lumo/gaugedual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | gauge with dual axes</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/heatmap.html
+++ b/dev/charts/lumo/heatmap.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | heatmap</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/line.html
+++ b/dev/charts/lumo/line.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | line</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/ohlc.html
+++ b/dev/charts/lumo/ohlc.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | ohlc</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/organization.html
+++ b/dev/charts/lumo/organization.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | organization</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/pie.html
+++ b/dev/charts/lumo/pie.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | pie</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/polar.html
+++ b/dev/charts/lumo/polar.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | polar</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/polygon.html
+++ b/dev/charts/lumo/polygon.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | polygon</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/pyramid.html
+++ b/dev/charts/lumo/pyramid.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | pyramid</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/scatter.html
+++ b/dev/charts/lumo/scatter.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | scatter</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/solidgauge.html
+++ b/dev/charts/lumo/solidgauge.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | solid gauge</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/spiderweb.html
+++ b/dev/charts/lumo/spiderweb.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | spiderweb</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/timeline.html
+++ b/dev/charts/lumo/timeline.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | timeline</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/treemap.html
+++ b/dev/charts/lumo/treemap.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | treemap</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/lumo/waterfall.html
+++ b/dev/charts/lumo/waterfall.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | treemap</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/area.html
+++ b/dev/charts/material/area.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | area</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/arearange.html
+++ b/dev/charts/material/arearange.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | area range</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script defer>

--- a/dev/charts/material/areaspline.html
+++ b/dev/charts/material/areaspline.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | area spline</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/areasplinerange.html
+++ b/dev/charts/material/areasplinerange.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | area spline range</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/bar.html
+++ b/dev/charts/material/bar.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | bar</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/boxplot.html
+++ b/dev/charts/material/boxplot.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | box plot</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/bubble.html
+++ b/dev/charts/material/bubble.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | bubble</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/bullet.html
+++ b/dev/charts/material/bullet.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | bullet</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/candlestick.html
+++ b/dev/charts/material/candlestick.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | candle stick</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/column.html
+++ b/dev/charts/material/column.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | column</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/columnrange.html
+++ b/dev/charts/material/columnrange.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | column range</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/errorbar.html
+++ b/dev/charts/material/errorbar.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | error bar</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/funnel.html
+++ b/dev/charts/material/funnel.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | funnel</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/gauge.html
+++ b/dev/charts/material/gauge.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | gauge</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/gaugedual.html
+++ b/dev/charts/material/gaugedual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | gauge with dual axes</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/heatmap.html
+++ b/dev/charts/material/heatmap.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | heatmap</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/line.html
+++ b/dev/charts/material/line.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | line</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/ohlc.html
+++ b/dev/charts/material/ohlc.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | ohlc</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/organization.html
+++ b/dev/charts/material/organization.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | organization</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/pie.html
+++ b/dev/charts/material/pie.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | pie</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/polar.html
+++ b/dev/charts/material/polar.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | polar</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/polygon.html
+++ b/dev/charts/material/polygon.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | polygon</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/pyramid.html
+++ b/dev/charts/material/pyramid.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | pyramid</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/scatter.html
+++ b/dev/charts/material/scatter.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | scatter</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/solidgauge.html
+++ b/dev/charts/material/solidgauge.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | solid gauge</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/spiderweb.html
+++ b/dev/charts/material/spiderweb.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | spiderweb</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/timeline.html
+++ b/dev/charts/material/timeline.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | timeline</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/treemap.html
+++ b/dev/charts/material/treemap.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | treemap</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/charts/material/waterfall.html
+++ b/dev/charts/material/waterfall.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Vaadin charts | treemap</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module">

--- a/dev/checkbox-group.html
+++ b/dev/checkbox-group.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Checkbox Group</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/checkbox-group';

--- a/dev/checkbox.html
+++ b/dev/checkbox.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/checkbox';

--- a/dev/combo-box.html
+++ b/dev/combo-box.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Combo box</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <script type="module">
       import '@vaadin/combo-box';
     </script>

--- a/dev/confirm-dialog.html
+++ b/dev/confirm-dialog.html
@@ -5,14 +5,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Confirm dialog</title>
+    <script type="module" src="./lumo-globals.js"></script>
+
     <script type="module">
       import '@vaadin/confirm-dialog';
-      import { color, typography } from '@vaadin/vaadin-lumo-styles';
-
-      // Global color and typography styles affect the contents of the dialog
-      const style = document.createElement('style');
-      style.innerHTML = `${color.toString()} ${typography.toString()}`;
-      document.head.appendChild(style);
     </script>
   </head>
   <body>

--- a/dev/context-menu.html
+++ b/dev/context-menu.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Context Menu</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/context-menu';

--- a/dev/crud.html
+++ b/dev/crud.html
@@ -5,18 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CRUD</title>
+    <script type="module" src="./lumo-globals.js"></script>
   </head>
 
   <body>
     <script type="module">
       import '@vaadin/crud';
       import '@vaadin/radio-group';
-      import { color, typography } from '@vaadin/vaadin-lumo-styles';
-
-      // Global color and typography styles affect the contents of the dialog
-      const style = document.createElement('style');
-      style.innerHTML = `${color.toString()} ${typography.toString()}`;
-      document.head.appendChild(style);
 
       const crud = document.querySelector('vaadin-crud');
       crud.items = [

--- a/dev/custom-field.html
+++ b/dev/custom-field.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Custom Field</title>
+    <script type="module" src="./lumo-globals.js"></script>
   </head>
 
   <body>

--- a/dev/date-picker.html
+++ b/dev/date-picker.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Date picker</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <script type="module">
       import '@vaadin/date-picker';
     </script>

--- a/dev/date-time-picker.html
+++ b/dev/date-time-picker.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Date Time picker</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <script type="module">
       import '@vaadin/date-time-picker';
     </script>

--- a/dev/details.html
+++ b/dev/details.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Details</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/details';

--- a/dev/email-field.html
+++ b/dev/email-field.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Email field</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/email-field';

--- a/dev/field-highlighter.html
+++ b/dev/field-highlighter.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Field highlighter</title>
+    <script type="module" src="./lumo-globals.js"></script>
   </head>
 
   <body>

--- a/dev/form-layout.html
+++ b/dev/form-layout.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Form Layout</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/form-layout';

--- a/dev/grid-pro.html
+++ b/dev/grid-pro.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Grid Pro</title>
+    <script type="module" src="./lumo-globals.js"></script>
   </head>
   <body>
     <vaadin-grid-pro single-cell-edit>

--- a/dev/grid.html
+++ b/dev/grid.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <script type="module" src="./lumo-globals.js"></script>
   </head>
   <body>
     <script type="module">

--- a/dev/icon.html
+++ b/dev/icon.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/icon';

--- a/dev/index.html
+++ b/dev/index.html
@@ -5,6 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dev pages</title>
+  <script type="module" src="./dev/lumo-globals.js"></script>
 </head>
 <body>
   <h1>Web Component development pages</h1>

--- a/dev/integer-field.html
+++ b/dev/integer-field.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Integer field</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/integer-field';

--- a/dev/lumo-globals.js
+++ b/dev/lumo-globals.js
@@ -1,0 +1,5 @@
+import { color, typography } from '@vaadin/vaadin-lumo-styles';
+
+const style = document.createElement('style');
+style.innerHTML = `${color.toString()} ${typography.toString()}`;
+document.head.appendChild(style);

--- a/dev/map.html
+++ b/dev/map.html
@@ -5,6 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Map</title>
+  <script type="module" src="./lumo-globals.js"></script>
   <style>
       vaadin-map {
           width: 100%;

--- a/dev/menu-bar.html
+++ b/dev/menu-bar.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Menu bar</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/menu-bar';

--- a/dev/number-field.html
+++ b/dev/number-field.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Number field</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/number-field';

--- a/dev/password-field.html
+++ b/dev/password-field.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Password field</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/password-field';

--- a/dev/radio-group.html
+++ b/dev/radio-group.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Radio Group</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/radio-group';

--- a/dev/scroller.html
+++ b/dev/scroller.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Scroller</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <script type="module">
       import '@vaadin/scroller';
 

--- a/dev/select.html
+++ b/dev/select.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Select</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <script type="module">
       import '@vaadin/select';
     </script>

--- a/dev/split-layout.html
+++ b/dev/split-layout.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Split Layout</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/split-layout';

--- a/dev/tabs.html
+++ b/dev/tabs.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tabs</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/tabs';

--- a/dev/text-area.html
+++ b/dev/text-area.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Text Area</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/text-area';

--- a/dev/text-field.html
+++ b/dev/text-field.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Text field</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/text-field';

--- a/dev/time-picker.html
+++ b/dev/time-picker.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Time picker</title>
+    <script type="module" src="./lumo-globals.js"></script>
     <script type="module">
       import '@vaadin/time-picker';
     </script>

--- a/dev/upload.html
+++ b/dev/upload.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Upload</title>
+    <script type="module" src="./lumo-globals.js"></script>
 
     <script type="module">
       import '@vaadin/upload';


### PR DESCRIPTION
Relates to https://github.com/vaadin/web-components/issues/3377

Add the standard Lumo typography and color styles on each dev page

Before:
<img width="718" alt="Screenshot 2022-02-03 at 9 24 51" src="https://user-images.githubusercontent.com/1222264/152299076-2310b5dc-c500-481d-8590-34035335b7dd.png">

After:
<img width="716" alt="Screenshot 2022-02-03 at 9 24 39" src="https://user-images.githubusercontent.com/1222264/152299058-c4c030f6-edb9-48e7-8bcd-876df4823858.png">