### PR TITLE
refactor: extract method for updating overflow

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -95,8 +95,13 @@ export const ButtonsMixin = (superClass) =>
           item.classList.remove('vaadin-menu-item');
         }
       }
-      this._overflow.item = { children: [] };
-      this._hasOverflow = false;
+      this.__updateOverflow([]);
+    }
+
+    /** @private */
+    __updateOverflow(items) {
+      this._overflow.item = { children: items };
+      this._hasOverflow = items.length > 0;
     }
 
     /** @private */
@@ -127,9 +132,8 @@ export const ButtonsMixin = (superClass) =>
           // Save width for buttons with component
           btn.style.width = btnStyle.width;
         }
-        overflow.item = {
-          children: buttons.filter((b, idx) => idx >= i).map((b) => b.item),
-        };
+        const items = buttons.filter((_, idx) => idx >= i).map((b) => b.item);
+        this.__updateOverflow(items);
       }
     }
 


### PR DESCRIPTION
## Description

The original issue contains an edge case where `container.offsetWidth` is `39` and `container.scrollWidth` is `40`: this only happens with certain customizations, see https://github.com/vaadin/flow-components/issues/2810#issuecomment-1060637732. I'm not sure if we should test that.

However, it still makes sense to make this logic more clear by ensuring `_hasOverflow` is only set to `true` when the count of the items in the overflow sub-menu is greater than `0`. This PR makes it explicit by adding another private method.

Fixes https://github.com/vaadin/flow-components/issues/2810

## Type of change

- Refactor