### PR TITLE
fix: set correct placeholder when removing items

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -240,6 +240,13 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
   pageSize: number;
 
   /**
+   * A hint to the user of what can be entered in the control.
+   * The placeholder will be only displayed in the case when
+   * there is no item selected.
+   */
+  placeholder: string;
+
+  /**
    * Custom function for rendering the content of every item.
    * Receives three arguments:
    *

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -365,6 +365,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       placeholder: {
         type: String,
+        value: '',
         observer: '_placeholderChanged',
       },
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -359,6 +359,16 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       },
 
       /**
+       * A hint to the user of what can be entered in the control.
+       * The placeholder will be only displayed in the case when
+       * there is no item selected.
+       */
+      placeholder: {
+        type: String,
+        observer: '_placeholderChanged',
+      },
+
+      /**
        * Custom function for rendering the content of every item.
        * Receives three arguments:
        *
@@ -560,6 +570,19 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /** @private */
+  _placeholderChanged(placeholder) {
+    const tmpPlaceholder = this.__tmpA11yPlaceholder;
+    // Do not store temporary placeholder
+    if (tmpPlaceholder !== placeholder) {
+      this.__savedPlaceholder = placeholder;
+
+      if (tmpPlaceholder) {
+        this.placeholder = tmpPlaceholder;
+      }
+    }
+  }
+
+  /** @private */
   _selectedItemsChanged(selectedItems) {
     this._hasValue = Boolean(selectedItems && selectedItems.length);
 
@@ -567,9 +590,11 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     // Use placeholder for announcing items
     if (this._hasValue) {
-      this.__savedPlaceholder = this.placeholder;
-      this.placeholder = selectedItems.map((item) => this._getItemLabel(item, this.itemLabelPath)).join(', ');
+      const tmpPlaceholder = selectedItems.map((item) => this._getItemLabel(item, this.itemLabelPath)).join(', ');
+      this.__tmpA11yPlaceholder = tmpPlaceholder;
+      this.placeholder = tmpPlaceholder;
     } else {
+      delete this.__tmpA11yPlaceholder;
       this.placeholder = this.__savedPlaceholder;
     }
 

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -51,6 +51,27 @@ describe('accessibility', () => {
           comboBox.selectedItems = [];
           expect(inputElement.getAttribute('placeholder')).to.equal('Fruits');
         });
+
+        it('should keep input placeholder when placeholder property is updated', () => {
+          comboBox.selectedItems = ['Apple', 'Banana'];
+          comboBox.placeholder = 'Options';
+          expect(inputElement.getAttribute('placeholder')).to.equal('Apple, Banana');
+        });
+
+        it('should restore updated placeholder when placeholder property is updated', () => {
+          comboBox.selectedItems = ['Apple', 'Banana'];
+          comboBox.placeholder = 'Options';
+          comboBox.selectedItems = [];
+          expect(inputElement.getAttribute('placeholder')).to.equal('Options');
+        });
+
+        it('should restore empty placeholder when selected items are removed', () => {
+          comboBox.placeholder = '';
+          comboBox.selectedItems = ['Apple', 'Banana'];
+          comboBox.selectedItems = [];
+          expect(comboBox.placeholder).to.be.equal('');
+          expect(inputElement.hasAttribute('placeholder')).to.be.false;
+        });
       });
     });
 

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -7,19 +7,15 @@ import '../vaadin-multi-select-combo-box.js';
 describe('accessibility', () => {
   let comboBox, inputElement;
 
-  beforeEach(() => {
-    comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
-    comboBox.items = ['Apple', 'Banana', 'Lemon', 'Orange'];
-    inputElement = comboBox.inputElement;
-  });
-
   describe('ARIA', () => {
     let scroller, items;
 
     describe('input', () => {
       describe('required', () => {
         beforeEach(() => {
-          comboBox.required = true;
+          comboBox = fixtureSync(`<vaadin-multi-select-combo-box required></vaadin-multi-select-combo-box>`);
+          comboBox.items = ['Apple', 'Banana', 'Lemon', 'Orange'];
+          inputElement = comboBox.inputElement;
         });
 
         it('should set aria-required attribute on the input when required', () => {
@@ -38,7 +34,13 @@ describe('accessibility', () => {
 
       describe('placeholder', () => {
         beforeEach(() => {
-          comboBox.placeholder = 'Fruits';
+          comboBox = fixtureSync(`
+            <vaadin-multi-select-combo-box
+              placeholder="Fruits"
+            ></vaadin-multi-select-combo-box>
+          `);
+          comboBox.items = ['Apple', 'Banana', 'Lemon', 'Orange'];
+          inputElement = comboBox.inputElement;
         });
 
         it('should set input placeholder when selected items are changed', () => {
@@ -77,8 +79,10 @@ describe('accessibility', () => {
 
     describe('items', () => {
       beforeEach(() => {
+        comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
+        comboBox.items = ['Apple', 'Banana', 'Lemon', 'Orange'];
         comboBox.selectedItems = ['Apple', 'Lemon'];
-        inputElement.click();
+        comboBox.inputElement.click();
         scroller = comboBox.$.comboBox.$.dropdown._scroller;
         items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
       });
@@ -114,6 +118,9 @@ describe('accessibility', () => {
     });
 
     beforeEach(() => {
+      comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
+      comboBox.items = ['Apple', 'Banana', 'Lemon', 'Orange'];
+      inputElement = comboBox.inputElement;
       clock = sinon.useFakeTimers();
     });
 


### PR DESCRIPTION
## Description

This is a fix for the problem introduced in #3740: the temporary a11y placeholder used for screen readers wasn't reset.

Added the observer for `placeholder` property that contains a following logic:

1. Store user-defined placeholder in a private property and re-apply it when all the selected items are removed,
2. Override user-defined placeholder changed while selected items are set with temporary a11y placeholder.

## Type of change

- Bugfix