### PR TITLE
fix: restore missing RTL pseudo element style

### DIFF
--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -131,6 +131,10 @@ registerStyles(
     }
 
     /* RTL specific styles */
+    :host([dir='rtl'])::after {
+      transform-origin: 0% 0;
+    }
+
     :host([theme~='align-left'][dir='rtl']) ::slotted(:not([slot$='fix'])) {
       --_lumo-text-field-overflow-mask-image: none;
     }


### PR DESCRIPTION
## Description

Added missing style to `vaadin-input-container` Lumo theme to fix regression in Vaadin 22+

Fixes #3622

## Type of change

- Bugfix