### PR TITLE
refactor: remove unused private property

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -298,9 +298,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       _overlayElement: Object,
 
       /** @private */
-      _inputElement: Object,
-
-      /** @private */
       _inputContainer: Object,
 
       /** @private */


### PR DESCRIPTION
## Description

This property is a leftover from older version of the component and it's not used anywhere.

## Type of change

- Refactor