### PR TITLE
feat: show dropdown with selected items when readonly

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -66,6 +66,17 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
+   * Override method inherited from the combo-box
+   * to allow opening dropdown when readonly.
+   * @override
+   */
+  open() {
+    if (!this.disabled && !(this.readonly && this._getOverlayItems().length === 0)) {
+      this.opened = true;
+    }
+  }
+
+  /**
    * @protected
    * @override
    */
@@ -113,6 +124,11 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
    * @override
    */
   _closeOrCommit() {
+    if (this.readonly) {
+      this.close();
+      return;
+    }
+
     if (this.__enterPressed) {
       this.__enterPressed = null;
 
@@ -128,12 +144,60 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
+   * Override method inherited from the combo-box
+   * to not update focused item when readonly.
+   * @protected
+   * @override
+   */
+  _onArrowDown() {
+    if (!this.readonly) {
+      super._onArrowDown();
+    } else if (!this.opened) {
+      this.open();
+    }
+  }
+
+  /**
+   * Override method inherited from the combo-box
+   * to not update focused item when readonly.
+   * @protected
+   * @override
+   */
+  _onArrowUp() {
+    if (!this.readonly) {
+      super._onArrowUp();
+    } else if (!this.opened) {
+      this.open();
+    }
+  }
+
+  /**
+   * Override method inherited from the combo-box
+   * to close dropdown on blur when readonly.
+   * @param {FocusEvent} event
+   * @protected
+   * @override
+   */
+  _onFocusout(event) {
+    super._onFocusout(event);
+
+    if (this.readonly && !this._closeOnBlurIsPrevented) {
+      this.close();
+    }
+  }
+
+  /**
    * @param {CustomEvent} event
    * @protected
    * @override
    */
   _overlaySelectedItemChanged(event) {
     event.stopPropagation();
+
+    // Do not un-select on click when readonly
+    if (this.readonly) {
+      return;
+    }
 
     if (event.detail.item instanceof ComboBoxPlaceholder) {
       return;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
@@ -23,8 +23,19 @@ class MultiSelectComboBoxScroller extends ComboBoxScroller {
       return false;
     }
 
+    if (this.comboBox.readonly) {
+      return false;
+    }
+
     const host = this.comboBox.getRootNode().host;
     return host._findIndex(item, host.selectedItems, itemIdPath) > -1;
+  }
+
+  /** @private */
+  __updateElement(el, index) {
+    super.__updateElement(el, index);
+
+    el.toggleAttribute('readonly', this.comboBox.readonly);
   }
 }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -255,7 +255,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       readonly: {
         type: Boolean,
         value: false,
-        observer: '_readOnlyChanged',
+        observer: '_readonlyChanged',
         reflectToAttribute: true
       },
 
@@ -476,24 +476,22 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /** @private */
-  _readOnlyChanged(readOnly, oldReadOnly) {
-    if (this.selectedItems.length) {
-      if (readOnly) {
-        this.__savedItems = this.$.comboBox._getOverlayItems();
-        this.$.comboBox._setOverlayItems(Array.from(this.selectedItems));
+  _readonlyChanged(readonly, oldReadonly) {
+    if (readonly) {
+      this.__savedItems = this.$.comboBox._getOverlayItems();
+      this.$.comboBox._setOverlayItems(Array.from(this.selectedItems));
 
-        // Update chips to hide remove button
-        this._chips.forEach((chip) => {
-          chip.setAttribute('readonly', '');
-        });
-      } else if (oldReadOnly) {
-        this.$.comboBox._setOverlayItems(this.__savedItems);
-        this.__savedItems = null;
+      // Update chips to hide remove button
+      this._chips.forEach((chip) => {
+        chip.setAttribute('readonly', '');
+      });
+    } else if (oldReadonly) {
+      this.$.comboBox._setOverlayItems(this.__savedItems);
+      this.__savedItems = null;
 
-        this._chips.forEach((chip) => {
-          chip.removeAttribute('readonly');
-        });
-      }
+      this._chips.forEach((chip) => {
+        chip.removeAttribute('readonly');
+      });
     }
   }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -627,6 +627,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     chip.item = item;
     chip.toggleAttribute('disabled', this.disabled);
+    chip.toggleAttribute('readonly', this.readonly);
 
     const label = this._getItemLabel(item, this.itemLabelPath);
     chip.label = label;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -481,9 +481,18 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       if (readOnly) {
         this.__savedItems = this.$.comboBox._getOverlayItems();
         this.$.comboBox._setOverlayItems(Array.from(this.selectedItems));
+
+        // Update chips to hide remove button
+        this._chips.forEach((chip) => {
+          chip.setAttribute('readonly', '');
+        });
       } else if (oldReadOnly) {
         this.$.comboBox._setOverlayItems(this.__savedItems);
         this.__savedItems = null;
+
+        this._chips.forEach((chip) => {
+          chip.removeAttribute('readonly');
+        });
       }
     }
   }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -250,6 +250,16 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       },
 
       /**
+       * When present, it specifies that the field is read-only.
+       */
+      readonly: {
+        type: Boolean,
+        value: false,
+        observer: '_readOnlyChanged',
+        reflectToAttribute: true
+      },
+
+      /**
        * The list of selected items.
        * Note: modifying the selected items creates a new array each time.
        */
@@ -466,6 +476,19 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /** @private */
+  _readOnlyChanged(readOnly, oldReadOnly) {
+    if (this.selectedItems.length) {
+      if (readOnly) {
+        this.__savedItems = this.$.comboBox._getOverlayItems();
+        this.$.comboBox._setOverlayItems(Array.from(this.selectedItems));
+      } else if (oldReadOnly) {
+        this.$.comboBox._setOverlayItems(this.__savedItems);
+        this.__savedItems = null;
+      }
+    }
+  }
+
+  /** @private */
   _pageSizeChanged(pageSize, oldPageSize) {
     if (Math.floor(pageSize) !== pageSize || pageSize <= 0) {
       this.pageSize = oldPageSize;
@@ -483,6 +506,10 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     // Re-render chips
     this.__updateChips();
+
+    if (this.readonly) {
+      this.$.comboBox._setOverlayItems(selectedItems);
+    }
 
     // Re-render scroller
     this.$.comboBox.$.dropdown._scroller.requestContentUpdate();

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -431,6 +431,27 @@ describe('basic', () => {
         });
       });
     });
+
+    describe('readonly', () => {
+      beforeEach(async () => {
+        comboBox.selectedItems = ['apple', 'banana'];
+        await nextRender();
+        comboBox.readonly = true;
+      });
+
+      it('should set readonly attribute on all chips when disabled', () => {
+        const chips = getChips(comboBox);
+        expect(chips[0].hasAttribute('readonly')).to.be.true;
+        expect(chips[1].hasAttribute('readonly')).to.be.true;
+      });
+
+      it('should remove readonly attribute from chips when re-enabled', () => {
+        comboBox.readonly = false;
+        const chips = getChips(comboBox);
+        expect(chips[0].hasAttribute('readonly')).to.be.false;
+        expect(chips[1].hasAttribute('readonly')).to.be.false;
+      });
+    });
   });
 
   describe('change event', () => {

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -439,17 +439,24 @@ describe('basic', () => {
         comboBox.readonly = true;
       });
 
-      it('should set readonly attribute on all chips when disabled', () => {
+      it('should set readonly attribute on all chips when readonly', () => {
         const chips = getChips(comboBox);
         expect(chips[0].hasAttribute('readonly')).to.be.true;
         expect(chips[1].hasAttribute('readonly')).to.be.true;
       });
 
-      it('should remove readonly attribute from chips when re-enabled', () => {
+      it('should remove readonly attribute from chips when not readonly', () => {
         comboBox.readonly = false;
         const chips = getChips(comboBox);
         expect(chips[0].hasAttribute('readonly')).to.be.false;
         expect(chips[1].hasAttribute('readonly')).to.be.false;
+      });
+
+      it('should set readonly attribute on added chips while readonly', () => {
+        comboBox.selectedItems = ['lemon', 'orange'];
+        const chips = getChips(comboBox);
+        expect(chips[0].hasAttribute('readonly')).to.be.true;
+        expect(chips[1].hasAttribute('readonly')).to.be.true;
       });
     });
   });

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -509,6 +509,108 @@ describe('basic', () => {
     });
   });
 
+  describe('readonly', () => {
+    beforeEach(() => {
+      comboBox.selectedItems = ['apple', 'orange'];
+      comboBox.readonly = true;
+      inputElement.focus();
+    });
+
+    it('should open the dropdown on input click when readonly', () => {
+      inputElement.click();
+      expect(internal.opened).to.be.true;
+    });
+
+    it('should open the dropdown on Arrow Down when readonly', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      expect(internal.opened).to.be.true;
+    });
+
+    it('should open the dropdown on Arrow Up when readonly', async () => {
+      await sendKeys({ down: 'ArrowUp' });
+      expect(internal.opened).to.be.true;
+    });
+
+    it('should close the dropdown on Tab when readonly', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'Tab' });
+      expect(internal.opened).to.be.false;
+    });
+
+    it('should close the dropdown on Enter when readonly', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'Enter' });
+      expect(internal.opened).to.be.false;
+    });
+
+    it('should close the dropdown on Esc when readonly', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'Escape' });
+      expect(internal.opened).to.be.false;
+    });
+
+    it('should not pre-fill focused item label on Arrow Down', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'ArrowDown' });
+      expect(inputElement.value).to.equal('');
+    });
+
+    it('should not pre-fill focused item label on Arrow Up', async () => {
+      await sendKeys({ down: 'ArrowUp' });
+      await sendKeys({ down: 'ArrowUp' });
+      expect(inputElement.value).to.equal('');
+    });
+
+    it('should not set item focus-ring attribute on Arrow Down', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'ArrowDown' });
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items[0].hasAttribute('focus-ring')).to.be.false;
+    });
+
+    it('should not set item focus-ring attribute on Arrow Up', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'ArrowDown' });
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items[1].hasAttribute('focus-ring')).to.be.false;
+    });
+
+    it('should only render selected items in the dropdown', () => {
+      inputElement.click();
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items.length).to.equal(2);
+      expect(items[0].textContent).to.equal('apple');
+      expect(items[1].textContent).to.equal('orange');
+    });
+
+    it('should not set selected attribute on the dropdown items', () => {
+      inputElement.click();
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items[0].hasAttribute('selected')).to.be.false;
+      expect(items[1].hasAttribute('selected')).to.be.false;
+    });
+
+    it('should set readonly attribute on the dropdown items', () => {
+      inputElement.click();
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items[0].hasAttribute('readonly')).to.be.true;
+      expect(items[1].hasAttribute('readonly')).to.be.true;
+    });
+
+    it('should not un-select item on click when readonly', () => {
+      inputElement.click();
+      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      item.click();
+      expect(comboBox.selectedItems.length).to.equal(2);
+    });
+
+    it('should not open the dropdown if selected items are empty', () => {
+      comboBox.selectedItems = [];
+      inputElement.click();
+      expect(internal.opened).to.be.false;
+    });
+  });
+
   describe('helper text', () => {
     it('should set helper text content using helperText property', async () => {
       comboBox.helperText = 'foo';

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -630,6 +630,15 @@ describe('basic', () => {
       inputElement.click();
       expect(internal.opened).to.be.false;
     });
+
+    it('should not open the dropdown if readonly is set after clearing', () => {
+      comboBox.readonly = false;
+      comboBox.selectedItems = [];
+
+      comboBox.readonly = true;
+      inputElement.click();
+      expect(internal.opened).to.be.false;
+    });
   });
 
   describe('helper text', () => {

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-chip-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-chip-styles.js
@@ -22,7 +22,7 @@ const chip = css`
     cursor: var(--lumo-clickable-cursor);
   }
 
-  :host(:not([part~='overflow'])) {
+  :host(:not([part~='overflow']):not([readonly]):not([disabled])) {
     padding-inline-end: 0;
   }
 
@@ -66,10 +66,6 @@ const chip = css`
   :host([part~='overflow-one'])::before,
   :host([part~='overflow-one'])::after {
     display: none;
-  }
-
-  :host(:not([readonly]):not([disabled])) {
-    padding-inline-end: 0;
   }
 
   [part='label'] {

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-chip-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-chip-styles.js
@@ -68,6 +68,10 @@ const chip = css`
     display: none;
   }
 
+  :host(:not([readonly]):not([disabled])) {
+    padding-inline-end: 0;
+  }
+
   [part='label'] {
     font-weight: 500;
     line-height: 1.25;
@@ -88,10 +92,15 @@ const chip = css`
     content: var(--lumo-icons-cross);
   }
 
-  :host([disabled]) [part] {
+  :host([disabled]) [part='label'] {
     color: var(--lumo-disabled-text-color);
     -webkit-text-fill-color: var(--lumo-disabled-text-color);
     pointer-events: none;
+  }
+
+  :host([readonly]) [part='remove-button'],
+  :host([disabled]) [part='remove-button'] {
+    display: none;
   }
 `;
 

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -41,7 +41,7 @@ const multiSelectComboBox = css`
     content: var(--lumo-icons-dropdown);
   }
 
-  :host([readonly]) [part='toggle-button'] {
+  :host([readonly][has-value]) [part='toggle-button'] {
     color: var(--lumo-contrast-60pct);
     cursor: var(--lumo-clickable-cursor);
   }

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -16,6 +16,7 @@ registerStyles(
     @media (any-hover: hover) {
       :host(:hover[readonly]) {
         background-color: transparent;
+        cursor: default;
       }
     }
   `,

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -10,6 +10,20 @@ import '@vaadin/vaadin-lumo-styles/typography.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
+registerStyles(
+  'vaadin-multi-select-combo-box-item',
+  css`
+    @media (any-hover: hover) {
+      :host(:hover[readonly]) {
+        background-color: transparent;
+      }
+    }
+  `,
+  {
+    moduleId: 'lumo-multi-select-combo-box-item'
+  }
+);
+
 const multiSelectComboBox = css`
   :host([has-value]) {
     padding-inline-start: 0;

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -40,6 +40,11 @@ const multiSelectComboBox = css`
   [part='toggle-button']::before {
     content: var(--lumo-icons-dropdown);
   }
+
+  :host([readonly]) [part='toggle-button'] {
+    color: var(--lumo-contrast-60pct);
+    cursor: var(--lumo-clickable-cursor);
+  }
 `;
 
 registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectComboBox], {

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-chip-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-chip-styles.js
@@ -20,10 +20,13 @@ const chip = css`
     font-family: var(--material-font-family);
   }
 
+  :host(:not([part~='overflow']):not([readonly]):not([disabled])) {
+    padding-inline-end: 0;
+  }
+
   :host([part~='overflow']) {
     position: relative;
     margin-inline-start: 0.5rem;
-    padding-inline-end: 0.5rem;
   }
 
   :host([part~='overflow'])::before,
@@ -60,10 +63,6 @@ const chip = css`
   :host([part~='overflow-one'])::before,
   :host([part~='overflow-one'])::after {
     display: none;
-  }
-
-  :host(:not([readonly]):not([disabled])) {
-    padding-inline-end: 0;
   }
 
   [part='label'] {

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-chip-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-chip-styles.js
@@ -13,7 +13,7 @@ const chip = css`
   :host {
     height: 1.25rem;
     margin-inline-end: 0.25rem;
-    padding-inline-start: 0.5rem;
+    padding: 0 0.5rem;
     border-radius: 4px;
     background-color: hsla(214, 53%, 23%, 0.1);
     cursor: default;
@@ -62,6 +62,10 @@ const chip = css`
     display: none;
   }
 
+  :host(:not([readonly]):not([disabled])) {
+    padding-inline-end: 0;
+  }
+
   [part='label'] {
     font-size: var(--material-caption-font-size);
     line-height: 1;
@@ -85,19 +89,15 @@ const chip = css`
     content: var(--material-icons-clear);
   }
 
-  /* Disabled */
-  :host([disabled]) [part] {
-    pointer-events: none;
-  }
-
   :host([disabled]) [part='label'] {
     color: var(--material-disabled-text-color);
     -webkit-text-fill-color: var(--material-disabled-text-color);
+    pointer-events: none;
   }
 
+  :host([readonly]) [part='remove-button'],
   :host([disabled]) [part='remove-button'] {
-    color: hsla(0, 0%, 100%, 0.75);
-    -webkit-text-fill-color: hsla(0, 0%, 100%, 0.75);
+    display: none;
   }
 `;
 

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -45,7 +45,7 @@ const multiSelectComboBox = css`
     transform: rotate(180deg);
   }
 
-  :host([readonly]) [part='toggle-button'] {
+  :host([readonly][has-value]) [part='toggle-button'] {
     color: var(--material-secondary-text-color);
   }
 `;

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -15,6 +15,7 @@ registerStyles(
     @media (any-hover: hover) {
       :host(:hover[readonly]) {
         background-color: transparent;
+        cursor: default;
       }
     }
   `,

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -9,6 +9,20 @@ import '@vaadin/vaadin-material-styles/typography.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
+registerStyles(
+  'vaadin-multi-select-combo-box-item',
+  css`
+    @media (any-hover: hover) {
+      :host(:hover[readonly]) {
+        background-color: transparent;
+      }
+    }
+  `,
+  {
+    moduleId: 'material-multi-select-combo-box-item'
+  }
+);
+
 const multiSelectComboBox = css`
   :host([readonly]) [part~='chip'] {
     opacity: 0.5;

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -44,6 +44,10 @@ const multiSelectComboBox = css`
   :host([opened]) [part='toggle-button'] {
     transform: rotate(180deg);
   }
+
+  :host([readonly]) [part='toggle-button'] {
+    color: var(--material-secondary-text-color);
+  }
 `;
 
 registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectComboBox], {


### PR DESCRIPTION
## Description

As discussed internally, the dropdown should be also available when readonly, so user can see all the selected items.
In this case, interacting with the items isn't possible: you can't un-select them with keyboard or mouse click.

![readonly-dropdown](https://user-images.githubusercontent.com/10589913/163784624-6177a1f5-3daf-4411-804c-9616d5164e3b.gif)

## Type of change

- Feature