### PR TITLE
refactor: make virtualizer use dynamic placeholder height

### DIFF
--- a/packages/combo-box/test/dynamic-size.test.js
+++ b/packages/combo-box/test/dynamic-size.test.js
@@ -35,6 +35,7 @@ describe('dynamic size change', () => {
       comboBox.opened = true;
       scrollToIndex(comboBox, comboBox.size - 1);
       flushComboBox(comboBox);
+      flushComboBox(comboBox);
       const items = getViewportItems(comboBox);
       expect(items.length).to.be.above(5);
       items.forEach((item) => {

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -26,6 +26,11 @@ export class IronListAdapter {
     // Iron-list uses this value to determine how many pages of elements to render
     this._maxPages = 1.3;
 
+    // Placeholder height (used for sizing elements that have intrinsic 0 height after update)
+    this.__placeholderHeight = 200;
+    // A queue of 10 previous element heights
+    this.__elementHeightQueue = Array(10);
+
     this.timeouts = {
       SCROLL_REORDER: 500,
       IGNORE_WHEEL: 500,
@@ -141,12 +146,22 @@ export class IronListAdapter {
       el.__lastUpdatedIndex = index;
     }
 
-    if (el.offsetHeight === 0) {
+    const elementHeight = el.offsetHeight;
+    if (elementHeight === 0) {
       // If the elements have 0 height after update (for example due to lazy rendering),
       // it results in iron-list requesting to create an unlimited count of elements.
       // Assign a temporary placeholder sizing to elements that would otherwise end up having
       // no height.
-      el.style.paddingTop = '200px';
+      el.style.paddingTop = `${this.__placeholderHeight}px`;
+    } else {
+      // Add element height to the queue
+      this.__elementHeightQueue.push(elementHeight);
+      this.__elementHeightQueue.shift();
+
+      // Calcualte new placeholder height based on the average of the defined values in the
+      // element height queue
+      const filteredHeights = this.__elementHeightQueue.filter((h) => h !== undefined);
+      this.__placeholderHeight = Math.round(filteredHeights.reduce((a, b) => a + b, 0) / filteredHeights.length);
     }
   }
 

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -312,16 +312,28 @@ export class IronListAdapter {
 
   _scrollHandler() {
     this._adjustVirtualIndexOffset(this._scrollTop - (this.__previousScrollTop || 0));
+    const delta = this.scrollTarget.scrollTop - this._scrollPosition;
 
     super._scrollHandler();
 
     if (this._physicalCount !== 0) {
-      // After running super._scrollHandler, fix _virtualStart to workaround an iron-list issue.
-      // See https://github.com/vaadin/web-components/issues/1691
-      const reusables = this._getReusables(true);
-      this._physicalTop = reusables.physicalTop;
-      this._virtualStart += reusables.indexes.length;
-      this._physicalStart += reusables.indexes.length;
+      const isScrollingDown = delta >= 0;
+      const reusables = this._getReusables(!isScrollingDown);
+
+      if (reusables.indexes.length) {
+        // After running super._scrollHandler, fix internal properties to workaround an iron-list issue.
+        // See https://github.com/vaadin/web-components/issues/1691
+        this._physicalTop = reusables.physicalTop;
+
+        if (isScrollingDown) {
+          this._virtualStart -= reusables.indexes.length;
+          this._physicalStart -= reusables.indexes.length;
+        } else {
+          this._virtualStart += reusables.indexes.length;
+          this._physicalStart += reusables.indexes.length;
+        }
+        this._resizeHandler();
+      }
     }
 
     if (this.reorderElements) {

--- a/packages/component-base/test/virtualizer-reorder-elements.test.js
+++ b/packages/component-base/test/virtualizer-reorder-elements.test.js
@@ -27,7 +27,7 @@ describe('reorder elements', () => {
         resolve(mutations.flatMap((record) => [...record.removedNodes]));
       }).observe(elementsContainer, { childList: true });
 
-      virtualizer.scrollToIndex(Math.ceil(elementsContainer.childElementCount / 3));
+      virtualizer.scrollToIndex(Math.ceil(elementsContainer.childElementCount / 2));
 
       if (!skipFlush) {
         virtualizer.flush();


### PR DESCRIPTION
Part of https://github.com/vaadin/flow-components/issues/3206

Using the static value of `200px` for the placeholder height doesn't play well when the actual item height is much smaller.

_Note: this is only an issue in the rare cases where the items have the intrinsic height of 0 after an update and then asynchronously increase in height._

This PR updates Virtualizer to dynamically update the placeholder height to be the average of the 10 previous actual item heights. Having the placeholder height be as close as possible to the actual item heights results in much nicer scrolling UX:

Static placholder height (of 200px):

https://user-images.githubusercontent.com/1222264/169641179-3c4fd9a6-3a83-4d9e-8ead-857c0c9c6f5c.mp4


Dynamic placeholder height:

https://user-images.githubusercontent.com/1222264/169641190-18298bf6-6480-4671-ac66-48a940e435d6.mp4