### PR TITLE
feat: show warning when engaging turbo mode in development mode

### DIFF
--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1797,7 +1797,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __checkTurboMode() {
-    const isDevelopmentMode = !!window.Vaadin.developmentModeCallback;
+    const isDevelopmentMode = !!window.Vaadin.developmentMode;
 
     if (!this.configuration || !isDevelopmentMode || this.__turboModeWarningAlreadyLogged) {
       return;

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -535,7 +535,15 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
       this._jsonConfigurationBuffer = null;
       this.__initChart(options);
       this.__addChildObserver();
+      this.__checkTurboMode();
     });
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.addEventListener('chart-redraw', this.__onRedraw.bind(this));
   }
 
   /**
@@ -1780,6 +1788,34 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   /** @private */
   __showWarn(propertyName, acceptedValues) {
     console.warn('<vaadin-chart> Acceptable values for "' + propertyName + '" are ' + acceptedValues);
+  }
+
+  /** @private */
+  __onRedraw() {
+    this.__checkTurboMode();
+  }
+
+  /** @private */
+  __checkTurboMode() {
+    const isDevelopmentMode = !!window.Vaadin.developmentModeCallback;
+
+    if (!this.configuration || !isDevelopmentMode || this.__turboModeWarningAlreadyLogged) {
+      return;
+    }
+
+    const exceedsTurboThreshold = this.configuration.series.some((series) => {
+      const threshold = (series.options && series.options.turboThreshold) || 0;
+      const dataLength = series.data.length;
+
+      return threshold > 0 && dataLength > threshold;
+    });
+
+    if (exceedsTurboThreshold) {
+      this.__turboModeWarningAlreadyLogged = true;
+      console.warn(
+        '<vaadin-chart> Turbo mode has been enabled for one or more series, because the number of data items exceeds the configured threshold. Turbo mode improves the performance of charts with lots of data, but is not compatible with every type of series. Please consult the documentation on compatibility, or how to disable turbo mode.'
+      );
+    }
   }
 }
 

--- a/packages/charts/test/turbo-mode.test.js
+++ b/packages/charts/test/turbo-mode.test.js
@@ -64,7 +64,7 @@ describe('turbo-mode warning', () => {
         expect(console.warn.called).to.be.false;
       });
       it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
-        addSeries(11, true);
+        addSeries(11);
         document.body.appendChild(chart);
         await waitUntilChartInitialized();
         expect(console.warn.called).to.be.true;
@@ -80,7 +80,7 @@ describe('turbo-mode warning', () => {
         expect(console.warn.called).to.be.false;
       });
       it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
-        addSeriesWithJS(11, true);
+        addSeriesWithJS(11);
         document.body.appendChild(chart);
         await waitUntilChartInitialized();
         expect(console.warn.called).to.be.true;

--- a/packages/charts/test/turbo-mode.test.js
+++ b/packages/charts/test/turbo-mode.test.js
@@ -170,12 +170,12 @@ describe('turbo-mode warning', () => {
     });
 
     describe('production mode', () => {
-      const originalDevmodeCallback = window.Vaadin.developmentModeCallback;
+      const originalDevelopmentMode = window.Vaadin.developmentMode;
       before(() => {
-        window.Vaadin.developmentModeCallback = null;
+        window.Vaadin.developmentMode = false;
       });
       after(() => {
-        window.Vaadin.developmentModeCallback = originalDevmodeCallback;
+        window.Vaadin.developmentMode = originalDevelopmentMode;
       });
 
       it('should not log warning in production', async () => {

--- a/packages/charts/test/turbo-mode.test.js
+++ b/packages/charts/test/turbo-mode.test.js
@@ -1,0 +1,193 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-chart.js';
+
+describe('turbo-mode warning', () => {
+  let chart;
+
+  beforeEach(async () => {
+    sinon.stub(console, 'warn');
+    chart = fixtureSync(`<vaadin-chart></vaadin-chart>`);
+    chart.updateConfiguration({
+      plotOptions: {
+        series: {
+          turboThreshold: 10
+        }
+      }
+    });
+    await nextRender();
+  });
+
+  afterEach(() => {
+    console.warn.restore();
+  });
+
+  function addSeries(numDataItems) {
+    const data = Array.from(Array(numDataItems).keys());
+    const series = fixtureSync(`<vaadin-chart-series values="[${data.join(',')}]"></vaadin-chart-series>`);
+    chart.appendChild(series);
+  }
+
+  function addSeriesWithJS(numDataItems) {
+    const data = Array.from(Array(numDataItems).keys());
+    chart.updateConfiguration({
+      series: [
+        {
+          type: 'column',
+          data
+        }
+      ]
+    });
+  }
+
+  function addPoint(seriesIndex, data) {
+    chart.configuration.series[seriesIndex].addPoint(data);
+  }
+
+  describe('adding series', () => {
+    it('should not log warning when no series exceeds the turbo threshold', async () => {
+      addSeries(4);
+      addSeries(9);
+      addSeries(0);
+      await oneEvent(chart, 'chart-redraw');
+
+      expect(console.warn.called).to.be.false;
+    });
+
+    it('should log warning when a series exceeds the turbo threshold', async () => {
+      await addSeries(11);
+      await oneEvent(chart, 'chart-redraw');
+      expect(console.warn.called).to.be.true;
+      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+    });
+  });
+
+  describe('adding series with JS', () => {
+    it('should not log warning when no series exceeds the turbo threshold', async () => {
+      await addSeriesWithJS(4);
+      await addSeriesWithJS(9);
+      await addSeriesWithJS(0);
+      await oneEvent(chart, 'chart-redraw');
+      expect(console.warn.called).to.be.false;
+    });
+
+    it('should log warning when a series exceeds the turbo threshold', async () => {
+      await addSeriesWithJS(11);
+      await oneEvent(chart, 'chart-redraw');
+      expect(console.warn.called).to.be.true;
+      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+    });
+  });
+
+  describe('initializing with series', () => {
+    beforeEach(async () => {
+      chart = document.createElement('vaadin-chart');
+      chart.updateConfiguration({
+        plotOptions: {
+          series: {
+            turboThreshold: 10
+          }
+        }
+      });
+    });
+
+    it('should not log warning when no series exceeds the turbo threshold', async () => {
+      addSeries(4);
+      addSeries(9);
+      addSeries(10);
+      document.body.appendChild(chart);
+      await nextRender();
+      expect(console.warn.called).to.be.false;
+    });
+    it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
+      await addSeries(11, true);
+      document.body.appendChild(chart);
+      await nextRender();
+      expect(console.warn.called).to.be.true;
+      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+    });
+  });
+
+  describe('initializing with series with JS', () => {
+    beforeEach(async () => {
+      chart = document.createElement('vaadin-chart');
+      chart.updateConfiguration({
+        plotOptions: {
+          series: {
+            turboThreshold: 10
+          }
+        }
+      });
+    });
+
+    it('should not log warning when no series exceeds the turbo threshold', async () => {
+      addSeriesWithJS(4);
+      addSeriesWithJS(9);
+      addSeriesWithJS(0);
+      document.body.appendChild(chart);
+      await nextRender();
+      expect(console.warn.called).to.be.false;
+    });
+    it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
+      await addSeriesWithJS(11, true);
+      document.body.appendChild(chart);
+      await nextRender();
+      expect(console.warn.called).to.be.true;
+      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+    });
+  });
+
+  describe('adding points', () => {
+    it('should not log warning when total number of items does not exceed the turbo threshold', async () => {
+      addSeriesWithJS(4);
+      await oneEvent(chart, 'chart-redraw');
+      addPoint(0, 5);
+      addPoint(0, 6);
+      addPoint(0, 7);
+      chart.configuration.redraw();
+      expect(console.warn.called).to.be.false;
+    });
+
+    it('should log warning when total number of items exceeds the turbo threshold', async () => {
+      addSeriesWithJS(10);
+      await oneEvent(chart, 'chart-redraw');
+      expect(console.warn.called).to.be.false;
+
+      addPoint(0, 11);
+      chart.configuration.redraw();
+      expect(console.warn.called).to.be.true;
+      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+    });
+  });
+
+  describe('single log entry', () => {
+    it('should only log the warning once', async () => {
+      addSeriesWithJS(13);
+      await oneEvent(chart, 'chart-redraw');
+      expect(console.warn.called).to.be.true;
+      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+
+      console.warn.resetHistory();
+      addSeriesWithJS(16);
+      await oneEvent(chart, 'chart-redraw');
+      expect(console.warn.called).to.be.false;
+    });
+  });
+
+  describe('production mode', () => {
+    const originalDevmodeCallback = window.Vaadin.developmentModeCallback;
+    before(() => {
+      window.Vaadin.developmentModeCallback = null;
+    });
+    after(() => {
+      window.Vaadin.developmentModeCallback = originalDevmodeCallback;
+    });
+
+    it('should not log warning in production', async () => {
+      addSeriesWithJS(13);
+      await oneEvent(chart, 'chart-redraw');
+      expect(console.warn.called).to.be.false;
+    });
+  });
+});

--- a/packages/charts/test/turbo-mode.test.js
+++ b/packages/charts/test/turbo-mode.test.js
@@ -3,7 +3,7 @@ import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-chart.js';
 
-describe('turbo-mode warning', () => {
+describe('turbo-mode', () => {
   let chart;
 
   beforeEach(async () => {
@@ -32,18 +32,6 @@ describe('turbo-mode warning', () => {
     });
   }
 
-  function addPoint(seriesIndex, data) {
-    chart.configuration.series[seriesIndex].addPoint(data);
-  }
-
-  async function waitUntilChartInitialized() {
-    while (!chart.configuration) {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 100);
-      });
-    }
-  }
-
   describe('when initializing chart', () => {
     beforeEach(async () => {
       chart = document.createElement('vaadin-chart');
@@ -54,20 +42,21 @@ describe('turbo-mode warning', () => {
           }
         }
       });
+      await nextRender();
     });
 
     describe('add series', () => {
       it('should not log warning when no series exceeds the turbo threshold', async () => {
         addSeries(9);
         document.body.appendChild(chart);
-        await waitUntilChartInitialized();
+        await nextRender();
         expect(console.warn.called).to.be.false;
       });
       it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
         addSeries(11);
         document.body.appendChild(chart);
-        await waitUntilChartInitialized();
-        expect(console.warn.called).to.be.true;
+        await nextRender();
+        expect(console.warn.calledOnce).to.be.true;
         expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
       });
     });
@@ -76,14 +65,14 @@ describe('turbo-mode warning', () => {
       it('should not log warning when no series exceeds the turbo threshold', async () => {
         addSeriesWithJS(9);
         document.body.appendChild(chart);
-        await waitUntilChartInitialized();
+        await nextRender();
         expect(console.warn.called).to.be.false;
       });
       it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
         addSeriesWithJS(11);
         document.body.appendChild(chart);
-        await waitUntilChartInitialized();
-        expect(console.warn.called).to.be.true;
+        await nextRender();
+        expect(console.warn.calledOnce).to.be.true;
         expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
       });
     });
@@ -112,7 +101,7 @@ describe('turbo-mode warning', () => {
       it('should log warning when a series exceeds the turbo threshold', async () => {
         addSeries(11);
         await oneEvent(chart, 'chart-redraw');
-        expect(console.warn.called).to.be.true;
+        expect(console.warn.calledOnce).to.be.true;
         expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
       });
     });
@@ -127,12 +116,16 @@ describe('turbo-mode warning', () => {
       it('should log warning when a series exceeds the turbo threshold', async () => {
         addSeriesWithJS(11);
         await oneEvent(chart, 'chart-redraw');
-        expect(console.warn.called).to.be.true;
+        expect(console.warn.calledOnce).to.be.true;
         expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
       });
     });
 
     describe('adding points', () => {
+      function addPoint(seriesIndex, data) {
+        chart.configuration.series[seriesIndex].addPoint(data);
+      }
+
       it('should not log warning when total number of items does not exceed the turbo threshold', async () => {
         addSeriesWithJS(4);
         await oneEvent(chart, 'chart-redraw');
@@ -150,7 +143,7 @@ describe('turbo-mode warning', () => {
 
         addPoint(0, 11);
         chart.configuration.redraw();
-        expect(console.warn.called).to.be.true;
+        expect(console.warn.calledOnce).to.be.true;
         expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
       });
     });
@@ -159,7 +152,7 @@ describe('turbo-mode warning', () => {
       it('should only log the warning once', async () => {
         addSeriesWithJS(13);
         await oneEvent(chart, 'chart-redraw');
-        expect(console.warn.called).to.be.true;
+        expect(console.warn.calledOnce).to.be.true;
         expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
 
         console.warn.resetHistory();

--- a/packages/charts/test/turbo-mode.test.js
+++ b/packages/charts/test/turbo-mode.test.js
@@ -8,15 +8,6 @@ describe('turbo-mode warning', () => {
 
   beforeEach(async () => {
     sinon.stub(console, 'warn');
-    chart = fixtureSync(`<vaadin-chart></vaadin-chart>`);
-    chart.updateConfiguration({
-      plotOptions: {
-        series: {
-          turboThreshold: 10
-        }
-      }
-    });
-    await nextRender();
   });
 
   afterEach(() => {
@@ -45,42 +36,15 @@ describe('turbo-mode warning', () => {
     chart.configuration.series[seriesIndex].addPoint(data);
   }
 
-  describe('adding series', () => {
-    it('should not log warning when no series exceeds the turbo threshold', async () => {
-      addSeries(4);
-      addSeries(9);
-      addSeries(0);
-      await oneEvent(chart, 'chart-redraw');
+  async function waitUntilChartInitialized() {
+    while (!chart.configuration) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+    }
+  }
 
-      expect(console.warn.called).to.be.false;
-    });
-
-    it('should log warning when a series exceeds the turbo threshold', async () => {
-      await addSeries(11);
-      await oneEvent(chart, 'chart-redraw');
-      expect(console.warn.called).to.be.true;
-      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
-    });
-  });
-
-  describe('adding series with JS', () => {
-    it('should not log warning when no series exceeds the turbo threshold', async () => {
-      await addSeriesWithJS(4);
-      await addSeriesWithJS(9);
-      await addSeriesWithJS(0);
-      await oneEvent(chart, 'chart-redraw');
-      expect(console.warn.called).to.be.false;
-    });
-
-    it('should log warning when a series exceeds the turbo threshold', async () => {
-      await addSeriesWithJS(11);
-      await oneEvent(chart, 'chart-redraw');
-      expect(console.warn.called).to.be.true;
-      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
-    });
-  });
-
-  describe('initializing with series', () => {
+  describe('when initializing chart', () => {
     beforeEach(async () => {
       chart = document.createElement('vaadin-chart');
       chart.updateConfiguration({
@@ -92,26 +56,42 @@ describe('turbo-mode warning', () => {
       });
     });
 
-    it('should not log warning when no series exceeds the turbo threshold', async () => {
-      addSeries(4);
-      addSeries(9);
-      addSeries(10);
-      document.body.appendChild(chart);
-      await nextRender();
-      expect(console.warn.called).to.be.false;
+    describe('add series', () => {
+      it('should not log warning when no series exceeds the turbo threshold', async () => {
+        addSeries(9);
+        document.body.appendChild(chart);
+        await waitUntilChartInitialized();
+        expect(console.warn.called).to.be.false;
+      });
+      it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
+        addSeries(11, true);
+        document.body.appendChild(chart);
+        await waitUntilChartInitialized();
+        expect(console.warn.called).to.be.true;
+        expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+      });
     });
-    it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
-      await addSeries(11, true);
-      document.body.appendChild(chart);
-      await nextRender();
-      expect(console.warn.called).to.be.true;
-      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+
+    describe('add series with JS', () => {
+      it('should not log warning when no series exceeds the turbo threshold', async () => {
+        addSeriesWithJS(9);
+        document.body.appendChild(chart);
+        await waitUntilChartInitialized();
+        expect(console.warn.called).to.be.false;
+      });
+      it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
+        addSeriesWithJS(11, true);
+        document.body.appendChild(chart);
+        await waitUntilChartInitialized();
+        expect(console.warn.called).to.be.true;
+        expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+      });
     });
   });
 
-  describe('initializing with series with JS', () => {
+  describe('with existing chart', () => {
     beforeEach(async () => {
-      chart = document.createElement('vaadin-chart');
+      chart = fixtureSync(`<vaadin-chart></vaadin-chart>`);
       chart.updateConfiguration({
         plotOptions: {
           series: {
@@ -119,75 +99,90 @@ describe('turbo-mode warning', () => {
           }
         }
       });
-    });
-
-    it('should not log warning when no series exceeds the turbo threshold', async () => {
-      addSeriesWithJS(4);
-      addSeriesWithJS(9);
-      addSeriesWithJS(0);
-      document.body.appendChild(chart);
       await nextRender();
-      expect(console.warn.called).to.be.false;
-    });
-    it('should log warning when initializing with a series that exceeds the turbo threshold', async () => {
-      await addSeriesWithJS(11, true);
-      document.body.appendChild(chart);
-      await nextRender();
-      expect(console.warn.called).to.be.true;
-      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
-    });
-  });
-
-  describe('adding points', () => {
-    it('should not log warning when total number of items does not exceed the turbo threshold', async () => {
-      addSeriesWithJS(4);
-      await oneEvent(chart, 'chart-redraw');
-      addPoint(0, 5);
-      addPoint(0, 6);
-      addPoint(0, 7);
-      chart.configuration.redraw();
-      expect(console.warn.called).to.be.false;
     });
 
-    it('should log warning when total number of items exceeds the turbo threshold', async () => {
-      addSeriesWithJS(10);
-      await oneEvent(chart, 'chart-redraw');
-      expect(console.warn.called).to.be.false;
+    describe('adding series', () => {
+      it('should not log warning when no series exceeds the turbo threshold', async () => {
+        addSeries(9);
+        await oneEvent(chart, 'chart-redraw');
+        expect(console.warn.called).to.be.false;
+      });
 
-      addPoint(0, 11);
-      chart.configuration.redraw();
-      expect(console.warn.called).to.be.true;
-      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
-    });
-  });
-
-  describe('single log entry', () => {
-    it('should only log the warning once', async () => {
-      addSeriesWithJS(13);
-      await oneEvent(chart, 'chart-redraw');
-      expect(console.warn.called).to.be.true;
-      expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
-
-      console.warn.resetHistory();
-      addSeriesWithJS(16);
-      await oneEvent(chart, 'chart-redraw');
-      expect(console.warn.called).to.be.false;
-    });
-  });
-
-  describe('production mode', () => {
-    const originalDevmodeCallback = window.Vaadin.developmentModeCallback;
-    before(() => {
-      window.Vaadin.developmentModeCallback = null;
-    });
-    after(() => {
-      window.Vaadin.developmentModeCallback = originalDevmodeCallback;
+      it('should log warning when a series exceeds the turbo threshold', async () => {
+        addSeries(11);
+        await oneEvent(chart, 'chart-redraw');
+        expect(console.warn.called).to.be.true;
+        expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+      });
     });
 
-    it('should not log warning in production', async () => {
-      addSeriesWithJS(13);
-      await oneEvent(chart, 'chart-redraw');
-      expect(console.warn.called).to.be.false;
+    describe('adding series with JS', () => {
+      it('should not log warning when no series exceeds the turbo threshold', async () => {
+        addSeriesWithJS(9);
+        await oneEvent(chart, 'chart-redraw');
+        expect(console.warn.called).to.be.false;
+      });
+
+      it('should log warning when a series exceeds the turbo threshold', async () => {
+        addSeriesWithJS(11);
+        await oneEvent(chart, 'chart-redraw');
+        expect(console.warn.called).to.be.true;
+        expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+      });
+    });
+
+    describe('adding points', () => {
+      it('should not log warning when total number of items does not exceed the turbo threshold', async () => {
+        addSeriesWithJS(4);
+        await oneEvent(chart, 'chart-redraw');
+        addPoint(0, 5);
+        addPoint(0, 6);
+        addPoint(0, 7);
+        chart.configuration.redraw();
+        expect(console.warn.called).to.be.false;
+      });
+
+      it('should log warning when total number of items exceeds the turbo threshold', async () => {
+        addSeriesWithJS(10);
+        await oneEvent(chart, 'chart-redraw');
+        expect(console.warn.called).to.be.false;
+
+        addPoint(0, 11);
+        chart.configuration.redraw();
+        expect(console.warn.called).to.be.true;
+        expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+      });
+    });
+
+    describe('single log entry', () => {
+      it('should only log the warning once', async () => {
+        addSeriesWithJS(13);
+        await oneEvent(chart, 'chart-redraw');
+        expect(console.warn.called).to.be.true;
+        expect(console.warn.args[0][0]).to.include('<vaadin-chart> Turbo mode has been enabled for one or more series');
+
+        console.warn.resetHistory();
+        addSeriesWithJS(16);
+        await oneEvent(chart, 'chart-redraw');
+        expect(console.warn.called).to.be.false;
+      });
+    });
+
+    describe('production mode', () => {
+      const originalDevmodeCallback = window.Vaadin.developmentModeCallback;
+      before(() => {
+        window.Vaadin.developmentModeCallback = null;
+      });
+      after(() => {
+        window.Vaadin.developmentModeCallback = originalDevmodeCallback;
+      });
+
+      it('should not log warning in production', async () => {
+        addSeriesWithJS(13);
+        await oneEvent(chart, 'chart-redraw');
+        expect(console.warn.called).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Shows a warning when one or more series contain more data items than the turbo threshold configured in the chart, or series, plot options. The turbo mode is a Highcharts feature, and not something that is implemented in our logic, as such it is not straightforward to detect. We basically want this warning when:
- initializing with a series with more items than the configured threshold
- adding a series with more items than the configured threshold
- adding more items to a series, which then exceeds the configured threshold
Apart from that the Flow component also uses the Highcharts API directly, so it was not possible to add the check to existing methods that cover the above cases. Instead I listen for the chart's redraw event, which should be triggered everytime the chart's data is modified, and then run the check from there.

Even though it's more of an information, I decided to use a warning, as it otherwise gets drowned in the noise that Flow logs to the console.

Part of https://github.com/vaadin/flow-components/issues/1728

Another part of the ticket is going to be to create the actual documentation about this mode.

## Type of change

- Feature
