### PR TITLE
Revert "fix: disable cancelSyntheticClickEvents globally (#3515)" (22.0)

### DIFF
--- a/packages/component-base/src/element-mixin.js
+++ b/packages/component-base/src/element-mixin.js
@@ -3,17 +3,10 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { setCancelSyntheticClickEvents } from '@polymer/polymer/lib/utils/settings.js';
 import { usageStatistics } from '@vaadin/vaadin-usage-statistics/vaadin-usage-statistics.js';
 import { idlePeriod } from './async.js';
 import { Debouncer, enqueueDebouncer } from './debounce.js';
 import { DirMixin } from './dir-mixin.js';
-
-// This setting affects the legacy Polymer gestures which get activated
-// once you import any iron component e.g iron-icon.
-// It has to be explicitly disabled to prevent click issues in iOS + VoiceOver
-// for buttons that are based on `[role=button]` e.g vaadin-button.
-setCancelSyntheticClickEvents(false);
 
 window.Vaadin = window.Vaadin || {};
 

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -33,11 +33,6 @@ describe('ElementMixin', () => {
       expect(window.Vaadin.developmentModeCallback).to.be.instanceOf(Object);
       expect(window.Vaadin.developmentModeCallback['vaadin-usage-statistics']).to.be.instanceOf(Function);
     });
-
-    it('should set the Polymer cancelSyntheticClickEvents setting to false', async () => {
-      const { cancelSyntheticClickEvents } = await import('@polymer/polymer/lib/utils/settings.js');
-      expect(cancelSyntheticClickEvents).to.be.false;
-    });
   });
 
   describe('version', () => {


### PR DESCRIPTION
This reverts commit 03b420e0bee214acc294e57934215f3cbe45d23d.

## Description

Reverting as the fix causes failures in Vaadin 22 when using with Flow (see https://github.com/vaadin/flow-components/pull/2795)

The reason is that V22 uses Polymer pinned to 3.2.0 and `setCancelSyntheticClickEvents` API was added later. 
This is not the case for V23 where we have upgraded Polymer to the latest one (3.4.1): https://github.com/vaadin/flow/pull/12935

The actual fix was targeting the issue with low impact (iOS VoiceOver users) and IMO it does not have to be in V22.
Users who care about a11y should use V23 instead as it contains more important fixes to other web components.

Also for pure web components users it can be easily done by applying the same fix manually.

## Type of change

- Revert