### PR TITLE
feat: add Lit renderer directives for grid

### DIFF
--- a/packages/grid/lit.d.ts
+++ b/packages/grid/lit.d.ts
@@ -1,0 +1,2 @@
+export * from './src/lit/renderer-directives.js';
+export * from './src/lit/column-renderer-directives.js';

--- a/packages/grid/lit.js
+++ b/packages/grid/lit.js
@@ -1,0 +1,2 @@
+export * from './src/lit/renderer-directives.js';
+export * from './src/lit/column-renderer-directives.js';

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -23,6 +23,8 @@
     "all-imports.js",
     "src",
     "theme",
+    "lit.js",
+    "lit.d.ts",
     "vaadin-*.d.ts",
     "vaadin-*.js"
   ],

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -43,6 +43,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/checkbox": "23.1.0-beta1",
     "@vaadin/component-base": "23.1.0-beta1",
+    "@vaadin/lit-renderer": "23.1.0-beta1",
     "@vaadin/text-field": "23.1.0-beta1",
     "@vaadin/vaadin-lumo-styles": "23.1.0-beta1",
     "@vaadin/vaadin-material-styles": "23.1.0-beta1",

--- a/packages/grid/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid/src/lit/column-renderer-directives.d.ts
@@ -62,7 +62,7 @@ export declare class GridColumnFooterRendererDirective extends AbstractGridColum
  * A Lit directive for rendering the content of the column's body cells.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
- * via the `renderer` property. The renderer is called for each grid item when assigned and whenever
+ * via the `renderer` property. The renderer is called for each column's body cell when assigned and whenever
  * a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *

--- a/packages/grid/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid/src/lit/column-renderer-directives.d.ts
@@ -27,7 +27,7 @@ declare abstract class AbstractGridColumnRendererDirective<R extends LitRenderer
   /**
    * A property to that the renderer callback will be assigned.
    */
-  abstract rendererProperty: string;
+  abstract rendererProperty: 'renderer' | 'headerRenderer' | 'footerRenderer';
 
   /**
    * Adds the renderer callback to the grid column.
@@ -48,55 +48,106 @@ declare abstract class AbstractGridColumnRendererDirective<R extends LitRenderer
 export declare class GridColumnBodyRendererDirective<TItem> extends AbstractGridColumnRendererDirective<
   GridColumnBodyLitRenderer<TItem>
 > {
-  rendererProperty: string;
+  rendererProperty: 'renderer';
 }
 
 export declare class GridColumnHeaderRendererDirective extends AbstractGridColumnRendererDirective<GridColumnHeaderLitRenderer> {
-  rendererProperty: string;
+  rendererProperty: 'headerRenderer';
 }
 
 export declare class GridColumnFooterRendererDirective extends AbstractGridColumnRendererDirective<GridColumnFooterLitRenderer> {
-  rendererProperty: string;
+  rendererProperty: 'footerRenderer';
 }
 
 /**
  * A Lit directive for populating the content of the column's body cells.
  *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
+ * via the `renderer` property. The renderer is called for each grid item to populate the content
+ * when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
  * ```js
  * `<vaadin-grid-column
  *   ${columnBodyRenderer((item, model, column) => html`...`)}
  * ></vaadin-grid-column>`
  * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
  */
 export declare function columnBodyRenderer<TItem>(
   renderer: GridColumnBodyLitRenderer<TItem>,
-  value?: unknown,
+  dependencies?: unknown,
 ): DirectiveResult<typeof GridColumnBodyRendererDirective>;
 
 /**
  * A Lit directive for populating the content of the column's header cell.
  *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
+ * via the `headerRenderer` property. The renderer is called once to populate the content
+ * when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
  * ```js
  * `<vaadin-grid-column
  *   ${columnHeaderRenderer((column) => html`...`)}
  * ></vaadin-grid-column>`
  * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
  */
 export declare function columnHeaderRenderer(
   renderer: GridColumnHeaderLitRenderer,
-  value?: unknown,
+  dependencies?: unknown,
 ): DirectiveResult<typeof GridColumnHeaderRendererDirective>;
 
 /**
  * A Lit directive for populating the content of the column's footer cell.
  *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
+ * via the `footerRenderer` property. The renderer is called once to populate the content
+ * when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
  * ```js
  * `<vaadin-grid-column
  *   ${columnFooterRenderer((column) => html`...`)}
  * ></vaadin-grid-column>`
  * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
  */
 export declare function columnFooterRenderer(
   renderer: GridColumnFooterLitRenderer,
-  value?: unknown,
+  dependencies?: unknown,
 ): DirectiveResult<typeof GridColumnFooterRendererDirective>;

--- a/packages/grid/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid/src/lit/column-renderer-directives.d.ts
@@ -59,11 +59,11 @@ export declare class GridColumnFooterRendererDirective extends AbstractGridColum
 }
 
 /**
- * A Lit directive for populating the content of the column's body cells.
+ * A Lit directive for rendering the content of the column's body cells.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
- * via the `renderer` property. The renderer is called for each grid item to populate the content
- * when assigned and whenever a single dependency or an array of dependencies changes.
+ * via the `renderer` property. The renderer is called for each grid item when assigned and whenever
+ * a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.
@@ -90,11 +90,11 @@ export declare function columnBodyRenderer<TItem>(
 ): DirectiveResult<typeof GridColumnBodyRendererDirective>;
 
 /**
- * A Lit directive for populating the content of the column's header cell.
+ * A Lit directive for rendering the content of the column's header cell.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
- * via the `headerRenderer` property. The renderer is called once to populate the content
- * when assigned and whenever a single dependency or an array of dependencies changes.
+ * via the `headerRenderer` property. The renderer is called once when assigned and whenever
+ * a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.
@@ -121,11 +121,11 @@ export declare function columnHeaderRenderer(
 ): DirectiveResult<typeof GridColumnHeaderRendererDirective>;
 
 /**
- * A Lit directive for populating the content of the column's footer cell.
+ * A Lit directive for rendering the content of the column's footer cell.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
- * via the `footerRenderer` property. The renderer is called once to populate the content
- * when assigned and whenever a single dependency or an array of dependencies changes.
+ * via the `footerRenderer` property. The renderer is called once when assigned and whenever
+ * a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.

--- a/packages/grid/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid/src/lit/column-renderer-directives.d.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+/* eslint-disable max-classes-per-file */
+import { TemplateResult } from 'lit';
+import { DirectiveResult } from 'lit/directive';
+import type { LitRenderer } from '@vaadin/lit-renderer';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+import { GridItemModel } from '../vaadin-grid.js';
+import { GridColumn } from '../vaadin-grid-column.js';
+
+export type GridColumnBodyLitRenderer<TItem> = (
+  item: TItem,
+  model: GridItemModel<TItem>,
+  column: GridColumn,
+) => TemplateResult;
+
+export type GridColumnHeaderLitRenderer = (column: GridColumn) => TemplateResult;
+export type GridColumnFooterLitRenderer = (column: GridColumn) => TemplateResult;
+
+declare abstract class AbstractGridColumnRendererDirective<R extends LitRenderer> extends LitRendererDirective<
+  GridColumn,
+  R
+> {
+  /**
+   * A property to that the renderer callback will be assigned.
+   */
+  abstract rendererProperty: string;
+
+  /**
+   * Adds the renderer callback to the grid column.
+   */
+  addRenderer(): void;
+
+  /**
+   * Runs the renderer callback on the grid column.
+   */
+  runRenderer(): void;
+
+  /**
+   * Removes the renderer callback from the grid column.
+   */
+  removeRenderer(): void;
+}
+
+export declare class GridColumnBodyRendererDirective<TItem> extends AbstractGridColumnRendererDirective<
+  GridColumnBodyLitRenderer<TItem>
+> {
+  rendererProperty: string;
+}
+
+export declare class GridColumnHeaderRendererDirective extends AbstractGridColumnRendererDirective<GridColumnHeaderLitRenderer> {
+  rendererProperty: string;
+}
+
+export declare class GridColumnFooterRendererDirective extends AbstractGridColumnRendererDirective<GridColumnFooterLitRenderer> {
+  rendererProperty: string;
+}
+
+/**
+ * A Lit directive for populating the content of the column's body cells.
+ *
+ * ```js
+ * `<vaadin-grid-column
+ *   ${columnBodyRenderer((item, model, column) => html`...`)}
+ * ></vaadin-grid-column>`
+ * ```
+ */
+export declare function columnBodyRenderer<TItem>(
+  renderer: GridColumnBodyLitRenderer<TItem>,
+  value?: unknown,
+): DirectiveResult<typeof GridColumnBodyRendererDirective>;
+
+/**
+ * A Lit directive for populating the content of the column's header cell.
+ *
+ * ```js
+ * `<vaadin-grid-column
+ *   ${columnHeaderRenderer((column) => html`...`)}
+ * ></vaadin-grid-column>`
+ * ```
+ */
+export declare function columnHeaderRenderer(
+  renderer: GridColumnHeaderLitRenderer,
+  value?: unknown,
+): DirectiveResult<typeof GridColumnHeaderRendererDirective>;
+
+/**
+ * A Lit directive for populating the content of the column's footer cell.
+ *
+ * ```js
+ * `<vaadin-grid-column
+ *   ${columnFooterRenderer((column) => html`...`)}
+ * ></vaadin-grid-column>`
+ * ```
+ */
+export declare function columnFooterRenderer(
+  renderer: GridColumnFooterLitRenderer,
+  value?: unknown,
+): DirectiveResult<typeof GridColumnFooterRendererDirective>;

--- a/packages/grid/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid/src/lit/column-renderer-directives.d.ts
@@ -6,8 +6,7 @@
 /* eslint-disable max-classes-per-file */
 import { TemplateResult } from 'lit';
 import { DirectiveResult } from 'lit/directive';
-import type { LitRenderer } from '@vaadin/lit-renderer';
-import { LitRendererDirective } from '@vaadin/lit-renderer';
+import { LitRenderer, LitRendererDirective } from '@vaadin/lit-renderer';
 import { GridItemModel } from '../vaadin-grid.js';
 import { GridColumn } from '../vaadin-grid-column.js';
 

--- a/packages/grid/src/lit/column-renderer-directives.js
+++ b/packages/grid/src/lit/column-renderer-directives.js
@@ -67,32 +67,84 @@ export class GridColumnFooterRendererDirective extends AbstractGridColumnRendere
 /**
  * A Lit directive for populating the content of the column's body cells.
  *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
+ * via the `renderer` property. The renderer is called for each grid item to populate the content
+ * when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
  * ```js
  * `<vaadin-grid-column
  *   ${columnBodyRenderer((item, model, column) => html`...`)}
  * ></vaadin-grid-column>`
  * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
  */
+
 export const columnBodyRenderer = directive(GridColumnBodyRendererDirective);
 
 /**
  * A Lit directive for populating the content of the column's header cell.
  *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
+ * via the `headerRenderer` property. The renderer is called once to populate the content
+ * when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
  * ```js
  * `<vaadin-grid-column
  *   ${columnHeaderRenderer((column) => html`...`)}
  * ></vaadin-grid-column>`
  * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
  */
 export const columnHeaderRenderer = directive(GridColumnHeaderRendererDirective);
 
 /**
  * A Lit directive for populating the content of the column's footer cell.
  *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
+ * via the `footerRenderer` property. The renderer is called once to populate the content
+ * when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
  * ```js
  * `<vaadin-grid-column
  *   ${columnFooterRenderer((column) => html`...`)}
  * ></vaadin-grid-column>`
  * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
  */
 export const columnFooterRenderer = directive(GridColumnFooterRendererDirective);

--- a/packages/grid/src/lit/column-renderer-directives.js
+++ b/packages/grid/src/lit/column-renderer-directives.js
@@ -68,7 +68,7 @@ export class GridColumnFooterRendererDirective extends AbstractGridColumnRendere
  * A Lit directive for rendering the content of the column's body cells.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
- * via the `renderer` property. The renderer is called for each grid item when assigned and whenever
+ * via the `renderer` property. The renderer is called for each column's body cell when assigned and whenever
  * a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *

--- a/packages/grid/src/lit/column-renderer-directives.js
+++ b/packages/grid/src/lit/column-renderer-directives.js
@@ -90,7 +90,6 @@ export class GridColumnFooterRendererDirective extends AbstractGridColumnRendere
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
  */
-
 export const columnBodyRenderer = directive(GridColumnBodyRendererDirective);
 
 /**

--- a/packages/grid/src/lit/column-renderer-directives.js
+++ b/packages/grid/src/lit/column-renderer-directives.js
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+/* eslint-disable max-classes-per-file */
+import { directive } from 'lit/directive.js';
+import { microTask } from '@vaadin/component-base/src/async';
+import { Debouncer } from '@vaadin/component-base/src/debounce';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+import { CONTENT_UPDATE_DEBOUNCER } from './renderer-directives.js';
+
+class AbstractGridColumnRendererDirective extends LitRendererDirective {
+  /**
+   * A property to that the renderer callback will be assigned.
+   *
+   * @abstract
+   */
+  rendererProperty;
+
+  /**
+   * Adds the renderer callback to the grid column.
+   */
+  addRenderer() {
+    this.element[this.rendererProperty] = (root, column) => {
+      this.renderRenderer(root, column);
+    };
+  }
+
+  /**
+   * Runs the renderer callback on the grid column.
+   */
+  runRenderer() {
+    const grid = this.element._grid;
+
+    grid[CONTENT_UPDATE_DEBOUNCER] = Debouncer.debounce(grid[CONTENT_UPDATE_DEBOUNCER], microTask, () => {
+      grid.requestContentUpdate();
+    });
+  }
+
+  /**
+   * Removes the renderer callback from the grid column.
+   */
+  removeRenderer() {
+    this.element[this.rendererProperty] = null;
+  }
+}
+
+export class GridColumnBodyRendererDirective extends AbstractGridColumnRendererDirective {
+  rendererProperty = 'renderer';
+
+  addRenderer() {
+    this.element[this.rendererProperty] = (root, column, model) => {
+      this.renderRenderer(root, model.item, model, column);
+    };
+  }
+}
+
+export class GridColumnHeaderRendererDirective extends AbstractGridColumnRendererDirective {
+  rendererProperty = 'headerRenderer';
+}
+
+export class GridColumnFooterRendererDirective extends AbstractGridColumnRendererDirective {
+  rendererProperty = 'footerRenderer';
+}
+
+/**
+ * A Lit directive for populating the content of the column's body cells.
+ *
+ * ```js
+ * `<vaadin-grid-column
+ *   ${columnBodyRenderer((item, model, column) => html`...`)}
+ * ></vaadin-grid-column>`
+ * ```
+ */
+export const columnBodyRenderer = directive(GridColumnBodyRendererDirective);
+
+/**
+ * A Lit directive for populating the content of the column's header cell.
+ *
+ * ```js
+ * `<vaadin-grid-column
+ *   ${columnHeaderRenderer((column) => html`...`)}
+ * ></vaadin-grid-column>`
+ * ```
+ */
+export const columnHeaderRenderer = directive(GridColumnHeaderRendererDirective);
+
+/**
+ * A Lit directive for populating the content of the column's footer cell.
+ *
+ * ```js
+ * `<vaadin-grid-column
+ *   ${columnFooterRenderer((column) => html`...`)}
+ * ></vaadin-grid-column>`
+ * ```
+ */
+export const columnFooterRenderer = directive(GridColumnFooterRendererDirective);

--- a/packages/grid/src/lit/column-renderer-directives.js
+++ b/packages/grid/src/lit/column-renderer-directives.js
@@ -65,11 +65,11 @@ export class GridColumnFooterRendererDirective extends AbstractGridColumnRendere
 }
 
 /**
- * A Lit directive for populating the content of the column's body cells.
+ * A Lit directive for rendering the content of the column's body cells.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
- * via the `renderer` property. The renderer is called for each grid item to populate the content
- * when assigned and whenever a single dependency or an array of dependencies changes.
+ * via the `renderer` property. The renderer is called for each grid item when assigned and whenever
+ * a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.
@@ -93,11 +93,11 @@ export class GridColumnFooterRendererDirective extends AbstractGridColumnRendere
 export const columnBodyRenderer = directive(GridColumnBodyRendererDirective);
 
 /**
- * A Lit directive for populating the content of the column's header cell.
+ * A Lit directive for rendering the content of the column's header cell.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
- * via the `headerRenderer` property. The renderer is called once to populate the content
- * when assigned and whenever a single dependency or an array of dependencies changes.
+ * via the `headerRenderer` property. The renderer is called once when assigned and whenever
+ * a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.
@@ -121,11 +121,11 @@ export const columnBodyRenderer = directive(GridColumnBodyRendererDirective);
 export const columnHeaderRenderer = directive(GridColumnHeaderRendererDirective);
 
 /**
- * A Lit directive for populating the content of the column's footer cell.
+ * A Lit directive for rendering the content of the column's footer cell.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid column
- * via the `footerRenderer` property. The renderer is called once to populate the content
- * when assigned and whenever a single dependency or an array of dependencies changes.
+ * via the `footerRenderer` property. The renderer is called once when assigned and whenever
+ * a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.

--- a/packages/grid/src/lit/renderer-directives.d.ts
+++ b/packages/grid/src/lit/renderer-directives.d.ts
@@ -30,7 +30,33 @@ export declare class GridRowDetailsRendererDirective<TItem> extends LitRendererD
   removeRenderer(): void;
 }
 
+/**
+ * A Lit directive for populating the content of the row details cell.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid
+ * via the `rowDetailsRenderer` property. The renderer is called for each grid item that is in `detailsOpened`
+ * to populate the content when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-grid
+ *   ${gridRowDetailsRenderer((item, model, grid) => html`...`)}
+ * ></vaadin-grid>`
+ * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
 export declare function gridRowDetailsRenderer<TItem>(
   renderer: GridRowDetailsLitRenderer<TItem>,
-  value?: unknown,
+  dependencies?: unknown,
 ): DirectiveResult<typeof GridRowDetailsRendererDirective>;

--- a/packages/grid/src/lit/renderer-directives.d.ts
+++ b/packages/grid/src/lit/renderer-directives.d.ts
@@ -31,11 +31,11 @@ export declare class GridRowDetailsRendererDirective<TItem> extends LitRendererD
 }
 
 /**
- * A Lit directive for populating the content of the row details cell.
+ * A Lit directive for rendering the content of the row details cell.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid
  * via the `rowDetailsRenderer` property. The renderer is called for each grid item that is in `detailsOpened`
- * to populate the content when assigned and whenever a single dependency or an array of dependencies changes.
+ * when assigned and whenever a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.

--- a/packages/grid/src/lit/renderer-directives.d.ts
+++ b/packages/grid/src/lit/renderer-directives.d.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { TemplateResult } from 'lit';
+import { DirectiveResult } from 'lit/directive';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+import { Grid, GridItemModel } from '../vaadin-grid.js';
+
+export type GridRowDetailsLitRenderer<TItem> = (item: TItem, model: GridItemModel<TItem>, grid: Grid) => TemplateResult;
+
+export declare class GridRowDetailsRendererDirective<TItem> extends LitRendererDirective<
+  Grid,
+  GridRowDetailsLitRenderer<TItem>
+> {
+  /**
+   * Adds the row details renderer callback to the grid.
+   */
+  addRenderer(): void;
+
+  /**
+   * Runs the row details renderer callback on the grid.
+   */
+  runRenderer(): void;
+
+  /**
+   * Removes the row details renderer callback from the grid.
+   */
+  removeRenderer(): void;
+}
+
+export declare function gridRowDetailsRenderer<TItem>(
+  renderer: GridRowDetailsLitRenderer<TItem>,
+  value?: unknown,
+): DirectiveResult<typeof GridRowDetailsRendererDirective>;

--- a/packages/grid/src/lit/renderer-directives.js
+++ b/packages/grid/src/lit/renderer-directives.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { directive } from 'lit/directive.js';
+import { microTask } from '@vaadin/component-base/src/async.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+
+export const CONTENT_UPDATE_DEBOUNCER = Symbol('contentUpdateDebouncer');
+
+export class GridRowDetailsRendererDirective extends LitRendererDirective {
+  /**
+   * Adds the row details renderer callback to the grid.
+   */
+  addRenderer() {
+    this.element.rowDetailsRenderer = (root, grid, model) => {
+      this.renderRenderer(root, model.item, model, grid);
+    };
+  }
+
+  /**
+   * Runs the row details renderer callback on the grid.
+   */
+  runRenderer() {
+    this.element[CONTENT_UPDATE_DEBOUNCER] = Debouncer.debounce(
+      this.element[CONTENT_UPDATE_DEBOUNCER],
+      microTask,
+      () => {
+        this.element.requestContentUpdate();
+      },
+    );
+  }
+
+  /**
+   * Removes the row details renderer callback from the grid.
+   */
+  removeRenderer() {
+    this.element.rowDetailsRenderer = null;
+  }
+}
+
+/**
+ * A Lit directive for populating the content of the row details cell.
+ *
+ * ```js
+ * `<vaadin-grid
+ *   ${gridRowDetailsRenderer((item, model, grid) => html`...`)}
+ * ></vaadin-grid>`
+ * ```
+ */
+export const gridRowDetailsRenderer = directive(GridRowDetailsRendererDirective);

--- a/packages/grid/src/lit/renderer-directives.js
+++ b/packages/grid/src/lit/renderer-directives.js
@@ -44,10 +44,27 @@ export class GridRowDetailsRendererDirective extends LitRendererDirective {
 /**
  * A Lit directive for populating the content of the row details cell.
  *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid
+ * via the `rowDetailsRenderer` property. The renderer is called for each grid item that is in `detailsOpened`
+ * to populate the content when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
  * ```js
  * `<vaadin-grid
  *   ${gridRowDetailsRenderer((item, model, grid) => html`...`)}
  * ></vaadin-grid>`
  * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
  */
 export const gridRowDetailsRenderer = directive(GridRowDetailsRendererDirective);

--- a/packages/grid/src/lit/renderer-directives.js
+++ b/packages/grid/src/lit/renderer-directives.js
@@ -42,11 +42,11 @@ export class GridRowDetailsRendererDirective extends LitRendererDirective {
 }
 
 /**
- * A Lit directive for populating the content of the row details cell.
+ * A Lit directive for rendering the content of the row details cell.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the grid
  * via the `rowDetailsRenderer` property. The renderer is called for each grid item that is in `detailsOpened`
- * to populate the content when assigned and whenever a single dependency or an array of dependencies changes.
+ * when assigned and whenever a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.

--- a/packages/grid/test/lit-renderer-directives.test.js
+++ b/packages/grid/test/lit-renderer-directives.test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import '../vaadin-grid.js';
 import { html, render } from 'lit';
 import { columnBodyRenderer, columnFooterRenderer, columnHeaderRenderer, gridRowDetailsRenderer } from '../lit.js';
+import { getCellContent, getContainerCell } from './helpers.js';
 
 async function renderGrid(container, { items, header, footer, rowDetails }) {
   render(
@@ -22,14 +23,6 @@ async function renderGrid(container, { items, header, footer, rowDetails }) {
   return container.querySelector('vaadin-grid');
 }
 
-function getCell(container, { row, col }) {
-  return container.children[row].querySelectorAll('[part~="cell"]')[col];
-}
-
-function getRowDetailsCell(container, { row }) {
-  return container.children[row].querySelector('[part~="details-cell"]');
-}
-
 describe('lit renderer directives', () => {
   let container, grid, column;
 
@@ -44,7 +37,7 @@ describe('lit renderer directives', () => {
       beforeEach(async () => {
         grid = await renderGrid(container, { items: ['Item'], rowDetails: 'Row Details' });
         grid.openItemDetails(grid.items[0]);
-        cell = getRowDetailsCell(grid.$.items, { row: 0 });
+        cell = getContainerCell(grid.$.items, 0, 1 /* column count + 1 = the row details cell */);
       });
 
       it('should set `rowDetailsRenderer` property when the directive is attached', () => {
@@ -57,12 +50,12 @@ describe('lit renderer directives', () => {
       });
 
       it('should render the row details cell content with the renderer', () => {
-        expect(cell._content.textContent).to.equal('Row Details');
+        expect(getCellContent(cell).textContent).to.equal('Row Details');
       });
 
       it('should re-render the row details cell content when a renderer dependency changes', async () => {
         await renderGrid(container, { items: ['Item'], rowDetails: 'New Row Details' });
-        expect(cell._content.textContent).to.equal('New Row Details');
+        expect(getCellContent(cell).textContent).to.equal('New Row Details');
       });
     });
 
@@ -86,7 +79,7 @@ describe('lit renderer directives', () => {
       });
 
       it('should pass the model to the renderer', () => {
-        const cell = getRowDetailsCell(grid.$.items, { row: 0 });
+        const cell = getContainerCell(grid.$.items, 0, 1 /* column count + 1 = the row details cell */);
         const model = grid.__getRowModel(cell.parentElement);
         expect(rendererSpy.firstCall.args[1]).to.deep.equal(model);
       });
@@ -103,7 +96,7 @@ describe('lit renderer directives', () => {
 
       beforeEach(async () => {
         grid = await renderGrid(container, { items: ['Item'] });
-        cell = getCell(grid.$.items, { row: 0, col: 0 });
+        cell = getContainerCell(grid.$.items, 0, 0);
         column = grid.querySelector('vaadin-grid-column');
       });
 
@@ -117,12 +110,12 @@ describe('lit renderer directives', () => {
       });
 
       it('should render the body cells content with the renderer', () => {
-        expect(cell._content.textContent).to.equal('Item');
+        expect(getCellContent(cell).textContent).to.equal('Item');
       });
 
       it('should re-render the body cells content when a renderer dependency changes', async () => {
         await renderGrid(container, { items: ['New Item'] });
-        expect(cell._content.textContent).to.equal('New Item');
+        expect(getCellContent(cell).textContent).to.equal('New Item');
       });
     });
 
@@ -145,7 +138,7 @@ describe('lit renderer directives', () => {
       });
 
       it('should pass the model to the renderer', () => {
-        const cell = getCell(grid.$.items, { row: 0, col: 0 });
+        const cell = getContainerCell(grid.$.items, 0, 0);
         const model = grid.__getRowModel(cell.parentElement);
         expect(rendererSpy.firstCall.args[1]).to.deep.equal(model);
       });
@@ -163,7 +156,7 @@ describe('lit renderer directives', () => {
 
       beforeEach(async () => {
         grid = await renderGrid(container, { header: 'Header' });
-        cell = getCell(grid.$.header, { row: 0, col: 0 });
+        cell = getContainerCell(grid.$.header, 0, 0);
         column = grid.querySelector('vaadin-grid-column');
       });
 
@@ -177,12 +170,12 @@ describe('lit renderer directives', () => {
       });
 
       it('should render the header cell content with the renderer', () => {
-        expect(cell._content.textContent).to.equal('Header');
+        expect(getCellContent(cell).textContent).to.equal('Header');
       });
 
       it('should re-render the header cell content when a renderer dependency changes', async () => {
         await renderGrid(container, { header: 'New Header' });
-        expect(cell._content.textContent).to.equal('New Header');
+        expect(getCellContent(cell).textContent).to.equal('New Header');
       });
     });
 
@@ -213,7 +206,7 @@ describe('lit renderer directives', () => {
 
       beforeEach(async () => {
         grid = await renderGrid(container, { footer: 'Footer' });
-        cell = getCell(grid.$.footer, { row: 0, col: 0 });
+        cell = getContainerCell(grid.$.footer, 0, 0);
         column = grid.querySelector('vaadin-grid-column');
       });
 
@@ -227,12 +220,12 @@ describe('lit renderer directives', () => {
       });
 
       it('should render the footer cell content with the renderer', () => {
-        expect(cell._content.textContent).to.equal('Footer');
+        expect(getCellContent(cell).textContent).to.equal('Footer');
       });
 
       it('should re-render the footer cell content when a renderer dependency changes', async () => {
         await renderGrid(container, { footer: 'New Footer' });
-        expect(cell._content.textContent).to.equal('New Footer');
+        expect(getCellContent(cell).textContent).to.equal('New Footer');
       });
     });
 

--- a/packages/grid/test/lit-renderer-directives.test.js
+++ b/packages/grid/test/lit-renderer-directives.test.js
@@ -1,0 +1,281 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-grid.js';
+import { html, render } from 'lit';
+import { columnBodyRenderer, columnFooterRenderer, columnHeaderRenderer, gridRowDetailsRenderer } from '../lit.js';
+
+async function renderGrid(container, { items, header, footer, rowDetails }) {
+  render(
+    html`<vaadin-grid
+      .items="${items}"
+      ${rowDetails ? gridRowDetailsRenderer(() => html`${rowDetails}`, rowDetails) : null}
+    >
+      <vaadin-grid-column
+        ${items ? columnBodyRenderer((item) => html`${item}`, items) : null}
+        ${header ? columnHeaderRenderer(() => html`${header}`, header) : null}
+        ${footer ? columnFooterRenderer(() => html`${footer}`, footer) : null}
+      ></vaadin-grid-column>
+    </vaadin-grid>`,
+    container,
+  );
+  return container.querySelector('vaadin-grid');
+}
+
+function getCell(container, { row, col }) {
+  return container.children[row].querySelectorAll('[part~="cell"]')[col];
+}
+
+function getRowDetailsCell(container, { row }) {
+  return container.children[row].querySelector('[part~="details-cell"]');
+}
+
+describe('lit renderer directives', () => {
+  let container, grid, column;
+
+  beforeEach(() => {
+    container = fixtureSync('<div></div>');
+  });
+
+  describe('gridRowDetailsRenderer', () => {
+    describe('basic', () => {
+      let cell;
+
+      beforeEach(async () => {
+        grid = await renderGrid(container, { items: ['Item'], rowDetails: 'Row Details' });
+        grid.openItemDetails(grid.items[0]);
+        cell = getRowDetailsCell(grid.$.items, { row: 0 });
+      });
+
+      it('should set `rowDetailsRenderer` property when the directive is attached', () => {
+        expect(grid.rowDetailsRenderer).to.exist;
+      });
+
+      it('should unset `rowDetailsRenderer` property when the directive is detached', async () => {
+        await renderGrid(container, { items: ['Item'] });
+        expect(grid.rowDetailsRenderer).not.to.exist;
+      });
+
+      it('should render the row details cell content with the renderer', () => {
+        expect(cell._content.textContent).to.equal('Row Details');
+      });
+
+      it('should re-render the row details cell content when a renderer dependency changes', async () => {
+        await renderGrid(container, { items: ['Item'], rowDetails: 'New Row Details' });
+        expect(cell._content.textContent).to.equal('New Row Details');
+      });
+    });
+
+    describe('arguments', () => {
+      let rendererSpy;
+
+      beforeEach(async () => {
+        rendererSpy = sinon.spy();
+        render(
+          html`<vaadin-grid .items="${['Item']}" ${gridRowDetailsRenderer(rendererSpy)}>
+            <vaadin-grid-column></vaadin-grid-column>
+          </vaadin-grid>`,
+          container,
+        );
+        grid = container.querySelector('vaadin-grid');
+        grid.openItemDetails(grid.items[0]);
+      });
+
+      it('should pass the item to the renderer', () => {
+        expect(rendererSpy.firstCall.args[0]).to.equal('Item');
+      });
+
+      it('should pass the model to the renderer', () => {
+        const cell = getRowDetailsCell(grid.$.items, { row: 0 });
+        const model = grid.__getRowModel(cell.parentElement);
+        expect(rendererSpy.firstCall.args[1]).to.deep.equal(model);
+      });
+
+      it('should pass the grid instance to the renderer', () => {
+        expect(rendererSpy.firstCall.args[2]).to.equal(grid);
+      });
+    });
+  });
+
+  describe('columnBodyRenderer', () => {
+    describe('basic', () => {
+      let cell;
+
+      beforeEach(async () => {
+        grid = await renderGrid(container, { items: ['Item'] });
+        cell = getCell(grid.$.items, { row: 0, col: 0 });
+        column = grid.querySelector('vaadin-grid-column');
+      });
+
+      it('should set `renderer` property when the directive is attached', () => {
+        expect(column.renderer).to.exist;
+      });
+
+      it('should unset `renderer` property when the directive is detached', async () => {
+        await renderGrid(container, {});
+        expect(column.renderer).not.to.exist;
+      });
+
+      it('should render the body cells content with the renderer', () => {
+        expect(cell._content.textContent).to.equal('Item');
+      });
+
+      it('should re-render the body cells content when a renderer dependency changes', async () => {
+        await renderGrid(container, { items: ['New Item'] });
+        expect(cell._content.textContent).to.equal('New Item');
+      });
+    });
+
+    describe('arguments', () => {
+      let rendererSpy;
+
+      beforeEach(async () => {
+        rendererSpy = sinon.spy();
+        render(
+          html`<vaadin-grid .items="${['Item']}">
+            <vaadin-grid-column ${columnBodyRenderer(rendererSpy)}></vaadin-grid-column>
+          </vaadin-grid>`,
+          container,
+        );
+        grid = container.querySelector('vaadin-grid');
+      });
+
+      it('should pass the item to the renderer', () => {
+        expect(rendererSpy.firstCall.args[0]).to.equal('Item');
+      });
+
+      it('should pass the model to the renderer', () => {
+        const cell = getCell(grid.$.items, { row: 0, col: 0 });
+        const model = grid.__getRowModel(cell.parentElement);
+        expect(rendererSpy.firstCall.args[1]).to.deep.equal(model);
+      });
+
+      it('should pass the column instance to the renderer', () => {
+        const column = grid.querySelector('vaadin-grid-column');
+        expect(rendererSpy.firstCall.args[2]).to.equal(column);
+      });
+    });
+  });
+
+  describe('columnHeaderRenderer', () => {
+    describe('basic', () => {
+      let cell;
+
+      beforeEach(async () => {
+        grid = await renderGrid(container, { header: 'Header' });
+        cell = getCell(grid.$.header, { row: 0, col: 0 });
+        column = grid.querySelector('vaadin-grid-column');
+      });
+
+      it('should set `headerRenderer` property when the directive is attached', () => {
+        expect(column.headerRenderer).to.exist;
+      });
+
+      it('should unset `headerRenderer` property when the directive is detached', async () => {
+        await renderGrid(container, {});
+        expect(column.headerRenderer).not.to.exist;
+      });
+
+      it('should render the header cell content with the renderer', () => {
+        expect(cell._content.textContent).to.equal('Header');
+      });
+
+      it('should re-render the header cell content when a renderer dependency changes', async () => {
+        await renderGrid(container, { header: 'New Header' });
+        expect(cell._content.textContent).to.equal('New Header');
+      });
+    });
+
+    describe('arguments', () => {
+      let rendererSpy;
+
+      beforeEach(async () => {
+        rendererSpy = sinon.spy();
+        render(
+          html`<vaadin-grid>
+            <vaadin-grid-column ${columnHeaderRenderer(rendererSpy)}></vaadin-grid-column>
+          </vaadin-grid>`,
+          container,
+        );
+        grid = container.querySelector('vaadin-grid');
+      });
+
+      it('should pass the column instance to the renderer', () => {
+        const column = grid.querySelector('vaadin-grid-column');
+        expect(rendererSpy.firstCall.args[0]).to.equal(column);
+      });
+    });
+  });
+
+  describe('columnFooterRenderer', () => {
+    describe('basic', () => {
+      let cell;
+
+      beforeEach(async () => {
+        grid = await renderGrid(container, { footer: 'Footer' });
+        cell = getCell(grid.$.footer, { row: 0, col: 0 });
+        column = grid.querySelector('vaadin-grid-column');
+      });
+
+      it('should set `footerRenderer` property when the directive is attached', () => {
+        expect(column.footerRenderer).to.exist;
+      });
+
+      it('should unset `footerRenderer` property when the directive is detached', async () => {
+        await renderGrid(container, {});
+        expect(column.footerRenderer).not.to.exist;
+      });
+
+      it('should render the footer cell content with the renderer', () => {
+        expect(cell._content.textContent).to.equal('Footer');
+      });
+
+      it('should re-render the footer cell content when a renderer dependency changes', async () => {
+        await renderGrid(container, { footer: 'New Footer' });
+        expect(cell._content.textContent).to.equal('New Footer');
+      });
+    });
+
+    describe('arguments', () => {
+      let rendererSpy;
+
+      beforeEach(async () => {
+        rendererSpy = sinon.spy();
+        render(
+          html`<vaadin-grid>
+            <vaadin-grid-column ${columnFooterRenderer(rendererSpy)}></vaadin-grid-column>
+          </vaadin-grid>`,
+          container,
+        );
+        grid = container.querySelector('vaadin-grid');
+      });
+
+      it('should pass the column instance to the renderer', () => {
+        const column = grid.querySelector('vaadin-grid-column');
+        expect(rendererSpy.firstCall.args[0]).to.equal(column);
+      });
+    });
+  });
+
+  describe('multiple renderers', () => {
+    beforeEach(async () => {
+      grid = await renderGrid(container, {
+        header: 'Header',
+        footer: 'Footer',
+        items: ['Item 1', 'Item 2'],
+        rowDetails: 'Row Details',
+      });
+    });
+
+    it('should only request one content update when triggering multiple renderers to update', async () => {
+      const spy = sinon.spy(grid, 'requestContentUpdate');
+      await renderGrid(container, {
+        header: 'New Header',
+        footer: 'New Footer',
+        items: ['New Item 1', 'New Item 2'],
+        rowDetails: 'New Row Details',
+      });
+      expect(spy.callCount).to.equal(1);
+    });
+  });
+});

--- a/packages/grid/test/typings/lit-renderer-directives.types.ts
+++ b/packages/grid/test/typings/lit-renderer-directives.types.ts
@@ -1,0 +1,24 @@
+import { DirectiveResult } from 'lit/directive';
+import {
+  columnBodyRenderer,
+  columnFooterRenderer,
+  columnHeaderRenderer,
+  GridColumnBodyLitRenderer,
+  GridColumnFooterLitRenderer,
+  GridColumnHeaderLitRenderer,
+  GridRowDetailsLitRenderer,
+  gridRowDetailsRenderer,
+} from '../../lit.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+interface TestGridItem {
+  testProperty: string;
+}
+
+assertType<(renderer: GridRowDetailsLitRenderer<TestGridItem>, value?: unknown) => DirectiveResult>(
+  gridRowDetailsRenderer,
+);
+assertType<(renderer: GridColumnBodyLitRenderer<TestGridItem>, value?: unknown) => DirectiveResult>(columnBodyRenderer);
+assertType<(renderer: GridColumnHeaderLitRenderer, value?: unknown) => DirectiveResult>(columnHeaderRenderer);
+assertType<(renderer: GridColumnFooterLitRenderer, value?: unknown) => DirectiveResult>(columnFooterRenderer);

--- a/packages/grid/test/typings/lit-renderer-directives.types.ts
+++ b/packages/grid/test/typings/lit-renderer-directives.types.ts
@@ -4,10 +4,14 @@ import {
   columnFooterRenderer,
   columnHeaderRenderer,
   GridColumnBodyLitRenderer,
+  GridColumnBodyRendererDirective,
   GridColumnFooterLitRenderer,
+  GridColumnFooterRendererDirective,
   GridColumnHeaderLitRenderer,
+  GridColumnHeaderRendererDirective,
   GridRowDetailsLitRenderer,
   gridRowDetailsRenderer,
+  GridRowDetailsRendererDirective,
 } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
@@ -16,9 +20,30 @@ interface TestGridItem {
   testProperty: string;
 }
 
-assertType<(renderer: GridRowDetailsLitRenderer<TestGridItem>, value?: unknown) => DirectiveResult>(
-  gridRowDetailsRenderer,
-);
-assertType<(renderer: GridColumnBodyLitRenderer<TestGridItem>, value?: unknown) => DirectiveResult>(columnBodyRenderer);
-assertType<(renderer: GridColumnHeaderLitRenderer, value?: unknown) => DirectiveResult>(columnHeaderRenderer);
-assertType<(renderer: GridColumnFooterLitRenderer, value?: unknown) => DirectiveResult>(columnFooterRenderer);
+assertType<
+  (
+    renderer: GridRowDetailsLitRenderer<TestGridItem>,
+    dependencies?: unknown,
+  ) => DirectiveResult<typeof GridRowDetailsRendererDirective>
+>(gridRowDetailsRenderer);
+
+assertType<
+  (
+    renderer: GridColumnBodyLitRenderer<TestGridItem>,
+    dependencies?: unknown,
+  ) => DirectiveResult<typeof GridColumnBodyRendererDirective>
+>(columnBodyRenderer);
+
+assertType<
+  (
+    renderer: GridColumnHeaderLitRenderer,
+    dependencies?: unknown,
+  ) => DirectiveResult<typeof GridColumnHeaderRendererDirective>
+>(columnHeaderRenderer);
+
+assertType<
+  (
+    renderer: GridColumnFooterLitRenderer,
+    dependencies?: unknown,
+  ) => DirectiveResult<typeof GridColumnFooterRendererDirective>
+>(columnFooterRenderer);


### PR DESCRIPTION
## Description

This PR implements a Lit renderer directive for each renderer property of the grid component in order to provide a better DX for Lit users.

Part of #266

### Grid Column Body Cells Renderer

```diff
import { columnBodyRenderer } from '@vaadin/grid/lit.js';

<vaadin-grid-column
-  .renderer="${(root, model, column) => render(html`...`, root, { eventContext: this })}"
+  ${columnBodyRenderer((item, model, column) => html`...`)}
></vaadin-grid-column>
```

### Grid Column Header Cell Renderer

```diff
import { columnHeaderRenderer } from '@vaadin/grid/lit.js';

<vaadin-grid-column
-  .headerRenderer="${(root, column) => render(html`...`, root, { eventContext: this })}"
+  ${columnHeaderRenderer((column) => html`...`)}
></vaadin-grid-column>
```

### Grid Column Footer Cell Renderer

```diff
import { columnFooterRenderer } from '@vaadin/grid/lit.js';

<vaadin-grid-column
-  .footerRenderer="${(root, column) => render(html`...`, root, { eventContext: this })}"
+  ${columnFooterRenderer((column) => html`...`)}
></vaadin-grid-column>
```

### Grid Row Details Cell Renderer

```diff
import { columnFooterRenderer } from '@vaadin/grid/lit.js';

<vaadin-grid
-  .rowDetailsRenderer="${(root, model, grid) => render(html`...`, root, { eventContext: this })}"
+  ${gridRowDetailsRenderer((item, model, grid) => html`...`)}
></vaadin-grid>
```

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
