### PR TITLE
chore: update yarn lock after bumping sinon

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9970,7 +9970,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-sinon@13.0.2:
+sinon@^13.0.2:
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-13.0.2.tgz#c6a8ddd655dc1415bbdc5ebf0e5b287806850c3a"
   integrity sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==


### PR DESCRIPTION
## Description

Corrects a mistake in `yarn.lock` that occurred because I forgot to run `yarn install` after manually changing the sinon version from `13.0.2` to `^13.0.2`.

A follow-up to #3699 

## Type of change

- [x] Internal
