### PR TITLE
chore: add script to run npm dist-tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ analysis.json
 yarn-error.log
 .env
 
+# List of packages
+scripts/packages.txt
+
 # Failures from visual tests
 packages/*/test/visual/*/screenshots/*/failed
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ analysis.json
 yarn-error.log
 .env
 
-# List of packages
-scripts/packages.txt
-
 # Failures from visual tests
 packages/*/test/visual/*/screenshots/*/failed
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,17 @@ This will symlink the individual component packages into the `node_modules` fold
 
 After that you can start / restart your application and it should use the source code from the monorepo.
 
+### Fixing npm dist-tag
+
+When maintaining two stable majors (e.g. 22.0.x and 23.0.x), it is important to maintain `latest` npm tag.
+For example, we release 22.0.7 after 23.0.1 but we still want to keep `latest` pointing to 23.0.1.
+
+Use the following script on `master` branch to run `npm dist-tag` for all packages:
+
+```sh
+./scripts/fixDistTag.sh
+```
+
 ## LICENSE
 
 For specific package(s), check the LICENSE file under the package folder.

--- a/scripts/fixDistTag.sh
+++ b/scripts/fixDistTag.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# List all packages managed by Lerna
+packages=$(./node_modules/.bin/lerna list)
+
+# Get latest version of all packages
+version=$(node -pe 'JSON.parse(process.argv[1]).version' "$(cat lerna.json)")
+
+fixDistTag() {
+  package=$1
+  echo fixing $package
+
+  # List npm tags
+  npm dist-tag ls $package
+
+  # Update "latest" tag to correct version
+  npm dist-tag add $package@$version latest
+}
+
+for i in $packages
+do
+  fixDistTag $i
+done


### PR DESCRIPTION
## Description

Added a script to run `npm dist-tag` for all packages after publishing a patch release.

Example: we published `23.0.1` and then `22.0.7` so it becomes marked as `latest`.
Run this script manually (for now) to ensure it updates `latest` tag back to `23.0.1` 

## Type of change

- Internal change