### PR TITLE
fix: do not disable pointer-events when readonly

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -39,10 +39,6 @@ const multiSelectComboBox = css`
     flex: 0 1 auto;
     min-width: var(--chip-min-width);
   }
-
-  :host([readonly]) [part~='chip'] {
-    pointer-events: none;
-  }
 `;
 
 registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectComboBox], {


### PR DESCRIPTION
## Description

This style was added before adding support for `title` attributes (#3632) and `readonly` dropdown (#3686).
We should remove it now, to make it possible for users to see tooltips also when component is readonly.

## Type of change

- Bugfix