### PR TITLE
fix: import themed overlay with themed extensions

### DIFF
--- a/packages/avatar-group/theme/lumo/vaadin-avatar-group.js
+++ b/packages/avatar-group/theme/lumo/vaadin-avatar-group.js
@@ -1,5 +1,6 @@
 import '@vaadin/avatar/theme/lumo/vaadin-avatar.js';
 import '@vaadin/item/theme/lumo/vaadin-item.js';
 import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
+import '@vaadin/vaadin-overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-avatar-group-styles.js';
 import '../../src/vaadin-avatar-group.js';

--- a/packages/avatar-group/theme/material/vaadin-avatar-group.js
+++ b/packages/avatar-group/theme/material/vaadin-avatar-group.js
@@ -1,5 +1,6 @@
 import '@vaadin/avatar/theme/material/vaadin-avatar.js';
 import '@vaadin/item/theme/material/vaadin-item.js';
 import '@vaadin/list-box/theme/material/vaadin-list-box.js';
+import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
 import './vaadin-avatar-group-styles.js';
 import '../../src/vaadin-avatar-group.js';

--- a/packages/combo-box/theme/material/vaadin-combo-box-dropdown-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-dropdown-styles.js
@@ -1,4 +1,5 @@
 import '@vaadin/vaadin-material-styles/color.js';
+import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
 import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/context-menu/theme/lumo/vaadin-context-menu.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu.js
@@ -1,4 +1,5 @@
 import './vaadin-context-menu-styles.js';
 import '@vaadin/item/theme/lumo/vaadin-item.js';
 import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
+import '@vaadin/vaadin-overlay/theme/lumo/vaadin-overlay.js';
 import '../../src/vaadin-context-menu.js';

--- a/packages/context-menu/theme/material/vaadin-context-menu.js
+++ b/packages/context-menu/theme/material/vaadin-context-menu.js
@@ -1,4 +1,5 @@
 import './vaadin-context-menu-styles.js';
 import '@vaadin/item/theme/material/vaadin-item.js';
+import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
 import '@vaadin/list-box/theme/material/vaadin-list-box.js';
 import '../../src/vaadin-context-menu.js';

--- a/packages/context-menu/theme/material/vaadin-context-menu.js
+++ b/packages/context-menu/theme/material/vaadin-context-menu.js
@@ -1,5 +1,5 @@
 import './vaadin-context-menu-styles.js';
 import '@vaadin/item/theme/material/vaadin-item.js';
-import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
 import '@vaadin/list-box/theme/material/vaadin-list-box.js';
+import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
 import '../../src/vaadin-context-menu.js';

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
@@ -1,5 +1,6 @@
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
+import '@vaadin/vaadin-overlay/theme/lumo/vaadin-overlay.js';
 import { menuOverlay } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-styles.js
@@ -1,3 +1,4 @@
+import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
 import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/dialog/theme/lumo/vaadin-dialog.js
+++ b/packages/dialog/theme/lumo/vaadin-dialog.js
@@ -1,2 +1,3 @@
+import '@vaadin/vaadin-overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-dialog-styles.js';
 import '../../src/vaadin-dialog.js';

--- a/packages/dialog/theme/material/vaadin-dialog.js
+++ b/packages/dialog/theme/material/vaadin-dialog.js
@@ -1,2 +1,3 @@
+import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
 import './vaadin-dialog-styles.js';
 import '../../src/vaadin-dialog.js';

--- a/packages/field-highlighter/theme/lumo/vaadin-user-tags.js
+++ b/packages/field-highlighter/theme/lumo/vaadin-user-tags.js
@@ -3,5 +3,6 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/vaadin-overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-user-tags-styles.js';
 import '../../src/vaadin-user-tags.js';

--- a/packages/field-highlighter/theme/material/vaadin-user-tags.js
+++ b/packages/field-highlighter/theme/material/vaadin-user-tags.js
@@ -3,5 +3,6 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
 import './vaadin-user-tags-styles.js';
 import '../../src/vaadin-user-tags.js';

--- a/packages/select/theme/lumo/vaadin-select.js
+++ b/packages/select/theme/lumo/vaadin-select.js
@@ -6,5 +6,6 @@
 import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import '@vaadin/item/theme/lumo/vaadin-item.js';
 import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
+import '@vaadin/vaadin-overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-select-styles.js';
 import '../../src/vaadin-select.js';

--- a/packages/select/theme/material/vaadin-select.js
+++ b/packages/select/theme/material/vaadin-select.js
@@ -6,5 +6,6 @@
 import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import '@vaadin/item/theme/material/vaadin-item.js';
 import '@vaadin/list-box/theme/material/vaadin-list-box.js';
+import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
 import './vaadin-select-styles.js';
 import '../../src/vaadin-select.js';


### PR DESCRIPTION
Add missing imports of `@vaadin/vaadin-overlay/theme/[themename]/vaadin-overlay.js` to components with overlay extensions:

- Avatar group
- ComboBox (material only)
- Context menu
- Datepicker
- Dialog
- User-tags
- Select

Fixes #3887 