### PR TITLE
fix: clear time-picker with clear button on Esc

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -106,6 +106,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
           value="{{_comboBoxValue}}"
           disabled="[[disabled]]"
           readonly="[[readonly]]"
+          clear-button-visible="[[clearButtonVisible]]"
           auto-open-disabled="[[autoOpenDisabled]]"
           position-target="[[_inputContainer]]"
           theme$="[[_theme]]"

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -209,6 +209,20 @@ describe('time-picker', () => {
 
       expect(event.defaultPrevented).to.be.true;
     });
+
+    it('should propagate clear button to the internal combo-box', () => {
+      expect(comboBox.clearButtonVisible).to.be.true;
+
+      timePicker.clearButtonVisible = false;
+      expect(comboBox.clearButtonVisible).to.be.false;
+    });
+
+    it('should clear value on Escape if clear button is visible', async () => {
+      timePicker.value = '00:00';
+      timePicker.inputElement.focus();
+      await sendKeys({ press: 'Escape' });
+      expect(timePicker.value).to.equal('');
+    });
   });
 
   describe('autoselect', () => {


### PR DESCRIPTION
## Description

The `clearButtonVisible` property in `vaadin-time-picker` was not propagated to the underlying combo-box.
As a result, the logic responsible for clearing the value on <kbd>Escape</kbd> was not called.

## Type of change

- Bugfix