### PR TITLE
fix: do not open dropdown on helper click

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -423,6 +423,16 @@ export const ComboBoxMixin = (subclass) =>
       }
     }
 
+    /**
+     * @param {Event} event
+     * @protected
+     */
+    _onHostClick(_event) {
+      if (!this.autoOpenDisabled) {
+        this.open();
+      }
+    }
+
     /** @private */
     _onClick(e) {
       this._closeOnBlurIsPrevented = true;
@@ -437,8 +447,8 @@ export const ComboBoxMixin = (subclass) =>
         } else {
           this.open();
         }
-      } else if (!this.autoOpenDisabled) {
-        this.open();
+      } else {
+        this._onHostClick(e);
       }
 
       this._closeOnBlurIsPrevented = false;

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -293,6 +293,19 @@ class ComboBox extends ComboBoxDataProviderMixin(
 
     this._handleClearButtonClick(event);
   }
+
+  /**
+   * @param {Event} event
+   * @protected
+   */
+  _onHostClick(event) {
+    const path = event.composedPath();
+
+    // Open dropdown only when clicking on the label or input field
+    if (path.includes(this._labelNode) || path.includes(this._positionTarget)) {
+      super._onHostClick(event);
+    }
+  }
 }
 
 customElements.define(ComboBox.is, ComboBox);

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -75,6 +75,19 @@ describe('toggling dropdown', () => {
       expect(comboBox.opened).to.be.true;
     });
 
+    it('should not open the overlay on helper click', () => {
+      comboBox.helperText = 'Helper Text';
+      comboBox.querySelector('[slot=helper]').click();
+      expect(comboBox.opened).to.be.false;
+    });
+
+    it('should not open the overlay on error message click', () => {
+      comboBox.invalid = true;
+      comboBox.errorMessage = 'Error message';
+      comboBox.querySelector('[slot=error-message]').click();
+      expect(comboBox.opened).to.be.false;
+    });
+
     it('should open on function call', () => {
       comboBox.open();
 


### PR DESCRIPTION
## Description

Updated host event listener to check if the click was on the label or input field.

Fixes #3399

## Type of change

- Bugfix