### PR TITLE
fix: do not mark as invalid when readonly

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -397,7 +397,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
    * @return {boolean}
    */
   checkValidity() {
-    return this.required ? this._hasValue : true;
+    return this.required && !this.readonly ? this._hasValue : true;
   }
 
   /**

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -700,5 +700,11 @@ describe('basic', () => {
       comboBox.shadowRoot.querySelector('[part="required-indicator"]').click();
       expect(comboBox.hasAttribute('focused')).to.be.true;
     });
+
+    it('should not be invalid when empty and readonly', () => {
+      comboBox.readonly = true;
+      expect(comboBox.validate()).to.be.true;
+      expect(comboBox.invalid).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Description

Updated the component to not run `validate()` on focusout when readonly.

Fixes #3750

## Type of change

- Bugfix