### PR TITLE
fix: improve resizing column min width logic

### DIFF
--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -58,11 +58,9 @@ export const ColumnResizingMixin = (superClass) =>
         const targetCell = columnRowCells.filter((cell) => cell._column === column)[0];
         // Resize the target column
         if (targetCell.offsetWidth) {
-          // Resize handle uses pseudo-element as its clickable area
-          const handleStyle = getComputedStyle(handle, '::before');
           const style = getComputedStyle(targetCell._content);
           const minWidth =
-            parseInt(handleStyle.width) +
+            10 +
             parseInt(style.paddingLeft) +
             parseInt(style.paddingRight) +
             parseInt(style.borderLeftWidth) +

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -58,9 +58,11 @@ export const ColumnResizingMixin = (superClass) =>
         const targetCell = columnRowCells.filter((cell) => cell._column === column)[0];
         // Resize the target column
         if (targetCell.offsetWidth) {
-          const style = window.getComputedStyle(targetCell);
+          // Resize handle uses pseudo-element as its clickable area
+          const handleStyle = getComputedStyle(handle, '::before');
+          const style = getComputedStyle(targetCell._content);
           const minWidth =
-            10 +
+            parseInt(handleStyle.width) +
             parseInt(style.paddingLeft) +
             parseInt(style.paddingRight) +
             parseInt(style.borderLeftWidth) +

--- a/packages/grid/test/column-resizing.test.js
+++ b/packages/grid/test/column-resizing.test.js
@@ -116,6 +116,21 @@ describe('column resizing', () => {
     });
   });
 
+  it('should set min width based on handle and cell content padding', () => {
+    const options = { node: handle };
+    const rect = headerCells[0].getBoundingClientRect();
+
+    const handleStyle = getComputedStyle(handle, '::before');
+    const contentStyle = getComputedStyle(headerCells[0]._content);
+    const minWidth =
+      parseInt(contentStyle.paddingLeft) + parseInt(contentStyle.paddingRight) + parseInt(handleStyle.width);
+
+    fire('track', { state: 'start' }, options);
+    fire('track', { state: 'track', x: rect.left - 100, y: 0 }, options);
+
+    expect(headerCells[0].clientWidth).to.be.equal(minWidth);
+  });
+
   it('should not listen to track event on scroller', () => {
     const scroller = grid.$.scroller;
     fire('track', { state: 'start' }, { node: scroller });

--- a/packages/grid/test/column-resizing.test.js
+++ b/packages/grid/test/column-resizing.test.js
@@ -116,19 +116,17 @@ describe('column resizing', () => {
     });
   });
 
-  it('should set min width based on handle and cell content padding', () => {
+  it('should set min width based on cell content padding', () => {
     const options = { node: handle };
     const rect = headerCells[0].getBoundingClientRect();
 
-    const handleStyle = getComputedStyle(handle, '::before');
     const contentStyle = getComputedStyle(headerCells[0]._content);
-    const minWidth =
-      parseInt(contentStyle.paddingLeft) + parseInt(contentStyle.paddingRight) + parseInt(handleStyle.width);
+    const padding = parseInt(contentStyle.paddingLeft) + parseInt(contentStyle.paddingRight);
 
     fire('track', { state: 'start' }, options);
     fire('track', { state: 'track', x: rect.left - 100, y: 0 }, options);
 
-    expect(headerCells[0].clientWidth).to.be.equal(minWidth);
+    expect(headerCells[0].clientWidth).to.be.greaterThan(padding);
   });
 
   it('should not listen to track event on scroller', () => {


### PR DESCRIPTION
## Description

Fixes #3588

1. Updated logic to check padding on `vaadin-grid-cell-content`
2. Replaced hardcoded `10` with the actual resize handle width

## Result

Normal column minimum width after resize (the resize handle uses `35px`).

![resize-normal](https://user-images.githubusercontent.com/10589913/159294517-4984101a-b4ef-49c8-b77d-82a1ef2dd545.png)

Last column minimum width after resize (the resize handle uses `18px`).

![resize-last](https://user-images.githubusercontent.com/10589913/159294512-a141a723-db33-4b7d-9220-def5ff8917cf.png)

We could probably hardcode `35` for performance and consistency 🙈 

## Type of change

- Bugfix