### PR TITLE
chore: add a cvdlName getter to pro components

### DIFF
--- a/packages/board/src/vaadin-board.js
+++ b/packages/board/src/vaadin-board.js
@@ -47,6 +47,10 @@ class Board extends ElementMixin(PolymerElement) {
     return 'vaadin-board';
   }
 
+  static get cvdlName() {
+    return 'vaadin-board';
+  }
+
   /**
    * @protected
    */

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -266,6 +266,10 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     return 'vaadin-chart';
   }
 
+  static get cvdlName() {
+    return 'vaadin-chart';
+  }
+
   /** @private */
   static __callHighchartsFunction(functionName, redrawCharts, ...args) {
     const functionToCall = Highcharts[functionName];

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -97,6 +97,10 @@ class ConfirmDialog extends SlotMixin(ElementMixin(ThemePropertyMixin(PolymerEle
     return 'vaadin-confirm-dialog';
   }
 
+  static get cvdlName() {
+    return 'vaadin-confirm-dialog';
+  }
+
   static get properties() {
     return {
       /**

--- a/packages/cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.js
@@ -52,6 +52,10 @@ class CookieConsent extends ElementMixin(PolymerElement) {
     return 'vaadin-cookie-consent';
   }
 
+  static get cvdlName() {
+    return 'vaadin-cookie-consent';
+  }
+
   static get properties() {
     return {
       /**

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -310,6 +310,10 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
     return 'vaadin-crud';
   }
 
+  static get cvdlName() {
+    return 'vaadin-crud';
+  }
+
   static get properties() {
     return {
       /**

--- a/packages/grid-pro/src/vaadin-grid-pro.js
+++ b/packages/grid-pro/src/vaadin-grid-pro.js
@@ -49,6 +49,10 @@ class GridPro extends InlineEditingMixin(Grid) {
     return 'vaadin-grid-pro';
   }
 
+  static get cvdlName() {
+    return 'vaadin-grid-pro';
+  }
+
   /**
    * @protected
    */

--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -376,6 +376,10 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
     return 'vaadin-map';
   }
 
+  static get cvdlName() {
+    return 'vaadin-map';
+  }
+
   /** @protected */
   static _finalizeClass() {
     super._finalizeClass();

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -362,6 +362,10 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     return 'vaadin-rich-text-editor';
   }
 
+  static get cvdlName() {
+    return 'vaadin-rich-text-editor';
+  }
+
   static get properties() {
     return {
       /**


### PR DESCRIPTION
## Description

The PR adds a `cvdlName` getter to every Vaadin pro component. The getter will be used in license checking. 

Note, I haven't dropped the logic in `_finalizeClass` related to the old way of license checking. We can only do that after the new license checker is off the feature flag.

Fixes #3773 

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
