### PR TITLE
fix: restore overlay opened state when moving within the DOM

### DIFF
--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -567,15 +567,20 @@ class Dialog extends ThemePropertyMixin(ElementMixin(DialogDraggableMixin(Dialog
   }
 
   /** @protected */
+  connectedCallback() {
+    super.connectedCallback();
+    // Restore opened state if overlay was opened when disconnecting
+    if (this.__restoreOpened) {
+      this.opened = true;
+    }
+  }
+
+  /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-    // Delay closing the dialog in case it, or an ancestor, was just
-    // attached to a different node
-    setTimeout(() => {
-      if (!this.isConnected) {
-        this.opened = false;
-      }
-    });
+    // Close overlay and memorize opened state
+    this.__restoreOpened = this.opened;
+    this.opened = false;
   }
 
   /** @private */

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -569,7 +569,13 @@ class Dialog extends ThemePropertyMixin(ElementMixin(DialogDraggableMixin(Dialog
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.opened = false;
+    // Delay closing the dialog in case it, or an ancestor, was just
+    // attached to a different node
+    setTimeout(() => {
+      if (!this.isConnected) {
+        this.opened = false;
+      }
+    });
   }
 
   /** @private */

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { esc, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, esc, fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-dialog.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -137,9 +137,19 @@ describe('vaadin-dialog', () => {
     });
 
     describe('detaching', () => {
-      it('should close the overlay when detached', () => {
+      it('should close the overlay when detached', async () => {
         dialog.parentNode.removeChild(dialog);
+        await aTimeout(0);
         expect(dialog.opened).to.be.false;
+      });
+
+      it('should not close the overlay when moved within the DOM', async () => {
+        const newParent = document.createElement('div');
+        document.body.appendChild(newParent);
+
+        newParent.appendChild(dialog);
+        await aTimeout(0);
+        expect(dialog.opened).to.be.true;
       });
     });
 

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -137,12 +137,12 @@ describe('vaadin-dialog', () => {
     });
 
     describe('detaching', () => {
-      it('should close the overlay when detached', async () => {
+      it('should close the overlay when detached', () => {
         dialog.parentNode.removeChild(dialog);
         expect(dialog.opened).to.be.false;
       });
 
-      it('should not close the overlay when moved within the DOM', async () => {
+      it('should not close the overlay when moved within the DOM', () => {
         const newParent = document.createElement('div');
         document.body.appendChild(newParent);
 

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, esc, fixtureSync } from '@vaadin/testing-helpers';
+import { esc, fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-dialog.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -139,7 +139,6 @@ describe('vaadin-dialog', () => {
     describe('detaching', () => {
       it('should close the overlay when detached', async () => {
         dialog.parentNode.removeChild(dialog);
-        await aTimeout(0);
         expect(dialog.opened).to.be.false;
       });
 
@@ -148,7 +147,6 @@ describe('vaadin-dialog', () => {
         document.body.appendChild(newParent);
 
         newParent.appendChild(dialog);
-        await aTimeout(0);
         expect(dialog.opened).to.be.true;
       });
     });

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -127,6 +127,11 @@ class LoginOverlay extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement)
 
     this.$.vaadinLoginOverlayWrapper.addEventListener('vaadin-overlay-outside-click', this._preventClosingLogin);
     this.$.vaadinLoginOverlayWrapper.addEventListener('vaadin-overlay-escape-press', this._preventClosingLogin);
+
+    // Restore opened state if overlay was open when disconnecting
+    if (this.__restoreOpened) {
+      this.$.vaadinLoginOverlayWrapper.opened = true;
+    }
   }
 
   /** @protected */
@@ -135,6 +140,9 @@ class LoginOverlay extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement)
 
     this.$.vaadinLoginOverlayWrapper.removeEventListener('vaadin-overlay-outside-click', this._preventClosingLogin);
     this.$.vaadinLoginOverlayWrapper.removeEventListener('vaadin-overlay-escape-press', this._preventClosingLogin);
+
+    // Close overlay and memorize opened state
+    this.__restoreOpened = this.$.vaadinLoginOverlayWrapper.opened;
     this.$.vaadinLoginOverlayWrapper.opened = false;
   }
 

--- a/packages/login/test/login-overlay.test.js
+++ b/packages/login/test/login-overlay.test.js
@@ -43,12 +43,20 @@ describe('opened overlay', () => {
 
   it('should set opened using attribute', () => {
     expect(overlay.opened).to.be.true;
-    expect(document.querySelector('vaadin-login-form-wrapper')).to.be.ok;
+    expect(document.querySelector('vaadin-login-form-wrapper')).to.exist;
   });
 
   it('should remove form wrapper when closed', () => {
     overlay.opened = false;
-    expect(document.querySelector('vaadin-login-form-wrapper')).to.be.not.ok;
+    expect(document.querySelector('vaadin-login-form-wrapper')).not.to.exist;
+  });
+
+  it('should not remove form wrapper when moved within DOM', () => {
+    const newParent = document.createElement('div');
+    document.body.appendChild(newParent);
+    newParent.appendChild(overlay);
+
+    expect(document.querySelector('vaadin-login-form-wrapper')).to.exist;
   });
 
   it('should propagate theme to a wrapper', () => {


### PR DESCRIPTION
## Description

Restores overlay opened state when disconnecting and then reconnecting the element, for example when moving the element in the DOM. Applies to `vaadin-dialog` and `vaadin-login-overlay`.

Fixes https://github.com/vaadin/flow-components/issues/2979
Fixes https://github.com/vaadin/flow-components/issues/2087
Fixes https://github.com/vaadin/web-components/issues/2125

## Type of change

- [x] Bugfix
