### PR TITLE
refactor: simplify selectors in dialog styles

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -20,11 +20,6 @@ registerStyles(
       height: var(--_vaadin-confirm-dialog-content-height);
     }
 
-    /* Override display: contents */
-    :host([has-header]) ::slotted([slot='header']) {
-      display: block;
-    }
-
     /* Make buttons clickable */
     [part='footer'] > * {
       pointer-events: all;

--- a/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
+++ b/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
@@ -5,7 +5,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-confirm-dialog-overlay',
   css`
-    :host([has-header]) [part='header'] ::slotted(h3) {
+    [part='header'] ::slotted(h3) {
       margin-top: 0 !important;
       margin-bottom: 0 !important;
       margin-inline-start: calc(var(--lumo-space-l) - var(--lumo-space-m));
@@ -27,7 +27,7 @@ registerStyles(
     }
 
     @media (max-width: 360px) {
-      :host([has-footer]) [part='footer'] {
+      [part='footer'] {
         flex-direction: column-reverse;
         align-items: stretch;
         padding: var(--lumo-space-s) var(--lumo-space-l);

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -15,14 +15,9 @@ registerStyles(
       min-width: 20em;
     }
 
-    footer[part='footer'] {
+    [part='footer'] {
       justify-content: flex-start;
       flex-direction: row-reverse;
-    }
-
-    /* Override display: contents */
-    :host([has-header]) ::slotted([slot='header']) {
-      display: block;
     }
 
     /* Make buttons clickable */

--- a/packages/crud/theme/lumo/vaadin-crud-styles.js
+++ b/packages/crud/theme/lumo/vaadin-crud-styles.js
@@ -131,7 +131,7 @@ registerStyles(
   [
     editorStyles,
     css`
-      :host([has-header]) [part='header'] ::slotted(h3) {
+      [part='header'] ::slotted(h3) {
         margin-top: 0 !important;
         margin-bottom: 0 !important;
         margin-inline-start: var(--lumo-space-s);

--- a/packages/crud/theme/material/vaadin-crud-styles.js
+++ b/packages/crud/theme/material/vaadin-crud-styles.js
@@ -129,7 +129,7 @@ registerStyles(
         animation: 0.25s material-overlay-dummy-animation;
       }
 
-      :host([has-header]) [part='header'] ::slotted(h3) {
+      [part='header'] ::slotted(h3) {
         margin-top: 0 !important;
         margin-bottom: 0 !important;
       }

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -15,10 +15,9 @@ import { DialogResizableMixin } from './vaadin-dialog-resizable-mixin.js';
 registerStyles(
   'vaadin-dialog-overlay',
   css`
-    /* prefixing with the element tags to avoid styling confirm-dialog header part */
-    header[part='header'],
+    [part='header'],
     [part='header-content'],
-    footer[part='footer'] {
+    [part='footer'] {
       display: flex;
       align-items: center;
       flex-wrap: wrap;
@@ -27,10 +26,9 @@ registerStyles(
       z-index: 1;
     }
 
-    :host(:is([has-title], [has-header])) ::slotted([slot='header']),
     ::slotted([slot='header-content']),
     ::slotted([slot='title']),
-    :host([has-footer]) ::slotted([slot='footer']) {
+    ::slotted([slot='footer']) {
       display: contents;
       pointer-events: auto;
     }
@@ -39,19 +37,16 @@ registerStyles(
       flex: 1;
     }
 
-    /* prefixing with the element tag to avoid styling confirm-dialog footer part */
     :host([has-title]) [part='header-content'],
-    footer[part='footer'] {
+    [part='footer'] {
       justify-content: flex-end;
     }
 
-    :host(:not([has-title]):not([has-header])) header[part='header'],
-    :host(:not([has-title])) [part='title'] {
-      display: none;
-    }
-
-    :host(:not([has-footer])) footer[part='footer'] {
-      display: none;
+    :host(:not([has-title]):not([has-header])) [part='header'],
+    :host(:not([has-header])) [part='header-content'],
+    :host(:not([has-title])) [part='title'],
+    :host(:not([has-footer])) [part='footer'] {
+      display: none !important;
     }
 
     :host(:is([has-title], [has-header], [has-footer])) [part='content'] {

--- a/packages/dialog/theme/lumo/vaadin-dialog-styles.js
+++ b/packages/dialog/theme/lumo/vaadin-dialog-styles.js
@@ -31,20 +31,20 @@ const dialogOverlay = css`
     padding-top: 0;
   }
 
-  :host(:is([has-header], [has-title])) [part='header'],
-  :host([has-header]) [part='header-content'],
-  :host([has-footer]) [part='footer'] {
+  [part='header'],
+  [part='header-content'],
+  [part='footer'] {
     gap: var(--lumo-space-xs) var(--lumo-space-s);
     line-height: var(--lumo-line-height-s);
   }
 
-  :host(:is([has-header], [has-title])) [part='header'] {
+  [part='header'] {
     padding: var(--lumo-space-m);
     background-color: var(--lumo-base-color);
     border-radius: var(--lumo-border-radius-l) var(--lumo-border-radius-l) 0 0; /* Needed for Safari */
   }
 
-  :host([has-footer]) [part='footer'] {
+  [part='footer'] {
     padding: var(--lumo-space-s) var(--lumo-space-m);
     background-color: var(--lumo-contrast-5pct);
     border-radius: 0 0 var(--lumo-border-radius-l) var(--lumo-border-radius-l); /* Needed for Safari */
@@ -63,7 +63,7 @@ const dialogOverlay = css`
   }
 
   @media (min-height: 320px) {
-    :host(:is([has-header], [has-title])[overflow~='top']) [part='header'] {
+    :host([overflow~='top']) [part='header'] {
       box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct);
     }
   }

--- a/packages/dialog/theme/material/vaadin-dialog-styles.js
+++ b/packages/dialog/theme/material/vaadin-dialog-styles.js
@@ -16,7 +16,7 @@ const dialogOverlay = css`
     padding: 24px;
   }
 
-  :host(:is([has-header], [has-title])) [part='header'] {
+  [part='header'] {
     padding: 16px;
   }
 
@@ -24,9 +24,9 @@ const dialogOverlay = css`
     padding-top: 0;
   }
 
-  :host(:is([has-header], [has-title])) [part='header'],
-  :host([has-header]) [part='header-content'],
-  :host([has-footer]) [part='footer'] {
+  [part='header'],
+  [part='header-content'],
+  [part='footer'] {
     gap: 8px;
     line-height: 1.2;
   }
@@ -37,16 +37,16 @@ const dialogOverlay = css`
     margin-inline-start: 8px;
   }
 
-  :host([has-footer]) [part='footer'] {
+  [part='footer'] {
     padding: 8px;
   }
 
   @media (min-height: 320px) {
-    :host(:is([has-header], [has-title])[overflow~='top']) [part='header'] {
+    :host([overflow~='top']) [part='header'] {
       box-shadow: 0 1px 0 0 var(--material-divider-color);
     }
 
-    :host([has-footer][overflow~='bottom']) [part='footer'] {
+    :host([overflow~='bottom']) [part='footer'] {
       box-shadow: 0 -1px 0 0 var(--material-divider-color);
     }
   }


### PR DESCRIPTION
## Description

Updated CSS to simplify selectors now when `vaadin-confirm-dialog` and `vaadin-crud` are updated to use new `header` and `footer` parts, so we no longer need prefixing workarounds that we originally had to implement.

## Type of change

- Refactor