### PR TITLE
fix: do not delegate focus when clicking on non-focusable child

### DIFF
--- a/packages/field-base/src/shadow-focus-mixin.js
+++ b/packages/field-base/src/shadow-focus-mixin.js
@@ -62,7 +62,9 @@ export const ShadowFocusMixin = (superClass) =>
         const path = event.composedPath();
 
         // When focus moves from outside and not with Shift + Tab, delegate it to focusElement.
-        if (path[0] === this && !this.contains(event.relatedTarget) && !this._isShiftTabbing) {
+        // This should only move focus when using keyboard navigation, for clicks we don't want to interfere,
+        // for example when the user tries to select some text
+        if (this._keyboardActive && path[0] === this && !this.contains(event.relatedTarget) && !this._isShiftTabbing) {
           this.focusElement.focus();
           return true;
         }

--- a/packages/field-base/test/shadow-focus-mixin.test.js
+++ b/packages/field-base/test/shadow-focus-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, focusin, focusout, keyboardEventFor, keyDownOn } from '@vaadin/testing-helpers';
-import { sendKeys, sendMouse } from '@web/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ShadowFocusMixin } from '../src/shadow-focus-mixin.js';
@@ -188,6 +188,10 @@ describe('shadow-focus-mixin', () => {
   });
 
   describe('focus', () => {
+    afterEach(async () => {
+      await resetMouse();
+    });
+
     it('should call focus on focusElement', () => {
       const spy = sinon.spy(focusElement, 'focus');
       customElement.focus();

--- a/packages/field-base/test/shadow-focus-mixin.test.js
+++ b/packages/field-base/test/shadow-focus-mixin.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, focusin, focusout, keyboardEventFor, keyDownOn } from '@vaadin/testing-helpers';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ShadowFocusMixin } from '../src/shadow-focus-mixin.js';
@@ -11,6 +12,7 @@ customElements.define(
       return html`
         <input id="input" />
         <input id="secondInput" />
+        <slot></slot>
       `;
     }
 
@@ -47,7 +49,7 @@ describe('shadow-focus-mixin', () => {
       expect(focusElement.getAttribute('tabindex')).to.be.equal('1');
     });
 
-    it('should se tabindex to 0 by default', () => {
+    it('should set tabindex to 0 by default', () => {
       expect(customElement.getAttribute('tabindex')).to.be.equal('0');
     });
 
@@ -202,7 +204,28 @@ describe('shadow-focus-mixin', () => {
       expect(customElement.hasAttribute('focused')).to.be.true;
     });
 
-    it('should not focus if the focus is not received from outside', () => {
+    it('should delegate focus if the focus is received from outside using keyboard navigation', async () => {
+      const spy = sinon.spy(focusElement, 'focus');
+      await sendKeys({ press: 'Tab' });
+      expect(spy.called).to.be.true;
+    });
+
+    it('should not delegate focus when clicking on non-focusable child', async () => {
+      const span = document.createElement('span');
+      span.textContent = 'test';
+      customElement.appendChild(span);
+
+      const spy = sinon.spy(focusElement, 'focus');
+      // Click center of span child element
+      const rect = span.getBoundingClientRect();
+      const middleX = Math.floor(rect.x + rect.width / 2);
+      const middleY = Math.floor(rect.y + rect.height / 2);
+      await sendMouse({ type: 'click', position: [middleX, middleY] });
+      // Clicking on some text content should not move focus
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not delegate focus if the focus is not received from outside', () => {
       const child = document.createElement('div');
       customElement.appendChild(child);
 


### PR DESCRIPTION
## Description

Fixes `vaadin-details` to only delegate focus to its summary element when moving the focus into the element using keyboard navigation. This solves issues like text selection or click events on details content not working, if the element is not already focused.

One concern here is that the fix is applied to `ShadowFocusMixin`, which is currently only used in `vaadin-details`. However someone might expect `ShadowFocusMixin` to work differently when applied to other components, in that it should always delegate the focus, regardless whether the `focusin` event was caused by clicks or keyboard. I'm open for adding an override of the relevant `_shouldSetFocus` method to `vaadin-details` itself, and only apply the fix there. Alternatively we could add some sort of option to `ShadowFocusMixin`, but given that we only have one usage that would be over-engineered.

Fixes #561
Fixes https://github.com/vaadin/flow-components/issues/2805

## Type of change

- Bugfix