### PR TITLE
refactor: enforce hiding confirm dialog host element

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -68,10 +68,7 @@ class ConfirmDialog extends SlotMixin(ElementMixin(ThemePropertyMixin(PolymerEle
   static get template() {
     return html`
       <style>
-        :host {
-          display: none;
-        }
-
+        :host,
         [hidden] {
           display: none !important;
         }

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -22,6 +22,19 @@ describe('vaadin-confirm-dialog', () => {
     });
   });
 
+  describe('host element', () => {
+    let confirm;
+
+    beforeEach(() => {
+      confirm = fixtureSync('<vaadin-confirm-dialog></vaadin-confirm-dialog>');
+    });
+
+    it('should enforce display: none to hide the host element', () => {
+      confirm.style.display = 'block';
+      expect(getComputedStyle(confirm).display).to.equal('none');
+    });
+  });
+
   describe('properties', () => {
     let confirm, dialog, overlay;
 


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow-components/issues/2909

We'd like to fix `HasStyle` in `ConfirmDialog` so that users would be able to set classes on the host element and then they would be propagated to the `vaadin-confirm-dialog-overlay` element for styling.

So we need to enforce `display: none` to ensure that setting CSS class on the host would not have any side effects.

## Type of change

- Refactor