### PR TITLE
fix: use ResizeMixin to observe chart resize

### DIFF
--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -5,6 +5,7 @@
  */
 import { Axis, Chart as HighchartsChart, ExtremesObject, Options, Point, Series } from 'highcharts';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export type ChartCategories = Array<string> | { [key: number]: string };
@@ -418,7 +419,7 @@ export type ChartEventMap = HTMLElementEventMap & ChartCustomEventMap;
  * @fires {CustomEvent} xaxes-extremes-set - Fired when when the minimum and maximum is set for the X axis.
  * @fires {CustomEvent} yaxes-extremes-set - Fired when when the minimum and maximum is set for the Y axis.
  */
-declare class Chart extends ThemableMixin(ElementMixin(HTMLElement)) {
+declare class Chart extends ResizeMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   readonly options: Options;
 
   /**

--- a/packages/charts/theme/vaadin-chart-base-theme.js
+++ b/packages/charts/theme/vaadin-chart-base-theme.js
@@ -1017,7 +1017,7 @@ const chartBaseTheme = css`
   }
 
   /* https://github.com/highcharts/highcharts/issues/16282 */
-  /* without this __mutationCallback always calls __reflow */
+  /* without this the resize callback always calls __reflow */
   ul[aria-hidden='false'] {
     margin: 0px;
   }


### PR DESCRIPTION
## Description

Replaced an old workaround that only handled `chart.style.height` with a proper `ResizeObserver`.

Note, this fix only goes to Vaadin 23 because there is no `ResizeMixin` in older versions.

Fixes #1605

## Type of change

- Bugfix