### PR TITLE
chore: update JSDoc to mention correct mixin

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -107,7 +107,7 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixi
   }
 
   /**
-   * Used by `ClearButtonMixin` as a reference to the clear button element.
+   * Used by `InputControlMixin` as a reference to the clear button element.
    * @protected
    * @return {!HTMLElement}
    */

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -224,7 +224,7 @@ class ComboBox extends ComboBoxDataProviderMixin(
   }
 
   /**
-   * Used by `ClearButtonMixin` as a reference to the clear button element.
+   * Used by `InputControlMixin` as a reference to the clear button element.
    * @protected
    * @return {!HTMLElement}
    */
@@ -282,7 +282,7 @@ class ComboBox extends ComboBoxDataProviderMixin(
   }
 
   /**
-   * Override method inherited from `ClearButtonMixin` to handle clear
+   * Override method inherited from `InputControlMixin` to handle clear
    * button click and stop event from propagating to the host element.
    * @param {Event} event
    * @protected

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -336,7 +336,7 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /**
-     * Override a getter from `ClearButtonMixin` to make it optional
+     * Override a getter from `InputControlMixin` to make it optional
      * and to prevent warning when a clear button is missing,
      * for example when using <vaadin-date-picker-light>.
      * @protected
@@ -911,7 +911,7 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /**
-     * Override an event listener from `ClearButtonMixin`
+     * Override an event listener from `InputControlMixin`
      * to validate and dispatch change on clear.
      * @protected
      */

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -186,7 +186,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
   }
 
   /**
-   * Used by `ClearButtonMixin` as a reference to the clear button element.
+   * Used by `InputControlMixin` as a reference to the clear button element.
    * @protected
    * @return {!HTMLElement}
    */

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -179,7 +179,7 @@ export const InputFieldMixin = (superclass) =>
     }
 
     /**
-     * Override an event listener from `ClearButtonMixin`
+     * Override an event listener from `InputControlMixin`
      * to avoid adding a separate listener.
      * @param {!KeyboardEvent} event
      * @protected

--- a/packages/message-input/src/vaadin-message-input-text-area.js
+++ b/packages/message-input/src/vaadin-message-input-text-area.js
@@ -61,7 +61,7 @@ class MessageInputTextArea extends TextArea {
   }
 
   /**
-   * Override an event listener from `ClearButtonMixin`
+   * Override an event listener from `InputControlMixin`
    * to dispatch a custom event on Enter key.
    * @param {!KeyboardEvent} event
    * @protected

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -429,7 +429,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /**
-   * Used by `ClearButtonMixin` as a reference to the clear button element.
+   * Used by `InputControlMixin` as a reference to the clear button element.
    * @protected
    * @return {!HTMLElement}
    */
@@ -821,7 +821,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /**
-   * Override method inherited from `ClearButtonMixin` and clear items.
+   * Override method inherited from `InputControlMixin` and clear items.
    * @protected
    * @override
    */

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -205,7 +205,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
   }
 
   /**
-   * Used by `ClearButtonMixin` as a reference to the clear button element.
+   * Used by `InputControlMixin` as a reference to the clear button element.
    * @protected
    */
   get clearElement() {
@@ -440,7 +440,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
   }
 
   /**
-   * Override an event listener from `ClearButtonMixin`
+   * Override an event listener from `InputControlMixin`
    * to avoid adding a separate listener.
    * @param {!KeyboardEvent} event
    * @protected

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -194,7 +194,7 @@ export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableM
   }
 
   /**
-   * Used by `ClearButtonMixin` as a reference to the clear button element.
+   * Used by `InputControlMixin` as a reference to the clear button element.
    * @protected
    */
   get clearElement() {

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -304,7 +304,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   }
 
   /**
-   * Used by `ClearButtonMixin` as a reference to the clear button element.
+   * Used by `InputControlMixin` as a reference to the clear button element.
    * @protected
    * @return {!HTMLElement}
    */
@@ -658,7 +658,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   }
 
   /**
-   * Override method inherited from `ClearButtonMixin`.
+   * Override method inherited from `InputControlMixin`.
    * @protected
    */
   _onClearButtonClick() {}


### PR DESCRIPTION
## Description

The JSDoc annotations in some components still mention `ClearButtonMixin` that no longer exists.
We have previously moved all the relevant APIs to `InputControlMixin` as part of #2632

## Type of change

- Internal change