### PR TITLE
refactor!: move date-picker overlay content to light DOM

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-light.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-light.d.ts
@@ -66,12 +66,6 @@ export interface DatePickerLightEventMap extends HTMLElementEventMap, DatePicker
  *
  * ### Styling
  *
- * The following shadow DOM parts are available for styling:
- *
- * Part name | Description | Theme for Element
- * ----------------|----------------|----------------
- * `overlay-content` | The overlay element | vaadin-date-picker-light
- *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *
  * In addition to `<vaadin-date-picker-light>` itself, the following

--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -77,25 +77,8 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(Polyme
         on-vaadin-overlay-closing="_onOverlayClosed"
         restore-focus-on-close
         restore-focus-node="[[inputElement]]"
-        theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"
-      >
-        <template>
-          <vaadin-date-picker-overlay-content
-            id="overlay-content"
-            i18n="[[i18n]]"
-            fullscreen$="[[_fullscreen]]"
-            label="[[label]]"
-            selected-date="[[_selectedDate]]"
-            focused-date="{{_focusedDate}}"
-            show-week-numbers="[[showWeekNumbers]]"
-            min-date="[[_minDate]]"
-            max-date="[[_maxDate]]"
-            part="overlay-content"
-            theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"
-          >
-          </vaadin-date-picker-overlay-content>
-        </template>
-      </vaadin-date-picker-overlay>
+        theme$="[[_theme]]"
+      ></vaadin-date-picker-overlay>
     `;
   }
 
@@ -115,23 +98,11 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(Polyme
         type: String,
         value: 'value',
       },
-
-      /**
-       * @type {boolean}
-       * @protected
-       */
-      _overlayInitialized: {
-        type: Boolean,
-        value: true,
-      },
     };
   }
 
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this._initOverlay();
+  static get observers() {
+    return ['__updateOverlayTheme(_overlayContent, _theme)'];
   }
 
   /** @protected */
@@ -160,6 +131,17 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(Polyme
 
     this.$.overlay.positionTarget = this.inputElement;
     this.$.overlay.noVerticalOverlap = true;
+  }
+
+  /** @private */
+  __updateOverlayTheme(overlayContent, theme) {
+    if (overlayContent) {
+      if (theme) {
+        overlayContent.setAttribute('theme', theme);
+      } else {
+        overlayContent.removeAttribute('theme');
+      }
+    }
   }
 }
 

--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -67,6 +67,7 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(Polyme
         id="overlay"
         fullscreen$="[[_fullscreen]]"
         opened="{{opened}}"
+        on-vaadin-overlay-escape-press="_onOverlayEscapePress"
         on-vaadin-overlay-open="_onOverlayOpened"
         on-vaadin-overlay-closing="_onOverlayClosed"
         restore-focus-on-close

--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -28,12 +28,6 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  *
  * ### Styling
  *
- * The following shadow DOM parts are available for styling:
- *
- * Part name | Description | Theme for Element
- * ----------------|----------------|----------------
- * `overlay-content` | The overlay element | vaadin-date-picker-light
- *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *
  * In addition to `<vaadin-date-picker-light>` itself, the following
@@ -101,10 +95,6 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(Polyme
     };
   }
 
-  static get observers() {
-    return ['__updateOverlayTheme(_overlayContent, _theme)'];
-  }
-
   /** @protected */
   connectedCallback() {
     super.connectedCallback();
@@ -131,17 +121,6 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(Polyme
 
     this.$.overlay.positionTarget = this.inputElement;
     this.$.overlay.noVerticalOverlap = true;
-  }
-
-  /** @private */
-  __updateOverlayTheme(overlayContent, theme) {
-    if (overlayContent) {
-      if (theme) {
-        overlayContent.setAttribute('theme', theme);
-      } else {
-        overlayContent.removeAttribute('theme');
-      }
-    }
   }
 }
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -416,15 +416,6 @@ export const DatePickerMixin = (subclass) =>
 
       this.addController(new VirtualKeyboardController(this));
 
-      this.$.overlay.addEventListener('opened-changed', (e) => {
-        this.opened = e.detail.value;
-      });
-
-      this.$.overlay.addEventListener('vaadin-overlay-escape-press', () => {
-        this._focusedDate = this._selectedDate;
-        this._close();
-      });
-
       this.$.overlay.renderer = this._boundOverlayRenderer;
 
       this.addEventListener('mousedown', () => this.__bringToFront());
@@ -799,6 +790,12 @@ export const DatePickerMixin = (subclass) =>
       if (overlayContent) {
         overlayContent.toggleAttribute('fullscreen', fullscreen);
       }
+    }
+
+    /** @protected */
+    _onOverlayEscapePress() {
+      this._focusedDate = this._selectedDate;
+      this._close();
     }
 
     /** @protected */

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -364,6 +364,7 @@ export const DatePickerMixin = (subclass) =>
 
       this._boundOnClick = this._onClick.bind(this);
       this._boundOnScroll = this._onScroll.bind(this);
+      this._boundOverlayRenderer = this._overlayRenderer.bind(this);
     }
 
     /**
@@ -424,19 +425,10 @@ export const DatePickerMixin = (subclass) =>
         this._close();
       });
 
+      this.$.overlay.renderer = this._boundOverlayRenderer;
+
       this.addEventListener('mousedown', () => this.__bringToFront());
       this.addEventListener('touchstart', () => this.__bringToFront());
-
-      this.$.overlay.renderer = (root) => {
-        if (!root.firstChild) {
-          // Create and store document content element
-          const content = document.createElement('vaadin-date-picker-overlay-content');
-          root.appendChild(content);
-          this._overlayContent = content;
-
-          this._initOverlayContent(content);
-        }
-      };
     }
 
     /** @protected */
@@ -482,7 +474,17 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /** @private */
-    _initOverlayContent(content) {
+    _overlayRenderer(root) {
+      if (root.firstChild) {
+        return;
+      }
+
+      // Create and store document content element
+      const content = document.createElement('vaadin-date-picker-overlay-content');
+      root.appendChild(content);
+
+      this._overlayContent = content;
+
       content.addEventListener('close', () => {
         this._close();
       });

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -683,8 +683,6 @@ export const DatePickerMixin = (subclass) =>
 
     /** @protected */
     _openedChanged(opened) {
-      this.$.overlay.opened = opened;
-
       if (this.inputElement) {
         this.inputElement.setAttribute('aria-expanded', opened);
       }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -318,8 +318,8 @@ export const DatePickerMixin = (subclass) =>
         '_selectedDateChanged(_selectedDate, i18n.formatDate)',
         '_focusedDateChanged(_focusedDate, i18n.formatDate)',
         '__updateOverlayContent(_overlayContent, i18n, label, _minDate, _maxDate, _focusedDate, _selectedDate, showWeekNumbers)',
-        '__updateOverlayTheme(_overlayContent, _theme)',
-        '__updateFullScreen(_overlayContent, _fullscreen)',
+        '__updateOverlayContentTheme(_overlayContent, _theme)',
+        '__updateOverlayContentFullScreen(_overlayContent, _fullscreen)',
       ];
     }
 
@@ -784,7 +784,7 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /** @private */
-    __updateOverlayTheme(overlayContent, theme) {
+    __updateOverlayContentTheme(overlayContent, theme) {
       if (overlayContent) {
         if (theme) {
           overlayContent.setAttribute('theme', theme);
@@ -795,7 +795,7 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /** @private */
-    __updateFullScreen(overlayContent, fullscreen) {
+    __updateOverlayContentFullScreen(overlayContent, fullscreen) {
       if (overlayContent) {
         overlayContent.toggleAttribute('fullscreen', fullscreen);
       }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -308,8 +308,8 @@ export const DatePickerMixin = (subclass) =>
         /** @private */
         _focusOverlayOnOpen: Boolean,
 
-        /** @protected */
-        _overlayInitialized: Boolean,
+        /** @private */
+        _overlayContent: Object,
       };
     }
 
@@ -317,6 +317,8 @@ export const DatePickerMixin = (subclass) =>
       return [
         '_selectedDateChanged(_selectedDate, i18n.formatDate)',
         '_focusedDateChanged(_focusedDate, i18n.formatDate)',
+        '__updateOverlayContent(_overlayContent, i18n, label, _minDate, _maxDate, _focusedDate, _selectedDate, showWeekNumbers)',
+        '__updateFullScreen(_overlayContent, _fullscreen)',
       ];
     }
 
@@ -411,6 +413,29 @@ export const DatePickerMixin = (subclass) =>
       );
 
       this.addController(new VirtualKeyboardController(this));
+
+      this.$.overlay.addEventListener('opened-changed', (e) => {
+        this.opened = e.detail.value;
+      });
+
+      this.$.overlay.addEventListener('vaadin-overlay-escape-press', () => {
+        this._focusedDate = this._selectedDate;
+        this._close();
+      });
+
+      this.addEventListener('mousedown', () => this.__bringToFront());
+      this.addEventListener('touchstart', () => this.__bringToFront());
+
+      this.$.overlay.renderer = (root) => {
+        if (!root.firstChild) {
+          // Create and store document content element
+          const content = document.createElement('vaadin-date-picker-overlay-content');
+          root.appendChild(content);
+          this._overlayContent = content;
+
+          this._initOverlayContent(content);
+        }
+      };
     }
 
     /** @protected */
@@ -452,33 +477,19 @@ export const DatePickerMixin = (subclass) =>
      * Closes the dropdown.
      */
     close() {
-      if (this._overlayInitialized || this.autoOpenDisabled) {
-        this.$.overlay.close();
-      }
+      this.$.overlay.close();
     }
 
-    /** @protected */
-    _initOverlay() {
-      this.$.overlay.removeAttribute('disable-upgrade');
-      this._overlayInitialized = true;
-
-      this.$.overlay.addEventListener('opened-changed', (e) => {
-        this.opened = e.detail.value;
-      });
-
-      this.$.overlay.addEventListener('vaadin-overlay-escape-press', () => {
-        this._focusedDate = this._selectedDate;
+    /** @private */
+    _initOverlayContent(content) {
+      content.addEventListener('close', () => {
         this._close();
       });
 
-      this._overlayContent.addEventListener('close', () => {
-        this._close();
-      });
-
-      this._overlayContent.addEventListener('focus-input', this._focusAndSelect.bind(this));
+      content.addEventListener('focus-input', this._focusAndSelect.bind(this));
 
       // User confirmed selected date by clicking the calendar.
-      this._overlayContent.addEventListener('date-tap', (e) => {
+      content.addEventListener('date-tap', (e) => {
         this.__userConfirmedDate = true;
 
         this._selectDate(e.detail.date);
@@ -487,7 +498,7 @@ export const DatePickerMixin = (subclass) =>
       });
 
       // User confirmed selected date by pressing Enter or Today.
-      this._overlayContent.addEventListener('date-selected', (e) => {
+      content.addEventListener('date-selected', (e) => {
         this.__userConfirmedDate = true;
 
         this._selectDate(e.detail.date);
@@ -495,14 +506,16 @@ export const DatePickerMixin = (subclass) =>
 
       // Set focus-ring attribute when moving focus to the overlay
       // by pressing Tab or arrow key, after opening it on click.
-      this._overlayContent.addEventListener('focusin', () => {
+      content.addEventListener('focusin', () => {
         if (this._keyboardActive) {
           this._setFocused(true);
         }
       });
 
-      this.addEventListener('mousedown', () => this.__bringToFront());
-      this.addEventListener('touchstart', () => this.__bringToFront());
+      // Two-way data binding for `focusedDate` property
+      content.addEventListener('focused-date-changed', (e) => {
+        this._focusedDate = e.detail.value;
+      });
     }
 
     /**
@@ -676,12 +689,8 @@ export const DatePickerMixin = (subclass) =>
 
     /** @protected */
     _openedChanged(opened) {
-      if (opened && !this._overlayInitialized) {
-        this._initOverlay();
-      }
-      if (this._overlayInitialized) {
-        this.$.overlay.opened = opened;
-      }
+      this.$.overlay.opened = opened;
+
       if (this.inputElement) {
         this.inputElement.setAttribute('aria-expanded', opened);
       }
@@ -714,13 +723,6 @@ export const DatePickerMixin = (subclass) =>
       }
       if (!this._ignoreFocusedDateChange && !this._noInput) {
         this._applyInputValue(focusedDate);
-      }
-    }
-
-    /** @private */
-    __getOverlayTheme(theme, overlayInitialized) {
-      if (overlayInitialized) {
-        return theme;
       }
     }
 
@@ -760,6 +762,29 @@ export const DatePickerMixin = (subclass) =>
       }
 
       this._toggleHasValue(this._hasValue);
+    }
+
+    /** @private */
+    // eslint-disable-next-line max-params
+    __updateOverlayContent(overlayContent, i18n, label, minDate, maxDate, focusedDate, selectedDate, showWeekNumbers) {
+      if (overlayContent) {
+        overlayContent.setProperties({
+          i18n,
+          label,
+          minDate,
+          maxDate,
+          focusedDate,
+          selectedDate,
+          showWeekNumbers,
+        });
+      }
+    }
+
+    /** @private */
+    __updateFullScreen(overlayContent, fullscreen) {
+      if (overlayContent) {
+        overlayContent.toggleAttribute('fullscreen', fullscreen);
+      }
     }
 
     /** @protected */
@@ -996,7 +1021,7 @@ export const DatePickerMixin = (subclass) =>
       const parsedDate = this._getParsedDate();
       const isValidDate = this._isValidDate(parsedDate);
       if (this.opened) {
-        if (this._overlayInitialized && this._overlayContent.focusedDate && isValidDate) {
+        if (this._overlayContent && this._overlayContent.focusedDate && isValidDate) {
           this._selectDate(this._overlayContent.focusedDate);
         }
         this.close();
@@ -1082,11 +1107,6 @@ export const DatePickerMixin = (subclass) =>
           this._ignoreFocusedDateChange = false;
         }
       }
-    }
-
-    /** @private */
-    get _overlayContent() {
-      return this.$.overlay.content.querySelector('#overlay-content');
     }
 
     /** @private */

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -318,6 +318,7 @@ export const DatePickerMixin = (subclass) =>
         '_selectedDateChanged(_selectedDate, i18n.formatDate)',
         '_focusedDateChanged(_focusedDate, i18n.formatDate)',
         '__updateOverlayContent(_overlayContent, i18n, label, _minDate, _maxDate, _focusedDate, _selectedDate, showWeekNumbers)',
+        '__updateOverlayTheme(_overlayContent, _theme)',
         '__updateFullScreen(_overlayContent, _fullscreen)',
       ];
     }
@@ -777,6 +778,17 @@ export const DatePickerMixin = (subclass) =>
           selectedDate,
           showWeekNumbers,
         });
+      }
+    }
+
+    /** @private */
+    __updateOverlayTheme(overlayContent, theme) {
+      if (overlayContent) {
+        if (theme) {
+          overlayContent.setAttribute('theme', theme);
+        } else {
+          overlayContent.removeAttribute('theme');
+        }
       }
     }
 

--- a/packages/date-picker/src/vaadin-date-picker-overlay.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DisableUpgradeMixin } from '@polymer/polymer/lib/mixins/disable-upgrade-mixin.js';
 import { OverlayElement } from '@vaadin/vaadin-overlay/src/vaadin-overlay.js';
 import { PositionMixin } from '@vaadin/vaadin-overlay/src/vaadin-overlay-position-mixin.js';
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -21,7 +20,7 @@ let memoizedTemplate;
  * @extends OverlayElement
  * @private
  */
-class DatePickerOverlay extends DisableUpgradeMixin(PositionMixin(OverlayElement)) {
+class DatePickerOverlay extends PositionMixin(OverlayElement) {
   static get is() {
     return 'vaadin-date-picker-overlay';
   }

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -79,7 +79,6 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  * Part name             | Description
  * ----------------------|--------------------
  * `toggle-button`       | Toggle button
- * `overlay-content`     | The overlay element
  *
  * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
  *

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -210,17 +210,6 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
   }
 
   /** @private */
-  __updateOverlayTheme(overlayContent, theme) {
-    if (overlayContent) {
-      if (theme) {
-        overlayContent.setAttribute('theme', theme);
-      } else {
-        overlayContent.removeAttribute('theme');
-      }
-    }
-  }
-
-  /** @private */
   _onVaadinOverlayClose(e) {
     if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this)) {
       e.preventDefault();
@@ -230,7 +219,11 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
   /** @private */
   _toggle(e) {
     e.stopPropagation();
-    this[this.$.overlay.opened ? 'close' : 'open']();
+    if (this.$.overlay.opened) {
+      this.close();
+    } else {
+      this.open();
+    }
   }
 
   // Workaround https://github.com/vaadin/web-components/issues/2855

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -161,6 +161,8 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
         id="overlay"
         fullscreen$="[[_fullscreen]]"
         theme$="[[_theme]]"
+        opened="{{opened}}"
+        on-vaadin-overlay-escape-press="_onOverlayEscapePress"
         on-vaadin-overlay-open="_onOverlayOpened"
         on-vaadin-overlay-closing="_onOverlayClosed"
         restore-focus-on-close

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -48,7 +48,6 @@ registerStyles('vaadin-date-picker', [inputFieldShared, datePickerStyles], { mod
  * Part name             | Description
  * ----------------------|--------------------
  * `toggle-button`       | Toggle button
- * `overlay-content`     | The overlay element
  *
  * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
  *
@@ -161,32 +160,19 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
       <vaadin-date-picker-overlay
         id="overlay"
         fullscreen$="[[_fullscreen]]"
-        theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"
+        theme$="[[_theme]]"
         on-vaadin-overlay-open="_onOverlayOpened"
         on-vaadin-overlay-closing="_onOverlayClosed"
         restore-focus-on-close
         restore-focus-node="[[inputElement]]"
-        disable-upgrade
-      >
-        <template>
-          <vaadin-date-picker-overlay-content
-            id="overlay-content"
-            i18n="[[i18n]]"
-            fullscreen$="[[_fullscreen]]"
-            label="[[label]]"
-            selected-date="[[_selectedDate]]"
-            focused-date="{{_focusedDate}}"
-            show-week-numbers="[[showWeekNumbers]]"
-            min-date="[[_minDate]]"
-            max-date="[[_maxDate]]"
-            part="overlay-content"
-            theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"
-          ></vaadin-date-picker-overlay-content>
-        </template>
-      </vaadin-date-picker-overlay>
+      ></vaadin-date-picker-overlay>
 
       <slot name="tooltip"></slot>
     `;
+  }
+
+  static get observers() {
+    return ['__updateOverlayTheme(_overlayContent, _theme)'];
   }
 
   /**
@@ -219,13 +205,19 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
 
     const toggleButton = this.shadowRoot.querySelector('[part="toggle-button"]');
     toggleButton.addEventListener('mousedown', (e) => e.preventDefault());
-  }
-
-  /** @protected */
-  _initOverlay() {
-    super._initOverlay();
 
     this.$.overlay.addEventListener('vaadin-overlay-close', this._onVaadinOverlayClose.bind(this));
+  }
+
+  /** @private */
+  __updateOverlayTheme(overlayContent, theme) {
+    if (overlayContent) {
+      if (theme) {
+        overlayContent.setAttribute('theme', theme);
+      } else {
+        overlayContent.removeAttribute('theme');
+      }
+    }
   }
 
   /** @private */
@@ -238,7 +230,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
   /** @private */
   _toggle(e) {
     e.stopPropagation();
-    this[this._overlayInitialized && this.$.overlay.opened ? 'close' : 'open']();
+    this[this.$.overlay.opened ? 'close' : 'open']();
   }
 
   // Workaround https://github.com/vaadin/web-components/issues/2855

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -171,10 +171,6 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
     `;
   }
 
-  static get observers() {
-    return ['__updateOverlayTheme(_overlayContent, _theme)'];
-  }
-
   /**
    * Used by `InputControlMixin` as a reference to the clear button element.
    * @protected

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -120,13 +120,12 @@ export function isFullscreen(datepicker) {
   return datepicker.$.overlay.getAttribute('fullscreen') !== null;
 }
 
-// As a side-effect has to toggle the overlay once to initialize it
 export function getOverlayContent(datepicker) {
-  if (datepicker.$.overlay.hasAttribute('disable-upgrade')) {
-    datepicker.open();
-    datepicker.close();
+  // Ensure overlay content is rendered
+  if (!datepicker._overlayContent) {
+    datepicker.$.overlay.requestContentUpdate();
   }
-  return datepicker.$.overlay.content.querySelector('#overlay-content');
+  return datepicker._overlayContent;
 }
 
 export function getFocusedMonth(overlayContent) {

--- a/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
@@ -329,12 +329,9 @@ snapshots["vaadin-date-picker shadow default"] =
   </div>
 </div>
 <vaadin-date-picker-overlay
-  disable-upgrade=""
   id="overlay"
   restore-focus-on-close=""
 >
-  <template>
-  </template>
 </vaadin-date-picker-overlay>
 <slot name="tooltip">
 </slot>
@@ -387,12 +384,9 @@ snapshots["vaadin-date-picker shadow disabled"] =
   </div>
 </div>
 <vaadin-date-picker-overlay
-  disable-upgrade=""
   id="overlay"
   restore-focus-on-close=""
 >
-  <template>
-  </template>
 </vaadin-date-picker-overlay>
 <slot name="tooltip">
 </slot>
@@ -445,12 +439,9 @@ snapshots["vaadin-date-picker shadow readonly"] =
   </div>
 </div>
 <vaadin-date-picker-overlay
-  disable-upgrade=""
   id="overlay"
   restore-focus-on-close=""
 >
-  <template>
-  </template>
 </vaadin-date-picker-overlay>
 <slot name="tooltip">
 </slot>
@@ -503,12 +494,9 @@ snapshots["vaadin-date-picker shadow invalid"] =
   </div>
 </div>
 <vaadin-date-picker-overlay
-  disable-upgrade=""
   id="overlay"
   restore-focus-on-close=""
 >
-  <template>
-  </template>
 </vaadin-date-picker-overlay>
 <slot name="tooltip">
 </slot>
@@ -561,12 +549,10 @@ snapshots["vaadin-date-picker shadow theme"] =
   </div>
 </div>
 <vaadin-date-picker-overlay
-  disable-upgrade=""
   id="overlay"
   restore-focus-on-close=""
+  theme="align-right"
 >
-  <template>
-  </template>
 </vaadin-date-picker-overlay>
 <slot name="tooltip">
 </slot>

--- a/packages/date-picker/test/theme-propagation.test.js
+++ b/packages/date-picker/test/theme-propagation.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-date-picker.js';
-import { open } from './common.js';
+import { getOverlayContent, open, waitForScrollToFinish } from './common.js';
 
 describe('theme attribute', () => {
   let datepicker;
@@ -16,29 +16,24 @@ describe('theme attribute', () => {
   });
 
   it('should propagate theme attribute to overlay', () => {
-    datepicker.open();
     expect(datepicker.$.overlay.getAttribute('theme')).to.equal('foo');
   });
 
   it('should propagate theme attribute to overlay content', () => {
     datepicker.open();
-    const overlayContent = datepicker.$.overlay.content.querySelector('#overlay-content');
+    const overlayContent = getOverlayContent(datepicker);
     expect(overlayContent.getAttribute('theme')).to.equal('foo');
   });
 
   describe('in content', () => {
-    let overlayContent;
-
     beforeEach(async () => {
       await open(datepicker);
-      overlayContent = datepicker.$.overlay.content.querySelector('#overlay-content');
-      overlayContent.$.yearScroller.bufferSize = 0;
-      overlayContent.$.monthScroller.bufferSize = 1;
-      overlayContent.$.yearScroller._finishInit();
-      overlayContent.$.monthScroller._finishInit();
+      await nextRender(datepicker);
     });
 
-    it('should propagate theme attribute to month calendar', () => {
+    it('should propagate theme attribute to month calendar', async () => {
+      const overlayContent = getOverlayContent(datepicker);
+      await waitForScrollToFinish(overlayContent);
       const monthCalendar = overlayContent.$.monthScroller.querySelector('vaadin-month-calendar');
       expect(monthCalendar.getAttribute('theme')).to.equal('foo');
     });

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -464,7 +464,7 @@ class DateTimePicker extends FieldMixin(
     if (
       this.__datePicker.contains(target) ||
       this.__timePicker.contains(target) ||
-      target === this.__datePicker.$.overlay
+      target === this.__datePicker._overlayContent
     ) {
       return false;
     }

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -106,8 +106,8 @@ describe('Basic features', () => {
     });
 
     it('should remove focused attribute on focusout', () => {
-      focusin(datePicker);
-      focusout(datePicker);
+      datePicker.focus();
+      datePicker.blur();
       expect(dateTimePicker.hasAttribute('focused')).to.be.false;
     });
 
@@ -126,7 +126,7 @@ describe('Basic features', () => {
     it('should not remove focused attribute when moving focus to overlay', () => {
       focusin(datePicker);
       datePicker.open();
-      focusout(datePicker, datePicker.$.overlay);
+      focusout(datePicker, datePicker._overlayContent);
       expect(dateTimePicker.hasAttribute('focused')).to.be.true;
     });
   });

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';
@@ -72,6 +72,10 @@ const fixtures = {
       datePicker.focus();
       // Move focus to time-picker
       await sendKeys({ press: 'Tab' });
+
+      // Wait to reduce flakiness
+      await aTimeout(1);
+
       // Move focus to date-picker
       await sendKeys({ down: 'Shift' });
       await sendKeys({ press: 'Tab' });


### PR DESCRIPTION
## Description

This PR changes the DOM structure of `vaadin-date-picker-overlay`, so it's possibly a breaking change.
The main benefit is being able to style `vaadin-date-picker-overlay-content` using `::part()`.
 
### Before

![Screenshot 2022-05-20 at 12 52 15](https://user-images.githubusercontent.com/10589913/169503233-8eab2ea9-695a-4b93-ba4f-1a885c1b1283.png)

### After 
 
![Screenshot 2022-05-20 at 12 51 41](https://user-images.githubusercontent.com/10589913/169503279-0a253240-bb76-4e65-bc98-0148ab3ada15.png)
 
## Type of change

- Refactor