### PR TITLE
feat: add screen reader announcements support

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
@@ -17,6 +17,19 @@ class MultiSelectComboBoxScroller extends ComboBoxScroller {
     return 'vaadin-multi-select-combo-box-scroller';
   }
 
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.setAttribute('aria-multiselectable', 'true');
+  }
+
+  /** @private */
+  __getAriaSelected(_focusedIndex, itemIndex) {
+    const item = this.items[itemIndex];
+    return this.__isItemSelected(item, null, this.itemIdPath).toString();
+  }
+
   /** @private */
   __isItemSelected(item, _selectedItem, itemIdPath) {
     if (item instanceof ComboBoxPlaceholder) {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -20,6 +20,13 @@ import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
+export interface MultiSelectComboBoxI18n {
+  cleared: string;
+  selected: string;
+  deselected: string;
+  total: string;
+}
+
 /**
  * Fired when the user commits a value change.
  */
@@ -198,6 +205,28 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
    * @attr {string} item-value-path
    */
   itemValuePath: string;
+
+  /**
+   * The object used to localize this component.
+   * To change the default localization, replace the entire
+   * _i18n_ object or just the property you want to modify.
+   *
+   * The object has the following JSON structure and default values:
+   * ```
+   * {
+   *   // Screen reader announcement on clear button click.
+   *   cleared: 'Selection cleared',
+   *   // Screen reader announcement when item is selected.
+   *   selected: 'added to selection',
+   *   // Screen reader announcement when item is deselected.
+   *   deselected: 'removed from selection',
+   *   // Screen reader announcement of the selected items count.
+   *   // {count} is replaced with the actual count of items.
+   *   total: '{count} items selected',
+   * }
+   * ```
+   */
+  i18n: MultiSelectComboBoxI18n;
 
   /**
    * True if the dropdown is open, false otherwise.

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -7,6 +7,7 @@ import './vaadin-multi-select-combo-box-chip.js';
 import './vaadin-multi-select-combo-box-container.js';
 import './vaadin-multi-select-combo-box-internal.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { announce } from '@vaadin/component-base/src/a11y-announcer.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
@@ -249,6 +250,40 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       itemIdPath: {
         type: String,
+      },
+
+      /**
+       * The object used to localize this component.
+       * To change the default localization, replace the entire
+       * _i18n_ object or just the property you want to modify.
+       *
+       * The object has the following JSON structure and default values:
+       * ```
+       * {
+       *   // Screen reader announcement on clear button click.
+       *   cleared: 'Selection cleared',
+       *   // Screen reader announcement when item is selected.
+       *   selected: 'added to selection',
+       *   // Screen reader announcement when item is deselected.
+       *   deselected: 'removed from selection',
+       *   // Screen reader announcement of the selected items count.
+       *   // {count} is replaced with the actual count of items.
+       *   total: '{count} items selected',
+       * }
+       * ```
+       * @type {!MultiSelectComboBoxI18n}
+       * @default {English/US}
+       */
+      i18n: {
+        type: Object,
+        value: () => {
+          return {
+            cleared: 'Selection cleared',
+            selected: 'added to selection',
+            deselected: 'removed from selection',
+            total: '{count} items selected',
+          };
+        },
       },
 
       /**
@@ -574,10 +609,18 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /** @private */
+  __announceItem(itemLabel, isSelected, itemCount) {
+    const state = isSelected ? 'selected' : 'deselected';
+    const total = this.i18n.total.replace('{count}', itemCount || 0);
+    announce(`${itemLabel} ${this.i18n[state]} ${total}`);
+  }
+
+  /** @private */
   __removeItem(item) {
     const itemsCopy = [...this.selectedItems];
     itemsCopy.splice(itemsCopy.indexOf(item), 1);
     this.__updateSelection(itemsCopy);
+    this.__announceItem(item, false, itemsCopy.length);
   }
 
   /** @private */
@@ -585,9 +628,13 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     const itemsCopy = [...this.selectedItems];
 
     const index = this._findIndex(item, itemsCopy, this.itemIdPath);
+    const itemLabel = this._getItemLabel(item, this.itemLabelPath);
+
+    let isSelected = false;
+
     if (index !== -1) {
       // Do not unselect when manually typing and committing an already selected item.
-      if (this.filter.toLowerCase() === this._getItemLabel(item, this.itemLabelPath).toLowerCase()) {
+      if (this.filter.toLowerCase() === itemLabel.toLowerCase()) {
         this.__clearFilter();
         return;
       }
@@ -595,12 +642,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       itemsCopy.splice(index, 1);
     } else {
       itemsCopy.push(item);
+      isSelected = true;
     }
 
     this.__updateSelection(itemsCopy);
 
     // Suppress `value-changed` event.
     this.__clearFilter();
+
+    this.__announceItem(itemLabel, isSelected, itemsCopy.length);
   }
 
   /** @private */
@@ -708,6 +758,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     event.stopPropagation();
 
     this.__updateSelection([]);
+
+    announce(this.i18n.cleared);
   }
 
   /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -559,6 +559,14 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     this._toggleHasValue();
 
+    // Use placeholder for announcing items
+    if (this._hasValue) {
+      this.__savedPlaceholder = this.placeholder;
+      this.placeholder = selectedItems.map((item) => this._getItemLabel(item, this.itemLabelPath)).join(', ');
+    } else {
+      this.placeholder = this.__savedPlaceholder;
+    }
+
     // Re-render chips
     this.__updateChips();
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -500,6 +500,26 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /**
+   * Override method from `DelegateStateMixin` to set required state
+   * using `aria-required` attribute instead of `required`, in order
+   * to prevent screen readers from announcing "invalid entry".
+   * @protected
+   * @override
+   */
+  _delegateAttribute(name, value) {
+    if (!this.stateTarget) {
+      return;
+    }
+
+    if (name === 'required') {
+      this._delegateAttribute('aria-required', value ? 'true' : false);
+      return;
+    }
+
+    super._delegateAttribute(name, value);
+  }
+
+  /**
    * Setting clear button visible reduces total space available
    * for rendering chips, and making it hidden increases it.
    * @private

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -16,32 +16,53 @@ describe('accessibility', () => {
   describe('ARIA', () => {
     let scroller, items;
 
-    beforeEach(() => {
-      comboBox.selectedItems = ['Apple', 'Lemon'];
-      inputElement.click();
-      scroller = comboBox.$.comboBox.$.dropdown._scroller;
-      items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+    describe('input', () => {
+      beforeEach(() => {
+        comboBox.required = true;
+      });
+
+      it('should set aria-required attribute on the input when required', () => {
+        expect(inputElement.getAttribute('aria-required')).to.equal('true');
+      });
+
+      it('should not set required attribute on the input when required', () => {
+        expect(inputElement.hasAttribute('required')).to.be.false;
+      });
+
+      it('should remove aria-required attribute from the input when not required', () => {
+        comboBox.required = false;
+        expect(inputElement.hasAttribute('aria-required')).to.be.false;
+      });
     });
 
-    it('should set aria-multiselectable attribute on the scroller', () => {
-      expect(scroller.getAttribute('aria-multiselectable')).to.equal('true');
-    });
+    describe('items', () => {
+      beforeEach(() => {
+        comboBox.selectedItems = ['Apple', 'Lemon'];
+        inputElement.click();
+        scroller = comboBox.$.comboBox.$.dropdown._scroller;
+        items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      });
 
-    it('should set aria-selected on the selected item elements', () => {
-      expect(items[0].getAttribute('aria-selected')).to.equal('true');
-      expect(items[1].getAttribute('aria-selected')).to.equal('false');
-      expect(items[2].getAttribute('aria-selected')).to.equal('true');
-      expect(items[3].getAttribute('aria-selected')).to.equal('false');
-    });
+      it('should set aria-multiselectable attribute on the scroller', () => {
+        expect(scroller.getAttribute('aria-multiselectable')).to.equal('true');
+      });
 
-    it('should update aria-selected when item is selected', () => {
-      items[1].click();
-      expect(items[1].getAttribute('aria-selected')).to.equal('true');
-    });
+      it('should set aria-selected on the selected item elements', () => {
+        expect(items[0].getAttribute('aria-selected')).to.equal('true');
+        expect(items[1].getAttribute('aria-selected')).to.equal('false');
+        expect(items[2].getAttribute('aria-selected')).to.equal('true');
+        expect(items[3].getAttribute('aria-selected')).to.equal('false');
+      });
 
-    it('should update aria-selected when item is deselected', () => {
-      items[0].click();
-      expect(items[0].getAttribute('aria-selected')).to.equal('false');
+      it('should update aria-selected when item is selected', () => {
+        items[1].click();
+        expect(items[1].getAttribute('aria-selected')).to.equal('true');
+      });
+
+      it('should update aria-selected when item is deselected', () => {
+        items[0].click();
+        expect(items[0].getAttribute('aria-selected')).to.equal('false');
+      });
     });
   });
 

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -17,21 +17,40 @@ describe('accessibility', () => {
     let scroller, items;
 
     describe('input', () => {
-      beforeEach(() => {
-        comboBox.required = true;
+      describe('required', () => {
+        beforeEach(() => {
+          comboBox.required = true;
+        });
+
+        it('should set aria-required attribute on the input when required', () => {
+          expect(inputElement.getAttribute('aria-required')).to.equal('true');
+        });
+
+        it('should not set required attribute on the input when required', () => {
+          expect(inputElement.hasAttribute('required')).to.be.false;
+        });
+
+        it('should remove aria-required attribute from the input when not required', () => {
+          comboBox.required = false;
+          expect(inputElement.hasAttribute('aria-required')).to.be.false;
+        });
       });
 
-      it('should set aria-required attribute on the input when required', () => {
-        expect(inputElement.getAttribute('aria-required')).to.equal('true');
-      });
+      describe('placeholder', () => {
+        beforeEach(() => {
+          comboBox.placeholder = 'Fruits';
+        });
 
-      it('should not set required attribute on the input when required', () => {
-        expect(inputElement.hasAttribute('required')).to.be.false;
-      });
+        it('should set input placeholder when selected items are changed', () => {
+          comboBox.selectedItems = ['Apple', 'Banana'];
+          expect(inputElement.getAttribute('placeholder')).to.equal('Apple, Banana');
+        });
 
-      it('should remove aria-required attribute from the input when not required', () => {
-        comboBox.required = false;
-        expect(inputElement.hasAttribute('aria-required')).to.be.false;
+        it('should restore original placeholder when selected items are removed', () => {
+          comboBox.selectedItems = ['Apple', 'Banana'];
+          comboBox.selectedItems = [];
+          expect(inputElement.getAttribute('placeholder')).to.equal('Fruits');
+        });
       });
     });
 

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -1,0 +1,97 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './not-animated-styles.js';
+import '../vaadin-multi-select-combo-box.js';
+
+describe('accessibility', () => {
+  let comboBox, inputElement;
+
+  beforeEach(() => {
+    comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
+    comboBox.items = ['Apple', 'Banana', 'Lemon', 'Orange'];
+    inputElement = comboBox.inputElement;
+  });
+
+  describe('ARIA', () => {
+    let scroller, items;
+
+    beforeEach(() => {
+      comboBox.selectedItems = ['Apple', 'Lemon'];
+      inputElement.click();
+      scroller = comboBox.$.comboBox.$.dropdown._scroller;
+      items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+    });
+
+    it('should set aria-multiselectable attribute on the scroller', () => {
+      expect(scroller.getAttribute('aria-multiselectable')).to.equal('true');
+    });
+
+    it('should set aria-selected on the selected item elements', () => {
+      expect(items[0].getAttribute('aria-selected')).to.equal('true');
+      expect(items[1].getAttribute('aria-selected')).to.equal('false');
+      expect(items[2].getAttribute('aria-selected')).to.equal('true');
+      expect(items[3].getAttribute('aria-selected')).to.equal('false');
+    });
+
+    it('should update aria-selected when item is selected', () => {
+      items[1].click();
+      expect(items[1].getAttribute('aria-selected')).to.equal('true');
+    });
+
+    it('should update aria-selected when item is deselected', () => {
+      items[0].click();
+      expect(items[0].getAttribute('aria-selected')).to.equal('false');
+    });
+  });
+
+  describe('announcements', () => {
+    let clock, region;
+
+    before(() => {
+      region = document.querySelector('[aria-live]');
+    });
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should announce when selecting an item', () => {
+      inputElement.click();
+
+      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      item.click();
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('Apple added to selection 1 items selected');
+    });
+
+    it('should announce when deselecting an item', () => {
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon'];
+      inputElement.click();
+
+      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      item.click();
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('Apple removed from selection 2 items selected');
+    });
+
+    it('should announce when clicking clear button', () => {
+      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon'];
+      comboBox.clearButtonVisible = true;
+
+      comboBox.$.clearButton.click();
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('Selection cleared');
+    });
+  });
+});

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -58,14 +58,6 @@ describe('basic', () => {
       expect(inputElement.placeholder).to.be.equal('foo');
     });
 
-    it('should propagate required property to input', () => {
-      comboBox.required = true;
-      expect(inputElement.required).to.be.true;
-
-      comboBox.required = false;
-      expect(inputElement.required).to.be.false;
-    });
-
     it('should propagate disabled property to combo-box', () => {
       expect(internal.disabled).to.be.false;
       comboBox.disabled = true;

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -18,6 +18,7 @@ import {
   MultiSelectComboBoxChangeEvent,
   MultiSelectComboBoxCustomValuesSetEvent,
   MultiSelectComboBoxFilterChangedEvent,
+  MultiSelectComboBoxI18n,
   MultiSelectComboBoxInvalidChangedEvent,
   MultiSelectComboBoxSelectedItemsChangedEvent,
 } from '../../vaadin-multi-select-combo-box.js';
@@ -70,6 +71,7 @@ assertType<TestComboBoxItem[] | undefined>(narrowedComboBox.items);
 assertType<string | null | undefined>(narrowedComboBox.itemIdPath);
 assertType<string>(narrowedComboBox.itemLabelPath);
 assertType<string>(narrowedComboBox.itemValuePath);
+assertType<MultiSelectComboBoxI18n>(narrowedComboBox.i18n);
 assertType<ComboBoxRenderer<TestComboBoxItem> | null | undefined>(narrowedComboBox.renderer);
 assertType<boolean>(narrowedComboBox.invalid);
 assertType<HTMLElement | null | undefined>(narrowedComboBox.focusElement);


### PR DESCRIPTION
## Description

1. Updated logic to set `aria-selected="true"` on selected items, and not on the focused item like in regular combo-box.
2. Added `aria-multiselectable="true"` on the scroller which has `role="listbox"` to indicate multi-selection support.
3. Added `i18n` and used `announce()` helper to announce selecting items - inspired by `<select multiple>`, see below:

![select-multiple](https://user-images.githubusercontent.com/10589913/165507683-6bd5ec50-df62-461f-ba35-6db0f619b9c8.gif)

Fixes #3711

## Type of change

- Feature