### PR TITLE
fix: do not dispatch cell-focus on mouse up outside of cell

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -7,7 +7,7 @@ import './vaadin-grid-column.js';
 import './vaadin-grid-styles.js';
 import { beforeNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { isAndroid, isFirefox, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { isAndroid, isChrome, isFirefox, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { TabindexMixin } from '@vaadin/component-base/src/tabindex-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
@@ -685,13 +685,16 @@ class Grid extends ElementMixin(
     // focusable slot wrapper, that is why cells are not focused with
     // mousedown. Workaround: listen for mousedown and focus manually.
     cellContent.addEventListener('mousedown', () => {
-      if (window.chrome) {
+      if (isChrome) {
         // Chrome bug: focusing before mouseup prevents text selection, see http://crbug.com/771903
-        const mouseUpListener = () => {
-          if (!cellContent.contains(this.getRootNode().activeElement)) {
+        const mouseUpListener = (event) => {
+          // If focus is on element within the cell content — respect it, do not change
+          const contentContainsFocusedElement = cellContent.contains(this.getRootNode().activeElement);
+          // Only focus if mouse is released on cell content itself
+          const mouseUpWithinCell = event.target === cellContent || cellContent.contains(event.target);
+          if (!contentContainsFocusedElement && mouseUpWithinCell) {
             cell.focus();
           }
-          // If focus is in the cell content — respect it, do not change.
           document.removeEventListener('mouseup', mouseUpListener, true);
         };
         document.addEventListener('mouseup', mouseUpListener, true);

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -691,7 +691,7 @@ class Grid extends ElementMixin(
           // If focus is on element within the cell content — respect it, do not change
           const contentContainsFocusedElement = cellContent.contains(this.getRootNode().activeElement);
           // Only focus if mouse is released on cell content itself
-          const mouseUpWithinCell = event.target === cellContent || cellContent.contains(event.target);
+          const mouseUpWithinCell = cellContent.contains(event.target);
           if (!contentContainsFocusedElement && mouseUpWithinCell) {
             cell.focus();
           }

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1892,8 +1892,8 @@ describe('keyboard navigation', () => {
     });
 
     // Chrome uses a workaround to dispatch cell-focus in mouse up,
-    // should dispatch event on mouse up events on cell itself
-    (isChrome ? it : it.skip)('should dispatch cell-focus on mouse up inside of cell', () => {
+    // should dispatch event when releasing mouse on cell content itself
+    (isChrome ? it : it.skip)('should dispatch cell-focus on mouse up on cell content', () => {
       const spy = sinon.spy();
       grid.addEventListener('cell-focus', spy);
 
@@ -1905,7 +1905,7 @@ describe('keyboard navigation', () => {
     });
 
     // Chrome uses a workaround to dispatch cell-focus in mouse up,
-    // should not dispatch event on mouse up events outside of cell
+    // should not dispatch event when releasing mouse outside of cell
     // Regression test for https://github.com/vaadin/flow-components/issues/2863
     (isChrome ? it : it.skip)('should not dispatch cell-focus on mouse up outside of cell', () => {
       const spy = sinon.spy();

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1893,8 +1893,8 @@ describe('keyboard navigation', () => {
 
     // Separate test suite for Chrome, where we use a workaround to dispatch
     // cell-focus on mouse up
-    describe('chrome', () => {
-      (isChrome ? it : it.skip)('should dispatch cell-focus on mouse up on cell content', () => {
+    (isChrome ? describe : describe.skip)('chrome', () => {
+      it('should dispatch cell-focus on mouse up on cell content', () => {
         const spy = sinon.spy();
         grid.addEventListener('cell-focus', spy);
 
@@ -1905,7 +1905,7 @@ describe('keyboard navigation', () => {
         expect(spy.calledOnce).to.be.true;
       });
 
-      (isChrome ? it : it.skip)('should dispatch cell-focus on mouse up within cell content', () => {
+      it('should dispatch cell-focus on mouse up within cell content', () => {
         const spy = sinon.spy();
         grid.addEventListener('cell-focus', spy);
 
@@ -1920,7 +1920,7 @@ describe('keyboard navigation', () => {
       });
 
       // Regression test for https://github.com/vaadin/flow-components/issues/2863
-      (isChrome ? it : it.skip)('should not dispatch cell-focus on mouse up outside of cell', () => {
+      it('should not dispatch cell-focus on mouse up outside of cell', () => {
         const spy = sinon.spy();
         grid.addEventListener('cell-focus', spy);
 

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -4,6 +4,7 @@ import {
   down as mouseDown,
   fixtureSync,
   focusin,
+  isChrome,
   keyboardEventFor,
   keyDownOn,
   keyUpOn,
@@ -18,7 +19,6 @@ import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
 import '../vaadin-grid-column-group.js';
 import '../vaadin-grid-selection-column.js';
-import { isChrome } from '@vaadin/component-base/src/browser-utils.js';
 import {
   flushGrid,
   getCell,

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1891,29 +1891,43 @@ describe('keyboard navigation', () => {
       grid.removeEventListener('cell-focus', spy);
     });
 
-    // Chrome uses a workaround to dispatch cell-focus in mouse up,
-    // should dispatch event when releasing mouse on cell content itself
-    (isChrome ? it : it.skip)('should dispatch cell-focus on mouse up on cell content', () => {
-      const spy = sinon.spy();
-      grid.addEventListener('cell-focus', spy);
+    // Separate test suite for Chrome, where we use a workaround to dispatch
+    // cell-focus on mouse up
+    describe('chrome', () => {
+      (isChrome ? it : it.skip)('should dispatch cell-focus on mouse up on cell content', () => {
+        const spy = sinon.spy();
+        grid.addEventListener('cell-focus', spy);
 
-      // Mouse down and release on cell content
-      const cell = getRowFirstCell(0);
-      mouseDown(cell._content);
-      mouseUp(cell._content);
-      expect(spy.calledOnce).to.be.true;
-    });
+        // Mouse down and release on cell content element
+        const cell = getRowFirstCell(0);
+        mouseDown(cell._content);
+        mouseUp(cell._content);
+        expect(spy.calledOnce).to.be.true;
+      });
 
-    // Chrome uses a workaround to dispatch cell-focus in mouse up,
-    // should not dispatch event when releasing mouse outside of cell
-    // Regression test for https://github.com/vaadin/flow-components/issues/2863
-    (isChrome ? it : it.skip)('should not dispatch cell-focus on mouse up outside of cell', () => {
-      const spy = sinon.spy();
-      grid.addEventListener('cell-focus', spy);
+      (isChrome ? it : it.skip)('should dispatch cell-focus on mouse up within cell content', () => {
+        const spy = sinon.spy();
+        grid.addEventListener('cell-focus', spy);
 
-      mouseDown(getRowFirstCell(0)._content);
-      mouseUp(document.body);
-      expect(spy.calledOnce).to.be.false;
+        // Mouse down and release on cell content child
+        const cell = getRowFirstCell(0);
+        const contentSpan = document.createElement('span');
+        cell._content.appendChild(contentSpan);
+
+        mouseDown(contentSpan);
+        mouseUp(contentSpan);
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      // Regression test for https://github.com/vaadin/flow-components/issues/2863
+      (isChrome ? it : it.skip)('should not dispatch cell-focus on mouse up outside of cell', () => {
+        const spy = sinon.spy();
+        grid.addEventListener('cell-focus', spy);
+
+        mouseDown(getRowFirstCell(0)._content);
+        mouseUp(document.body);
+        expect(spy.calledOnce).to.be.false;
+      });
     });
   });
 });

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -18,6 +18,7 @@ import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
 import '../vaadin-grid-column-group.js';
 import '../vaadin-grid-selection-column.js';
+import { isChrome } from '@vaadin/component-base/src/browser-utils.js';
 import {
   flushGrid,
   getCell,
@@ -1888,6 +1889,31 @@ describe('keyboard navigation', () => {
       expect(e.detail.context).to.be.deep.equal(expectedContext);
 
       grid.removeEventListener('cell-focus', spy);
+    });
+
+    // Chrome uses a workaround to dispatch cell-focus in mouse up,
+    // should dispatch event on mouse up events on cell itself
+    (isChrome ? it : it.skip)('should dispatch cell-focus on mouse up inside of cell', () => {
+      const spy = sinon.spy();
+      grid.addEventListener('cell-focus', spy);
+
+      // Mouse down and release on cell content
+      const cell = getRowFirstCell(0);
+      mouseDown(cell._content);
+      mouseUp(cell._content);
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    // Chrome uses a workaround to dispatch cell-focus in mouse up,
+    // should not dispatch event on mouse up events outside of cell
+    // Regression test for https://github.com/vaadin/flow-components/issues/2863
+    (isChrome ? it : it.skip)('should not dispatch cell-focus on mouse up outside of cell', () => {
+      const spy = sinon.spy();
+      grid.addEventListener('cell-focus', spy);
+
+      mouseDown(getRowFirstCell(0)._content);
+      mouseUp(document.body);
+      expect(spy.calledOnce).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes a workaround in Chrome for the cell-focus event, where a mouse up event outside of the grid could trigger a cell focus event from a cell. The fix involves checking if the mouse up event occured on the same cell as the mouse down event.

Fixes https://github.com/vaadin/flow-components/issues/2863

## Type of change

- [x] Bugfix
