### PR TITLE
fix: handle list-box set before renderer

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -432,10 +432,14 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
   _assignMenuElement(menuElement) {
     if (menuElement && menuElement !== this.__lastMenuElement) {
       this._menuElement = menuElement;
+
+      // Ensure items are initialized
+      this.__initMenuItems(menuElement);
+
       menuElement.addEventListener('items-changed', () => {
-        this._items = menuElement.items;
-        this._items.forEach((item) => item.setAttribute('role', 'option'));
+        this.__initMenuItems(menuElement);
       });
+
       menuElement.addEventListener('selected-changed', () => this.__updateValueButton());
       // Use capture phase to make it possible for `<vaadin-grid-pro-edit-select>`
       // to override and handle the keydown event before the value change happens.
@@ -453,6 +457,14 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
 
       // Store the menu element reference
       this.__lastMenuElement = menuElement;
+    }
+  }
+
+  /** @private */
+  __initMenuItems(menuElement) {
+    if (menuElement.items) {
+      this._items = menuElement.items;
+      this._items.forEach((item) => item.setAttribute('role', 'option'));
     }
   }
 

--- a/packages/select/test/renderer.test.js
+++ b/packages/select/test/renderer.test.js
@@ -133,4 +133,26 @@ describe('renderer', () => {
       document.body.removeChild(select);
     }).to.not.throw(Error);
   });
+
+  describe('child list-box', () => {
+    beforeEach(async () => {
+      // Mimic the Flow component behavior
+      select.appendChild(rendererContent);
+      // Wait for list-box items to be set
+      await nextFrame();
+    });
+
+    it('should work with list-box connected before renderer is set', () => {
+      select.renderer = (root) => {
+        const listBox = Array.from(select.children).find((el) => el.tagName.toLowerCase() === 'vaadin-list-box');
+        if (listBox) {
+          if (root.firstChild) {
+            root.removeChild(root.firstChild);
+          }
+          root.appendChild(listBox);
+        }
+      };
+      expect(select._items).to.eql(rendererContent.items);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes vaadin/flow-components#2553

The way how Flow component works is not fully clear to me: for some reason, the original issue only manifests in Safari but not Chrome, and only on reattach. Finally, there has to be some other component present (see also #428).

However, I was able to reproduce the root cause with a test case that roughly mimics Flow connector:

1. Create a [list-box element](https://github.com/vaadin/flow-components/blob/839a1c46ee19ef55253d9da4524df47ec5b689cd/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java#L87) and [append it as a child](https://github.com/vaadin/flow-components/blob/839a1c46ee19ef55253d9da4524df47ec5b689cd/vaadin-select-flow-parent/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java#L133) in the constructor,
2. In `renderer` function, move the [list-box child](https://github.com/vaadin/flow-components/blob/839a1c46ee19ef55253d9da4524df47ec5b689cd/vaadin-select-flow-parent/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js#L25) to `root` element.

The actual problem: if `menuElement.items` is already defined by the time we initialize it, there will be no `items-changed` event fired. As a result, `this._items` will remain `undefined` and the subsequent renderer call will throw an error here:

https://github.com/vaadin/web-components/blob/87bbb0e333cd037c006c6cf279f574aa28cedd01/packages/select/src/vaadin-select.js#L631

## Type of change

- Bugfix