### PR TITLE
fix: do not hide caret when input is empty

### DIFF
--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -30,6 +30,10 @@ const multiSelectComboBox = css`
     padding-inline-start: 0;
   }
 
+  :host([has-value]) ::slotted(input:placeholder-shown) {
+    caret-color: var(--lumo-body-text-color) !important;
+  }
+
   [part~='chip']:not(:last-of-type) {
     margin-inline-end: var(--lumo-space-xs);
   }

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -25,6 +25,10 @@ registerStyles(
 );
 
 const multiSelectComboBox = css`
+  :host([has-value]) ::slotted(input:placeholder-shown) {
+    caret-color: var(--material-body-text-color) !important;
+  }
+
   [part='input-field'] {
     height: auto;
     min-height: 32px;


### PR DESCRIPTION
## Description

Currently, `<vaadin-multi-select-combo-box>` uses the following styles to hide placeholder text when value is set:

https://github.com/vaadin/web-components/blob/dbf014832da46cb617d027276158ffc7098fa833/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js#L34-L36

This is especially useful because placeholder in this case is used for screen reader announcement of selected items.

However, this currently causes the problem of making the cursor caret hidden when focusing empty input.
This PR adds the styles for enforcing `caret-color` to Lumo and Material, to make the caret visible again.

## Type of change

- Bugfix