### PR TITLE
fix: clear filter when clicking matching value

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -82,6 +82,8 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
+   * Override method from `InputMixin`.
+   *
    * @protected
    * @override
    */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -81,6 +81,18 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     this._toggleElement = this.querySelector('.toggle-button');
   }
 
+  /**
+   * @protected
+   * @override
+   */
+  clear() {
+    super.clear();
+
+    if (this.inputElement) {
+      this.inputElement.value = '';
+    }
+  }
+
   /** @protected */
   _isClearButton(event) {
     return (

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -452,6 +452,7 @@ class MultiSelectComboBox extends InputControlMixin(ThemableMixin(ElementMixin(P
 
   /** @private */
   __clearFilter() {
+    this.filter = '';
     this.$.comboBox.clear();
   }
 

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -383,6 +383,22 @@ describe('basic', () => {
       await sendKeys({ type: 'pear' });
       await sendKeys({ down: 'Enter' });
       expect(internal.value).to.equal('');
+      expect(inputElement.value).to.equal('');
+    });
+
+    it('should clear input element value after clicking matching value', async () => {
+      await sendKeys({ type: 'ora' });
+      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      item.click();
+      expect(internal.value).to.equal('');
+      expect(inputElement.value).to.equal('');
+    });
+
+    it('should clear filter property after clicking matching value', async () => {
+      await sendKeys({ type: 'ora' });
+      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      item.click();
+      expect(comboBox.filter).to.equal('');
     });
 
     it('should not add custom value to selectedItems automatically', async () => {


### PR DESCRIPTION
## Description

The issue with not clearing the input was coming from the fact that by default, `clear()` method only sets 'value' to empty string. However, it was already empty for an internal combo-box, so the observer to reset input value wasn't triggered.

Updated to manually set `inputElement.value` to empty string. Also, added logic to reset `filter` property, so that the component shows all the items after clicking / pressing <kbd>Enter</kbd> on the matching item in the dropdown.

Fixes #3644

## Type of change

- Bugfix