### PR TITLE
refactor: move base styles from themes to src

### DIFF
--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -114,7 +114,13 @@ export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableM
           box-shadow: none;
         }
 
-        [part='input-field'] ::slotted(*) {
+        /* Override styles from <vaadin-input-container> */
+        [part='input-field'] ::slotted(textarea) {
+          align-self: stretch;
+          white-space: pre-wrap;
+        }
+
+        [part='input-field'] ::slotted(:not(textarea)) {
           align-self: flex-start;
         }
 

--- a/packages/text-area/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area-styles.js
@@ -51,8 +51,6 @@ const textArea = css`
   }
 
   [part='input-field'] ::slotted(textarea) {
-    white-space: pre-wrap; /* override "nowrap" from <vaadin-text-field> */
-    align-self: stretch; /* override "baseline" from <vaadin-text-field> */
     line-height: inherit;
     --_lumo-text-field-overflow-mask-image: none;
   }

--- a/packages/text-area/theme/material/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/material/vaadin-text-area-styles.js
@@ -17,11 +17,6 @@ const textArea = css`
     margin-top: 4px;
   }
 
-  [part='input-field'] ::slotted(textarea) {
-    white-space: pre-wrap; /* override "nowrap" from <vaadin-text-field> */
-    align-self: stretch; /* override "baseline" from <vaadin-text-field> */
-  }
-
   [part='input-field']::before,
   [part='input-field']::after {
     bottom: calc(var(--_text-area-vertical-scroll-position) * -1);


### PR DESCRIPTION
## Description

When converting `vaadin-text-area` to Lit, I noticed that some styles placed in themes should be in `src`.

Using `white-space: pre-wrap` is needed to override this line:

https://github.com/vaadin/web-components/blob/54decd0cc017ec15d717a063aba63a4c4ccc396a/packages/input-container/src/vaadin-input-container.js#L34

Setting `align-self` for slotted `<textarea>` overrides this line:

https://github.com/vaadin/web-components/blob/54decd0cc017ec15d717a063aba63a4c4ccc396a/packages/input-container/src/vaadin-input-container.js#L21

## Type of change

- Refactor