### PR TITLE
refactor: cleanup no longer used button roles

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -199,7 +199,6 @@ class DatePickerOverlayContent extends ThemableMixin(DirMixin(PolymerElement)) {
           <template>
             <div
               part="year-number"
-              role="button"
               current$="[[_isCurrentYear(index)]]"
               selected$="[[_isSelectedYear(index, selectedDate)]]"
             >

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -145,7 +145,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
           <slot name="prefix" slot="prefix"></slot>
           <slot name="input"></slot>
           <div id="clearButton" part="clear-button" slot="suffix" aria-hidden="true"></div>
-          <div part="toggle-button" slot="suffix" role="button" aria-hidden="true"></div>
+          <div part="toggle-button" slot="suffix" aria-hidden="true"></div>
         </vaadin-input-container>
 
         <div part="helper-text">

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -6,11 +6,10 @@ import { activateScroller, getDefaultI18n, open } from './common.js';
 
 describe('WAI-ARIA', () => {
   describe('date picker', () => {
-    let datepicker, toggleButton, input, label, helper, error;
+    let datepicker, input, label, helper, error;
 
     beforeEach(() => {
       datepicker = fixtureSync(`<vaadin-date-picker helper-text="Week day" label="Date"></vaadin-date-picker>`);
-      toggleButton = datepicker.shadowRoot.querySelector('[part="toggle-button"]');
       input = datepicker.inputElement;
       label = datepicker.querySelector('[slot=label]');
       error = datepicker.querySelector('[slot=error-message]');
@@ -41,23 +40,6 @@ describe('WAI-ARIA', () => {
       const aria = input.getAttribute('aria-describedby');
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);
-    });
-
-    it('should have button roles on buttons', () => {
-      // Indicate icon buttons as clickable. Especially helpful on touch devices.
-      expect(toggleButton.getAttribute('role')).to.equal('button');
-    });
-
-    // TODO: clarify if this is still needed
-    it.skip('should have label properties on buttons', () => {
-      // Give spoken names for the icon buttons.
-      expect(toggleButton.getAttribute('aria-label')).to.equal('Calendar');
-    });
-
-    // TODO: clarify if this is still needed
-    it.skip('should have label properties on buttons in correct locale', () => {
-      datepicker.set('i18n.calendar', 'kalenteri');
-      expect(toggleButton.getAttribute('aria-label')).to.equal('kalenteri');
     });
 
     it('should set aria-haspopup attribute on the input', () => {
@@ -108,16 +90,6 @@ describe('WAI-ARIA', () => {
 
       it('should set aria-hidden on the year scroller', () => {
         expect(scroller.getAttribute('aria-hidden')).to.equal('true');
-      });
-
-      it('should contain button role for years', () => {
-        // Indicate years as clickable.
-        const years = Array.from(yearScrollerContents).filter((el) => /\d+/.test(el.textContent));
-
-        expect(years).to.not.be.empty;
-        years.forEach((year) => {
-          expect(year.getAttribute('role')).to.equal('button');
-        });
       });
 
       it('should have hidden state for dots', () => {


### PR DESCRIPTION
## Description

Removed `role="button"` from the internal elements that are excluded from screen readers using `aria-hidden`

1. Date-picker toggle button - see #3375
2. Date-picker year buttons - see #3349

## Type of change

- Refactor