### PR TITLE
fix: prevent toggling overlay opened state when filtering

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -79,6 +79,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       // Can't depend on filter in this observer as we don't want
       // to clear the filter whenever it's set
       if (dataProvider && !this.loading && this.filter && !(opened && this.autoOpenDisabled && value === this.filter)) {
+        this.loading = this._shouldFetchData();
         this.size = undefined;
         this._pendingRequests = {};
         this.filter = '';
@@ -118,6 +119,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
         return;
       }
 
+      this.loading = true;
       this.size = undefined;
       this._pendingRequests = {};
       this.clearCache();

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -74,19 +74,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       ];
     }
 
-    /** @private */
-    _dataProviderClearFilter(dataProvider, opened, value) {
-      // Can't depend on filter in this observer as we don't want
-      // to clear the filter whenever it's set
-      if (dataProvider && !this.loading && this.filter && !(opened && this.autoOpenDisabled && value === this.filter)) {
-        this.loading = this._shouldFetchData();
-        this.size = undefined;
-        this._pendingRequests = {};
-        this.filter = '';
-        this.clearCache();
-      }
-    }
-
     /** @protected */
     ready() {
       super.ready();
@@ -119,9 +106,32 @@ export const ComboBoxDataProviderMixin = (superClass) =>
         return;
       }
 
-      this.loading = true;
+      this._refreshData();
+    }
+
+    /** @private */
+    _dataProviderClearFilter(dataProvider, opened, value) {
+      // Can't depend on filter in this observer as we don't want
+      // to clear the filter whenever it's set
+      if (dataProvider && !this.loading && this.filter && !(opened && this.autoOpenDisabled && value === this.filter)) {
+        this._refreshData(true);
+      }
+    }
+
+    /** @private */
+    _refreshData(clearFilter) {
+      // Immediately mark as loading if this refresh leads to re-fetching pages
+      // This prevents some issues with the properties below triggering
+      // observers that also rely on the loading state
+      this.loading = this._shouldFetchData();
+      // Reset size and internal loading state
       this.size = undefined;
       this._pendingRequests = {};
+      // Clear filter if requested
+      if (clearFilter) {
+        this.filter = '';
+      }
+      // Clear cached pages, and reload current page if we need the data
       this.clearCache();
     }
 

--- a/packages/combo-box/test/dropdown.test.js
+++ b/packages/combo-box/test/dropdown.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../src/vaadin-combo-box.js';
 import '../src/vaadin-combo-box-overlay.js';
 
 describe('overlay', () => {

--- a/packages/combo-box/test/dropdown.test.js
+++ b/packages/combo-box/test/dropdown.test.js
@@ -47,7 +47,7 @@ describe('overlay', () => {
   describe('with data provider', () => {
     let comboBox, dropdown;
     let dataProviderSpy;
-    let openedChangedSpy;
+    let openedSpy;
 
     beforeEach(() => {
       dataProviderSpy = sinon.spy((params, callback) => {
@@ -60,38 +60,36 @@ describe('overlay', () => {
       dropdown = comboBox.$.dropdown;
       comboBox.dataProvider = dataProviderSpy;
       comboBox.opened = true;
+      dataProviderSpy.resetHistory();
 
-      openedChangedSpy = sinon.spy(dropdown, '_openedChanged');
+      openedSpy = sinon.spy();
+      dropdown.addEventListener('vaadin-combo-box-dropdown-opened', openedSpy);
     });
 
-    it.skip('should not toggle between opened and closed when filtering', () => {
-      dataProviderSpy.resetHistory();
+    it('should not toggle between opened and closed when filtering', () => {
       // Filter for something that should return results
       comboBox.filter = 'item';
       // Verify data provider has been called
       expect(dataProviderSpy.calledOnce).to.be.true;
-      // Overlay opened state should not change during fetching data
-      expect(openedChangedSpy.called).to.be.false;
+      // Overlay should not have been closed and re-opened
+      expect(openedSpy.called).to.be.false;
     });
 
-    it.skip('should not toggle between opened and closed when setting a value', () => {
-      dataProviderSpy.resetHistory();
+    it('should not toggle between opened and closed when setting a value', () => {
+      // Filter for something that should return results
+      comboBox.filter = 'item';
       // Set a value
       comboBox.value = 'item 1';
-      // Verify data provider has been called
-      expect(dataProviderSpy.calledOnce).to.be.true;
-      // Overlay opened state should not change during fetching data
-      expect(openedChangedSpy.called).to.be.false;
+      // Overlay should not have been closed and re-opened
+      expect(openedSpy.called).to.be.false;
     });
 
-    it('should eventually close when there are no items', async () => {
-      dataProviderSpy.resetHistory();
+    it('should close when there are no items', () => {
       // Filter for something that doesn't exist
       comboBox.filter = 'doesnotexist';
       // Verify data provider has been called
       expect(dataProviderSpy.calledOnce).to.be.true;
       // Overlay should close
-      expect(openedChangedSpy.called).to.be.true;
       expect(dropdown._overlayOpened).to.be.false;
     });
   });

--- a/packages/combo-box/test/dropdown.test.js
+++ b/packages/combo-box/test/dropdown.test.js
@@ -1,9 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import sinon from 'sinon';
 import '../src/vaadin-combo-box.js';
 import '../src/vaadin-combo-box-overlay.js';
-import { makeItems } from './helpers.js';
 
 describe('overlay', () => {
   let overlay;
@@ -41,56 +39,6 @@ describe('overlay', () => {
 
     it('should be before content part', () => {
       expect(loader.nextElementSibling.getAttribute('part')).to.include('content');
-    });
-  });
-
-  describe('with data provider', () => {
-    let comboBox, dropdown;
-    let dataProviderSpy;
-    let openedSpy;
-
-    beforeEach(() => {
-      dataProviderSpy = sinon.spy((params, callback) => {
-        const items = makeItems(10);
-        const filteredItems = items.filter((item) => item.includes(params.filter));
-        callback(filteredItems, filteredItems.length);
-      });
-
-      comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
-      dropdown = comboBox.$.dropdown;
-      comboBox.dataProvider = dataProviderSpy;
-      comboBox.opened = true;
-      dataProviderSpy.resetHistory();
-
-      openedSpy = sinon.spy();
-      dropdown.addEventListener('vaadin-combo-box-dropdown-opened', openedSpy);
-    });
-
-    it('should not toggle between opened and closed when filtering', () => {
-      // Filter for something that should return results
-      comboBox.filter = 'item';
-      // Verify data provider has been called
-      expect(dataProviderSpy.calledOnce).to.be.true;
-      // Overlay should not have been closed and re-opened
-      expect(openedSpy.called).to.be.false;
-    });
-
-    it('should not toggle between opened and closed when setting a value', () => {
-      // Filter for something that should return results
-      comboBox.filter = 'item';
-      // Set a value
-      comboBox.value = 'item 1';
-      // Overlay should not have been closed and re-opened
-      expect(openedSpy.called).to.be.false;
-    });
-
-    it('should close when there are no items', () => {
-      // Filter for something that doesn't exist
-      comboBox.filter = 'doesnotexist';
-      // Verify data provider has been called
-      expect(dataProviderSpy.calledOnce).to.be.true;
-      // Overlay should close
-      expect(dropdown._overlayOpened).to.be.false;
     });
   });
 });

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -1135,6 +1135,48 @@ describe('lazy loading', () => {
         expect(comboBox.filteredItems).to.contain('item 293');
       });
     });
+
+    describe('dropdown behaviour', () => {
+      let dropdown;
+      let openedSpy;
+
+      beforeEach(() => {
+        dropdown = comboBox.$.dropdown;
+        comboBox.dataProvider = spyDataProvider;
+        comboBox.opened = true;
+        spyDataProvider.resetHistory();
+
+        openedSpy = sinon.spy();
+        dropdown.addEventListener('vaadin-combo-box-dropdown-opened', openedSpy);
+      });
+
+      it('should not toggle between opened and closed when filtering', () => {
+        // Filter for something that should return results
+        comboBox.filter = 'item';
+        // Verify data provider has been called
+        expect(spyDataProvider.calledOnce).to.be.true;
+        // Dropdown should not have been closed and re-opened
+        expect(openedSpy.called).to.be.false;
+      });
+
+      it('should not toggle between opened and closed when setting a value', () => {
+        // Filter for something that should return results
+        comboBox.filter = 'item';
+        // Set a value
+        comboBox.value = 'item 1';
+        // Dropdown should not have been closed and re-opened
+        expect(openedSpy.called).to.be.false;
+      });
+
+      it('should close when there are no items', () => {
+        // Filter for something that doesn't exist
+        comboBox.filter = 'doesnotexist';
+        // Verify data provider has been called
+        expect(spyDataProvider.calledOnce).to.be.true;
+        // Dropdown should close
+        expect(dropdown._overlayOpened).to.be.false;
+      });
+    });
   };
 
   describe('combo-box', () => {


### PR DESCRIPTION
## Description

Due to how observers in the combo box dropdown are set up, the dropdown toggles its opened state whenever the filter, or the value is changed. To determine its opened state, the dropdown basically checks whether the combo box has any items or if it is loading. The problem is that the refresh logic in the data provider mixin clears the items before setting a loading state, and afterwards enables the loading state, which causes the dropdown to briefly close, before being opened again. This causes some noticable flickering while typing a filter. This also causes side-effects, such as https://github.com/vaadin/web-components/issues/3875.

This fix introduces a `_refreshData` method to the data provider mixin, that is called whenever the data should be cleared, and then possibly reloaded. The method will set the loading state immediately (if we actually want to reload), and only then updates the other observed properties.

Fixes #3875

## Type of change

- Bugfix