### PR TITLE
fix: set focused index but not scroll into view

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -971,19 +971,15 @@ export const ComboBoxMixin = (subclass) =>
           this._selectItemForValue(this.value);
         }
 
-        // Do not update `_focusedIndex` to from `-1` to old value during scroll.
-        // Otherwise, the scroll would jump back to the previously focused item.
-        if (!this.loading) {
-          const inputValue = this._inputElementValue;
-          if (inputValue === undefined || inputValue === this._getItemLabel(this.selectedItem)) {
-            // When the input element value is the same as the current value or not defined,
-            // set the focused index to the item that matches the value.
-            this._focusedIndex = this.$.dropdown.indexOfLabel(this._getItemLabel(this.selectedItem));
-          } else {
-            // When the user filled in something that is different from the current value = filtering is enabled,
-            // set the focused index to the item that matches the filter query.
-            this._focusedIndex = this.$.dropdown.indexOfLabel(this.filter);
-          }
+        const inputValue = this._inputElementValue;
+        if (inputValue === undefined || inputValue === this._getItemLabel(this.selectedItem)) {
+          // When the input element value is the same as the current value or not defined,
+          // set the focused index to the item that matches the value.
+          this._focusedIndex = this.$.dropdown.indexOfLabel(this._getItemLabel(this.selectedItem));
+        } else {
+          // When the user filled in something that is different from the current value = filtering is enabled,
+          // set the focused index to the item that matches the filter query.
+          this._focusedIndex = this.$.dropdown.indexOfLabel(this.filter);
         }
       }
     }

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -259,7 +259,9 @@ export class ComboBoxScroller extends PolymerElement {
       this.requestContentUpdate();
     }
 
-    if (index >= 0) {
+    // Do not jump back to the previously focused item while loading
+    // when requesting next page from the data provider on scroll.
+    if (index >= 0 && !this.loading) {
       this.scrollIntoView(index);
     }
   }

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -429,6 +429,7 @@ describe('lazy loading', () => {
           // Wait for the timeout in __loadingChanged
           await aTimeout(0);
 
+          expect(comboBox._focusedIndex).to.equal(8);
           const items = getViewportItems(comboBox);
           expect(items.some((item) => item.index === 50)).to.be.true;
         });


### PR DESCRIPTION
## Description

The previous fix (#3855) was incorrect as it did not set `_focusedIndex` for user's filter while loading.
As a result, the item loaded while user was typing did not get highlighted, causing Flow ITs to fail.

This change addresses the original issue in a less intrusive way: while `_focusedIndex` is still updated,
we now check if `loading` is true and only scroll to the focused index in case if loading has completed.

## Type of change

- Bugfix