### PR TITLE
chore: avoid running PolymerElement specific code with LitElement

### DIFF
--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css, CSSResult, LitElement, unsafeCSS } from 'lit';
+import { css, CSSResult, unsafeCSS } from 'lit';
 import { ThemePropertyMixin } from './vaadin-theme-property-mixin.js';
 
 export { css, unsafeCSS };
@@ -205,7 +205,7 @@ export const ThemableMixin = (superClass) =>
       super.finalize();
 
       // Make sure not to run the logic intended for PolymerElement when LitElement is used.
-      if (this.prototype instanceof LitElement) {
+      if (this.elementStyles) {
         return;
       }
 

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css, CSSResult, unsafeCSS } from 'lit';
+import { css, CSSResult, LitElement, unsafeCSS } from 'lit';
 import { ThemePropertyMixin } from './vaadin-theme-property-mixin.js';
 
 export { css, unsafeCSS };
@@ -203,6 +203,11 @@ export const ThemableMixin = (superClass) =>
      */
     static finalize() {
       super.finalize();
+
+      // Make sure not to run the logic intended for PolymerElement when LitElement is used.
+      if (this.prototype instanceof LitElement) {
+        return;
+      }
 
       const template = this.prototype._template;
       if (!template || classHasThemes(this)) {


### PR DESCRIPTION
Addresses https://github.com/vaadin/web-components/issues/401#issuecomment-1106332369

The current code in ThemableMixin wouldn't pass the `!template` check [here](https://github.com/vaadin/web-components/blob/7ed1bda135dfe08a49cca552d329d2bbe1e767c4/packages/vaadin-themable-mixin/vaadin-themable-mixin.js#L208) anyway, but it's better to add an explicit check to avoid regressions in case the logic is changed in the future.