### PR TITLE
docs: restore missing DatePickerMixin

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -113,6 +113,7 @@ registerStyles('vaadin-date-picker', [inputFieldShared, datePickerStyles], { mod
  * @mixes ElementMixin
  * @mixes ThemableMixin
  * @mixes InputControlMixin
+ * @mixes DatePickerMixin
  */
 class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
   static get is() {


### PR DESCRIPTION
## Description

Restores `@mixes DatePickerMixin` on `vaadin-date-picker`. I think this was accidentally removed in https://github.com/vaadin/web-components/pull/2632
