### PR TITLE
feat: add LitElement support to DirMixin

### DIFF
--- a/packages/component-base/src/dir-mixin.js
+++ b/packages/component-base/src/dir-mixin.js
@@ -48,7 +48,15 @@ export const DirMixin = (superClass) =>
         dir: {
           type: String,
           value: '',
-          reflectToAttribute: true
+          reflectToAttribute: true,
+          converter: {
+            fromAttribute: (attr) => {
+              return !attr ? '' : attr;
+            },
+            toAttribute: (prop) => {
+              return prop === '' ? null : prop;
+            }
+          }
         }
       };
     }

--- a/packages/component-base/test/dir-mixin.test.js
+++ b/packages/component-base/test/dir-mixin.test.js
@@ -1,23 +1,37 @@
 import { expect } from '@esm-bundle/chai';
+import { nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { LitElement } from 'lit';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DirMixin } from '../src/dir-mixin.js';
 
-class DirMixinElement extends DirMixin(PolymerElement) {
+class DirMixinPolymerElement extends DirMixin(PolymerElement) {
   static get is() {
-    return 'dir-mixin-element';
+    return 'dir-mixin-polymer-element';
   }
 }
 
-customElements.define(DirMixinElement.is, DirMixinElement);
+customElements.define(DirMixinPolymerElement.is, DirMixinPolymerElement);
 
-describe('DirMixin', () => {
+class DirMixinLitElement extends DirMixin(PolylitMixin(LitElement)) {
+  static get is() {
+    return 'dir-mixin-lit-element';
+  }
+}
+
+customElements.define(DirMixinLitElement.is, DirMixinLitElement);
+
+const runTests = (baseClass) => {
+  const tag = `dir-mixin-${baseClass}-element`;
+
   describe('Native HTMLElement.dir API', () => {
     let element;
 
-    beforeEach(() => {
-      element = document.createElement('dir-mixin-element');
+    beforeEach(async () => {
+      element = document.createElement(tag);
       document.body.appendChild(element);
+      await nextFrame();
     });
 
     afterEach(() => {
@@ -29,55 +43,69 @@ describe('DirMixin', () => {
       expect(element.hasAttribute('dir')).to.be.false;
     });
 
-    it('should match native behavior when setting property', () => {
+    it('should match native behavior when setting property', async () => {
       element.dir = 'rtl';
+      await nextFrame();
       expect(element.dir).to.equal('rtl');
       expect(element.getAttribute('dir')).to.equal('rtl');
     });
 
-    it('should match native behavior when setting attribute', () => {
+    it('should match native behavior when setting attribute', async () => {
       element.setAttribute('dir', 'rtl');
+      await nextFrame();
       expect(element.dir).to.equal('rtl');
       expect(element.getAttribute('dir')).to.equal('rtl');
     });
 
-    it('should match native behavior when clearing property', () => {
+    it('should match native behavior when clearing property', async () => {
       element.dir = 'rtl';
+      await nextFrame();
+
       element.dir = '';
+      await nextFrame();
       expect(element.dir).to.equal('');
       expect(element.hasAttribute('dir')).to.be.false;
     });
 
-    it('should match native behavior when clearing attribute', () => {
+    it('should match native behavior when clearing attribute', async () => {
       element.setAttribute('dir', 'rtl');
+      await nextFrame();
+
       element.removeAttribute('dir');
+      await nextFrame();
       expect(element.dir).to.equal('');
       expect(element.hasAttribute('dir')).to.be.false;
     });
 
-    it('should not call removeAttribute twice when clearing value', () => {
+    it('should not call removeAttribute twice when clearing value', async () => {
       element.dir = 'rtl';
+      await nextFrame();
+
       const spy = sinon.spy(element, 'removeAttribute');
       element.removeAttribute('dir');
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
   });
 
   describe('Document dir sync', () => {
-    const element = document.createElement('dir-mixin-element');
+    const element = document.createElement(tag);
 
-    before(() => {
+    before(async () => {
       document.body.appendChild(element);
+      await nextFrame();
     });
 
     after(() => {
       document.body.removeChild(element);
+      document.documentElement.removeAttribute('dir');
     });
 
-    beforeEach(() => {
+    beforeEach(async () => {
       // Clean up the dir attribute
       document.documentElement.removeAttribute('dir');
       element.removeAttribute('dir');
+      await nextFrame();
     });
 
     // Check that for each `documentDirections` value set, `element` dir
@@ -105,52 +133,62 @@ describe('DirMixin', () => {
 
     it('should preserve direction if was set by the user with setAttribute', async () => {
       element.setAttribute('dir', 'ltr');
+      await nextFrame();
 
       await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
     });
 
     it('should preserve direction if was set by the user with property', async () => {
       element.dir = 'ltr';
+      await nextFrame();
 
       await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
     });
 
     it('should subscribe to the changes if set to equal the document direction using setAttribute', async () => {
       element.setAttribute('dir', 'ltr');
+      await nextFrame();
 
       await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
       element.setAttribute('dir', 'rtl');
+      await nextFrame();
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
     });
 
     it('should subscribe to the changes if set to equal the document direction using property', async () => {
       element.dir = 'ltr';
+      await nextFrame();
 
       await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
       element.dir = 'rtl';
+      await nextFrame();
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
     });
 
     it('should subscribe to the changes if attribute removed', async () => {
       element.setAttribute('dir', 'ltr');
+      await nextFrame();
 
       await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
       element.removeAttribute('dir');
+      await nextFrame();
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
     });
 
     it('should subscribe to the changes if property cleared', async () => {
       element.dir = 'ltr';
+      await nextFrame();
 
       await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
       element.dir = '';
+      await nextFrame();
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
     });
@@ -159,6 +197,7 @@ describe('DirMixin', () => {
       await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
 
       element.setAttribute('dir', 'ltr');
+      await nextFrame();
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
     });
@@ -167,6 +206,7 @@ describe('DirMixin', () => {
       await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
 
       element.dir = 'ltr';
+      await nextFrame();
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
     });
@@ -182,4 +222,12 @@ describe('DirMixin', () => {
       expect(element.getAttribute('dir')).to.eql('ltr');
     });
   });
+};
+
+describe('DirMixin + Polymer', () => {
+  runTests('polymer');
+});
+
+describe('DirMixin + Lit', () => {
+  runTests('lit');
 });


### PR DESCRIPTION
## Description

The only addition is `converter` for `dir` property that replicates the behavior of the overridden Polymer methods:

- `_attributeToProperty` -> `fromAttribute`
- `_valueToNodeAttribute` - `toAttriubute`

## Type of change

- Internal feature