### PR TITLE
feat: add Lit renderer directive for context-menu

### DIFF
--- a/packages/context-menu/lit.d.ts
+++ b/packages/context-menu/lit.d.ts
@@ -1,0 +1,1 @@
+export * from './src/lit/renderer-directives.js';

--- a/packages/context-menu/lit.js
+++ b/packages/context-menu/lit.js
@@ -1,0 +1,1 @@
+export * from './src/lit/renderer-directives.js';

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -22,6 +22,8 @@
   "files": [
     "src",
     "theme",
+    "lit.js",
+    "lit.d.ts",
     "vaadin-*.d.ts",
     "vaadin-*.js"
   ],
@@ -38,6 +40,7 @@
     "@vaadin/component-base": "23.1.0-beta1",
     "@vaadin/item": "23.1.0-beta1",
     "@vaadin/list-box": "23.1.0-beta1",
+    "@vaadin/lit-renderer": "23.1.0-beta1",
     "@vaadin/vaadin-lumo-styles": "23.1.0-beta1",
     "@vaadin/vaadin-material-styles": "23.1.0-beta1",
     "@vaadin/vaadin-overlay": "23.1.0-beta1",

--- a/packages/context-menu/src/lit/renderer-directives.d.ts
+++ b/packages/context-menu/src/lit/renderer-directives.d.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { TemplateResult } from 'lit';
+import { DirectiveResult } from 'lit/directive.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+import { ContextMenu, ContextMenuRendererContext } from '../vaadin-context-menu.js';
+
+export type ContextMenuLitRenderer = (context: ContextMenuRendererContext, menu: ContextMenu) => TemplateResult;
+
+export class ContextMenuRendererDirective extends LitRendererDirective<ContextMenu, ContextMenuLitRenderer> {
+  /**
+   * Adds the renderer callback to the context-menu.
+   */
+  addRenderer(): void;
+
+  /**
+   * Runs the renderer callback on the context-menu.
+   */
+  runRenderer(): void;
+
+  /**
+   * Removes the renderer callback from the context-menu.
+   */
+  removeRenderer(): void;
+}
+
+/**
+ * A Lit directive for populating the content of the context-menu.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the context-menu
+ * via the `renderer` property. The renderer is called once to populate the content when assigned
+ * and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-context-menu
+ *   ${contextMenuRenderer((context, menu) => html`...`)}
+ * ></vaadin-context-menu>`
+ * ```
+ *
+ * @param renderer the renderer callback that returns a Lit template.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export declare function contextMenuRenderer(
+  renderer: ContextMenuLitRenderer,
+  dependencies?: unknown,
+): DirectiveResult<typeof ContextMenuRendererDirective>;

--- a/packages/context-menu/src/lit/renderer-directives.js
+++ b/packages/context-menu/src/lit/renderer-directives.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { directive } from 'lit/directive.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+
+export class ContextMenuRendererDirective extends LitRendererDirective {
+  /**
+   * Adds the renderer callback to the context-menu.
+   */
+  addRenderer() {
+    this.element.renderer = (root, contextMenu, context) => {
+      this.renderRenderer(root, context, contextMenu);
+    };
+  }
+
+  /**
+   * Runs the renderer callback on the context-menu.
+   */
+  runRenderer() {
+    this.element.requestContentUpdate();
+  }
+
+  /**
+   * Removes the renderer callback from the context-menu.
+   */
+  removeRenderer() {
+    this.element.renderer = null;
+  }
+}
+
+/**
+ * A Lit directive for populating the content of the context-menu.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the context-menu
+ * via the `renderer` property. The renderer is called once to populate the content when assigned
+ * and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-context-menu
+ *   ${contextMenuRenderer((context, menu) => html`...`)}
+ * ></vaadin-context-menu>`
+ * ```
+ *
+ * @param renderer the renderer callback that returns a Lit template.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export const contextMenuRenderer = directive(ContextMenuRendererDirective);

--- a/packages/context-menu/test/lit-renderer-directives.test.js
+++ b/packages/context-menu/test/lit-renderer-directives.test.js
@@ -1,0 +1,83 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import { html, render } from 'lit';
+import { contextMenuRenderer } from '../lit.js';
+
+async function renderContextMenu(container, { content }) {
+  render(
+    html`<vaadin-context-menu open-on="click" ${content ? contextMenuRenderer(() => html`${content}`, content) : null}>
+      <button>Target</button>
+    </vaadin-context-menu>`,
+    container,
+  );
+  await nextFrame();
+  return container.querySelector('vaadin-context-menu');
+}
+
+describe('lit renderer directives', () => {
+  let container, contextMenu, target, overlay;
+
+  beforeEach(() => {
+    container = fixtureSync('<div></div>');
+  });
+
+  describe('contextMenuRenderer', () => {
+    describe('basic', () => {
+      beforeEach(async () => {
+        contextMenu = await renderContextMenu(container, { content: 'Content' });
+        target = contextMenu.querySelector('button');
+        overlay = contextMenu.$.overlay;
+      });
+
+      it('should set `renderer` property when the directive is attached', () => {
+        expect(contextMenu.renderer).to.exist;
+      });
+
+      it('should unset `renderer` property when the directive is detached', async () => {
+        await renderContextMenu(container, {});
+        expect(contextMenu.renderer).not.to.exist;
+      });
+
+      it('should render the content with the renderer when the menu is opened', () => {
+        target.click();
+        expect(overlay.textContent).to.equal('Content');
+      });
+
+      it('should re-render the content when the menu is opened and a renderer dependency changes', async () => {
+        target.click();
+        await renderContextMenu(container, { content: 'New Content' });
+        expect(overlay.textContent).to.equal('New Content');
+      });
+    });
+
+    describe('arguments', () => {
+      let rendererSpy;
+
+      beforeEach(async () => {
+        rendererSpy = sinon.spy();
+        render(
+          html`<vaadin-context-menu open-on="click" ${contextMenuRenderer(rendererSpy)}>
+            <button></button>
+          </vaadin-context-menu>`,
+          container,
+        );
+        await nextFrame();
+        contextMenu = container.querySelector('vaadin-context-menu');
+        target = contextMenu.querySelector('button');
+        target.click();
+      });
+
+      it('should pass the context object to the renderer', () => {
+        expect(rendererSpy.firstCall.args[0]).to.have.property('detail');
+        expect(rendererSpy.firstCall.args[0]).to.have.property('target');
+      });
+
+      it('should pass the context-menu instance to the renderer', () => {
+        expect(rendererSpy.firstCall.args[1]).to.equal(contextMenu);
+      });
+    });
+  });
+});

--- a/packages/context-menu/test/typings/lit.types.ts
+++ b/packages/context-menu/test/typings/lit.types.ts
@@ -1,0 +1,8 @@
+import { DirectiveResult } from 'lit/directive.js';
+import { ContextMenuLitRenderer, contextMenuRenderer, ContextMenuRendererDirective } from '../../lit.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+assertType<
+  (renderer: ContextMenuLitRenderer, dependencies?: unknown) => DirectiveResult<typeof ContextMenuRendererDirective>
+>(contextMenuRenderer);


### PR DESCRIPTION
## Description

This PR implements a Lit renderer directive for the `renderer` property of the context-menu component in order to provide a better DX for Lit users.

Part of #266

### Select Renderer

```diff
import { contextMenuRenderer } from '@vaadin/context-menu/lit.js';

<vaadin-context-menu
-  .renderer="${(root, menu, context) => render(html`...`, root, { eventContext: this })}"
+  ${contextMenuRenderer((context, menu) => html`...`)}
></vaadin-context-menu>
```

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
