### PR TITLE
fix: clear on Esc if clear button is visible

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -823,6 +823,12 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
    */
   _onKeyDown(event) {
     const items = this.selectedItems || [];
+
+    if (event.key === 'Escape' && this.clearButtonVisible && items.length) {
+      this.selectedItems = [];
+      return;
+    }
+
     if (!this.readonly && event.key === 'Backspace' && items.length && this.inputElement.value === '') {
       this.__removeItem(items[items.length - 1]);
     }

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -243,6 +243,21 @@ describe('basic', () => {
       clearButton.click();
       expect(internal.opened).to.be.false;
     });
+
+    it('should clear selected items on Esc when clear button is visible', async () => {
+      comboBox.selectedItems = ['apple', 'orange'];
+      inputElement.focus();
+      await sendKeys({ press: 'Escape' });
+      expect(comboBox.selectedItems).to.deep.equal([]);
+    });
+
+    it('should not clear selected items on Esc when clear button is not visible', async () => {
+      comboBox.selectedItems = ['apple', 'orange'];
+      comboBox.clearButtonVisible = false;
+      inputElement.focus();
+      await sendKeys({ press: 'Escape' });
+      expect(comboBox.selectedItems).to.deep.equal(['apple', 'orange']);
+    });
   });
 
   describe('chips', () => {


### PR DESCRIPTION
## Description

Added logic to clear selected items on <kbd>Esc</kbd> to align with the regular combo-box.

Fixes #3788

## Type of change

- Bugfix