### PR TITLE
chore: make sure iron-list internal properties are in sync

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -308,7 +308,9 @@ export class IronListAdapter {
       // After running super._scrollHandler, fix _virtualStart to workaround an iron-list issue.
       // See https://github.com/vaadin/web-components/issues/1691
       const reusables = this._getReusables(true);
+      this._physicalTop = reusables.physicalTop;
       this._virtualStart += reusables.indexes.length;
+      this._physicalStart += reusables.indexes.length;
     }
 
     if (this.reorderElements) {

--- a/packages/component-base/test/virtualizer-scrolling.test.js
+++ b/packages/component-base/test/virtualizer-scrolling.test.js
@@ -227,6 +227,11 @@ describe('virtualizer - scrollbar scrolling', () => {
     for (let i = 0; i < 10; i++) {
       await nextFrame();
       scrollTarget.scrollTop -= 1000;
+
+      // Sanity check for iron-list internal properties
+      const adapter = virtualizer.__adapter;
+      const firstItem = adapter._physicalItems[adapter._physicalStart];
+      expect(firstItem.__virtualIndex).to.equal(adapter._virtualStart);
     }
 
     // There should be an item at the bottom of the viewport


### PR DESCRIPTION
Follow-up for #3843

To be on the safe side, also update `_physicalTop` and `_physicalStart` alongside `_virtualStart` [as done in `_render()`](https://github.com/vaadin/web-components/blob/d736621117d022ef276f9241526862f42980609e/packages/component-base/src/iron-list-core.js#L537-L539)