### PR TITLE
feat: add Lit renderer directive for combo-box

### DIFF
--- a/packages/combo-box/lit.d.ts
+++ b/packages/combo-box/lit.d.ts
@@ -1,0 +1,1 @@
+export * from './src/lit/renderer-directives.js';

--- a/packages/combo-box/lit.js
+++ b/packages/combo-box/lit.js
@@ -1,0 +1,1 @@
+export * from './src/lit/renderer-directives.js';

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -21,6 +21,8 @@
   "files": [
     "src",
     "theme",
+    "lit.js",
+    "lit.d.ts",
     "vaadin-*.d.ts",
     "vaadin-*.js"
   ],
@@ -38,6 +40,7 @@
     "@vaadin/field-base": "23.1.0-beta1",
     "@vaadin/input-container": "23.1.0-beta1",
     "@vaadin/item": "23.1.0-beta1",
+    "@vaadin/lit-renderer": "23.1.0-beta1",
     "@vaadin/vaadin-lumo-styles": "23.1.0-beta1",
     "@vaadin/vaadin-material-styles": "23.1.0-beta1",
     "@vaadin/vaadin-overlay": "23.1.0-beta1",

--- a/packages/combo-box/src/lit/renderer-directives.d.ts
+++ b/packages/combo-box/src/lit/renderer-directives.d.ts
@@ -32,7 +32,7 @@ export class ComboBoxRendererDirective<TItem> extends LitRendererDirective<Combo
 }
 
 /**
- * A Lit directive for populating the list of combo-box options.
+ * A Lit directive for rendering the content of the `<vaadin-combo-box-item>` elements.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the combo-box
  * via the `renderer` property. The renderer is called for each combo-box item to populate options

--- a/packages/combo-box/src/lit/renderer-directives.d.ts
+++ b/packages/combo-box/src/lit/renderer-directives.d.ts
@@ -32,10 +32,10 @@ export class ComboBoxRendererDirective<TItem> extends LitRendererDirective<Combo
 }
 
 /**
- * A Lit directive for populating the content of the combo-box.
+ * A Lit directive for populating the list of combo-box options.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the combo-box
- * via the `renderer` property. The renderer is called for each combo-box item to populate the content
+ * via the `renderer` property. The renderer is called for each combo-box item to populate options
  * when assigned and whenever a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *

--- a/packages/combo-box/src/lit/renderer-directives.d.ts
+++ b/packages/combo-box/src/lit/renderer-directives.d.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { TemplateResult } from 'lit';
+import { DirectiveResult } from 'lit/directive.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+import { ComboBox, ComboBoxItemModel } from '../vaadin-combo-box.js';
+
+export type ComboBoxLitRenderer<TItem> = (
+  item: TItem,
+  model: ComboBoxItemModel<TItem>,
+  comboBox: ComboBox<TItem>,
+) => TemplateResult;
+
+export class ComboBoxRendererDirective<TItem> extends LitRendererDirective<ComboBox, ComboBoxLitRenderer<TItem>> {
+  /**
+   * Adds the renderer callback to the combo-box.
+   */
+  addRenderer(): void;
+
+  /**
+   * Runs the renderer callback on the combo-box.
+   */
+  runRenderer(): void;
+
+  /**
+   * Removes the renderer callback from the combo-box.
+   */
+  removeRenderer(): void;
+}
+
+/**
+ * A Lit directive for populating the content of the combo-box.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the combo-box
+ * via the `renderer` property. The renderer is called for each combo-box item to populate the content
+ * when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-combo-box
+ *   ${comboBoxRenderer((item, model, comboBox) => html`...`)}
+ * ></vaadin-combo-box>`
+ * ```
+ *
+ * @param renderer the renderer callback that returns a Lit template.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export declare function comboBoxRenderer<TItem>(
+  renderer: ComboBoxLitRenderer<TItem>,
+  dependencies?: unknown,
+): DirectiveResult<typeof ComboBoxRendererDirective>;

--- a/packages/combo-box/src/lit/renderer-directives.d.ts
+++ b/packages/combo-box/src/lit/renderer-directives.d.ts
@@ -35,8 +35,8 @@ export class ComboBoxRendererDirective<TItem> extends LitRendererDirective<Combo
  * A Lit directive for rendering the content of the `<vaadin-combo-box-item>` elements.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the combo-box
- * via the `renderer` property. The renderer is called for each combo-box item to populate options
- * when assigned and whenever a single dependency or an array of dependencies changes.
+ * via the `renderer` property. The renderer is called for each combo-box item when assigned
+ * and whenever a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.

--- a/packages/combo-box/src/lit/renderer-directives.js
+++ b/packages/combo-box/src/lit/renderer-directives.js
@@ -32,7 +32,7 @@ export class ComboBoxRendererDirective extends LitRendererDirective {
 }
 
 /**
- * A Lit directive for populating the list of combo-box options.
+ * A Lit directive for rendering the content of the `<vaadin-combo-box-item>` elements.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the combo-box
  * via the `renderer` property. The renderer is called for each combo-box item to populate options

--- a/packages/combo-box/src/lit/renderer-directives.js
+++ b/packages/combo-box/src/lit/renderer-directives.js
@@ -35,8 +35,8 @@ export class ComboBoxRendererDirective extends LitRendererDirective {
  * A Lit directive for rendering the content of the `<vaadin-combo-box-item>` elements.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the combo-box
- * via the `renderer` property. The renderer is called for each combo-box item to populate options
- * when assigned and whenever a single dependency or an array of dependencies changes.
+ * via the `renderer` property. The renderer is called for each combo-box item when assigned
+ * and whenever a single dependency or an array of dependencies changes.
  * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
  *
  * Dependencies can be a single value or an array of values.

--- a/packages/combo-box/src/lit/renderer-directives.js
+++ b/packages/combo-box/src/lit/renderer-directives.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { directive } from 'lit/directive.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+
+export class ComboBoxRendererDirective extends LitRendererDirective {
+  /**
+   * Adds the renderer callback to the combo-box.
+   */
+  addRenderer() {
+    this.element.renderer = (root, comboBox, model) => {
+      this.renderRenderer(root, model.item, model, comboBox);
+    };
+  }
+
+  /**
+   * Runs the renderer callback on the combo-box.
+   */
+  runRenderer() {
+    this.element.requestContentUpdate();
+  }
+
+  /**
+   * Removes the renderer callback from the combo-box.
+   */
+  removeRenderer() {
+    this.element.renderer = null;
+  }
+}
+
+/**
+ * A Lit directive for populating the list of combo-box options.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the combo-box
+ * via the `renderer` property. The renderer is called for each combo-box item to populate options
+ * when assigned and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-combo-box
+ *   ${comboBoxRenderer((item, model, comboBox) => html`...`)}
+ * ></vaadin-combo-box>`
+ * ```
+ *
+ * @param renderer the renderer callback that returns a Lit template.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export const comboBoxRenderer = directive(ComboBoxRendererDirective);

--- a/packages/combo-box/test/lit-renderer-directives.test.js
+++ b/packages/combo-box/test/lit-renderer-directives.test.js
@@ -1,0 +1,88 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-combo-box.js';
+import { html, render } from 'lit';
+import { comboBoxRenderer } from '../lit.js';
+import { getAllItems } from './helpers.js';
+
+async function renderComboBox(container, { items }) {
+  render(
+    html`<vaadin-combo-box
+      .items="${items}"
+      ${items ? comboBoxRenderer((item) => html`${item}`, items) : null}
+    ></vaadin-combo-box>`,
+    container,
+  );
+  await nextFrame();
+  return container.querySelector('vaadin-combo-box');
+}
+
+describe('lit renderer directives', () => {
+  let container, comboBox;
+
+  beforeEach(() => {
+    container = fixtureSync('<div></div>');
+  });
+
+  describe('comboBoxRenderer', () => {
+    describe('basic', () => {
+      beforeEach(async () => {
+        comboBox = await renderComboBox(container, { items: ['Item'] });
+      });
+
+      it('should set `renderer` property when the directive is attached', () => {
+        expect(comboBox.renderer).to.exist;
+      });
+
+      it('should unset `renderer` property when the directive is detached', async () => {
+        await renderComboBox(container, {});
+        expect(comboBox.renderer).not.to.exist;
+      });
+
+      it('should render items with the renderer when the combo-box is opened', () => {
+        comboBox.opened = true;
+        const items = getAllItems(comboBox);
+        expect(items[0].textContent).to.equal('Item');
+      });
+
+      it('should re-render items when the combo-box is opened and a renderer dependency changes', async () => {
+        comboBox.opened = true;
+        await renderComboBox(container, { items: ['New Item'] });
+        const items = getAllItems(comboBox);
+        expect(items[0].textContent).to.equal('New Item');
+      });
+    });
+
+    describe('arguments', () => {
+      let rendererSpy;
+
+      beforeEach(async () => {
+        rendererSpy = sinon.spy();
+        render(
+          html`<vaadin-combo-box opened .items="${['Item']}" ${comboBoxRenderer(rendererSpy)}></vaadin-combo-box>`,
+          container,
+        );
+        await nextFrame();
+        comboBox = container.querySelector('vaadin-combo-box');
+      });
+
+      it('should pass the item to the renderer', () => {
+        expect(rendererSpy.firstCall.args[0]).to.equal('Item');
+      });
+
+      it('should pass the model to the renderer', () => {
+        expect(rendererSpy.firstCall.args[1]).to.deep.equal({
+          item: 'Item',
+          index: 0,
+          focused: false,
+          selected: false,
+        });
+      });
+
+      it('should pass the combo-box instance to the renderer', () => {
+        expect(rendererSpy.firstCall.args[2]).to.equal(comboBox);
+      });
+    });
+  });
+});

--- a/packages/combo-box/test/typings/lit.types.ts
+++ b/packages/combo-box/test/typings/lit.types.ts
@@ -1,0 +1,15 @@
+import { DirectiveResult } from 'lit/directive.js';
+import { ComboBoxLitRenderer, comboBoxRenderer, ComboBoxRendererDirective } from '../../lit.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+interface TestComboBoxItem {
+  testProperty: string;
+}
+
+assertType<
+  (
+    renderer: ComboBoxLitRenderer<TestComboBoxItem>,
+    value?: unknown,
+  ) => DirectiveResult<typeof ComboBoxRendererDirective>
+>(comboBoxRenderer);

--- a/packages/combo-box/test/typings/lit.types.ts
+++ b/packages/combo-box/test/typings/lit.types.ts
@@ -10,6 +10,6 @@ interface TestComboBoxItem {
 assertType<
   (
     renderer: ComboBoxLitRenderer<TestComboBoxItem>,
-    value?: unknown,
+    dependencies?: unknown,
   ) => DirectiveResult<typeof ComboBoxRendererDirective>
 >(comboBoxRenderer);


### PR DESCRIPTION
## Description

This PR implements a Lit renderer directive for the `renderer` property of the combo-box component in order to provide a better DX for Lit users.

Part of #266

### ComboBox Renderer

```diff
import { comboBoxRenderer } from '@vaadin/combo-box/lit.js';

<vaadin-combo-box
-  .renderer="${(root, model, column) => render(html`...`, root, { eventContext: this })}"
+  ${comboBoxRenderer((item, model, column) => html`...`)}
></vaadin-combo-box>
```

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
