### PR TITLE
fix: check last custom value on focusout

### DIFF
--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -271,6 +271,39 @@ describe('Properties', () => {
 
         expect(spy.calledOnce).to.be.true;
       });
+
+      it('should not fire twice when the custom value set listener causes blur', () => {
+        const spy = sinon.spy();
+        comboBox.addEventListener('custom-value-set', spy);
+
+        // Emulate opening the overlay that causes blur
+        comboBox.addEventListener('custom-value-set', () => {
+          comboBox.blur();
+        });
+
+        comboBox.open();
+        input.value = 'foo';
+        input.dispatchEvent(new CustomEvent('input'));
+        comboBox.close();
+
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should fire twice when another custom value is committed by the user', () => {
+        const spy = sinon.spy();
+        comboBox.addEventListener('custom-value-set', spy);
+
+        comboBox.open();
+        input.value = 'foo';
+        input.dispatchEvent(new CustomEvent('input'));
+        comboBox.close();
+
+        input.value = 'bar';
+        input.dispatchEvent(new CustomEvent('input'));
+        focusout(input);
+
+        expect(spy.calledTwice).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Updated the original fix to only check last custom value on `focusout` where the actual problem manifested.
To me it seems like a cleaner approach than attempting to reset that flag in all the possible cases.

Fixes https://github.com/vaadin/flow-components/issues/2523

## Type of change

- Bugfix