### PR TITLE
test: update combo-box test to use helpers

### DIFF
--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -15,15 +15,10 @@ import {
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-combo-box.js';
-import { getViewportItems, getVisibleItemsCount, onceScrolled, scrollToIndex } from './helpers.js';
+import { getViewportItems, getVisibleItemsCount, onceScrolled, scrollToIndex, setInputValue } from './helpers.js';
 
 describe('keyboard', () => {
   let comboBox, input;
-
-  function filter(value) {
-    input.value = value;
-    fire(input, 'input');
-  }
 
   function getFocusedIndex() {
     return comboBox._focusedIndex;
@@ -138,7 +133,7 @@ describe('keyboard', () => {
     });
 
     it('should focus only on filtered items', () => {
-      filter('foo');
+      setInputValue(comboBox, 'foo');
       arrowDownKeyDown(input);
 
       expect(getFocusedIndex()).to.equal(0);
@@ -202,7 +197,7 @@ describe('keyboard', () => {
       });
 
       it('should clear the selection with enter when input is cleared', () => {
-        filter('');
+        setInputValue(comboBox, '');
         enterKeyDown(input);
 
         expect(comboBox.value).to.eql('');
@@ -210,7 +205,7 @@ describe('keyboard', () => {
 
       it('should close the overlay with enter when custom values are allowed', () => {
         comboBox.allowCustomValue = true;
-        filter('foobar');
+        setInputValue(comboBox, 'foobar');
 
         enterKeyDown(input);
 
@@ -226,7 +221,7 @@ describe('keyboard', () => {
       });
 
       it('should stop propagation of the keyboard enter event when input value is invalid', () => {
-        filter('foobar');
+        setInputValue(comboBox, 'foobar');
         const keydownSpy = sinon.spy();
         document.addEventListener('keydown', keydownSpy);
         enterKeyDown(input);
@@ -234,7 +229,7 @@ describe('keyboard', () => {
       });
 
       it('should not close the overlay with enter when custom values are not allowed', () => {
-        filter('foobar');
+        setInputValue(comboBox, 'foobar');
 
         enterKeyDown(input);
 
@@ -245,7 +240,7 @@ describe('keyboard', () => {
       it('should revert to the custom value after filtering', () => {
         comboBox.allowCustomValue = true;
         comboBox.value = 'foobar';
-        filter('bar');
+        setInputValue(comboBox, 'bar');
         escKeyDown(input);
         expect(input.value).to.eql('bar');
         escKeyDown(input);
@@ -255,7 +250,7 @@ describe('keyboard', () => {
       it('should revert a non-listed value to the custom value after filtering', () => {
         comboBox.allowCustomValue = true;
         comboBox.value = 'foobar';
-        filter('barbaz');
+        setInputValue(comboBox, 'barbaz');
         escKeyDown(input);
         expect(input.value).to.equal('foobar');
       });
@@ -304,7 +299,7 @@ describe('keyboard', () => {
       });
 
       it('should cancel typing with escape', () => {
-        filter('baz');
+        setInputValue(comboBox, 'baz');
 
         escKeyDown(input);
 
@@ -312,7 +307,7 @@ describe('keyboard', () => {
       });
 
       it('should select typed item', () => {
-        filter('baz');
+        setInputValue(comboBox, 'baz');
 
         enterKeyDown(input);
 
@@ -336,7 +331,7 @@ describe('keyboard', () => {
       });
 
       it('should not prefill the input when there are no items to navigate', () => {
-        filter('invalid filter');
+        setInputValue(comboBox, 'invalid filter');
 
         arrowDownKeyDown(input);
         expect(input.value).to.eql('invalid filter');
@@ -349,7 +344,7 @@ describe('keyboard', () => {
       });
 
       it('should revert back to filter with escape', async () => {
-        filter('b');
+        setInputValue(comboBox, 'b');
 
         arrowDownKeyDown(input);
         await aTimeout(1);
@@ -359,7 +354,7 @@ describe('keyboard', () => {
       });
 
       it('should remove selection from the input value when reverting', () => {
-        filter('b');
+        setInputValue(comboBox, 'b');
         arrowDownKeyDown(input);
         escKeyDown(input);
 
@@ -418,7 +413,7 @@ describe('keyboard', () => {
       });
 
       it('should stop propagation of the keyboard enter event when input value is invalid', () => {
-        filter('foobar');
+        setInputValue(comboBox, 'foobar');
         const keydownSpy = sinon.spy();
         document.addEventListener('keydown', keydownSpy);
         enterKeyDown(input);
@@ -426,7 +421,7 @@ describe('keyboard', () => {
       });
 
       it('should not stop propagation of the keyboard enter event when input has a predefined option', async () => {
-        filter('foo');
+        setInputValue(comboBox, 'foo');
         expect(comboBox.opened).to.be.false;
         const keydownSpy = sinon.spy();
         document.addEventListener('keydown', keydownSpy);
@@ -436,7 +431,7 @@ describe('keyboard', () => {
 
       it('should not stop propagation of the keyboard enter event when input has a custom value', () => {
         comboBox.allowCustomValue = true;
-        filter('foobar');
+        setInputValue(comboBox, 'foobar');
         const keydownSpy = sinon.spy();
         document.addEventListener('keydown', keydownSpy);
         enterKeyDown(input);
@@ -445,7 +440,7 @@ describe('keyboard', () => {
 
       it('should not stop propagation of the keyboard enter event when input is empty', () => {
         comboBox.allowCustomValue = true;
-        filter('');
+        setInputValue(comboBox, '');
         const keydownSpy = sinon.spy();
         document.addEventListener('keydown', keydownSpy);
         enterKeyDown(input);

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, enterKeyDown, fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, enterKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
 import './not-animated-styles.js';
@@ -14,7 +14,8 @@ import {
   getSelectedItem,
   getViewportItems,
   getVisibleItemsCount,
-  makeItems
+  makeItems,
+  setInputValue
 } from './helpers.js';
 
 registerStyles(
@@ -55,15 +56,6 @@ describe('lazy loading', () => {
       return { id: i, value: `value ${i}`, label: `label ${i}` };
     });
     callback(dataProviderItems, SIZE);
-  };
-
-  const setInputValue = (value) => {
-    if (comboBox.inputElement.tagName === 'IRON-INPUT') {
-      comboBox.inputElement._initSlottedInput();
-      comboBox.inputElement.inputElement.value = value;
-    } else {
-      comboBox.inputElement.value = value;
-    }
   };
 
   before(() => {
@@ -141,8 +133,7 @@ describe('lazy loading', () => {
           expect(comboBox.autoOpenDisabled).to.be.true;
           expect(comboBox.opened).to.be.false;
           comboBox.dataProvider = spyDataProvider;
-          setInputValue('item 1');
-          fire(comboBox.inputElement, 'input');
+          setInputValue(comboBox, 'item 1');
           comboBox.opened = true;
           expect(comboBox.filter).to.equal('item 1');
           const { filter } = spyDataProvider.lastCall.args[0];
@@ -351,8 +342,7 @@ describe('lazy loading', () => {
 
         // FIXME: fails for combo-box-light (items are not updated)
         (isComboBoxLight ? it.skip : it)('should not be invoked if items are filtered', () => {
-          setInputValue('1');
-          fire(comboBox.inputElement, 'input');
+          setInputValue(comboBox, '1');
 
           spyDataProvider.resetHistory();
 
@@ -414,8 +404,7 @@ describe('lazy loading', () => {
           comboBox.dataProvider = spyAsyncDataProvider;
           comboBox.opened = true;
 
-          setInputValue('custom value');
-          fire(comboBox.inputElement, 'input');
+          setInputValue(comboBox, 'custom value');
 
           enterKeyDown(comboBox.inputElement);
           expect(comboBox.value).to.eql('custom value');
@@ -888,9 +877,15 @@ describe('lazy loading', () => {
 
       describe('using data provider, lost focus before data is returned', () => {
         let returnedItems;
+
         const bluringDataProvider = (params, callback) => {
           comboBox.blur();
           callback(returnedItems, returnedItems.length);
+        };
+
+        const setFilterValue = (filterValue) => {
+          comboBox._inputElementValue = filterValue;
+          comboBox.filter = filterValue;
         };
 
         beforeEach(() => {
@@ -906,9 +901,8 @@ describe('lazy loading', () => {
           comboBox.autoOpenDisabled = false;
           expect(comboBox.autoOpenDisabled).to.be.false;
 
-          const filterValue = 'item 12';
-          comboBox._inputElementValue = filterValue;
-          comboBox.filter = filterValue;
+          setFilterValue('item 12');
+
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('item 12');
@@ -918,9 +912,8 @@ describe('lazy loading', () => {
           comboBox.autoOpenDisabled = true;
           expect(comboBox.autoOpenDisabled).to.be.true;
 
-          const filterValue = 'item 12';
-          comboBox._inputElementValue = filterValue;
-          comboBox.filter = filterValue;
+          setFilterValue('item 12');
+
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('item 12');
@@ -930,9 +923,8 @@ describe('lazy loading', () => {
           comboBox.autoOpenDisabled = false;
           expect(comboBox.autoOpenDisabled).to.be.false;
 
-          const filterValue = 'ItEm 12';
-          comboBox._inputElementValue = filterValue;
-          comboBox.filter = filterValue;
+          setFilterValue('ItEm 12');
+
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('item 12');
@@ -942,9 +934,8 @@ describe('lazy loading', () => {
           comboBox.autoOpenDisabled = true;
           expect(comboBox.autoOpenDisabled).to.be.true;
 
-          const filterValue = 'iTem 12';
-          comboBox._inputElementValue = filterValue;
-          comboBox.filter = filterValue;
+          setFilterValue('iTem 12');
+
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('item 12');
@@ -953,17 +944,15 @@ describe('lazy loading', () => {
         it('should set first value of multiple matches that differ only in case', () => {
           returnedItems = ['item 12', 'IteM 12'];
 
-          const filterValue = 'IteM 12';
-          comboBox._inputElementValue = filterValue;
-          comboBox.filter = filterValue;
+          setFilterValue('IteM 12');
+
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('item 12');
         });
 
         it('should keep empty value if it is not an exact match', () => {
-          comboBox._inputElementValue = 'item';
-          comboBox.filter = 'item';
+          setFilterValue('item');
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('');
@@ -975,9 +964,8 @@ describe('lazy loading', () => {
           expect(comboBox.value).to.equal('other value');
 
           returnedItems = ['item 12'];
-          const filterValue = 'item 1';
-          comboBox._inputElementValue = filterValue;
-          comboBox.filter = filterValue;
+          setFilterValue('item 1');
+
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('other value');
@@ -986,14 +974,12 @@ describe('lazy loading', () => {
         it('should keep previous value if allow-custom-value is set', () => {
           comboBox.allowCustomValue = true;
           comboBox.open();
-          setInputValue('other value');
-          fire(comboBox.inputElement, 'input');
+          setInputValue(comboBox, 'other value');
           comboBox.close();
           expect(comboBox.value).to.eql('other value');
 
           comboBox.focus();
-          setInputValue('item 12');
-          comboBox.filter = 'item 12';
+          setFilterValue('item 12');
 
           expect(comboBox.value).to.eql('other value');
           expect(comboBox.inputElement.value).to.eql('other value');

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -884,7 +884,7 @@ describe('lazy loading', () => {
         };
 
         const setFilterValue = (filterValue) => {
-          comboBox._inputElementValue = filterValue;
+          comboBox.inputElement.value = filterValue;
           comboBox.filter = filterValue;
         };
 

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -883,25 +883,20 @@ describe('lazy loading', () => {
           callback(returnedItems, returnedItems.length);
         };
 
-        const setFilterValue = (filterValue) => {
-          comboBox.inputElement.value = filterValue;
-          comboBox.filter = filterValue;
-        };
-
         beforeEach(() => {
           returnedItems = ['item 12'];
           comboBox.focus();
           comboBox.opened = true;
           comboBox.dataProvider = bluringDataProvider;
           comboBox.opened = false;
-          comboBox.focus();
+          comboBox.inputElement.focus();
         });
 
         it('should set value without auto-open-disabled', () => {
           comboBox.autoOpenDisabled = false;
           expect(comboBox.autoOpenDisabled).to.be.false;
 
-          setFilterValue('item 12');
+          setInputValue(comboBox, 'item 12');
 
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
@@ -912,7 +907,7 @@ describe('lazy loading', () => {
           comboBox.autoOpenDisabled = true;
           expect(comboBox.autoOpenDisabled).to.be.true;
 
-          setFilterValue('item 12');
+          setInputValue(comboBox, 'item 12');
 
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
@@ -923,7 +918,7 @@ describe('lazy loading', () => {
           comboBox.autoOpenDisabled = false;
           expect(comboBox.autoOpenDisabled).to.be.false;
 
-          setFilterValue('ItEm 12');
+          setInputValue(comboBox, 'ItEm 12');
 
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
@@ -934,7 +929,7 @@ describe('lazy loading', () => {
           comboBox.autoOpenDisabled = true;
           expect(comboBox.autoOpenDisabled).to.be.true;
 
-          setFilterValue('iTem 12');
+          setInputValue(comboBox, 'iTem 12');
 
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
@@ -944,7 +939,7 @@ describe('lazy loading', () => {
         it('should set first value of multiple matches that differ only in case', () => {
           returnedItems = ['item 12', 'IteM 12'];
 
-          setFilterValue('IteM 12');
+          setInputValue(comboBox, 'IteM 12');
 
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
@@ -952,7 +947,7 @@ describe('lazy loading', () => {
         });
 
         it('should keep empty value if it is not an exact match', () => {
-          setFilterValue('item');
+          setInputValue(comboBox, 'item');
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('');
@@ -964,7 +959,7 @@ describe('lazy loading', () => {
           expect(comboBox.value).to.equal('other value');
 
           returnedItems = ['item 12'];
-          setFilterValue('item 1');
+          setInputValue(comboBox, 'item 1');
 
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
@@ -979,7 +974,10 @@ describe('lazy loading', () => {
           expect(comboBox.value).to.eql('other value');
 
           comboBox.focus();
-          setFilterValue('item 12');
+          // FIXME: fails when using `setInputValue()`
+          const filterValue = 'item 12';
+          comboBox.inputElement.value = filterValue;
+          comboBox.filter = filterValue;
 
           expect(comboBox.value).to.eql('other value');
           expect(comboBox.inputElement.value).to.eql('other value');

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fire, fixtureSync, isIOS } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, isIOS } from '@vaadin/testing-helpers';
 import '../src/vaadin-combo-box.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { makeItems } from './helpers.js';
+import { makeItems, setInputValue } from './helpers.js';
 
 class XFixed extends PolymerElement {
   static get template() {
@@ -17,7 +17,7 @@ class XFixed extends PolymerElement {
 customElements.define('x-fixed', XFixed);
 
 describe('overlay position', () => {
-  let comboBox, dropdown, overlayPart, inputField, input;
+  let comboBox, dropdown, overlayPart, inputField;
 
   let wh, ww, xCenter, xStart, xEnd, yCenter, yTop, yBottom;
 
@@ -39,7 +39,6 @@ describe('overlay position', () => {
     inputField = comboBox.shadowRoot.querySelector('[part="input-field"]');
     dropdown = comboBox.$.dropdown;
     overlayPart = dropdown.$.overlay.$.overlay;
-    input = comboBox.inputElement;
 
     // Subtract the combo-box size from the coordinates range in order not to
     // move it outside the viewport boundaries when changing top and left.
@@ -164,8 +163,7 @@ describe('overlay position', () => {
     it('should reposition after filtering', async () => {
       moveComboBox(xCenter, yBottom, 300);
 
-      input.value = 'item 1';
-      fire(input, 'input');
+      setInputValue(comboBox, 'item 1');
 
       comboBox.open();
       await aTimeout(0);

--- a/packages/combo-box/test/selecting-items.test.js
+++ b/packages/combo-box/test/selecting-items.test.js
@@ -3,7 +3,7 @@ import { aTimeout, fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
-import { getAllItems, getFirstItem, onceScrolled, scrollToIndex, selectItem } from './helpers.js';
+import { getAllItems, getFirstItem, onceScrolled, scrollToIndex, selectItem, setInputValue } from './helpers.js';
 
 describe('selecting items', () => {
   let comboBox;
@@ -308,11 +308,6 @@ describe('clearing a selection', () => {
 describe('selecting a custom value', () => {
   let comboBox;
 
-  function filter(value) {
-    comboBox.inputElement.value = value;
-    fire(comboBox.inputElement, 'input');
-  }
-
   beforeEach(async () => {
     comboBox = fixtureSync('<vaadin-combo-box style="width: 320px" allow-custom-value></vaadin-combo-box>');
     comboBox.items = ['foo', 'bar', 'barbar'];
@@ -321,7 +316,7 @@ describe('selecting a custom value', () => {
   });
 
   it('should select a value when closing when having a single exact match', () => {
-    filter('barbar');
+    setInputValue(comboBox, 'barbar');
 
     comboBox.close();
 
@@ -329,7 +324,7 @@ describe('selecting a custom value', () => {
   });
 
   it('should select a value when closing when having multiple matches', () => {
-    filter('BAR');
+    setInputValue(comboBox, 'BAR');
 
     comboBox.close();
 
@@ -339,7 +334,7 @@ describe('selecting a custom value', () => {
   it('should clear the selection when closing the overlay and input is cleared', () => {
     comboBox.value = 'foo';
 
-    filter('');
+    setInputValue(comboBox, '');
 
     comboBox.close();
 
@@ -362,7 +357,7 @@ describe('selecting a custom value', () => {
   it('should clear the custom value on clear', () => {
     comboBox.value = 'foobar';
 
-    filter('');
+    setInputValue(comboBox, '');
 
     comboBox.close();
 


### PR DESCRIPTION
## Description

Did some cleanup to use `setInputValue()` helper instead of duplicating `filter()` helper functions in tests.

## Type of change

- Tests