### PR TITLE
refactor: cleanup no longer used code

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -691,11 +691,6 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _onClosed() {
-      // Happens when the overlay is closed by clicking outside
-      if (this.opened) {
-        this.close();
-      }
-
       if (!this.loading || this.allowCustomValue) {
         this._commitValue();
       }


### PR DESCRIPTION
## Description

The `_onClosed` method is only called in the observer, when `opened` is set to `false` so the check is redundant.
Previously, this method used to be called twice but that has been changed in https://github.com/vaadin/vaadin-combo-box/pull/799 

## Type of change

- Refactor