### PR TITLE
test: disable buttons animation in visual tests

### DIFF
--- a/packages/menu-bar/test/not-animated-styles.js
+++ b/packages/menu-bar/test/not-animated-styles.js
@@ -11,3 +11,14 @@ registerStyles(
     }
   `
 );
+
+registerStyles(
+  'vaadin-menu-bar-button',
+  css`
+    :host,
+    :host::before,
+    :host::after {
+      transition: none !important;
+    }
+  `
+);


### PR DESCRIPTION
## Description

It turned out that there was a box-shadow animation of menu-bar buttons in the Material theme that wasn't disabled in visual tests which resulted in their instability. The PR disables that animation.

Note, during the animation, the browser may allocate the involved elements to separate layers for optimization purposes, which in turn may affect the font rendering making the test flaky.

Part of #3538 

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
