### PR TITLE
fix: do not override visibility of added columns when group is auto-hidden

### DIFF
--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -90,7 +90,6 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
       '_groupFrozenChanged(frozen, _rootColumns)',
       '_groupFrozenToEndChanged(frozenToEnd, _rootColumns)',
       '_groupHiddenChanged(hidden, _rootColumns)',
-      '_visibleChildColumnsChanged(_visibleChildColumns)',
       '_colSpanChanged(_colSpan, _headerCell, _footerCell)',
       '_groupOrderChanged(_order, _rootColumns)',
       '_groupReorderStatusChanged(_reorderStatus, _rootColumns)',
@@ -119,7 +118,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
    * @protected
    */
   _columnPropChanged(path, value) {
-    if (path === 'hidden') {
+    if (path === 'hidden' && !this._preventHiddenCascade) {
       this._preventHiddenCascade = true;
       this._updateVisibleChildColumns(this._childColumns);
       this._preventHiddenCascade = false;
@@ -205,6 +204,17 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
   /** @private */
   _updateVisibleChildColumns(childColumns) {
     this._visibleChildColumns = Array.prototype.filter.call(childColumns, (col) => !col.hidden);
+    this._colSpan = this._visibleChildColumns.length;
+
+    if (!this._ignoreVisibleChildColumns) {
+      if (this._visibleChildColumns.length === 0) {
+        if (!this.hidden) {
+          this._autoHidden = this.hidden = true;
+        }
+      } else if (this.hidden && this._autoHidden) {
+        this._autoHidden = this.hidden = false;
+      }
+    }
   }
 
   /** @private */
@@ -266,19 +276,6 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
     }
 
     this._columnPropChanged('hidden');
-  }
-
-  /** @private */
-  _visibleChildColumnsChanged(visibleChildColumns) {
-    this._colSpan = visibleChildColumns.length;
-
-    if (!this._ignoreVisibleChildColumns) {
-      if (visibleChildColumns.length === 0) {
-        this._autoHidden = this.hidden = true;
-      } else if (this.hidden && this._autoHidden) {
-        this._autoHidden = this.hidden = false;
-      }
-    }
   }
 
   /** @private */

--- a/packages/grid/test/column-group.test.js
+++ b/packages/grid/test/column-group.test.js
@@ -179,8 +179,6 @@ describe('column group', () => {
 
     it('should propagate hidden to added column when group is set to hidden', () => {
       group.hidden = true;
-      expect(group.hidden).to.be.true;
-      expect(group._autoHidden).not.to.be.true;
 
       const visibleColumn = document.createElement('vaadin-grid-column');
       visibleColumn.hidden = false;
@@ -188,6 +186,15 @@ describe('column group', () => {
       group._observer.flush();
 
       expect(visibleColumn.hidden).to.be.true;
+    });
+
+    it('should not propagate hidden to added column when group is visible', () => {
+      const hiddenColumn = document.createElement('vaadin-grid-column');
+      hiddenColumn.hidden = true;
+      group.appendChild(hiddenColumn);
+      group._observer.flush();
+
+      expect(hiddenColumn.hidden).to.be.true;
     });
 
     it('should not unhide when adding a visible column', () => {
@@ -268,7 +275,7 @@ describe('column group', () => {
       expect(group.hidden).to.be.true;
     });
 
-    it('should not propagate hidden to added columns when group is auto-hidden', () => {
+    it('should not propagate hidden to added columns while auto-hidden', () => {
       // auto-hide group
       columns[0].hidden = true;
       columns[1].hidden = true;


### PR DESCRIPTION
## Description

Fixes the grid's column group to not override the `hidden` state of added columns when it is only auto-hidden. This can be the case in the Flow grid, which:
- first creates the column group, which is empty, so it is auto-hidden
- then creates columns, which can be either hidden or not
- then adds the columns, which removes auto-hidden from the group -> this change was propagated to the columns, which means that an added hidden column becomes visible

I found the whole `hidden` propagation between group and child columns very hard to reason about. I think an approach to use a computed state for column/group visibility, instead of overriding each others `hidden` state, might be a better option here, but that results in a lot more changes.

Fixes https://github.com/vaadin/flow-components/issues/2959

## Type of change

- Bugfix