### PR TITLE
refactor: use smaller chip min-width for Material

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -687,7 +687,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     for (let i = items.length - 1; i >= 0; i--) {
       // Ensure there is enough space for another chip
-      if (totalWidth < chipMinWidth) {
+      if (totalWidth <= chipMinWidth) {
         break;
       }
 

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-chip-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-chip-styles.js
@@ -79,6 +79,7 @@ const chip = css`
     justify-content: center;
     margin-top: -0.3125em;
     margin-bottom: -0.3125em;
+    margin-inline-start: auto;
     width: 1.25em;
     height: 1.25em;
     font-size: 1.5em;

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-chip-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-chip-styles.js
@@ -79,6 +79,7 @@ const chip = css`
     box-sizing: border-box;
     width: 20px;
     height: 20px;
+    margin-inline-start: auto;
     line-height: 20px;
     padding: 0;
     font-size: 0.75em;

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -25,6 +25,10 @@ registerStyles(
 );
 
 const multiSelectComboBox = css`
+  :host {
+    --chip-min-width: var(--vaadin-multi-select-combo-box-chip-min-width, 3em);
+  }
+
   [part='input-field'] {
     height: auto;
     min-height: 32px;


### PR DESCRIPTION
## Description

Current min-width `4em` makes the chip look weird:

![material-4em](https://user-images.githubusercontent.com/10589913/165693756-f156dbcb-b541-4f93-9b5d-90ecf391fc01.png)

Updated to use `3em` which looks slightly better.

![material-3em](https://user-images.githubusercontent.com/10589913/165693851-08c8eaf5-e790-4df0-a3bf-8d8db57c3ace.png)

## Type of change

- Refactor