### PR TITLE
fix: use computed hidden state to determine column visibility

### DIFF
--- a/dev/grid.html
+++ b/dev/grid.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
-    <script type="module" src="./common.js"></script>
-  </head>
-  <body>
-    <script type="module">
-      import '@vaadin/grid/all-imports';
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Document</title>
+  <script type="module" src="./common.js"></script>
+</head>
+<body>
+<script type="module">
+  import "@vaadin/grid/all-imports";
 
-      const grid = document.querySelector('vaadin-grid');
+  const grid = document.querySelector("vaadin-grid");
 
       grid.dataProvider = ({ parentItem, page, pageSize }, cb) => {
         // Let's have 100 root-level items and 5 items on every child level
@@ -30,12 +30,13 @@
       };
     </script>
 
-    <vaadin-grid item-id-path="name">
-      <vaadin-grid-selection-column auto-select frozen></vaadin-grid-selection-column>
-      <vaadin-grid-tree-column frozen path="name" width="200px" flex-shrink="0"></vaadin-grid-tree-column>
-      <vaadin-grid-column path="name" width="200px" flex-shrink="0"></vaadin-grid-column>
-      <vaadin-grid-column path="name" width="200px" flex-shrink="0"></vaadin-grid-column>
-      <vaadin-grid-column path="name" width="200px" flex-shrink="0"></vaadin-grid-column>
-    </vaadin-grid>
-  </body>
+<vaadin-grid>
+  <vaadin-grid-column-group header="group 1">
+    <vaadin-grid-column header="column 1"></vaadin-grid-column>
+    <vaadin-grid-column header="column 2"></vaadin-grid-column>
+  </vaadin-grid-column-group>
+  <vaadin-grid-column header="column 3"></vaadin-grid-column>
+</vaadin-grid>
+<button id="remove-columns">Remove columns</button>
+</body>
 </html>

--- a/dev/grid.html
+++ b/dev/grid.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Document</title>
-  <script type="module" src="./common.js"></script>
-</head>
-<body>
-<script type="module">
-  import "@vaadin/grid/all-imports";
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+    <script type="module" src="./common.js"></script>
+  </head>
+  <body>
+    <script type="module">
+      import '@vaadin/grid/all-imports';
 
-  const grid = document.querySelector("vaadin-grid");
+      const grid = document.querySelector('vaadin-grid');
 
       grid.dataProvider = ({ parentItem, page, pageSize }, cb) => {
         // Let's have 100 root-level items and 5 items on every child level
@@ -30,13 +30,12 @@
       };
     </script>
 
-<vaadin-grid>
-  <vaadin-grid-column-group header="group 1">
-    <vaadin-grid-column header="column 1"></vaadin-grid-column>
-    <vaadin-grid-column header="column 2"></vaadin-grid-column>
-  </vaadin-grid-column-group>
-  <vaadin-grid-column header="column 3"></vaadin-grid-column>
-</vaadin-grid>
-<button id="remove-columns">Remove columns</button>
-</body>
+    <vaadin-grid item-id-path="name">
+      <vaadin-grid-selection-column auto-select frozen></vaadin-grid-selection-column>
+      <vaadin-grid-tree-column frozen path="name" width="200px" flex-shrink="0"></vaadin-grid-tree-column>
+      <vaadin-grid-column path="name" width="200px" flex-shrink="0"></vaadin-grid-column>
+      <vaadin-grid-column path="name" width="200px" flex-shrink="0"></vaadin-grid-column>
+      <vaadin-grid-column path="name" width="200px" flex-shrink="0"></vaadin-grid-column>
+    </vaadin-grid>
+  </body>
 </html>

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -194,7 +194,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
 
   /** @private */
   _updateVisibleChildColumns() {
-    this._visibleChildColumns = Array.prototype.filter.call(this._childColumns, (col) => col._isVisible);
+    this._visibleChildColumns = Array.prototype.filter.call(this._childColumns, (col) => !col._effectiveHidden);
     this._colSpan = this._visibleChildColumns.length;
   }
 
@@ -243,7 +243,21 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
   /**
    * @override
    * @protected
-   * */
+   */
+  get _effectiveHidden() {
+    if (!this.parentElement) {
+      return true;
+    }
+    if (this.hidden) {
+      return true;
+    }
+    return this._childColumns.every((column) => column._effectiveHidden);
+  }
+
+  /**
+   * @override
+   * @protected
+   */
   _updateHiddenState() {
     super._updateHiddenState();
     this._updateVisibleChildColumns();
@@ -302,16 +316,6 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
       }
     });
     this._observer.flush();
-  }
-
-  get _isVisible() {
-    if (!this.parentElement) {
-      return false;
-    }
-    if (this.hidden) {
-      return false;
-    }
-    return this._childColumns.some((column) => column._isVisible);
   }
 
   /**

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -115,7 +115,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
    * @protected
    */
   _columnPropChanged(path, value) {
-    if (/flexGrow|width|hidden|_childColumns/.test(path)) {
+    if (/flexGrow|width|_childColumns/.test(path)) {
       this._updateFlexAndWidth();
     }
 
@@ -244,13 +244,14 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
    * @override
    * @protected
    * */
-  _updateHiddenCells() {
-    super._updateHiddenCells();
+  _updateHiddenState() {
+    super._updateHiddenState();
     this._updateVisibleChildColumns();
+    this._updateFlexAndWidth();
     // Recursively update child columns
     this._childColumns.forEach((column) => {
-      if (column._updateHiddenCells) {
-        column._updateHiddenCells();
+      if (column._updateHiddenState) {
+        column._updateHiddenState();
       }
     });
   }

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -241,6 +241,13 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
   }
 
   /**
+   * Computes the whether the column group should effectively be hidden or not.
+   * A column group is effectively hidden if:
+   * - it is not attached
+   * - it is hidden
+   * - it does not have any child columns or groups
+   * - if all child columns or groups are effectively hidden
+   *
    * @override
    * @protected
    */
@@ -255,6 +262,11 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
   }
 
   /**
+   * Overrides hidden update logic from `ColumnBaseMixin` to additionally:
+   * - recalculate which child columns or groups are visible
+   * - update width related styles
+   * - recursively update the hidden state of child columns or groups
+   *
    * @override
    * @protected
    */

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -87,7 +87,6 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
     return [
       '_groupFrozenChanged(frozen, _rootColumns)',
       '_groupFrozenToEndChanged(frozenToEnd, _rootColumns)',
-      '_groupHiddenChanged(hidden, _rootColumns)',
       '_colSpanChanged(_colSpan, _headerCell, _footerCell)',
       '_groupOrderChanged(_order, _rootColumns)',
       '_groupReorderStatusChanged(_reorderStatus, _rootColumns)',
@@ -116,11 +115,6 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
    * @protected
    */
   _columnPropChanged(path, value) {
-    if (path === 'hidden') {
-      this._updateVisibleChildColumns();
-      this._updateHiddenCells();
-    }
-
     if (/flexGrow|width|hidden|_childColumns/.test(path)) {
       this._updateFlexAndWidth();
     }
@@ -246,17 +240,13 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
     }
   }
 
-  /** @private */
-  _groupHiddenChanged() {
-    this._updateVisibleChildColumns();
-  }
-
   /**
    * @override
    * @protected
    * */
   _updateHiddenCells() {
     super._updateHiddenCells();
+    this._updateVisibleChildColumns();
     // Recursively update child columns
     this._childColumns.forEach((column) => {
       if (column._updateHiddenCells) {
@@ -305,13 +295,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
         microTask.run(() => {
           if (this._grid && this._grid._updateColumnTree) {
             this._grid._updateColumnTree();
-            // Recursively update hidden cells for the whole hierarchy,
-            // starting from the root column / group
-            const columnHierarchy = this._getColumnHierarchy();
-            const topLevelColumnOrGroup = columnHierarchy[0];
-            if (topLevelColumnOrGroup._updateHiddenCells) {
-              topLevelColumnOrGroup._updateHiddenCells();
-            }
+            this._notifyHiddenChange();
           }
         });
       }

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -118,6 +118,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
   _columnPropChanged(path, value) {
     if (path === 'hidden') {
       this._updateVisibleChildColumns();
+      this._updateHiddenState();
     }
 
     if (/flexGrow|width|hidden|_childColumns/.test(path)) {

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -322,6 +322,9 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
         microTask.run(() => {
           if (this._grid && this._grid._updateColumnTree) {
             this._grid._updateColumnTree();
+            // TODO: without this call the column group header cells might not be rendered, which causes the header row to be hidden
+            // Check why the previous call to _updateColumnTree does not render header cells
+            this._grid._renderColumnTree(this._grid._columnTree);
             this._notifyHiddenChange();
           }
         });

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -198,7 +198,7 @@ export const ColumnReorderingMixin = (superClass) =>
       return this._columnTree
         .slice(0)
         .pop()
-        .filter((c) => !c.hidden)
+        .filter((c) => c._isVisible)
         .sort((b, a) => b._order - a._order);
     }
 

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -198,7 +198,7 @@ export const ColumnReorderingMixin = (superClass) =>
       return this._columnTree
         .slice(0)
         .pop()
-        .filter((c) => c._isVisible)
+        .filter((c) => !c._effectiveHidden)
         .sort((b, a) => b._order - a._order);
     }
 

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -45,7 +45,7 @@ export const ColumnResizingMixin = (superClass) =>
           column = column._childColumns
             .slice(0)
             .sort((a, b) => a._order - b._order)
-            .filter((column) => column._isVisible)
+            .filter((column) => !column._effectiveHidden)
             .pop();
         }
 

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -45,7 +45,7 @@ export const ColumnResizingMixin = (superClass) =>
           column = column._childColumns
             .slice(0)
             .sort((a, b) => a._order - b._order)
-            .filter((column) => !column.hidden)
+            .filter((column) => column._isVisible)
             .pop();
         }
 

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -467,7 +467,7 @@ export const ColumnBaseMixin = (superClass) =>
       }
 
       if (!!hidden !== !!this._previousHidden && this._grid) {
-        if (hidden === true) {
+        if (!this._isVisible) {
           this._allCells.forEach((cell) => {
             if (cell._content.parentNode) {
               cell._content.parentNode.removeChild(cell._content);
@@ -495,6 +495,31 @@ export const ColumnBaseMixin = (superClass) =>
       this._previousHidden = hidden;
     }
 
+    get _isVisible() {
+      if (!this.parentElement) {
+        return false;
+      }
+      if (this.hidden) {
+        return false;
+      }
+      const parentColumns = [];
+      let currentParent = this.parentElement;
+      while (currentParent && this._isColumnElement(currentParent)) {
+        parentColumns.push(currentParent);
+        currentParent = currentParent.parentElement;
+      }
+      return !parentColumns.some((parentColumn) => !!parentColumn.hidden);
+    }
+
+    /**
+     * @param {!Node} node
+     * @return {boolean}
+     * @protected
+     */
+    _isColumnElement(node) {
+      return node.nodeType === Node.ELEMENT_NODE && /\bcolumn\b/.test(node.localName);
+    }
+
     /** @protected */
     _runRenderer(renderer, cell, model) {
       const args = [cell._content, this];
@@ -512,7 +537,7 @@ export const ColumnBaseMixin = (superClass) =>
      */
     __renderCellsContent(renderer, cells) {
       // Skip if the column is hidden or not attached to a grid.
-      if (this.hidden || !this._grid) {
+      if (!this._isVisible || !this._grid) {
         return;
       }
 

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -466,33 +466,41 @@ export const ColumnBaseMixin = (superClass) =>
         this.parentElement._columnPropChanged('hidden', hidden);
       }
 
-      if (!!hidden !== !!this._previousHidden && this._grid) {
-        if (!this._isVisible) {
-          this._allCells.forEach((cell) => {
-            if (cell._content.parentNode) {
-              cell._content.parentNode.removeChild(cell._content);
-            }
-          });
-        }
-        this._grid._debouncerHiddenChanged = Debouncer.debounce(
-          this._grid._debouncerHiddenChanged,
-          animationFrame,
-          () => {
-            if (this._grid && this._grid._renderColumnTree) {
-              this._grid._renderColumnTree(this._grid._columnTree);
-            }
-          },
-        );
-
-        if (this._grid._updateFrozenColumn) {
-          this._grid._updateFrozenColumn();
-        }
-
-        if (this._grid._resetKeyboardNavigation) {
-          this._grid._resetKeyboardNavigation();
-        }
+      if (!!hidden !== !!this._previousHidden) {
+        this._updateHiddenState();
       }
       this._previousHidden = hidden;
+    }
+
+    /** @protected */
+    _updateHiddenState() {
+      if (!this._grid) {
+        return;
+      }
+      if (!this._isVisible) {
+        this._allCells.forEach((cell) => {
+          if (cell._content.parentNode) {
+            cell._content.parentNode.removeChild(cell._content);
+          }
+        });
+      }
+      this._grid._debouncerHiddenChanged = Debouncer.debounce(
+        this._grid._debouncerHiddenChanged,
+        animationFrame,
+        () => {
+          if (this._grid && this._grid._renderColumnTree) {
+            this._grid._renderColumnTree(this._grid._columnTree);
+          }
+        },
+      );
+
+      if (this._grid._updateFrozenColumn) {
+        this._grid._updateFrozenColumn();
+      }
+
+      if (this._grid._resetKeyboardNavigation) {
+        this._grid._resetKeyboardNavigation();
+      }
     }
 
     get _isVisible() {

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -212,7 +212,6 @@ export const ColumnBaseMixin = (superClass) =>
         '_onFooterRendererOrBindingChanged(_footerRenderer, _footerCell)',
         '_resizableChanged(resizable, _headerCell)',
         '_reorderStatusChanged(_reorderStatus, _headerCell, _footerCell, _cells.*)',
-        '_hiddenChanged(hidden)',
       ];
     }
 

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -462,10 +462,27 @@ export const ColumnBaseMixin = (superClass) =>
       });
     }
 
+    get _isVisible() {
+      if (!this.parentElement) {
+        return false;
+      }
+      const columnHierarchy = this._getColumnHierarchy();
+      return !columnHierarchy.some((column) => !!column.hidden);
+    }
+
+    _getColumnHierarchy() {
+      const hierarchy = [this];
+      let currentElement = this.parentElement;
+      while (currentElement && this._isColumnElement(currentElement)) {
+        hierarchy.unshift(currentElement);
+        currentElement = currentElement.parentElement;
+      }
+      return hierarchy;
+    }
+
     /** @private */
     _hiddenChanged(hidden, oldValue) {
       if (!!hidden !== !!oldValue) {
-        console.log('_hiddenChanged', hidden, oldValue);
         if (this._grid) {
           this._grid._debouncerHiddenChanged = Debouncer.debounce(
             this._grid._debouncerHiddenChanged,
@@ -489,18 +506,17 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     _notifyHiddenChange() {
-      // Recursively update hidden cells for the whole hierarchy,
+      // Recursively update hidden state for the whole hierarchy,
       // starting from the root column / group
       const columnHierarchy = this._getColumnHierarchy();
       const topLevelColumnOrGroup = columnHierarchy[0];
-      if (topLevelColumnOrGroup._updateHiddenCells) {
-        topLevelColumnOrGroup._updateHiddenCells();
+      if (topLevelColumnOrGroup._updateHiddenState) {
+        topLevelColumnOrGroup._updateHiddenState();
       }
     }
 
     /** @protected */
-    _updateHiddenCells() {
-      console.log('_updateHiddenCells');
+    _updateHiddenState() {
       if (!this._isVisible) {
         this._allCells.forEach((cell) => {
           if (cell._content.parentNode) {
@@ -508,24 +524,6 @@ export const ColumnBaseMixin = (superClass) =>
           }
         });
       }
-    }
-
-    get _isVisible() {
-      if (!this.parentElement) {
-        return false;
-      }
-      const columnHierarchy = this._getColumnHierarchy();
-      return !columnHierarchy.some((column) => !!column.hidden);
-    }
-
-    _getColumnHierarchy() {
-      const hierarchy = [this];
-      let currentElement = this.parentElement;
-      while (currentElement && this._isColumnElement(currentElement)) {
-        hierarchy.unshift(currentElement);
-        currentElement = currentElement.parentElement;
-      }
-      return hierarchy;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -461,7 +461,14 @@ export const ColumnBaseMixin = (superClass) =>
       });
     }
 
-    /** @protected */
+    /**
+     * Computes the whether the column should effectively be hidden or not.
+     * A column is effectively hidden if:
+     * - it is not attached
+     * - itself, or any of its ancestors is hidden
+     *
+     * @protected
+     */
     get _effectiveHidden() {
       if (!this.parentElement) {
         return true;
@@ -470,6 +477,12 @@ export const ColumnBaseMixin = (superClass) =>
       return columnHierarchy.some((column) => !!column.hidden);
     }
 
+    /**
+     * Returns an array of all ancestor columns or groups, including the
+     * current columns itself. Does not include any children.
+     *
+     * @protected
+     */
     _getColumnHierarchy() {
       const hierarchy = [this];
       let currentElement = this.parentElement;
@@ -505,9 +518,15 @@ export const ColumnBaseMixin = (superClass) =>
       }
     }
 
+    /**
+     * Notifies the top-level column or group in this column hierarchy that
+     * the hidden state of a column or group has changed. This causes a
+     * recursive update through the hierarchy to update each column
+     * or group based on its effective hidden state.
+     *
+     * @private
+     */
     _notifyHiddenChange() {
-      // Recursively update hidden state for the whole hierarchy,
-      // starting from the root column / group
       const columnHierarchy = this._getColumnHierarchy();
       const topLevelColumnOrGroup = columnHierarchy[0];
       if (topLevelColumnOrGroup._updateHiddenState) {
@@ -515,7 +534,11 @@ export const ColumnBaseMixin = (superClass) =>
       }
     }
 
-    /** @protected */
+    /**
+     * Updates the column based on its current effective hidden state
+     *
+     * @protected
+     */
     _updateHiddenState() {
       if (this._effectiveHidden) {
         this._allCells.forEach((cell) => {

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -462,12 +462,13 @@ export const ColumnBaseMixin = (superClass) =>
       });
     }
 
-    get _isVisible() {
+    /** @protected */
+    get _effectiveHidden() {
       if (!this.parentElement) {
-        return false;
+        return true;
       }
       const columnHierarchy = this._getColumnHierarchy();
-      return !columnHierarchy.some((column) => !!column.hidden);
+      return columnHierarchy.some((column) => !!column.hidden);
     }
 
     _getColumnHierarchy() {
@@ -517,7 +518,7 @@ export const ColumnBaseMixin = (superClass) =>
 
     /** @protected */
     _updateHiddenState() {
-      if (!this._isVisible) {
+      if (this._effectiveHidden) {
         this._allCells.forEach((cell) => {
           if (cell._content.parentNode) {
             cell._content.parentNode.removeChild(cell._content);
@@ -552,7 +553,7 @@ export const ColumnBaseMixin = (superClass) =>
      */
     __renderCellsContent(renderer, cells) {
       // Skip if the column is hidden or not attached to a grid.
-      if (!this._isVisible || !this._grid) {
+      if (this._effectiveHidden || !this._grid) {
         return;
       }
 

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -488,7 +488,7 @@ export const KeyboardNavigationMixin = (superClass) =>
         if (isCurrentCellRowDetails) {
           this._focusedColumnOrder = 0;
         } else {
-          this._focusedColumnOrder = this._getColumns(activeRowGroup, currentRowIndex).filter((c) => !c.hidden)[
+          this._focusedColumnOrder = this._getColumns(activeRowGroup, currentRowIndex).filter((c) => c._isVisible)[
             columnIndex
           ]._order;
         }
@@ -505,7 +505,7 @@ export const KeyboardNavigationMixin = (superClass) =>
         // original _focusedColumnOrder in the sorted array of orders
         // of the visible columns on the destination row.
         const dstRowIndex = this.__getIndexInGroup(dstRow, this._focusedItemIndex);
-        const dstColumns = this._getColumns(activeRowGroup, dstRowIndex).filter((c) => !c.hidden);
+        const dstColumns = this._getColumns(activeRowGroup, dstRowIndex).filter((c) => c._isVisible);
         const dstSortedColumnOrders = dstColumns.map((c) => c._order).sort((b, a) => b - a);
         const maxOrderedColumnIndex = dstSortedColumnOrders.length - 1;
         const orderedColumnIndex = dstSortedColumnOrders.indexOf(

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -488,9 +488,9 @@ export const KeyboardNavigationMixin = (superClass) =>
         if (isCurrentCellRowDetails) {
           this._focusedColumnOrder = 0;
         } else {
-          this._focusedColumnOrder = this._getColumns(activeRowGroup, currentRowIndex).filter((c) => c._isVisible)[
-            columnIndex
-          ]._order;
+          this._focusedColumnOrder = this._getColumns(activeRowGroup, currentRowIndex).filter(
+            (c) => !c._effectiveHidden,
+          )[columnIndex]._order;
         }
       }
 
@@ -505,7 +505,7 @@ export const KeyboardNavigationMixin = (superClass) =>
         // original _focusedColumnOrder in the sorted array of orders
         // of the visible columns on the destination row.
         const dstRowIndex = this.__getIndexInGroup(dstRow, this._focusedItemIndex);
-        const dstColumns = this._getColumns(activeRowGroup, dstRowIndex).filter((c) => c._isVisible);
+        const dstColumns = this._getColumns(activeRowGroup, dstRowIndex).filter((c) => !c._effectiveHidden);
         const dstSortedColumnOrders = dstColumns.map((c) => c._order).sort((b, a) => b - a);
         const maxOrderedColumnIndex = dstSortedColumnOrders.length - 1;
         const orderedColumnIndex = dstSortedColumnOrders.indexOf(

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -227,7 +227,7 @@ export const ScrollMixin = (superClass) =>
           firstFrozenToEnd = i;
         }
 
-        if (col.frozen && !col.hidden) {
+        if (col.frozen && col._isVisible) {
           lastFrozen = i;
         }
       }

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -227,7 +227,7 @@ export const ScrollMixin = (superClass) =>
           firstFrozenToEnd = i;
         }
 
-        if (col.frozen && col._isVisible) {
+        if (col.frozen && !col._effectiveHidden) {
           lastFrozen = i;
         }
       }

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -609,7 +609,7 @@ class Grid extends ElementMixin(
     if (this._cache.isLoading()) {
       this._recalculateColumnWidthOnceLoadingFinished = true;
     } else {
-      const cols = this._getColumns().filter((col) => col._isVisible && col.autoWidth);
+      const cols = this._getColumns().filter((col) => !col._effectiveHidden && col.autoWidth);
       this._recalculateColumnWidths(cols);
     }
   }
@@ -712,7 +712,7 @@ class Grid extends ElementMixin(
     row.innerHTML = '';
 
     columns
-      .filter((column) => column._isVisible)
+      .filter((column) => !column._effectiveHidden)
       .forEach((column, index, cols) => {
         let cell;
 

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -609,7 +609,7 @@ class Grid extends ElementMixin(
     if (this._cache.isLoading()) {
       this._recalculateColumnWidthOnceLoadingFinished = true;
     } else {
-      const cols = this._getColumns().filter((col) => !col.hidden && col.autoWidth);
+      const cols = this._getColumns().filter((col) => col._isVisible && col.autoWidth);
       this._recalculateColumnWidths(cols);
     }
   }
@@ -712,7 +712,7 @@ class Grid extends ElementMixin(
     row.innerHTML = '';
 
     columns
-      .filter((column) => !column.hidden)
+      .filter((column) => column._isVisible)
       .forEach((column, index, cols) => {
         let cell;
 

--- a/packages/grid/test/column-group.test.js
+++ b/packages/grid/test/column-group.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
@@ -27,40 +27,40 @@ describe('column group', () => {
     columns = group.querySelectorAll('vaadin-grid-column');
   });
 
-  it.skip('should sum child column flex-grow', () => {
+  it('should sum child column flex-grow', () => {
     expect(group.flexGrow).to.eql(3);
   });
 
-  it.skip('should sum child column widths', () => {
+  it('should sum child column widths', () => {
     expect(group.width).to.eql('calc(20% + 200px)');
   });
 
-  it.skip('should strip nested `calc` keywords', () => {
+  it('should strip nested `calc` keywords', () => {
     columns[0].width = 'calc(50% + 10px)';
 
     expect(group.width).to.eql('calc((50% + 10px) + 200px)');
   });
 
-  it.skip('should react to child column flex-grow changes', () => {
+  it('should react to child column flex-grow changes', () => {
     columns[0].flexGrow = 3;
 
     expect(group.flexGrow).to.eql(5);
   });
 
-  it.skip('should react to child column width changes', () => {
+  it('should react to child column width changes', () => {
     columns[0].width = '10%';
 
     expect(group.width).to.eql('calc(10% + 200px)');
   });
 
-  it.skip('should get frozen when child column freezes', () => {
+  it('should get frozen when child column freezes', () => {
     columns[0].frozen = true;
 
     expect(group.frozen).to.be.true;
   });
 
   // this test is aimed for Safari 9, see #552
-  it.skip('should propagate frozen from children when attached', () => {
+  it('should propagate frozen from children when attached', () => {
     const parent = group.parentElement;
     parent.removeChild(group);
 
@@ -71,7 +71,7 @@ describe('column group', () => {
     expect(group.frozen).to.be.true;
   });
 
-  it.skip('should propagate frozen to child columns', () => {
+  it('should propagate frozen to child columns', () => {
     columns[0].frozen = false;
     group.frozen = true;
 
@@ -80,28 +80,28 @@ describe('column group', () => {
   });
 
   /*
-  it.skip('should hide group column', () => {
+  it('should hide group column', () => {
     columns[0].hidden = true;
     columns[1].hidden = true;
 
     expect(group.hidden).to.be.true;
   });
 
-  it.skip('should unhide group column', () => {
+  it('should unhide group column', () => {
     group.hidden = true;
     columns[0].hidden = false;
 
     expect(group.hidden).to.be.false;
   });
 
-  it.skip('should not unhide other columns', () => {
+  it('should not unhide other columns', () => {
     group.hidden = true;
     columns[0].hidden = false;
 
     expect(columns[1].hidden).to.be.true;
   });
 
-  it.skip('should propagate hidden to child columns', () => {
+  it('should propagate hidden to child columns', () => {
     columns[0].hidden = false;
     group.hidden = true;
 
@@ -110,7 +110,7 @@ describe('column group', () => {
     expect(group.hidden).to.be.true;
   });
 
-  it.skip('should propagate hidden to child columns 2', () => {
+  it('should propagate hidden to child columns 2', () => {
     group.hidden = true;
     group.hidden = false;
 
@@ -119,7 +119,7 @@ describe('column group', () => {
     expect(group.hidden).to.be.false;
   });
 
-  it.skip('should hide the group', () => {
+  it('should hide the group', () => {
     group.removeChild(columns[0]);
     group.removeChild(columns[1]);
     group._observer.flush();
@@ -127,7 +127,7 @@ describe('column group', () => {
     expect(group.hidden).to.be.true;
   });
 
-  it.skip('should unhide the group', () => {
+  it('should unhide the group', () => {
     group.removeChild(columns[0]);
     group.removeChild(columns[1]);
     group._observer.flush();
@@ -138,7 +138,7 @@ describe('column group', () => {
     expect(group.hidden).to.be.false;
   });
 
-  it.skip('should not unhide the group', () => {
+  it('should not unhide the group', () => {
     group.removeChild(columns[0]);
     group.removeChild(columns[1]);
     group._observer.flush();
@@ -151,13 +151,13 @@ describe('column group', () => {
   });
    */
 
-  it.skip('should calculate column group width after hiding a column', () => {
+  it('should calculate column group width after hiding a column', () => {
     columns[0].hidden = true;
 
     expect(group.width).to.eql('calc(200px)');
   });
 
-  it.skip('should calculate column group flexGrow after hiding a column', () => {
+  it('should calculate column group flexGrow after hiding a column', () => {
     columns[0].hidden = true;
 
     expect(group.flexGrow).to.eql(2);
@@ -193,7 +193,7 @@ describe('column group', () => {
         }
       });
 
-      it.skip(`should observe for adding ${templateName} templates`, async () => {
+      it(`should observe for adding ${templateName} templates`, async () => {
         const template = fixtureSync(`
           <template class="${templateName}">content</template>
         `);
@@ -204,7 +204,7 @@ describe('column group', () => {
         expect(cell._content.textContent).to.equal('content');
       });
 
-      it.skip(`should observe for replacing ${templateName} templates`, async () => {
+      it(`should observe for replacing ${templateName} templates`, async () => {
         const template1 = fixtureSync(`
           <template class="${templateName}">content1</template>
         `);
@@ -227,7 +227,7 @@ describe('column group', () => {
   });
 
   describe('inheritance', () => {
-    it.skip('both, class and super observers, should be called', () => {
+    it('both, class and super observers, should be called', () => {
       const superSpy = sinon.spy(group, '_resizableChanged');
       const thisSpy = sinon.spy(group, '_groupResizableChanged');
       group.resizable = true;
@@ -239,7 +239,7 @@ describe('column group', () => {
   describe('hidden', () => {
     let grid, group, column1, column2;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       grid = fixtureSync(`
         <vaadin-grid>
           <vaadin-grid-column-group header="group 1">
@@ -262,6 +262,7 @@ describe('column group', () => {
       column2 = allColumns[1];
 
       flushGrid(grid);
+      await nextFrame();
     });
 
     function verifyColumnGroupCellsAreVisible() {
@@ -300,14 +301,14 @@ describe('column group', () => {
       });
     }
 
-    it.skip('should be visible by default', () => {
+    it('should be visible by default', () => {
       expect(group.hidden).to.be.false;
       verifyColumnGroupCellsAreVisible(group);
       verifyColumnCellsAreVisible(column1);
       verifyColumnCellsAreVisible(column2);
     });
 
-    it.skip('should not be visible when hidden', () => {
+    it('should not be visible when hidden', () => {
       group.hidden = true;
       flushGrid(grid);
 
@@ -316,9 +317,12 @@ describe('column group', () => {
       verifyColumnCellsAreHidden(column2);
     });
 
-    it.skip('should become visible again when removing hidden', () => {
+    it('should become visible again when removing hidden', () => {
       group.hidden = true;
       flushGrid(grid);
+
+      verifyColumnGroupCellsAreHidden(group);
+
       group.hidden = false;
       flushGrid(grid);
 
@@ -327,7 +331,7 @@ describe('column group', () => {
       verifyColumnCellsAreVisible(column2);
     });
 
-    it.skip('should be hidden when all columns are hidden', () => {
+    it('should be hidden when all columns are hidden', () => {
       column1.hidden = true;
       column2.hidden = true;
       flushGrid(grid);
@@ -337,15 +341,43 @@ describe('column group', () => {
       verifyColumnCellsAreHidden(column2);
     });
 
-    it('should be hidden when all columns are removed', async () => {
-      flushGrid(grid);
-      group.removeChild(column1);
-      group.removeChild(column2);
-      group._observer.flush();
+    it('should become visible again when making a column visible', () => {
+      column1.hidden = true;
+      column2.hidden = true;
       flushGrid(grid);
 
       verifyColumnGroupCellsAreHidden(group);
+
+      column1.hidden = false;
+      flushGrid(grid);
+
+      verifyColumnGroupCellsAreVisible(group);
+      verifyColumnCellsAreVisible(column1);
+      verifyColumnCellsAreHidden(column2);
+    });
+
+    it('should be hidden when all columns are removed', async () => {
+      group.removeChild(column1);
+      group.removeChild(column2);
+      await nextFrame();
+
+      verifyColumnGroupCellsAreHidden(group);
       verifyColumnCellsAreHidden(column1);
+      verifyColumnCellsAreHidden(column2);
+    });
+
+    it('should become visible again when adding visible column', async () => {
+      group.removeChild(column1);
+      group.removeChild(column2);
+      await nextFrame();
+
+      verifyColumnGroupCellsAreHidden(group);
+
+      group.appendChild(column1);
+      await nextFrame();
+
+      verifyColumnGroupCellsAreVisible(group);
+      verifyColumnCellsAreVisible(column1);
       verifyColumnCellsAreHidden(column2);
     });
   });

--- a/packages/grid/test/column-group.test.js
+++ b/packages/grid/test/column-group.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
-import { flushGrid, getContainerCell } from './helpers.js';
+import { flushGrid, getContainerCell, hasCellForColumn } from './helpers.js';
 
 describe('column group', () => {
   let group, columns;
@@ -27,40 +27,40 @@ describe('column group', () => {
     columns = group.querySelectorAll('vaadin-grid-column');
   });
 
-  it('should sum child column flex-grow', () => {
+  it.skip('should sum child column flex-grow', () => {
     expect(group.flexGrow).to.eql(3);
   });
 
-  it('should sum child column widths', () => {
+  it.skip('should sum child column widths', () => {
     expect(group.width).to.eql('calc(20% + 200px)');
   });
 
-  it('should strip nested `calc` keywords', () => {
+  it.skip('should strip nested `calc` keywords', () => {
     columns[0].width = 'calc(50% + 10px)';
 
     expect(group.width).to.eql('calc((50% + 10px) + 200px)');
   });
 
-  it('should react to child column flex-grow changes', () => {
+  it.skip('should react to child column flex-grow changes', () => {
     columns[0].flexGrow = 3;
 
     expect(group.flexGrow).to.eql(5);
   });
 
-  it('should react to child column width changes', () => {
+  it.skip('should react to child column width changes', () => {
     columns[0].width = '10%';
 
     expect(group.width).to.eql('calc(10% + 200px)');
   });
 
-  it('should get frozen when child column freezes', () => {
+  it.skip('should get frozen when child column freezes', () => {
     columns[0].frozen = true;
 
     expect(group.frozen).to.be.true;
   });
 
   // this test is aimed for Safari 9, see #552
-  it('should propagate frozen from children when attached', () => {
+  it.skip('should propagate frozen from children when attached', () => {
     const parent = group.parentElement;
     parent.removeChild(group);
 
@@ -71,7 +71,7 @@ describe('column group', () => {
     expect(group.frozen).to.be.true;
   });
 
-  it('should propagate frozen to child columns', () => {
+  it.skip('should propagate frozen to child columns', () => {
     columns[0].frozen = false;
     group.frozen = true;
 
@@ -79,28 +79,29 @@ describe('column group', () => {
     expect(columns[1].frozen).to.be.true;
   });
 
-  it('should hide group column', () => {
+  /*
+  it.skip('should hide group column', () => {
     columns[0].hidden = true;
     columns[1].hidden = true;
 
     expect(group.hidden).to.be.true;
   });
 
-  it('should unhide group column', () => {
+  it.skip('should unhide group column', () => {
     group.hidden = true;
     columns[0].hidden = false;
 
     expect(group.hidden).to.be.false;
   });
 
-  it('should not unhide other columns', () => {
+  it.skip('should not unhide other columns', () => {
     group.hidden = true;
     columns[0].hidden = false;
 
     expect(columns[1].hidden).to.be.true;
   });
 
-  it('should propagate hidden to child columns', () => {
+  it.skip('should propagate hidden to child columns', () => {
     columns[0].hidden = false;
     group.hidden = true;
 
@@ -109,7 +110,7 @@ describe('column group', () => {
     expect(group.hidden).to.be.true;
   });
 
-  it('should propagate hidden to child columns 2', () => {
+  it.skip('should propagate hidden to child columns 2', () => {
     group.hidden = true;
     group.hidden = false;
 
@@ -118,7 +119,7 @@ describe('column group', () => {
     expect(group.hidden).to.be.false;
   });
 
-  it('should hide the group', () => {
+  it.skip('should hide the group', () => {
     group.removeChild(columns[0]);
     group.removeChild(columns[1]);
     group._observer.flush();
@@ -126,7 +127,7 @@ describe('column group', () => {
     expect(group.hidden).to.be.true;
   });
 
-  it('should unhide the group', () => {
+  it.skip('should unhide the group', () => {
     group.removeChild(columns[0]);
     group.removeChild(columns[1]);
     group._observer.flush();
@@ -137,7 +138,7 @@ describe('column group', () => {
     expect(group.hidden).to.be.false;
   });
 
-  it('should not unhide the group', () => {
+  it.skip('should not unhide the group', () => {
     group.removeChild(columns[0]);
     group.removeChild(columns[1]);
     group._observer.flush();
@@ -148,14 +149,15 @@ describe('column group', () => {
 
     expect(group.hidden).to.be.true;
   });
+   */
 
-  it('should calculate column group width after hiding a column', () => {
+  it.skip('should calculate column group width after hiding a column', () => {
     columns[0].hidden = true;
 
     expect(group.width).to.eql('calc(200px)');
   });
 
-  it('should calculate column group flexGrow after hiding a column', () => {
+  it.skip('should calculate column group flexGrow after hiding a column', () => {
     columns[0].hidden = true;
 
     expect(group.flexGrow).to.eql(2);
@@ -191,7 +193,7 @@ describe('column group', () => {
         }
       });
 
-      it(`should observe for adding ${templateName} templates`, async () => {
+      it.skip(`should observe for adding ${templateName} templates`, async () => {
         const template = fixtureSync(`
           <template class="${templateName}">content</template>
         `);
@@ -202,7 +204,7 @@ describe('column group', () => {
         expect(cell._content.textContent).to.equal('content');
       });
 
-      it(`should observe for replacing ${templateName} templates`, async () => {
+      it.skip(`should observe for replacing ${templateName} templates`, async () => {
         const template1 = fixtureSync(`
           <template class="${templateName}">content1</template>
         `);
@@ -225,12 +227,126 @@ describe('column group', () => {
   });
 
   describe('inheritance', () => {
-    it('both, class and super observers, should be called', () => {
+    it.skip('both, class and super observers, should be called', () => {
       const superSpy = sinon.spy(group, '_resizableChanged');
       const thisSpy = sinon.spy(group, '_groupResizableChanged');
       group.resizable = true;
       expect(superSpy.called).to.be.true;
       expect(thisSpy.called).to.be.true;
+    });
+  });
+
+  describe('hidden', () => {
+    let grid, group, column1, column2;
+
+    beforeEach(() => {
+      grid = fixtureSync(`
+        <vaadin-grid>
+          <vaadin-grid-column-group header="group 1">
+            <vaadin-grid-column header="column 1"></vaadin-grid-column>
+            <vaadin-grid-column header="column 2"></vaadin-grid-column>
+          </vaadin-grid-column-group>
+          <vaadin-grid-column header="column 3"></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+      const allColumns = grid.querySelectorAll('vaadin-grid-column');
+      allColumns.forEach(
+        (column) =>
+          // Let each column render a text like `colum1 - item1`
+          (column.renderer = (root, column, model) => (root.textContent = `${column.header} - ${model.item}`)),
+      );
+
+      grid.items = ['item1', 'item2'];
+      group = grid.firstElementChild;
+      column1 = allColumns[0];
+      column2 = allColumns[1];
+
+      flushGrid(grid);
+    });
+
+    function verifyColumnGroupCellsAreVisible() {
+      // Should have a header cell
+      expect(hasCellForColumn(grid.$.header, group)).to.be.true;
+      // Should have header cell content
+      expect(grid.textContent).to.have.string(group.header);
+    }
+
+    function verifyColumnGroupCellsAreHidden(group) {
+      // Should not have a header cell
+      expect(hasCellForColumn(grid.$.header, group)).to.be.false;
+      // Should not have header cell content
+      expect(grid.textContent).not.to.have.string(group.header);
+    }
+
+    function verifyColumnCellsAreVisible(column) {
+      // Should have cells in header, items and footer
+      expect(hasCellForColumn(grid.$.header, column)).to.be.true;
+      expect(hasCellForColumn(grid.$.items, column)).to.be.true;
+      expect(hasCellForColumn(grid.$.footer, column)).to.be.true;
+      // Should have cell content
+      grid.items.forEach((item) => {
+        expect(grid.textContent).to.have.string(`${column.header} - ${item}`);
+      });
+    }
+
+    function verifyColumnCellsAreHidden(column) {
+      // Should not have cells in header, items and footer
+      expect(hasCellForColumn(grid.$.header, column)).to.be.false;
+      expect(hasCellForColumn(grid.$.items, column)).to.be.false;
+      expect(hasCellForColumn(grid.$.footer, column)).to.be.false;
+      // Should not have cell content
+      grid.items.forEach((item) => {
+        expect(grid.textContent).not.to.have.string(`${column.header} - ${item}`);
+      });
+    }
+
+    it.skip('should be visible by default', () => {
+      expect(group.hidden).to.be.false;
+      verifyColumnGroupCellsAreVisible(group);
+      verifyColumnCellsAreVisible(column1);
+      verifyColumnCellsAreVisible(column2);
+    });
+
+    it.skip('should not be visible when hidden', () => {
+      group.hidden = true;
+      flushGrid(grid);
+
+      verifyColumnGroupCellsAreHidden(group);
+      verifyColumnCellsAreHidden(column1);
+      verifyColumnCellsAreHidden(column2);
+    });
+
+    it.skip('should become visible again when removing hidden', () => {
+      group.hidden = true;
+      flushGrid(grid);
+      group.hidden = false;
+      flushGrid(grid);
+
+      verifyColumnGroupCellsAreVisible(group);
+      verifyColumnCellsAreVisible(column1);
+      verifyColumnCellsAreVisible(column2);
+    });
+
+    it.skip('should be hidden when all columns are hidden', () => {
+      column1.hidden = true;
+      column2.hidden = true;
+      flushGrid(grid);
+
+      verifyColumnGroupCellsAreHidden(group);
+      verifyColumnCellsAreHidden(column1);
+      verifyColumnCellsAreHidden(column2);
+    });
+
+    it('should be hidden when all columns are removed', async () => {
+      flushGrid(grid);
+      group.removeChild(column1);
+      group.removeChild(column2);
+      group._observer.flush();
+      flushGrid(grid);
+
+      verifyColumnGroupCellsAreHidden(group);
+      verifyColumnCellsAreHidden(column1);
+      verifyColumnCellsAreHidden(column2);
     });
   });
 });

--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -475,6 +475,8 @@ describe('column groups', () => {
     });
   });
 
+  // TODO: Remove or refactor
+  /*
   describe('hidden group', () => {
     it('should hide children', async () => {
       init('hidden-group');
@@ -492,6 +494,7 @@ describe('column groups', () => {
       expect(columns[1].hidden).not.to.be.true;
     });
   });
+   */
 
   describe('Large nested groups', () => {
     let grid;

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -128,6 +128,11 @@ export const getRowCells = (row) => {
   return Array.prototype.slice.call(row.querySelectorAll('[part~="cell"]'));
 };
 
+export const hasCellForColumn = (container, column) => {
+  const cells = container.querySelectorAll('[part~="cell"]');
+  return Array.from(cells).some((cell) => cell._column === column);
+};
+
 export const getCellContent = (cell) => {
   return cell ? cell.querySelector('slot').assignedNodes()[0] : null;
 };


### PR DESCRIPTION
## Description

WIP

Currently the grid's column and column group synchronize their `hidden` state to their respective parent column groups (in case of a column), or child columns (in case of a column group). The logic is hard to reason about, requires several temporary states to avoid synchronization in some cases, and does not cover all edge-cases like the bug mentioned below.

This change refactors the column and column group to use a computed hidden state, and updates the remaining parts of the grid to use that computed state.

Fixes https://github.com/vaadin/flow-components/issues/2959

