### PR TITLE
feat: add a getAncestorRootNodes DOM utility

### DIFF
--- a/packages/component-base/src/dom-utils.d.ts
+++ b/packages/component-base/src/dom-utils.d.ts
@@ -1,4 +1,10 @@
 /**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
  * Returns an array of ancestor root nodes for the given node.
  *
  * A root node is either a document node or a document fragment node (Shadow Root).

--- a/packages/component-base/src/dom-utils.d.ts
+++ b/packages/component-base/src/dom-utils.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns an array of ancestor root nodes for the given node.
+ *
+ * A root node is either a document node or a document fragment node (Shadow Root).
+ * The array is collected by a bottom-up DOM traversing that starts with the given node
+ * and involves both the light DOM and ancestor shadow DOM trees.
+ */
+export function getAncestorRootNodes(node: Node): Node[];

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -1,4 +1,10 @@
 /**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
  * Returns an array of ancestor root nodes for the given node.
  *
  * A root node is either a document node or a document fragment node (Shadow Root).

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -1,0 +1,35 @@
+/**
+ * Returns an array of ancestor root nodes for the given node.
+ *
+ * A root node is either a document node or a document fragment node (Shadow Root).
+ * The array is collected by a bottom-up DOM traversing that starts with the given node
+ * and involves both the light DOM and ancestor shadow DOM trees.
+ *
+ * @param {Node} node
+ * @return {Node[]}
+ */
+export function getAncestorRootNodes(node) {
+  const result = [];
+
+  while (node) {
+    if (node.nodeType === Node.DOCUMENT_NODE) {
+      result.push(node);
+      break;
+    }
+
+    if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+      result.push(node);
+      node = node.host;
+      continue;
+    }
+
+    if (node.assignedSlot) {
+      node = node.assignedSlot;
+      continue;
+    }
+
+    node = node.parentNode;
+  }
+
+  return result;
+}

--- a/packages/component-base/test/dom-utils.test.js
+++ b/packages/component-base/test/dom-utils.test.js
@@ -1,0 +1,39 @@
+import { expect } from '@esm-bundle/chai';
+import { defineCE, fixtureSync } from '@vaadin/testing-helpers';
+import { getAncestorRootNodes } from '../src/dom-utils.js';
+
+describe('dom-utils', () => {
+  describe('getAncestorRootNodes', () => {
+    let element, child;
+
+    const tag = defineCE(
+      class ShadowElement extends HTMLElement {
+        constructor() {
+          super();
+          this.attachShadow({ mode: 'open' });
+          this.shadowRoot.innerHTML = `
+          <div class="root">
+            <slot></slot>
+          </div>
+        `;
+        }
+      },
+    );
+
+    beforeEach(() => {
+      element = fixtureSync(`
+        <${tag}>
+          <div class="child"></div>
+        </${tag}>
+      `);
+      child = element.querySelector('.child');
+    });
+
+    it('should return an array of the ancestor root nodes for a node', () => {
+      const nodes = getAncestorRootNodes(child);
+      expect(nodes).to.have.lengthOf(2);
+      expect(nodes[0]).to.equal(element.shadowRoot);
+      expect(nodes[1]).to.equal(document);
+    });
+  });
+});


### PR DESCRIPTION
## Description

The PR adds a `getAncestorRootNodes` DOM utility for obtaining an array of ancestor root nodes for any given node. 

A use-case can be to subscribe to `scroll` events on the ancestor root nodes in order to get notified whenever any of the scrollable ancestors is scrolling and run some specific logic e.g. repositioning the original node relative to the currently scrolling ancestor.

A part of https://github.com/vaadin/web-components/issues/3540

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
