### PR TITLE
refactor: use gap for mscb chip spacing

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -177,18 +177,18 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
             invalid="[[invalid]]"
             theme$="[[theme]]"
           >
-            <vaadin-multi-select-combo-box-chip
-              id="overflow"
-              slot="prefix"
-              part$="[[_getOverflowPart(_overflowItems.length)]]"
-              disabled="[[disabled]]"
-              readonly="[[readonly]]"
-              label="[[_getOverflowLabel(_overflowItems.length)]]"
-              title$="[[_getOverflowTitle(_overflowItems)]]"
-              hidden$="[[_isOverflowHidden(_overflowItems.length)]]"
-              on-mousedown="_preventBlur"
-            ></vaadin-multi-select-combo-box-chip>
-            <div id="chips" part="chips" slot="prefix"></div>
+            <div id="chips" part="chips" slot="prefix">
+              <vaadin-multi-select-combo-box-chip
+                id="overflow"
+                part$="[[_getOverflowPart(_overflowItems.length)]]"
+                disabled="[[disabled]]"
+                readonly="[[readonly]]"
+                label="[[_getOverflowLabel(_overflowItems.length)]]"
+                title$="[[_getOverflowTitle(_overflowItems)]]"
+                hidden$="[[_isOverflowHidden(_overflowItems.length)]]"
+                on-mousedown="_preventBlur"
+              ></vaadin-multi-select-combo-box-chip>
+            </div>
             <slot name="input"></slot>
             <div id="clearButton" part="clear-button" slot="suffix"></div>
             <div id="toggleButton" class="toggle-button" part="toggle-button" slot="suffix"></div>

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -34,12 +34,8 @@ const multiSelectComboBox = css`
     caret-color: var(--lumo-body-text-color) !important;
   }
 
-  [part~='chip']:not(:last-of-type) {
-    margin-inline-end: var(--lumo-space-xs);
-  }
-
-  [part~='overflow']:not([hidden]) + :not(:empty) {
-    margin-inline-start: var(--lumo-space-xs);
+  [part~='chips'] {
+    gap: var(--lumo-space-xs);
   }
 
   [part='toggle-button']::before {

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-chip-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-chip-styles.js
@@ -12,7 +12,6 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 const chip = css`
   :host {
     height: 1.25rem;
-    margin-inline-end: 0.25rem;
     padding: 0 0.5rem;
     border-radius: 4px;
     background-color: rgba(0, 0, 0, 0.08);

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -38,6 +38,10 @@ const multiSelectComboBox = css`
     padding: 6px 0;
   }
 
+  [part='chips'] {
+    gap: 0.25rem;
+  }
+
   [part='toggle-button']::before {
     content: var(--material-icons-dropdown);
   }


### PR DESCRIPTION
- Move the overflow chip inside the "chips" container
- Use `gap` for spacing the chips