### PR TITLE
fix: add missing .js extensions to imports

### DIFF
--- a/packages/grid/src/lit/column-renderer-directives.js
+++ b/packages/grid/src/lit/column-renderer-directives.js
@@ -5,8 +5,8 @@
  */
 /* eslint-disable max-classes-per-file */
 import { directive } from 'lit/directive.js';
-import { microTask } from '@vaadin/component-base/src/async';
-import { Debouncer } from '@vaadin/component-base/src/debounce';
+import { microTask } from '@vaadin/component-base/src/async.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import { CONTENT_UPDATE_DEBOUNCER } from './renderer-directives.js';
 


### PR DESCRIPTION
## Description

Added missing extensions which break some tools, e.g. `webpack` 5 logs the following error:

```
Module not found: Error: Can't resolve '@vaadin/component-base/src/debounce' in '/Users/serhii/cf/ts-vaadin-examples/node_modules/@vaadin/grid/src/lit'
Did you mean 'debounce.js'?
BREAKING CHANGE: The request '@vaadin/component-base/src/debounce' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
resolve '@vaadin/component-base/src/debounce' in '/Users/serhii/cf/ts-vaadin-examples/node_modules/@vaadin/grid/src/lit'
```

## Type of change

- Bugfix