### PR TITLE
refactor: enforce hiding cookie consent host element

### DIFF
--- a/packages/cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.js
@@ -42,7 +42,7 @@ class CookieConsent extends ElementMixin(PolymerElement) {
     return html`
       <style>
         :host {
-          display: none;
+          display: none !important;
         }
       </style>
     `;

--- a/packages/cookie-consent/test/cookie-consent.test.js
+++ b/packages/cookie-consent/test/cookie-consent.test.js
@@ -20,6 +20,19 @@ describe('vaadin-cookie-consent', () => {
     });
   });
 
+  describe('host element', () => {
+    let consent;
+
+    beforeEach(() => {
+      consent = fixtureSync('<vaadin-cookie-consent></vaadin-cookie-consent>');
+    });
+
+    it('should enforce display: none to hide the host element', () => {
+      consent.style.display = 'block';
+      expect(getComputedStyle(consent).display).to.equal('none');
+    });
+  });
+
   describe('cooke consent window', () => {
     let consent, ccWindow;
 


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow-components/issues/2855

We'd like to add `HasStyle` to `vaadin-cookie-consent` so that users would be able to set classes on the host element and then they would be propagated to the actual element with `.cc-window` class.

So we need to enforce `display: none` to ensure that setting CSS class on the host would not have any side effects.

## Type of change

- Refactor