### PR TITLE
feat: use CSS `color-scheme` property

### DIFF
--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -158,11 +158,13 @@ const color = css`
   html {
     color: var(--lumo-body-text-color);
     background-color: var(--lumo-base-color);
+    color-scheme: light;
   }
 
   [theme~='dark'] {
     color: var(--lumo-body-text-color);
     background-color: var(--lumo-base-color);
+    color-scheme: dark;
   }
 
   h1,


### PR DESCRIPTION
This allows the OS/browser to adjust the styles of native controls to better conform to the color schemed defined by Lumo. It is especially noticeable with scrollbars:

Before:
<img width="95" alt="Screen Shot 2022-04-08 at 12 17 45" src="https://user-images.githubusercontent.com/66382/162405797-8a9e1cca-c80e-4755-9aae-7a6dbc35d183.png">

After:
<img width="103" alt="Screen Shot 2022-04-08 at 12 18 16" src="https://user-images.githubusercontent.com/66382/162405891-71b9c6ac-3afe-42ad-b024-a2556bbfcebd.png">

