### PR TITLE
test: add LitElement tests for input mixins

### DIFF
--- a/packages/field-base/test/delegate-state-mixin.test.js
+++ b/packages/field-base/test/delegate-state-mixin.test.js
@@ -1,78 +1,80 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { DelegateStateMixin } from '../src/delegate-state-mixin.js';
+import { define } from './helpers.js';
 
-customElements.define(
-  'delegate-state-mixin-element',
-  class extends DelegateStateMixin(PolymerElement) {
-    static get properties() {
-      return {
-        title: {
-          type: String,
-          reflectToAttribute: true,
-        },
+const runTests = (baseClass) => {
+  const tag = define[baseClass](
+    'delegate-state-mixin',
+    '<input id="input">',
+    (Base) =>
+      class extends DelegateStateMixin(Base) {
+        static get properties() {
+          return {
+            title: {
+              type: String,
+              reflectToAttribute: true,
+            },
 
-        invalid: {
-          type: Boolean,
-          reflectToAttribute: true,
-        },
+            invalid: {
+              type: Boolean,
+              reflectToAttribute: true,
+            },
 
-        indeterminate: {
-          type: Boolean,
-          value: true,
-        },
-      };
-    }
+            indeterminate: {
+              type: Boolean,
+              value: true,
+            },
+          };
+        }
 
-    static get delegateAttrs() {
-      return ['title', 'invalid'];
-    }
+        static get delegateAttrs() {
+          return ['title', 'invalid'];
+        }
 
-    static get delegateProps() {
-      return ['indeterminate'];
-    }
+        static get delegateProps() {
+          return ['indeterminate'];
+        }
 
-    static get template() {
-      return html`<input id="input" />`;
-    }
+        ready() {
+          super.ready();
 
-    ready() {
-      super.ready();
+          this.stateTarget = this.$.input;
+        }
+      },
+  );
 
-      this.stateTarget = this.$.input;
-    }
-  },
-);
-
-describe('delegate-state-mixin', () => {
   let element, target;
 
   describe('title attribute', () => {
     describe('default', () => {
-      beforeEach(() => {
-        element = fixtureSync('<delegate-state-mixin-element></delegate-state-mixin-element>');
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag}></${tag}>`);
+        await nextRender();
         target = element.stateTarget;
       });
 
-      it('should delegate title attribute to the target', () => {
+      it('should delegate title attribute to the target', async () => {
         expect(target.hasAttribute('title')).to.be.false;
 
         element.setAttribute('title', 'foo');
+        await nextFrame();
         expect(target.getAttribute('title')).to.equal('foo');
       });
     });
 
     describe('initially set', () => {
-      beforeEach(() => {
-        element = fixtureSync('<delegate-state-mixin-element title="foo"></delegate-state-mixin-element>');
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag} title="foo"></${tag}>`);
+        await nextRender();
         target = element.stateTarget;
       });
 
-      it('should delegate title attribute to the target', () => {
+      it('should delegate title attribute to the target', async () => {
         expect(target.getAttribute('title')).to.equal('foo');
 
         element.removeAttribute('title');
+        await nextFrame();
         expect(target.hasAttribute('title')).to.be.false;
       });
     });
@@ -80,59 +82,75 @@ describe('delegate-state-mixin', () => {
 
   describe('invalid attribute', () => {
     describe('default', () => {
-      beforeEach(() => {
-        element = fixtureSync('<delegate-state-mixin-element></delegate-state-mixin-element>');
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag}></${tag}>`);
+        await nextRender();
         target = element.stateTarget;
       });
 
-      it('should delegate invalid attribute to the target', () => {
+      it('should delegate invalid attribute to the target', async () => {
         expect(target.hasAttribute('invalid')).to.be.false;
 
         element.toggleAttribute('invalid', true);
+        await nextFrame();
         expect(target.hasAttribute('invalid')).to.be.true;
       });
 
-      it('should delegate aria-invalid attribute to the target', () => {
+      it('should delegate aria-invalid attribute to the target', async () => {
         expect(target.hasAttribute('aria-invalid')).to.be.false;
 
         element.toggleAttribute('invalid', true);
+        await nextFrame();
         expect(target.hasAttribute('aria-invalid')).to.be.true;
       });
     });
 
     describe('initially set', () => {
-      beforeEach(() => {
-        element = fixtureSync('<delegate-state-mixin-element invalid></delegate-state-mixin-element>');
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag} invalid></${tag}>`);
+        await nextRender();
         target = element.stateTarget;
       });
 
-      it('should delegate invalid attribute to the target', () => {
+      it('should delegate invalid attribute to the target', async () => {
         expect(target.hasAttribute('invalid')).to.be.true;
 
         element.removeAttribute('invalid');
+        await nextFrame();
         expect(target.hasAttribute('invalid')).to.be.false;
       });
 
-      it('should delegate aria-invalid attribute to the target', () => {
+      it('should delegate aria-invalid attribute to the target', async () => {
         expect(target.hasAttribute('aria-invalid')).to.be.true;
 
         element.removeAttribute('invalid');
+        await nextFrame();
         expect(target.hasAttribute('aria-invalid')).to.be.false;
       });
     });
   });
 
   describe('indeterminate property', () => {
-    beforeEach(() => {
-      element = fixtureSync('<delegate-state-mixin-element></delegate-state-mixin-element>');
+    beforeEach(async () => {
+      element = fixtureSync(`<${tag}></${tag}>`);
+      await nextRender();
       target = element.stateTarget;
     });
 
-    it('should delegate indeterminate property to the target', () => {
+    it('should delegate indeterminate property to the target', async () => {
       expect(target.indeterminate).to.be.true;
 
       target.indeterminate = false;
+      await nextFrame();
       expect(target.indeterminate).to.be.false;
     });
   });
+};
+
+describe('DelegateStateMixin + Polymer', () => {
+  runTests('polymer');
+});
+
+describe('DelegateStateMixin + Lit', () => {
+  runTests('lit');
 });

--- a/packages/field-base/test/helpers.js
+++ b/packages/field-base/test/helpers.js
@@ -1,0 +1,38 @@
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { html, LitElement } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+
+export const define = {
+  polymer: (prefix, htmlString, classFactory) => {
+    const tag = `${prefix}-polymer-element`;
+
+    customElements.define(
+      tag,
+      class extends classFactory(ControllerMixin(PolymerElement)) {
+        static get template() {
+          const tpl = document.createElement('template');
+          tpl.innerHTML = htmlString;
+          return tpl;
+        }
+      },
+    );
+
+    return tag;
+  },
+  lit: (prefix, htmlString, classFactory) => {
+    const tag = `${prefix}-lit-element`;
+
+    customElements.define(
+      tag,
+      class extends classFactory(PolylitMixin(LitElement)) {
+        render() {
+          return html`${unsafeHTML(htmlString)}`;
+        }
+      },
+    );
+
+    return tag;
+  },
+};

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -1,174 +1,194 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { InputConstraintsMixin } from '../src/input-constraints-mixin.js';
 import { InputController } from '../src/input-controller.js';
+import { define } from './helpers.js';
 
-customElements.define(
-  'input-constraints-mixin-element',
-  class extends InputConstraintsMixin(ControllerMixin(PolymerElement)) {
-    static get template() {
-      return html`
-        <slot name="input"></slot>
-        <div part="error-message">
-          <slot name="error-message"></slot>
-        </div>
-        <slot name="helper"></slot>
-      `;
-    }
+const runTests = (baseClass) => {
+  const tag = define[baseClass](
+    'input-constraints-mixin',
+    '<slot name="input"></slot>',
+    (Base) =>
+      class extends InputConstraintsMixin(Base) {
+        static get properties() {
+          return {
+            minlength: {
+              type: Number,
+            },
+            maxlength: {
+              type: Number,
+            },
+            pattern: {
+              type: String,
+            },
+          };
+        }
 
-    static get properties() {
-      return {
-        minlength: {
-          type: Number,
-        },
-        maxlength: {
-          type: Number,
-        },
-        pattern: {
-          type: String,
-        },
-      };
-    }
+        static get delegateAttrs() {
+          return [...super.delegateAttrs, 'minlength', 'maxlength', 'pattern'];
+        }
 
-    static get delegateAttrs() {
-      return [...super.delegateAttrs, 'minlength', 'maxlength', 'pattern'];
-    }
+        static get constraints() {
+          return [...super.constraints, 'minlength', 'maxlength', 'pattern'];
+        }
 
-    static get constraints() {
-      return [...super.constraints, 'minlength', 'maxlength', 'pattern'];
-    }
+        ready() {
+          super.ready();
 
-    constructor() {
-      super();
+          this.addController(
+            new InputController(this, (input) => {
+              this._setInputElement(input);
+              this.stateTarget = input;
+            }),
+          );
+        }
+      },
+  );
 
-      this.addController(
-        new InputController(this, (input) => {
-          this._setInputElement(input);
-          this.stateTarget = input;
-        }),
-      );
-    }
-  },
-);
-
-describe('input-constraints-mixin', () => {
   let element, input;
 
-  beforeEach(() => {
-    element = fixtureSync('<input-constraints-mixin-element></input-constraints-mixin-element>');
+  beforeEach(async () => {
+    element = fixtureSync(`<${tag}></${tag}>`);
+    await nextRender();
     input = element.querySelector('[slot=input]');
   });
 
   describe('validation', () => {
-    it('should not validate the field when minlength is set', () => {
+    it('should not validate the field when minlength is set', async () => {
       element.minlength = 2;
+      await nextFrame();
       expect(element.invalid).to.be.false;
     });
 
-    it('should not validate the field when maxlength is set', () => {
+    it('should not validate the field when maxlength is set', async () => {
       element.maxlength = 6;
+      await nextFrame();
       expect(element.invalid).to.be.false;
     });
 
-    it('should not validate the field when pattern is set', () => {
+    it('should not validate the field when pattern is set', async () => {
       element.pattern = '[-+\\d]';
+      await nextFrame();
       expect(element.invalid).to.be.false;
     });
 
-    it('should validate the field when invalid after minlength is changed', () => {
+    it('should validate the field when invalid after minlength is changed', async () => {
       element.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(element, 'validate');
       element.minlength = 2;
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should validate the field when invalid after maxlength is changed', () => {
+    it('should validate the field when invalid after maxlength is changed', async () => {
       element.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(element, 'validate');
       element.maxlength = 6;
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should validate the field when invalid after minlength is set to 0', () => {
+    it('should validate the field when invalid after minlength is set to 0', async () => {
       element.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(element, 'validate');
       element.minlength = 0;
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should validate the field when invalid after maxlength is set to 0', () => {
+    it('should validate the field when invalid after maxlength is set to 0', async () => {
       element.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(element, 'validate');
       element.maxlength = 0;
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should validate the field when invalid after pattern is changed', () => {
+    it('should validate the field when invalid after pattern is changed', async () => {
       element.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(element, 'validate');
       element.pattern = '[-+\\d]';
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should call checkValidity on the input when invalid after minlength is changed', () => {
+    it('should call checkValidity on the input when invalid after minlength is changed', async () => {
       element.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(input, 'checkValidity');
       element.minlength = 2;
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should call checkValidity on the input when invalid after maxlength is changed', () => {
+    it('should call checkValidity on the input when invalid after maxlength is changed', async () => {
       element.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(input, 'checkValidity');
       element.maxlength = 6;
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should call checkValidity on the input when invalid after pattern is changed', () => {
+    it('should call checkValidity on the input when invalid after pattern is changed', async () => {
       element.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(input, 'checkValidity');
       element.pattern = '[-+\\d]';
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should update invalid state when required is removed', () => {
+    it('should update invalid state when required is removed', async () => {
       element.required = true;
+      await nextFrame();
       element.validate();
       expect(element.invalid).to.be.true;
 
       element.required = false;
+      await nextFrame();
       expect(element.invalid).to.be.false;
     });
 
-    it('should update invalid state when pattern is removed', () => {
+    it('should update invalid state when pattern is removed', async () => {
       input.value = '123foo';
       element.pattern = '\\d+';
+      await nextFrame();
 
       element.validate();
       expect(element.invalid).to.be.true;
 
       element.pattern = '';
+      await nextFrame();
       expect(element.invalid).to.be.false;
     });
 
-    it('should update invalid state when a constraint is removed even if other constraints are active', () => {
+    it('should update invalid state when a constraint is removed even if other constraints are active', async () => {
       element.required = true;
       element.pattern = '\\d*';
+      await nextFrame();
+
       element.validate();
       expect(element.invalid).to.be.true;
 
       element.required = false;
+      await nextFrame();
       expect(element.invalid).to.be.false;
     });
 
-    it('should override explicitly set invalid when required is set', () => {
+    it('should override explicitly set invalid when required is set', async () => {
       element.invalid = true;
       element.value = 'foo';
+      await nextFrame();
 
       element.required = true;
+      await nextFrame();
       expect(element.invalid).to.be.false;
     });
 
@@ -201,14 +221,22 @@ describe('input-constraints-mixin', () => {
 
   describe('checkValidity', () => {
     it('should return true when called before connected to the DOM', () => {
-      const field = document.createElement('input-constraints-mixin-element');
+      const field = document.createElement(tag);
       expect(field.checkValidity()).to.be.true;
     });
 
     it('should return false when called before connected to the DOM and invalid', () => {
-      const field = document.createElement('input-constraints-mixin-element');
+      const field = document.createElement(tag);
       field.invalid = true;
       expect(field.checkValidity()).to.be.false;
     });
   });
+};
+
+describe('InputConstraintsMixin + Polymer', () => {
+  runTests('polymer');
+});
+
+describe('InputConstraintsMixin + Lit', () => {
+  runTests('lit');
 });

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,72 +1,78 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { PatternMixin } from '../src/pattern-mixin.js';
+import { define } from './helpers.js';
 
-customElements.define(
-  'pattern-mixin-element',
-  class extends PatternMixin(ControllerMixin(PolymerElement)) {
-    static get template() {
-      return html`<slot name="label"></slot><slot name="input"></slot>`;
-    }
+const runTests = (baseClass) => {
+  const tag = define[baseClass](
+    'pattern-mixin',
+    '<slot name="input"></slot>',
+    (Base) =>
+      class extends PatternMixin(Base) {
+        ready() {
+          super.ready();
 
-    constructor() {
-      super();
+          this.addController(
+            new InputController(this, (input) => {
+              this._setInputElement(input);
+              this.stateTarget = input;
+            }),
+          );
+        }
+      },
+  );
 
-      this.addController(
-        new InputController(this, (input) => {
-          this._setInputElement(input);
-          this.stateTarget = input;
-        }),
-      );
-    }
-  },
-);
-
-describe('pattern-mixin', () => {
   let element, input;
 
-  beforeEach(() => {
-    element = fixtureSync('<pattern-mixin-element></pattern-mixin-element>');
+  beforeEach(async () => {
+    element = fixtureSync(`<${tag}></${tag}>`);
+    await nextRender();
     input = element.querySelector('[slot=input]');
   });
 
   describe('pattern', () => {
-    it('should propagate pattern property to the input', () => {
+    it('should propagate pattern property to the input', async () => {
       element.pattern = '[-+\\d]';
+      await nextFrame();
       expect(input.pattern).to.equal('[-+\\d]');
     });
 
-    it('should not validate the field when pattern is set', () => {
+    it('should not validate the field when pattern is set', async () => {
       element.pattern = '[-+\\d]';
+      await nextFrame();
       expect(element.invalid).to.be.false;
     });
 
-    it('should validate the field when invalid after pattern is changed', () => {
+    it('should validate the field when invalid after pattern is changed', async () => {
       element.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(element, 'validate');
       element.pattern = '[-+\\d]';
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should update invalid state when pattern is removed', () => {
+    it('should update invalid state when pattern is removed', async () => {
       input.value = '123foo';
       element.pattern = '\\d+';
+      await nextFrame();
+
       element.validate();
       expect(element.invalid).to.be.true;
 
       element.pattern = '';
+      await nextFrame();
       expect(element.invalid).to.be.false;
     });
   });
 
   describe('prevent invalid input', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       element.preventInvalidInput = true;
       element.value = '1';
+      await nextFrame();
     });
 
     function inputText(value) {
@@ -74,64 +80,89 @@ describe('pattern-mixin', () => {
       input.dispatchEvent(new CustomEvent('input'));
     }
 
-    it('should prevent invalid pattern', () => {
+    it('should prevent invalid pattern', async () => {
       element.pattern = '[0-9]*';
+      await nextFrame();
       inputText('f');
+      await nextFrame();
       expect(element.value).to.equal('1');
     });
 
-    it('should temporarily set input-prevented attribute on invalid input', () => {
+    it('should temporarily set input-prevented attribute on invalid input', async () => {
       element.pattern = '[0-9]*';
+      await nextFrame();
       inputText('f');
+      await nextFrame();
       expect(element.hasAttribute('input-prevented')).to.be.true;
     });
 
-    it('should not set input-prevented attribute on valid input', () => {
+    it('should not set input-prevented attribute on valid input', async () => {
       element.pattern = '[0-9]*';
+      await nextFrame();
       inputText('1');
+      await nextFrame();
       expect(element.hasAttribute('input-prevented')).to.be.false;
     });
 
-    it('should remove input-prevented attribute after 200ms timeout', () => {
-      const clock = sinon.useFakeTimers();
+    it('should remove input-prevented attribute after 200ms timeout', async () => {
       element.pattern = '[0-9]*';
+      await nextFrame();
+      const clock = sinon.useFakeTimers();
       inputText('f');
       clock.tick(200);
       expect(element.hasAttribute('input-prevented')).to.be.false;
       clock.restore();
     });
 
-    it('should prevent entering invalid characters', () => {
+    it('should prevent entering invalid characters', async () => {
       element.value = '';
       element.pattern = '[0-9]*';
+      await nextFrame();
       inputText('f');
+      await nextFrame();
       expect(input.value).to.equal('');
     });
 
-    it('should not fire value-changed event when prevented', () => {
+    it('should not fire value-changed event when prevented', async () => {
       const spy = sinon.spy();
       element.addEventListener('value-changed', spy);
       element.pattern = '[0-9]*';
+      await nextFrame();
       inputText('f');
+      await nextFrame();
       expect(spy.called).to.be.false;
     });
 
-    it('should not prevent valid pattern', () => {
+    it('should not prevent valid pattern', async () => {
       element.pattern = '[0-9]*';
+      await nextFrame();
       inputText('2');
+      await nextFrame();
       expect(input.value).to.equal('2');
     });
 
-    it('should not prevent too short value', () => {
+    it('should not prevent too short value', async () => {
       input.minlength = 1;
+      await nextFrame();
       inputText('');
+      await nextFrame();
       expect(input.value).to.equal('');
     });
 
-    it('should not prevent empty value for required field', () => {
+    it('should not prevent empty value for required field', async () => {
       element.required = true;
+      await nextFrame();
       inputText('');
+      await nextFrame();
       expect(input.value).to.equal('');
     });
   });
+};
+
+describe('PatternMixin + Polymer', () => {
+  runTests('polymer');
+});
+
+describe('PatternMixin + Lit', () => {
+  runTests('lit');
 });

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -1,43 +1,40 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { ValidateMixin } from '../src/validate-mixin.js';
+import { define } from './helpers.js';
 
-customElements.define(
-  'validate-mixin-element',
-  class extends ValidateMixin(PolymerElement) {
-    static get template() {
-      return html`<input />`;
-    }
-  },
-);
+const runTests = (baseClass) => {
+  const tag = define[baseClass]('validate-mixin', '<input>', (Base) => class extends ValidateMixin(Base) {});
 
-describe('validate-mixin', () => {
   let element;
 
   describe('properties', () => {
-    beforeEach(() => {
-      element = fixtureSync(`<validate-mixin-element></validate-mixin-element>`);
+    beforeEach(async () => {
+      element = fixtureSync(`<${tag}></${tag}>`);
+      await nextRender();
     });
 
-    it('should reflect required property to attribute', () => {
+    it('should reflect required property to attribute', async () => {
       expect(element.hasAttribute('required')).to.be.false;
 
       element.required = true;
+      await nextFrame();
       expect(element.hasAttribute('required')).to.be.true;
     });
 
-    it('should reflect invalid property to attribute', () => {
+    it('should reflect invalid property to attribute', async () => {
       expect(element.hasAttribute('invalid')).to.be.false;
 
       element.invalid = true;
+      await nextFrame();
       expect(element.hasAttribute('invalid')).to.be.true;
     });
   });
 
   describe('checkValidity', () => {
-    beforeEach(() => {
-      element = fixtureSync(`<validate-mixin-element></validate-mixin-element>`);
+    beforeEach(async () => {
+      element = fixtureSync(`<${tag}></$${tag}>`);
+      await nextRender();
     });
 
     it('should return true when element is not required', () => {
@@ -57,8 +54,9 @@ describe('validate-mixin', () => {
   });
 
   describe('validate', () => {
-    beforeEach(() => {
-      element = fixtureSync(`<validate-mixin-element></validate-mixin-element>`);
+    beforeEach(async () => {
+      element = fixtureSync(`<${tag}></${tag}>`);
+      await nextRender();
     });
 
     it('should return true when element is not required', () => {
@@ -103,4 +101,12 @@ describe('validate-mixin', () => {
       expect(element.invalid).to.be.false;
     });
   });
+};
+
+describe('ValidateMixin + Polymer', () => {
+  runTests('polymer');
+});
+
+describe('ValidateMixin + Lit', () => {
+  runTests('lit');
 });


### PR DESCRIPTION
## Description

Updated some of the `field-base` mixins to run tests for both Polymer and LitElement:

- `DelegateStateMixin`
- `InputConstraintsMixin`
- `InputMixin`
- `PatternMixin`
- `ValidateMixin`

## Type of change

- Tests