### PR TITLE
fix: add lit entrypoints to package.json

### DIFF
--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -22,6 +22,8 @@
   "files": [
     "src",
     "theme",
+    "lit.js",
+    "lit.d.ts",
     "vaadin-*.d.ts",
     "vaadin-*.js"
   ],


### PR DESCRIPTION
## Description

Added `lit.js` and `lit.d.ts` entrypoints to `files` of the dialog component `package.json`.

A follow-up to #3755

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
