### PR TITLE
fix: stop cell editing when disabling grid

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -148,6 +148,23 @@ export const InlineEditingMixin = (superClass) =>
       }
     }
 
+    /**
+     * Override an observer from `DisabledMixin` to stop
+     * editing when grid element becomes disabled.
+     *
+     * @param {boolean} disabled
+     * @param {boolean} oldDisabled
+     * @protected
+     * @override
+     */
+    _disabledChanged(disabled, oldDisabled) {
+      super._disabledChanged(disabled, oldDisabled);
+
+      if (disabled && this.__edited) {
+        this._stopEdit(true);
+      }
+    }
+
     /** @protected */
     _checkImports() {
       super._checkImports();
@@ -291,7 +308,8 @@ export const InlineEditingMixin = (superClass) =>
 
     /** @private */
     _startEdit(cell, column) {
-      if (this._editingDisabled) {
+      // TODO: remove `_editingDisabled` after Flow counterpart is updated.
+      if (this.disabled || this._editingDisabled) {
         return;
       }
       // cancel debouncer enqueued on focusout

--- a/packages/grid-pro/test/edit-column.test.js
+++ b/packages/grid-pro/test/edit-column.test.js
@@ -541,6 +541,22 @@ describe('edit column', () => {
       const input = getCellEditor(cell);
       expect(input).to.be.not.ok;
     });
+
+    it('should not show editor when disabled is set to true', () => {
+      const cell = getContainerCell(grid.$.items, 1, 0);
+      grid.disabled = true;
+      enter(cell);
+      const input = getCellEditor(cell);
+      expect(input).to.be.not.ok;
+    });
+
+    it('should cancel editing when disabled is set to true', () => {
+      const cell = getContainerCell(grid.$.items, 1, 0);
+      const oldContent = cell._content.textContent;
+      enter(cell);
+      grid.disabled = true;
+      expect(cell._content.textContent).to.equal(oldContent);
+    });
   });
 
   describe('vertical scrolling', () => {


### PR DESCRIPTION
## Description

Now when `vaadin-grid-pro` supports `disabled` state inherited from `vaadin-grid`, we should use it to actually cancel editing instead of the old internal property that we used in https://github.com/vaadin/vaadin-grid-pro-flow/pull/79

Fixes #827

## Type of change

- Internal feature