### PR TITLE
fix: do not unselect committed item on focusout

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -179,11 +179,35 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
    * @override
    */
   _onFocusout(event) {
+    // Disable combo-box logic that updates selectedItem
+    // based on the overlay focused index on input blur
+    this._ignoreCommitValue = true;
+
     super._onFocusout(event);
 
     if (this.readonly && !this._closeOnBlurIsPrevented) {
       this.close();
     }
+  }
+
+  /**
+   * Override method inherited from the combo-box
+   * to not commit an already selected item again
+   * on blur, which would result in un-selecting.
+   * @protected
+   * @override
+   */
+  _detectAndDispatchChange() {
+    if (this._ignoreCommitValue) {
+      this._ignoreCommitValue = false;
+
+      // Reset internal combo-box state
+      this.selectedItem = null;
+      this._inputElementValue = '';
+      return;
+    }
+
+    super._detectAndDispatchChange();
   }
 
   /**

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -197,6 +197,14 @@ describe('basic', () => {
       const item = document.querySelectorAll('vaadin-multi-select-combo-box-item')[1];
       expect(item.hasAttribute('focused')).to.be.true;
     });
+
+    it('should not unselect previously committed item on focusout', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'Enter' });
+      await sendKeys({ down: 'Tab' });
+      expect(comboBox.selectedItems).to.deep.equal(['apple']);
+    });
   });
 
   describe('pageSize', () => {


### PR DESCRIPTION
## Description

Fixes #3787

Updated internal `focusout` listener to prevent dispatching extra `change` event for a dropdown item that matches `_focusedIndex` - currently, this extra event causes the previously selected item to be incorrectly unseleted.

Note, this PR does not cover #3645: custom values are handled differently and `custom-value-set` still fires on focusout.

## Type of change

- Bugfix