### PR TITLE
test: do not tweak infinite scroller buffers

### DIFF
--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -104,10 +104,7 @@ export function getOverlayContent(datepicker) {
     datepicker.open();
     datepicker.close();
   }
-  const overlayContent = datepicker.$.overlay.content.querySelector('#overlay-content');
-  overlayContent.$.monthScroller.bufferSize = 0;
-  overlayContent.$.yearScroller.bufferSize = 0;
-  return overlayContent;
+  return datepicker.$.overlay.content.querySelector('#overlay-content');
 }
 
 export function getFocusedMonth(overlayContent) {


### PR DESCRIPTION
## Description

For some reason, the logic in `getOverlayContent` helper updates buffer size for internal infinite scrollers.
This causes problems in particular when using `sendKeys({ press: 'Tab' })` to focus month calendar.

An example of such a test can be seen in #3910 - it passes in CI but fails locally in Chrome:

https://user-images.githubusercontent.com/10589913/169849752-119d0a90-b5e4-4482-8254-f3067afe1fa5.mp4

It's not fully clear to me why the problem happens, but at least `scroller._debouncerUpdateClones` looks suspicious.
After removing this logic, it seems like the problem with tests that use `sendKeys` no longer happens.

## Type of change

- Internal change