### PR TITLE
fix: restore old logic for getting focusable elements

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/dialog": "23.0.0-beta1",
     "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^9.2.1"
   }

--- a/packages/accordion/test/dialog.test.js
+++ b/packages/accordion/test/dialog.test.js
@@ -1,0 +1,81 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import '@vaadin/dialog';
+import '../vaadin-accordion.js';
+
+describe('accordion in dialog', () => {
+  let dialog, overlay, accordion, panels;
+
+  beforeEach(async () => {
+    dialog = fixtureSync(`<vaadin-dialog></vaadin-dialog>`);
+    dialog.renderer = (root) => {
+      root.innerHTML = `
+        <vaadin-accordion>
+          <vaadin-accordion-panel>
+            <div slot="summary">Panel 1</div>
+            <button>Button 1</button>
+          </vaadin-accordion-panel>
+          <vaadin-accordion-panel>
+            <div slot="summary">Panel 2</div>
+            <button>Button 2</button>
+          </vaadin-accordion-panel>
+        </vaadin-accordion>
+      `;
+    };
+    dialog.opened = true;
+    overlay = dialog.$.overlay;
+    await oneEvent(overlay, 'vaadin-overlay-open');
+    await nextFrame();
+    accordion = overlay.querySelector('vaadin-accordion');
+    panels = accordion.items;
+  });
+
+  it('should move focus from panel heading to content on Tab', async () => {
+    // Focus first panel (opened)
+    await sendKeys({ press: 'Tab' });
+    expect(document.activeElement).to.equal(panels[0]);
+
+    // Move focus to the content
+    await sendKeys({ press: 'Tab' });
+    expect(document.activeElement).to.equal(panels[0].querySelector('button'));
+  });
+
+  it('should move focus from panel content to heading on Shift + Tab', async () => {
+    // Focus the first panel content
+    panels[0].querySelector('button').focus();
+
+    // Move focus back to heading
+    await sendKeys({ down: 'Shift' });
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ up: 'Shift' });
+
+    expect(document.activeElement).to.equal(panels[0]);
+  });
+
+  it('should skip focusable element in closed panel on Tab', async () => {
+    accordion.opened = 1;
+
+    // Focus first panel (closed)
+    await sendKeys({ press: 'Tab' });
+    expect(document.activeElement).to.equal(panels[0]);
+
+    // Focus second panel (opened)
+    await sendKeys({ press: 'Tab' });
+    expect(document.activeElement).to.equal(panels[1]);
+  });
+
+  it('should skip focusable element in closed panel on Shift + Tab', async () => {
+    accordion.opened = 1;
+
+    // Focus second panel (opened)
+    panels[1].focus();
+
+    // Move focus back to first panel
+    await sendKeys({ down: 'Shift' });
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ up: 'Shift' });
+
+    expect(document.activeElement).to.equal(panels[0]);
+  });
+});

--- a/packages/component-base/src/focus-trap-controller.js
+++ b/packages/component-base/src/focus-trap-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { getFocusableElements, isElementFocused, isElementHidden } from './focus-utils.js';
+import { getFocusableElements, isElementFocused } from './focus-utils.js';
 
 /**
  * A controller for trapping focus within a DOM node.
@@ -110,10 +110,7 @@ export class FocusTrapController {
    * @private
    */
   __focusNextElement(backward = false) {
-    // Filter out hidden elements before detecting which element to focus next.
-    // We can't do that during initialization, because by the time `trapFocus()`
-    // is called in case of overlay, focusable items might not yet be visible.
-    const focusableElements = this.__focusableElements.filter((el) => !isElementHidden(el));
+    const focusableElements = this.__focusableElements;
     const step = backward ? -1 : 1;
     const currentIndex = this.__focusedElementIndex;
     const nextIndex = (focusableElements.length + currentIndex + step) % focusableElements.length;
@@ -137,6 +134,7 @@ export class FocusTrapController {
    * @private
    */
   get __focusedElementIndex() {
-    return this.__focusableElements.findIndex(isElementFocused);
+    const focusableElements = this.__focusableElements;
+    return focusableElements.indexOf(focusableElements.filter(isElementFocused).pop());
   }
 }

--- a/packages/component-base/src/focus-trap-controller.js
+++ b/packages/component-base/src/focus-trap-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { getFocusableElements, isElementFocused } from './focus-utils.js';
+import { getFocusableElements, isElementFocused, isElementHidden } from './focus-utils.js';
 
 /**
  * A controller for trapping focus within a DOM node.
@@ -110,7 +110,10 @@ export class FocusTrapController {
    * @private
    */
   __focusNextElement(backward = false) {
-    const focusableElements = this.__focusableElements;
+    // Filter out hidden elements before detecting which element to focus next.
+    // We can't do that during initialization, because by the time `trapFocus()`
+    // is called in case of overlay, focusable items might not yet be visible.
+    const focusableElements = this.__focusableElements.filter((el) => !isElementHidden(el));
     const step = backward ? -1 : 1;
     const currentIndex = this.__focusedElementIndex;
     const nextIndex = (focusableElements.length + currentIndex + step) % focusableElements.length;

--- a/packages/component-base/src/focus-utils.js
+++ b/packages/component-base/src/focus-utils.js
@@ -39,7 +39,7 @@ function isElementHiddenDirectly(element) {
  * @return {number}
  */
 function normalizeTabIndex(element) {
-  if (!isElementFocusable(element) || isElementHiddenDirectly(element)) {
+  if (!isElementFocusable(element)) {
     return -1;
   }
 
@@ -116,8 +116,8 @@ function sortElementsByTabIndex(elements) {
  * @private
  */
 function collectFocusableNodes(node, result) {
-  if (node.nodeType !== Node.ELEMENT_NODE) {
-    // Don't traverse children if the node is not an HTML element.
+  if (node.nodeType !== Node.ELEMENT_NODE || isElementHiddenDirectly(node)) {
+    // Don't traverse children if the node is not an HTML element or not visible.
     return false;
   }
 

--- a/packages/component-base/test/focus-trap-controller.test.js
+++ b/packages/component-base/test/focus-trap-controller.test.js
@@ -21,7 +21,9 @@ customElements.define(
           <div id="trap">
             <input id="trap-input-1" />
             <input id="trap-input-2" />
-            <input id="trap-input-3" />
+            <div id="parent">
+              <input id="trap-input-3" />
+            </div>
           </div>
 
           <input id="outside-input-2" />
@@ -199,6 +201,51 @@ describe('focus-trap-controller', () => {
             'trap-input-1',
             'trap-input-2',
             'trap-input-1'
+          ]);
+        });
+      });
+
+      describe('hidden elements', () => {
+        beforeEach(() => {
+          controller.trapFocus(trap);
+        });
+
+        it('should exclude elements hidden with display: none', async () => {
+          trapInput3.style.display = 'none';
+
+          const activeElement1 = await tab();
+          const activeElement2 = await tab();
+          const activeElement3 = await tab();
+          expect([activeElement1.id, activeElement2.id, activeElement3.id]).to.deep.equal([
+            'trap-input-2',
+            'trap-input-1',
+            'trap-input-2'
+          ]);
+        });
+
+        it('should exclude elements hidden with visibility: hidden', async () => {
+          trapInput3.style.visibility = 'hidden';
+
+          const activeElement1 = await tab();
+          const activeElement2 = await tab();
+          const activeElement3 = await tab();
+          expect([activeElement1.id, activeElement2.id, activeElement3.id]).to.deep.equal([
+            'trap-input-2',
+            'trap-input-1',
+            'trap-input-2'
+          ]);
+        });
+
+        it('should exclude elements whose parent node is not visible', async () => {
+          trapInput3.parentNode.style.display = 'none';
+
+          const activeElement1 = await tab();
+          const activeElement2 = await tab();
+          const activeElement3 = await tab();
+          expect([activeElement1.id, activeElement2.id, activeElement3.id]).to.deep.equal([
+            'trap-input-2',
+            'trap-input-1',
+            'trap-input-2'
           ]);
         });
       });


### PR DESCRIPTION
## Description

1. Restored the previous (Vaadin 14-23) logic for collecting focusable elements that was changed in #3141 and added tests for handling hidden elements
2. Added tests for `vaadin-accordion` inside `vaadin-dialog` to ensure <kbd>Tab</kbd> works

Fixes #3410

## Type of change

- Bugfix