### PR TITLE
feat: add Lit renderer directive for notification

### DIFF
--- a/packages/notification/lit.d.ts
+++ b/packages/notification/lit.d.ts
@@ -1,0 +1,1 @@
+export * from './src/lit/renderer-directives.js';

--- a/packages/notification/lit.js
+++ b/packages/notification/lit.js
@@ -1,0 +1,1 @@
+export * from './src/lit/renderer-directives.js';

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.1.0-beta1",
+    "@vaadin/lit-renderer": "23.1.0-beta1",
     "@vaadin/vaadin-lumo-styles": "23.1.0-beta1",
     "@vaadin/vaadin-material-styles": "23.1.0-beta1",
     "@vaadin/vaadin-themable-mixin": "23.1.0-beta1",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -22,6 +22,8 @@
   "files": [
     "src",
     "theme",
+    "lit.js",
+    "lit.d.ts",
     "vaadin-*.d.ts",
     "vaadin-*.js"
   ],

--- a/packages/notification/src/lit/renderer-directives.d.ts
+++ b/packages/notification/src/lit/renderer-directives.d.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { TemplateResult } from 'lit';
+import { DirectiveResult } from 'lit/directive.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+import { Notification } from '../vaadin-notification.js';
+
+export type NotificationLitRenderer = (notification: Notification) => TemplateResult;
+
+export class NotificationRendererDirective extends LitRendererDirective<Notification, NotificationLitRenderer> {
+  /**
+   * Adds the renderer callback to the notification.
+   */
+  addRenderer(): void;
+
+  /**
+   * Runs the renderer callback on the notification.
+   */
+  runRenderer(): void;
+
+  /**
+   * Removes the renderer callback from the notification.
+   */
+  removeRenderer(): void;
+}
+
+/**
+ * A Lit directive for populating the content of the notification.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the notification
+ * via the `renderer` property. The renderer is called once to populate the content when assigned
+ * and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-notification
+ *   ${notificationRenderer((notification) => html`...`)}
+ * ></vaadin-notification>`
+ * ```
+ *
+ * @param renderer the renderer callback that returns a Lit template.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export declare function notificationRenderer(
+  renderer: NotificationLitRenderer,
+  dependencies?: unknown,
+): DirectiveResult<typeof NotificationRendererDirective>;

--- a/packages/notification/src/lit/renderer-directives.js
+++ b/packages/notification/src/lit/renderer-directives.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { directive } from 'lit/directive.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+
+export class NotificationRendererDirective extends LitRendererDirective {
+  /**
+   * Adds the renderer callback to the notification.
+   */
+  addRenderer() {
+    this.element.renderer = (root, notification) => {
+      this.renderRenderer(root, notification);
+    };
+  }
+
+  /**
+   * Runs the renderer callback on the notification.
+   */
+  runRenderer() {
+    this.element.requestContentUpdate();
+  }
+
+  /**
+   * Removes the renderer callback from the notification.
+   */
+  removeRenderer() {
+    this.element.renderer = null;
+  }
+}
+
+/**
+ * A Lit directive for populating the content of the notification.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the notification
+ * via the `renderer` property. The renderer is called once to populate the content when assigned
+ * and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-notification
+ *   ${notificationRenderer((notification) => html`...`)}
+ * ></vaadin-notification>`
+ * ```
+ *
+ * @param renderer the renderer callback that returns a Lit template.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export const notificationRenderer = directive(NotificationRendererDirective);

--- a/packages/notification/test/lit-renderer-directives.test.js
+++ b/packages/notification/test/lit-renderer-directives.test.js
@@ -1,0 +1,71 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-notification.js';
+import { html, render } from 'lit';
+import { notificationRenderer } from '../lit.js';
+
+async function renderNotification(container, { content }) {
+  render(
+    html`<vaadin-notification
+      ${content ? notificationRenderer(() => html`${content}`, content) : null}
+    ></vaadin-notification>`,
+    container,
+  );
+  await nextFrame();
+  return container.querySelector('vaadin-notification');
+}
+
+describe('lit renderer directives', () => {
+  let container, notification, card;
+
+  beforeEach(() => {
+    container = fixtureSync('<div></div>');
+  });
+
+  describe('notificationRenderer', () => {
+    describe('basic', () => {
+      beforeEach(async () => {
+        notification = await renderNotification(container, { content: 'Content' });
+        card = notification.shadowRoot.querySelector('vaadin-notification-card');
+        notification.open();
+      });
+
+      it('should set `renderer` property when the directive is attached', () => {
+        expect(notification.renderer).to.exist;
+      });
+
+      it('should unset `renderer` property when the directive is detached', async () => {
+        await renderNotification(container, {});
+        expect(notification.renderer).not.to.exist;
+      });
+
+      it('should render the content with the renderer', () => {
+        expect(card.textContent).to.equal('Content');
+      });
+
+      it('should re-render the content when a renderer dependency changes', async () => {
+        await renderNotification(container, { content: 'New Content' });
+        expect(card.textContent).to.equal('New Content');
+      });
+    });
+
+    describe('arguments', () => {
+      let rendererSpy;
+
+      beforeEach(async () => {
+        rendererSpy = sinon.spy();
+        render(
+          html`<vaadin-notification opened ${notificationRenderer(rendererSpy)}></vaadin-notification>`,
+          container,
+        );
+        await nextFrame();
+        notification = container.querySelector('vaadin-notification');
+      });
+
+      it('should pass the notification instance to the renderer', () => {
+        expect(rendererSpy.firstCall.args[0]).to.equal(notification);
+      });
+    });
+  });
+});

--- a/packages/notification/test/typings/lit.types.ts
+++ b/packages/notification/test/typings/lit.types.ts
@@ -1,0 +1,8 @@
+import { DirectiveResult } from 'lit/directive.js';
+import { NotificationLitRenderer, notificationRenderer, NotificationRendererDirective } from '../../lit.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+assertType<
+  (renderer: NotificationLitRenderer, dependencies?: unknown) => DirectiveResult<typeof NotificationRendererDirective>
+>(notificationRenderer);


### PR DESCRIPTION
## Description

This PR implements a Lit renderer directive for the `renderer` property of the notification component in order to provide a better DX for Lit users.

Part of #266

### Select Renderer

```diff
import { notifitionRenderer } from '@vaadin/notification/lit.js';

<vaadin-notification
-  .renderer="${(root, notification) => render(html`...`, root, { eventContext: this })}"
+  ${notificationRenderer((notification) => html`...`)}
></vaadin-notification>
```

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
