### PR TITLE
chore: improve integration tests section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ yarn update:lumo --group vaadin-upload
 
 ### Integration tests
 
-Run integration tests in the separate `integration` folder:
+Run integration tests that are in the separate `integration` folder:
 
 ```sh
 yarn test:it


### PR DESCRIPTION
## Description

The previous wording in the "Integration Tests" section was a bit confusing as it could be interpreted as you need to run `yarn test:it` in the `integrations` folder which is not right. All the commands should be run in the root directory.

## Type of change

- [x] Internal
