### PR TITLE
refactor: Improve performance of SelectionMixinClass#isSelected

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -33,7 +33,10 @@ export const SelectionMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['_itemIdPathChanged(itemIdPath)', '_selectedItemsChanged(selectedItems.*)'];
+      return [
+        '_updateSelectionForItemIdPathChange(itemIdPath)',
+        '_updateSelectionForSelectedItemsChange(selectedItems.*)'
+      ];
     }
 
     /**
@@ -85,12 +88,12 @@ export const SelectionMixin = (superClass) =>
     }
 
     /** @private */
-    _itemIdPathChanged() {
+    _updateSelectionForItemIdPathChange() {
       this.__cacheSelectedKeys();
     }
 
     /** @private */
-    _selectedItemsChanged() {
+    _updateSelectionForSelectedItemsChange() {
       this.__cacheSelectedKeys();
       this.requestContentUpdate();
     }

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -33,10 +33,7 @@ export const SelectionMixin = (superClass) =>
     }
 
     static get observers() {
-      return [
-        '_updateSelectionForItemIdPathChange(itemIdPath)',
-        '_updateSelectionForSelectedItemsChange(selectedItems.*)',
-      ];
+      return ['_updateSelectedKeys(itemIdPath, selectedItems.*)'];
     }
 
     /**
@@ -88,23 +85,14 @@ export const SelectionMixin = (superClass) =>
     }
 
     /** @private */
-    _updateSelectionForItemIdPathChange() {
-      this.__cacheSelectedKeys();
-    }
-
-    /** @private */
-    _updateSelectionForSelectedItemsChange() {
-      this.__cacheSelectedKeys();
-      this.requestContentUpdate();
-    }
-
-    /** @private */
-    __cacheSelectedKeys() {
+    _updateSelectedKeys() {
       const selectedItems = this.selectedItems || [];
       this.__selectedKeys = new Set();
       selectedItems.forEach((item) => {
         this.__selectedKeys.add(this.getItemId(item));
       });
+
+      this.requestContentUpdate();
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -35,7 +35,7 @@ export const SelectionMixin = (superClass) =>
     static get observers() {
       return [
         '_updateSelectionForItemIdPathChange(itemIdPath)',
-        '_updateSelectionForSelectedItemsChange(selectedItems.*)'
+        '_updateSelectionForSelectedItemsChange(selectedItems.*)',
       ];
     }
 
@@ -100,12 +100,11 @@ export const SelectionMixin = (superClass) =>
 
     /** @private */
     __cacheSelectedKeys() {
-      if (this.selectedItems) {
-        this.__selectedKeys = new Set();
-        this.selectedItems.forEach((item) => {
-          this.__selectedKeys.add(this.getItemId(item));
-        });
-      }
+      const selectedItems = this.selectedItems || [];
+      this.__selectedKeys = new Set();
+      selectedItems.forEach((item) => {
+        this.__selectedKeys.add(this.getItemId(item));
+      });
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -20,11 +20,20 @@ export const SelectionMixin = (superClass) =>
           notify: true,
           value: () => [],
         },
+
+        /**
+         * Set of selected item ids
+         * @private
+         */
+        __selectedKeys: {
+          type: Object,
+          value: () => new Set(),
+        },
       };
     }
 
     static get observers() {
-      return ['_selectedItemsChanged(selectedItems.*)'];
+      return ['_itemIdPathChanged(itemIdPath)', '_selectedItemsChanged(selectedItems.*)'];
     }
 
     /**
@@ -33,7 +42,7 @@ export const SelectionMixin = (superClass) =>
      * @protected
      */
     _isSelected(item) {
-      return this.selectedItems && this._getItemIndexInArray(item, this.selectedItems) > -1;
+      return this.__selectedKeys.has(this.getItemId(item));
     }
 
     /**
@@ -68,8 +77,7 @@ export const SelectionMixin = (superClass) =>
      * @protected
      */
     _toggleItem(item) {
-      const index = this._getItemIndexInArray(item, this.selectedItems);
-      if (index === -1) {
+      if (!this._isSelected(item)) {
         this.selectItem(item);
       } else {
         this.deselectItem(item);
@@ -77,8 +85,24 @@ export const SelectionMixin = (superClass) =>
     }
 
     /** @private */
+    _itemIdPathChanged() {
+      this.__cacheSelectedKeys();
+    }
+
+    /** @private */
     _selectedItemsChanged() {
+      this.__cacheSelectedKeys();
       this.requestContentUpdate();
+    }
+
+    /** @private */
+    __cacheSelectedKeys() {
+      if (this.selectedItems) {
+        this.__selectedKeys = new Set();
+        this.selectedItems.forEach((item) => {
+          this.__selectedKeys.add(this.getItemId(item));
+        });
+      }
     }
 
     /**


### PR DESCRIPTION
## Description

Maintain a Set containing the selected item ids to speed up isSelected queries

Fixes #3844

I'm afraid my JS skills are incredibly rusty and I have no experience with Polymer at all, so this may be completely incorrect. My intention with this PR was to get a discussion going if this approach made sense. Consider it a first draft of a suggested possible fix.

The idea here is that the selection mixin maintains a Set of the selected item ids alongside the existing selectedItems array. Lookups in a Set are typically `O(1)` instead of `O(n)` (depends on the exact implementation of course) which makes a significant difference when many items are selected.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
