### PR TITLE
fix: focus selected item set before filtered items

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -971,7 +971,12 @@ export const ComboBoxMixin = (subclass) =>
           this._selectItemForValue(this.value);
         }
 
-        if (this._inputElementValue === undefined || this._inputElementValue === this.value) {
+        const inputValue = this._inputElementValue;
+        if (
+          inputValue === undefined ||
+          inputValue === this.value ||
+          inputValue === this._getItemLabel(this.selectedItem)
+        ) {
           // When the input element value is the same as the current value or not defined,
           // set the focused index to the item that matches the value.
           this._focusedIndex = this._indexOfValue(this.value, this.filteredItems);

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -975,7 +975,7 @@ export const ComboBoxMixin = (subclass) =>
         if (inputValue === undefined || inputValue === this._getItemLabel(this.selectedItem)) {
           // When the input element value is the same as the current value or not defined,
           // set the focused index to the item that matches the value.
-          this._focusedIndex = this._indexOfValue(this.value, this.filteredItems);
+          this._focusedIndex = this.$.dropdown.indexOfLabel(this._getItemLabel(this.selectedItem));
         } else {
           // When the user filled in something that is different from the current value = filtering is enabled,
           // set the focused index to the item that matches the filter query.

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -972,11 +972,7 @@ export const ComboBoxMixin = (subclass) =>
         }
 
         const inputValue = this._inputElementValue;
-        if (
-          inputValue === undefined ||
-          inputValue === this.value ||
-          inputValue === this._getItemLabel(this.selectedItem)
-        ) {
+        if (inputValue === undefined || inputValue === this._getItemLabel(this.selectedItem)) {
           // When the input element value is the same as the current value or not defined,
           // set the focused index to the item that matches the value.
           this._focusedIndex = this._indexOfValue(this.value, this.filteredItems);

--- a/packages/combo-box/test/external-filtering.test.js
+++ b/packages/combo-box/test/external-filtering.test.js
@@ -227,4 +227,31 @@ describe('external filtering', () => {
       expect(comboBox.value).to.equal('custom');
     });
   });
+
+  describe('selectedItem is set before', () => {
+    const items = [
+      { label: 'Item 0', value: '0' },
+      { label: 'Item 1', value: '1' },
+      { label: 'Item 2', value: '2' },
+    ];
+
+    beforeEach(() => {
+      comboBox = fixtureSync(`<vaadin-combo-box></vaadin-combo-box>`);
+      comboBox.selectedItem = items[0];
+      comboBox.filteredItems = items;
+    });
+
+    it('should set component value based on selected item', () => {
+      expect(comboBox.value).to.equal('0');
+    });
+
+    it('should set input value based on selected item', () => {
+      expect(comboBox.inputElement.value).to.equal('Item 0');
+    });
+
+    it('should have the correct item focused when opened', () => {
+      comboBox.open();
+      expect(getFocusedItemIndex(comboBox)).to.equal(0);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/3115

Previously, the component accepted `selectedItem` set before `filteredItems` but did not set focused index correctly.
This turned out to be the case with the Flow component where the logic makes property observers run in this order:

<img width="1026" alt="Screenshot 2022-05-03 at 17 02 31" src="https://user-images.githubusercontent.com/10589913/166467881-b57939f0-f0ea-467f-bc76-f2358facd2ee.png">

Note: setting `filteredItems` to an array of `ComboBoxPlaceholder` and then updating them later is how the ComboBox connector works, it's not important for this particular issue, only the order of the property observers matters.

## Type of change

- Bugfix