### PR TITLE
chore: add typings for async and debounce

### DIFF
--- a/packages/component-base/src/async.d.ts
+++ b/packages/component-base/src/async.d.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+export interface AsyncInterface {
+  run: (fn: Function, delay?: number) => number;
+  cancel: (handle: number) => void;
+}
+
+/**
+ * Not defined in the TypeScript DOM library.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/IdleDeadline
+ */
+export interface IdleDeadline {
+  didTimeout: boolean;
+  timeRemaining(): number;
+}
+
+/**
+ * Async interface wrapper around `setTimeout`.
+ */
+declare namespace timeOut {
+  /**
+   * Returns a sub-module with the async interface providing the provided
+   * delay.
+   *
+   * @returns An async timeout interface
+   */
+  function after(delay?: number): AsyncInterface;
+
+  /**
+   * Enqueues a function called in the next task.
+   *
+   * @returns Handle used for canceling task
+   */
+  function run(fn: Function, delay?: number): number;
+
+  /**
+   * Cancels a previously enqueued `timeOut` callback.
+   */
+  function cancel(handle: number): void;
+}
+
+export { timeOut };
+
+/**
+ * Async interface wrapper around `requestAnimationFrame`.
+ */
+declare namespace animationFrame {
+  /**
+   * Enqueues a function called at `requestAnimationFrame` timing.
+   *
+   * @returns Handle used for canceling task
+   */
+  function run(fn: (p0: number) => void): number;
+
+  /**
+   * Cancels a previously enqueued `animationFrame` callback.
+   */
+  function cancel(handle: number): void;
+}
+
+export { animationFrame };
+
+/**
+ * Async interface wrapper around `requestIdleCallback`. Falls back to
+ * `setTimeout` on browsers that do not support `requestIdleCallback`.
+ */
+declare namespace idlePeriod {
+  /**
+   * Enqueues a function called at `requestIdleCallback` timing.
+   *
+   * @returns Handle used for canceling task
+   */
+  function run(fn: (p0: IdleDeadline) => void): number;
+
+  /**
+   * Cancels a previously enqueued `idlePeriod` callback.
+   */
+  function cancel(handle: number): void;
+}
+
+export { idlePeriod };
+
+/**
+ * Async interface for enqueuing callbacks that run at microtask timing.
+ *
+ * Note that microtask timing is achieved via a single `MutationObserver`,
+ * and thus callbacks enqueued with this API will all run in a single
+ * batch, and not interleaved with other microtasks such as promises.
+ * Promises are avoided as an implementation choice for the time being
+ * due to Safari bugs that cause Promises to lack microtask guarantees.
+ */
+declare namespace microTask {
+  /**
+   * Enqueues a function called at microtask timing.
+   *
+   * @returns Handle used for canceling task
+   */
+  function run(callback?: Function): number;
+
+  /**
+   * Cancels a previously enqueued `microTask` callback.
+   */
+  function cancel(handle: number): void;
+}
+
+export { microTask };

--- a/packages/component-base/src/debounce.d.ts
+++ b/packages/component-base/src/debounce.d.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+import { AsyncInterface } from './async.js';
+
+export declare class Debouncer {
+  constructor();
+
+  /**
+   * Creates a debouncer if no debouncer is passed as a parameter
+   * or it cancels an active debouncer otherwise. The following
+   * example shows how a debouncer can be called multiple times within a
+   * microtask and "debounced" such that the provided callback function is
+   * called once. Add this method to a custom element:
+   *
+   * ```js
+   * import {microTask} from '@vaadin/component-base/src/async.js';
+   * import {Debouncer} from '@vaadin/component-base/src/debounce.js';
+   * // ...
+   *
+   * _debounceWork() {
+   *   this._debounceJob = Debouncer.debounce(this._debounceJob,
+   *       microTask, () => this._doWork());
+   * }
+   * ```
+   *
+   * If the `_debounceWork` method is called multiple times within the same
+   * microtask, the `_doWork` function will be called only once at the next
+   * microtask checkpoint.
+   *
+   * Note: In testing it is often convenient to avoid asynchrony. To accomplish
+   * this with a debouncer, you can use `enqueueDebouncer` and
+   * `flush`. For example, extend the above example by adding
+   * `enqueueDebouncer(this._debounceJob)` at the end of the
+   * `_debounceWork` method. Then in a test, call `flush` to ensure
+   * the debouncer has completed.
+   *
+   * @param debouncer Debouncer object.
+   * @param asyncModule Object with Async interface
+   * @param callback Callback to run.
+   * @returns Returns a debouncer object.
+   */
+  static debounce(debouncer: Debouncer | null, asyncModule: AsyncInterface, callback: () => any): Debouncer;
+
+  /**
+   * Sets the scheduler; that is, a module with the Async interface,
+   * a callback and optional arguments to be passed to the run function
+   * from the async module.
+   *
+   * @param asyncModule Object with Async interface.
+   * @param callback Callback to run.
+   */
+  setConfig(asyncModule: AsyncInterface, callback: () => any): void;
+
+  /**
+   * Cancels an active debouncer and returns a reference to itself.
+   */
+  cancel(): void;
+
+  /**
+   * Cancels a debouncer's async callback.
+   */
+  _cancelAsync(): void;
+
+  /**
+   * Flushes an active debouncer and returns a reference to itself.
+   */
+  flush(): void;
+
+  /**
+   * Returns true if the debouncer is active.
+   *
+   * @returns True if active.
+   */
+  isActive(): boolean;
+}
+
+/**
+ * Adds a `Debouncer` to a list of globally flushable tasks.
+ */
+export declare function enqueueDebouncer(debouncer: Debouncer): void;
+
+/**
+ * Flushes any enqueued debouncers.
+ *
+ * @returns Returns whether any debouncers were flushed
+ */
+export declare function flushDebouncers(): boolean;
+
+/**
+ * Forces debouncers added via `enqueueDebouncer` to flush.
+ *
+ * @return {void}
+ */
+export declare function flush(): void;


### PR DESCRIPTION
## Description

Added missing typings for `async.js` and `debounce.js` modules, so they can be used with TS. 

## Type of change

- Internal feature