### PR TITLE
fix: do not stop propagation of Esc when fullscreen

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -767,7 +767,10 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
   __onTodayButtonKeyDown(event) {
     if (this.hasAttribute('fullscreen')) {
-      event.stopPropagation();
+      // Do not prevent closing on Esc
+      if (event.key !== 'Escape') {
+        event.stopPropagation();
+      }
       return;
     }
 
@@ -782,7 +785,10 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
   __onCancelButtonKeyDown(event) {
     if (this.hasAttribute('fullscreen')) {
-      event.stopPropagation();
+      // Do not prevent closing on Esc
+      if (event.key !== 'Escape') {
+        event.stopPropagation();
+      }
       return;
     }
 

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -93,6 +93,13 @@ describe('basic features', () => {
     expect(datepicker.hasAttribute('focused')).to.be.true;
   });
 
+  it('should close the dropdown on Esc when on fullscreen', async () => {
+    datepicker._fullscreen = true;
+    datepicker.click();
+    await sendKeys({ press: 'Escape' });
+    expect(datepicker.opened).to.be.false;
+  });
+
   it('should remove focused attribute when closed and not focused', async () => {
     datepicker._fullscreen = true;
     datepicker.click();

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -227,31 +227,31 @@ describe('basic features', () => {
       datepicker._fullscreen = true;
     });
 
-    it('should blur when focused on fullscreen', () => {
+    it('should blur when focused', () => {
       const spy = sinon.spy(input, 'blur');
       input.dispatchEvent(new CustomEvent('focus'));
 
       expect(spy.called).to.be.true;
     });
 
-    it('should blur the input on fullscreen', () => {
+    it('should blur the input', () => {
       datepicker.focus();
       expect(isFocused(input)).to.be.false;
     });
 
-    it('should not focus the input on touch tap on fullscreen', () => {
+    it('should not focus the input on touch tap', () => {
       touchTap(input);
       expect(isFocused(input)).to.be.false;
     });
 
-    it('should set focused attribute when focused on fullscreen', async () => {
+    it('should set focused attribute when focused', async () => {
       datepicker.focus();
       await open(datepicker);
       await nextRender();
       expect(datepicker.hasAttribute('focused')).to.be.true;
     });
 
-    it('should close the dropdown on Today button Esc on fullscreen', async () => {
+    it('should close the dropdown on Today button Esc', async () => {
       await open(datepicker);
       await nextRender();
 
@@ -261,7 +261,7 @@ describe('basic features', () => {
       expect(datepicker.opened).to.be.false;
     });
 
-    it('should close the dropdown on Cancel button Esc on fullscreen', async () => {
+    it('should close the dropdown on Cancel button Esc', async () => {
       await open(datepicker);
       await nextRender();
 
@@ -281,7 +281,7 @@ describe('basic features', () => {
       expect(datepicker.hasAttribute('focused')).to.be.false;
     });
 
-    it('should blur when datepicker is opened on fullscreen', async () => {
+    it('should blur when datepicker is opened', async () => {
       const spy = sinon.spy(input, 'blur');
       await open(datepicker);
       expect(spy.called).to.be.true;

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -56,15 +56,6 @@ describe('basic features', () => {
     expect(spy.calledOnce).to.be.true;
   });
 
-  it('should blur when focused on fullscreen', () => {
-    datepicker._fullscreen = true;
-
-    const spy = sinon.spy(input, 'blur');
-    input.dispatchEvent(new CustomEvent('focus'));
-
-    expect(spy.called).to.be.true;
-  });
-
   it('should keep focused attribute when focus moves to overlay', async () => {
     datepicker.focus();
     await sendKeys({ press: 'ArrowDown' });
@@ -83,35 +74,6 @@ describe('basic features', () => {
     await sendKeys({ press: 'ArrowDown' });
     await sendKeys({ press: 'Escape' });
     expect(datepicker.hasAttribute('focused')).to.be.true;
-  });
-
-  it('should set focused attribute when focused on fullscreen', async () => {
-    datepicker._fullscreen = true;
-    datepicker.focus();
-    await open(datepicker);
-    await nextRender();
-    expect(datepicker.hasAttribute('focused')).to.be.true;
-  });
-
-  it('should close the dropdown on Esc when on fullscreen', async () => {
-    datepicker._fullscreen = true;
-    datepicker.click();
-    await sendKeys({ press: 'Escape' });
-    expect(datepicker.opened).to.be.false;
-  });
-
-  it('should remove focused attribute when closed and not focused', async () => {
-    datepicker._fullscreen = true;
-    datepicker.click();
-    await sendKeys({ press: 'Escape' });
-    expect(datepicker.hasAttribute('focused')).to.be.false;
-  });
-
-  it('should blur when datepicker is opened on fullscreen', async () => {
-    datepicker._fullscreen = true;
-    const spy = sinon.spy(input, 'blur');
-    await open(datepicker);
-    expect(spy.called).to.be.true;
   });
 
   it('should notify opened changed on open and close', async () => {
@@ -137,18 +99,6 @@ describe('basic features', () => {
   it('should focus the input on touch tap', () => {
     touchTap(input);
     expect(isFocused(input)).to.be.true;
-  });
-
-  it('should not focus the input on touch tap on fullscreen', () => {
-    datepicker._fullscreen = true;
-    touchTap(input);
-    expect(isFocused(input)).to.be.false;
-  });
-
-  it('should blur the input on fullscreen', () => {
-    datepicker._fullscreen = true;
-    datepicker.focus();
-    expect(isFocused(input)).to.be.false;
   });
 
   it('should pass the placeholder attribute to the input tag', () => {
@@ -270,6 +220,72 @@ describe('basic features', () => {
   it('should set has-value attribute when value is set', () => {
     datepicker.value = '2000-02-01';
     expect(datepicker.hasAttribute('has-value')).to.be.true;
+  });
+
+  describe('fullscreen', () => {
+    beforeEach(() => {
+      datepicker._fullscreen = true;
+    });
+
+    it('should blur when focused on fullscreen', () => {
+      const spy = sinon.spy(input, 'blur');
+      input.dispatchEvent(new CustomEvent('focus'));
+
+      expect(spy.called).to.be.true;
+    });
+
+    it('should blur the input on fullscreen', () => {
+      datepicker.focus();
+      expect(isFocused(input)).to.be.false;
+    });
+
+    it('should not focus the input on touch tap on fullscreen', () => {
+      touchTap(input);
+      expect(isFocused(input)).to.be.false;
+    });
+
+    it('should set focused attribute when focused on fullscreen', async () => {
+      datepicker.focus();
+      await open(datepicker);
+      await nextRender();
+      expect(datepicker.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should close the dropdown on Today button Esc on fullscreen', async () => {
+      await open(datepicker);
+      await nextRender();
+
+      getOverlayContent(datepicker).$.todayButton.focus();
+      await sendKeys({ press: 'Escape' });
+
+      expect(datepicker.opened).to.be.false;
+    });
+
+    it('should close the dropdown on Cancel button Esc on fullscreen', async () => {
+      await open(datepicker);
+      await nextRender();
+
+      getOverlayContent(datepicker).$.cancelButton.focus();
+      await sendKeys({ press: 'Escape' });
+
+      expect(datepicker.opened).to.be.false;
+    });
+
+    it('should remove focused attribute when closed and not focused', async () => {
+      await open(datepicker);
+      await nextRender();
+
+      getOverlayContent(datepicker).$.todayButton.focus();
+      await sendKeys({ press: 'Escape' });
+
+      expect(datepicker.hasAttribute('focused')).to.be.false;
+    });
+
+    it('should blur when datepicker is opened on fullscreen', async () => {
+      const spy = sinon.spy(input, 'blur');
+      await open(datepicker);
+      expect(spy.called).to.be.true;
+    });
   });
 
   describe('value property formats', () => {


### PR DESCRIPTION
## Description

This is a fix for a regression introduced in #3872 which made it not possible to close date-picker on <kbd>Esc</kbd> when in fullscreen mode. Note, this logic can be probably removed in the future as part of #3918

## Type of change

- Bugfix