### PR TITLE
fix: make charts respect global Highcharts no data message

### DIFF
--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -62,6 +62,10 @@ export function deepMerge(target, source) {
   /* eslint-enable no-invalid-this */
 });
 
+// Init Highcharts global language defaults
+// No data message should be empty by default
+Highcharts.setOptions({ lang: { noData: '' } });
+
 /**
  * `<vaadin-chart>` is a Web Component for creating high quality charts.
  *
@@ -428,7 +432,6 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
        */
       emptyText: {
         type: String,
-        value: ' ',
         reflectToAttribute: true
       },
 
@@ -1032,13 +1035,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     // Best effort to make chart display custom empty-text messages when series are removed.
     // This is needed because Highcharts currently doesn't react. A condition not catered for is
     // when all points are removed from all series without removing any series.
-    const isEmpty =
-      this.configuration.series.length === 0 ||
-      this.configuration.series.map((e) => e.data.length === 0).reduce((e1, e2) => e1 && e2, true);
-    if (isEmpty) {
-      this.configuration.hideNoData();
-      this.configuration.showNoData(this.emptyText);
-    }
+    this.__updateNoDataElement(this.configuration);
   }
 
   /** @private */
@@ -1664,8 +1661,21 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
         noData: emptyText
       }
     });
-    config.hideNoData();
-    config.showNoData(emptyText);
+    this.__updateNoDataElement(config);
+  }
+
+  /**
+   * Force the no data text element to become visible if the chart has no data.
+   * This is necessary in cases where Highcharts does not update the element
+   * automatically, for example when setting the language config
+   * @private */
+  __updateNoDataElement(config) {
+    const isEmpty =
+      config.series.length === 0 || config.series.map((e) => e.data.length === 0).reduce((e1, e2) => e1 && e2, true);
+    if (isEmpty) {
+      config.hideNoData();
+      config.showNoData(this.emptyText);
+    }
   }
 
   /** @private */

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1671,8 +1671,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
    * @private
    */
   __updateNoDataElement(config) {
-    const isEmpty =
-      config.series.length === 0 || config.series.map((e) => e.data.length === 0).reduce((e1, e2) => e1 && e2, true);
+    const isEmpty = config.series.every((e) => e.data.length === 0);
     if (isEmpty) {
       config.hideNoData();
       config.showNoData(this.emptyText);

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1668,7 +1668,8 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
    * Force the no data text element to become visible if the chart has no data.
    * This is necessary in cases where Highcharts does not update the element
    * automatically, for example when setting the language config
-   * @private */
+   * @private
+   */
   __updateNoDataElement(config) {
     const isEmpty =
       config.series.length === 0 || config.series.map((e) => e.data.length === 0).reduce((e1, e2) => e1 && e2, true);


### PR DESCRIPTION
## Description

Make `vaadin-chart` respect the global Highcharts language setting for the no data message. Also fixes an issue where setting the chart-specific empty text lazily would show the no data element even if the chart has data.

Note that there are other issues related to this behavior:
- clearing the chart-specific empty text does not revert to using the global language setting, but uses an empty string instead. Tried some solutions to properly clear the chart-specific setting, but none worked. Might be a Highcharts issue.
- updating the global setting does not affect existing charts (that is probably expected behavior by Highcharts)

Fixes https://github.com/vaadin/flow-components/issues/3003

## Type of change

- Bugfix
