### PR TITLE
refactor: cleanup date-picker overlay content logic

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -89,7 +89,6 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
             show-week-numbers="[[showWeekNumbers]]"
             min-date="[[_minDate]]"
             max-date="[[_maxDate]]"
-            on-date-tap="_close"
             role="dialog"
             part="overlay-content"
             theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"

--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -84,7 +84,6 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
             fullscreen$="[[_fullscreen]]"
             label="[[label]]"
             selected-date="[[_selectedDate]]"
-            slot="dropdown-content"
             focused-date="{{_focusedDate}}"
             show-week-numbers="[[showWeekNumbers]]"
             min-date="[[_minDate]]"

--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -88,7 +88,6 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
             show-week-numbers="[[showWeekNumbers]]"
             min-date="[[_minDate]]"
             max-date="[[_maxDate]]"
-            role="dialog"
             part="overlay-content"
             theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"
           >

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -488,6 +488,8 @@ export const DatePickerMixin = (subclass) =>
         this.__userConfirmedDate = true;
 
         this._selectDate(e.detail.date);
+
+        this._close(e);
       });
 
       // User confirmed selected date by pressing Enter or Today.

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -326,6 +326,9 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
   ready() {
     super.ready();
+
+    this.setAttribute('role', 'dialog');
+
     addListener(this, 'tap', this._stopPropagation);
     addListener(this.$.scrollers, 'track', this._track.bind(this));
     addListener(this.shadowRoot.querySelector('[part="clear-button"]'), 'tap', this._clear.bind(this));

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -179,7 +179,6 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
             min-date="[[_minDate]]"
             max-date="[[_maxDate]]"
             role="dialog"
-            on-date-tap="_close"
             part="overlay-content"
             theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"
           ></vaadin-date-picker-overlay-content>

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -177,7 +177,6 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
             show-week-numbers="[[showWeekNumbers]]"
             min-date="[[_minDate]]"
             max-date="[[_maxDate]]"
-            role="dialog"
             part="overlay-content"
             theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"
           ></vaadin-date-picker-overlay-content>

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -173,7 +173,6 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
             fullscreen$="[[_fullscreen]]"
             label="[[label]]"
             selected-date="[[_selectedDate]]"
-            slot="dropdown-content"
             focused-date="{{_focusedDate}}"
             show-week-numbers="[[showWeekNumbers]]"
             min-date="[[_minDate]]"


### PR DESCRIPTION
## Description

1. Updated logic to use single `date-tap` listener instead of two separate listeners
2. Removed obsolete `slot="dropdown-content"` leftovers from [`iron-dropdown`](https://github.com/PolymerElements/iron-dropdown/blob/daa603c091cd432a15cb999a6005fdf9dfdec73a/iron-dropdown.js#L37) 
3. Moved setting `role="dialog"` to the overlay content element itself in `ready()`

## Type of change

- Refactor