### PR TITLE
refactor!: align custom value property and event

### DIFF
--- a/dev/multi-select-combo-box.html
+++ b/dev/multi-select-combo-box.html
@@ -18,7 +18,7 @@
       clear-button-visible
       required
       error-message="Select at least one"
-      allow-custom-values
+      allow-custom-value
       style="width: 300px"
     ></vaadin-multi-select-combo-box>
 
@@ -69,11 +69,11 @@
 
       comboBox.selectedItems = ['Hydrogen', 'Helium', 'Lithium'];
 
-      comboBox.addEventListener('custom-values-set', (event) => {
+      comboBox.addEventListener('custom-value-set', (event) => {
         const item = event.detail;
         comboBox.items.push(item);
         comboBox.selectedItems = [...comboBox.selectedItems, item];
-        console.log('custom-values-set', item);
+        console.log('custom-value-set', item);
       });
 
       comboBox.addEventListener('change', () => {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -38,7 +38,7 @@ export type MultiSelectComboBoxChangeEvent<TItem> = Event & {
 /**
  * Fired when the user sets a custom value.
  */
-export type MultiSelectComboBoxCustomValuesSetEvent = CustomEvent<string>;
+export type MultiSelectComboBoxCustomValueSetEvent = CustomEvent<string>;
 
 /**
  * Fired when the `filter` property changes.
@@ -58,7 +58,7 @@ export type MultiSelectComboBoxSelectedItemsChangedEvent<TItem> = CustomEvent<{ 
 export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap {
   change: MultiSelectComboBoxChangeEvent<TItem>;
 
-  'custom-values-set': MultiSelectComboBoxCustomValuesSetEvent;
+  'custom-value-set': MultiSelectComboBoxCustomValueSetEvent;
 
   'filter-changed': MultiSelectComboBoxFilterChangedEvent;
 
@@ -138,7 +138,7 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
- * @fires {CustomEvent} custom-values-set - Fired when the user sets a custom value.
+ * @fires {CustomEvent} custom-value-set - Fired when the user sets a custom value.
  * @fires {CustomEvent} filter-changed - Fired when the `filter` property changes.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
@@ -146,9 +146,9 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
 declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLElement {
   /**
    * When true, the user can input a value that is not present in the items list.
-   * @attr {boolean} allow-custom-values
+   * @attr {boolean} allow-custom-value
    */
-  allowCustomValues: boolean;
+  allowCustomValue: boolean;
 
   /**
    * Set true to prevent the overlay from opening automatically.

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -126,7 +126,7 @@ registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectCo
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.
- * @fires {CustomEvent} custom-values-set - Fired when the user sets a custom value.
+ * @fires {CustomEvent} custom-value-set - Fired when the user sets a custom value.
  * @fires {CustomEvent} filter-changed - Fired when the `filter` property changes.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
@@ -159,7 +159,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           disabled="[[disabled]]"
           readonly="[[readonly]]"
           auto-open-disabled="[[autoOpenDisabled]]"
-          allow-custom-value="[[allowCustomValues]]"
+          allow-custom-value="[[allowCustomValue]]"
           data-provider="[[dataProvider]]"
           filter="{{filter}}"
           filtered-items="[[filteredItems]]"
@@ -354,9 +354,9 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
       /**
        * When true, the user can input a value that is not present in the items list.
-       * @attr {boolean} allow-custom-values
+       * @attr {boolean} allow-custom-value
        */
-      allowCustomValues: {
+      allowCustomValue: {
         type: Boolean,
         value: false,
       },
@@ -970,10 +970,13 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     // Do not set combo-box value
     event.preventDefault();
 
+    // Stop the original event
+    event.stopPropagation();
+
     this.__clearFilter();
 
     this.dispatchEvent(
-      new CustomEvent('custom-values-set', {
+      new CustomEvent('custom-value-set', {
         detail: event.detail,
         composed: true,
         bubbles: true,

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -649,17 +649,17 @@ describe('basic', () => {
     });
   });
 
-  describe('allowCustomValues', () => {
+  describe('allowCustomValue', () => {
     beforeEach(async () => {
-      comboBox.allowCustomValues = true;
+      comboBox.allowCustomValue = true;
       comboBox.selectedItems = ['apple'];
       await nextRender();
       inputElement.focus();
     });
 
-    it('should fire custom-values-set event when entering custom value', async () => {
+    it('should fire custom-value-set event when entering custom value', async () => {
       const spy = sinon.spy();
-      comboBox.addEventListener('custom-values-set', spy);
+      comboBox.addEventListener('custom-value-set', spy);
       await sendKeys({ type: 'pear' });
       await sendKeys({ down: 'Enter' });
       expect(spy.calledOnce).to.be.true;

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -16,7 +16,7 @@ import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
 import {
   MultiSelectComboBox,
   MultiSelectComboBoxChangeEvent,
-  MultiSelectComboBoxCustomValuesSetEvent,
+  MultiSelectComboBoxCustomValueSetEvent,
   MultiSelectComboBoxFilterChangedEvent,
   MultiSelectComboBoxI18n,
   MultiSelectComboBoxInvalidChangedEvent,
@@ -40,8 +40,8 @@ narrowedComboBox.addEventListener('change', (event) => {
   assertType<MultiSelectComboBox<TestComboBoxItem>>(event.target);
 });
 
-narrowedComboBox.addEventListener('custom-values-set', (event) => {
-  assertType<MultiSelectComboBoxCustomValuesSetEvent>(event);
+narrowedComboBox.addEventListener('custom-value-set', (event) => {
+  assertType<MultiSelectComboBoxCustomValueSetEvent>(event);
   assertType<string>(event.detail);
 });
 
@@ -63,7 +63,7 @@ narrowedComboBox.addEventListener('selected-items-changed', (event) => {
 // Properties
 assertType<() => boolean>(narrowedComboBox.checkValidity);
 assertType<() => boolean>(narrowedComboBox.validate);
-assertType<boolean>(narrowedComboBox.allowCustomValues);
+assertType<boolean>(narrowedComboBox.allowCustomValue);
 assertType<boolean | null | undefined>(narrowedComboBox.autoOpenDisabled);
 assertType<string>(narrowedComboBox.filter);
 assertType<TestComboBoxItem[] | undefined>(narrowedComboBox.filteredItems);

--- a/packages/multi-select-combo-box/test/visual/lumo/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/visual/lumo/multi-select-combo-box.test.js
@@ -47,7 +47,7 @@ describe('multi-select-combo-box', () => {
   });
 
   it('custom value', async () => {
-    element.allowCustomValues = true;
+    element.allowCustomValue = true;
     element.selectedItems = ['Orange'];
     await visualDiff(div, 'custom-value');
   });

--- a/packages/multi-select-combo-box/test/visual/material/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/visual/material/multi-select-combo-box.test.js
@@ -47,7 +47,7 @@ describe('multi-select-combo-box', () => {
   });
 
   it('custom value', async () => {
-    element.allowCustomValues = true;
+    element.allowCustomValue = true;
     element.selectedItems = ['Orange'];
     await visualDiff(div, 'custom-value');
   });


### PR DESCRIPTION
## Description

1. Updated `vaadin-multi-select-combo-box` to use same property / event for custom values as `vaadin-combo-box`.
2. Added `stopPropagation()` for the original `custom-value-set` event to ensure it can't mess up the users logic

## Type of change

- Refactor