### PR TITLE
fix: restore tabindex when field is re-enabled

### DIFF
--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -306,10 +306,11 @@ export class PasswordField extends SlotStylesMixin(SlotMixin(TextField)) {
    * Override method inherited from `DisabledMixin` to synchronize the reveal button
    * disabled state with the password field disabled state.
    * @param {boolean} disabled
+   * @param {boolean} oldDisabled
    * @protected
    */
-  _disabledChanged(disabled) {
-    super._disabledChanged(disabled);
+  _disabledChanged(disabled, oldDisabled) {
+    super._disabledChanged(disabled, oldDisabled);
 
     if (this._revealNode) {
       this._revealNode.disabled = disabled;

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -207,13 +207,14 @@ describe('invalid with value', () => {
 
 describe('disabled', () => {
   let passwordField;
+  let revealButton;
 
   beforeEach(() => {
     passwordField = fixtureSync('<vaadin-password-field disabled></vaadin-password-field>');
+    revealButton = passwordField.querySelector('[slot=reveal]');
   });
 
   describe('reveal button focus', () => {
-    let revealButton;
     let focusInput;
 
     async function shiftTab() {
@@ -223,7 +224,6 @@ describe('disabled', () => {
     }
 
     beforeEach(async () => {
-      revealButton = passwordField.querySelector('[slot=reveal]');
       focusInput = fixtureSync('<input>');
       // Move focus to the input after the field so we can shift-tab to the reveal button in tests
       focusInput.focus();
@@ -245,6 +245,18 @@ describe('disabled', () => {
       passwordField.disabled = true;
       await shiftTab();
       expect(document.activeElement).not.to.equal(revealButton);
+    });
+  });
+
+  describe('tabindex', () => {
+    it('should restore button tabindex when field is re-enabled', () => {
+      passwordField.disabled = false;
+      expect(revealButton.tabIndex).to.equal(0);
+    });
+
+    it('should restore input tabindex when field is re-enabled', () => {
+      passwordField.disabled = false;
+      expect(passwordField.inputElement.tabIndex).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## Description

This is a fix for regression introduced by #3416 and caused by incorrect overriding of the observer.

## Type of change

- Bugfix