### PR TITLE
fix: do not throw on Tab if grid has tabindex

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -617,6 +617,11 @@ export const KeyboardNavigationMixin = (superClass) =>
     _onTabKeyDown(e) {
       const focusTarget = this._predictFocusStepTarget(e.composedPath()[0], e.shiftKey ? -1 : 1);
 
+      // Can be undefined if grid has tabindex
+      if (!focusTarget) {
+        return;
+      }
+
       // Prevent focus-trap logic from intercepting the event.
       e.stopPropagation();
 

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -2198,6 +2198,16 @@ describe('empty grid', () => {
     // Expect programmatic focus on focus exit element
     expect(grid.shadowRoot.activeElement).to.equal(grid.$.focusexit);
   });
+
+  it('should not throw on Shift + Tab when grid has tabindex', () => {
+    grid.setAttribute('tabindex', '0');
+
+    grid.focus();
+
+    expect(() => {
+      shiftTab();
+    }).to.not.throw(Error);
+  });
 });
 
 describe('hierarchical data', () => {

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -2205,7 +2205,7 @@ describe('empty grid', () => {
     grid.focus();
 
     expect(() => {
-      shiftTab();
+      shiftTab(grid);
     }).to.not.throw(Error);
   });
 });


### PR DESCRIPTION
## Description

When setting `tabindex` attribute on `vaadin-grid`, pressing <kbd>Shift</kbd> + <kbd>Tab</kbd> on it throws an error.
This is due to the fact that `_predictFocusStepTarget()` method returns `undefined` in this case.

Added a check for `undefined` value to not throw and not call `preventDefault()` so that native keyboard focus works.

Fixes https://github.com/vaadin/flow-components/issues/2181

## Type of change

- Bugfix