### PR TITLE
fix: do not throw when setting theme attribute

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -1009,13 +1009,16 @@ class DateTimePicker extends FieldMixin(
 
   /** @private */
   __themeChanged(theme, datePicker, timePicker) {
+    if (!datePicker || !timePicker) {
+      // Both pickers are not ready yet
+      return;
+    }
+
     [datePicker, timePicker].forEach((picker) => {
-      if (picker) {
-        if (theme) {
-          picker.setAttribute('theme', theme);
-        } else {
-          picker.removeAttribute('theme');
-        }
+      if (theme) {
+        picker.setAttribute('theme', theme);
+      } else {
+        picker.removeAttribute('theme');
       }
     });
   }

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -305,18 +305,50 @@ describe('Theme attribute', () => {
   let datePicker;
   let timePicker;
 
-  beforeEach(() => {
-    dateTimePicker = fixtureSync('<vaadin-date-time-picker theme="foo"></vaadin-date-time-picker>');
-    datePicker = getDatePicker(dateTimePicker);
-    timePicker = getTimePicker(dateTimePicker);
+  describe('default', () => {
+    beforeEach(() => {
+      dateTimePicker = fixtureSync('<vaadin-date-time-picker theme="foo"></vaadin-date-time-picker>');
+      datePicker = getDatePicker(dateTimePicker);
+      timePicker = getTimePicker(dateTimePicker);
+    });
+
+    it('should propagate theme attribute to date-picker', () => {
+      expect(datePicker.getAttribute('theme')).to.equal('foo');
+    });
+
+    it('should propagate theme attribute to time-picker', () => {
+      expect(timePicker.getAttribute('theme')).to.equal('foo');
+    });
   });
 
-  it('should propagate theme attribute to date-picker', () => {
-    expect(datePicker.getAttribute('theme')).to.equal('foo');
-  });
+  describe('slotted', () => {
+    beforeEach(() => {
+      dateTimePicker = document.createElement('vaadin-date-time-picker');
 
-  it('should propagate theme attribute to time-picker', () => {
-    expect(timePicker.getAttribute('theme')).to.equal('foo');
+      datePicker = document.createElement('vaadin-date-time-picker-date-picker');
+      datePicker.setAttribute('slot', 'date-picker');
+      dateTimePicker.appendChild(datePicker);
+
+      timePicker = document.createElement('vaadin-date-time-picker-time-picker');
+      timePicker.setAttribute('slot', 'time-picker');
+      dateTimePicker.appendChild(timePicker);
+    });
+
+    afterEach(() => {
+      dateTimePicker.remove();
+    });
+
+    it('should propagate theme attribute to date-picker', () => {
+      dateTimePicker.setAttribute('theme', 'foo');
+      document.body.appendChild(dateTimePicker);
+      expect(datePicker.getAttribute('theme')).to.equal('foo');
+    });
+
+    it('should propagate theme attribute to time-picker', () => {
+      dateTimePicker.setAttribute('theme', 'foo');
+      document.body.appendChild(dateTimePicker);
+      expect(timePicker.getAttribute('theme')).to.equal('foo');
+    });
   });
 });
 

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -338,13 +338,13 @@ describe('Theme attribute', () => {
       dateTimePicker.remove();
     });
 
-    it('should propagate theme attribute to date-picker', () => {
+    it('should propagate theme attribute to date-picker when set before adding to DOM', () => {
       dateTimePicker.setAttribute('theme', 'foo');
       document.body.appendChild(dateTimePicker);
       expect(datePicker.getAttribute('theme')).to.equal('foo');
     });
 
-    it('should propagate theme attribute to time-picker', () => {
+    it('should propagate theme attribute to time-picker when set before adding to DOM', () => {
       dateTimePicker.setAttribute('theme', 'foo');
       document.body.appendChild(dateTimePicker);
       expect(timePicker.getAttribute('theme')).to.equal('foo');


### PR DESCRIPTION
## Description

This issue resolves a failure discovered while reviewing https://github.com/vaadin/flow-components/pull/2887

Fixes https://github.com/vaadin/flow-components/issues/2899

## Note

The root cause of the change is how Polymer runs observers:

1. First, `vaadin-date-time-picker` runs `__themeChanged` for `theme` property (set by attribute)
2. Then, adding the slotted date-picker calls the observer once again (the time-picker is still empty)
3. Setting `theme` on the date-picker triggers its `_propertiesChanged` callback and `notify` effects
4. Then `value-changed` event is fired and `__valueChangedEventHandler` event listener is called
5. Finally, `__formattedValue` is called and it tries to access `__timePicker.value` which throws

In theory, the same issue could happen if we had any other complex observer using `__datePicker` and `__timePicker` as dependencies (so it would end up in a point of time where `__datePicker` is defined but `__timePicker` is not).

IMO the fix is enough as there are no other problematic observers at the moment.

## Type of change

- Bugfix