### PR TITLE
refactor: add more rules to ESLint config, fix warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,13 @@
       }
     ],
     "no-unused-vars": "off",
+    "@typescript-eslint/array-type": [
+      "error",
+      {
+        "default": "array-simple",
+        "readonly": "array-simple"
+      }
+    ],
     "@typescript-eslint/no-unused-vars": ["error", {
       "argsIgnorePattern": "^_"
     }],

--- a/packages/charts/src/vaadin-chart-series.d.ts
+++ b/packages/charts/src/vaadin-chart-series.d.ts
@@ -22,7 +22,7 @@ export interface ChartSeriesConfig {
 
 export type ChartSeriesOptions = ChartSeriesConfig & SeriesOptionsType;
 
-export type ChartSeriesValues = Array<number | Array<number> | PointOptionsObject>;
+export type ChartSeriesValues = Array<number | number[] | PointOptionsObject>;
 
 /**
  * `<vaadin-chart-series>` is a custom element for creating series for Vaadin Charts.

--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -8,7 +8,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export type ChartCategories = Array<string> | { [key: number]: string };
+export type ChartCategories = string[] | { [key: number]: string };
 
 export type ChartCategoryPosition = 'left' | 'right' | 'top' | 'bottom';
 

--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -17,7 +17,7 @@ export type CheckboxGroupInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 /**
  * Fired when the `value` property changes.
  */
-export type CheckboxGroupValueChangedEvent = CustomEvent<{ value: Array<string> }>;
+export type CheckboxGroupValueChangedEvent = CustomEvent<{ value: string[] }>;
 
 export interface CheckboxGroupCustomEventMap {
   'invalid-changed': CheckboxGroupInvalidChangedEvent;

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
@@ -5,7 +5,7 @@
  */
 import { Constructor } from '@open-wc/dedupe-mixin';
 
-export type ComboBoxDataProviderCallback<TItem> = (items: Array<TItem>, size: number) => void;
+export type ComboBoxDataProviderCallback<TItem> = (items: TItem[], size: number) => void;
 
 export interface ComboBoxDataProviderParams {
   page: number;

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -72,7 +72,7 @@ export declare class ComboBoxMixinClass<TItem> {
    * A full set of items to filter the visible options from.
    * The items can be of either `String` or `Object` type.
    */
-  items: Array<TItem> | undefined;
+  items: TItem[] | undefined;
 
   /**
    * If `true`, the user can input a value that is not present in the items list.
@@ -88,7 +88,7 @@ export declare class ComboBoxMixinClass<TItem> {
    * can be assigned directly to omit the internal filtering functionality.
    * The items can be of either `String` or `Object` type.
    */
-  filteredItems: Array<TItem> | undefined;
+  filteredItems: TItem[] | undefined;
 
   /**
    * The `String` value for the selected item of the combo box.

--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -8,13 +8,13 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { GridFilterDefinition, GridSorterDefinition } from '@vaadin/grid/src/vaadin-grid.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export type CrudDataProviderCallback<T> = (items: Array<T>, size?: number) => void;
+export type CrudDataProviderCallback<T> = (items: T[], size?: number) => void;
 
 export type CrudDataProviderParams = {
   page: number;
   pageSize: number;
-  filters: Array<GridFilterDefinition>;
-  sortOrders: Array<GridSorterDefinition>;
+  filters: GridFilterDefinition[];
+  sortOrders: GridSorterDefinition[];
 };
 
 export type CrudDataProvider<T> = (params: CrudDataProviderParams, callback: CrudDataProviderCallback<T>) => void;
@@ -61,7 +61,7 @@ export type CrudEditedItemChangedEvent<T> = CustomEvent<{ value: T }>;
 /**
  * Fired when the `items` property changes.
  */
-export type CrudItemsChangedEvent<T> = CustomEvent<{ value: Array<T> }>;
+export type CrudItemsChangedEvent<T> = CustomEvent<{ value: T[] }>;
 
 /**
  * Fired when the `size` property changes.
@@ -247,7 +247,7 @@ declare class Crud<Item> extends ControllerMixin(ElementMixin(ThemableMixin(HTML
   /**
    * An array containing the items which will be stamped to the column template instances.
    */
-  items: Array<Item> | null | undefined;
+  items: Item[] | null | undefined;
 
   /**
    * The item being edited in the dialog.

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -8,9 +8,9 @@ import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export type CustomFieldParseValueFn = (value: string) => Array<unknown>;
+export type CustomFieldParseValueFn = (value: string) => unknown[];
 
-export type CustomFieldFormatValueFn = (inputValues: Array<unknown>) => string;
+export type CustomFieldFormatValueFn = (inputValues: unknown[]) => string;
 
 export interface CustomFieldI18n {
   parseValue: CustomFieldParseValueFn;

--- a/packages/grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/grid-pro/test/typings/grid-pro.types.ts
@@ -56,7 +56,7 @@ narrowedGrid.addEventListener('cell-activate', (event) => {
 
 narrowedGrid.addEventListener('column-reorder', (event) => {
   assertType<GridColumnReorderEvent<TestGridItem>>(event);
-  assertType<GridColumn<TestGridItem>[]>(event.detail.columns);
+  assertType<Array<GridColumn<TestGridItem>>>(event.detail.columns);
 });
 
 narrowedGrid.addEventListener('column-resize', (event) => {

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
@@ -18,13 +18,13 @@ export interface GridSorterDefinition {
   direction: GridSorterDirection;
 }
 
-export type GridDataProviderCallback<TItem> = (items: Array<TItem>, size?: number) => void;
+export type GridDataProviderCallback<TItem> = (items: TItem[], size?: number) => void;
 
 export type GridDataProviderParams<TItem> = {
   page: number;
   pageSize: number;
-  filters: Array<GridFilterDefinition>;
-  sortOrders: Array<GridSorterDefinition>;
+  filters: GridFilterDefinition[];
+  sortOrders: GridSorterDefinition[];
   parentItem?: TItem;
 };
 

--- a/packages/grid/src/vaadin-grid-row-details-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.d.ts
@@ -20,7 +20,7 @@ export declare class RowDetailsMixinClass<TItem> {
   /**
    * An array containing references to items with open row details.
    */
-  detailsOpenedItems: Array<TItem>;
+  detailsOpenedItems: TItem[];
 
   /**
    * Custom function for rendering the content of the row details.

--- a/packages/grid/src/vaadin-grid-selection-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-mixin.d.ts
@@ -13,7 +13,7 @@ export declare class SelectionMixinClass<TItem> {
   /**
    * An array that contains the selected items.
    */
-  selectedItems: Array<TItem>;
+  selectedItems: TItem[];
 
   /**
    * Selects the given item.

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -78,7 +78,7 @@ export type GridCellFocusEvent<TItem> = CustomEvent<{ context: GridEventContext<
 /**
  * Fired when the columns in the grid are reordered.
  */
-export type GridColumnReorderEvent<TItem> = CustomEvent<{ columns: GridColumn<TItem>[] }>;
+export type GridColumnReorderEvent<TItem> = CustomEvent<{ columns: Array<GridColumn<TItem>> }>;
 
 /**
  * Fired when the grid column resize is finished.

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -92,7 +92,7 @@ narrowedGrid.addEventListener('cell-focus', (event) => {
 
 narrowedGrid.addEventListener('column-reorder', (event) => {
   assertType<GridColumnReorderEvent<TestGridItem>>(event);
-  assertType<GridColumn<TestGridItem>[]>(event.detail.columns);
+  assertType<Array<GridColumn<TestGridItem>>>(event.detail.columns);
 });
 
 narrowedGrid.addEventListener('column-resize', (event) => {

--- a/packages/list-box/src/vaadin-list-box.d.ts
+++ b/packages/list-box/src/vaadin-list-box.d.ts
@@ -11,7 +11,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * Fired when the `items` property changes.
  */
-export type ListBoxItemsChangedEvent = CustomEvent<{ value: Array<Element> }>;
+export type ListBoxItemsChangedEvent = CustomEvent<{ value: Element[] }>;
 
 /**
  * Fired when the `selected` property changes.
@@ -21,7 +21,7 @@ export type ListBoxSelectedChangedEvent = CustomEvent<{ value: number }>;
 /**
  * Fired when the `selectedValues` property changes.
  */
-export type ListBoxSelectedValuesChangedEvent = CustomEvent<{ value: Array<number> }>;
+export type ListBoxSelectedValuesChangedEvent = CustomEvent<{ value: number[] }>;
 
 export interface ListBoxCustomEventMap {
   'items-changed': ListBoxItemsChangedEvent;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -53,7 +53,7 @@ export type MultiSelectComboBoxInvalidChangedEvent = CustomEvent<{ value: boolea
 /**
  * Fired when the `selectedItems` property changes.
  */
-export type MultiSelectComboBoxSelectedItemsChangedEvent<TItem> = CustomEvent<{ value: Array<TItem> }>;
+export type MultiSelectComboBoxSelectedItemsChangedEvent<TItem> = CustomEvent<{ value: TItem[] }>;
 
 export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap {
   change: MultiSelectComboBoxChangeEvent<TItem>;
@@ -175,7 +175,7 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
    * can be assigned directly to omit the internal filtering functionality.
    * The items can be of either `String` or `Object` type.
    */
-  filteredItems: Array<TItem> | undefined;
+  filteredItems: TItem[] | undefined;
 
   /**
    * Filtering string the user has typed into the input field.
@@ -186,7 +186,7 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
    * A full set of items to filter the visible options from.
    * The items can be of either `String` or `Object` type.
    */
-  items: Array<TItem> | undefined;
+  items: TItem[] | undefined;
 
   /**
    * The item property used for a visual representation of the item.
@@ -266,7 +266,7 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
    * The list of selected items.
    * Note: modifying the selected items creates a new array each time.
    */
-  selectedItems: Array<TItem>;
+  selectedItems: TItem[];
 
   addEventListener<K extends keyof MultiSelectComboBoxEventMap<TItem>>(
     type: K,

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -57,7 +57,7 @@ narrowedComboBox.addEventListener('invalid-changed', (event) => {
 
 narrowedComboBox.addEventListener('selected-items-changed', (event) => {
   assertType<MultiSelectComboBoxSelectedItemsChangedEvent<TestComboBoxItem>>(event);
-  assertType<Array<TestComboBoxItem>>(event.detail.value);
+  assertType<TestComboBoxItem[]>(event.detail.value);
 });
 
 // Properties

--- a/packages/tabs/src/vaadin-tabs.d.ts
+++ b/packages/tabs/src/vaadin-tabs.d.ts
@@ -13,7 +13,7 @@ export type TabsOrientation = 'horizontal' | 'vertical';
 /**
  * Fired when the `items` property changes.
  */
-export type TabsItemsChangedEvent = CustomEvent<{ value: Array<Element> }>;
+export type TabsItemsChangedEvent = CustomEvent<{ value: Element[] }>;
 
 /**
  * Fired when the `selected` property changes.

--- a/packages/virtual-list/src/vaadin-virtual-list.d.ts
+++ b/packages/virtual-list/src/vaadin-virtual-list.d.ts
@@ -57,7 +57,7 @@ declare class VirtualList<TItem = VirtualListDefaultItem> extends ElementMixin(T
   /**
    * An array containing items determining how many instances to render.
    */
-  items: Array<TItem> | undefined;
+  items: TItem[] | undefined;
 
   /**
    * Scroll to a specific index in the virtual list.

--- a/packages/virtual-list/test/typings/virtual-list.types.ts
+++ b/packages/virtual-list/test/typings/virtual-list.types.ts
@@ -19,7 +19,7 @@ assertType<VirtualList<TestVirtualListItem>>(virtualList);
 
 virtualList.items = [{ testProperty: '1' }, { testProperty: '2' }, { testProperty: '3' }];
 
-assertType<Array<TestVirtualListItem>>(virtualList.items);
+assertType<TestVirtualListItem[]>(virtualList.items);
 
 virtualList.renderer = (root, virtualList, model) => {
   assertType<HTMLElement>(root);


### PR DESCRIPTION
## Description

The PR adds the following rules to the project's ESLint config:

- [x] @typescript-eslint/array-type

Part of https://github.com/vaadin/eslint-config-vaadin/issues/16

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
