### PR TITLE
refactor: do not set part on the internal wrapper

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-container.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-container.js
@@ -9,7 +9,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-multi-select-combo-box-container',
   css`
-    [part='wrapper'] {
+    .wrapper {
       display: flex;
       width: 100%;
     }
@@ -39,7 +39,7 @@ class MultiSelectComboBoxContainer extends InputContainer {
       const slots = content.querySelectorAll('slot');
 
       const wrapper = document.createElement('div');
-      wrapper.setAttribute('part', 'wrapper');
+      wrapper.setAttribute('class', 'wrapper');
       content.insertBefore(wrapper, slots[2]);
 
       wrapper.appendChild(slots[0]);


### PR DESCRIPTION
## Description

This element is only used to have a wrapper around chips and the input, and not intended to be used for theming.
Therefore we should not use `part` attribute for it, and use `class` instead to indicate it is internal.

## Type of change

- Refactor