### PR TITLE
fix: material button alignment in Firefox

### DIFF
--- a/dev/custom-field.html
+++ b/dev/custom-field.html
@@ -9,9 +9,12 @@
   </head>
 
   <body>
-
-
-    <div style="border: solid 1px gray">
+    <vaadin-custom-field
+      label="Phone number"
+      required
+      error-message="This field is required"
+      helper-text="Your public phone number"
+    >
       <vaadin-select style="width: 6rem" value="+358" required></vaadin-select>
       <vaadin-text-field
         prevent-invalid-input
@@ -21,19 +24,15 @@
         required
       ></vaadin-text-field>
       <vaadin-number-field required></vaadin-number-field>
-      <vaadin-button theme="outlined">Baseline</vaadin-button>
-
-    </div>
+    </vaadin-custom-field>
 
     <script type="module">
       import '@vaadin/custom-field';
       import '@vaadin/item';
       import '@vaadin/list-box';
-
-      import '@vaadin/number-field/theme/material/vaadin-number-field.js';
-      import '@vaadin/text-field/theme/material/vaadin-text-field.js';
-      import '@vaadin/select/theme/material/vaadin-select.js';
-      import '@vaadin/button/theme/material/vaadin-button.js';
+      import '@vaadin/number-field';
+      import '@vaadin/text-field';
+      import '@vaadin/select';
 
       const select = document.querySelector('vaadin-select');
       select.focusElement.setAttribute('aria-label', 'Country code');

--- a/dev/custom-field.html
+++ b/dev/custom-field.html
@@ -9,12 +9,9 @@
   </head>
 
   <body>
-    <vaadin-custom-field
-      label="Phone number"
-      required
-      error-message="This field is required"
-      helper-text="Your public phone number"
-    >
+
+
+    <div style="border: solid 1px gray">
       <vaadin-select style="width: 6rem" value="+358" required></vaadin-select>
       <vaadin-text-field
         prevent-invalid-input
@@ -24,15 +21,19 @@
         required
       ></vaadin-text-field>
       <vaadin-number-field required></vaadin-number-field>
-    </vaadin-custom-field>
+      <vaadin-button theme="outlined">Baseline</vaadin-button>
+
+    </div>
 
     <script type="module">
       import '@vaadin/custom-field';
       import '@vaadin/item';
       import '@vaadin/list-box';
-      import '@vaadin/number-field';
-      import '@vaadin/text-field';
-      import '@vaadin/select';
+
+      import '@vaadin/number-field/theme/material/vaadin-number-field.js';
+      import '@vaadin/text-field/theme/material/vaadin-text-field.js';
+      import '@vaadin/select/theme/material/vaadin-select.js';
+      import '@vaadin/button/theme/material/vaadin-button.js';
 
       const select = document.querySelector('vaadin-select');
       select.focusElement.setAttribute('aria-label', 'Country code');

--- a/packages/button/theme/material/vaadin-button-styles.js
+++ b/packages/button/theme/material/vaadin-button-styles.js
@@ -27,12 +27,6 @@ const button = css`
     -moz-osx-font-smoothing: grayscale;
   }
 
-  @-moz-document url-prefix() {
-    :host {
-      vertical-align: -13px;
-    }
-  }
-
   :host::before,
   :host::after {
     content: '';


### PR DESCRIPTION
## Description

Removes a Firefox specific style rule for changing the vertical alignment of buttons using the Material theme by `-13px`. The style rule was introduced with the initial commit for the Material theme with no specific mentions of the Firefox-specific behavior: https://github.com/vaadin/vaadin-button/pull/90. It seems that this was a workaround that is not necessary anymore:

Before:
<img width="436" alt="Bildschirmfoto 2022-03-25 um 10 01 29" src="https://user-images.githubusercontent.com/357820/160089977-8ce79143-017b-4d4e-929e-7782c25c04c4.png">

After:
<img width="432" alt="Bildschirmfoto 2022-03-25 um 10 01 55" src="https://user-images.githubusercontent.com/357820/160089996-d357a2ad-623c-427f-8197-7b7779b990f7.png">

## Type of change

- [x] Bugfix
