### PR TITLE
refactor: use toggle button click instead of tap

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -9,7 +9,6 @@ import './vaadin-date-picker-overlay.js';
 import './vaadin-date-picker-overlay-content.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { addListener } from '@vaadin/component-base/src/gestures.js';
 import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
@@ -145,7 +144,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
           <slot name="prefix" slot="prefix"></slot>
           <slot name="input"></slot>
           <div id="clearButton" part="clear-button" slot="suffix" aria-hidden="true"></div>
-          <div part="toggle-button" slot="suffix" aria-hidden="true"></div>
+          <div part="toggle-button" slot="suffix" aria-hidden="true" on-click="_toggle"></div>
         </vaadin-input-container>
 
         <div part="helper-text">
@@ -215,7 +214,6 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
 
     const toggleButton = this.shadowRoot.querySelector('[part="toggle-button"]');
-    addListener(toggleButton, 'tap', this._toggle.bind(this));
     toggleButton.addEventListener('mousedown', (e) => e.preventDefault());
   }
 

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -218,6 +218,14 @@ describe('basic features', () => {
     await oneEvent(datepicker.$.overlay, 'vaadin-overlay-open');
   });
 
+  it('should close on subsequent toggle button click', () => {
+    toggleButton.click();
+    expect(datepicker.opened).to.be.true;
+
+    toggleButton.click();
+    expect(datepicker.opened).to.be.false;
+  });
+
   it('should scroll to a date on open', async () => {
     const overlayContent = getOverlayContent(datepicker);
     // We must scroll to a date on every open because at least IE11 seems to reset


### PR DESCRIPTION
## Description

Currently, when clicking a toggle button the date-picker is opened, it closes and opens again:

https://user-images.githubusercontent.com/10589913/152781758-1dae1bbb-002a-425a-80e4-da4819d253f9.mp4

The reason is this event listener for `click` event:
https://github.com/vaadin/web-components/blob/67b8a7ce8d12ef24d8208c41be1f616fc51ccb60/packages/date-picker/src/vaadin-date-picker-mixin.js#L414-L418

We call `event.stopPropagation()` but for `tap` event, and that does not prevent the `click` event:

https://github.com/vaadin/web-components/blob/67b8a7ce8d12ef24d8208c41be1f616fc51ccb60/packages/date-picker/src/vaadin-date-picker.js#L235-L236

https://github.com/vaadin/web-components/blob/67b8a7ce8d12ef24d8208c41be1f616fc51ccb60/packages/date-picker/src/vaadin-date-picker.js#L218


Now when I'm trying date-picker on mobile, I see no reason to use `tap`. In combo-box we use `click` and it works.
Updated the logic to make toggle button work properly, also added a tests for subsequent toggle button click.

## Type of change

- Refactor