### PR TITLE
fix: make Tab navigation work inside a dialog

### DIFF
--- a/integration/tests/dialog-date-picker.test.js
+++ b/integration/tests/dialog-date-picker.test.js
@@ -27,23 +27,22 @@ describe('date-picker in dialog', () => {
   });
 
   describe('modal', () => {
-    let overlayContent;
-
     beforeEach(async () => {
       datepicker.inputElement.focus();
       await open(datepicker);
       await nextRender();
-      overlayContent = getOverlayContent(datepicker);
     });
 
     it('should focus the Today button on second Tab when inside a dialog', async () => {
       // Focus the month calendar
       await sendKeys({ press: 'Tab' });
 
+      await nextRender();
+
       // Focus the Today button
       await sendKeys({ press: 'Tab' });
 
-      expect(overlayContent.$.todayButton.hasAttribute('focused')).to.be.true;
+      expect(getOverlayContent(datepicker).$.todayButton.hasAttribute('focused')).to.be.true;
     });
 
     it('should focus the Cancel button on Shift + Tab when inside a dialog', async () => {
@@ -52,12 +51,14 @@ describe('date-picker in dialog', () => {
       await sendKeys({ press: 'Tab' });
       await sendKeys({ up: 'Shift' });
 
-      expect(overlayContent.$.cancelButton.hasAttribute('focused')).to.be.true;
+      expect(getOverlayContent(datepicker).$.cancelButton.hasAttribute('focused')).to.be.true;
     });
 
     it('should focus the input on calendar date Shift Tab when inside a dialog', async () => {
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
+
+      await nextRender();
 
       const spy = sinon.spy(datepicker.inputElement, 'focus');
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -982,6 +982,7 @@ export const DatePickerMixin = (subclass) =>
         case 'Tab':
           if (this.opened) {
             e.preventDefault();
+            e.stopPropagation();
             // Clear the selection range (remains visible on IE)
             this._setSelectionRange(0, 0);
             if (e.shiftKey) {

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -755,6 +755,9 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
         this._moveFocusByMonths(event.shiftKey ? -12 : -1);
         handled = true;
         break;
+      case 'Tab':
+        this._onTabKeyDown(event, 'calendar');
+        break;
       default:
         break;
     }
@@ -762,6 +765,38 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     if (handled) {
       event.preventDefault();
       event.stopPropagation();
+    }
+  }
+
+  _onTabKeyDown(event, section) {
+    // Stop propagation to avoid focus-trap
+    // listener when used in a modal dialog.
+    event.stopPropagation();
+
+    switch (section) {
+      case 'calendar':
+        if (event.shiftKey) {
+          // Return focus back to the input field.
+          event.preventDefault();
+          this.__focusInput();
+        }
+        break;
+      case 'today':
+        if (event.shiftKey) {
+          // Browser returns focus back to the calendar.
+          // We need to move the scroll to focused date.
+          setTimeout(() => this.revealDate(this.focusedDate), 1);
+        }
+        break;
+      case 'cancel':
+        if (!event.shiftKey) {
+          // Return focus back to the input field.
+          event.preventDefault();
+          this.__focusInput();
+        }
+        break;
+      default:
+        break;
     }
   }
 
@@ -774,12 +809,8 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
       return;
     }
 
-    if (event.key === 'Tab' && event.shiftKey) {
-      event.stopPropagation();
-
-      // Browser returns focus back to the calendar.
-      // We need to move the scroll to focused date.
-      setTimeout(() => this.revealDate(this.focusedDate), 1);
+    if (event.key === 'Tab') {
+      this._onTabKeyDown(event, 'today');
     }
   }
 
@@ -792,12 +823,13 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
       return;
     }
 
-    if (event.key === 'Tab' && !event.shiftKey) {
-      // Return focus back to the input field
-      event.preventDefault();
-      event.stopPropagation();
-      this.dispatchEvent(new CustomEvent('focus-input', { bubbles: true, composed: true }));
+    if (event.key === 'Tab') {
+      this._onTabKeyDown(event, 'cancel');
     }
+  }
+
+  __focusInput() {
+    this.dispatchEvent(new CustomEvent('focus-input', { bubbles: true, composed: true }));
   }
 
   __tryFocusDate() {

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -270,6 +270,21 @@ describe('keyboard', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
+    it('should move focus back to the input on calendar date Shift Tab', async () => {
+      // Move focus to the calendar
+      await sendKeys({ press: 'Tab' });
+
+      await nextRender();
+
+      const spy = sinon.spy(input, 'focus');
+
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+
+      expect(spy.calledOnce).to.be.true;
+    });
+
     it('should move focus to the input on Cancel button Tab', async () => {
       overlayContent.$.cancelButton.focus();
       const spy = sinon.spy(input, 'focus');

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -114,7 +114,7 @@ describe('keyboard', () => {
       input.select();
       await sendKeys({ press: 'Backspace' });
       const spy = sinon.spy(datepicker, 'validate');
-      await sendKeys({ press: 'Tab' });
+      input.blur();
       expect(spy.callCount).to.equal(1);
       expect(datepicker.invalid).to.be.false;
     });


### PR DESCRIPTION
## Description

Added back logic related to calling `event.stopPropagation()` for <kbd>Tab</kbd> that was present in Vaadin 22.

Fixes #3881

## Type of change

- Bugfix