### PR TITLE
refactor: remove obsolete overlay content code

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -689,12 +689,6 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
   }
 
   _close() {
-    const overlayContent = this.getRootNode().host;
-    const overlay = overlayContent ? overlayContent.getRootNode().host : null;
-    if (overlay) {
-      overlay.opened = false;
-    }
-
     this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
   }
 


### PR DESCRIPTION
## Description

There is a code in the overlay content that accesses the `vaadin-date-picker-overlay` and sets `opened` to `false`.

This is not needed because the following `close` event will do it by using the `_close` method:

https://github.com/vaadin/web-components/blob/ddb628d61064147ecfbbbbf8e8490b46e89857c7/packages/date-picker/src/vaadin-date-picker-mixin.js#L488

https://github.com/vaadin/web-components/blob/ddb628d61064147ecfbbbbf8e8490b46e89857c7/packages/date-picker/src/vaadin-date-picker-mixin.js#L572-L578

## Type of change

- Refactor