### PR TITLE
refactor: use --lumo-clickable-cursor for details' summary

### DIFF
--- a/packages/details/theme/lumo/vaadin-details-styles.js
+++ b/packages/details/theme/lumo/vaadin-details-styles.js
@@ -26,7 +26,7 @@ const details = css`
     color: var(--lumo-secondary-text-color);
     background-color: inherit;
     border-radius: var(--lumo-border-radius-m);
-    cursor: default;
+    cursor: var(--lumo-clickable-cursor);
     -webkit-tap-highlight-color: transparent;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Description

Other interactive components like button have this configure-able cursor - was wondering: should the details' summary have it as well? Somebody can interact with it.

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
