### PR TITLE
test: add TS tests making sure that Lit directive classes are exported

### DIFF
--- a/packages/dialog/test/typings/lit.types.ts
+++ b/packages/dialog/test/typings/lit.types.ts
@@ -1,8 +1,24 @@
 import { DirectiveResult } from 'lit/directive.js';
-import { dialogFooterRenderer, dialogHeaderRenderer, DialogLitRenderer, dialogRenderer } from '../../lit.js';
+import {
+  dialogFooterRenderer,
+  DialogFooterRendererDirective,
+  dialogHeaderRenderer,
+  DialogHeaderRendererDirective,
+  DialogLitRenderer,
+  dialogRenderer,
+  DialogRendererDirective,
+} from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-assertType<(renderer: DialogLitRenderer, value?: unknown) => DirectiveResult>(dialogRenderer);
-assertType<(renderer: DialogLitRenderer, value?: unknown) => DirectiveResult>(dialogHeaderRenderer);
-assertType<(renderer: DialogLitRenderer, value?: unknown) => DirectiveResult>(dialogFooterRenderer);
+assertType<(renderer: DialogLitRenderer, dependencies?: unknown) => DirectiveResult<typeof DialogRendererDirective>>(
+  dialogRenderer,
+);
+
+assertType<
+  (renderer: DialogLitRenderer, dependencies?: unknown) => DirectiveResult<typeof DialogHeaderRendererDirective>
+>(dialogHeaderRenderer);
+
+assertType<
+  (renderer: DialogLitRenderer, dependencies?: unknown) => DirectiveResult<typeof DialogFooterRendererDirective>
+>(dialogFooterRenderer);


### PR DESCRIPTION
## Description

A minor improvement of the dialog Lit directives TS tests to make them also verify that directive classes are exported.

A follow-up to #3755 

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
