### PR TITLE
fix: update incorrect fullscreen mode focus logic

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -505,7 +505,7 @@ export const DatePickerMixin = (subclass) =>
       });
 
       // Keep focus attribute in focusElement for styling
-      this._overlayContent.addEventListener('focus', () => {
+      this._overlayContent.addEventListener('focusin', () => {
         this._setFocused(true);
       });
 
@@ -774,6 +774,7 @@ export const DatePickerMixin = (subclass) =>
 
       if (this._noInput && this.focusElement) {
         this.focusElement.blur();
+        this._overlayContent.focusDateElement();
       }
     }
 
@@ -860,11 +861,7 @@ export const DatePickerMixin = (subclass) =>
 
     /** @protected */
     _focus() {
-      if (this._noInput) {
-        if (this._overlayInitialized) {
-          this._overlayContent.focus();
-        }
-      } else {
+      if (!this._noInput) {
         this.inputElement.focus();
       }
     }

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -4,7 +4,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import * as settings from '@polymer/polymer/lib/utils/settings.js';
-import { close, getFocusedCell, getOverlayContent, monthsEqual, open } from './common.js';
+import { close, getFocusedCell, getOverlayContent, monthsEqual, open, waitForScrollToFinish } from './common.js';
 
 settings.setCancelSyntheticClickEvents(false);
 
@@ -88,8 +88,8 @@ describe('basic features', () => {
   it('should focus date element when focused on fullscreen', async () => {
     datepicker._fullscreen = true;
     await open(datepicker);
-    await nextRender();
     const content = getOverlayContent(datepicker);
+    await waitForScrollToFinish(content);
     const cell = getFocusedCell(content);
     expect(isFocused(cell)).to.be.true;
   });

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -87,6 +87,7 @@ describe('basic features', () => {
 
   it('should set focused attribute when focused on fullscreen', async () => {
     datepicker._fullscreen = true;
+    datepicker.focus();
     await open(datepicker);
     await nextRender();
     expect(datepicker.hasAttribute('focused')).to.be.true;

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, click, fixtureSync, makeSoloTouchEvent, oneEvent, tap } from '@vaadin/testing-helpers';
+import { aTimeout, click, fixtureSync, makeSoloTouchEvent, nextRender, oneEvent, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import * as settings from '@polymer/polymer/lib/utils/settings.js';
-import { close, getOverlayContent, monthsEqual, open } from './common.js';
+import { close, getFocusedCell, getOverlayContent, monthsEqual, open } from './common.js';
 
 settings.setCancelSyntheticClickEvents(false);
 
@@ -82,6 +82,22 @@ describe('basic features', () => {
     datepicker.focus();
     await sendKeys({ press: 'ArrowDown' });
     await sendKeys({ press: 'Escape' });
+    expect(datepicker.hasAttribute('focused')).to.be.true;
+  });
+
+  it('should focus date element when focused on fullscreen', async () => {
+    datepicker._fullscreen = true;
+    await open(datepicker);
+    await nextRender();
+    const content = getOverlayContent(datepicker);
+    const cell = getFocusedCell(content);
+    expect(isFocused(cell)).to.be.true;
+  });
+
+  it('should set focused attribute when focused on fullscreen', async () => {
+    datepicker._fullscreen = true;
+    await open(datepicker);
+    await nextRender();
     expect(datepicker.hasAttribute('focused')).to.be.true;
   });
 

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -4,7 +4,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import * as settings from '@polymer/polymer/lib/utils/settings.js';
-import { close, getFocusedCell, getOverlayContent, monthsEqual, open, waitForScrollToFinish } from './common.js';
+import { close, getOverlayContent, monthsEqual, open } from './common.js';
 
 settings.setCancelSyntheticClickEvents(false);
 
@@ -83,15 +83,6 @@ describe('basic features', () => {
     await sendKeys({ press: 'ArrowDown' });
     await sendKeys({ press: 'Escape' });
     expect(datepicker.hasAttribute('focused')).to.be.true;
-  });
-
-  it('should focus date element when focused on fullscreen', async () => {
-    datepicker._fullscreen = true;
-    await open(datepicker);
-    const content = getOverlayContent(datepicker);
-    await waitForScrollToFinish(content);
-    const cell = getFocusedCell(content);
-    expect(isFocused(cell)).to.be.true;
   });
 
   it('should set focused attribute when focused on fullscreen', async () => {


### PR DESCRIPTION
## Description

This PR updates the "fullscreen" mode logic that is no longer relevant after #3372 was implemented.

The `overlayContent` element itself can't be focused now, so calling `.focus()` does nothing and `focus` event does not work anymore. I missed to address this in the original PR so this was unnoticed until today 😕 

## Type of change

- Refactor