### PR TITLE
feat: add Lit renderer directive for grid-pro

### DIFF
--- a/packages/grid-pro/lit.d.ts
+++ b/packages/grid-pro/lit.d.ts
@@ -1,0 +1,1 @@
+export * from './src/lit/column-renderer-directives.js';

--- a/packages/grid-pro/lit.js
+++ b/packages/grid-pro/lit.js
@@ -1,0 +1,1 @@
+export * from './src/lit/column-renderer-directives.js';

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -22,6 +22,8 @@
   "files": [
     "src",
     "theme",
+    "lit.js",
+    "lit.d.ts",
     "vaadin-*.d.ts",
     "vaadin-*.js"
   ],
@@ -40,6 +42,7 @@
     "@vaadin/grid": "23.1.0-beta1",
     "@vaadin/item": "23.1.0-beta1",
     "@vaadin/list-box": "23.1.0-beta1",
+    "@vaadin/lit-renderer": "23.1.0-beta1",
     "@vaadin/select": "23.1.0-beta1",
     "@vaadin/text-field": "23.1.0-beta1",
     "@vaadin/vaadin-license-checker": "^2.1.0",

--- a/packages/grid-pro/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid-pro/src/lit/column-renderer-directives.d.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { TemplateResult } from 'lit';
+import { DirectiveResult } from 'lit/directive';
+import { GridItemModel } from '@vaadin/grid';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+import { GridProEditColumn } from '../vaadin-grid-pro-edit-column.js';
+
+export type GridProColumnEditModeLitRenderer<TItem> = (
+  item: TItem,
+  model: GridItemModel<TItem>,
+  column: GridProEditColumn,
+) => TemplateResult;
+
+export declare class GridProColumnEditModeRendererDirective<TItem> extends LitRendererDirective<
+  GridProEditColumn,
+  GridProColumnEditModeLitRenderer<TItem>
+> {
+  /**
+   * Adds the renderer callback to the grid edit column.
+   */
+  addRenderer(): void;
+
+  /**
+   * Runs the renderer callback on the grid edit column.
+   */
+  runRenderer(): void;
+
+  /**
+   * Removes the renderer callback from the grid edit column.
+   */
+  removeRenderer(): void;
+}
+
+/**
+ * A Lit directive for rendering the content of column's body cells when they are in edit mode.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid edit column
+ * via the `editModeRenderer` property. The renderer is called when a column's body cell switches to edit mode
+ * and whenever a single dependency or an array of dependencies changes as long as edit mode is on.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-grid-pro-edit-column
+ *   ${columnEditModeRenderer((item, model, column) => html`...`)}
+ * ></vaadin-grid-pro-edit-column>`
+ * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export declare function columnEditModeRenderer<TItem>(
+  renderer: GridProColumnEditModeLitRenderer<TItem>,
+  dependencies?: unknown,
+): DirectiveResult<typeof GridProColumnEditModeRendererDirective>;

--- a/packages/grid-pro/src/lit/column-renderer-directives.js
+++ b/packages/grid-pro/src/lit/column-renderer-directives.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { directive } from 'lit/directive.js';
+import { microTask } from '@vaadin/component-base/src/async';
+import { Debouncer } from '@vaadin/component-base/src/debounce';
+import { CONTENT_UPDATE_DEBOUNCER } from '@vaadin/grid/src/lit/renderer-directives.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+
+export class GridProColumnEditModeRendererDirective extends LitRendererDirective {
+  /**
+   * Adds the renderer callback to the grid edit column.
+   */
+  addRenderer() {
+    this.element.editModeRenderer = (root, column, model) => {
+      this.renderRenderer(root, model.item, model, column);
+    };
+  }
+
+  /**
+   * Runs the renderer callback on the grid edit column.
+   */
+  runRenderer() {
+    const grid = this.element._grid;
+
+    grid[CONTENT_UPDATE_DEBOUNCER] = Debouncer.debounce(grid[CONTENT_UPDATE_DEBOUNCER], microTask, () => {
+      grid.requestContentUpdate();
+    });
+  }
+
+  /**
+   * Removes the renderer callback from the grid edit column.
+   */
+  removeRenderer() {
+    this.element.editModeRenderer = null;
+  }
+}
+
+/**
+ * A Lit directive for rendering the content of column's body cells when they are in edit mode.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the grid edit column
+ * via the `editModeRenderer` property. The renderer is called when a column's body cell switches to edit mode
+ * and whenever a single dependency or an array of dependencies changes as long as edit mode is on.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-grid-pro-edit-column
+ *   ${columnEditModeRenderer((item, model, column) => html`...`)}
+ * ></vaadin-grid-pro-edit-column>`
+ * ```
+ *
+ * @param renderer the renderer callback.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export const columnEditModeRenderer = directive(GridProColumnEditModeRendererDirective);

--- a/packages/grid-pro/src/lit/column-renderer-directives.js
+++ b/packages/grid-pro/src/lit/column-renderer-directives.js
@@ -4,8 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { directive } from 'lit/directive.js';
-import { microTask } from '@vaadin/component-base/src/async';
-import { Debouncer } from '@vaadin/component-base/src/debounce';
+import { microTask } from '@vaadin/component-base/src/async.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { CONTENT_UPDATE_DEBOUNCER } from '@vaadin/grid/src/lit/renderer-directives.js';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 

--- a/packages/grid-pro/test/lit-renderer-directives.test.js
+++ b/packages/grid-pro/test/lit-renderer-directives.test.js
@@ -1,0 +1,122 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-grid-pro.js';
+import '../vaadin-grid-pro-edit-column.js';
+import { html, render } from 'lit';
+import { columnHeaderRenderer } from '@vaadin/grid/lit.js';
+import { columnEditModeRenderer } from '../lit.js';
+import { createItems, getCellContent, getContainerCell } from './helpers.js';
+
+async function renderGrid(container, { header, items, editMode }) {
+  render(
+    html`<vaadin-grid-pro .items="${items}">
+      <vaadin-grid-pro-edit-column
+        path="name"
+        ${header ? columnHeaderRenderer(() => html`${header}`, header) : null}
+        ${editMode ? columnEditModeRenderer(() => html`<div>${editMode}</div>`, editMode) : null}
+      ></vaadin-grid-pro-edit-column>
+    </vaadin-grid-pro>`,
+    container,
+  );
+  await nextFrame();
+  return container.querySelector('vaadin-grid-pro');
+}
+
+describe('lit renderer directives', () => {
+  let container, grid, column, items;
+
+  beforeEach(() => {
+    items = createItems();
+    container = fixtureSync('<div></div>');
+  });
+
+  describe('columnEditModeRenderer', () => {
+    describe('basic', () => {
+      let cell;
+
+      beforeEach(async () => {
+        grid = await renderGrid(container, { items, editMode: 'Edit Mode Content' });
+        cell = getContainerCell(grid.$.items, 0, 0);
+        column = grid.querySelector('vaadin-grid-pro-edit-column');
+      });
+
+      it('should set `editModeRenderer` property when the directive is attached', () => {
+        expect(column.editModeRenderer).to.exist;
+      });
+
+      it('should unset `editModeRenderer` property when the directive is detached', async () => {
+        await renderGrid(container, { items });
+        expect(column.editModeRenderer).not.to.exist;
+      });
+
+      it('should render the content with the renderer when switching to edit mode', () => {
+        fire(getCellContent(cell), 'dblclick');
+        expect(getCellContent(cell).textContent).to.equal('Edit Mode Content');
+      });
+
+      it('should re-render the content when the cell is in edit mode and a renderer dependency changes', async () => {
+        fire(getCellContent(cell), 'dblclick');
+        await renderGrid(container, { items, editMode: 'New Edit Mode Content' });
+        expect(getCellContent(cell).textContent).to.equal('New Edit Mode Content');
+      });
+    });
+
+    describe('arguments', () => {
+      let rendererSpy;
+
+      beforeEach(async () => {
+        rendererSpy = sinon.spy(() => html`<input />`);
+        render(
+          html`<vaadin-grid-pro .items="${items}">
+            <vaadin-grid-pro-edit-column
+              path="name"
+              ${columnEditModeRenderer(rendererSpy)}
+            ></vaadin-grid-pro-edit-column>
+          </vaadin-grid-pro>`,
+          container,
+        );
+        await nextFrame();
+        grid = container.querySelector('vaadin-grid-pro');
+        column = grid.querySelector('vaadin-grid-pro-edit-column');
+
+        const cell = getContainerCell(grid.$.items, 0, 0);
+        fire(getCellContent(cell), 'dblclick');
+      });
+
+      it('should pass the item to the renderer', () => {
+        expect(rendererSpy.firstCall.args[0]).to.equal(items[0]);
+      });
+
+      it('should pass the model to the renderer', () => {
+        const cell = getContainerCell(grid.$.items, 0, 0);
+        const model = grid.__getRowModel(cell.parentElement);
+        expect(rendererSpy.firstCall.args[1]).to.deep.equal(model);
+      });
+
+      it('should pass the column instance to the renderer', () => {
+        expect(rendererSpy.firstCall.args[2]).to.equal(column);
+      });
+    });
+  });
+
+  describe('multiple renderers', () => {
+    beforeEach(async () => {
+      grid = await renderGrid(container, {
+        items,
+        header: 'Header',
+        editMode: 'Edit Mode Content',
+      });
+    });
+
+    it('should only request one content update when triggering multiple renderers to update', async () => {
+      const spy = sinon.spy(grid, 'requestContentUpdate');
+      await renderGrid(container, {
+        items,
+        header: 'New Header',
+        editMode: 'New Edit Mode Content',
+      });
+      expect(spy.callCount).to.equal(1);
+    });
+  });
+});

--- a/packages/grid-pro/test/typings/lit-renderer-directives.types.ts
+++ b/packages/grid-pro/test/typings/lit-renderer-directives.types.ts
@@ -1,0 +1,19 @@
+import { DirectiveResult } from 'lit/directive';
+import {
+  columnEditModeRenderer,
+  GridProColumnEditModeLitRenderer,
+  GridProColumnEditModeRendererDirective,
+} from '../../lit.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+interface TestGridItem {
+  testProperty: string;
+}
+
+assertType<
+  (
+    renderer: GridProColumnEditModeLitRenderer<TestGridItem>,
+    dependencies?: unknown,
+  ) => DirectiveResult<typeof GridProColumnEditModeRendererDirective>
+>(columnEditModeRenderer);


### PR DESCRIPTION
## Description

This PR implements a Lit renderer directive for each `editModeRenderer` property of the grid component in order to provide a better DX for Lit users.

Part of #266

### Grid Pro Column Edit Mode Renderer

```diff
import { columnEditModeRenderer } from '@vaadin/grid-pro/lit.js';

<vaadin-grid-pro-edit-column
-  .editModeRenderer="${(root, model, column) => render(html`...`, root, { eventContext: this })}"
+  ${columnEditModeRenderer((item, model, column) => html`...`)}
></vaadin-grid-pro-edit-column>
```

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
