### PR TITLE
test: remove non-null assertion in select types test

### DIFF
--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -24,7 +24,7 @@ assertType<() => void>(select.requestContentUpdate);
 assertType<() => boolean>(select.validate);
 
 // Item properties
-const item: SelectItem = select.items![0];
+const item: SelectItem = select.items ? select.items[0] : {};
 assertType<string | undefined>(item.label);
 assertType<string | undefined>(item.value);
 assertType<boolean | undefined>(item.disabled);


### PR DESCRIPTION
Removes the linter warning (currently shown in every PR)