### PR TITLE
fix: reset stored column order on mousedown

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -92,10 +92,8 @@ export const KeyboardNavigationMixin = (superClass) =>
         this.toggleAttribute('navigating', false);
         this._isMousedown = true;
 
-        if (this._focusedColumnOrder !== undefined) {
-          // Reset stored order when moving focus with mouse.
-          this._focusedColumnOrder = undefined;
-        }
+        // Reset stored order when moving focus with mouse.
+        this._focusedColumnOrder = undefined;
       });
       this.addEventListener('mouseup', () => (this._isMousedown = false));
     }

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -91,6 +91,11 @@ export const KeyboardNavigationMixin = (superClass) =>
       this.addEventListener('mousedown', () => {
         this.toggleAttribute('navigating', false);
         this._isMousedown = true;
+
+        if (this._focusedColumnOrder !== undefined) {
+          // Reset stored order when moving focus with mouse.
+          this._focusedColumnOrder = undefined;
+        }
       });
       this.addEventListener('mouseup', () => (this._isMousedown = false));
     }

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -708,6 +708,24 @@ describe('keyboard navigation', () => {
       });
     });
 
+    describe('mixing keyboard and mouse', () => {
+      it('should update column after mousedown on other cell', () => {
+        // Focus cell in third column
+        focusWithMouse(getRowCell(0, 2));
+
+        down();
+
+        expect(getFocusedCellIndex()).to.equal(2);
+
+        // Focus cell in first column
+        focusWithMouse(getRowCell(0, 0));
+
+        down();
+
+        expect(getFocusedCellIndex()).to.equal(0);
+      });
+    });
+
     describe('with hidden columns', () => {
       it('should skip over hidden column with right arrow', () => {
         grid._columnTree[0][1].hidden = true;


### PR DESCRIPTION
## Description

Currently, the stored column order is only reset on navigating left and right using keyboard.
This PR changes it to also reset on `mousedown` event to avoid using wrong column.

Fixes #2134

## Type of change

- Bugfix