### PR TITLE
refactor: drop legacy outerscroller accessor

### DIFF
--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -63,9 +63,6 @@ export const ScrollMixin = (superClass) =>
     ready() {
       super.ready();
 
-      // Preserve accessor to the legacy scrolling functionality
-      this.$.outerscroller = document.createElement('div');
-
       this.scrollTarget = this.$.table;
 
       this.$.items.addEventListener('focusin', (e) => {


### PR DESCRIPTION
## Description

This was originally added as part of updating `vaadin-grid` to use `position: sticky` in https://github.com/vaadin/vaadin-grid/pull/1791/commits/0915ff74153107ef8612a9fb8ad3983a254a8e3d
There has been several major releases since then, I think we can now safely drop this legacy accessor.

## Type of change

- Refactor