### PR TITLE
[date-picker] fix: prevent input blur on calendar icon click

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -213,7 +213,10 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
       })
     );
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
-    addListener(this.shadowRoot.querySelector('[part="toggle-button"]'), 'tap', this._toggle.bind(this));
+
+    const toggleButton = this.shadowRoot.querySelector('[part="toggle-button"]');
+    addListener(toggleButton, 'tap', this._toggle.bind(this));
+    toggleButton.addEventListener('mousedown', (e) => e.preventDefault());
   }
 
   /** @private */

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -71,6 +71,13 @@ describe('basic features', () => {
     expect(datepicker.hasAttribute('focused')).to.be.true;
   });
 
+  it('should not blur when toggle button is clicked', async () => {
+    const e = new CustomEvent('mousedown', { bubbles: true });
+    const spy = sinon.spy(e, 'preventDefault');
+    toggleButton.dispatchEvent(e);
+    expect(spy.calledOnce).to.be.true;
+  });
+
   it('should have focused attribute when closed and focused', async () => {
     datepicker.focus();
     await sendKeys({ press: 'ArrowDown' });


### PR DESCRIPTION
## Description

As described on [this issue](https://github.com/vaadin/flow-components/issues/2428), when the user clicks on the calendar icon when the `DatePicker` (or, in the case reported by the issue, a `DateTimePicker`) is inside a` GridPro`, the editor gets closed. The same do not happen when the clock icon on the TimePicker is clicked. 

The issue comes to the fact that when the user clicks on the calendar icon, the input field is briefly blurred, which causes a `blur` event that is listened by the `GridPro` and it stops the edit mode of the cell.

This change applies the same code that is used on ComboBox to prevent the blur event from being fired when the user clicks on the toggle button.

Part of https://github.com/vaadin/flow-components/issues/2428

## Type of change

- [x] Bugfix
- [ ] Feature
