### PR TITLE
refactor: keep overlay open when pressing Enter

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -103,6 +103,38 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
+   * Override Enter handler to keep overlay open
+   * when item is selected or unselected.
+   * @param {!Event} event
+   * @protected
+   * @override
+   */
+  _onEnter(event) {
+    this.__enterPressed = true;
+
+    super._onEnter(event);
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  _closeOrCommit() {
+    if (this.__enterPressed) {
+      this.__enterPressed = null;
+
+      // Keep focused index after committing
+      const focusedIndex = this._focusedIndex;
+      this._commitValue();
+      this._focusedIndex = focusedIndex;
+
+      return;
+    }
+
+    super._closeOrCommit();
+  }
+
+  /**
    * @param {CustomEvent} event
    * @protected
    * @override

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -174,6 +174,21 @@ describe('basic', () => {
       await sendKeys({ down: 'Enter' });
       expect(spy.calledOnce).to.be.false;
     });
+
+    it('should keep overlay open when selecting an item', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'Enter' });
+      expect(internal.opened).to.be.true;
+    });
+
+    it('should keep overlay focused index when selecting an item', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'Enter' });
+      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      expect(item.hasAttribute('focused')).to.be.true;
+    });
   });
 
   describe('pageSize', () => {


### PR DESCRIPTION
## Description

This PR makes it possible to select multiple items by pressing <kbd>Enter</kbd> without closing overlay.
In order to close the overlay from keyboard, <kbd>Esc</kbd> should be used. 

Fixes #3650

## Type of change

- Bugfix