### PR TITLE
fix: only run the crud grid header renderer once

### DIFF
--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -167,6 +167,10 @@ class CrudGrid extends IncludedMixin(Grid) {
     if (!this.noHead && path) {
       // Create a header renderer for the column (or column group)
       col.headerRenderer = (root) => {
+        if (root.firstElementChild) {
+          return;
+        }
+
         const label = this._generateHeader(path);
 
         if (col.__sortColumnGroup || (this.noFilter && !this.noSort)) {

--- a/packages/crud/test/crud-grid.test.js
+++ b/packages/crud/test/crud-grid.test.js
@@ -194,6 +194,13 @@ describe('crud grid', () => {
         it('should capitalize correctly', () => {
           expect(grid.__capitalize('aa.bb cc-dd FF')).to.be.equal('Aa bb cc dd ff');
         });
+
+        it('should only render one control in a cell', async () => {
+          grid.requestContentUpdate();
+          await nextRender(grid);
+          expect(getHeaderCellContent(grid, 1, 0).childElementCount).to.equal(1);
+          expect(getHeaderCellContent(grid, 2, 0).childElementCount).to.equal(1);
+        });
       });
     });
   });


### PR DESCRIPTION
Fixes #3384 