### PR TITLE
fix: reposition the overlay on scroll of position target ancestors

### DIFF
--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -80,7 +80,7 @@ export const PositionMixin = (superClass) =>
 
     static get observers() {
       return [
-        '__positionSettingsChanged(positionTarget, horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap)',
+        '__positionSettingsChanged(horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap)',
         '__overlayOpenedChanged(opened, positionTarget)',
       ];
     }
@@ -91,6 +91,7 @@ export const PositionMixin = (superClass) =>
       this._updatePosition = this._updatePosition.bind(this);
     }
 
+    /** @protected */
     connectedCallback() {
       super.connectedCallback();
 
@@ -99,6 +100,7 @@ export const PositionMixin = (superClass) =>
       }
     }
 
+    /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
       this.__removeUpdatePositionEventListeners();

--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -127,11 +127,10 @@ export const PositionMixin = (superClass) =>
     }
 
     __overlayOpenedChanged(opened, positionTarget) {
-      // Toggle the event listeners that cause the overlay to update its position
+      this.__removeUpdatePositionEventListeners();
+
       if (opened && positionTarget) {
         this.__addUpdatePositionEventListeners();
-      } else {
-        this.__removeUpdatePositionEventListeners();
       }
 
       if (opened) {

--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -126,6 +126,7 @@ export const PositionMixin = (superClass) =>
       }
     }
 
+    /** @private */
     __overlayOpenedChanged(opened, positionTarget) {
       this.__removeUpdatePositionEventListeners();
 

--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -81,7 +81,7 @@ export const PositionMixin = (superClass) =>
     static get observers() {
       return [
         '__positionSettingsChanged(positionTarget, horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap)',
-        '__overlayOpenedChanged(opened)',
+        '__overlayOpenedChanged(opened, positionTarget)',
       ];
     }
 
@@ -126,9 +126,9 @@ export const PositionMixin = (superClass) =>
       }
     }
 
-    __overlayOpenedChanged(opened) {
+    __overlayOpenedChanged(opened, positionTarget) {
       // Toggle the event listeners that cause the overlay to update its position
-      if (opened) {
+      if (opened && positionTarget) {
         this.__addUpdatePositionEventListeners();
       } else {
         this.__removeUpdatePositionEventListeners();

--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-
 import { getAncestorRootNodes } from '@vaadin/component-base/src/dom-utils.js';
 
 const PROP_NAMES_VERTICAL = {

--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -101,17 +101,15 @@ export const PositionMixin = (superClass) =>
 
     disconnectedCallback() {
       super.disconnectedCallback();
-
       this.__removeUpdatePositionEventListeners();
-      this.__ancestorRootNodes = null;
     }
 
     /** @private */
     __addUpdatePositionEventListeners() {
       window.addEventListener('resize', this._updatePosition);
 
-      this.__ancestorRootNodes = this.__ancestorRootNodes || getAncestorRootNodes(this.positionTarget);
-      this.__ancestorRootNodes.forEach((node) => {
+      this.__positionTargetAncestorRootNodes = getAncestorRootNodes(this.positionTarget);
+      this.__positionTargetAncestorRootNodes.forEach((node) => {
         node.addEventListener('scroll', this._updatePosition, true);
       });
     }
@@ -120,10 +118,11 @@ export const PositionMixin = (superClass) =>
     __removeUpdatePositionEventListeners() {
       window.removeEventListener('resize', this._updatePosition);
 
-      if (this.__ancestorRootNodes) {
-        this.__ancestorRootNodes.forEach((node) => {
+      if (this.__positionTargetAncestorRootNodes) {
+        this.__positionTargetAncestorRootNodes.forEach((node) => {
           node.removeEventListener('scroll', this._updatePosition, true);
         });
+        this.__positionTargetAncestorRootNodes = null;
       }
     }
 

--- a/packages/vaadin-overlay/test/position-mixin-listeners.test.js
+++ b/packages/vaadin-overlay/test/position-mixin-listeners.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-overlay.js';
 import { OverlayElement } from '../src/vaadin-overlay.js';
 import { PositionMixin } from '../src/vaadin-overlay-position-mixin.js';
 

--- a/packages/vaadin-overlay/test/position-mixin-listeners.test.js
+++ b/packages/vaadin-overlay/test/position-mixin-listeners.test.js
@@ -1,0 +1,105 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-overlay.js';
+import { OverlayElement } from '../src/vaadin-overlay.js';
+import { PositionMixin } from '../src/vaadin-overlay-position-mixin.js';
+
+class PositionedOverlay extends PositionMixin(OverlayElement) {
+  static get is() {
+    return 'vaadin-positioned-overlay';
+  }
+}
+customElements.define(PositionedOverlay.is, PositionedOverlay);
+
+class ScrollableWrapper extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
+      <div id="scrollable" style="overflow: scroll; height: 200px;">
+        <div style="height: 400px;">
+          <slot></slot>
+        </div>
+      </div>
+    `;
+  }
+}
+customElements.define('scrollable-wrapper', ScrollableWrapper);
+
+describe('position mixin listeners', () => {
+  let wrapper, target, overlay, updatePositionSpy;
+
+  beforeEach(() => {
+    wrapper = fixtureSync(`
+      <scrollable-wrapper>
+        <div id="target" style="position: fixed; top: 100px; left: 100px; width: 20px; height: 20px; border: 1px solid">
+          target
+        </div>
+        <vaadin-positioned-overlay id="overlay">
+          <template>
+            <div id="overlay-child" style="width: 50px; height: 50px;"></div>
+          </template>
+        </vaadin-positioned-overlay>
+      </scrollable-wrapper>
+    `);
+    target = wrapper.querySelector('#target');
+    overlay = wrapper.querySelector('#overlay');
+    updatePositionSpy = sinon.spy(overlay, '_updatePosition');
+    overlay.positionTarget = target;
+    overlay.opened = true;
+    updatePositionSpy.resetHistory();
+  });
+
+  it('should update position on resize when opened', () => {
+    fire(window, 'resize');
+    expect(updatePositionSpy.called).to.be.true;
+  });
+
+  it('should not update position on resize when closed', () => {
+    overlay.opened = false;
+    fire(window, 'resize');
+    expect(updatePositionSpy.called).to.be.false;
+  });
+
+  ['document', 'ancestor'].forEach((name) => {
+    describe(name, () => {
+      let scrollableNode;
+
+      beforeEach(() => {
+        if (name === 'document') {
+          scrollableNode = document;
+        }
+        if (name === 'ancestor') {
+          scrollableNode = wrapper.shadowRoot.querySelector('#scrollable');
+        }
+      });
+
+      it(`should update position on ${name} scroll when opened`, () => {
+        fire(scrollableNode, 'scroll');
+        expect(updatePositionSpy.called).to.be.true;
+      });
+
+      it(`should not update position on ${name} scroll when closed`, () => {
+        overlay.opened = false;
+        fire(scrollableNode, 'scroll');
+        expect(updatePositionSpy.called).to.be.false;
+      });
+
+      it(`should not update position on ${name} scroll when disconnected from the DOM`, () => {
+        const parentElement = overlay.parentElement;
+        parentElement.removeChild(overlay);
+        fire(scrollableNode, 'scroll');
+        expect(updatePositionSpy.called).to.be.false;
+      });
+
+      it(`should update position on ${name} scroll when reconnected to the DOM`, () => {
+        const parentElement = overlay.parentElement;
+        parentElement.removeChild(overlay);
+        parentElement.appendChild(overlay);
+        fire(scrollableNode, 'scroll');
+        expect(updatePositionSpy.called).to.be.true;
+      });
+    });
+  });
+});

--- a/packages/vaadin-overlay/test/position-mixin-listeners.test.js
+++ b/packages/vaadin-overlay/test/position-mixin-listeners.test.js
@@ -162,6 +162,41 @@ describe('position mixin listeners', () => {
       });
     });
 
+    describe('the position target is changed', () => {
+      let newWrapper, newTarget;
+
+      beforeEach(() => {
+        newWrapper = fixtureSync(`
+          <scrollable-wrapper>
+            <div id="target" style="position: fixed; top: 100px; left: 100px; width: 20px; height: 20px; border: 1px solid">
+              New Target
+            </div>
+          </scrollable-wrapper>
+        `);
+        newWrapper.appendChild(target);
+        newTarget = newWrapper.querySelector('#target');
+        overlay.positionTarget = newTarget;
+        updatePositionSpy.resetHistory();
+      });
+
+      it('should update position on document scroll', () => {
+        scroll(document);
+        expect(updatePositionSpy.called).to.be.true;
+      });
+
+      it('should not update position on old ancestor scroll', () => {
+        const oldScrollableAncestor = wrapper.shadowRoot.querySelector('#scrollable');
+        scroll(oldScrollableAncestor);
+        expect(updatePositionSpy.called).to.be.false;
+      });
+
+      it('should update position on new ancestor scroll', () => {
+        const newScrollableAncestor = newWrapper.shadowRoot.querySelector('#scrollable');
+        scroll(newScrollableAncestor);
+        expect(updatePositionSpy.called).to.be.true;
+      });
+    });
+
     describe('the position target is moved within the DOM', () => {
       let newWrapper;
 

--- a/packages/vaadin-overlay/test/position-mixin.test.js
+++ b/packages/vaadin-overlay/test/position-mixin.test.js
@@ -30,7 +30,7 @@ registerStyles(
   `,
 );
 
-describe('position target', () => {
+describe('position mixin', () => {
   const TOP = 'top';
   const BOTTOM = 'bottom';
   const START = 'start';

--- a/packages/vaadin-overlay/test/position-mixin.test.js
+++ b/packages/vaadin-overlay/test/position-mixin.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import '../vaadin-overlay.js';
 import { css } from 'lit';
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
 import { OverlayElement } from '../src/vaadin-overlay.js';

--- a/packages/vaadin-overlay/test/position-mixin.test.js
+++ b/packages/vaadin-overlay/test/position-mixin.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import sinon from 'sinon';
 import '../vaadin-overlay.js';
 import { css } from 'lit';
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
@@ -95,23 +94,6 @@ describe('position mixin', () => {
     overlay.opened = true;
     expectEdgesAligned(TOP, TOP);
     expectEdgesAligned(LEFT, LEFT);
-  });
-
-  ['scroll', 'resize'].forEach((event) => {
-    it(`should update position on ${event}`, () => {
-      target.style.top = '5px';
-      target.style.left = '10px';
-      window.dispatchEvent(new Event(event));
-      expectEdgesAligned(TOP, TOP);
-      expectEdgesAligned(LEFT, LEFT);
-    });
-  });
-
-  it('should remove listeners on close', () => {
-    const spy = sinon.spy(window, 'removeEventListener');
-    overlay.opened = false;
-    expect(spy.calledWith('scroll')).to.be.true;
-    expect(spy.calledWith('resize')).to.be.true;
   });
 
   describe('vertical align top', () => {


### PR DESCRIPTION
## Description

The PR improves `PositionMixin` to run the reposition logic not only on `window` scroll but generally on scroll of any position target ancestor. This is needed to ensure the overlay is positioned properly when the position target is scrolling inside an element other than `document`. For example, this can be the case when using an overlay-based component in an app-layout (the app-layout's content has an individual scrollbar).

A part of https://github.com/vaadin/web-components/issues/3540

Based on the prototype: https://github.com/vaadin/web-components/pull/3841

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
