### PR TITLE
chore: update license for grid-pro renderer

### DIFF
--- a/packages/grid-pro/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid-pro/src/lit/column-renderer-directives.d.ts
@@ -1,7 +1,8 @@
 /**
  * @license
- * Copyright (c) 2017 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * Copyright (c) 2018 - 2022 Vaadin Ltd.
+ * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
+ * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
 import { TemplateResult } from 'lit';
 import { DirectiveResult } from 'lit/directive';

--- a/packages/grid-pro/src/lit/column-renderer-directives.js
+++ b/packages/grid-pro/src/lit/column-renderer-directives.js
@@ -1,7 +1,8 @@
 /**
  * @license
- * Copyright (c) 2017 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * Copyright (c) 2018 - 2022 Vaadin Ltd.
+ * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
+ * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
 import { directive } from 'lit/directive.js';
 import { microTask } from '@vaadin/component-base/src/async.js';


### PR DESCRIPTION
## Description

The license headers were incorrectly copied from elsewhere. Updated them to use CVDL as in `vaadin-grid-pro`.

## Type of change

- Internal change