### PR TITLE
refactor: only apply no-padding theme to dialog content

### DIFF
--- a/packages/dialog/theme/lumo/vaadin-dialog-styles.js
+++ b/packages/dialog/theme/lumo/vaadin-dialog-styles.js
@@ -62,14 +62,6 @@ const dialogOverlay = css`
     padding: 0;
   }
 
-  :host([theme~='no-padding']:is([has-header], [has-title])) [part='header'] {
-    padding: 0;
-  }
-
-  :host([theme~='no-padding'][has-footer]) [part='footer'] {
-    padding: 0;
-  }
-
   @media (min-height: 320px) {
     :host(:is([has-header], [has-title])[overflow~='top']) [part='header'] {
       box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct);


### PR DESCRIPTION
Lumo theme currently set `padding: 0` to `[part=header]` and `[part=footer]` when theme `no-padding` is used. Remove the styling, as it makes sense to only apply it to `[part=content]`.

#### Before

<img width="693" alt="image" src="https://user-images.githubusercontent.com/262432/163159119-9e9818f7-2b3c-4a96-9e55-13d25f131b36.png">


#### After

<img width="681" alt="image" src="https://user-images.githubusercontent.com/262432/163158907-16b09fae-c442-4050-a03e-1a7bb53a8d17.png">
