### PR TITLE
test: remove no longer needed Polymer flush

### DIFF
--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -3,7 +3,6 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import { getAllItems, getFocusedItemIndex, makeItems, onceOpened, setInputValue } from './helpers.js';
 
@@ -260,7 +259,6 @@ describe('internal filtering', () => {
     it('should properly display all items in the selector', () => {
       comboBox.open();
       comboBox.filteredItems = makeItems(10);
-      flush();
       expect(getAllItems(comboBox).length).to.equal(10);
     });
   });

--- a/packages/combo-box/test/item-template.test.js
+++ b/packages/combo-box/test/item-template.test.js
@@ -5,7 +5,6 @@ import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import './fixtures/mock-combo-box-template-wrapper.js';
 import './fixtures/mock-combo-box-light-template-wrapper.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { getFirstItem } from './helpers.js';
 
 describe('item template', () => {
@@ -18,8 +17,6 @@ describe('item template', () => {
         comboBox = wrapper.$.comboBox;
         comboBox.items = ['foo', 'bar'];
         comboBox.open();
-
-        flush();
         firstItem = getFirstItem(comboBox);
       });
 

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -5,7 +5,6 @@ import '@vaadin/text-field/vaadin-text-field.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 import '../vaadin-combo-box-light.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import {
@@ -131,7 +130,6 @@ describe('lazy loading', () => {
         comboBox.clearButtonVisible = true;
         comboBox.$.clearButton.click();
         comboBox.opened = true;
-        flush();
         expect(comboBox.value).to.be.empty;
         expect(comboBox.selectedItem).to.be.null;
       });
@@ -146,7 +144,6 @@ describe('lazy loading', () => {
           setInputValue('item 1');
           fire(comboBox.inputElement, 'input');
           comboBox.opened = true;
-          flush();
           expect(comboBox.filter).to.equal('item 1');
           const { filter } = spyDataProvider.lastCall.args[0];
           expect(filter).to.equal('item 1');
@@ -234,7 +231,6 @@ describe('lazy loading', () => {
           comboBox.filter = 'item 1';
           comboBox.value = 'item 1';
           comboBox.value = '';
-          flush();
           expect(comboBox.filter).to.equal('');
         });
 
@@ -242,7 +238,6 @@ describe('lazy loading', () => {
           comboBox.dataProvider = dataProvider;
           comboBox.filter = 'item 1';
           comboBox.opened = false;
-          flush();
           expect(comboBox.filter).to.equal('');
         });
 
@@ -277,7 +272,6 @@ describe('lazy loading', () => {
           comboBox.filter = 'it';
           spyDataProvider.resetHistory();
           comboBox.cancel();
-          flush();
           comboBox.opened = true;
           const params = spyDataProvider.lastCall.args[0];
           expect(params.filter).to.equal('');
@@ -346,7 +340,6 @@ describe('lazy loading', () => {
         beforeEach(() => {
           comboBox.dataProvider = spyDataProvider;
           comboBox.open();
-          flush();
         });
 
         it('should not be invoked', () => {
@@ -361,7 +354,6 @@ describe('lazy loading', () => {
           setInputValue('1');
           fire(comboBox.inputElement, 'input');
 
-          flush();
           spyDataProvider.resetHistory();
 
           getFirstItem(comboBox).click();
@@ -760,7 +752,6 @@ describe('lazy loading', () => {
         comboBox.dataProvider = objectDataProvider;
         comboBox.opened = true;
         await nextFrame();
-        flush();
         const selectedRenderedItemElements = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
         // doesn't work when run on SauceLabs, work locally
         // expect(selectedRenderedItemElements).to.have.lengthOf(1);
@@ -783,7 +774,6 @@ describe('lazy loading', () => {
         };
         comboBox.opened = true;
         await nextFrame();
-        flush();
         const selectedRenderedItemElements = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
         // doesn't work when run on SauceLabs, work locally
         // expect(selectedRenderedItemElements).to.have.lengthOf(1);
@@ -1083,7 +1073,6 @@ describe('lazy loading', () => {
 
         comboBox.dataProvider = getDataProvider(allItems);
         comboBox.opened = true;
-        flush();
 
         // Scroll to the end, as though if we drag the scrollbar and move it
         // to the bottom
@@ -1092,7 +1081,6 @@ describe('lazy loading', () => {
 
         // Flush the pending changes after the scrolling
         await nextFrame();
-        flush();
 
         const lastVisibleIndex = getViewportItems(comboBox).pop().index;
         // Check if the next few items after the last visible item are not empty

--- a/packages/combo-box/test/selecting-items.test.js
+++ b/packages/combo-box/test/selecting-items.test.js
@@ -3,7 +3,6 @@ import { aTimeout, fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { getAllItems, getFirstItem, onceScrolled, scrollToIndex, selectItem } from './helpers.js';
 
 describe('selecting items', () => {
@@ -37,7 +36,6 @@ describe('selecting items', () => {
 
   it('should fire `selection-changed` when clicked on an item', () => {
     comboBox.opened = true;
-    flush();
     getFirstItem(comboBox).click();
     expect(selectionChangedSpy.calledOnce).to.be.true;
     expect(selectionChangedSpy.args[0][0].detail.item).to.eql(comboBox.items[0]);
@@ -71,7 +69,6 @@ describe('selecting items', () => {
 
   it('should close the dropdown on selection', () => {
     comboBox.open();
-    flush();
 
     getFirstItem(comboBox).click();
 

--- a/packages/crud/test/helpers.js
+++ b/packages/crud/test/helpers.js
@@ -1,5 +1,3 @@
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
-
 export const flushGrid = (grid) => {
   grid._observer.flush();
   if (grid._debounceScrolling) {
@@ -8,7 +6,6 @@ export const flushGrid = (grid) => {
   if (grid._debounceScrollPeriod) {
     grid._debounceScrollPeriod.flush();
   }
-  flush();
   if (grid._debouncerLoad) {
     grid._debouncerLoad.flush();
   }
@@ -18,7 +15,6 @@ export const flushGrid = (grid) => {
   while (grid._debounceIncreasePool) {
     grid._debounceIncreasePool.flush();
     grid._debounceIncreasePool = null;
-    flush();
   }
 };
 

--- a/packages/grid-pro/test/helpers.js
+++ b/packages/grid-pro/test/helpers.js
@@ -1,5 +1,4 @@
 import { isIOS } from '@vaadin/testing-helpers';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 
 export const infiniteDataProvider = (params, callback) => {
   callback(
@@ -88,10 +87,6 @@ export const flushGrid = (grid) => {
   if (grid._debounceScrolling) {
     grid._debounceScrolling.flush();
   }
-  if (grid._debouncerForceReflow) {
-    grid._debouncerForceReflow.flush();
-  }
-  flush();
   grid._afterScroll();
   if (grid._debounceOverflow) {
     grid._debounceOverflow.flush();

--- a/packages/grid/test/column-group.test.js
+++ b/packages/grid/test/column-group.test.js
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { flushGrid, getContainerCell } from './helpers.js';
 
 describe('column group', () => {
@@ -68,7 +67,6 @@ describe('column group', () => {
     columns[0].frozen = true;
 
     parent.appendChild(group);
-    flush();
 
     expect(group.frozen).to.be.true;
   });
@@ -123,7 +121,6 @@ describe('column group', () => {
   it('should hide the group', () => {
     group.removeChild(columns[0]);
     group.removeChild(columns[1]);
-    flush();
     group._observer.flush();
 
     expect(group.hidden).to.be.true;

--- a/packages/grid/test/column-reordering.test.js
+++ b/packages/grid/test/column-reordering.test.js
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import {
   dragAndDropOver,
   dragOver,
@@ -142,7 +141,6 @@ describe('reordering simple grid', () => {
   it('should have the ghost visible again', () => {
     dragAndDropOver(headerContent[0], headerContent[1]);
     dragStart(headerContent[0]);
-    flush();
     expect(grid._reorderGhost.style.visibility).to.equal('visible');
   });
 

--- a/packages/grid/test/column-resizing.test.js
+++ b/packages/grid/test/column-resizing.test.js
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import {
   dragAndDropOver,
   fire,
@@ -263,7 +262,6 @@ describe('column group resizing', () => {
   it('should inherit resizable value from parent group', async () => {
     const newColumn = document.createElement('vaadin-grid-column');
     grid._columnTree[0][0].appendChild(newColumn);
-    flush();
     grid._columnTree[0][0]._observer.flush();
 
     await nextFrame();

--- a/packages/grid/test/filtering.test.js
+++ b/packages/grid/test/filtering.test.js
@@ -6,7 +6,6 @@ import '../vaadin-grid.js';
 import '../vaadin-grid-filter.js';
 import '../vaadin-grid-filter-column.js';
 import '../vaadin-grid-sorter.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { flushGrid, getBodyCellContent, getHeaderCellContent, getVisibleItems, scrollToEnd } from './helpers.js';
 
@@ -338,7 +337,6 @@ describe('lazy init', () => {
     grid.dataProvider = () => {
       // Don't provide any data
     };
-    flush();
     expect(flushFilters.bind(window, grid)).to.not.throw(Error);
   });
 });

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -1,15 +1,10 @@
 import sinon from 'sinon';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 
 export const flushGrid = (grid) => {
   grid._observer.flush();
   if (grid._debounceScrolling) {
     grid._debounceScrolling.flush();
   }
-  if (grid._debouncerForceReflow) {
-    grid._debouncerForceReflow.flush();
-  }
-  flush();
   grid._afterScroll();
   if (grid._debounceOverflow) {
     grid._debounceOverflow.flush();


### PR DESCRIPTION
## Description

Removed no longer necessary calls for `flush()` as tests for combo-box and grid pass without them.
This makes sense as we now have our own copy of `debounce` and no longer support ShadyDOM.

## Type of change

- Test