### PR TITLE
fix: allow modeless overlay to close on Esc

### DIFF
--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -515,6 +515,11 @@ class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(PolymerEleme
       return;
     }
 
+    // Only close modeless overlay on Esc press when it contains focus
+    if (this.modeless && !event.composedPath().includes(this.$.overlay)) {
+      return;
+    }
+
     if (event.key === 'Escape') {
       const evt = new CustomEvent('vaadin-overlay-escape-press', {
         bubbles: true,

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -559,6 +559,8 @@ class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(PolymerEleme
         this.dispatchEvent(evt);
       });
 
+      document.addEventListener('keydown', this._boundKeydownListener);
+
       if (!this.modeless) {
         this._addGlobalListeners();
       }
@@ -566,6 +568,8 @@ class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(PolymerEleme
       this.__focusTrapController.releaseFocus();
 
       this._animatedClosing();
+
+      document.removeEventListener('keydown', this._boundKeydownListener);
 
       if (!this.modeless) {
         this._removeGlobalListeners();
@@ -753,7 +757,6 @@ class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(PolymerEleme
     // Firefox leaks click to document on contextmenu even if prevented
     // https://bugzilla.mozilla.org/show_bug.cgi?id=990614
     document.documentElement.addEventListener('click', this._boundOutsideClickListener, true);
-    document.addEventListener('keydown', this._boundKeydownListener);
   }
 
   /** @protected */
@@ -778,7 +781,6 @@ class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(PolymerEleme
     document.removeEventListener('mousedown', this._boundMouseDownListener);
     document.removeEventListener('mouseup', this._boundMouseUpListener);
     document.documentElement.removeEventListener('click', this._boundOutsideClickListener, true);
-    document.removeEventListener('keydown', this._boundKeydownListener);
   }
 
   /** @protected */

--- a/packages/vaadin-overlay/test/multiple.test.js
+++ b/packages/vaadin-overlay/test/multiple.test.js
@@ -165,11 +165,13 @@ describe('multiple overlays', () => {
           <vaadin-overlay modeless>
             <template>
               overlay 1
+              <input />
             </template>
           </vaadin-overlay>
           <vaadin-overlay modeless>
             <template>
               overlay 2
+              <input />
             </template>
           </vaadin-overlay>
         </div>
@@ -240,6 +242,29 @@ describe('multiple overlays', () => {
       expect(modeless2.style.zIndex).to.be.empty;
     });
 
+    it('should not fire the vaadin-overlay-escape-press if the overlay does not contain focus', () => {
+      const spy = sinon.spy();
+      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
+
+      modeless1.opened = true;
+
+      escKeyDown(document.body);
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not fire the vaadin-overlay-escape-press if the overlay contains focus', () => {
+      const spy = sinon.spy();
+      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
+
+      modeless1.opened = true;
+
+      const input = modeless1.content.querySelector('input');
+      input.focus();
+
+      escKeyDown(input);
+      expect(spy.called).to.be.true;
+    });
+
     it('should fire the vaadin-overlay-escape-press if the overlay is the frontmost one', () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
@@ -248,7 +273,10 @@ describe('multiple overlays', () => {
       modeless2.opened = true;
       modeless1.bringToFront();
 
-      escKeyDown(document.body);
+      const input = modeless1.content.querySelector('input');
+      input.focus();
+
+      escKeyDown(input);
       expect(spy.called).to.be.true;
     });
 
@@ -259,7 +287,10 @@ describe('multiple overlays', () => {
       modeless1.opened = true;
       modeless2.opened = true;
 
-      escKeyDown(document.body);
+      const input = modeless2.content.querySelector('input');
+      input.focus();
+
+      escKeyDown(input);
       expect(spy.called).to.be.false;
     });
   });

--- a/packages/vaadin-overlay/test/multiple.test.js
+++ b/packages/vaadin-overlay/test/multiple.test.js
@@ -239,5 +239,28 @@ describe('multiple overlays', () => {
       modeless2.opened = true;
       expect(modeless2.style.zIndex).to.be.empty;
     });
+
+    it('should fire the vaadin-overlay-escape-press if the overlay is the frontmost one', () => {
+      const spy = sinon.spy();
+      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
+
+      modeless1.opened = true;
+      modeless2.opened = true;
+      modeless1.bringToFront();
+
+      escKeyDown(document.body);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should not fire the vaadin-overlay-escape-press if the overlay is not the frontmost', () => {
+      const spy = sinon.spy();
+      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
+
+      modeless1.opened = true;
+      modeless2.opened = true;
+
+      escKeyDown(document.body);
+      expect(spy.called).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Description

Updated the logic to also add `keydown` listener for modeless overlays, to allow closing them on <kbd>Esc</kbd> key.
Note, this can't be backported to V22 as is, because there we also use the same event listener for focus trap logic.

Fixes #867

## Type of change

- Bugfix