### PR TITLE
fix: propagate enter key event when combo box is not opened

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -587,17 +587,16 @@ export const ComboBoxMixin = (subclass) =>
         return;
       }
 
-      const wasOpened = this.opened;
-      this._closeOrCommit();
-
-      // stop propagation of the enter event only if the dropdown was closed, this
+      // stop propagation of the enter event only if the dropdown is opened, this
       // "consumes" the enter event for the action of closing the dropdown
-      if (wasOpened) {
+      if (this.opened) {
         // Do not submit the surrounding form.
         e.preventDefault();
         // Do not trigger global listeners
         e.stopPropagation();
       }
+
+      this._closeOrCommit();
     }
 
     /**

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -577,14 +577,21 @@ export const ComboBoxMixin = (subclass) =>
     /** @private */
     _onEnter(e) {
       // do not commit value when custom values are disallowed and input value is not a valid option
+      // also stop propagation of the event, otherwise the user could submit a form while the input
+      // still contains an invalid value
       if (!this.allowCustomValue && this._inputElementValue !== '' && this._focusedIndex < 0) {
+        // Do not submit the surrounding form.
+        e.preventDefault();
+        // Do not trigger global listeners
+        e.stopPropagation();
         return;
       }
 
       const wasOpened = this.opened;
       this._closeOrCommit();
 
-      // cancel enter keydown event only if the dropdown was closed
+      // stop propagation of the enter event only if the dropdown was closed, this
+      // "consumes" the enter event for the action of closing the dropdown
       if (wasOpened) {
         // Do not submit the surrounding form.
         e.preventDefault();

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -576,17 +576,18 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _onEnter(e) {
-      // should close on enter when custom values are allowed, input field is cleared, or when an existing
-      // item is focused with keyboard. If auto open is disabled, under the same conditions, commit value.
-      if (
-        (this.opened || this.autoOpenDisabled) &&
-        (this.allowCustomValue || this._inputElementValue === '' || this._focusedIndex > -1)
-      ) {
-        this._closeOrCommit();
+      // do not commit value when custom values are disallowed and input value is not a valid option
+      if (!this.allowCustomValue && this._inputElementValue !== '' && this._focusedIndex < 0) {
+        return;
+      }
 
+      const wasOpened = this.opened;
+      this._closeOrCommit();
+
+      // cancel enter keydown event only if the dropdown was closed
+      if (wasOpened) {
         // Do not submit the surrounding form.
         e.preventDefault();
-
         // Do not trigger global listeners
         e.stopPropagation();
       }

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -225,12 +225,12 @@ describe('keyboard', () => {
         expect(keydownSpy.called).to.be.false;
       });
 
-      it('should not stop propagation of the keyboard enter event when input value is invalid', () => {
+      it('should stop propagation of the keyboard enter event when input value is invalid', () => {
         filter('foobar');
         const keydownSpy = sinon.spy();
         document.addEventListener('keydown', keydownSpy);
         enterKeyDown(input);
-        expect(keydownSpy.called).to.be.true;
+        expect(keydownSpy.called).to.be.false;
       });
 
       it('should not close the overlay with enter when custom values are not allowed', () => {
@@ -415,6 +415,14 @@ describe('keyboard', () => {
         comboBox.autoOpenDisabled = true;
         comboBox.focus();
         await aTimeout(1);
+      });
+
+      it('should stop propagation of the keyboard enter event when input value is invalid', () => {
+        filter('foobar');
+        const keydownSpy = sinon.spy();
+        document.addEventListener('keydown', keydownSpy);
+        enterKeyDown(input);
+        expect(keydownSpy.called).to.be.false;
       });
 
       it('should not stop propagation of the keyboard enter event when input has a predefined option', async () => {

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -184,220 +184,265 @@ describe('keyboard', () => {
   });
 
   describe('selecting items', () => {
-    beforeEach(async () => {
-      comboBox.value = 'bar';
+    describe('auto-open', () => {
+      beforeEach(async () => {
+        comboBox.value = 'bar';
 
-      comboBox.focus();
-      comboBox.open();
-      await aTimeout(1);
+        comboBox.focus();
+        comboBox.open();
+        await aTimeout(1);
+      });
+
+      it('should select focused item with enter', async () => {
+        arrowDownKeyDown(input);
+        await aTimeout(1);
+        enterKeyDown(input);
+        await aTimeout(1);
+        expect(comboBox.value).to.equal('baz');
+      });
+
+      it('should clear the selection with enter when input is cleared', () => {
+        filter('');
+        enterKeyDown(input);
+
+        expect(comboBox.value).to.eql('');
+      });
+
+      it('should close the overlay with enter when custom values are allowed', () => {
+        comboBox.allowCustomValue = true;
+        filter('foobar');
+
+        enterKeyDown(input);
+
+        expect(comboBox.value).to.equal('foobar');
+        expect(comboBox.opened).to.equal(false);
+      });
+
+      it('should stop propagation of the keyboard enter event when dropdown is opened', () => {
+        const keydownSpy = sinon.spy();
+        document.addEventListener('keydown', keydownSpy);
+        enterKeyDown(input);
+        expect(keydownSpy.called).to.be.false;
+      });
+
+      it('should not stop propagation of the keyboard enter event when input value is invalid', () => {
+        filter('foobar');
+        const keydownSpy = sinon.spy();
+        document.addEventListener('keydown', keydownSpy);
+        enterKeyDown(input);
+        expect(keydownSpy.called).to.be.true;
+      });
+
+      it('should not close the overlay with enter when custom values are not allowed', () => {
+        filter('foobar');
+
+        enterKeyDown(input);
+
+        expect(comboBox.value).to.equal('bar');
+        expect(comboBox.opened).to.equal(true);
+      });
+
+      it('should revert to the custom value after filtering', () => {
+        comboBox.allowCustomValue = true;
+        comboBox.value = 'foobar';
+        filter('bar');
+        escKeyDown(input);
+        expect(input.value).to.eql('bar');
+        escKeyDown(input);
+        expect(input.value).to.equal('foobar');
+      });
+
+      it('should revert a non-listed value to the custom value after filtering', () => {
+        comboBox.allowCustomValue = true;
+        comboBox.value = 'foobar';
+        filter('barbaz');
+        escKeyDown(input);
+        expect(input.value).to.equal('foobar');
+      });
+
+      it('should revert to the custom value after keyboard navigation', () => {
+        comboBox.allowCustomValue = true;
+        comboBox.value = 'foobar';
+        arrowDownKeyDown(input);
+        escKeyDown(input);
+        expect(input.value).to.eql('foobar');
+        escKeyDown(input);
+        expect(input.value).to.equal('foobar');
+      });
+
+      it('should close the overlay with enter', () => {
+        enterKeyDown(input);
+
+        expect(comboBox.opened).to.equal(false);
+      });
+
+      it('should remove focus with escape', () => {
+        comboBox._focusedIndex = 0;
+
+        escKeyDown(input);
+
+        expect(comboBox.opened).to.equal(true);
+        expect(comboBox._focusedIndex).to.eql(-1);
+      });
+
+      it('should close the overlay with escape if there is no focus', () => {
+        comboBox._focusedIndex = -1;
+
+        escKeyDown(input);
+
+        expect(comboBox.opened).to.equal(false);
+      });
+
+      it('escape key event should not be propagated', () => {
+        const spy = sinon.spy();
+
+        document.body.addEventListener('keydown', spy);
+        escKeyDown(input);
+        document.body.removeEventListener('keydown', spy);
+
+        expect(spy.called).to.be.false;
+      });
+
+      it('should cancel typing with escape', () => {
+        filter('baz');
+
+        escKeyDown(input);
+
+        expect(comboBox.value).to.equal('bar');
+      });
+
+      it('should select typed item', () => {
+        filter('baz');
+
+        enterKeyDown(input);
+
+        expect(comboBox.value).to.equal('baz');
+      });
+
+      it('should prefill the input field when navigating down', () => {
+        arrowDownKeyDown(input);
+        expect(input.value).to.eql('baz');
+      });
+
+      it('should select the input field text when navigating down', () => {
+        arrowDownKeyDown(input);
+        expect(input.selectionStart).to.eql(0);
+        expect(input.selectionEnd).to.eql(3);
+      });
+
+      it('should prefill the input field when navigating up', () => {
+        arrowUpKeyDown(input);
+        expect(input.value).to.eql('foo');
+      });
+
+      it('should not prefill the input when there are no items to navigate', () => {
+        filter('invalid filter');
+
+        arrowDownKeyDown(input);
+        expect(input.value).to.eql('invalid filter');
+      });
+
+      it('should select the input field text when navigating up', () => {
+        arrowUpKeyDown(input);
+        expect(input.selectionStart).to.eql(0);
+        expect(input.selectionEnd).to.eql(3);
+      });
+
+      it('should revert back to filter with escape', async () => {
+        filter('b');
+
+        arrowDownKeyDown(input);
+        await aTimeout(1);
+        expect(input.value).to.eql('bar');
+        escKeyDown(input);
+        expect(input.value).to.eql('b');
+      });
+
+      it('should remove selection from the input value when reverting', () => {
+        filter('b');
+        arrowDownKeyDown(input);
+        escKeyDown(input);
+
+        expect(input.selectionStart).to.eql(input.selectionEnd);
+      });
+
+      it('should revert back to value if there is no filter', () => {
+        arrowDownKeyDown(input);
+
+        escKeyDown(input);
+
+        expect(input.value).to.eql('bar');
+      });
+
+      it('should keep selected item on escape when custom value allowed', () => {
+        comboBox.allowCustomValue = true;
+        escKeyDown(input);
+        escKeyDown(input);
+        expect(comboBox.selectedItem).to.eql('bar');
+      });
+
+      it('should remove selection from the input value selecting value', async () => {
+        arrowDownKeyDown(input);
+        await aTimeout(1);
+        enterKeyDown(input);
+
+        expect(input.selectionStart).to.eql(3);
+        expect(input.selectionEnd).to.eql(3);
+      });
+
+      it('should not clear the value on esc if clear button is not visible', () => {
+        escKeyDown(input);
+        expect(comboBox.value).to.equal('bar');
+      });
+
+      it('should clear the value on esc if clear button is visible', () => {
+        comboBox.close();
+        comboBox.clearButtonVisible = true;
+        escKeyDown(input);
+        expect(comboBox.value).to.equal('');
+      });
+
+      it('should not clear the value on esc if the overlay is open', () => {
+        comboBox.clearButtonVisible = true;
+        comboBox.opened = true;
+        escKeyDown(input);
+        expect(comboBox.value).to.equal('bar');
+      });
     });
 
-    it('should select focused item with enter', async () => {
-      arrowDownKeyDown(input);
-      await aTimeout(1);
-      enterKeyDown(input);
-      await aTimeout(1);
-      expect(comboBox.value).to.equal('baz');
-    });
+    describe('auto-open disabled', () => {
+      beforeEach(async () => {
+        comboBox.autoOpenDisabled = true;
+        comboBox.focus();
+        await aTimeout(1);
+      });
 
-    it('should clear the selection with enter when input is cleared', () => {
-      filter('');
-      enterKeyDown(input);
+      it('should not stop propagation of the keyboard enter event when input has a predefined option', async () => {
+        filter('foo');
+        expect(comboBox.opened).to.be.false;
+        const keydownSpy = sinon.spy();
+        document.addEventListener('keydown', keydownSpy);
+        enterKeyDown(input);
+        expect(keydownSpy.called).to.be.true;
+      });
 
-      expect(comboBox.value).to.eql('');
-    });
+      it('should not stop propagation of the keyboard enter event when input has a custom value', () => {
+        comboBox.allowCustomValue = true;
+        filter('foobar');
+        const keydownSpy = sinon.spy();
+        document.addEventListener('keydown', keydownSpy);
+        enterKeyDown(input);
+        expect(keydownSpy.called).to.be.true;
+      });
 
-    it('should close the overlay with enter when custom values are allowed', () => {
-      comboBox.allowCustomValue = true;
-      filter('foobar');
-
-      enterKeyDown(input);
-
-      expect(comboBox.value).to.equal('foobar');
-      expect(comboBox.opened).to.equal(false);
-    });
-
-    it('should stop propagation of the keyboard enter event', () => {
-      const keydownSpy = sinon.spy();
-      document.addEventListener('keydown', keydownSpy);
-      enterKeyDown(input);
-      expect(keydownSpy.called).to.be.false;
-    });
-
-    it('should not close the overlay with enter when custom values are not allowed', () => {
-      filter('foobar');
-
-      enterKeyDown(input);
-
-      expect(comboBox.value).to.equal('bar');
-      expect(comboBox.opened).to.equal(true);
-    });
-
-    it('should revert to the custom value after filtering', () => {
-      comboBox.allowCustomValue = true;
-      comboBox.value = 'foobar';
-      filter('bar');
-      escKeyDown(input);
-      expect(input.value).to.eql('bar');
-      escKeyDown(input);
-      expect(input.value).to.equal('foobar');
-    });
-
-    it('should revert a non-listed value to the custom value after filtering', () => {
-      comboBox.allowCustomValue = true;
-      comboBox.value = 'foobar';
-      filter('barbaz');
-      escKeyDown(input);
-      expect(input.value).to.equal('foobar');
-    });
-
-    it('should revert to the custom value after keyboard navigation', () => {
-      comboBox.allowCustomValue = true;
-      comboBox.value = 'foobar';
-      arrowDownKeyDown(input);
-      escKeyDown(input);
-      expect(input.value).to.eql('foobar');
-      escKeyDown(input);
-      expect(input.value).to.equal('foobar');
-    });
-
-    it('should close the overlay with enter', () => {
-      enterKeyDown(input);
-
-      expect(comboBox.opened).to.equal(false);
-    });
-
-    it('should remove focus with escape', () => {
-      comboBox._focusedIndex = 0;
-
-      escKeyDown(input);
-
-      expect(comboBox.opened).to.equal(true);
-      expect(comboBox._focusedIndex).to.eql(-1);
-    });
-
-    it('should close the overlay with escape if there is no focus', () => {
-      comboBox._focusedIndex = -1;
-
-      escKeyDown(input);
-
-      expect(comboBox.opened).to.equal(false);
-    });
-
-    it('escape key event should not be propagated', () => {
-      const spy = sinon.spy();
-
-      document.body.addEventListener('keydown', spy);
-      escKeyDown(input);
-      document.body.removeEventListener('keydown', spy);
-
-      expect(spy.called).to.be.false;
-    });
-
-    it('should cancel typing with escape', () => {
-      filter('baz');
-
-      escKeyDown(input);
-
-      expect(comboBox.value).to.equal('bar');
-    });
-
-    it('should select typed item', () => {
-      filter('baz');
-
-      enterKeyDown(input);
-
-      expect(comboBox.value).to.equal('baz');
-    });
-
-    it('should prefill the input field when navigating down', () => {
-      arrowDownKeyDown(input);
-      expect(input.value).to.eql('baz');
-    });
-
-    it('should select the input field text when navigating down', () => {
-      arrowDownKeyDown(input);
-      expect(input.selectionStart).to.eql(0);
-      expect(input.selectionEnd).to.eql(3);
-    });
-
-    it('should prefill the input field when navigating up', () => {
-      arrowUpKeyDown(input);
-      expect(input.value).to.eql('foo');
-    });
-
-    it('should not prefill the input when there are no items to navigate', () => {
-      filter('invalid filter');
-
-      arrowDownKeyDown(input);
-      expect(input.value).to.eql('invalid filter');
-    });
-
-    it('should select the input field text when navigating up', () => {
-      arrowUpKeyDown(input);
-      expect(input.selectionStart).to.eql(0);
-      expect(input.selectionEnd).to.eql(3);
-    });
-
-    it('should revert back to filter with escape', async () => {
-      filter('b');
-
-      arrowDownKeyDown(input);
-      await aTimeout(1);
-      expect(input.value).to.eql('bar');
-      escKeyDown(input);
-      expect(input.value).to.eql('b');
-    });
-
-    it('should remove selection from the input value when reverting', () => {
-      filter('b');
-      arrowDownKeyDown(input);
-      escKeyDown(input);
-
-      expect(input.selectionStart).to.eql(input.selectionEnd);
-    });
-
-    it('should revert back to value if there is no filter', () => {
-      arrowDownKeyDown(input);
-
-      escKeyDown(input);
-
-      expect(input.value).to.eql('bar');
-    });
-
-    it('should keep selected item on escape when custom value allowed', () => {
-      comboBox.allowCustomValue = true;
-      escKeyDown(input);
-      escKeyDown(input);
-      expect(comboBox.selectedItem).to.eql('bar');
-    });
-
-    it('should remove selection from the input value selecting value', async () => {
-      arrowDownKeyDown(input);
-      await aTimeout(1);
-      enterKeyDown(input);
-
-      expect(input.selectionStart).to.eql(3);
-      expect(input.selectionEnd).to.eql(3);
-    });
-
-    it('should not clear the value on esc if clear button is not visible', () => {
-      escKeyDown(input);
-      expect(comboBox.value).to.equal('bar');
-    });
-
-    it('should clear the value on esc if clear button is visible', () => {
-      comboBox.close();
-      comboBox.clearButtonVisible = true;
-      escKeyDown(input);
-      expect(comboBox.value).to.equal('');
-    });
-
-    it('should not clear the value on esc if the overlay is open', () => {
-      comboBox.clearButtonVisible = true;
-      comboBox.opened = true;
-      escKeyDown(input);
-      expect(comboBox.value).to.equal('bar');
+      it('should not stop propagation of the keyboard enter event when input is empty', () => {
+        comboBox.allowCustomValue = true;
+        filter('');
+        const keydownSpy = sinon.spy();
+        document.addEventListener('keydown', keydownSpy);
+        enterKeyDown(input);
+        expect(keydownSpy.called).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Currently the combo box stops propagation of enter key events whenever a value is committed. That leads to several problematic cases when auto open is disabled:
- enter a predefined option -> hit enter
- enter a custom option -> hit enter
- empty input -> hit enter

I'd say in all of that cases the combo box should commit the value and then let the enter key event bubble up, just like regular inputs and all the other fields we have do. It seems the propagation logic was not properly considered before, and the current logic in `onEnter` just evolved to a state where committing the value, maybe closing the combo box, and stopping propagation are mixed up as the same thing.

This PR changes the `onEnter` behavior to only stop propagation if the combo box is currently opened. That way the enter key event is "consumed" for the action of selecting a value from the dropdown, or just closing it without selecting a value (e.g. when custom values are allowed). If the combo box was not opened, then in all cases allow propagation of the event, which then enables to commit forms with the same key press, or make use of keyboard shortcuts using enter.

Fixes #3064 

## Type of change

- [x] Bugfix
