### PR TITLE
docs: restore JSDoc for input and change events

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -377,6 +377,12 @@ class CustomField extends FieldMixin(FocusMixin(ThemableMixin(ElementMixin(Polym
       this.validate();
     }
   }
+
+  /**
+   * Fired when the user commits a value change for any of the internal inputs.
+   *
+   * @event change
+   */
 }
 
 customElements.define(CustomField.is, CustomField);

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -170,4 +170,17 @@ export const InputControlMixin = (superclass) =>
       this.inputElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
       this.inputElement.dispatchEvent(new Event('change', { bubbles: true }));
     }
+
+    /**
+     * Fired when the user commits a value change.
+     *
+     * @event change
+     */
+
+    /**
+     * Fired when the value is changed by the user: on every typing keystroke,
+     * and the value is cleared using the clear button.
+     *
+     * @event input
+     */
   };


### PR DESCRIPTION
## Description

Added JSDoc for events that were documented in `21.0` branch but are currently missing on `master`:

https://github.com/vaadin/web-components/blob/824e52a9aea964e57cc2937c097a375097c24a05/packages/vaadin-text-field/src/vaadin-text-field-mixin.js#L856-L867

https://github.com/vaadin/web-components/blob/824e52a9aea964e57cc2937c097a375097c24a05/packages/vaadin-custom-field/src/vaadin-custom-field-mixin.js#L248-L252

## Type of change

- Docs