### PR TITLE
refactor: add option to observe parent resize

### DIFF
--- a/packages/component-base/src/resize-mixin.d.ts
+++ b/packages/component-base/src/resize-mixin.d.ts
@@ -16,4 +16,10 @@ export declare class ResizeMixinClass {
    * Override the method to implement your own behavior.
    */
   protected _onResize(contentRect: DOMRect): void;
+
+  /**
+   * When true, the parent element resize will be also observed.
+   * Override this getter and return `true` to enable this.
+   */
+  protected readonly _observeParent: boolean;
 }

--- a/packages/component-base/test/resize-mixin.test.js
+++ b/packages/component-base/test/resize-mixin.test.js
@@ -5,7 +5,7 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ResizeMixin } from '../src/resize-mixin.js';
 
 describe('resize-mixin', () => {
-  let element;
+  let element, observeParent;
 
   before(() => {
     customElements.define(
@@ -20,6 +20,10 @@ describe('resize-mixin', () => {
             </style>
             <div></div>
           `;
+        }
+
+        get _observeParent() {
+          return observeParent;
         }
 
         _onResize() {
@@ -67,6 +71,70 @@ describe('resize-mixin', () => {
       element.notifyResize();
       expect(console.warn.calledOnce).to.be.true;
       expect(console.warn.args[0][0]).to.include('WARNING: Since Vaadin 23, notifyResize() is deprecated.');
+    });
+  });
+
+  describe('observe parent', () => {
+    let parent;
+
+    beforeEach(() => {
+      parent = fixtureSync('<div style="display: flex"></div>');
+      observeParent = true;
+    });
+
+    describe('light DOM', () => {
+      beforeEach(async () => {
+        parent.appendChild(element);
+        // Wait for the initial resize.
+        await element.nextResize();
+      });
+
+      it('should notify parent element resize', async () => {
+        parent.style.width = '100px';
+        await element.nextResize();
+      });
+
+      describe('multiple children', () => {
+        let sibling, spy1, spy2;
+
+        beforeEach(() => {
+          sibling = element.cloneNode(true);
+          parent.appendChild(sibling);
+
+          spy1 = sinon.spy(element, '_onResize');
+          spy2 = sinon.spy(sibling, '_onResize');
+        });
+
+        it('should notify resize once per element', async () => {
+          parent.style.width = '100px';
+          await aTimeout(20);
+          expect(spy1.calledOnce).to.be.true;
+          expect(spy2.calledOnce).to.be.true;
+        });
+
+        it('should not notify element when detached', async () => {
+          parent.removeChild(element);
+
+          parent.style.width = '100px';
+          await aTimeout(20);
+          expect(spy1.called).to.be.false;
+          expect(spy2.calledOnce).to.be.true;
+        });
+      });
+    });
+
+    describe('shadow DOM', () => {
+      beforeEach(async () => {
+        parent.attachShadow({ mode: 'open' });
+        parent.shadowRoot.appendChild(element);
+        // Wait for the initial resize.
+        await element.nextResize();
+      });
+
+      it('should notify shadow host resize', async () => {
+        parent.style.width = '100px';
+        await element.nextResize();
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Added option to observe parent element resize to `ResizeMixin` - see #3824
Note: this isn't marked as `feat:` to make backporting possible.

## Type of change

- Internal feature