### PR TITLE
refactor: cleanup multi-select-combo-box logic

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -619,13 +619,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       this.$.comboBox._setOverlayItems(selectedItems);
     }
 
-    // Re-render scroller
-    this.$.comboBox.$.dropdown._scroller.requestContentUpdate();
-
-    // Wait for chips to render
-    requestAnimationFrame(() => {
-      this.$.comboBox.$.dropdown._setOverlayWidth();
-    });
+    // Update selected for dropdown items
+    this.$.comboBox.requestContentUpdate();
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/test/visual/lumo/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/visual/lumo/multi-select-combo-box.test.js
@@ -116,22 +116,24 @@ describe('multi-select-combo-box', () => {
   describe('opened', () => {
     beforeEach(() => {
       div.style.height = '200px';
-      element.$.comboBox.click();
     });
 
     it('opened', async () => {
+      element.$.comboBox.click();
       await visualDiff(div, 'opened');
     });
 
     it('opened selected', async () => {
       element.style.width = '250px';
       element.selectedItems = ['Apple', 'Banana'];
+      element.$.comboBox.click();
       await visualDiff(div, 'opened-selected');
     });
 
     it('opened readonly', async () => {
       element.selectedItems = ['Apple', 'Banana'];
       element.readonly = true;
+      element.$.comboBox.click();
       await visualDiff(div, 'opened-readonly');
     });
   });

--- a/packages/multi-select-combo-box/test/visual/material/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/visual/material/multi-select-combo-box.test.js
@@ -116,22 +116,24 @@ describe('multi-select-combo-box', () => {
   describe('opened', () => {
     beforeEach(() => {
       div.style.height = '200px';
-      element.$.comboBox.click();
     });
 
     it('opened', async () => {
+      element.$.comboBox.click();
       await visualDiff(div, 'opened');
     });
 
     it('opened selected', async () => {
       element.style.width = '250px';
       element.selectedItems = ['Apple', 'Banana'];
+      element.$.comboBox.click();
       await visualDiff(div, 'opened-selected');
     });
 
     it('opened readonly', async () => {
       element.selectedItems = ['Apple', 'Banana'];
       element.readonly = true;
+      element.$.comboBox.click();
       await visualDiff(div, 'opened-readonly');
     });
   });


### PR DESCRIPTION
## Description

1. Removed logic responsible for updating overlay width because the `vaadin-multi-select-combo-box` no longer changes its input width dynamically based on the amount of chips selected (that's how the original addon worked).
2. Updated to use public `requestContentUpdate()` instead of accessing scroller. Also, clarified the related comment.
3. Updated visual tests to change input width before opening, to not rely on the removed behavior (see 1.)

## Type of change

- Refactor