### PR TITLE
refactor: handle user-selected date properly

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -83,7 +83,7 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
             i18n="[[i18n]]"
             fullscreen$="[[_fullscreen]]"
             label="[[label]]"
-            selected-date="{{_selectedDate}}"
+            selected-date="[[_selectedDate]]"
             slot="dropdown-content"
             focused-date="{{_focusedDate}}"
             show-week-numbers="[[showWeekNumbers]]"

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -237,8 +237,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
        * The value for this element.
        */
       selectedDate: {
-        type: Date,
-        notify: true
+        type: Date
       },
 
       /**
@@ -370,6 +369,17 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     this._scrollToPosition(this._differenceInMonths(date, this._originDate), animate);
   }
 
+  /**
+   * Select a date and fire event indicating user interaction.
+   * @protected
+   */
+  _selectDate(dateToSelect) {
+    this.selectedDate = dateToSelect;
+    this.dispatchEvent(
+      new CustomEvent('date-selected', { detail: { date: dateToSelect }, bubbles: true, composed: true })
+    );
+  }
+
   _focusedDateChanged(focusedDate) {
     this.revealDate(focusedDate);
   }
@@ -460,7 +470,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     if (Math.abs(this.$.monthScroller.position - this._differenceInMonths(today, this._originDate)) < 0.001) {
       // Select today only if the month scroller is positioned approximately
       // at the beginning of the current month
-      this.selectedDate = today;
+      this._selectDate(today);
       this._close();
     } else {
       this._scrollToCurrentMonth();
@@ -659,7 +669,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
   }
 
   _clear() {
-    this.selectedDate = '';
+    this._selectDate('');
   }
 
   _close() {
@@ -683,10 +693,10 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
   __toggleDate(date) {
     if (dateEquals(date, this.selectedDate)) {
-      this.selectedDate = '';
+      this._clear();
       this.focusedDate = date;
     } else {
-      this.selectedDate = date;
+      this._selectDate(date);
     }
   }
 
@@ -711,7 +721,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
         handled = true;
         break;
       case 'Enter':
-        this.selectedDate = this.focusedDate;
+        this._selectDate(this.focusedDate);
         this._close();
         handled = true;
         break;

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -171,7 +171,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
             i18n="[[i18n]]"
             fullscreen$="[[_fullscreen]]"
             label="[[label]]"
-            selected-date="{{_selectedDate}}"
+            selected-date="[[_selectedDate]]"
             slot="dropdown-content"
             focused-date="{{_focusedDate}}"
             show-week-numbers="[[showWeekNumbers]]"

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -369,7 +369,9 @@ class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
   _handleTap(e) {
     if (!this.ignoreTaps && !this._notTapping && e.target.date && !e.target.hasAttribute('disabled')) {
       this.selectedDate = e.target.date;
-      this.dispatchEvent(new CustomEvent('date-tap', { bubbles: true, composed: true }));
+      this.dispatchEvent(
+        new CustomEvent('date-tap', { detail: { date: e.target.date }, bubbles: true, composed: true })
+      );
     }
   }
 

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -190,7 +190,8 @@ describe('basic features', () => {
   it('should close on overlay date tap', async () => {
     await open(datepicker);
     const spy = sinon.spy(datepicker, 'close');
-    getOverlayContent(datepicker).dispatchEvent(new CustomEvent('date-tap', { bubbles: true, composed: true }));
+    const evt = new CustomEvent('date-tap', { detail: { date: new Date() }, bubbles: true, composed: true });
+    getOverlayContent(datepicker).dispatchEvent(evt);
     expect(spy.called).to.be.true;
   });
 
@@ -424,7 +425,7 @@ describe('basic features', () => {
       });
 
       datepicker.open();
-      getOverlayContent(datepicker).selectedDate = new Date('2017-01-01'); // invalid
+      getOverlayContent(datepicker)._selectDate(new Date('2017-01-01')); // invalid
     });
 
     it('should change invalid state only once', (done) => {
@@ -436,7 +437,7 @@ describe('basic features', () => {
       const invalidChangedSpy = sinon.spy();
       datepicker.addEventListener('invalid-changed', invalidChangedSpy);
       datepicker.open();
-      getOverlayContent(datepicker).selectedDate = new Date('2017-01-01');
+      getOverlayContent(datepicker)._selectDate(new Date('2017-01-01'));
     });
 
     it('should scroll to min date when today is not allowed', (done) => {


### PR DESCRIPTION
## Description

This PR updates the date-picker logic in preparation for fixing events being fired in the wrong order.

Related to #3379

## Problem

There are two different ways of how `vaadin-date-picker` value can be updated:

1. Programmatically, by setting `value` property with JS,
2. User-selected (by typing or selecting from the overlay).

In the first case, `value` is set and then internal `_selectedDate` property is updated accordingly. This works fine.

In the second case, `_selectedDate` is set first, then `value` is updated and then `_selectedDate` is set again:

https://github.com/vaadin/web-components/blob/4be73e80304191b3d518003c932ba7b3d25ec54f/packages/date-picker/src/vaadin-date-picker-mixin.js#L672

This part of logic is problematic because of how internal flags are used. Currently, there are two of them:

- `__userInputOccured` - set when `_focusedDate` changes (cover changing date in the overlay month calendar),
- `__dispatchChange` - set inside the `_selectedDateChanged` observer if `__userInputOccured` is set to `true`. 

The actual problem with the current implementation is how these flags are reset in the second observer run. 

1. Right now, when firing `change` event inside of the `_valueChaned` observer, the flag is still there. 
2. If we move `change` event to `value-changed` event listener, by that time the flag is already removed.

This is understandable because Polymer runs `notify` events [after the property observers](https://github.com/Polymer/polymer/blob/65039eebe167bf110850ea0320f87bb3014c5c24/lib/mixins/property-effects.js#L1921-L1926).

## Solution

1. Removed using two-way data binding for `_selectedDate` property to use one-way data flow instead.
2. Added `_selectDate` method to be called on user interactions only (e.g. selecting date with mouse or keyboard).
3. Moved setting `__dispatchChange` flag to `_selectDate` method to not modify it in `_selectedDateChanged`.
4. Added internal `date-selected` event to be used for keys, similarly to how `date-tap` is used for mouse clicks.

These changes would make it easier to move the logic for `change` event (will be done in a separate PR).

## Type of change

- Refactor