### PR TITLE
fix: initialize date-picker-light overlay properly

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -126,6 +126,13 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
   }
 
   /** @protected */
+  ready() {
+    super.ready();
+
+    this._initOverlay();
+  }
+
+  /** @protected */
   connectedCallback() {
     super.connectedCallback();
     const cssSelector = 'vaadin-text-field,iron-input,paper-input,.paper-input-input,.input';

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -473,7 +473,7 @@ export const DatePickerMixin = (subclass) =>
       }
     }
 
-    /** @private */
+    /** @protected */
     _initOverlay() {
       this.$.overlay.removeAttribute('disable-upgrade');
       this._overlayInitialized = true;
@@ -508,8 +508,6 @@ export const DatePickerMixin = (subclass) =>
       this._overlayContent.addEventListener('focusin', () => {
         this._setFocused(true);
       });
-
-      this.$.overlay.addEventListener('vaadin-overlay-close', this._onVaadinOverlayClose.bind(this));
 
       this.addEventListener('mousedown', () => this.__bringToFront());
       this.addEventListener('touchstart', () => this.__bringToFront());

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -212,6 +212,13 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
     toggleButton.addEventListener('mousedown', (e) => e.preventDefault());
   }
 
+  /** @protected */
+  _initOverlay() {
+    super._initOverlay();
+
+    this.$.overlay.addEventListener('vaadin-overlay-close', this._onVaadinOverlayClose.bind(this));
+  }
+
   /** @private */
   _onVaadinOverlayClose(e) {
     if (this._openedWithFocusRing && this.hasAttribute('focused')) {

--- a/packages/date-picker/test/custom-input.test.js
+++ b/packages/date-picker/test/custom-input.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, nextRender, tap } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker-light.js';
 import { getOverlayContent, open, waitForScrollToFinish } from './common.js';
@@ -33,6 +34,14 @@ describe('custom input', () => {
     input.value = '1';
     fire(input, 'input');
     expect(overlay.opened).not.to.be.true;
+  });
+
+  it('should close on overlay date tap', async () => {
+    datepicker.open();
+    const spy = sinon.spy(datepicker, 'close');
+    const evt = new CustomEvent('date-tap', { detail: { date: new Date() }, bubbles: true, composed: true });
+    getOverlayContent(datepicker).dispatchEvent(evt);
+    expect(spy.called).to.be.true;
   });
 
   it('should show week numbers', () => {


### PR DESCRIPTION
## Description

The `vaadin-date-picker-light` is currently quite broken because the `_initOverlay()` does not get called for it.

This is due to the fact that we set `_overlayInitialized` to `true` so the logic in the observer is not executed - see the original issue for an explanation. I also had to update the method `_initOverlay()` for now to make it protected.

Note, this is supposed to be eventually changed in #3904 after we remove the usage of `disable-upgrade` hack.
However, that change affects the DOM structure so it will be only available in the next minor (Vaadin 23.2).

Fixes #3746

## Type of change

- Bugfix