### PR TITLE
refactor: add more rules to ESLint config, fix warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,7 @@
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/prefer-function-type": "error",
     "accessor-pairs": "error",
     "array-callback-return": "error",
     "capitalized-comments": ["error", "always", {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,59 @@
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/member-ordering": [
+      "error",
+      {
+        "default": [
+          "public-static-field",
+          "protected-static-field",
+          "private-static-field",
+
+          "public-static-method",
+          "protected-static-method",
+          "private-static-method",
+
+          "public-instance-field",
+          "protected-instance-field",
+          "private-instance-field",
+
+          "public-abstract-field",
+          "protected-abstract-field",
+          "private-abstract-field",
+
+          "public-field",
+          "protected-field",
+          "private-field",
+
+          "static-field",
+          "instance-field",
+          "abstract-field",
+
+          "field",
+
+          "constructor",
+
+          "public-instance-method",
+          "protected-instance-method",
+          "private-instance-method",
+
+          "public-abstract-method",
+          "protected-abstract-method",
+          "private-abstract-method",
+
+          "public-method",
+          "protected-method",
+          "private-method",
+
+          "static-method",
+          "instance-method",
+          "abstract-method",
+          "method"
+        ],
+        "interfaces": ["field", "constructor", "method"],
+        "typeLiterals": ["field", "constructor", "method"]
+      }
+    ],
     "accessor-pairs": "error",
     "array-callback-return": "error",
     "capitalized-comments": ["error", "always", {

--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -125,6 +125,11 @@ export type AppLayoutEventMap = HTMLElementEventMap & AppLayoutCustomEventMap;
  */
 declare class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(HTMLElement))) {
   /**
+   * Helper static method that dispatches a `close-overlay-drawer` event
+   */
+  static dispatchCloseOverlayDrawerEvent(): void;
+
+  /**
    * The object used to localize this component.
    * To change the default localization, replace the entire
    * `i18n` object with a custom one.
@@ -176,11 +181,6 @@ declare class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(HTMLE
    * @attr {string} close-drawer-on
    */
   closeDrawerOn: string;
-
-  /**
-   * Helper static method that dispatches a `close-overlay-drawer` event
-   */
-  static dispatchCloseOverlayDrawerEvent(): void;
 
   addEventListener<K extends keyof AppLayoutEventMap>(
     type: K,

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -405,6 +405,13 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     };
   }
 
+  /**
+   * Helper static method that dispatches a `close-overlay-drawer` event
+   */
+  static dispatchCloseOverlayDrawerEvent() {
+    window.dispatchEvent(new CustomEvent('close-overlay-drawer'));
+  }
+
   constructor() {
     super();
     // TODO(jouni): might want to debounce
@@ -471,13 +478,6 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     window.removeEventListener('resize', this.__boundResizeListener);
     this.removeEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
     window.removeEventListener('close-overlay-drawer', this.__drawerToggleClickListener);
-  }
-
-  /**
-   * Helper static method that dispatches a `close-overlay-drawer` event
-   */
-  static dispatchCloseOverlayDrawerEvent() {
-    window.dispatchEvent(new CustomEvent('close-overlay-drawer'));
   }
 
   /**

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -31,14 +31,6 @@ export declare function ComboBoxMixin<TItem, T extends Constructor<HTMLElement>>
   Constructor<KeyboardMixinClass>;
 
 export declare class ComboBoxMixinClass<TItem> {
-  protected readonly _propertyForValue: string;
-
-  protected _inputElementValue: string | undefined;
-
-  protected _revertInputValue(): void;
-
-  protected _getItemElements(): HTMLElement[];
-
   /**
    * True if the dropdown is open, false otherwise.
    */
@@ -151,6 +143,10 @@ export declare class ComboBoxMixinClass<TItem> {
    */
   invalid: boolean;
 
+  protected readonly _propertyForValue: string;
+
+  protected _inputElementValue: string | undefined;
+
   /**
    * Requests an update for the content of items.
    * While performing the update, it invokes the renderer (passed in the `renderer` property) once an item.
@@ -179,4 +175,8 @@ export declare class ComboBoxMixinClass<TItem> {
    * You can override this method for custom validations.
    */
   checkValidity(): boolean;
+
+  protected _revertInputValue(): void;
+
+  protected _getItemElements(): HTMLElement[];
 }

--- a/packages/component-base/src/debounce.d.ts
+++ b/packages/component-base/src/debounce.d.ts
@@ -10,8 +10,6 @@
 import { AsyncInterface } from './async.js';
 
 export declare class Debouncer {
-  constructor();
-
   /**
    * Creates a debouncer if no debouncer is passed as a parameter
    * or it cancels an active debouncer otherwise. The following
@@ -47,6 +45,8 @@ export declare class Debouncer {
    * @returns Returns a debouncer object.
    */
   static debounce(debouncer: Debouncer | null, asyncModule: AsyncInterface, callback: () => any): Debouncer;
+
+  constructor();
 
   /**
    * Sets the scheduler; that is, a module with the Async interface,

--- a/packages/component-base/src/debounce.js
+++ b/packages/component-base/src/debounce.js
@@ -12,6 +12,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
  * @summary Collapse multiple callbacks into one invocation after a timer.
  */
 export class Debouncer {
+  /**
+   * Creates a debouncer if no debouncer is passed as a parameter
+   * or it cancels an active debouncer otherwise. The following
+   * example shows how a debouncer can be called multiple times within a
+   * microtask and "debounced" such that the provided callback function is
+   * called once. Add this method to a custom element:
+   *
+   * ```js
+   * import {microTask} from '@vaadin/component-base/src/async.js';
+   * import {Debouncer} from '@vaadin/component-base/src/debounce.js';
+   * // ...
+   *
+   * _debounceWork() {
+   *   this._debounceJob = Debouncer.debounce(this._debounceJob,
+   *       microTask, () => this._doWork());
+   * }
+   * ```
+   *
+   * If the `_debounceWork` method is called multiple times within the same
+   * microtask, the `_doWork` function will be called only once at the next
+   * microtask checkpoint.
+   *
+   * Note: In testing it is often convenient to avoid asynchrony. To accomplish
+   * this with a debouncer, you can use `enqueueDebouncer` and
+   * `flush`. For example, extend the above example by adding
+   * `enqueueDebouncer(this._debounceJob)` at the end of the
+   * `_debounceWork` method. Then in a test, call `flush` to ensure
+   * the debouncer has completed.
+   *
+   * @param {Debouncer?} debouncer Debouncer object.
+   * @param {!AsyncInterface} asyncModule Object with Async interface
+   * @param {function()} callback Callback to run.
+   * @return {!Debouncer} Returns a debouncer object.
+   */
+  static debounce(debouncer, asyncModule, callback) {
+    if (debouncer instanceof Debouncer) {
+      // Cancel the async callback, but leave in debouncerQueue if it was
+      // enqueued, to maintain 1.x flush order
+      debouncer._cancelAsync();
+    } else {
+      debouncer = new Debouncer();
+    }
+    debouncer.setConfig(asyncModule, callback);
+    return debouncer;
+  }
+
   constructor() {
     this._asyncModule = null;
     this._callback = null;
@@ -84,52 +130,6 @@ export class Debouncer {
    */
   isActive() {
     return this._timer != null;
-  }
-
-  /**
-   * Creates a debouncer if no debouncer is passed as a parameter
-   * or it cancels an active debouncer otherwise. The following
-   * example shows how a debouncer can be called multiple times within a
-   * microtask and "debounced" such that the provided callback function is
-   * called once. Add this method to a custom element:
-   *
-   * ```js
-   * import {microTask} from '@vaadin/component-base/src/async.js';
-   * import {Debouncer} from '@vaadin/component-base/src/debounce.js';
-   * // ...
-   *
-   * _debounceWork() {
-   *   this._debounceJob = Debouncer.debounce(this._debounceJob,
-   *       microTask, () => this._doWork());
-   * }
-   * ```
-   *
-   * If the `_debounceWork` method is called multiple times within the same
-   * microtask, the `_doWork` function will be called only once at the next
-   * microtask checkpoint.
-   *
-   * Note: In testing it is often convenient to avoid asynchrony. To accomplish
-   * this with a debouncer, you can use `enqueueDebouncer` and
-   * `flush`. For example, extend the above example by adding
-   * `enqueueDebouncer(this._debounceJob)` at the end of the
-   * `_debounceWork` method. Then in a test, call `flush` to ensure
-   * the debouncer has completed.
-   *
-   * @param {Debouncer?} debouncer Debouncer object.
-   * @param {!AsyncInterface} asyncModule Object with Async interface
-   * @param {function()} callback Callback to run.
-   * @return {!Debouncer} Returns a debouncer object.
-   */
-  static debounce(debouncer, asyncModule, callback) {
-    if (debouncer instanceof Debouncer) {
-      // Cancel the async callback, but leave in debouncerQueue if it was
-      // enqueued, to maintain 1.x flush order
-      debouncer._cancelAsync();
-    } else {
-      debouncer = new Debouncer();
-    }
-    debouncer.setConfig(asyncModule, callback);
-    return debouncer;
   }
 }
 

--- a/packages/component-base/src/focus-trap-controller.d.ts
+++ b/packages/component-base/src/focus-trap-controller.d.ts
@@ -9,16 +9,16 @@ import { ReactiveController } from 'lit';
  * A controller for trapping focus within a DOM node.
  */
 export class FocusTrapController implements ReactiveController {
+  /**
+   * The controller host element.
+   */
+  host: HTMLElement;
+
   constructor(node: HTMLElement);
 
   hostConnected(): void;
 
   hostDisconnected(): void;
-
-  /**
-   * The controller host element.
-   */
-  host: HTMLElement;
 
   /**
    * Activates a focus trap for a DOM node that will prevent focus from escaping the node.

--- a/packages/component-base/src/media-query-controller.d.ts
+++ b/packages/component-base/src/media-query-controller.d.ts
@@ -10,15 +10,6 @@ import { ReactiveController } from 'lit';
  */
 export class MediaQueryController implements ReactiveController {
   /**
-   * @param {HTMLElement} host
-   */
-  constructor(query: string, callback: (matches: boolean) => void);
-
-  hostConnected(): void;
-
-  hostDisconnected(): void;
-
-  /**
    * The CSS media query to evaluate.
    */
   protected query: string;
@@ -27,4 +18,13 @@ export class MediaQueryController implements ReactiveController {
    * Function to call when media query changes.
    */
   protected callback: (matches: boolean) => void;
+
+  /**
+   * @param {HTMLElement} host
+   */
+  constructor(query: string, callback: (matches: boolean) => void);
+
+  hostConnected(): void;
+
+  hostDisconnected(): void;
 }

--- a/packages/component-base/src/resize-mixin.d.ts
+++ b/packages/component-base/src/resize-mixin.d.ts
@@ -12,14 +12,14 @@ export declare function ResizeMixin<T extends Constructor<HTMLElement>>(base: T)
 
 export declare class ResizeMixinClass {
   /**
-   * A handler invoked on host resize. By default, it does nothing.
-   * Override the method to implement your own behavior.
-   */
-  protected _onResize(contentRect: DOMRect): void;
-
-  /**
    * When true, the parent element resize will be also observed.
    * Override this getter and return `true` to enable this.
    */
   protected readonly _observeParent: boolean;
+
+  /**
+   * A handler invoked on host resize. By default, it does nothing.
+   * Override the method to implement your own behavior.
+   */
+  protected _onResize(contentRect: DOMRect): void;
 }

--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -6,15 +6,6 @@
 import { ReactiveController } from 'lit';
 
 export class SlotController extends EventTarget implements ReactiveController {
-  constructor(
-    host: HTMLElement,
-    slotName: string,
-    slotFactory?: () => HTMLElement,
-    slotInitializer?: (host: HTMLElement, node: HTMLElement) => void,
-  );
-
-  hostConnected(): void;
-
   /**
    * The controller host element.
    */
@@ -25,16 +16,25 @@ export class SlotController extends EventTarget implements ReactiveController {
    */
   node: HTMLElement;
 
-  /**
-   * Return a reference to the node managed by the controller.
-   */
-  getSlotChild(): Node;
-
   protected initialized: boolean;
 
   protected defaultNode: Node;
 
   protected defaultId: string;
+
+  constructor(
+    host: HTMLElement,
+    slotName: string,
+    slotFactory?: () => HTMLElement,
+    slotInitializer?: (host: HTMLElement, node: HTMLElement) => void,
+  );
+
+  hostConnected(): void;
+
+  /**
+   * Return a reference to the node managed by the controller.
+   */
+  getSlotChild(): Node;
 
   protected attachDefaultNode(): Node | undefined;
 

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -10,16 +10,6 @@ import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nod
  * A controller for providing content to slot element and observing changes.
  */
 export class SlotController extends EventTarget {
-  constructor(host, slotName, slotFactory, slotInitializer) {
-    super();
-
-    this.host = host;
-    this.slotName = slotName;
-    this.slotFactory = slotFactory;
-    this.slotInitializer = slotInitializer;
-    this.defaultId = SlotController.generateId(slotName, host);
-  }
-
   /**
    * Ensure that every instance has unique ID.
    *
@@ -38,6 +28,16 @@ export class SlotController extends EventTarget {
     this[field] = 1 + this[field] || 0;
 
     return `${prefix}-${host.localName}-${this[field]}`;
+  }
+
+  constructor(host, slotName, slotFactory, slotInitializer) {
+    super();
+
+    this.host = host;
+    this.slotName = slotName;
+    this.slotFactory = slotFactory;
+    this.slotInitializer = slotInitializer;
+    this.defaultId = SlotController.generateId(slotName, host);
   }
 
   hostConnected() {

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -40,8 +40,6 @@ declare class ContextMenuListBox extends ListBox {}
 export declare function ItemsMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ItemsMixinClass>;
 
 export declare class ItemsMixinClass {
-  protected readonly __isRTL: boolean;
-
   /**
    * Defines a (hierarchical) menu structure for the component.
    * If a menu item has a non-empty `children` set, a sub-menu with the child items is opened
@@ -71,4 +69,6 @@ export declare class ItemsMixinClass {
    * ```
    */
   items: ContextMenuItem[] | undefined;
+
+  protected readonly __isRTL: boolean;
 }

--- a/packages/field-base/src/field-aria-controller.d.ts
+++ b/packages/field-base/src/field-aria-controller.d.ts
@@ -9,12 +9,12 @@
  * either the component itself or slotted `<input>` element.
  */
 export class FieldAriaController {
-  constructor(host: HTMLElement);
-
   /**
    * The controller host element.
    */
   host: HTMLElement;
+
+  constructor(host: HTMLElement);
 
   /**
    * Sets a target element to which ARIA attributes are added.

--- a/packages/field-base/src/label-controller.d.ts
+++ b/packages/field-base/src/label-controller.d.ts
@@ -10,6 +10,11 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  */
 export class LabelController extends SlotController {
   /**
+   * ID attribute value set on the label element.
+   */
+  labelId: string;
+
+  /**
    * String used for the label.
    */
   protected label: string | null | undefined;
@@ -18,9 +23,4 @@ export class LabelController extends SlotController {
    * Set label based on corresponding host property.
    */
   setLabel(label: string | null | undefined): void;
-
-  /**
-   * ID attribute value set on the label element.
-   */
-  labelId: string;
 }

--- a/packages/field-base/src/slot-target-controller.d.ts
+++ b/packages/field-base/src/slot-target-controller.d.ts
@@ -6,14 +6,6 @@
 import { ReactiveController } from 'lit';
 
 export class SlotTargetController implements ReactiveController {
-  constructor(
-    sourceSlot: HTMLSlotElement,
-    targetFactory: () => HTMLElement,
-    copyCallback?: (nodes: HTMLElement[]) => void,
-  );
-
-  hostConnected(): void;
-
   /**
    * The source `<slot>` element to copy nodes from.
    */
@@ -28,4 +20,12 @@ export class SlotTargetController implements ReactiveController {
    * Function called after copying nodes to target.
    */
   protected copyCallback?: (nodes: HTMLElement[]) => void;
+
+  constructor(
+    sourceSlot: HTMLSlotElement,
+    targetFactory: () => HTMLElement,
+    copyCallback?: (nodes: HTMLElement[]) => void,
+  );
+
+  hostConnected(): void;
 }

--- a/packages/field-highlighter/src/vaadin-field-highlighter.d.ts
+++ b/packages/field-highlighter/src/vaadin-field-highlighter.d.ts
@@ -20,8 +20,6 @@ export interface FieldHighlighterUser {
  * See https://vaadin.com/collaboration for Collaboration Engine documentation.
  */
 declare class FieldHighlighterController implements ReactiveController {
-  constructor(host: HTMLElement);
-
   /**
    * The controller host element.
    */
@@ -46,6 +44,8 @@ declare class FieldHighlighterController implements ReactiveController {
    * A list of users who have focused the field.
    */
   users: FieldHighlighterUser[];
+
+  constructor(host: HTMLElement);
 
   hostConnected(): void;
 

--- a/packages/item/src/vaadin-item-mixin.d.ts
+++ b/packages/item/src/vaadin-item-mixin.d.ts
@@ -25,14 +25,14 @@ export declare class ItemMixinClass {
   value: string;
 
   /**
+   * If true, the item is in selected state.
+   */
+  selected: boolean;
+
+  /**
    * Used for mixin detection because `instanceof` does not work with mixins.
    * e.g. in VaadinListMixin it filters items by using the
    * `element._hasVaadinItemMixin` condition.
    */
   protected _hasVaadinItemMixin: boolean;
-
-  /**
-   * If true, the item is in selected state.
-   */
-  selected: boolean;
 }

--- a/packages/lit-renderer/src/lit-renderer.d.ts
+++ b/packages/lit-renderer/src/lit-renderer.d.ts
@@ -15,11 +15,11 @@ export abstract class LitRendererDirective<E extends Element, R extends LitRende
 
   protected renderer: R;
 
-  protected renderRenderer(container: Element, ...args: Parameters<R>): void;
-
   render(_renderer: R, _value?: unknown): typeof nothing;
 
   update(_part: ElementPart, props: [R, unknown]): typeof nothing;
+
+  protected renderRenderer(container: Element, ...args: Parameters<R>): void;
 
   /**
    * Adds the renderer callback to the element.

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -135,12 +135,6 @@ declare class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(Eleme
    */
   i18n: MenuBarI18n;
 
-  /**
-   * A callback for the `_theme` property observer.
-   * It propagates the host theme to the buttons and the sub menu.
-   */
-  protected _themeChanged(theme: string | null): void;
-
   addEventListener<K extends keyof MenuBarEventMap>(
     type: K,
     listener: (this: MenuBar, ev: MenuBarEventMap[K]) => void,
@@ -152,6 +146,12 @@ declare class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(Eleme
     listener: (this: MenuBar, ev: MenuBarEventMap[K]) => void,
     options?: boolean | EventListenerOptions,
   ): void;
+
+  /**
+   * A callback for the `_theme` property observer.
+   * It propagates the host theme to the buttons and the sub menu.
+   */
+  protected _themeChanged(theme: string | null): void;
 }
 
 declare global {

--- a/packages/notification/src/vaadin-notification.d.ts
+++ b/packages/notification/src/vaadin-notification.d.ts
@@ -101,6 +101,29 @@ declare class NotificationCard extends ThemableMixin(HTMLElement) {}
  */
 declare class Notification extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   /**
+   * Shows a notification with the given content.
+   * By default, positions the notification at `bottom-start` and uses a 5 second duration.
+   * An options object can be passed to configure the notification.
+   * The options object has the following structure:
+   *
+   * ```
+   * {
+   *   position?: string
+   *   duration?: number
+   *   theme?: string
+   * }
+   * ```
+   *
+   * See the individual documentation for:
+   * - [`position`](#/elements/vaadin-notification#property-position)
+   * - [`duration`](#/elements/vaadin-notification#property-duration)
+   *
+   * @param contents the contents to show, either as a string or a Lit template.
+   * @param options optional options for customizing the notification.
+   */
+  static show(contents: string | TemplateResult, options?: ShowOptions): Notification;
+
+  /**
    * The duration in milliseconds to show the notification.
    * Set to `0` or a negative number to disable the notification auto-closing.
    */
@@ -156,29 +179,6 @@ declare class Notification extends ThemePropertyMixin(ElementMixin(HTMLElement))
     listener: (this: Notification, ev: NotificationEventMap[K]) => void,
     options?: boolean | EventListenerOptions,
   ): void;
-
-  /**
-   * Shows a notification with the given content.
-   * By default, positions the notification at `bottom-start` and uses a 5 second duration.
-   * An options object can be passed to configure the notification.
-   * The options object has the following structure:
-   *
-   * ```
-   * {
-   *   position?: string
-   *   duration?: number
-   *   theme?: string
-   * }
-   * ```
-   *
-   * See the individual documentation for:
-   * - [`position`](#/elements/vaadin-notification#property-position)
-   * - [`duration`](#/elements/vaadin-notification#property-duration)
-   *
-   * @param contents the contents to show, either as a string or a Lit template.
-   * @param options optional options for customizing the notification.
-   */
-  static show(contents: string | TemplateResult, options?: ShowOptions): Notification;
 }
 
 declare global {

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -16,10 +16,10 @@ export interface TimePickerTime {
 }
 
 export interface TimePickerI18n {
-  parseTime(time: string): TimePickerTime | undefined;
-  formatTime(time: TimePickerTime | undefined): string;
   clear: string;
   selector: string;
+  parseTime(time: string): TimePickerTime | undefined;
+  formatTime(time: TimePickerTime | undefined): string;
 }
 
 /**

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.d.ts
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.d.ts
@@ -11,10 +11,6 @@ import { Constructor } from '@open-wc/dedupe-mixin';
 export declare function ListMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ListMixinClass>;
 
 export declare class ListMixinClass {
-  protected readonly focused: Element | null;
-
-  protected readonly _scrollerElement: HTMLElement;
-
   /**
    * Used for mixin detection because `instanceof` does not work with mixins.
    */
@@ -45,4 +41,8 @@ export declare class ListMixinClass {
    * you have to use `dom-repeat` and place it to the light DOM.
    */
   readonly items: Element[] | undefined;
+
+  protected readonly focused: Element | null;
+
+  protected readonly _scrollerElement: HTMLElement;
 }

--- a/packages/virtual-list/src/vaadin-virtual-list.d.ts
+++ b/packages/virtual-list/src/vaadin-virtual-list.d.ts
@@ -42,6 +42,16 @@ export type VirtualListRenderer<TItem> = (
  */
 declare class VirtualList<TItem = VirtualListDefaultItem> extends ElementMixin(ThemableMixin(HTMLElement)) {
   /**
+   * Gets the index of the first visible item in the viewport.
+   */
+  readonly firstVisibleIndex: number;
+
+  /**
+   * Gets the index of the last visible item in the viewport.
+   */
+  readonly lastVisibleIndex: number;
+
+  /**
    * Custom function for rendering the content of every item.
    * Receives three arguments:
    *
@@ -63,16 +73,6 @@ declare class VirtualList<TItem = VirtualListDefaultItem> extends ElementMixin(T
    * Scroll to a specific index in the virtual list.
    */
   scrollToIndex(index: number): void;
-
-  /**
-   * Gets the index of the first visible item in the viewport.
-   */
-  readonly firstVisibleIndex: number;
-
-  /**
-   * Gets the index of the last visible item in the viewport.
-   */
-  readonly lastVisibleIndex: number;
 
   /**
    * Requests an update for the content of the rows.


### PR DESCRIPTION
## Description

The PR adds the following rules to the project's ESLint config:

- [x] @typescript-eslint/prefer-function-type _(no errors)_
- [x] @typescript-eslint/member-ordering

I guess it would make sense to back-port this PR to earlier versions to keep automatic cherry-picks working.

Part of https://github.com/vaadin/eslint-config-vaadin/issues/16

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
