### PR TITLE
fix: don't cancel text-area wheel event unnecessarily

### DIFF
--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -205,9 +205,13 @@ export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableM
     // event, scrolling manually and then synchronously updating the scroll position CSS variable
     // allows us to avoid some jumpy behavior that would occur on wheel otherwise.
     this._inputField.addEventListener('wheel', (e) => {
-      e.preventDefault();
+      const scrollTopBefore = this._inputField.scrollTop;
       this._inputField.scrollTop += e.deltaY;
-      this.__scrollPositionUpdated();
+
+      if (scrollTopBefore !== this._inputField.scrollTop) {
+        e.preventDefault();
+        this.__scrollPositionUpdated();
+      }
     });
 
     this._updateHeight();

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -386,6 +386,11 @@ describe('text-area', () => {
         expect(e.defaultPrevented).to.be.true;
       });
 
+      it('should not cancel wheel event if text area is not scrolled', () => {
+        const e = wheel({ deltaY: -10 });
+        expect(e.defaultPrevented).to.be.false;
+      });
+
       it('should update value on resize', async () => {
         inputField.scrollTop = 10;
         await nextFrame();


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/3494