### PR TITLE
fix: Removed readOnly from theme property

### DIFF
--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
@@ -29,17 +29,8 @@ export const ThemePropertyMixin = (superClass) =>
          */
         theme: {
           type: String,
-          readOnly: true
+          reflectToAttribute: true
         }
       };
-    }
-
-    /** @protected */
-    attributeChangedCallback(name, oldValue, newValue) {
-      super.attributeChangedCallback(name, oldValue, newValue);
-
-      if (name === 'theme') {
-        this._setTheme(newValue);
-      }
     }
   };


### PR DESCRIPTION
## Description

The readOnly parameter on the theme property makes the theme attribute to be removed form the DOM. I have investigated how other attributes are defined and reproduced the same behaviour from the TabindexMixin class.

Fixes #3483 

## Type of change

- [X] Bugfix

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [X] I have performed self-review and corrected misspellings.
