### PR TITLE
refactor: remove unused code from time-picker

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-combo-box.js
+++ b/packages/time-picker/src/vaadin-time-picker-combo-box.js
@@ -79,27 +79,6 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
     // See https://github.com/vaadin/vaadin-time-picker/issues/145
     this.setAttribute('dir', 'ltr');
   }
-
-  /** @protected */
-  _isClearButton(event) {
-    return (
-      super._isClearButton(event) ||
-      (event.type === 'input' && !event.isTrusted) || // fake input event dispatched by clear button
-      event.composedPath()[0].getAttribute('part') === 'clear-button'
-    );
-  }
-
-  /**
-   * @param {!Event} event
-   * @protected
-   */
-  _onChange(event) {
-    super._onChange(event);
-
-    if (this._isClearButton(event)) {
-      this._clear();
-    }
-  }
 }
 
 customElements.define(TimePickerComboBox.is, TimePickerComboBox);


### PR DESCRIPTION
## Description

This code was introduced in https://github.com/vaadin/web-components/pull/2618 and appears to be a copy-paste from `vaadin-combo-box-light` component.
The `_onChange` override is not needed because the clear button click is handled in `ComboBoxMixin`:

https://github.com/vaadin/web-components/blob/9b9fa8a6e26d6154cb06b27c1ddd3bda6e21e1df/packages/combo-box/src/vaadin-combo-box-mixin.js#L416-L418

Also `_isClearButton()` override isn't needed because in case of time-picker we can be sure that `clearElement` exists by the time when the component is initialised, and `this.querySelector('[part="clear-button"]')` returns a reference to it.

## Type of change

- Refactor