### PR TITLE
fix: inherit parent styles to extensions without is getter

### DIFF
--- a/packages/vaadin-themable-mixin/test/lit-setup.js
+++ b/packages/vaadin-themable-mixin/test/lit-setup.js
@@ -6,13 +6,10 @@ import { ThemableMixin } from '../vaadin-themable-mixin.js';
  * By default, the suite creates PolymerElement based custom elements, but in the
  * -lit.test.js tests, we specifically want to create LitElement based custom elements instead.
  */
-window.defineCustomElementFunction = (name, parentName, content, styles) => {
+// eslint-disable-next-line max-params
+window.defineCustomElementFunction = (name, parentName, content, styles, noIs) => {
   const parentElement = parentName ? customElements.get(parentName) : LitElement;
   class CustomElement extends ThemableMixin(parentElement) {
-    static get is() {
-      return name;
-    }
-
     static get styles() {
       return styles ? unsafeCSS(styles) : undefined;
     }
@@ -25,6 +22,14 @@ window.defineCustomElementFunction = (name, parentName, content, styles) => {
       }
       return super.render();
     }
+  }
+
+  if (!noIs) {
+    Object.defineProperty(CustomElement, 'is', {
+      get() {
+        return name;
+      }
+    });
   }
 
   customElements.define(name, CustomElement);

--- a/packages/vaadin-themable-mixin/test/lit-setup.js
+++ b/packages/vaadin-themable-mixin/test/lit-setup.js
@@ -13,15 +13,14 @@ window.defineCustomElementFunction = (name, parentName, content, styles, noIs) =
     static get styles() {
       return styles ? unsafeCSS(styles) : undefined;
     }
+  }
 
-    render() {
-      if (content) {
-        const template = document.createElement('template');
-        template.innerHTML = content;
-        return template.content;
-      }
-      return super.render();
-    }
+  if (content) {
+    CustomElement.prototype.render = function () {
+      const template = document.createElement('template');
+      template.innerHTML = content;
+      return template.content;
+    };
   }
 
   if (!noIs) {

--- a/packages/vaadin-themable-mixin/test/themable-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/themable-mixin.test.js
@@ -14,9 +14,11 @@ const defineCustomElement =
   // eslint-disable-next-line max-params
   ((name, parentName, content, styles, noIs) => {
     const parentElement = parentName ? customElements.get(parentName) : PolymerElement;
-    class CustomElement extends ThemableMixin(parentElement) {
-      static get template() {
-        if (content) {
+    class CustomElement extends ThemableMixin(parentElement) {}
+
+    if (content) {
+      Object.defineProperty(CustomElement, 'template', {
+        get() {
           if (styles) {
             content = `<style>${styles}</style>${content}`;
           }
@@ -25,8 +27,7 @@ const defineCustomElement =
           template.innerHTML = content;
           return template;
         }
-        return super.template;
-      }
+      });
     }
 
     if (!noIs) {
@@ -205,6 +206,8 @@ defineCustomElement('test-own-template-no-is', 'test-foo', '<div part="text" id=
 
 defineCustomElement('test-no-template', '', '');
 
+defineCustomElement('test-inherited-no-content-no-is', 'test-foo', '', undefined, true);
+
 defineCustomElement('test-style-override', '', '<div part="text" id="text">text</div>');
 
 defineCustomElement(
@@ -235,6 +238,7 @@ describe('ThemableMixin', () => {
         <test-own-template></test-own-template>
         <test-own-template-no-is></test-own-template-no-is>
         <test-no-template></test-no-template>
+        <test-inherited-no-content-no-is></test-inherited-no-content-no-is>
         <test-style-override></test-style-override>
         <test-own-styles></test-own-styles>
       </div>
@@ -290,6 +294,12 @@ describe('ThemableMixin', () => {
 
   it('should inherit parent themes to own custom template with no is defined', async () => {
     expect(getComputedStyle(getText(components['test-own-template-no-is'])).backgroundColor).to.equal('rgb(255, 0, 0)');
+  });
+
+  it('should inherit parent themes with no is nor content defined', async () => {
+    expect(getComputedStyle(getText(components['test-inherited-no-content-no-is'])).backgroundColor).to.equal(
+      'rgb(255, 0, 0)'
+    );
   });
 
   it('should override vaadin module styles', () => {

--- a/packages/vaadin-themable-mixin/test/themable-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/themable-mixin.test.js
@@ -11,13 +11,10 @@ const createStyles =
 
 const defineCustomElement =
   window.defineCustomElementFunction ||
-  ((name, parentName, content, styles) => {
+  // eslint-disable-next-line max-params
+  ((name, parentName, content, styles, noIs) => {
     const parentElement = parentName ? customElements.get(parentName) : PolymerElement;
     class CustomElement extends ThemableMixin(parentElement) {
-      static get is() {
-        return name;
-      }
-
       static get template() {
         if (content) {
           if (styles) {
@@ -30,6 +27,14 @@ const defineCustomElement =
         }
         return super.template;
       }
+    }
+
+    if (!noIs) {
+      Object.defineProperty(CustomElement, 'is', {
+        get() {
+          return name;
+        }
+      });
     }
 
     customElements.define(name, CustomElement);
@@ -196,6 +201,8 @@ defineCustomElement('test-qux', '', '<div part="text" id="text">text</div>');
 
 defineCustomElement('test-own-template', 'test-foo', '<div part="text" id="text">text</div>');
 
+defineCustomElement('test-own-template-no-is', 'test-foo', '<div part="text" id="text">text</div>', undefined, true);
+
 defineCustomElement('test-no-template', '', '');
 
 defineCustomElement('test-style-override', '', '<div part="text" id="text">text</div>');
@@ -226,6 +233,7 @@ describe('ThemableMixin', () => {
         <test-baz></test-baz>
         <test-qux></test-qux>
         <test-own-template></test-own-template>
+        <test-own-template-no-is></test-own-template-no-is>
         <test-no-template></test-no-template>
         <test-style-override></test-style-override>
         <test-own-styles></test-own-styles>
@@ -278,6 +286,10 @@ describe('ThemableMixin', () => {
 
   it('should inherit parent themes to own custom template', () => {
     expect(getComputedStyle(getText(components['test-own-template'])).backgroundColor).to.equal('rgb(255, 0, 0)');
+  });
+
+  it('should inherit parent themes to own custom template with no is defined', async () => {
+    expect(getComputedStyle(getText(components['test-own-template-no-is'])).backgroundColor).to.equal('rgb(255, 0, 0)');
   });
 
   it('should override vaadin module styles', () => {

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -179,7 +179,15 @@ function getThemes(tagName) {
  * @returns {boolean}
  */
 function hasThemes(tagName) {
-  const elementClass = customElements.get(tagName);
+  return classHasThemes(customElements.get(tagName));
+}
+
+/**
+ * Check if the custom element type has themes applied.
+ * @param {Function} elementClass
+ * @returns {boolean}
+ */
+function classHasThemes(elementClass) {
   return elementClass && Object.prototype.hasOwnProperty.call(elementClass, '__themes');
 }
 
@@ -197,7 +205,7 @@ export const ThemableMixin = (superClass) =>
       super.finalize();
 
       const template = this.prototype._template;
-      if (!template || hasThemes(this.is)) {
+      if (!template || classHasThemes(this)) {
         return;
       }
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/3616