### PR TITLE
chore: update change detection branch to 23.0

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -48,7 +48,7 @@ const isLockfileChanged = () => {
  * Get packages changed since master.
  */
 const getChangedPackages = () => {
-  const output = execSync('./node_modules/.bin/lerna ls --since origin/master --json --loglevel silent');
+  const output = execSync('./node_modules/.bin/lerna ls --since origin/23.0 --json --loglevel silent');
   return JSON.parse(output.toString()).map((project) => project.name.replace('@vaadin/', ''));
 };
 


### PR DESCRIPTION
## Description

Update the web test runner change detection script to use `23.0` as a base branch for Vaadin 23.0

## Type of change

- Internal change