### PR TITLE
fix: cell-focus on click from within shadow DOM

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -669,7 +669,7 @@ class Grid extends ElementMixin(
           // If focus is on element within the cell content — respect it, do not change
           const contentContainsFocusedElement = cellContent.contains(this.getRootNode().activeElement);
           // Only focus if mouse is released on cell content itself
-          const mouseUpWithinCell = cellContent.contains(event.target);
+          const mouseUpWithinCell = event.composedPath().indexOf(cellContent) >= 0;
           if (!contentContainsFocusedElement && mouseUpWithinCell) {
             cell.focus();
           }

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1920,6 +1920,23 @@ describe('keyboard navigation', () => {
         expect(spy.calledOnce).to.be.true;
       });
 
+      it('should dispatch cell-focus on mouse up on cell content, when grid is in shadow DOM', () => {
+        const spy = sinon.spy();
+        grid.addEventListener('cell-focus', spy);
+
+        // Move grid into a shadow DOM
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        container.attachShadow({ mode: 'open' });
+        container.shadowRoot.appendChild(grid);
+
+        // Mouse down and release on cell content element
+        const cell = getRowFirstCell(0);
+        mouseDown(cell._content);
+        mouseUp(cell._content);
+        expect(spy.calledOnce).to.be.true;
+      });
+
       it('should dispatch cell-focus on mouse up within cell content', () => {
         const spy = sinon.spy();
         grid.addEventListener('cell-focus', spy);


### PR DESCRIPTION
## Description

Fixes a regression from #3587. The previous fix used `HTMLElement.contains` to check whether the mouse up event originated from within the cell, which does not work if the grid is within a shadow DOM. This effectivly breaks cell-focus on click, in Chrome. Changed the solution to use `event.composedPath`.

## Type of change

- Bugfix
