### PR TITLE
fix: don't prevent custom values when autoOpenDisabled

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1038,15 +1038,21 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _indexOfValue(value, items) {
-      if (items && this._isValidValue(value)) {
-        for (let i = 0; i < items.length; i++) {
-          if (items[i] !== this.__placeHolder && this._getItemValue(items[i]) === value) {
-            return i;
-          }
-        }
+      if (!items || !this._isValidValue(value)) {
+        return -1;
       }
 
-      return -1;
+      return items.findIndex((item) => {
+        if (item instanceof ComboBoxPlaceholder) {
+          return false;
+        }
+
+        if (this._getItemValue(item) === value) {
+          return true;
+        }
+
+        return false;
+      });
     }
 
     /**

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -376,6 +376,10 @@ export const ComboBoxMixin = (subclass) =>
         }
 
         this.__restoreFocusOnClose = true;
+
+        if (!this.filter) {
+          this._focusedIndex = this._indexOfValue(this.value, this.filteredItems);
+        }
       } else {
         this._onClosed();
         if (this._openedWithFocusRing && this.hasAttribute('focused')) {
@@ -967,13 +971,10 @@ export const ComboBoxMixin = (subclass) =>
       if (e.path === 'filteredItems' || e.path === 'filteredItems.splices') {
         this._setOverlayItems(this.filteredItems);
 
-        const filterIndex = this.$.dropdown.indexOfLabel(this.filter);
-        if (this.opened) {
-          this._focusedIndex = filterIndex;
+        if (this.opened || this.autoOpenDisabled) {
+          this._focusedIndex = this.$.dropdown.indexOfLabel(this.filter);
         } else {
-          // Pre-select item matching the filter to focus it later when overlay opens
-          const valueIndex = this._indexOfValue(this.value, this.filteredItems);
-          this._focusedIndex = filterIndex === -1 ? valueIndex : filterIndex;
+          this._focusedIndex = this._indexOfValue(this.value, this.filteredItems);
         }
 
         // see https://github.com/vaadin/web-components/issues/2615

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -376,10 +376,6 @@ export const ComboBoxMixin = (subclass) =>
         }
 
         this.__restoreFocusOnClose = true;
-
-        if (this.autoOpenDisabled && !this.filter) {
-          this._focusedIndex = this._indexOfValue(this.value, this.filteredItems);
-        }
       } else {
         this._onClosed();
         if (this._openedWithFocusRing && this.hasAttribute('focused')) {
@@ -980,10 +976,14 @@ export const ComboBoxMixin = (subclass) =>
           this._selectItemForValue(this.value);
         }
 
-        if (this.opened || this.autoOpenDisabled) {
-          this._focusedIndex = this.$.dropdown.indexOfLabel(this.filter);
+        if (this._inputElementValue === undefined || this._inputElementValue === this.value) {
+          // When the input element value is the same as the current value or not defined,
+          // set the focused index to the item that matches the value.
+          this._focusedIndex = this._indexOfValue(this.value, this.filteredItems);
         } else {
-          this._focusedIndex = valueIndex;
+          // When the user filled in something that is different from the current value = filtering is enabled,
+          // set the focused index to the item that matches the filter query.
+          this._focusedIndex = this.$.dropdown.indexOfLabel(this.filter);
         }
       }
     }

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1047,11 +1047,7 @@ export const ComboBoxMixin = (subclass) =>
           return false;
         }
 
-        if (this._getItemValue(item) === value) {
-          return true;
-        }
-
-        return false;
+        return this._getItemValue(item) === value;
       });
     }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -377,7 +377,7 @@ export const ComboBoxMixin = (subclass) =>
 
         this.__restoreFocusOnClose = true;
 
-        if (!this.filter) {
+        if (this.autoOpenDisabled && !this.filter) {
           this._focusedIndex = this._indexOfValue(this.value, this.filteredItems);
         }
       } else {

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -971,10 +971,10 @@ export const ComboBoxMixin = (subclass) =>
       if (e.path === 'filteredItems' || e.path === 'filteredItems.splices') {
         this._setOverlayItems(this.filteredItems);
 
-        // When `filteredItems` is the source of data (= neither `items` nor data provider is provided)
-        // and `value` has been set before `filteredItems`, we need to ensure the selected item
-        // is initialized with the current value once the filtered items are provided.
-        // In other cases, it is already initialized in such observers as `valueChanged`, `_itemsOrPathsChanged`.
+        // When the external filtering is used and `value` was provided before `filteredItems`,
+        // initialize the selected item with the current value here. This will also cause
+        // the input element value to sync. In other cases, the selected item is already initialized
+        // in other observers such as `valueChanged`, `_itemsOrPathsChanged`.
         const valueIndex = this._indexOfValue(this.value, this.filteredItems);
         if (this.selectedItem === null && valueIndex >= 0) {
           this._selectItemForValue(this.value);

--- a/packages/combo-box/test/external-filtering.test.js
+++ b/packages/combo-box/test/external-filtering.test.js
@@ -208,7 +208,13 @@ describe('external filtering', () => {
       expect(comboBox.value).to.equal('foo');
     });
 
-    it('should commit the empty value', async () => {
+    it('should have no item focused when opened after clearing the filter', () => {
+      setInputValue(comboBox, '');
+      comboBox.open();
+      expect(getFocusedItemIndex(comboBox)).to.equal(-1);
+    });
+
+    it('should commit an empty value', async () => {
       setInputValue(comboBox, '');
       enter(comboBox.inputElement);
       expect(comboBox.value).to.equal('');

--- a/packages/combo-box/test/external-filtering.test.js
+++ b/packages/combo-box/test/external-filtering.test.js
@@ -179,33 +179,33 @@ describe('external filtering', () => {
 
   describe('value is set before + autoOpenDisabled', () => {
     beforeEach(() => {
-      comboBox = fixtureSync(`<vaadin-combo-box auto-open-disabled value="foo"></vaadin-combo-box>`);
+      comboBox = fixtureSync(`<vaadin-combo-box auto-open-disabled value="bar"></vaadin-combo-box>`);
       comboBox.filteredItems = ['foo', 'bar'];
     });
 
     it('should have the selected item', () => {
-      expect(comboBox.selectedItem).to.equal('foo');
+      expect(comboBox.selectedItem).to.equal('bar');
     });
 
     it('should have the input value', () => {
-      expect(comboBox.inputElement.value).to.equal('foo');
+      expect(comboBox.inputElement.value).to.equal('bar');
     });
 
     it('should have the value item focused when opened', () => {
       comboBox.open();
-      expect(getFocusedItemIndex(comboBox)).to.equal(0);
-    });
-
-    it('should have the filtered item focused when opened after changing the filter', () => {
-      setInputValue(comboBox, 'bar');
-      comboBox.open();
       expect(getFocusedItemIndex(comboBox)).to.equal(1);
     });
 
+    it('should have the filtered item focused when opened after changing the filter', () => {
+      setInputValue(comboBox, 'foo');
+      comboBox.open();
+      expect(getFocusedItemIndex(comboBox)).to.equal(0);
+    });
+
     it('should commit the filtered value', async () => {
-      setInputValue(comboBox, 'bar');
+      setInputValue(comboBox, 'foo');
       enter(comboBox.inputElement);
-      expect(comboBox.value).to.equal('bar');
+      expect(comboBox.value).to.equal('foo');
     });
 
     it('should have no item focused when opened after clearing the filter', () => {

--- a/packages/combo-box/test/external-filtering.test.js
+++ b/packages/combo-box/test/external-filtering.test.js
@@ -208,12 +208,6 @@ describe('external filtering', () => {
       expect(comboBox.value).to.equal('foo');
     });
 
-    it('should have no item focused when opened after clearing the filter', () => {
-      setInputValue(comboBox, '');
-      comboBox.open();
-      expect(getFocusedItemIndex(comboBox)).to.equal(-1);
-    });
-
     it('should commit the empty value', async () => {
       setInputValue(comboBox, '');
       enter(comboBox.inputElement);

--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -271,7 +271,7 @@ describe('internal filtering', () => {
       comboBox.items = [new ComboBoxPlaceholder(), new ComboBoxPlaceholder()];
     });
 
-    it('should have no selected item', () => {
+    it('should have no selected item when value is empty', () => {
       expect(comboBox.selectedItem).to.not.be.instanceOf(ComboBoxPlaceholder);
     });
   });

--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
+import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import { getAllItems, getFocusedItemIndex, makeItems, onceOpened, setInputValue } from './helpers.js';
 
 describe('internal filtering', () => {
@@ -261,6 +262,17 @@ describe('internal filtering', () => {
 
     it('should properly display all items in the selector', () => {
       expect(getAllItems(comboBox).length).to.equal(10);
+    });
+  });
+
+  describe('setting placeholder items', () => {
+    beforeEach(() => {
+      comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
+      comboBox.items = [new ComboBoxPlaceholder(), new ComboBoxPlaceholder()];
+    });
+
+    it('should have no selected item', () => {
+      expect(comboBox.selectedItem).to.not.be.instanceOf(ComboBoxPlaceholder);
     });
   });
 });

--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -7,15 +7,14 @@ import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { getAllItems, getFocusedItemIndex, makeItems, onceOpened, setInputValue } from './helpers.js';
 
 describe('internal filtering', () => {
-  let comboBox, overlay;
-
-  beforeEach(() => {
-    comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
-    comboBox.items = ['foo', 'bar', 'baz'];
-    overlay = comboBox.$.dropdown.$.overlay;
-  });
+  let comboBox;
 
   describe('setting the input field value', () => {
+    beforeEach(() => {
+      comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
+      comboBox.items = ['foo', 'bar', 'baz'];
+    });
+
     it('should open the popup if closed', () => {
       comboBox.close();
 
@@ -109,6 +108,11 @@ describe('internal filtering', () => {
   });
 
   describe('focusing items while filtering', () => {
+    beforeEach(() => {
+      comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
+      comboBox.items = ['foo', 'bar', 'baz'];
+    });
+
     it('should focus on an exact match', () => {
       setInputValue(comboBox, 'bar');
 
@@ -152,6 +156,14 @@ describe('internal filtering', () => {
   });
 
   describe('filtering items', () => {
+    let overlay;
+
+    beforeEach(() => {
+      comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
+      comboBox.items = ['foo', 'bar', 'baz'];
+      overlay = comboBox.$.dropdown.$.overlay;
+    });
+
     it('should filter items using contains', () => {
       setInputValue(comboBox, 'a');
 
@@ -238,15 +250,16 @@ describe('internal filtering', () => {
     });
   });
 
-  describe('setting items when opened', () => {
+  describe('setting filtered items when opened', () => {
     beforeEach(() => {
+      comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
       comboBox.items = [];
-    });
-
-    it('should properly display all items in the selector', () => {
       comboBox.open();
       comboBox.filteredItems = makeItems(10);
       flush();
+    });
+
+    it('should properly display all items in the selector', () => {
       expect(getAllItems(comboBox).length).to.equal(10);
     });
   });

--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -251,16 +251,16 @@ describe('internal filtering', () => {
     });
   });
 
-  describe('setting filtered items when opened', () => {
+  describe('setting items when opened', () => {
     beforeEach(() => {
       comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
       comboBox.items = [];
-      comboBox.open();
-      comboBox.filteredItems = makeItems(10);
-      flush();
     });
 
     it('should properly display all items in the selector', () => {
+      comboBox.open();
+      comboBox.filteredItems = makeItems(10);
+      flush();
       expect(getAllItems(comboBox).length).to.equal(10);
     });
   });

--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -109,14 +109,14 @@ describe('autoOpenDisabled', () => {
     expect(items[5].hasAttribute('focused')).to.be.true;
   });
 
-  it('should apply a custom value', async () => {
+  it('should commit a custom value', async () => {
     inputElement.focus();
     inputElement.value = '05:10';
     await sendKeys({ press: 'Enter' });
     expect(timePicker.value).to.equal('05:10');
   });
 
-  it('should apply the empty value', async () => {
+  it('should commit the empty value', async () => {
     inputElement.focus();
     inputElement.value = '';
     await sendKeys({ press: 'Enter' });

--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
-import { sendKeys } from '@web/test-runner-commands';
+import { enter, fire, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-time-picker.js';
 
 describe('combo-box', () => {
@@ -110,16 +109,16 @@ describe('autoOpenDisabled', () => {
   });
 
   it('should commit a custom value after setting a predefined value', async () => {
-    inputElement.focus();
     inputElement.value = '05:10';
-    await sendKeys({ press: 'Enter' });
+    fire(inputElement, 'input');
+    enter(inputElement);
     expect(timePicker.value).to.equal('05:10');
   });
 
   it('should commit an empty value after setting a predefined value', async () => {
-    inputElement.focus();
     inputElement.value = '';
-    await sendKeys({ press: 'Enter' });
+    fire(inputElement, 'input');
+    enter(inputElement);
     expect(timePicker.value).to.equal('');
   });
 });

--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -109,7 +109,7 @@ describe('autoOpenDisabled', () => {
     expect(items[5].hasAttribute('focused')).to.be.true;
   });
 
-  it('should commit a custom value', async () => {
+  it('should commit a custom value after setting a predefined value', async () => {
     inputElement.focus();
     inputElement.value = '05:10';
     await sendKeys({ press: 'Enter' });

--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import '../vaadin-time-picker.js';
 
 describe('combo-box', () => {
@@ -93,11 +94,12 @@ describe('combo-box', () => {
 });
 
 describe('autoOpenDisabled', () => {
-  let timePicker, comboBox;
+  let timePicker, comboBox, inputElement;
 
   beforeEach(() => {
     timePicker = fixtureSync(`<vaadin-time-picker auto-open-disabled value="05:00"></vaadin-time-picker>`);
     comboBox = timePicker.$.comboBox;
+    inputElement = timePicker.inputElement;
   });
 
   it('should focus the correct item when opened', () => {
@@ -105,5 +107,19 @@ describe('autoOpenDisabled', () => {
 
     const items = document.querySelectorAll('vaadin-time-picker-item');
     expect(items[5].hasAttribute('focused')).to.be.true;
+  });
+
+  it('should apply a custom value', async () => {
+    inputElement.focus();
+    inputElement.value = '05:10';
+    await sendKeys({ press: 'Enter' });
+    expect(timePicker.value).to.equal('05:10');
+  });
+
+  it('should apply the empty value', async () => {
+    inputElement.focus();
+    inputElement.value = '';
+    await sendKeys({ press: 'Enter' });
+    expect(timePicker.value).to.equal('');
   });
 });

--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -116,7 +116,7 @@ describe('autoOpenDisabled', () => {
     expect(timePicker.value).to.equal('05:10');
   });
 
-  it('should commit the empty value', async () => {
+  it('should commit an empty value after setting a predefined value', async () => {
     inputElement.focus();
     inputElement.value = '';
     await sendKeys({ press: 'Enter' });


### PR DESCRIPTION
## Description

Fixes the regression where it was not possible to commit a custom value to a time-picker / combo-box after a value from the dropdown has been set.

The regression originates from #3316.

Fixes #3590

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
