### PR TITLE
fix: run the class name generator only for loaded rows

### DIFF
--- a/packages/grid/src/vaadin-grid-styling-mixin.js
+++ b/packages/grid/src/vaadin-grid-styling-mixin.js
@@ -49,7 +49,7 @@ export const StylingMixin = (superClass) =>
      */
     generateCellClassNames() {
       Array.from(this.$.items.children)
-        .filter((row) => !row.hidden)
+        .filter((row) => !row.hidden && !row.hasAttribute('loading'))
         .forEach((row) => this._generateCellClassNames(row, this.__getRowModel(row)));
     }
 

--- a/packages/grid/test/class-name-generator.test.js
+++ b/packages/grid/test/class-name-generator.test.js
@@ -125,4 +125,35 @@ describe('class name generator', () => {
     assertClassList(getContainerCell(grid.$.items, 1, 0), ['odd']);
     assertClassList(getContainerCell(grid.$.items, 1, 1), ['odd']);
   });
+
+  describe('async data provider', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({
+        shouldClearNativeTimers: true,
+      });
+
+      grid.dataProvider = (params, callback) => {
+        setTimeout(() => infiniteDataProvider(params, callback), 10);
+      };
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should only run the generator for the rows that are loaded', async () => {
+      const spy = sinon.spy();
+      grid.cellClassNameGenerator = spy;
+      spy.resetHistory();
+
+      grid.generateCellClassNames();
+      expect(spy.called).to.be.false;
+
+      clock.tick(10);
+      grid.generateCellClassNames();
+      expect(spy.called).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Description

The PR prevents the grid css class name generator from running on the rows that the data provider is still loading. That way [the Flow Grid class name generator](https://github.com/vaadin/flow-components/blob/52ddb8202580c9c9cd545e3e519174a589cffbab/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js#L1141-L1147) does no longer receive the cells that don't have `_item` assigned yet and thus the original error reported in the issue no longer takes place:

```
Cannot read properties of undefined (reading 'style')
```

**Scenario**: When a column group changes its hidden state, it triggers the cells' class names to re-generate. When that coincides with the data provider loading more rows, there may occur a race condition because of using debouncers so that the generator will be invoked on the rows that the virtualizer has already created but which don't have `_item` assigned yet.

Note, it is fine to just filter out such loading rows before running the generator since the data provider will run the generator as soon as all the rows are loaded anyway.

Fixes https://github.com/vaadin/flow-components/issues/3082

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
