### PR TITLE
refactor: add more rules to ESLint config, fix warnings (2)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -78,7 +78,8 @@
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "space-in-parens": ["error", "never"],
-    "spaced-comment": ["error", "always"]
+    "spaced-comment": ["error", "always"],
+    "eqeqeq": ["error", "always", { "null": "ignore" }]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,16 +43,17 @@
       "argsIgnorePattern": "^_"
     }],
     "@typescript-eslint/ban-types": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/no-explicit-any": "off",
     "accessor-pairs": "error",
     "array-callback-return": "error",
     "curly": ["error", "all"],
     "default-case": ["error", { "commentPattern": "^no\\sdefault" }],
     "default-param-last": "error",
     "dot-notation": ["error", { "allowPattern": "^[a-zA-Z]+([_-][a-zA-Z]+)+$" }],
+    "eqeqeq": ["error", "always", { "null": "ignore" }],
     "func-style": ["error", "declaration", { "allowArrowFunctions": true }],
     "grouped-accessor-pairs": ["error", "getBeforeSet"],
     "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
@@ -78,8 +79,7 @@
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "space-in-parens": ["error", "never"],
-    "spaced-comment": ["error", "always"],
-    "eqeqeq": ["error", "always", { "null": "ignore" }]
+    "spaced-comment": ["error", "always"]
   },
   "overrides": [
     {

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -733,7 +733,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
 
   /** @protected */
   _updateTouchOptimizedMode() {
-    const touchOptimized = this._getCustomPropertyValue('--vaadin-app-layout-touch-optimized') == 'true';
+    const touchOptimized = this._getCustomPropertyValue('--vaadin-app-layout-touch-optimized') === 'true';
 
     const navbarItems = this.querySelectorAll('[slot*="navbar"]');
 

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -545,7 +545,7 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement)
     const { marginLeft, marginRight } = getComputedStyle(avatars[1]);
 
     const offset =
-      this.getAttribute('dir') == 'rtl'
+      this.getAttribute('dir') === 'rtl'
         ? parseInt(marginRight, 0) - parseInt(marginLeft, 0)
         : parseInt(marginLeft, 0) - parseInt(marginRight, 0);
 

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -352,7 +352,7 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement)
 
   /** @private */
   _onVaadinOverlayClose(e) {
-    if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().indexOf(this) !== -1) {
+    if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this)) {
       e.preventDefault();
     }
   }

--- a/packages/board/src/vaadin-board-row.js
+++ b/packages/board/src/vaadin-board-row.js
@@ -131,7 +131,7 @@ class BoardRow extends ResizeMixin(ElementMixin(PolymerElement)) {
   _calculateFlexBasis(colSpan, width, colsInRow, breakpoints) {
     if (width < breakpoints.smallSize) {
       colsInRow = 1;
-    } else if (width < breakpoints.mediumSize && colsInRow == 4) {
+    } else if (width < breakpoints.mediumSize && colsInRow === 4) {
       colsInRow = 2;
     }
     let flexBasis = (colSpan / colsInRow) * 100;
@@ -231,9 +231,9 @@ class BoardRow extends ResizeMixin(ElementMixin(PolymerElement)) {
     const breakpoints = this._measureBreakpointsInPx();
     if (
       forceResize ||
-      width != this._oldWidth ||
-      breakpoints.smallSize != this._oldBreakpoints.smallSize ||
-      breakpoints.mediumSize != this._oldBreakpoints.mediumSize
+      width !== this._oldWidth ||
+      breakpoints.smallSize !== this._oldBreakpoints.smallSize ||
+      breakpoints.mediumSize !== this._oldBreakpoints.mediumSize
     ) {
       const nodes = this.$.insertionPoint.assignedNodes({ flatten: true });
       const isElementNode = (node) => {
@@ -245,7 +245,7 @@ class BoardRow extends ResizeMixin(ElementMixin(PolymerElement)) {
       const colsInRow = boardCols.reduce((a, b) => a + b, 0);
       this._removeExtraNodesFromDOM(boardCols, filteredNodes).forEach((e, i) => {
         const newFlexBasis = this._calculateFlexBasis(boardCols[i], width, colsInRow, breakpoints);
-        if (forceResize || !this._oldFlexBasis[i] || this._oldFlexBasis[i] != newFlexBasis) {
+        if (forceResize || !this._oldFlexBasis[i] || this._oldFlexBasis[i] !== newFlexBasis) {
           this._oldFlexBasis[i] = newFlexBasis;
           e.style.flexBasis = newFlexBasis;
         }

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1766,7 +1766,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   __updateStyles() {
     // Chrome returns default value if property is not set
     // check if flex is defined for chart, and different than default value
-    const isFlex = getComputedStyle(this).flex != '0 1 auto';
+    const isFlex = getComputedStyle(this).flex !== '0 1 auto';
 
     // If chart element is a flexible item the chartContainer should be flex too
     if (isFlex) {

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -218,7 +218,7 @@ export class ComboBoxScroller extends PolymerElement {
 
   /** @private */
   __isItemFocused(focusedIndex, itemIndex) {
-    return focusedIndex == itemIndex;
+    return focusedIndex === itemIndex;
   }
 
   /** @private */

--- a/packages/component-base/src/iron-list-core.js
+++ b/packages/component-base/src/iron-list-core.js
@@ -454,7 +454,7 @@ export const ironList = {
 
   _isClientFull: function () {
     return (
-      this._scrollBottom != 0 &&
+      this._scrollBottom !== 0 &&
       this._physicalBottom - 1 >= this._scrollBottom &&
       this._physicalTop <= this._scrollPosition
     );

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -389,7 +389,7 @@ class ConfirmDialog extends SlotMixin(ElementMixin(ThemePropertyMixin(PolymerEle
     addedNodes.forEach((node) => {
       this.__slottedNodes.push(node);
 
-      const isElementNode = node.nodeType == Node.ELEMENT_NODE;
+      const isElementNode = node.nodeType === Node.ELEMENT_NODE;
       const slotName = isElementNode ? node.getAttribute('slot') : '';
 
       // Handle named slots (header and buttons).
@@ -397,11 +397,11 @@ class ConfirmDialog extends SlotMixin(ElementMixin(ThemePropertyMixin(PolymerEle
         if (slotName.indexOf('button') >= 0) {
           const [button] = slotName.split('-');
           this[`_${button}Button`] = node;
-        } else if (slotName == 'header') {
+        } else if (slotName === 'header') {
           this._headerNode = node;
         }
       } else {
-        const isNotEmptyText = node.nodeType == Node.TEXT_NODE && node.textContent.trim() !== '';
+        const isNotEmptyText = node.nodeType === Node.TEXT_NODE && node.textContent.trim() !== '';
         // Handle default slot (message element).
         if (isNotEmptyText || (isElementNode && node.slot === '')) {
           this._messageNode = node;

--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -54,7 +54,7 @@ class CrudGrid extends IncludedMixin(Grid) {
 
   /** @private */
   __onItemsChange(items) {
-    if ((!this.dataProvider || this.dataProvider == this._arrayDataProvider) && !this.include && items && items[0]) {
+    if ((!this.dataProvider || this.dataProvider === this._arrayDataProvider) && !this.include && items && items[0]) {
       this._configure(items[0]);
     }
   }
@@ -79,7 +79,7 @@ class CrudGrid extends IncludedMixin(Grid) {
   /** @private */
   __dataProviderWrapper(params, callback) {
     this.__dataProvider(params, (items, size) => {
-      if (this.innerHTML == '' && !this.include && items[0]) {
+      if (this.innerHTML === '' && !this.include && items[0]) {
         this._configure(items[0]);
       }
       callback(items, size);
@@ -91,9 +91,9 @@ class CrudGrid extends IncludedMixin(Grid) {
    * @private
    */
   _dataProviderChanged(dataProvider, oldDataProvider) {
-    if (this._arrayDataProvider == dataProvider) {
+    if (this._arrayDataProvider === dataProvider) {
       super._dataProviderChanged(dataProvider, oldDataProvider);
-    } else if (this.__dataProviderWrapper != dataProvider) {
+    } else if (this.__dataProviderWrapper !== dataProvider) {
       this.innerHTML = '';
       this.__dataProvider = dataProvider;
       this.dataProvider = this.__dataProviderWrapper;

--- a/packages/crud/src/vaadin-crud-include-mixin.js
+++ b/packages/crud/src/vaadin-crud-include-mixin.js
@@ -40,14 +40,14 @@ export const IncludedMixin = (superClass) =>
 
     /** @private */
     __onExcludeChange(exclude) {
-      if (typeof exclude == 'string') {
+      if (typeof exclude === 'string') {
         this.exclude = exclude ? RegExp(exclude.replace(/, */g, '|'), 'i') : undefined;
       }
     }
 
     /** @private */
     __onIncludeChange(include) {
-      if (typeof include == 'string') {
+      if (typeof include === 'string') {
         this.include = include ? include.split(/, */) : undefined;
       } else if (!this._fields && Array.isArray(include)) {
         const item = {};

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -624,7 +624,7 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
 
   /** @private */
   static _isValidEditorPosition(editorPosition) {
-    return ['bottom', 'aside'].indexOf(editorPosition) !== -1;
+    return ['bottom', 'aside'].includes(editorPosition);
   }
 
   /** @protected */

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -624,7 +624,7 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
 
   /** @private */
   static _isValidEditorPosition(editorPosition) {
-    return ['bottom', 'aside'].indexOf(editorPosition) != -1;
+    return ['bottom', 'aside'].indexOf(editorPosition) !== -1;
   }
 
   /** @protected */
@@ -841,17 +841,17 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
           return;
         }
 
-        if (slotAttributeValue == 'grid') {
+        if (slotAttributeValue === 'grid') {
           // Force to remove listener on previous grid first
           this.__editOnClickChanged(false, this._grid);
           this._grid = node;
           this.__editOnClickChanged(this.editOnClick, this._grid);
-        } else if (slotAttributeValue == 'form') {
+        } else if (slotAttributeValue === 'form') {
           this._form = node;
         } else if (slotAttributeValue.indexOf('button') >= 0) {
           const [button] = slotAttributeValue.split('-');
           this[`_${button}Button`] = node;
-        } else if (slotAttributeValue == 'header') {
+        } else if (slotAttributeValue === 'header') {
           this._headerNode = node;
         }
       });
@@ -1177,7 +1177,7 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
   /** @private */
   __new(event) {
     // This allows listening to parent element and fire only when clicking on default or custom new-button.
-    if (event.composedPath().filter((e) => e.nodeType == 1 && e.hasAttribute('new-button'))[0]) {
+    if (event.composedPath().filter((e) => e.nodeType === 1 && e.hasAttribute('new-button'))[0]) {
       this.__confirmBeforeChangingEditedItem(null, true);
     }
   }

--- a/packages/crud/test/crud-grid.test.js
+++ b/packages/crud/test/crud-grid.test.js
@@ -133,7 +133,7 @@ describe('crud grid', () => {
     ['items', 'dataProvider'].forEach((type) => {
       describe(type, () => {
         beforeEach(async () => {
-          if (type == 'items') {
+          if (type === 'items') {
             grid.items = items;
           } else {
             grid.dataProvider = (_, callback) => {

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -367,7 +367,7 @@ class CustomField extends FieldMixin(FocusMixin(ThemableMixin(ElementMixin(Polym
     this.__toggleHasValue(value);
 
     const valuesArray = this.i18n.parseValue(value);
-    if (!valuesArray || valuesArray.length == 0) {
+    if (!valuesArray || valuesArray.length === 0) {
       console.warn('Value parser has not provided values array');
       return;
     }

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -221,7 +221,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
     } else if (!this.hasAttribute('focused')) {
       this.blur();
     }
-    if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().indexOf(this) !== -1) {
+    if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this)) {
       e.preventDefault();
     }
   }

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -851,7 +851,7 @@ class DateTimePicker extends FieldMixin(
   /** @private */
   // eslint-disable-next-line getter-return
   get __stepSegment() {
-    const step = this.step == undefined ? 60 : parseFloat(this.step);
+    const step = this.step == null ? 60 : parseFloat(this.step);
     if (step % 3600 === 0) {
       // Accept hours
       return 1;

--- a/packages/field-base/src/input-controller.js
+++ b/packages/field-base/src/input-controller.js
@@ -27,7 +27,7 @@ export class InputController extends SlotController {
         host._inputId = `${host.localName}-${uniqueId}`;
         node.id = host._inputId;
 
-        if (typeof callback == 'function') {
+        if (typeof callback === 'function') {
           callback(node);
         }
       }

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -105,7 +105,7 @@ export const InputMixin = dedupingMixin(
           return;
         }
 
-        if (value != undefined) {
+        if (value != null) {
           this.inputElement.value = value;
         } else {
           this.inputElement.value = '';

--- a/packages/field-base/src/slot-target-controller.js
+++ b/packages/field-base/src/slot-target-controller.js
@@ -73,7 +73,7 @@ export class SlotTargetController {
     // Exclude whitespace text nodes
     const nodes = this.sourceSlot
       .assignedNodes({ flatten: true })
-      .filter((node) => !(node.nodeType == Node.TEXT_NODE && node.textContent.trim() === ''));
+      .filter((node) => !(node.nodeType === Node.TEXT_NODE && node.textContent.trim() === ''));
 
     if (nodes.length > 0) {
       slotTarget.innerHTML = '';

--- a/packages/field-base/src/text-area-controller.js
+++ b/packages/field-base/src/text-area-controller.js
@@ -30,7 +30,7 @@ export class TextAreaController extends SlotController {
         host._textareaId = `${host.localName}-${uniqueId}`;
         node.id = host._textareaId;
 
-        if (typeof callback == 'function') {
+        if (typeof callback === 'function') {
           callback(node);
         }
       }

--- a/packages/field-highlighter/src/fields/vaadin-checkbox-group-observer.js
+++ b/packages/field-highlighter/src/fields/vaadin-checkbox-group-observer.js
@@ -12,6 +12,6 @@ export class CheckboxGroupObserver extends FieldObserver {
 
   getFocusTarget(event) {
     const fields = this.getFields();
-    return Array.from(event.composedPath()).filter((node) => fields.indexOf(node) !== -1)[0];
+    return Array.from(event.composedPath()).filter((node) => fields.includes(node))[0];
   }
 }

--- a/packages/field-highlighter/src/fields/vaadin-list-box-observer.js
+++ b/packages/field-highlighter/src/fields/vaadin-list-box-observer.js
@@ -12,6 +12,6 @@ export class ListBoxObserver extends FieldObserver {
 
   getFocusTarget(event) {
     const fields = this.getFields();
-    return Array.from(event.composedPath()).filter((node) => fields.indexOf(node) !== -1)[0];
+    return Array.from(event.composedPath()).filter((node) => fields.includes(node))[0];
   }
 }

--- a/packages/field-highlighter/src/fields/vaadin-radio-group-observer.js
+++ b/packages/field-highlighter/src/fields/vaadin-radio-group-observer.js
@@ -12,6 +12,6 @@ export class RadioGroupObserver extends FieldObserver {
 
   getFocusTarget(event) {
     const fields = this.getFields();
-    return Array.from(event.composedPath()).filter((node) => fields.indexOf(node) !== -1)[0];
+    return Array.from(event.composedPath()).filter((node) => fields.includes(node))[0];
   }
 }

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
@@ -122,7 +122,7 @@ class GridProEditColumn extends GridColumn {
 
   /** @private */
   _pathChanged(path) {
-    if (!path || path.length == 0) {
+    if (!path || path.length === 0) {
       throw new Error('You should specify the path for the edit column');
     }
   }
@@ -243,7 +243,7 @@ class GridProEditColumn extends GridColumn {
   _setEditorValue(editor, value) {
     const path = this.editorType === 'checkbox' ? 'checked' : this.editorValuePath;
     // FIXME(yuriy): Required for the flow counterpart as it is passing the string value to webcomponent
-    value = this.editorType === 'checkbox' && typeof value === 'string' ? value == 'true' : value;
+    value = this.editorType === 'checkbox' && typeof value === 'string' ? value === 'true' : value;
     set(editor, path, value);
     editor.notifyPath && editor.notifyPath(path, value);
   }

--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -112,6 +112,6 @@ export const isFocusable = (target) => {
     )
   ).filter((element) => element.getAttribute('part') !== 'cell body-cell');
 
-  const isFocusableElement = focusables.indexOf(target) !== -1;
+  const isFocusableElement = focusables.includes(target);
   return !target.disabled && isFocusableElement;
 };

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -21,7 +21,7 @@ export const ColumnResizingMixin = (superClass) =>
       // Disable contextmenu on any resize separator.
       scroller.addEventListener(
         'contextmenu',
-        (e) => e.target.getAttribute('part') == 'resize-handle' && e.preventDefault()
+        (e) => e.target.getAttribute('part') === 'resize-handle' && e.preventDefault()
       );
 
       // Disable native cell focus when resizing

--- a/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -8,6 +8,25 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 
+function arrayEquals(arr1, arr2) {
+  if (!arr1 || !arr2 || arr1.length !== arr2.length) {
+    return false;
+  }
+
+  for (let i = 0, l = arr1.length; i < l; i++) {
+    // Check if we have nested arrays
+    if (arr1[i] instanceof Array && arr2[i] instanceof Array) {
+      // recurse into the nested arrays
+      if (!arrayEquals(arr1[i], arr2[i])) {
+        return false;
+      }
+    } else if (arr1[i] !== arr2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * @polymerMixin
  */
@@ -79,7 +98,7 @@ export const DynamicColumnsMixin = (superClass) =>
     /** @protected */
     _updateColumnTree() {
       const columnTree = this._getColumnTree();
-      if (!this._arrayEquals(columnTree, this._columnTree)) {
+      if (!arrayEquals(columnTree, this._columnTree)) {
         this._columnTree = columnTree;
       }
     }
@@ -106,26 +125,6 @@ export const DynamicColumnsMixin = (superClass) =>
 
         this._ensureFirstPageLoaded();
       });
-    }
-
-    /** @private */
-    _arrayEquals(arr1, arr2) {
-      if (!arr1 || !arr2 || arr1.length != arr2.length) {
-        return false;
-      }
-
-      for (let i = 0, l = arr1.length; i < l; i++) {
-        // Check if we have nested arrays
-        if (arr1[i] instanceof Array && arr2[i] instanceof Array) {
-          // recurse into the nested arrays
-          if (!this._arrayEquals(arr1[i], arr2[i])) {
-            return false;
-          }
-        } else if (arr1[i] != arr2[i]) {
-          return false;
-        }
-      }
-      return true;
     }
 
     /** @protected */

--- a/packages/grid/src/vaadin-grid-filter-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-mixin.js
@@ -37,7 +37,7 @@ export const FilterMixin = (superClass) =>
 
     /** @private */
     __removeFilters(filtersToRemove) {
-      if (filtersToRemove.length == 0) {
+      if (filtersToRemove.length === 0) {
         return;
       }
 

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -183,7 +183,7 @@ export const ScrollMixin = (superClass) =>
         const value = overflow.trim();
         if (value.length > 0 && this.getAttribute('overflow') !== value) {
           this.setAttribute('overflow', value);
-        } else if (value.length == 0 && this.hasAttribute('overflow')) {
+        } else if (value.length === 0 && this.hasAttribute('overflow')) {
           this.removeAttribute('overflow');
         }
       });

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -58,7 +58,7 @@ export const SortMixin = (superClass) =>
 
     /** @private */
     __removeSorters(sortersToRemove) {
-      if (sortersToRemove.length == 0) {
+      if (sortersToRemove.length === 0) {
         return;
       }
 
@@ -89,7 +89,7 @@ export const SortMixin = (superClass) =>
         }
         this.__updateSortOrders();
       } else if (sorter.direction) {
-        const otherSorters = this._sorters.filter((s) => s != sorter);
+        const otherSorters = this._sorters.filter((s) => s !== sorter);
         this._sorters = [sorter];
         otherSorters.forEach((sorter) => {
           sorter._order = null;

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -80,8 +80,8 @@ describe('accessibility', () => {
   }
 
   function initRendererFixture(fixtureName) {
-    initGridRenderer(fixtureName == 'group');
-    if (fixtureName == 'details') {
+    initGridRenderer(fixtureName === 'group');
+    if (fixtureName === 'details') {
       grid.rowDetailsRenderer = (root) => (root.textContent = 'details');
     }
   }

--- a/packages/grid/test/data-provider.test.js
+++ b/packages/grid/test/data-provider.test.js
@@ -342,7 +342,7 @@ describe('data provider', () => {
       ['renderer', 'template'].forEach((type) => {
         describe(`${type}`, () => {
           beforeEach(() => {
-            if (type == 'renderer') {
+            if (type === 'renderer') {
               grid = fixtureSync(`
                 <vaadin-grid>
                   <vaadin-grid-column></vaadin-grid-column>

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -114,7 +114,7 @@ describe('selection', () => {
     describe(`${type} cells`, () => {
       beforeEach(() => {
         grid = fixtureSync(fixtures[type]);
-        if (type == 'renderer') {
+        if (type === 'renderer') {
           const cols = grid.children;
           cols[0].renderer = (root) => (root.textContent = 'foo');
           cols[1].renderer = (root) => (root.textContent = 'bar');
@@ -122,8 +122,8 @@ describe('selection', () => {
         configureGrid();
       });
 
-      (type == 'template' ? it : it.skip)('should reflect cell instance value', () => {
-        if (type == 'template') {
+      (type === 'template' ? it : it.skip)('should reflect cell instance value', () => {
+        if (type === 'template') {
           const cells = getRowCells(rows[0]);
           cells[0]._content.__templateInstance.selected = false;
           expect(cells[0]._content.__templateInstance.selected).to.be.false;

--- a/packages/login/test/login-submit.test.js
+++ b/packages/login/test/login-submit.test.js
@@ -35,7 +35,7 @@ describe('login form submit', () => {
     const input = element.querySelector('input');
     tabKeyUp(input);
     setTimeout(() => {
-      const selected = input.selectionEnd - input.selectionStart == input.value.length;
+      const selected = input.selectionEnd - input.selectionStart === input.value.length;
       expect(selected).to.be.true;
       done();
     }, 1);

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -206,8 +206,8 @@ class MessageList extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   _getIndexOfFocusableElement() {
-    const index = this._messages.findIndex((e) => e.tabIndex == 0);
-    return index != -1 ? index : 0;
+    const index = this._messages.findIndex((e) => e.tabIndex === 0);
+    return index !== -1 ? index : 0;
   }
 }
 

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -452,7 +452,7 @@ class Notification extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   _animatedRemoveNotificationCard() {
     this._card.setAttribute('closing', '');
     const name = getComputedStyle(this._card).getPropertyValue('animation-name');
-    if (name && name != 'none') {
+    if (name && name !== 'none') {
       const listener = () => {
         this._removeNotificationCard();
         this._card.removeEventListener('animationend', listener);

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -288,7 +288,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
     let value = parseFloat(this.value);
 
     if (!this.value) {
-      if ((this.min == 0 && incr < 0) || (this.max == 0 && incr > 0) || (this.max == 0 && this.min == 0)) {
+      if ((this.min === 0 && incr < 0) || (this.max === 0 && incr > 0) || (this.max === 0 && this.min === 0)) {
         incr = 0;
         value = 0;
       } else if ((this.max == null || this.max >= 0) && (this.min == null || this.min <= 0)) {
@@ -319,7 +319,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
     }
 
     const newValue = this._getIncrement(incr, value);
-    if (!this.value || incr == 0 || this._incrementIsInsideTheLimits(incr, value)) {
+    if (!this.value || incr === 0 || this._incrementIsInsideTheLimits(incr, value)) {
       this._setValue(newValue);
     }
   }

--- a/packages/progress-bar/src/vaadin-progress-mixin.js
+++ b/packages/progress-bar/src/vaadin-progress-mixin.js
@@ -92,7 +92,7 @@ export const ProgressMixin = (superClass) =>
     _normalizeValue(value, min, max) {
       let nV;
 
-      if (!value && value != 0) {
+      if (!value && value !== 0) {
         nV = 0;
       } else if (min >= max) {
         nV = 1;

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -687,7 +687,7 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   __createFakeFocusTarget() {
-    const isRTL = document.documentElement.getAttribute('dir') == 'rtl';
+    const isRTL = document.documentElement.getAttribute('dir') === 'rtl';
     const elem = document.createElement('textarea');
     // Reset box model
     elem.style.border = '0';
@@ -1056,7 +1056,7 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
       return;
     }
 
-    if (value == null || value == '[{"insert":"\\n"}]') {
+    if (value == null || value === '[{"insert":"\\n"}]') {
       this.value = '';
       return;
     }

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -260,7 +260,7 @@ class SplitLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
       if (i === 0) {
         this._primaryChild = child;
         child.setAttribute('slot', 'primary');
-      } else if (i == 1) {
+      } else if (i === 1) {
         this._secondaryChild = child;
         child.setAttribute('slot', 'secondary');
       } else {

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -251,7 +251,7 @@ class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(PolymerEleme
     let overflow = scrollPosition > 0 ? 'start' : '';
     overflow += scrollPosition + this._scrollOffset < scrollSize ? ' end' : '';
 
-    if (this.__direction == 1) {
+    if (this.__direction === 1) {
       overflow = overflow.replace(/start|end/gi, (matched) => {
         return matched === 'start' ? 'end' : 'start';
       });

--- a/packages/tabs/test/tabs.test.js
+++ b/packages/tabs/test/tabs.test.js
@@ -145,7 +145,7 @@ describe('tabs', () => {
 
             // Cannot set negative values to native scroll, monkey patching the properties
             let pixels = 0;
-            Object.defineProperty(scroll, orientation == 'horizontal' ? 'scrollLeft' : 'scrollTop', {
+            Object.defineProperty(scroll, orientation === 'horizontal' ? 'scrollLeft' : 'scrollTop', {
               get: () => pixels,
               set: (v) => {
                 pixels = v;

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -549,7 +549,7 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   _configureXhr(xhr) {
-    if (typeof this.headers == 'string') {
+    if (typeof this.headers === 'string') {
       try {
         this.headers = JSON.parse(this.headers);
       } catch (e) {
@@ -635,7 +635,7 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
 
     // More reliable than xhr.onload
     xhr.onreadystatechange = () => {
-      if (xhr.readyState == 4) {
+      if (xhr.readyState === 4) {
         clearTimeout(stalledId);
         file.indeterminate = file.uploading = false;
         if (file.abort) {
@@ -894,12 +894,12 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   _i18nPlural(value, plural) {
-    return value == 1 ? plural.one : plural.many;
+    return value === 1 ? plural.one : plural.many;
   }
 
   /** @private */
   _isMultiple(maxFiles) {
-    return maxFiles != 1;
+    return maxFiles !== 1;
   }
 
   /**

--- a/packages/upload/test/mock-http-request.js
+++ b/packages/upload/test/mock-http-request.js
@@ -269,9 +269,9 @@ MockHttpRequest.prototype = {
     mimetype = mimetype && mimetype.split(';', 1)[0];
     if (
       mimetype == null ||
-      mimetype == 'text/xml' ||
-      mimetype == 'application/xml' ||
-      (mimetype && mimetype.substring(mimetype.length - 4) == '+xml')
+      mimetype === 'text/xml' ||
+      mimetype === 'application/xml' ||
+      (mimetype && mimetype.substring(mimetype.length - 4) === '+xml')
     ) {
       // Attempt to produce an xml response
       // and it will fail if not a good xml
@@ -297,15 +297,15 @@ MockHttpRequest.prototype = {
       }
       // parse errors also yield a null.
       if (
-        (xmlDoc && xmlDoc.parseError && xmlDoc.parseError.errorCode != 0) ||
-        (xmlDoc && xmlDoc.documentElement && xmlDoc.documentElement.nodeName == 'parsererror') ||
+        (xmlDoc && xmlDoc.parseError && xmlDoc.parseError.errorCode !== 0) ||
+        (xmlDoc && xmlDoc.documentElement && xmlDoc.documentElement.nodeName === 'parsererror') ||
         (xmlDoc &&
           xmlDoc.documentElement &&
-          xmlDoc.documentElement.nodeName == 'html' &&
+          xmlDoc.documentElement.nodeName === 'html' &&
           xmlDoc.documentElement.firstChild &&
-          xmlDoc.documentElement.firstChild.nodeName == 'body' &&
+          xmlDoc.documentElement.firstChild.nodeName === 'body' &&
           xmlDoc.documentElement.firstChild.firstChild &&
-          xmlDoc.documentElement.firstChild.firstChild.nodeName == 'parsererror')
+          xmlDoc.documentElement.firstChild.firstChild.nodeName === 'parsererror')
       ) {
         xmlDoc = null;
       }

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -508,7 +508,7 @@ describe('upload', () => {
 
     it('should fire `file-remove` and remove from files', async () => {
       upload.addEventListener('upload-progress', (e) => {
-        if (e.detail.file == files[0] && e.detail.file.progress == 50) {
+        if (e.detail.file === files[0] && e.detail.file.progress === 50) {
           upload._abortFileUpload(e.detail.file);
         }
       });

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.js
@@ -240,7 +240,7 @@ export const ListMixin = (superClass) =>
      */
     _getAvailableIndex(idx, increment, condition) {
       const totalItems = this.items.length;
-      for (let i = 0; typeof idx == 'number' && i < totalItems; i++, idx += increment || 1) {
+      for (let i = 0; typeof idx === 'number' && i < totalItems; i++, idx += increment || 1) {
         if (idx < 0) {
           idx = totalItems - 1;
         } else if (idx >= totalItems) {

--- a/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.js
@@ -60,7 +60,7 @@ export const MultiSelectListMixin = (superClass) =>
 
       if (selectedValues) {
         const selectedItems = selectedValues.map((selectedId) => items[selectedId]);
-        items.forEach((item) => (item.selected = selectedItems.indexOf(item) !== -1));
+        items.forEach((item) => (item.selected = selectedItems.includes(item)));
       }
 
       this._scrollToLastSelectedItem();
@@ -86,7 +86,7 @@ export const MultiSelectListMixin = (superClass) =>
       }
 
       event.preventDefault();
-      if (this.selectedValues.indexOf(idx) !== -1) {
+      if (this.selectedValues.includes(idx)) {
         this.selectedValues = this.selectedValues.filter((v) => v !== idx);
       } else {
         this.selectedValues = this.selectedValues.concat(idx);

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -587,7 +587,7 @@ class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(PolymerEleme
   _shouldAnimate() {
     const name = getComputedStyle(this).getPropertyValue('animation-name');
     const hidden = getComputedStyle(this).getPropertyValue('display') === 'none';
-    return !hidden && name && name != 'none';
+    return !hidden && name && name !== 'none';
   }
 
   /**

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -483,7 +483,7 @@ class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(PolymerEleme
    * @private
    */
   _outsideClickListener(event) {
-    if (event.composedPath().indexOf(this.$.overlay) !== -1 || this._mouseDownInside || this._mouseUpInside) {
+    if (event.composedPath().includes(this.$.overlay) || this._mouseDownInside || this._mouseUpInside) {
       this._mouseDownInside = false;
       this._mouseUpInside = false;
       return;

--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -102,7 +102,7 @@ function parseLog(log) {
         result = /^ +([A-Z][\w-]+): +(.*)$/.exec(line);
         if (result) {
           const k = result[1].toLowerCase();
-          if (k == 'warranty') {
+          if (k === 'warranty') {
             commit.bfp = true;
           }
           if (/(fixes|fix|related-to|connected-to|warranty)/i.test(k)) {

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -24,7 +24,7 @@ async function exe(cmd, quiet) {
 
   return new Promise((resolve, reject) => {
     child.on('exit', async function (code) {
-      if (code == 0) {
+      if (code === 0) {
         resolve(out);
       } else {
         reject(`${quiet ? out : ''}\n!!! ERROR !!! Process '${cmd}' exited with code ${code}`);

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -32,9 +32,9 @@ const filterBrowserLogs = (log) => {
   return !isHidden;
 };
 
-const hasGroupParam = process.argv.indexOf('--group') !== -1;
-const hasCoverageParam = process.argv.indexOf('--coverage') !== -1;
-const hasAllParam = process.argv.indexOf('--all') !== -1;
+const hasGroupParam = process.argv.includes('--group');
+const hasCoverageParam = process.argv.includes('--coverage');
+const hasAllParam = process.argv.includes('--all');
 
 /**
  * Check if lockfile has changed.


### PR DESCRIPTION
## Description

The PR adds the following rules to the project's ESLint config:

- [x] eqeqeq

Along the way, I also replaced `indexOf(...) !== -1` with `includes(...)`.

Part of https://github.com/vaadin/eslint-config-vaadin/issues/16

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
