### PR TITLE
chore: fix flaky shadow focus mixin test

### DIFF
--- a/packages/field-base/test/shadow-focus-mixin.test.js
+++ b/packages/field-base/test/shadow-focus-mixin.test.js
@@ -209,6 +209,7 @@ describe('shadow-focus-mixin', () => {
     });
 
     it('should delegate focus if the focus is received from outside using keyboard navigation', async () => {
+      document.body.focus();
       const spy = sinon.spy(focusElement, 'focus');
       await sendKeys({ press: 'Tab' });
       expect(spy.called).to.be.true;


### PR DESCRIPTION
## Description

Fixes a flaky test in FF that was introduced by #3565 

Only targeting `master` and `23.0`, for 22 I added a separate commit here: https://github.com/vaadin/web-components/pull/3568/commits/c59a66b0ad701abd010cb87d9054b8bc17807b81