### PR TITLE
fix: make nested focus trap controllers work

### DIFF
--- a/packages/component-base/src/focus-trap-controller.js
+++ b/packages/component-base/src/focus-trap-controller.js
@@ -58,12 +58,12 @@ export class FocusTrapController {
   trapFocus(trapNode) {
     this.__trapNode = trapNode;
 
-    instances.push(this);
-
     if (this.__focusableElements.length === 0) {
       this.__trapNode = null;
       throw new Error('The trap node should have at least one focusable descendant or be focusable itself.');
     }
+
+    instances.push(this);
 
     if (this.__focusedElementIndex === -1) {
       this.__focusableElements[0].focus();

--- a/packages/component-base/src/focus-trap-controller.js
+++ b/packages/component-base/src/focus-trap-controller.js
@@ -77,7 +77,7 @@ export class FocusTrapController {
   releaseFocus() {
     this.__trapNode = null;
 
-    instances.splice(instances.indexOf(this), 1);
+    instances.pop();
   }
 
   /**

--- a/packages/component-base/src/focus-trap-controller.js
+++ b/packages/component-base/src/focus-trap-controller.js
@@ -5,6 +5,8 @@
  */
 import { getFocusableElements, isElementFocused } from './focus-utils.js';
 
+const instances = [];
+
 /**
  * A controller for trapping focus within a DOM node.
  */
@@ -56,6 +58,8 @@ export class FocusTrapController {
   trapFocus(trapNode) {
     this.__trapNode = trapNode;
 
+    instances.push(this);
+
     if (this.__focusableElements.length === 0) {
       this.__trapNode = null;
       throw new Error('The trap node should have at least one focusable descendant or be focusable itself.');
@@ -72,6 +76,8 @@ export class FocusTrapController {
    */
   releaseFocus() {
     this.__trapNode = null;
+
+    instances.splice(instances.indexOf(this), 1);
   }
 
   /**
@@ -87,6 +93,11 @@ export class FocusTrapController {
    */
   __onKeyDown(event) {
     if (!this.__trapNode) {
+      return;
+    }
+
+    // Only handle events for the last instance
+    if (this !== Array.from(instances).pop()) {
       return;
     }
 

--- a/packages/component-base/test/focus-trap-controller.test.js
+++ b/packages/component-base/test/focus-trap-controller.test.js
@@ -298,7 +298,7 @@ describe('focus-trap-controller', () => {
   });
 
   describe('nested', () => {
-    let wrapper, wrapperController, wrapperTrap, trapInput1, trapInput2;
+    let wrapper, wrapperController, wrapperTrap, trapInput1, trapInput2, trapInput3;
 
     beforeEach(() => {
       wrapper = fixtureSync(`<focus-trap-wrapper></focus-trap-wrapper>`);
@@ -313,6 +313,7 @@ describe('focus-trap-controller', () => {
 
       trapInput1 = trap.querySelector('#trap-input-1');
       trapInput2 = trap.querySelector('#trap-input-2');
+      trapInput3 = trap.querySelector('#trap-input-3');
     });
 
     it('should only take last active controller instance into account', async () => {
@@ -323,6 +324,24 @@ describe('focus-trap-controller', () => {
       await tab();
 
       expect(document.activeElement).to.equal(trapInput2);
+    });
+
+    it('should use outer trap when nested controller is de-activated', async () => {
+      wrapperController.trapFocus(wrapperTrap);
+      controller.trapFocus(trap);
+
+      trapInput1.focus();
+      await shiftTab();
+
+      expect(document.activeElement).to.equal(trapInput3);
+
+      controller.releaseFocus();
+
+      await tab();
+      await tab();
+      await tab();
+
+      expect(document.activeElement).to.equal(trapInput1);
     });
   });
 });


### PR DESCRIPTION
## Description

In Vaadin 22, the focus trap logic was placed in `vaadin-overlay` where we checked if the current instance is the last one:

https://github.com/vaadin/web-components/blob/2d360f043e4825bc431c55ba41a269d38c6009cc/packages/vaadin-overlay/src/vaadin-overlay.js#L514-L517

Implemented similar "stack" logic in `FocusTrapController` to make sure it covers all the components using it.
For example, there could be a `vaadin-dialog` opened from the `vaadin-app-layout` modal drawer, etc.

Fixes #3491

## Type of change

- Bugfix