### PR TITLE
fix: only release focus if overlay focus-trap is set (#3882) (CP: 23.0)

### DIFF
--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -563,7 +563,9 @@ class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(PolymerEleme
         this._addGlobalListeners();
       }
     } else if (wasOpened) {
-      this.__focusTrapController.releaseFocus();
+      if (this.focusTrap) {
+        this.__focusTrapController.releaseFocus();
+      }
 
       this._animatedClosing();
 

--- a/packages/vaadin-overlay/test/focus-trap.test.js
+++ b/packages/vaadin-overlay/test/focus-trap.test.js
@@ -64,7 +64,25 @@ customElements.define(
   },
 );
 
-describe('focus-trap', function () {
+customElements.define(
+  'nested-overlay-wrapper',
+  class extends PolymerElement {
+    static get template() {
+      return html`
+        <vaadin-overlay id="outer" focus-trap>
+          <template>
+            <button>Button</button>
+            <vaadin-overlay id="nested">
+              <template>Inner content</template>
+            </vaadin-overlay>
+          </template>
+        </vaadin-overlay>
+      `;
+    }
+  },
+);
+
+describe('focus-trap', () => {
   let overlay, parent, overlayPart, focusableElements;
 
   function getFocusedElementIndex() {
@@ -456,6 +474,35 @@ describe('focus-trap', function () {
         expect(focusableElements[0]).to.be.eql(overlayPart);
         expect(getFocusedElementIndex()).to.eql(0);
       });
+    });
+  });
+
+  describe('nested overlay', () => {
+    let nested;
+
+    beforeEach(async () => {
+      parent = fixtureSync('<nested-overlay-wrapper></nested-overlay-wrapper>');
+      overlay = parent.$.outer;
+      overlay.opened = true;
+      focusableElements = getFocusableElements(overlay.$.overlay);
+      await nextRender();
+      nested = overlay.content.querySelector('#nested');
+    });
+
+    afterEach(() => {
+      overlay.opened = false;
+    });
+
+    it('should not release focus when closing nested overlay without focus-trap', async () => {
+      nested.opened = true;
+      await nextRender();
+      nested.opened = false;
+
+      const button = overlay.content.querySelector('button');
+      button.focus();
+      tabKeyDown(button);
+
+      expect(getFocusedElementIndex()).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## Description

Cherry-pick of #3882 to `23.0` branch.
The automated cherry-pick failed due to `describe` change to use arrow function.

## Type of change

- Cherry-pick