### PR TITLE
test: remove no longer existing property

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -324,7 +324,6 @@ describe('basic features', () => {
           return [d.day, d.month + 1, d.year].join('.');
         }
       });
-      datepicker.set('i18n.calendar', 'Kalenteri');
       datepicker.set('i18n.clear', 'Tyhjennä');
       datepicker.set('i18n.today', 'Tänään');
       datepicker.set('i18n.cancel', 'Peruuta');


### PR DESCRIPTION
## Description

We have removed `i18n.calendar` in Vaadin 23 as the toggle button is no longer supposed to be announced.
This is the only place where it remains to be set, so let's remove it as well.

## Type of change

- Tests