### PR TITLE
fix: add missing themable-mixin dependency

### DIFF
--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -37,6 +37,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.0.0-beta3",
     "@vaadin/vaadin-license-checker": "^2.1.0",
+    "@vaadin/vaadin-themable-mixin": "23.0.0-beta3",
     "ol": "6.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This PR addresses the following problem:

```
node_modules/@vaadin/map/src/vaadin-map.d.ts:8:31 - error TS2307: Cannot find module '@vaadin/vaadin-themable-mixin' or its corresponding type declarations.

8 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
```

Fixes #3465

## Type of change

- Bugfix