### PR TITLE
test: speed up the keyboard tests

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -233,6 +233,11 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
   static get properties() {
     return {
+      scrollDuration: {
+        type: Number,
+        default: 300,
+      },
+
       /**
        * The value for this element.
        */
@@ -524,7 +529,6 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
       return (-c / 2) * (t * (t - 2) - 1) + b;
     };
 
-    var duration = animate ? 300 : 0;
     var start = 0;
     var initialPosition = this.$.monthScroller.position;
 
@@ -532,8 +536,13 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
       start = start || timestamp;
       var currentTime = timestamp - start;
 
-      if (currentTime < duration) {
-        var currentPos = easingFunction(currentTime, initialPosition, this._targetPosition - initialPosition, duration);
+      if (currentTime < this.scrollDuration) {
+        var currentPos = easingFunction(
+          currentTime,
+          initialPosition,
+          this._targetPosition - initialPosition,
+          this.scrollDuration,
+        );
         this.$.monthScroller.position = currentPos;
         window.requestAnimationFrame(smoothScroll);
       } else {

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -126,6 +126,7 @@ import { getDefaultI18n, getFocusedCell, getOverlayContent, open, waitForScrollT
       overlay = fixtureSync(`
       <vaadin-date-picker-overlay-content
         style="position: absolute; top: 0"
+        scroll-duration="0"
       ></vaadin-date-picker-overlay-content>`);
       overlay.i18n = getDefaultI18n();
 


### PR DESCRIPTION
## Description

This PR sets the scroll duration to `0` for the date-picker keyboard tests to speed them up.

**Before:**

```
yarn run v1.22.18
$ web-test-runner --group date-picker

Finished running tests in 14.2s, all tests passed! 🎉

✨  Done in 14.67s.
```

**After:**

```
yarn run v1.22.18
$ web-test-runner --group date-picker

Finished running tests in 4.9s, all tests passed! 🎉

✨  Done in 5.28s.
```

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
