### PR TITLE
fix: close all menus when pressing Tab

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -328,7 +328,7 @@ export const ItemsMixin = (superClass) =>
           if ((!isRTL && e.keyCode === 37) || (isRTL && e.keyCode === 39)) {
             menu.close();
             menu.listenOn.focus();
-          } else if (e.keyCode === 27) {
+          } else if (e.key === 'Escape' || e.key === 'Tab') {
             menu.dispatchEvent(new CustomEvent('close-all-menus'));
           }
         });

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -11,6 +11,7 @@ import {
   nextFrame,
   nextRender,
   spaceKeyDown,
+  tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
@@ -284,6 +285,11 @@ describe('items', () => {
 
     it('should close all menus on esc', () => {
       escKeyDown(menuComponents(subMenu)[0]);
+      expect(rootMenu.opened).to.be.false;
+    });
+
+    it('should close all menus on Tab', () => {
+      tabKeyDown(menuComponents(subMenu)[0]);
       expect(rootMenu.opened).to.be.false;
     });
 


### PR DESCRIPTION
## Description

Aligned `vaadin-context-menu` behavior with `vaadin-select` that has logic to close on overlay <kbd>Tab</kbd>:

https://github.com/vaadin/web-components/blob/e2d1c472aa0c5a58738cdc896fa97c6548b111e0/packages/select/src/vaadin-select.js#L520-L522

Here is a video illustrating how the context-menu closes and moves focus to the `<vaadin-button>` on <kbd>Tab</kbd>:

https://user-images.githubusercontent.com/10589913/170043037-8991151a-ed85-4f34-b827-affa02ba2dd6.mp4

Fixes https://github.com/vaadin/flow-components/issues/3221

## Type of change

- Bugfix