### PR TITLE
chore: add a cvdlName field to package.json of pro components

### DIFF
--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -6,6 +6,7 @@
   },
   "description": "Polymer element to create flexible responsive layouts and build nice looking dashboard.",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/board/LICENSE.txt",
+  "cvdlName": "vaadin-board",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-charts",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/charts/LICENSE",
+  "cvdlName": "vaadin-chart",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-confirm-dialog",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/confirm-dialog/LICENSE",
+  "cvdlName": "vaadin-confirm-dialog",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-cookie-consent",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/cookie-consent/LICENSE",
+  "cvdlName": "vaadin-cookie-consent",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-crud",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/crud/LICENSE",
+  "cvdlName": "vaadin-crud",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-grid-pro",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/grid-pro/LICENSE",
+  "cvdlName": "vaadin-grid-pro",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-map",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/map/LICENSE",
+  "cvdlName": "vaadin-map",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-rich-text-editor",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/rich-text-editor/LICENSE",
+  "cvdlName": "vaadin-rich-text-editor",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/vaadin-board/package.json
+++ b/packages/vaadin-board/package.json
@@ -6,6 +6,7 @@
   },
   "description": "Polymer element to create flexible responsive layouts and build nice looking dashboard.",
   "license": "https://raw.githubusercontent.com/vaadin/vaadin-board/master/LICENSE.txt",
+  "cvdlName": "vaadin-board",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/vaadin-charts/package.json
+++ b/packages/vaadin-charts/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-charts",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/vaadin-charts/LICENSE",
+  "cvdlName": "vaadin-chart",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/vaadin-confirm-dialog/package.json
+++ b/packages/vaadin-confirm-dialog/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-confirm-dialog",
   "license": "https://raw.githubusercontent.com/vaadin/vaadin-confirm-dialog/master/LICENSE",
+  "cvdlName": "vaadin-confirm-dialog",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/vaadin-cookie-consent/package.json
+++ b/packages/vaadin-cookie-consent/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-cookie-consent",
   "license": "https://raw.githubusercontent.com/vaadin/vaadin-cookie-consent/master/LICENSE",
+  "cvdlName": "vaadin-cookie-consent",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/vaadin-crud/package.json
+++ b/packages/vaadin-crud/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-crud",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/vaadin-crud/LICENSE",
+  "cvdlName": "vaadin-crud",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/vaadin-grid-pro/package.json
+++ b/packages/vaadin-grid-pro/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-grid-pro",
   "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/vaadin-grid-pro/LICENSE",
+  "cvdlName": "vaadin-grid-pro",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",

--- a/packages/vaadin-rich-text-editor/package.json
+++ b/packages/vaadin-rich-text-editor/package.json
@@ -6,6 +6,7 @@
   },
   "description": "vaadin-rich-text-editor",
   "license": "https://raw.githubusercontent.com/vaadin/vaadin-rich-text-editor/master/LICENSE",
+  "cvdlName": "vaadin-rich-text-editor",
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",


### PR DESCRIPTION
## Description

The PR adds `cvdlName` to `package.json` for every Vaadin pro component. This is needed for the new Flow license checker to be able to check the license at the project's build time.

Part of #3773

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
