### PR TITLE
fix: Remove -webkit-overflow-scrolling style setting

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -956,8 +956,6 @@ class Grid extends ElementMixin(
 
       requestAnimationFrame(() => {
         this.__scrollToPendingIndex();
-        // This needs to be set programmatically in order to avoid an iOS 10 bug (disappearing grid)
-        this.$.table.style.webkitOverflowScrolling = 'touch';
       });
     }
   }


### PR DESCRIPTION
This workaround was needed for iOS 10.

The  -webkit-overflow-scrolling is not supported after iOS 12. Vaadin 23 does not support these old versions, thus this setting is not needed anymore.

Furthermore, programmatic setting is prone to timing glitches.

Fixes https://github.com/vaadin/flow-components/issues/3037