### PR TITLE
refactor: enforce hiding dialog host element

### DIFF
--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -175,7 +175,7 @@ class Dialog extends ThemePropertyMixin(ElementMixin(DialogDraggableMixin(Dialog
     return html`
       <style>
         :host {
-          display: none;
+          display: none !important;
         }
       </style>
 

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -45,6 +45,19 @@ describe('vaadin-dialog', () => {
     });
   });
 
+  describe('host element', () => {
+    let dialog;
+
+    beforeEach(() => {
+      dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+    });
+
+    it('should enforce display: none to hide the host element', () => {
+      dialog.style.display = 'block';
+      expect(getComputedStyle(dialog).display).to.equal('none');
+    });
+  });
+
   describe('opened', () => {
     let dialog, backdrop, overlay;
 


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow-components/issues/2856

We'd like to add `HasStyle` to `Dialog` so that users would be able to set classes on the host element and then they would be propagated to the `vaadin-dialog-overlay` element for styling.

So we need to enforce `display: none` to ensure that setting CSS class on the host would not have any side effects.

## Type of change

- Refactor