### PR TITLE
fix: check if item exists before accessing it

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -395,7 +395,9 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement)
     const result = [];
     for (let i = limit; i < items; i++) {
       const item = this.items[i];
-      result.push(item.name || item.abbr || 'anonymous');
+      if (item) {
+        result.push(item.name || item.abbr || 'anonymous');
+      }
     }
     // override generated title attribute
     this.$.overflow.setAttribute('title', result.join('\n'));


### PR DESCRIPTION
## Description

I wasn't able to reproduce the original issue, so it's unclear how this can be tested. 

Fixes #1885

## Type of change

- Bugfix