### PR TITLE
refactor: add default values for item properties

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -750,7 +750,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     chip.disabled = this.disabled;
     chip.readonly = this.readonly;
 
-    const label = this._getItemLabel(item, this.itemLabelPath);
+    const label = this._getItemLabel(item);
     chip.label = label;
     chip.setAttribute('title', label);
 
@@ -953,7 +953,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       // Announce focused chip
       if (focusedIndex > -1) {
         const item = chips[focusedIndex].item;
-        const itemLabel = this._getItemLabel(item, this.itemLabelPath);
+        const itemLabel = this._getItemLabel(item);
         announce(`${itemLabel} ${this.i18n.focused}`);
       }
     }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -239,6 +239,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       itemLabelPath: {
         type: String,
+        value: 'label',
       },
 
       /**
@@ -248,6 +249,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       itemValuePath: {
         type: String,
+        value: 'value',
       },
 
       /**
@@ -602,7 +604,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     // Use placeholder for announcing items
     if (this._hasValue) {
-      const tmpPlaceholder = selectedItems.map((item) => this._getItemLabel(item, this.itemLabelPath)).join(', ');
+      const tmpPlaceholder = this._mergeItemLabels(selectedItems);
       this.__tmpA11yPlaceholder = tmpPlaceholder;
       this.placeholder = tmpPlaceholder;
     } else {
@@ -627,8 +629,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /** @private */
-  _getItemLabel(item, itemLabelPath) {
-    return item && Object.prototype.hasOwnProperty.call(item, itemLabelPath) ? item[itemLabelPath] : item;
+  _getItemLabel(item) {
+    return item && Object.prototype.hasOwnProperty.call(item, this.itemLabelPath) ? item[this.itemLabelPath] : item;
   }
 
   /** @private */
@@ -651,12 +653,17 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   /** @private */
   _getOverflowTitle(items) {
-    return items.map((item) => this._getItemLabel(item, this.itemLabelPath)).join(', ');
+    return this._mergeItemLabels(items);
   }
 
   /** @private */
   _isOverflowHidden(length) {
     return length === 0;
+  }
+
+  /** @private */
+  _mergeItemLabels(items) {
+    return items.map((item) => this._getItemLabel(item)).join(', ');
   }
 
   /** @private */
@@ -699,7 +706,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     const itemsCopy = [...this.selectedItems];
 
     const index = this._findIndex(item, itemsCopy, this.itemIdPath);
-    const itemLabel = this._getItemLabel(item, this.itemLabelPath);
+    const itemLabel = this._getItemLabel(item);
 
     let isSelected = false;
 

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -86,6 +86,24 @@ describe('basic', () => {
       comboBox.renderer = renderer;
       expect(internal.renderer).to.equal(renderer);
     });
+
+    it('should set itemLabelPath property by default', () => {
+      expect(comboBox.itemLabelPath).to.equal('label');
+    });
+
+    it('should propagate itemLabelPath property to combo-box', () => {
+      comboBox.itemLabelPath = 'title';
+      expect(internal.itemLabelPath).to.equal('title');
+    });
+
+    it('should set itemValuePath property by default', () => {
+      expect(comboBox.itemValuePath).to.equal('value');
+    });
+
+    it('should propagate itemValuePath property to combo-box', () => {
+      comboBox.itemValuePath = 'key';
+      expect(internal.itemValuePath).to.equal('key');
+    });
   });
 
   describe('selecting items', () => {


### PR DESCRIPTION
## Description

Added default values for `itemLabelPath` and `itemValuePath` to align with the regular combo-box.

## Type of change

- Refactor