### PR TITLE
fix: disable cancelSyntheticClickEvents globally

### DIFF
--- a/packages/component-base/src/element-mixin.js
+++ b/packages/component-base/src/element-mixin.js
@@ -3,10 +3,17 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { setCancelSyntheticClickEvents } from '@polymer/polymer/lib/utils/settings.js';
 import { usageStatistics } from '@vaadin/vaadin-usage-statistics/vaadin-usage-statistics.js';
 import { idlePeriod } from './async.js';
 import { Debouncer, enqueueDebouncer } from './debounce.js';
 import { DirMixin } from './dir-mixin.js';
+
+// This setting affects the legacy Polymer gestures which get activated
+// once you import any iron component e.g iron-icon.
+// It has to be explicitly disabled to prevent click issues in iOS + VoiceOver
+// for buttons that are based on `[role=button]` e.g vaadin-button.
+setCancelSyntheticClickEvents(false);
 
 window.Vaadin = window.Vaadin || {};
 

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { click, touchend, touchstart } from '@vaadin/testing-helpers';
+import { click, fixtureSync, touchend, touchstart } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { flush } from '../src/debounce.js';
@@ -34,22 +34,10 @@ describe('ElementMixin', () => {
       expect(window.Vaadin.developmentModeCallback).to.be.instanceOf(Object);
       expect(window.Vaadin.developmentModeCallback['vaadin-usage-statistics']).to.be.instanceOf(Function);
     });
-  });
 
-  describe('cancelSyntheticClickEvents', () => {
-    let button;
-
-    beforeEach(() => {
-      button = document.createElement('div');
-      document.body.appendChild(button);
-    });
-
-    afterEach(() => {
-      button.remove();
-    });
-
-    it('should disable cancelSyntheticClickEvents globally', async () => {
+    it('should set the Polymer cancelSyntheticClickEvents setting to false', async () => {
       await import('@polymer/polymer/lib/utils/gestures.js');
+      const button = fixtureSync('<button></button>');
       touchstart(button);
       touchend(button);
       const event = click(button);

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@esm-bundle/chai';
+import { click, touchend, touchstart } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { flush } from '../src/debounce.js';
@@ -32,6 +33,27 @@ describe('ElementMixin', () => {
     it('should collect usage statistics', () => {
       expect(window.Vaadin.developmentModeCallback).to.be.instanceOf(Object);
       expect(window.Vaadin.developmentModeCallback['vaadin-usage-statistics']).to.be.instanceOf(Function);
+    });
+  });
+
+  describe('cancelSyntheticClickEvents', () => {
+    let button;
+
+    beforeEach(() => {
+      button = document.createElement('div');
+      document.body.appendChild(button);
+    });
+
+    afterEach(() => {
+      button.remove();
+    });
+
+    it('should disable cancelSyntheticClickEvents globally', async () => {
+      await import('@polymer/polymer/lib/utils/gestures.js');
+      touchstart(button);
+      touchend(button);
+      const event = click(button);
+      expect(event.__polymerGesturesHandled).to.be.undefined;
     });
   });
 

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import { click, fixtureSync, touchend, touchstart } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { flush } from '../src/debounce.js';
@@ -36,12 +35,8 @@ describe('ElementMixin', () => {
     });
 
     it('should set the Polymer cancelSyntheticClickEvents setting to false', async () => {
-      await import('@polymer/polymer/lib/utils/gestures.js');
-      const button = fixtureSync('<button></button>');
-      touchstart(button);
-      touchend(button);
-      const event = click(button);
-      expect(event.__polymerGesturesHandled).to.be.undefined;
+      const { cancelSyntheticClickEvents } = await import('@polymer/polymer/lib/utils/settings.js');
+      expect(cancelSyntheticClickEvents).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

The PR disables the `cancelSyntheticClickEvents` Polymer setting through `ElementMixin`.

This setting determines whether the legacy Polymer gestures module should globally listen for click events on the page and cancel them if they are considered synthetic. Normally, the legacy gestures module is not supposed to be imported anywhere in the web components and `component-base/src/gestures.js` should be used instead which doesn't have that logic. However, if you import an iron component e.g. iron-icon or iron-list, it will implicitly cause the legacy gestures module to import.

This setting has to be disabled because otherwise, it affects `vaadin-button` components, preventing them from triggering actions on click. It occurs when (a) both a button and an iron component are used on the same page (b) iOS VoiceOver is used as a screen assistant.

Since the canceling synthetic clicks logic was introduced mainly for old browsers, it is no longer reasonable to keep it enabled.

Fixes #3364 #3367 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
