### PR TITLE
fix: observe parent resize to detect overflow

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -28,14 +28,14 @@ export const ButtonsMixin = (superClass) =>
       return ['_menuItemsChanged(items, items.splices)'];
     }
 
-    constructor() {
-      super();
-
-      this.__parentResizeObserver = new ResizeObserver(() => {
-        setTimeout(() => {
-          this.__detectOverflow();
-        });
-      });
+    /**
+     * Override getter from `ResizeMixin` to observe parent.
+     *
+     * @protected
+     * @override
+     */
+    get _observeParent() {
+      return true;
     }
 
     /** @protected */
@@ -50,18 +50,6 @@ export const ButtonsMixin = (superClass) =>
       super.connectedCallback();
 
       this._initButtonAttrs(this._overflow);
-
-      // Observe parent node resize to detect overflow
-      this.__parent = this.parentNode instanceof ShadowRoot ? this.parentNode.host : this.parentNode;
-      this.__parentResizeObserver.observe(this.__parent);
-    }
-
-    /** @protected */
-    disconnectedCallback() {
-      super.disconnectedCallback();
-
-      this.__parentResizeObserver.unobserve(this.__parent);
-      delete this.__parent;
     }
 
     /**

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -28,6 +28,16 @@ export const ButtonsMixin = (superClass) =>
       return ['_menuItemsChanged(items, items.splices)'];
     }
 
+    constructor() {
+      super();
+
+      this.__parentResizeObserver = new ResizeObserver(() => {
+        setTimeout(() => {
+          this.__detectOverflow();
+        });
+      });
+    }
+
     /** @protected */
     ready() {
       super.ready();
@@ -40,6 +50,18 @@ export const ButtonsMixin = (superClass) =>
       super.connectedCallback();
 
       this._initButtonAttrs(this._overflow);
+
+      // Observe parent node resize to detect overflow
+      this.__parent = this.parentNode instanceof ShadowRoot ? this.parentNode.host : this.parentNode;
+      this.__parentResizeObserver.observe(this.__parent);
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+
+      this.__parentResizeObserver.unobserve(this.__parent);
+      delete this.__parent;
     }
 
     /**

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -542,6 +542,20 @@ describe('parent resize', () => {
       assertVisible(buttons[2]);
       assertVisible(buttons[3]);
     });
+
+    it('should show buttons after attaching another container and increasing its width', async () => {
+      const other = document.createElement('div');
+      other.style.display = 'flex';
+      other.style.maxWidth = '300px';
+      container.parentNode.appendChild(other);
+
+      other.append(text, menu);
+      other.style.maxWidth = '400px';
+      await onceResized(menu);
+
+      assertVisible(buttons[2]);
+      assertVisible(buttons[3]);
+    });
   });
 
   describe('shadow host', () => {

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -513,6 +513,58 @@ describe('responsive behaviour in container', () => {
   });
 });
 
+describe('parent resize', () => {
+  let container, text, menu, buttons;
+
+  beforeEach(() => {
+    container = fixtureSync('<div style="display: flex; max-width: 300px"></div>');
+    text = document.createElement('div');
+    text.textContent = 'Sibling';
+    menu = document.createElement('vaadin-menu-bar');
+    menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }, { text: 'Item 4' }];
+    menu.style.minWidth = '100px';
+  });
+
+  describe('container', () => {
+    beforeEach(async () => {
+      container.append(text, menu);
+      await onceResized(menu);
+      buttons = menu._buttons;
+    });
+
+    it('should show buttons when container width increases and menu-bar width stays the same', async () => {
+      assertHidden(buttons[2]);
+      assertHidden(buttons[3]);
+
+      container.style.maxWidth = '400px';
+      await onceResized(menu);
+
+      assertVisible(buttons[2]);
+      assertVisible(buttons[3]);
+    });
+  });
+
+  describe('shadow host', () => {
+    beforeEach(async () => {
+      container.attachShadow({ mode: 'open' });
+      container.shadowRoot.append(text, menu);
+      await onceResized(menu);
+      buttons = menu._buttons;
+    });
+
+    it('should show buttons when shadow host width increases and menu-bar width stays the same', async () => {
+      assertHidden(buttons[2]);
+      assertHidden(buttons[3]);
+
+      container.style.maxWidth = '400px';
+      await onceResized(menu);
+
+      assertVisible(buttons[2]);
+      assertVisible(buttons[3]);
+    });
+  });
+});
+
 describe('item components', () => {
   let menu, buttons, overflow;
 


### PR DESCRIPTION
## Description

Added `ResizeObserver` for the menu-bar parent to detect cases when its width increases.

Note, this does not cover the following case described in the original issue:

> Changing of the content -> Update view title to be longer (e.g. upon navigation), MenuBar overflow is created, update title to be shorter overflow is not being updated.

Fixes #3739

## Type of change

- Bugfix