### PR TITLE
refactor: clean up button container styles

### DIFF
--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -99,10 +99,6 @@ class Button extends ActiveMixin(TabindexMixin(FocusMixin(ElementMixin(ThemableM
           height: 100%;
           min-height: inherit;
           text-shadow: inherit;
-          background: transparent;
-          padding: 0;
-          border: none;
-          box-shadow: none;
         }
 
         [part='prefix'],


### PR DESCRIPTION
## Description

It turns out the button component specifies some CSS properties for the container that are just a repetition of the default ones and therefore can be dropped. I guess they came out of the a11y refactoring whose initial version was based on the native `<button>`.

A finding from #3612 

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
