### PR TITLE
fix: do not expand to full available width

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -65,7 +65,7 @@ class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(
       <style>
         :host {
           display: block;
-          width: 100%; /* make overflow work in flex */
+          align-self: stretch; /* make overflow work in flex */
         }
 
         :host([hidden]) {

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -603,3 +603,22 @@ describe('item components', () => {
     expect(Number(style.zIndex)).to.equal(1);
   });
 });
+
+describe('menu-bar in flex', () => {
+  let wrapper;
+  let menu;
+
+  beforeEach(() => {
+    wrapper = fixtureSync(`
+      <div style="display: flex; width: 400px;">
+        <vaadin-menu-bar></vaadin-menu-bar>
+      </div>
+    `);
+    menu = wrapper.firstElementChild;
+    menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }];
+  });
+
+  it('should not expand to full width of the container', () => {
+    expect(menu.offsetWidth).to.be.lessThan(wrapper.offsetWidth);
+  });
+});


### PR DESCRIPTION
## Description

Updated to use the same approach as for other components, e.g. `vaadin-grid`:

https://github.com/vaadin/web-components/blob/36dea1bb06a51c566151a27f9c50c8ac56fe4403/packages/grid/src/vaadin-grid-styles.js#L22

Fixes #3503

## Type of change

- Bugfix