### PR TITLE
fix: ensure slotted label ID is set properly

### DIFF
--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -41,6 +41,8 @@ export class LabelController extends SlotController {
    * @override
    */
   initCustomNode(labelNode) {
+    this.__updateLabelId(labelNode);
+
     const hasLabel = this.__hasLabel(labelNode);
     this.__toggleHasLabel(hasLabel);
   }

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -674,6 +674,26 @@ describe('field-mixin', () => {
         });
       });
     });
+
+    describe('slotted label', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`
+          <field-mixin-element>
+            <label slot="label">Label</label>
+            <input slot="input">
+          </field-mixin-element>
+        `);
+        input = element.querySelector('[slot=input]');
+        label = element.querySelector('[slot=label]');
+        await nextFrame();
+      });
+
+      it('should set aria-labelledby on the custom slotted label', () => {
+        const aria = input.getAttribute('aria-labelledby');
+        expect(aria).to.be.ok;
+        expect(aria).to.equal(label.id);
+      });
+    });
   });
 
   describe('aria-required', () => {


### PR DESCRIPTION
## Description

The root cause of the issue was the wrong initialization order:

1. `initCustomNode` is called and it toggles `has-label` state which fires `label-changed` event
2. Inside the `FieldAriaController` we attempt to set `aria-labelledby` but the label ID is still empty
3. `initNode` is called and the slot initializer runs for the custom slotted label, setting the ID too late

Overall, I'm not happy about the implementation as it's quite a bit messy.

But this PR makes it work and aligns `LabelController` with other controllers:

https://github.com/vaadin/web-components/blob/4a031fefe3c64e425d5fcd25766d4b74b637f298/packages/field-base/src/helper-controller.js#L28-L29

https://github.com/vaadin/web-components/blob/4a031fefe3c64e425d5fcd25766d4b74b637f298/packages/field-base/src/error-controller.js#L63-L64

Fixes #3446

## Type of change

- Bugfix