### PR TITLE
fix: make virtualizer react to asynchronous item size increase

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -132,8 +132,8 @@ export class IronListAdapter {
 
   __updateElement(el, index, forceSameIndexUpdates) {
     // Clean up temporary placeholder sizing
-    if (el.style.paddingBottom) {
-      el.style.paddingBottom = '';
+    if (el.style.paddingTop) {
+      el.style.paddingTop = '';
     }
 
     if (!this.__preventElementUpdates && (el.__lastUpdatedIndex !== index || forceSameIndexUpdates)) {
@@ -146,7 +146,7 @@ export class IronListAdapter {
       // it results in iron-list requesting to create an unlimited count of elements.
       // Assign a temporary placeholder sizing to elements that would otherwise end up having
       // no height.
-      el.style.paddingBottom = '200px';
+      el.style.paddingTop = '200px';
     }
   }
 

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -131,9 +131,9 @@ export class IronListAdapter {
   }
 
   __updateElement(el, index, forceSameIndexUpdates) {
-    // Clean up temporary min height
-    if (el.style.minHeight) {
-      el.style.minHeight = '';
+    // Clean up temporary placeholder sizing
+    if (el.style.paddingBottom) {
+      el.style.paddingBottom = '';
     }
 
     if (!this.__preventElementUpdates && (el.__lastUpdatedIndex !== index || forceSameIndexUpdates)) {
@@ -144,9 +144,9 @@ export class IronListAdapter {
     if (el.offsetHeight === 0) {
       // If the elements have 0 height after update (for example due to lazy rendering),
       // it results in iron-list requesting to create an unlimited count of elements.
-      // Assign a temporary min height to elements that would otherwise end up having
+      // Assign a temporary placeholder sizing to elements that would otherwise end up having
       // no height.
-      el.style.minHeight = '200px';
+      el.style.paddingBottom = '200px';
     }
   }
 

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -1,0 +1,54 @@
+import { expect } from '@esm-bundle/chai';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { Virtualizer } from '../src/virtualizer.js';
+
+describe('virtualizer - item height', () => {
+  let elementsContainer;
+  const ITEM_HEIGHT = 20;
+
+  beforeEach(async () => {
+    const scrollTarget = fixtureSync(`
+      <div style="height: 300px;">
+        <div class="container"></div>
+      </div>
+    `);
+    const scrollContainer = scrollTarget.firstElementChild;
+    elementsContainer = scrollContainer;
+
+    const virtualizer = new Virtualizer({
+      createElements: (count) => Array.from({ length: count }, () => document.createElement('div')),
+      updateElement: (el, index) => {
+        el.style.width = '100%';
+
+        if (el.id !== index) {
+          el.id = `item-${index}`;
+
+          // The element initially has a height of 0.
+          el.style.height = '';
+
+          // Update the element content dynamically (after a timeout) so its intrinsic height increases.
+          setTimeout(() => {
+            el.textContent = el.id;
+            el.style.height = `${ITEM_HEIGHT}px`;
+          }, 50);
+        }
+      },
+      scrollTarget,
+      scrollContainer,
+    });
+
+    virtualizer.size = 10000;
+  });
+
+  it('should have the initial placeholder height', async () => {
+    const firstItem = elementsContainer.querySelector(`#item-0`);
+    expect(firstItem.offsetHeight).to.equal(200);
+  });
+
+  it('should resize the elements once the content updates', async () => {
+    const firstItem = elementsContainer.querySelector(`#item-0`);
+    // Wait for the content to update
+    await aTimeout(100);
+    expect(firstItem.offsetHeight).to.equal(ITEM_HEIGHT);
+  });
+});


### PR DESCRIPTION
Part of https://github.com/vaadin/flow-components/issues/3206

If a virtualizer child element has a height of 0 after an update, currently the Virtualizer would set `min-height: 200px` for it to avoid `iron-list-core` from generating an unlimited amount of elements while trying to cover the viewport.

The problem with `min-height` is that once the element content gets changed asynchronously (in the case of `<flow-component-renderer>` when the content component gets loaded and appended), the effective height of the element would not change (it would still remain 200 pixels high) and internal resizing logic would not invoke.

This PR changes the Virtualizer to use `padding-top` instead of `min-height` for the placeholder size so that once the content updates, the element's effective height will actually change, which in turn invokes the internal `ResizeObserver`.

NOTE: The initial revision of this PR used `padding-bottom`, but an inline padding-bottom style is [already used by `<vaadin-grid>`'s row details -feature ](https://github.com/vaadin/web-components/blob/b2ad3cab6a84c0b2a050aaa8f97d8f549b2a238f/packages/grid/src/vaadin-grid-row-details-mixin.js#L159)so it's not an option.