### PR TITLE
feat: add controller to handle media queries

### DIFF
--- a/packages/component-base/src/media-query-controller.d.ts
+++ b/packages/component-base/src/media-query-controller.d.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ReactiveController } from 'lit';
+
+/**
+ * A controller for listening on media query changes.
+ */
+export class MediaQueryController implements ReactiveController {
+  /**
+   * @param {HTMLElement} host
+   */
+  constructor(query: string, callback: (matches: boolean) => void);
+
+  hostConnected(): void;
+
+  hostDisconnected(): void;
+
+  /**
+   * The CSS media query to evaluate.
+   */
+  protected query: string;
+
+  /**
+   * Function to call when media query changes.
+   */
+  protected callback: (matches: boolean) => void;
+}

--- a/packages/component-base/src/media-query-controller.js
+++ b/packages/component-base/src/media-query-controller.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A controller for listening on media query changes.
+ */
+export class MediaQueryController {
+  constructor(query, callback) {
+    /**
+     * The CSS media query to evaluate.
+     *
+     * @type {string}
+     * @protected
+     */
+    this.query = query;
+
+    /**
+     * Function to call when media query changes.
+     *
+     * @type {Function}
+     * @protected
+     */
+    this.callback = callback;
+
+    this._boundQueryHandler = this._queryHandler.bind(this);
+  }
+
+  hostConnected() {
+    this._removeListener();
+
+    this._mediaQuery = window.matchMedia(this.query);
+
+    this._addListener();
+
+    this._queryHandler(this._mediaQuery);
+  }
+
+  hostDisconnected() {
+    this._removeListener();
+  }
+
+  /** @private */
+  _addListener() {
+    if (this._mediaQuery) {
+      this._mediaQuery.addListener(this._boundQueryHandler);
+    }
+  }
+
+  /** @private */
+  _removeListener() {
+    if (this._mediaQuery) {
+      this._mediaQuery.removeListener(this._boundQueryHandler);
+    }
+
+    this._mediaQuery = null;
+  }
+
+  /** @private */
+  _queryHandler(mediaQuery) {
+    if (typeof this.callback === 'function') {
+      this.callback(mediaQuery.matches);
+    }
+  }
+}

--- a/packages/component-base/test/media-query-controller.test.js
+++ b/packages/component-base/test/media-query-controller.test.js
@@ -1,0 +1,51 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '../src/controller-mixin.js';
+import { MediaQueryController } from '../src/media-query-controller.js';
+
+customElements.define(
+  'media-query-element',
+  class extends ControllerMixin(PolymerElement) {
+    static get template() {
+      return html`<slot></slot>`;
+    }
+  }
+);
+
+describe('media-query-controller', () => {
+  let element, controller;
+
+  beforeEach(() => {
+    element = fixtureSync(`<media-query-element></media-query-element>`);
+  });
+
+  it('should return true when media query matches', () => {
+    const stub = sinon.stub();
+    controller = new MediaQueryController('(min-width: 1px)', stub);
+    element.addController(controller);
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.firstCall.args[0]).to.be.true;
+  });
+
+  it('should return false when media query does not match', () => {
+    const stub = sinon.stub();
+    controller = new MediaQueryController('(min-width: 100000px)', stub);
+    element.addController(controller);
+    expect(stub.calledOnce).to.be.true;
+    expect(stub.firstCall.args[0]).to.be.false;
+  });
+
+  it('should run the callback again when the element is re-attached', () => {
+    const stub = sinon.stub();
+    controller = new MediaQueryController('(min-width: 1px)', stub);
+    element.addController(controller);
+
+    const parent = element.parentNode;
+    parent.removeChild(element);
+    parent.appendChild(element);
+
+    expect(stub.calledTwice).to.be.true;
+  });
+});


### PR DESCRIPTION
## Description

Added `MediaQueryController` to replace `<iron-media-query>` currently used in some components.

## Type of change

- Internal feature