### PR TITLE
fix: prevent child elements being drawn outside dialog content area

### DIFF
--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -24,6 +24,7 @@ registerStyles(
     .resizer-container {
       overflow: auto;
       flex-grow: 1;
+      border-radius: inherit; /* prevent child elements being drawn outside part=overlay */
     }
 
     [part='overlay'][style] .resizer-container {


### PR DESCRIPTION
Prevent any “corner bleed” of contained elements, such as headers and footers.