### PR TITLE
refactor: update select to not use button

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -32,6 +32,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.1.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "23.1.0-alpha1",

--- a/packages/button/src/vaadin-button-mixin.d.ts
+++ b/packages/button/src/vaadin-button-mixin.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Constructor } from '@open-wc/dedupe-mixin';
+import { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mixin.js';
+
+/**
+ * A mixin providing common button functionality.
+ */
+export declare function ButtonMixin<T extends Constructor<HTMLElement>>(
+  base: T
+): T &
+  Constructor<ActiveMixinClass> &
+  Constructor<DisabledMixinClass> &
+  Constructor<FocusMixinClass> &
+  Constructor<KeyboardMixinClass> &
+  Constructor<TabindexMixinClass>;

--- a/packages/button/src/vaadin-button-mixin.js
+++ b/packages/button/src/vaadin-button-mixin.js
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
+import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
+import { TabindexMixin } from '@vaadin/component-base/src/tabindex-mixin.js';
+
+/**
+ * A mixin providing common button functionality.
+ *
+ * @polymerMixin
+ * @mixes ActiveMixin
+ * @mixes FocusMixin
+ * @mixes TabindexMixin
+ */
+export const ButtonMixin = (superClass) =>
+  class ButtonMixinClass extends ActiveMixin(TabindexMixin(FocusMixin(superClass))) {
+    /**
+     * By default, `Space` is the only possible activation key for a focusable HTML element.
+     * Nonetheless, the button is an exception as it can be also activated by pressing `Enter`.
+     * See the "Keyboard Support" section in https://www.w3.org/TR/wai-aria-practices/examples/button/button.html.
+     *
+     * @protected
+     * @override
+     */
+    get _activeKeys() {
+      return ['Enter', ' '];
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      // By default, if the user hasn't provided a custom role,
+      // the role attribute is set to "button".
+      if (!this.hasAttribute('role')) {
+        this.setAttribute('role', 'button');
+      }
+    }
+
+    /**
+     * Since the button component is designed on the base of the `[role=button]` attribute,
+     * and doesn't have a native <button> inside, in order to be fully accessible from the keyboard,
+     * it should manually fire the `click` event once an activation key is pressed,
+     * as it follows from the WAI-ARIA specifications:
+     * https://www.w3.org/TR/wai-aria-practices-1.1/#button
+     *
+     * According to the UI Events specifications,
+     * the `click` event should be fired exactly on `keydown`:
+     * https://www.w3.org/TR/uievents/#event-type-keydown
+     *
+     * @param {KeyboardEvent} event
+     * @protected
+     * @override
+     */
+    _onKeyDown(event) {
+      super._onKeyDown(event);
+
+      if (this._activeKeys.includes(event.key)) {
+        event.preventDefault();
+
+        // `DisabledMixin` overrides the standard `click()` method
+        // so that it doesn't fire the `click` event when the element is disabled.
+        this.click();
+      }
+    }
+  };

--- a/packages/button/src/vaadin-button-mixin.js
+++ b/packages/button/src/vaadin-button-mixin.js
@@ -17,6 +17,20 @@ import { TabindexMixin } from '@vaadin/component-base/src/tabindex-mixin.js';
  */
 export const ButtonMixin = (superClass) =>
   class ButtonMixinClass extends ActiveMixin(TabindexMixin(FocusMixin(superClass))) {
+    static get properties() {
+      return {
+        /**
+         * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
+         *
+         * @override
+         * @protected
+         */
+        tabindex: {
+          value: 0
+        }
+      };
+    }
+
     /**
      * By default, `Space` is the only possible activation key for a focusable HTML element.
      * Nonetheless, the button is an exception as it can be also activated by pressing `Enter`.

--- a/packages/button/src/vaadin-button.d.ts
+++ b/packages/button/src/vaadin-button.d.ts
@@ -3,11 +3,9 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
-import { TabindexMixin } from '@vaadin/component-base/src/tabindex-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ButtonMixin } from './vaadin-button-mixin.js';
 
 /**
  * `<vaadin-button>` is an accessible and customizable button that allows users to perform actions.
@@ -37,7 +35,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  */
-declare class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableMixin(HTMLElement))))) {}
+declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(HTMLElement))) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -4,11 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
-import { TabindexMixin } from '@vaadin/component-base/src/tabindex-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ButtonMixin } from './vaadin-button-mixin.js';
 
 /**
  * `<vaadin-button>` is an accessible and customizable button that allows users to perform actions.
@@ -39,13 +37,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @extends HTMLElement
- * @mixes ActiveMixin
- * @mixes TabindexMixin
- * @mixes FocusMixin
+ * @mixes ButtonMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerElement))))) {
+class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-button';
   }
@@ -128,56 +124,6 @@ class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableM
         </span>
       </div>
     `;
-  }
-
-  /**
-   * By default, `Space` is the only possible activation key for a focusable HTML element.
-   * Nonetheless, the button is an exception as it can be also activated by pressing `Enter`.
-   * See the "Keyboard Support" section in https://www.w3.org/TR/wai-aria-practices/examples/button/button.html.
-   *
-   * @protected
-   * @override
-   */
-  get _activeKeys() {
-    return ['Enter', ' '];
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    // By default, if the user hasn't provided a custom role,
-    // the role attribute is set to "button".
-    if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'button');
-    }
-  }
-
-  /**
-   * Since the button component is designed on the base of the `[role=button]` attribute,
-   * and doesn't have a native <button> inside, in order to be fully accessible from the keyboard,
-   * it should manually fire the `click` event once an activation key is pressed,
-   * as it follows from the WAI-ARIA specifications:
-   * https://www.w3.org/TR/wai-aria-practices-1.1/#button
-   *
-   * According to the UI Events specifications,
-   * the `click` event should be fired exactly on `keydown`:
-   * https://www.w3.org/TR/uievents/#event-type-keydown
-   *
-   * @param {KeyboardEvent} event
-   * @protected
-   * @override
-   */
-  _onKeyDown(event) {
-    super._onKeyDown(event);
-
-    if (this._activeKeys.includes(event.key)) {
-      event.preventDefault();
-
-      // `DisabledMixin` overrides the standard `click()` method
-      // so that it doesn't fire the `click` event when the element is disabled.
-      this.click();
-    }
   }
 }
 

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -46,20 +46,6 @@ class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     return 'vaadin-button';
   }
 
-  static get properties() {
-    return {
-      /**
-       * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
-       *
-       * @override
-       * @protected
-       */
-      tabindex: {
-        value: 0
-      }
-    };
-  }
-
   static get template() {
     return html`
       <style>

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -34,7 +34,6 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.2.0",
-    "@vaadin/button": "23.1.0-alpha1",
     "@vaadin/component-base": "23.1.0-alpha1",
     "@vaadin/field-base": "23.1.0-alpha1",
     "@vaadin/input-container": "23.1.0-alpha1",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.2.0",
+    "@vaadin/button": "23.1.0-alpha1",
     "@vaadin/component-base": "23.1.0-alpha1",
     "@vaadin/field-base": "23.1.0-alpha1",
     "@vaadin/input-container": "23.1.0-alpha1",

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -35,14 +35,14 @@ class SelectValueButton extends ButtonMixin(ThemableMixin(PolymerElement)) {
           width: 0;
         }
 
-        ::slotted(:not([slot])) {
+        ::slotted(*) {
           padding-left: 0;
           padding-right: 0;
           flex: auto;
         }
 
         /* placeholder styles */
-        ::slotted(:not([slot]):not([selected])) {
+        ::slotted(*:not([selected])) {
           line-height: 1;
         }
 

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -3,17 +3,19 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Button } from '@vaadin/button/src/vaadin-button.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
+import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
+import { TabindexMixin } from '@vaadin/component-base/src/tabindex-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-select-value-button',
   css`
     :host {
-      margin: 0;
       min-width: 0;
       width: 0;
-      height: auto;
     }
 
     ::slotted(:not([slot])) {
@@ -25,11 +27,6 @@ registerStyles(
     /* placeholder styles */
     ::slotted(:not([slot]):not([selected])) {
       line-height: 1;
-    }
-
-    /* TODO: unsupported selector */
-    .vaadin-button-container {
-      text-align: inherit;
     }
 
     [part='label'] {
@@ -44,12 +41,55 @@ registerStyles(
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
- * @extends Button
+ * @extends HTMLElement
+ * @mixes ActiveMixin
+ * @mixes TabindexMixin
+ * @mixes FocusMixin
+ * @mixes ThemableMixin
  * @protected
  */
-class SelectValueButton extends Button {
+class SelectValueButton extends ActiveMixin(TabindexMixin(FocusMixin(ThemableMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-select-value-button';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: inline-block;
+          position: relative;
+          outline: none;
+          white-space: nowrap;
+          -webkit-user-select: none;
+          -moz-user-select: none;
+          user-select: none;
+        }
+
+        .vaadin-button-container {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          text-align: inherit;
+          width: 100%;
+          height: 100%;
+          min-height: inherit;
+          background: transparent;
+          padding: 0;
+        }
+
+        [part='label'] {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      </style>
+      <div class="vaadin-button-container">
+        <span part="label">
+          <slot></slot>
+        </span>
+      </div>
+    `;
   }
 }
 

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -4,9 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
-import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
-import { TabindexMixin } from '@vaadin/component-base/src/tabindex-mixin.js';
+import { ButtonMixin } from '@vaadin/button/src/vaadin-button-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -42,13 +40,11 @@ registerStyles(
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
  * @extends HTMLElement
- * @mixes ActiveMixin
- * @mixes TabindexMixin
- * @mixes FocusMixin
+ * @mixes ButtonMixin
  * @mixes ThemableMixin
  * @protected
  */
-class SelectValueButton extends ActiveMixin(TabindexMixin(FocusMixin(ThemableMixin(PolymerElement)))) {
+class SelectValueButton extends ButtonMixin(ThemableMixin(PolymerElement)) {
   static get is() {
     return 'vaadin-select-value-button';
   }

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -6,35 +6,6 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ButtonMixin } from '@vaadin/button/src/vaadin-button-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-
-registerStyles(
-  'vaadin-select-value-button',
-  css`
-    :host {
-      min-width: 0;
-      width: 0;
-    }
-
-    ::slotted(:not([slot])) {
-      padding-left: 0;
-      padding-right: 0;
-      flex: auto;
-    }
-
-    /* placeholder styles */
-    ::slotted(:not([slot]):not([selected])) {
-      line-height: 1;
-    }
-
-    [part='label'] {
-      width: 100%;
-      padding: 0;
-      line-height: inherit;
-    }
-  `,
-  { moduleId: 'vaadin-select-value-button-styles' }
-);
 
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
@@ -60,6 +31,19 @@ class SelectValueButton extends ButtonMixin(ThemableMixin(PolymerElement)) {
           -webkit-user-select: none;
           -moz-user-select: none;
           user-select: none;
+          min-width: 0;
+          width: 0;
+        }
+
+        ::slotted(:not([slot])) {
+          padding-left: 0;
+          padding-right: 0;
+          flex: auto;
+        }
+
+        /* placeholder styles */
+        ::slotted(:not([slot]):not([selected])) {
+          line-height: 1;
         }
 
         .vaadin-button-container {
@@ -70,14 +54,15 @@ class SelectValueButton extends ButtonMixin(ThemableMixin(PolymerElement)) {
           width: 100%;
           height: 100%;
           min-height: inherit;
-          background: transparent;
-          padding: 0;
+          text-shadow: inherit;
         }
 
         [part='label'] {
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
+          width: 100%;
+          line-height: inherit;
         }
       </style>
       <div class="vaadin-button-container">

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -142,7 +142,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       <style>
         ::slotted([slot='value']) {
           flex-grow: 1;
-          background-color: transparent;
         }
       </style>
 
@@ -318,6 +317,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       ...super.slots,
       value: () => {
         const button = document.createElement('vaadin-select-value-button');
+        button.setAttribute('role', 'button');
         button.setAttribute('aria-haspopup', 'listbox');
         return button;
       }

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -317,7 +317,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       ...super.slots,
       value: () => {
         const button = document.createElement('vaadin-select-value-button');
-        button.setAttribute('role', 'button');
         button.setAttribute('aria-haspopup', 'listbox');
         return button;
       }
@@ -448,6 +447,7 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       menuElement.addEventListener(
         'click',
         () => {
+          console.log('click');
           this.__userInteraction = true;
           this.opened = false;
         },

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -447,7 +447,6 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
       menuElement.addEventListener(
         'click',
         () => {
-          console.log('click');
           this.__userInteraction = true;
           this.opened = false;
         },

--- a/packages/select/theme/lumo/vaadin-select-styles.js
+++ b/packages/select/theme/lumo/vaadin-select-styles.js
@@ -48,7 +48,7 @@ const select = css`
   }
 
   :host([theme~='small']) [part='input-field'] ::slotted([slot='value']) {
-    --lumo-button-size: var(--lumo-size-s);
+    --_lumo-selected-item-height: var(--lumo-size-s);
     --_lumo-selected-item-padding: 0;
   }
 `;
@@ -59,21 +59,15 @@ registerStyles(
   'vaadin-select-value-button',
   css`
     :host {
+      font-family: var(--lumo-font-family);
+      font-size: var(--lumo-font-size-m);
       padding: 0 0.25em;
+      --_lumo-selected-item-height: var(--lumo-size-m);
       --_lumo-selected-item-padding: 0.5em;
     }
 
-    :host::before,
-    :host::after {
-      display: none;
-    }
-
-    :host([focus-ring]) {
-      box-shadow: none;
-    }
-
     ::slotted(:not([slot])) {
-      min-height: var(--lumo-button-size);
+      min-height: var(--_lumo-selected-item-height);
       padding-top: var(--_lumo-selected-item-padding);
       padding-bottom: var(--_lumo-selected-item-padding);
     }

--- a/packages/select/theme/lumo/vaadin-select-styles.js
+++ b/packages/select/theme/lumo/vaadin-select-styles.js
@@ -66,13 +66,13 @@ registerStyles(
       --_lumo-selected-item-padding: 0.5em;
     }
 
-    ::slotted(:not([slot])) {
+    ::slotted(*) {
       min-height: var(--_lumo-selected-item-height);
       padding-top: var(--_lumo-selected-item-padding);
       padding-bottom: var(--_lumo-selected-item-padding);
     }
 
-    ::slotted(:not([slot]):hover) {
+    ::slotted(*:hover) {
       background-color: transparent;
     }
   `,

--- a/packages/select/theme/lumo/vaadin-select.js
+++ b/packages/select/theme/lumo/vaadin-select.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/button/theme/lumo/vaadin-button.js';
 import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import '@vaadin/item/theme/lumo/vaadin-item.js';
 import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';

--- a/packages/select/theme/material/vaadin-select-styles.js
+++ b/packages/select/theme/material/vaadin-select-styles.js
@@ -49,11 +49,6 @@ registerStyles(
       text-transform: none;
     }
 
-    :host::before,
-    :host::after {
-      display: none;
-    }
-
     ::slotted(:not([slot])) {
       font: inherit;
       padding: 4px 0;

--- a/packages/select/theme/material/vaadin-select-styles.js
+++ b/packages/select/theme/material/vaadin-select-styles.js
@@ -49,12 +49,12 @@ registerStyles(
       text-transform: none;
     }
 
-    ::slotted(:not([slot])) {
+    ::slotted(*) {
       font: inherit;
       padding: 4px 0;
     }
 
-    ::slotted(:not([slot]):hover) {
+    ::slotted(*:hover) {
       background-color: transparent;
     }
   `,

--- a/packages/select/theme/material/vaadin-select.js
+++ b/packages/select/theme/material/vaadin-select.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/button/theme/material/vaadin-button.js';
 import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import '@vaadin/item/theme/material/vaadin-item.js';
 import '@vaadin/list-box/theme/material/vaadin-list-box.js';


### PR DESCRIPTION
## Description

Updated `vaadin-select-value-button` to use mixins instead of extending `vaadin-button` directly.

Fixes #3607

## Type of change

- Refactor