### PR TITLE
refactor: add more rules to ESLint config, fix warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,7 @@
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "no-public" }],
     "accessor-pairs": "error",
     "array-callback-return": "error",
     "curly": ["error", "all"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -78,13 +78,15 @@
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "space-in-parens": ["error", "never"],
-    "spaced-comment": ["error", "always"]
+    "spaced-comment": ["error", "always"],
+    "no-console": ["error", { "allow": ["warn", "error"] }]
   },
   "overrides": [
     {
       "files": ["scripts/**/*.js", "*.js"],
       "rules": {
-        "@typescript-eslint/no-var-requires": "off"
+        "@typescript-eslint/no-var-requires": "off",
+        "no-console": "off"
       }
     },
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,7 +81,8 @@
     "space-in-parens": ["error", "never"],
     "spaced-comment": ["error", "always"],
     "no-console": ["error", { "allow": ["warn", "error"] }],
-    "consistent-this": ["error", "self"]
+    "consistent-this": ["error", "self"],
+    "no-bitwise": "off"
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,13 +43,14 @@
       "argsIgnorePattern": "^_"
     }],
     "@typescript-eslint/ban-types": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "no-public" }],
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "no-public" }],
+    "@typescript-eslint/no-explicit-any": "off",
     "accessor-pairs": "error",
     "array-callback-return": "error",
+    "consistent-this": ["error", "self"],
     "curly": ["error", "all"],
     "default-case": ["error", { "commentPattern": "^no\\sdefault" }],
     "default-param-last": "error",
@@ -59,6 +60,8 @@
     "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
     "max-classes-per-file": ["error", 3],
     "max-params": ["error", 4],
+    "no-bitwise": "off",
+    "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-else-return": "error",
     "no-eval": "error",
     "no-implicit-coercion": ["error", { "allow": ["!!"] }],
@@ -71,6 +74,7 @@
     "no-sequences": "error",
     "no-sync": "off",
     "no-throw-literal": "error",
+    "no-unused-expressions": "error",
     "no-useless-return": "error",
     "operator-assignment": ["error", "always"],
     "prefer-const": ["error", { "ignoreReadBeforeAssign": true }],
@@ -79,11 +83,7 @@
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "space-in-parens": ["error", "never"],
-    "spaced-comment": ["error", "always"],
-    "no-console": ["error", { "allow": ["warn", "error"] }],
-    "consistent-this": ["error", "self"],
-    "no-bitwise": "off",
-    "no-unused-expressions": "error"
+    "spaced-comment": ["error", "always"]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -96,6 +96,8 @@
       "files": ["packages/**/test/**"],
       "rules": {
         "no-await-in-loop": "off",
+        // TODO: Use chai-friendly plugin
+        "no-unused-expressions": "off",
         "max-classes-per-file": "off",
         "simple-import-sort/imports": [
           "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,7 +80,8 @@
     "prefer-spread": "error",
     "space-in-parens": ["error", "never"],
     "spaced-comment": ["error", "always"],
-    "no-console": ["error", { "allow": ["warn", "error"] }]
+    "no-console": ["error", { "allow": ["warn", "error"] }],
+    "consistent-this": ["error", "self"]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -82,7 +82,8 @@
     "spaced-comment": ["error", "always"],
     "no-console": ["error", { "allow": ["warn", "error"] }],
     "consistent-this": ["error", "self"],
-    "no-bitwise": "off"
+    "no-bitwise": "off",
+    "no-unused-expressions": "error"
   },
   "overrides": [
     {

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -458,9 +458,16 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
   disconnectedCallback() {
     super.disconnectedCallback();
 
-    this._navbarChildObserver && this._navbarChildObserver.disconnect();
-    this._drawerChildObserver && this._drawerChildObserver.disconnect();
-    this._touchChildObserver && this._touchChildObserver.disconnect();
+    if (this._navbarChildObserver) {
+      this._navbarChildObserver.disconnect();
+    }
+    if (this._drawerChildObserver) {
+      this._drawerChildObserver.disconnect();
+    }
+    if (this._touchChildObserver) {
+      this._touchChildObserver.disconnect();
+    }
+
     window.removeEventListener('resize', this.__boundResizeListener);
     this.removeEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
     window.removeEventListener('close-overlay-drawer', this.__drawerToggleClickListener);

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1066,7 +1066,9 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-    this._childObserver && this._childObserver.disconnect();
+    if (this._childObserver) {
+      this._childObserver.disconnect();
+    }
   }
 
   /**

--- a/packages/component-base/src/async.js
+++ b/packages/component-base/src/async.js
@@ -153,7 +153,11 @@ const idlePeriod = {
    * @return {void}
    */
   cancel(handle) {
-    window.cancelIdleCallback ? window.cancelIdleCallback(handle) : window.clearTimeout(handle);
+    if (window.cancelIdleCallback) {
+      window.cancelIdleCallback(handle);
+    } else {
+      window.clearTimeout(handle);
+    }
   }
 };
 export { idlePeriod };

--- a/packages/component-base/src/controller-mixin.js
+++ b/packages/component-base/src/controller-mixin.js
@@ -27,7 +27,9 @@ export const ControllerMixin = dedupingMixin(
         super.connectedCallback();
 
         this.__controllers.forEach((c) => {
-          c.hostConnected && c.hostConnected();
+          if (c.hostConnected) {
+            c.hostConnected();
+          }
         });
       }
 
@@ -36,7 +38,9 @@ export const ControllerMixin = dedupingMixin(
         super.disconnectedCallback();
 
         this.__controllers.forEach((c) => {
-          c.hostDisconnected && c.hostDisconnected();
+          if (c.hostDisconnected) {
+            c.hostDisconnected();
+          }
         });
       }
 

--- a/packages/component-base/src/dir-mixin.js
+++ b/packages/component-base/src/dir-mixin.js
@@ -135,9 +135,11 @@ export const DirMixin = (superClass) =>
     /** @private */
     __subscribe(push = true) {
       if (push) {
-        directionSubscribers.indexOf(this) === -1 && directionSubscribers.push(this);
-      } else {
-        directionSubscribers.indexOf(this) > -1 && directionSubscribers.splice(directionSubscribers.indexOf(this), 1);
+        if (!directionSubscribers.includes(this)) {
+          directionSubscribers.push(this);
+        }
+      } else if (directionSubscribers.includes(this)) {
+        directionSubscribers.splice(directionSubscribers.indexOf(this), 1);
       }
     }
 

--- a/packages/component-base/src/iron-list-core.js
+++ b/packages/component-base/src/iron-list-core.js
@@ -553,7 +553,9 @@ export const ironList = {
     }
     this.notifyResize();
     flush();
-    newGrid && this._updateGridMetrics();
+    if (newGrid) {
+      this._updateGridMetrics();
+    }
   },
 
   /**

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -118,8 +118,12 @@ export class IronListAdapter {
     this._resizeHandler();
     flush();
     this._scrollHandler();
-    this.__scrollReorderDebouncer && this.__scrollReorderDebouncer.flush();
-    this.__debouncerWheelAnimationFrame && this.__debouncerWheelAnimationFrame.flush();
+    if (this.__scrollReorderDebouncer) {
+      this.__scrollReorderDebouncer.flush();
+    }
+    if (this.__debouncerWheelAnimationFrame) {
+      this.__debouncerWheelAnimationFrame.flush();
+    }
   }
 
   update(startIndex = 0, endIndex = this.size - 1) {
@@ -245,7 +249,9 @@ export class IronListAdapter {
     this._viewportWidth = this.elementsContainer.offsetWidth;
     this._viewportHeight = this.scrollTarget.offsetHeight;
     this._scrollPageHeight = this._viewportHeight - this._scrollLineHeight;
-    this.grid && this._updateGridMetrics();
+    if (this.grid) {
+      this._updateGridMetrics();
+    }
   }
 
   /** @private */

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -280,7 +280,9 @@ export const ItemsMixin = (superClass) =>
       `;
         flush();
         const listBox = root.querySelector('vaadin-context-menu-list-box');
-        this._theme && listBox.setAttribute('theme', this._theme);
+        if (this._theme) {
+          listBox.setAttribute('theme', this._theme);
+        }
         listBox.classList.add('vaadin-menu-list-box');
         requestAnimationFrame(() => listBox.setAttribute('role', 'menu'));
 
@@ -373,7 +375,9 @@ export const ItemsMixin = (superClass) =>
           const shouldOpenSubMenu =
             (!isRTL && e.keyCode === 39) || (isRTL && e.keyCode === 37) || e.keyCode === 13 || e.keyCode === 32;
 
-          shouldOpenSubMenu && openSubMenu(e);
+          if (shouldOpenSubMenu) {
+            openSubMenu(e);
+          }
         });
       } else {
         const listBox = root.querySelector('vaadin-context-menu-list-box');

--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -70,7 +70,9 @@ class CrudGrid extends IncludedMixin(Grid) {
   __toggleEditColumn() {
     const el = this.querySelector('vaadin-crud-edit-column');
     if (this.hideEditColumn) {
-      el && this.removeChild(el);
+      if (el) {
+        this.removeChild(el);
+      }
     } else if (!el) {
       this.appendChild(document.createElement('vaadin-crud-edit-column'));
     }
@@ -195,7 +197,9 @@ class CrudGrid extends IncludedMixin(Grid) {
           textField.setAttribute('slot', 'filter');
           textField.setAttribute('focus-target', true);
           textField.style.width = '100%';
-          this.noSort && (textField.placeholder = label);
+          if (this.noSort) {
+            textField.placeholder = label;
+          }
           textField.addEventListener('value-changed', function (event) {
             filter.value = event.detail.value;
           });

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -1132,7 +1132,9 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
       this._form.item = item;
       this._fields.forEach((e) => {
         const path = e.path || e.getAttribute('path');
-        path && (e.value = this.get(path, item));
+        if (path) {
+          e.value = this.get(path, item);
+        }
       });
 
       this.__isNew = this.__isNew || (this.items && this.items.indexOf(item) < 0);
@@ -1214,7 +1216,9 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
     const item = { ...this.editedItem };
     this._fields.forEach((e) => {
       const path = e.path || e.getAttribute('path');
-      path && this.__set(path, e.value, item);
+      if (path) {
+        this.__set(path, e.value, item);
+      }
     });
     const evt = this.dispatchEvent(new CustomEvent('save', { detail: { item: item }, cancelable: true }));
     if (evt) {

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -226,7 +226,9 @@ class CustomField extends FieldMixin(FocusMixin(ThemableMixin(ElementMixin(Polym
 
   /** @protected */
   focus() {
-    this.inputs && this.inputs[0] && this.inputs[0].focus();
+    if (this.inputs && this.inputs[0]) {
+      this.inputs[0].focus();
+    }
   }
 
   /**

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -380,7 +380,9 @@ export const DatePickerMixin = (subclass) =>
     _onFocus(event) {
       super._onFocus(event);
 
-      this._noInput && event.target.blur();
+      if (this._noInput) {
+        event.target.blur();
+      }
     }
 
     /**
@@ -662,7 +664,9 @@ export const DatePickerMixin = (subclass) =>
       }
       const value = this._formatISO(selectedDate);
 
-      this.__keepInputValue || this._applyInputValue(selectedDate);
+      if (!this.__keepInputValue) {
+        this._applyInputValue(selectedDate);
+      }
 
       if (value !== this.value) {
         this.validate();
@@ -704,7 +708,9 @@ export const DatePickerMixin = (subclass) =>
       }
       if (!dateEquals(this[property], date)) {
         this[property] = date;
-        this.value && this.validate();
+        if (this.value) {
+          this.validate();
+        }
       }
     }
 
@@ -848,7 +854,9 @@ export const DatePickerMixin = (subclass) =>
     /** @protected */
     _focus() {
       if (this._noInput) {
-        this._overlayInitialized && this._overlayContent.focus();
+        if (this._overlayInitialized) {
+          this._overlayContent.focus();
+        }
       } else {
         this.inputElement.focus();
       }

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -618,7 +618,11 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
   }
 
   _toggleYearScroller() {
-    this._isYearScrollerVisible() ? this._closeYearScroller() : this._openYearScroller();
+    if (this._isYearScrollerVisible()) {
+      this._closeYearScroller();
+    } else {
+      this._openYearScroller();
+    }
   }
 
   _openYearScroller() {

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -82,7 +82,9 @@ export const DialogDraggableMixin = (superClass) =>
         });
 
         if ((isResizerContainer && !isResizerContainerScrollbar) || isContentPart || isDraggable) {
-          !isDraggable && e.preventDefault();
+          if (!isDraggable) {
+            e.preventDefault();
+          }
           this._originalBounds = this.$.overlay.getBounds();
           const event = getMouseOrFirstTouchEvent(e);
           this._originalMouseCoords = { top: event.pageY, left: event.pageX };

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -357,8 +357,12 @@ export class UserTags extends PolymerElement {
   }
 
   stopFlash() {
-    this._debounceFlashStart && this._debounceFlashStart.flush();
-    this._debounceFlashEnd && this._debounceFlashEnd.flush();
+    if (this._debounceFlashStart) {
+      this._debounceFlashStart.flush();
+    }
+    if (this._debounceFlashEnd) {
+      this._debounceFlashEnd.flush();
+    }
     this.$.overlay._flushAnimation('closing');
   }
 

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
@@ -245,7 +245,9 @@ class GridProEditColumn extends GridColumn {
     // FIXME(yuriy): Required for the flow counterpart as it is passing the string value to webcomponent
     value = this.editorType === 'checkbox' && typeof value === 'string' ? value == 'true' : value;
     set(editor, path, value);
-    editor.notifyPath && editor.notifyPath(path, value);
+    if (editor.notifyPath) {
+      editor.notifyPath(path, value);
+    }
   }
 
   /**

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
@@ -72,7 +72,9 @@ class GridProEditSelect extends Select {
     }
 
     if (event.keyCode === 9) {
-      !this._grid.singleCellEdit && this._grid._switchEditCell(event);
+      if (!this._grid.singleCellEdit) {
+        this._grid._switchEditCell(event);
+      }
     }
 
     // Call `super` to close overlay on Tab.

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -80,19 +80,31 @@ export const InlineEditingMixin = (superClass) =>
       this.addEventListener('keydown', (e) => {
         switch (e.keyCode) {
           case 27:
-            this.__edited && this._stopEdit(true);
+            if (this.__edited) {
+              this._stopEdit(true);
+            }
             break;
           case 9:
-            this.__edited && this._switchEditCell(e);
+            if (this.__edited) {
+              this._switchEditCell(e);
+            }
             break;
           case 13:
-            this.__edited ? this._switchEditCell(e) : this._enterEditFromEvent(e);
+            if (this.__edited) {
+              this._switchEditCell(e);
+            } else {
+              this._enterEditFromEvent(e);
+            }
             break;
           case 32:
-            !this.__edited && this._enterEditFromEvent(e);
+            if (!this.__edited) {
+              this._enterEditFromEvent(e);
+            }
             break;
           default:
-            e.key && e.key.length === 1 && this._enterEditFromEvent(e, 'text');
+            if (e.key && e.key.length === 1) {
+              this._enterEditFromEvent(e, 'text');
+            }
             break;
         }
       });

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -108,7 +108,9 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-    this._observer && this._observer.disconnect();
+    if (this._observer) {
+      this._observer.disconnect();
+    }
   }
 
   /**
@@ -290,11 +292,15 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
   _colSpanChanged(colSpan, headerCell, footerCell) {
     if (headerCell) {
       headerCell.setAttribute('colspan', colSpan);
-      this._grid && this._grid._a11yUpdateCellColspan(headerCell, colSpan);
+      if (this._grid) {
+        this._grid._a11yUpdateCellColspan(headerCell, colSpan);
+      }
     }
     if (footerCell) {
       footerCell.setAttribute('colspan', colSpan);
-      this._grid && this._grid._a11yUpdateCellColspan(footerCell, colSpan);
+      if (this._grid) {
+        this._grid._a11yUpdateCellColspan(footerCell, colSpan);
+      }
     }
   }
 
@@ -321,7 +327,9 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
 
         // Update the column tree with microtask timing to avoid shady style scope issues
         microTask.run(() => {
-          this._grid && this._grid._updateColumnTree && this._grid._updateColumnTree();
+          if (this._grid && this._grid._updateColumnTree) {
+            this._grid._updateColumnTree();
+          }
         });
       }
     });

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -337,7 +337,9 @@ export const ColumnBaseMixin = (superClass) =>
 
       this._allCells.forEach((cell) => cell.toggleAttribute('frozen', frozen));
 
-      this._grid && this._grid._frozenCellsChanged && this._grid._frozenCellsChanged();
+      if (this._grid && this._grid._frozenCellsChanged) {
+        this._grid._frozenCellsChanged();
+      }
     }
 
     /** @private */
@@ -354,7 +356,9 @@ export const ColumnBaseMixin = (superClass) =>
         cell.toggleAttribute('frozen-to-end', frozenToEnd);
       });
 
-      this._grid && this._grid._frozenCellsChanged && this._grid._frozenCellsChanged();
+      if (this._grid && this._grid._frozenCellsChanged) {
+        this._grid._frozenCellsChanged();
+      }
     }
 
     /** @private */
@@ -480,8 +484,13 @@ export const ColumnBaseMixin = (superClass) =>
           }
         );
 
-        this._grid._updateFrozenColumn && this._grid._updateFrozenColumn();
-        this._grid._resetKeyboardNavigation && this._grid._resetKeyboardNavigation();
+        if (this._grid._updateFrozenColumn) {
+          this._grid._updateFrozenColumn();
+        }
+
+        if (this._grid._resetKeyboardNavigation) {
+          this._grid._resetKeyboardNavigation();
+        }
       }
       this._previousHidden = hidden;
     }
@@ -609,7 +618,9 @@ export const ColumnBaseMixin = (superClass) =>
 
     /** @private */
     __setTextContent(node, textContent) {
-      node.textContent !== textContent && (node.textContent = textContent);
+      if (node.textContent !== textContent) {
+        node.textContent = textContent;
+      }
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -267,7 +267,7 @@ export const ColumnBaseMixin = (superClass) =>
      * @protected
      */
     _findHostGrid() {
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      // eslint-disable-next-line @typescript-eslint/no-this-alias, consistent-this
       let el = this;
       // Custom elements extending grid must have a specific localName
       while (el && !/^vaadin.*grid(-pro)?$/.test(el.localName)) {

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -482,7 +482,9 @@ class Grid extends ElementMixin(
   __focusBodyCell({ item, column }) {
     const row = this._getVisibleRows().find((row) => row._item === item);
     const cell = row && [...row.children].find((cell) => cell._column === column);
-    cell && cell.focus();
+    if (cell) {
+      cell.focus();
+    }
   }
 
   /** @private */
@@ -497,7 +499,9 @@ class Grid extends ElementMixin(
       virtualizer.flush();
 
       // If the focused cell's parent row got hidden by the size change, focus the corresponding new cell
-      cellCoordinates && cell.parentElement.hidden && this.__focusBodyCell(cellCoordinates);
+      if (cellCoordinates && cell.parentElement.hidden) {
+        this.__focusBodyCell(cellCoordinates);
+      }
 
       // Make sure the body has a tabbable element
       this._resetKeyboardNavigation();
@@ -1001,7 +1005,9 @@ class Grid extends ElementMixin(
 
   /** @protected */
   __updateVisibleRows(start, end) {
-    this.__virtualizer && this.__virtualizer.update(start, end);
+    if (this.__virtualizer) {
+      this.__virtualizer.update(start, end);
+    }
   }
 
   /**

--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -81,6 +81,7 @@ class Item extends ItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
      * Submittable string value. The default value is the trimmed text content of the element.
      * @type {string}
      */
+    // eslint-disable-next-line no-unused-expressions
     this.value;
   }
 }

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -88,6 +88,7 @@ class ListBox extends ElementMixin(MultiSelectListMixin(ThemableMixin(Controller
      * @type {Element | null}
      * @protected
      */
+    // eslint-disable-next-line no-unused-expressions
     this.focused;
   }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -352,7 +352,9 @@ export const InteractionsMixin = (superClass) =>
     _focusLastItem() {
       const list = this._subMenu.$.overlay.firstElementChild;
       const item = list.items[list.items.length - 1];
-      item && item.focus();
+      if (item) {
+        item.focus();
+      }
     }
 
     /** @private */
@@ -397,6 +399,8 @@ export const InteractionsMixin = (superClass) =>
     _close(restoreFocus) {
       this.style.pointerEvents = '';
       this.__deactivateButton(restoreFocus);
-      this._subMenu.opened && this._subMenu.close();
+      if (this._subMenu.opened) {
+        this._subMenu.close();
+      }
     }
   };

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -437,14 +437,18 @@ class Notification extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
   /** @private */
   _removeNotificationCard() {
-    this._card.parentNode && this._card.parentNode.removeChild(this._card);
+    if (this._card.parentNode) {
+      this._card.parentNode.removeChild(this._card);
+    }
     this._card.removeAttribute('closing');
     this._container.opened = Boolean(this._container.firstElementChild);
   }
 
   /** @private */
   _closeNotificationCard() {
-    this._durationTimeoutId && clearTimeout(this._durationTimeoutId);
+    if (this._durationTimeoutId) {
+      clearTimeout(this._durationTimeoutId);
+    }
     this._animatedRemoveNotificationCard();
   }
 

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -257,7 +257,11 @@ class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(PolymerEleme
       });
     }
 
-    overflow ? this.setAttribute('overflow', overflow.trim()) : this.removeAttribute('overflow');
+    if (overflow) {
+      this.setAttribute('overflow', overflow.trim());
+    } else {
+      this.removeAttribute('overflow');
+    }
   }
 }
 

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -256,8 +256,12 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
               // Always display hour and minute
               let timeString = `${pad(time.hours)}:${pad(time.minutes)}`;
               // Adding second and millisecond depends on resolution
-              time.seconds !== undefined && (timeString += `:${pad(time.seconds)}`);
-              time.milliseconds !== undefined && (timeString += `.${pad(time.milliseconds, '000')}`);
+              if (time.seconds !== undefined) {
+                timeString += `:${pad(time.seconds)}`;
+              }
+              if (time.milliseconds !== undefined) {
+                timeString += `.${pad(time.milliseconds, '000')}`;
+              }
               return timeString;
             },
             parseTime: (text) => {

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -884,12 +884,20 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   _dragoverChanged(dragover) {
-    dragover ? this.setAttribute('dragover', dragover) : this.removeAttribute('dragover');
+    if (dragover) {
+      this.setAttribute('dragover', dragover);
+    } else {
+      this.removeAttribute('dragover');
+    }
   }
 
   /** @private */
   _dragoverValidChanged(dragoverValid) {
-    dragoverValid ? this.setAttribute('dragover-valid', dragoverValid) : this.removeAttribute('dragover-valid');
+    if (dragoverValid) {
+      this.setAttribute('dragover-valid', dragoverValid);
+    } else {
+      this.removeAttribute('dragover-valid');
+    }
   }
 
   /** @private */

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.js
@@ -97,7 +97,11 @@ export const ListMixin = (superClass) =>
         if (items) {
           this.setAttribute('aria-orientation', orientation || 'vertical');
           this.items.forEach((item) => {
-            orientation ? item.setAttribute('orientation', orientation) : item.removeAttribute('orientation');
+            if (orientation) {
+              item.setAttribute('orientation', orientation);
+            } else {
+              item.removeAttribute('orientation');
+            }
           });
 
           this._setFocusable(selected || 0);
@@ -302,7 +306,9 @@ export const ListMixin = (superClass) =>
 
     focus() {
       // In initialization (e.g vaadin-select) observer might not been run yet.
-      this._observer && this._observer.flush();
+      if (this._observer) {
+        this._observer.flush();
+      }
       const firstItem = this.querySelector('[tabindex="0"]') || (this.items ? this.items[0] : null);
       this._focusItem(firstItem);
     }

--- a/packages/virtual-list/src/vaadin-virtual-list.js
+++ b/packages/virtual-list/src/vaadin-virtual-list.js
@@ -183,7 +183,9 @@ class VirtualList extends ElementMixin(ThemableMixin(PolymerElement)) {
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
   requestContentUpdate() {
-    this.__virtualizer && this.__virtualizer.update();
+    if (this.__virtualizer) {
+      this.__virtualizer.update();
+    }
   }
 }
 

--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -198,13 +198,19 @@ function logCommit(c) {
   let indent = '';
   if (!compact) {
     const components = getComponents(c);
-    components && (log += `${components}\n`);
+    if (components) {
+      log += `${components}\n`;
+    }
     indent = '  ';
   }
   log += `${indent}- ` + parseLinks(c.commit.substring(0, 7) + ' ' + c.title[0].toUpperCase() + c.title.slice(1));
   const tickets = getTickets(c);
-  tickets && (log += `. ${tickets}`);
-  c.body && (log += `\n\n        _${c.body}_`);
+  if (tickets) {
+    log += `. ${tickets}`;
+  }
+  if (c.body) {
+    log += `\n\n        _${c.body}_`;
+  }
   console.log(log);
 }
 
@@ -264,7 +270,9 @@ function logCommitsByComponent(commits) {
         }
         log += `${indent}- ` + parseLinks(c.commit.substring(0, 7) + ' ' + c.title[0].toUpperCase() + c.title.slice(1));
         const tickets = getTickets(c);
-        tickets && (log += `. ${tickets}`);
+        if (tickets) {
+          log += `. ${tickets}`;
+        }
       });
       console.log(log.replace(/^\s*[\r\n]/gm, ''));
     });

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -15,7 +15,9 @@ async function exe(cmd, quiet) {
   let out = '';
   const capture = (data) => {
     const s = data.toString('utf-8');
-    !quiet && process.stdout.write(s);
+    if (!quiet) {
+      process.stdout.write(s);
+    }
     out += s;
   };
 


### PR DESCRIPTION
## Description

The PR adds the following rules to the project's ESLint config:

- [x] @typescript-eslint/explicit-member-accessibility _(no warnings)_
- [x] no-console _(no warnings)_
- [x] consistent-this _(no warnings)_
- [x] no-bitwise _(no warnings, decided to disable it in advance)_
- [x] no-unused-expressions

Part of https://github.com/vaadin/eslint-config-vaadin/issues/16

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
