### PR TITLE
fix: don't use public class field syntax in Lit renderer directives

### DIFF
--- a/packages/dialog/src/lit/renderer-directives.js
+++ b/packages/dialog/src/lit/renderer-directives.js
@@ -17,7 +17,9 @@ class AbstractDialogRendererDirective extends LitRendererDirective {
    *
    * @abstract
    */
-  rendererProperty;
+  get rendererProperty() {
+    throw new Error('The `rendererProperty` getter must be implemented.');
+  }
 
   /**
    * Adds the renderer callback to the dialog.
@@ -51,15 +53,21 @@ class AbstractDialogRendererDirective extends LitRendererDirective {
 }
 
 export class DialogRendererDirective extends AbstractDialogRendererDirective {
-  rendererProperty = 'renderer';
+  get rendererProperty() {
+    return 'renderer';
+  }
 }
 
 export class DialogHeaderRendererDirective extends AbstractDialogRendererDirective {
-  rendererProperty = 'headerRenderer';
+  get rendererProperty() {
+    return 'headerRenderer';
+  }
 }
 
 export class DialogFooterRendererDirective extends AbstractDialogRendererDirective {
-  rendererProperty = 'footerRenderer';
+  get rendererProperty() {
+    return 'footerRenderer';
+  }
 }
 
 /**

--- a/packages/grid/src/lit/column-renderer-directives.js
+++ b/packages/grid/src/lit/column-renderer-directives.js
@@ -16,7 +16,9 @@ class AbstractGridColumnRendererDirective extends LitRendererDirective {
    *
    * @abstract
    */
-  rendererProperty;
+  get rendererProperty() {
+    throw new Error('The `rendererProperty` getter must be implemented.');
+  }
 
   /**
    * Adds the renderer callback to the grid column.
@@ -47,7 +49,9 @@ class AbstractGridColumnRendererDirective extends LitRendererDirective {
 }
 
 export class GridColumnBodyRendererDirective extends AbstractGridColumnRendererDirective {
-  rendererProperty = 'renderer';
+  get rendererProperty() {
+    return 'renderer';
+  }
 
   addRenderer() {
     this.element[this.rendererProperty] = (root, column, model) => {
@@ -57,11 +61,15 @@ export class GridColumnBodyRendererDirective extends AbstractGridColumnRendererD
 }
 
 export class GridColumnHeaderRendererDirective extends AbstractGridColumnRendererDirective {
-  rendererProperty = 'headerRenderer';
+  get rendererProperty() {
+    return 'headerRenderer';
+  }
 }
 
 export class GridColumnFooterRendererDirective extends AbstractGridColumnRendererDirective {
-  rendererProperty = 'footerRenderer';
+  get rendererProperty() {
+    return 'footerRenderer';
+  }
 }
 
 /**

--- a/packages/lit-renderer/src/lit-renderer.js
+++ b/packages/lit-renderer/src/lit-renderer.js
@@ -11,14 +11,14 @@ import { PartType } from 'lit/directive.js';
 const VALUE_NOT_INITIALIZED = Symbol('valueNotInitialized');
 
 export class LitRendererDirective extends AsyncDirective {
-  /** @protected */
-  previousValue = VALUE_NOT_INITIALIZED;
-
   constructor(part) {
     super(part);
+
     if (part.type !== PartType.ELEMENT) {
       throw new Error(`\`${this.constructor.name}\` must be bound to an element.`);
     }
+
+    this.previousValue = VALUE_NOT_INITIALIZED;
   }
 
   /** @override */


### PR DESCRIPTION
## Description

The PR replaces public class field syntax with getters for Lit renderer directives because the Flow Webpack config turned out not to support that syntax at the moment:

```
ERROR in ../node_modules/@vaadin/lit-renderer/src/lit-renderer.js 15:16
Module parse failed: Unexpected token (15:16)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| export class LitRendererDirective extends AsyncDirective {
|   /** @protected */
>   previousValue = VALUE_NOT_INITIALIZED;
| 
|   constructor(part) {
```

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
