### PR TITLE
fix: make header-title be announced by screen readers

### DIFF
--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -33,6 +33,10 @@ registerStyles(
       pointer-events: auto;
     }
 
+    ::slotted([slot='title']) {
+      pointer-events: auto;
+    }
+
     [part='header-content'] {
       flex: 1;
     }
@@ -99,7 +103,7 @@ export class DialogOverlay extends OverlayElement {
       memoizedTemplate = super.template.cloneNode(true);
       const contentPart = memoizedTemplate.content.querySelector('[part="content"]');
       const overlayPart = memoizedTemplate.content.querySelector('[part="overlay"]');
-      const resizerContainer = document.createElement('div');
+      const resizerContainer = document.createElement('section');
       resizerContainer.id = 'resizerContainer';
       resizerContainer.classList.add('resizer-container');
       resizerContainer.appendChild(contentPart);
@@ -160,9 +164,6 @@ export class DialogOverlay extends OverlayElement {
   /** @protected */
   ready() {
     super.ready();
-
-    const uniqueId = (DialogOverlay._uniqueId = 1 + DialogOverlay._uniqueId || 0);
-    this._titleId = `${this.constructor.is}-title-${uniqueId}`;
 
     // Update overflow attribute on resize
     this.__resizeObserver = new ResizeObserver(() => {
@@ -264,18 +265,14 @@ export class DialogOverlay extends OverlayElement {
     if (this.headerTitle) {
       if (!this.headerTitleElement) {
         this.headerTitleElement = document.createElement('span');
-        this.headerTitleElement.id = this._titleId;
         this.headerTitleElement.setAttribute('slot', 'title');
         this.headerTitleElement.classList.add('draggable');
-
-        this.setAttribute('aria-labelledby', this._titleId);
       }
       this.appendChild(this.headerTitleElement);
       this.headerTitleElement.textContent = this.headerTitle;
     } else if (this.headerTitleElement) {
       this.headerTitleElement.remove();
       this.headerTitleElement = null;
-      this.removeAttribute('aria-labelledby');
     }
   }
 
@@ -594,7 +591,7 @@ class Dialog extends ThemePropertyMixin(ElementMixin(DialogDraggableMixin(Dialog
   static get observers() {
     return [
       '_openedChanged(opened)',
-      '_ariaLabelChanged(ariaLabel)',
+      '_ariaLabelChanged(ariaLabel, headerTitle)',
       '_rendererChanged(renderer, headerRenderer, footerRenderer)',
     ];
   }
@@ -648,9 +645,9 @@ class Dialog extends ThemePropertyMixin(ElementMixin(DialogDraggableMixin(Dialog
   }
 
   /** @private */
-  _ariaLabelChanged(ariaLabel) {
-    if (ariaLabel) {
-      this.$.overlay.setAttribute('aria-label', ariaLabel);
+  _ariaLabelChanged(ariaLabel, headerTitle) {
+    if (ariaLabel || headerTitle) {
+      this.$.overlay.setAttribute('aria-label', ariaLabel || headerTitle);
     } else {
       this.$.overlay.removeAttribute('aria-label');
     }

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -33,10 +33,6 @@ registerStyles(
       pointer-events: auto;
     }
 
-    ::slotted([slot='title']) {
-      pointer-events: auto;
-    }
-
     [part='header-content'] {
       flex: 1;
     }

--- a/packages/dialog/test/header-footer.test.js
+++ b/packages/dialog/test/header-footer.test.js
@@ -86,35 +86,31 @@ describe('header/footer feature', () => {
     });
 
     describe('accessibility', () => {
-      it('should add arial-labelledby to overlay if header-title is set', () => {
-        expect(overlay.hasAttribute('aria-labelledby')).to.be.false;
+      it('should set arial-label to overlay if header-title is set', () => {
+        expect(overlay.hasAttribute('aria-label')).to.be.false;
 
         dialog.headerTitle = HEADER_TITLE;
         dialog.opened = true;
 
-        expect(overlay.hasAttribute('aria-labelledby')).to.be.true;
-        const title = overlay.querySelector('[slot=title]');
-        expect(overlay.getAttribute('aria-labelledby')).to.equal(title.id);
+        expect(overlay.hasAttribute('aria-label')).to.be.true;
+        expect(overlay.getAttribute('aria-label')).to.equal(HEADER_TITLE);
       });
 
-      it('should remove aria-labelledby if header-title is unset', () => {
+      it('should remove aria-label if header-title is unset', () => {
         dialog.headerTitle = HEADER_TITLE;
         dialog.opened = true;
 
         dialog.headerTitle = null;
-        expect(overlay.hasAttribute('aria-labelledby')).to.be.false;
+        expect(overlay.hasAttribute('aria-label')).to.be.false;
       });
 
-      it('two dialogs should not have the same `aria-labelledby` value', () => {
-        const anotherDialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
-        const anotherOverlay = anotherDialog.$.overlay;
-        anotherDialog.headerTitle = HEADER_TITLE;
-        anotherDialog.opened = true;
-
+      it('overlay should get the value from aria-label attribute if aria-label and header-title are set', () => {
+        const ARIA_LABEL = '__ARIA_LABEL__';
         dialog.headerTitle = HEADER_TITLE;
+        dialog.ariaLabel = ARIA_LABEL;
         dialog.opened = true;
 
-        expect(anotherOverlay.getAttribute('aria-labelledby')).to.be.not.equal(overlay.getAttribute('aria-labelledby'));
+        expect(overlay.getAttribute('aria-label')).to.be.equal(ARIA_LABEL);
       });
     });
   });


### PR DESCRIPTION
## Description

- Make header-title set `aria-label` instead of using `aria-labelleby` as it seems that Chrome + VoiceOver is not capable of announce the later.
- Make sure that the `aria-label` property set on the dialog is set in case both `aria-label` and `header-title` are defined.
- Change the markup of the resize container from `<div>` to `<section>`.

Fixes #3702
