### PR TITLE
refactor: do not change readonly chips opacity

### DIFF
--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -30,10 +30,6 @@ const multiSelectComboBox = css`
     padding-inline-start: 0;
   }
 
-  :host([readonly]) [part~='chip'] {
-    opacity: 0.7;
-  }
-
   [part~='chip']:not(:last-of-type) {
     margin-inline-end: var(--lumo-space-xs);
   }

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -25,10 +25,6 @@ registerStyles(
 );
 
 const multiSelectComboBox = css`
-  :host([readonly]) [part~='chip'] {
-    opacity: 0.5;
-  }
-
   [part='input-field'] {
     height: auto;
     min-height: 32px;


### PR DESCRIPTION
## Description

Using `opacity` makes chips look a bit faint, especially with Material. 
Also, It's not really needed as we hide "remove" button anyway.

Here is how the component would look like with this change:

![readonly-lumo](https://user-images.githubusercontent.com/10589913/165758105-c2775040-e408-4fc8-a9c2-fd6afd181f00.png)

![readonly-material](https://user-images.githubusercontent.com/10589913/165758113-b21d4cc0-cd88-4cc4-8ea2-c61d3fc89f35.png)

## Type of change

- Refactor