### PR TITLE
fix: use solid background for editable cells

### DIFF
--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
@@ -24,14 +24,12 @@ registerStyles(
     [part~='editable-cell']:hover,
     [part~='editable-cell']:focus {
       background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
-      background-clip: padding-box;
     }
 
     /* Indicate editable cells */
 
     :host([theme~='highlight-editable-cells']) [part~='editable-cell'] {
       background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
-      background-clip: border-box;
     }
 
     :host([theme~='highlight-editable-cells']) [part~='editable-cell']:hover,

--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
@@ -24,12 +24,14 @@ registerStyles(
     [part~='editable-cell']:hover,
     [part~='editable-cell']:focus {
       background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
+      background-clip: padding-box;
     }
 
     /* Indicate editable cells */
 
     :host([theme~='highlight-editable-cells']) [part~='editable-cell'] {
       background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
+      background-clip: border-box;
     }
 
     :host([theme~='highlight-editable-cells']) [part~='editable-cell']:hover,

--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
@@ -23,20 +23,18 @@ registerStyles(
 
     [part~='editable-cell']:hover,
     [part~='editable-cell']:focus {
-      background-color: var(--lumo-contrast-5pct);
-      background-clip: padding-box;
+      background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
     }
 
     /* Indicate editable cells */
 
     :host([theme~='highlight-editable-cells']) [part~='editable-cell'] {
-      background-color: var(--lumo-contrast-5pct);
-      background-clip: border-box;
+      background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
     }
 
     :host([theme~='highlight-editable-cells']) [part~='editable-cell']:hover,
     :host([theme~='highlight-editable-cells']) [part~='editable-cell']:focus {
-      background-color: var(--lumo-contrast-10pct);
+      background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-10pct), var(--lumo-contrast-10pct));
     }
 
     /* Indicate read-only cells */

--- a/packages/grid-pro/theme/material/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/material/vaadin-grid-pro-styles.js
@@ -16,8 +16,7 @@ registerStyles(
 
     [part~='row'] > [part~='editable-cell']:hover,
     [part~='row'] > [part~='editable-cell']:focus {
-      background-color: var(--material-grid-pro-editable-cell-hover-background-color, rgba(0, 0, 0, 0.04));
-      background-clip: padding-box;
+      background: var(--material-background-color) linear-gradient(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.08));
     }
   `,
   { moduleId: 'material-grid-pro' }

--- a/packages/grid-pro/theme/material/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/material/vaadin-grid-pro-styles.js
@@ -17,7 +17,6 @@ registerStyles(
     [part~='row'] > [part~='editable-cell']:hover,
     [part~='row'] > [part~='editable-cell']:focus {
       background: var(--material-background-color) linear-gradient(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.08));
-      background-clip: padding-box;
     }
   `,
   { moduleId: 'material-grid-pro' }

--- a/packages/grid-pro/theme/material/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/material/vaadin-grid-pro-styles.js
@@ -17,6 +17,7 @@ registerStyles(
     [part~='row'] > [part~='editable-cell']:hover,
     [part~='row'] > [part~='editable-cell']:focus {
       background: var(--material-background-color) linear-gradient(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.08));
+      background-clip: padding-box;
     }
   `,
   { moduleId: 'material-grid-pro' }


### PR DESCRIPTION
## Description

Fixes editable cell styles to use an opaque background on hover / focus, which prevents underlying cells from bleeding into the foreground.

The fix is based on the suggestion by Jouni here: https://github.com/vaadin/flow-components/issues/2365#issuecomment-1111155072

Fixes https://github.com/vaadin/flow-components/issues/2365

Lumo theme:

https://user-images.githubusercontent.com/357820/165781083-17871ede-3bdd-4c94-b684-dacc15f32d65.mp4

Lumo with `highlight-editable-cells` theme variant:

https://user-images.githubusercontent.com/357820/165780414-85499b44-beae-4d33-b4cc-77a6e32994c3.mp4

Material theme:

https://user-images.githubusercontent.com/357820/165781385-71d674a7-1785-460a-9de0-bec9ffb9c8c6.mp4

## Type of change

- Bugfix