### PR TITLE
refactor: update cached keys to use computed properties

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -219,13 +219,13 @@ export const DataProviderMixin = (superClass) =>
          */
         __expandedKeys: {
           type: Object,
-          value: () => new Set(),
+          computed: '__computeExpandedKeys(itemIdPath, expandedItems.*)',
         },
       };
     }
 
     static get observers() {
-      return ['_sizeChanged(size)', '_itemIdPathChanged(itemIdPath)', '_expandedItemsChanged(expandedItems.*)'];
+      return ['_sizeChanged(size)', '_expandedItemsChanged(expandedItems.*)'];
     }
 
     /** @private */
@@ -282,25 +282,20 @@ export const DataProviderMixin = (superClass) =>
 
     /** @private */
     _expandedItemsChanged() {
-      this.__cacheExpandedKeys();
       this._cache.updateSize();
       this._effectiveSize = this._cache.effectiveSize;
       this.__updateVisibleRows();
     }
 
     /** @private */
-    _itemIdPathChanged() {
-      this.__cacheExpandedKeys();
-    }
+    __computeExpandedKeys(itemIdPath, expandedItems) {
+      const expanded = expandedItems.base || [];
+      const expandedKeys = new Set();
+      expanded.forEach((item) => {
+        expandedKeys.add(this.getItemId(item));
+      });
 
-    /** @private */
-    __cacheExpandedKeys() {
-      if (this.expandedItems) {
-        this.__expandedKeys = new Set();
-        this.expandedItems.forEach((item) => {
-          this.__expandedKeys.add(this.getItemId(item));
-        });
-      }
+      return expandedKeys;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -33,7 +33,7 @@ export const SelectionMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['_selectedItemsChanged(itemIdPath, selectedItems.*)'];
+      return ['__selectedItemsChanged(itemIdPath, selectedItems.*)'];
     }
 
     /**
@@ -85,7 +85,7 @@ export const SelectionMixin = (superClass) =>
     }
 
     /** @private */
-    _selectedItemsChanged() {
+    __selectedItemsChanged() {
       this.requestContentUpdate();
     }
 

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -33,7 +33,7 @@ export const SelectionMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['requestContentUpdate(itemIdPath, selectedItems.*)'];
+      return ['_selectedItemsChanged(itemIdPath, selectedItems.*)'];
     }
 
     /**
@@ -82,6 +82,11 @@ export const SelectionMixin = (superClass) =>
       } else {
         this.deselectItem(item);
       }
+    }
+
+    /** @private */
+    _selectedItemsChanged() {
+      this.requestContentUpdate();
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -27,13 +27,13 @@ export const SelectionMixin = (superClass) =>
          */
         __selectedKeys: {
           type: Object,
-          value: () => new Set(),
+          computed: '__computeSelectedKeys(itemIdPath, selectedItems.*)',
         },
       };
     }
 
     static get observers() {
-      return ['_updateSelectedKeys(itemIdPath, selectedItems.*)'];
+      return ['requestContentUpdate(itemIdPath, selectedItems.*)'];
     }
 
     /**
@@ -85,14 +85,14 @@ export const SelectionMixin = (superClass) =>
     }
 
     /** @private */
-    _updateSelectedKeys() {
-      const selectedItems = this.selectedItems || [];
-      this.__selectedKeys = new Set();
-      selectedItems.forEach((item) => {
-        this.__selectedKeys.add(this.getItemId(item));
+    __computeSelectedKeys(itemIdPath, selectedItems) {
+      const selected = selectedItems.base || [];
+      const selectedKeys = new Set();
+      selected.forEach((item) => {
+        selectedKeys.add(this.getItemId(item));
       });
 
-      this.requestContentUpdate();
+      return selectedKeys;
     }
 
     /**


### PR DESCRIPTION
## Description

__selectedKeys and __expandedKeys are updated using observers. If other observers keyed on the same properties are triggered before the cache update observers, then those first observers may read stale values when calling _isSelected or _isExpanded.

Fixes #3844

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
