### PR TITLE
refactor: enforce hiding notification host element

### DIFF
--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -257,7 +257,7 @@ class Notification extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     return html`
       <style>
         :host {
-          display: none;
+          display: none !important;
         }
       </style>
       <vaadin-notification-card theme$="[[_theme]]"> </vaadin-notification-card>

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -34,6 +34,11 @@ describe('vaadin-notification', () => {
     expect(notification._card.getAttribute('id')).to.be.null;
   });
 
+  it('should enforce display: none to hide the host element', () => {
+    notification.style.display = 'block';
+    expect(getComputedStyle(notification).display).to.equal('none');
+  });
+
   describe('vaadin-notification-container', () => {
     it('should be in the body when notification opens', () => {
       expect(document.body.querySelectorAll('vaadin-notification-container').length).to.be.equal(1);


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow-components/issues/2857

We'd like to add `HasStyle` to `Notification` so that users would be able to set classes on the `vaadin-notification` host element and then they would be propagated to the `vaadin-notification-card` element by the connector.

So we need to enforce `display: none` to ensure that setting CSS class on the host would not have any side effects.

## Type of change

- Refactor