### PR TITLE
feat: add default size for map component

### DIFF
--- a/dev/map.html
+++ b/dev/map.html
@@ -6,12 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Map</title>
   <script type="module" src="./common.js"></script>
-  <style>
-      vaadin-map {
-          width: 100%;
-          height: 400px;
-      }
-  </style>
 </head>
 <body>
 <script type="module">

--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -63,7 +63,9 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
       <style>
         :host {
           display: block;
-          width: 100%;
+          height: 400px;
+          flex: 1 1 auto;
+          align-self: stretch;
           overflow: hidden;
         }
 

--- a/packages/map/test/map.test.js
+++ b/packages/map/test/map.test.js
@@ -44,8 +44,6 @@ describe('configuration in detached state', () => {
 
   beforeEach(() => {
     map = document.createElement('vaadin-map');
-    map.style.width = '100px';
-    map.style.height = '100px';
   });
 
   afterEach(() => {

--- a/packages/map/test/styles.test.js
+++ b/packages/map/test/styles.test.js
@@ -18,4 +18,10 @@ describe('vaadin-map styles', () => {
     displayValue = getComputedStyle(map).display;
     expect(displayValue).to.equal('none');
   });
+
+  it('should have a default size', () => {
+    const computedStyles = getComputedStyle(map);
+    expect(parseInt(computedStyles.width)).to.be.gt(0);
+    expect(parseInt(computedStyles.height)).to.equal(400);
+  });
 });


### PR DESCRIPTION
## Description

Adds a default size for the map component. The element already was a block element, which covers width. For height the element should align with Grid and Charts, which both have a default height of 400px.

Fixes https://github.com/vaadin/web-components/issues/3449

## Type of change

- [x] Feature