### PR TITLE
fix: do not fire custom-value-set event twice

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -708,6 +708,7 @@ export const ComboBoxMixin = (subclass) =>
         this.selectedItem = null;
 
         if (this.allowCustomValue) {
+          delete this._lastCustomValue;
           this.value = '';
         }
       } else {
@@ -724,17 +725,27 @@ export const ComboBoxMixin = (subclass) =>
           // to prevent a repetitive input value being saved after pressing ESC and Tab.
           !itemMatchingByLabel
         ) {
+          const customValue = this._inputElementValue;
+
+          // User's logic in `custom-value-set` event listener might cause input to blur,
+          // which will result in attempting to commit the same custom value once again.
+          if (this._lastCustomValue === customValue) {
+            return;
+          }
+
+          // Store reference to the last custom value for checking it
+          this._lastCustomValue = customValue;
+
           // An item matching by label was not found, but custom values are allowed.
           // Dispatch a custom-value-set event with the input value.
           const e = new CustomEvent('custom-value-set', {
-            detail: this._inputElementValue,
+            detail: customValue,
             composed: true,
             cancelable: true,
             bubbles: true
           });
           this.dispatchEvent(e);
           if (!e.defaultPrevented) {
-            const customValue = this._inputElementValue;
             this._selectItemForValue(customValue);
             this.value = customValue;
           }

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -304,6 +304,26 @@ describe('Properties', () => {
 
         expect(spy.calledTwice).to.be.true;
       });
+      
+      it('should fire when setting the same custom value after clearing', () => {
+        const spy = sinon.spy();
+        comboBox.addEventListener('custom-value-set', spy);
+
+        input.value = 'foo';
+        input.dispatchEvent(new CustomEvent('input'));
+        focusout(input);
+
+        input.value = '';
+        input.dispatchEvent(new CustomEvent('input'));
+        focusout(input);
+
+        spy.resetHistory();
+        input.value = 'foo';
+        input.dispatchEvent(new CustomEvent('input'));
+        focusout(input);
+
+        expect(spy.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -304,7 +304,7 @@ describe('Properties', () => {
 
         expect(spy.calledTwice).to.be.true;
       });
-      
+
       it('should fire when setting the same custom value after clearing', () => {
         const spy = sinon.spy();
         comboBox.addEventListener('custom-value-set', spy);

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -300,7 +300,7 @@ describe('Properties', () => {
 
         input.value = 'bar';
         input.dispatchEvent(new CustomEvent('input'));
-        input.blur();
+        focusout(input);
 
         expect(spy.calledTwice).to.be.true;
       });

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -271,6 +271,39 @@ describe('Properties', () => {
 
         expect(spy.calledOnce).to.be.true;
       });
+
+      it('should not fire twice when the custom value set listener causes blur', () => {
+        const spy = sinon.spy();
+        comboBox.addEventListener('custom-value-set', spy);
+
+        // Emulate opening the overlay that causes blur
+        comboBox.addEventListener('custom-value-set', () => {
+          comboBox.blur();
+        });
+
+        comboBox.open();
+        input.value = 'foo';
+        input.dispatchEvent(new CustomEvent('input'));
+        comboBox.close();
+
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should fire twice when another custom value is committed by the user', () => {
+        const spy = sinon.spy();
+        comboBox.addEventListener('custom-value-set', spy);
+
+        comboBox.open();
+        input.value = 'foo';
+        input.dispatchEvent(new CustomEvent('input'));
+        comboBox.close();
+
+        input.value = 'bar';
+        input.dispatchEvent(new CustomEvent('input'));
+        input.blur();
+
+        expect(spy.calledTwice).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Currently the `custom-value-set` event can be fired in several cases:

1. When user "commits" the input value by pressing <kbd>Enter</kbd> key
2. When `opened` property changes to `false` (in the observer)
3. When combo-box loses focus (in the `focusout` listener)

However, user can perform custom logic on `custom-value-set` event.
For example, it can be opening a dialog that would cause blur.

Added a check to ensure the same custom value isn't confirmed twice.

Fixes https://github.com/vaadin/flow-components/issues/2523

## Type of change

- Bugfix