### PR TITLE
fix: call stopPropagation() when clearing on Esc

### DIFF
--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -136,6 +136,7 @@ export const InputControlMixin = (superclass) =>
       super._onKeyDown(event);
 
       if (event.key === 'Escape' && this.clearButtonVisible && !!this.value) {
+        event.stopPropagation();
         this.__clear();
       }
     }

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { escKeyDown, fixtureSync } from '@vaadin/testing-helpers';
+import { escKeyDown, fixtureSync, keyboardEventFor } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { InputControlMixin } from '../src/input-control-mixin.js';
@@ -134,6 +134,21 @@ describe('input-control-mixin', () => {
       const event = spy.firstCall.args[0];
       expect(event.bubbles).to.be.true;
       expect(event.composed).to.be.false;
+    });
+
+    it('should call stopPropagation() on Esc when clearButtonVisible is true', () => {
+      element.clearButtonVisible = true;
+      const event = keyboardEventFor('keydown', 27, [], 'Escape');
+      const spy = sinon.spy(event, 'stopPropagation');
+      button.dispatchEvent(event);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should not call stopPropagation() on Esc when clearButtonVisible is false', () => {
+      const event = keyboardEventFor('keydown', 27, [], 'Escape');
+      const spy = sinon.spy(event, 'stopPropagation');
+      button.dispatchEvent(event);
+      expect(spy.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

See https://github.com/vaadin/web-components/pull/3872#discussion_r876794175

Note: the `vaadin-combo-box` that has custom logic for clear button already uses `stopPropagation()`:

https://github.com/vaadin/web-components/blob/d19635afe89c647a260ecbe39c157fedadfbde25/packages/combo-box/src/vaadin-combo-box-mixin.js#L633-L636

## Type of change

- Bugfix