### PR TITLE
refactor: improve selecting item with keyboard

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -123,10 +123,10 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     if (this.__enterPressed) {
       this.__enterPressed = null;
 
-      // Keep focused index after committing
-      const focusedIndex = this._focusedIndex;
+      // Keep selected item focused after committing on Enter.
+      const focusedItem = this.filteredItems[this._focusedIndex];
       this._commitValue();
-      this._focusedIndex = focusedIndex;
+      this._focusedIndex = this.filteredItems.indexOf(focusedItem);
 
       return;
     }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -423,7 +423,7 @@ class MultiSelectComboBox extends InputControlMixin(ThemableMixin(ElementMixin(P
     this.__updateChips();
 
     // Re-render scroller
-    this.$.comboBox.$.dropdown._scroller.__virtualizer.update();
+    this.$.comboBox.$.dropdown._scroller.requestContentUpdate();
 
     // Wait for chips to render
     requestAnimationFrame(() => {
@@ -468,15 +468,18 @@ class MultiSelectComboBox extends InputControlMixin(ThemableMixin(ElementMixin(P
 
     const index = this._findIndex(item, itemsCopy, this.itemIdPath);
     if (index !== -1) {
+      // Do not unselect when manually typing and committing an already selected item.
+      if (this.filter.toLowerCase() === this._getItemLabel(item, this.itemLabelPath).toLowerCase()) {
+        this.__clearFilter();
+        return;
+      }
+
       itemsCopy.splice(index, 1);
     } else {
       itemsCopy.push(item);
     }
 
     this.__updateSelection(itemsCopy);
-
-    // Reset the overlay focused index.
-    this.$.comboBox._focusedIndex = -1;
 
     // Suppress `value-changed` event.
     this.__clearFilter();

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -115,6 +115,13 @@ describe('basic', () => {
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
 
+    it('should not un-select item when typing its value manually', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ type: 'orange' });
+      await sendKeys({ down: 'Enter' });
+      expect(comboBox.selectedItems).to.deep.equal(['orange']);
+    });
+
     it('should update has-value attribute on selected items change', () => {
       expect(comboBox.hasAttribute('has-value')).to.be.false;
       comboBox.selectedItems = ['apple', 'banana'];
@@ -187,6 +194,14 @@ describe('basic', () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'Enter' });
       const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      expect(item.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should keep overlay focused index when entering and committing', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ type: 'banana' });
+      await sendKeys({ down: 'Enter' });
+      const item = document.querySelectorAll('vaadin-multi-select-combo-box-item')[1];
       expect(item.hasAttribute('focused')).to.be.true;
     });
   });
@@ -280,7 +295,7 @@ describe('basic', () => {
 
       it('should re-render chips when un-selecting the item', async () => {
         await sendKeys({ down: 'ArrowDown' });
-        await sendKeys({ type: 'orange' });
+        await sendKeys({ down: 'ArrowUp' });
         await sendKeys({ down: 'Enter' });
         await nextRender();
         expect(getChips(comboBox).length).to.equal(0);

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -116,6 +116,7 @@ describe('basic', () => {
     });
 
     it('should not un-select item when typing its value manually', async () => {
+      comboBox.selectedItems = ['orange'];
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ type: 'orange' });
       await sendKeys({ down: 'Enter' });


### PR DESCRIPTION
## Description

Fixes #3643

This PR introduces two improvements for `vaadin-multi-select-combo-box`:

1. Do not unselect item when typing it manually and pressing <kbd>Enter</kbd>
2. Set correct focused index after selecting item, and preserve it on deselecting.

https://user-images.githubusercontent.com/10589913/162208437-c463f308-69fa-42b9-95a0-90ec01a86bfb.mp4


## Type of change

- Refactor