### PR TITLE
refactor: move positioning logic to overlay

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-dropdown.js
+++ b/packages/combo-box/src/vaadin-combo-box-dropdown.js
@@ -48,7 +48,6 @@ export class ComboBoxDropdown extends PolymerElement {
        */
       positionTarget: {
         type: Object,
-        observer: '_positionTargetChanged',
       },
 
       /**
@@ -185,8 +184,6 @@ export class ComboBoxDropdown extends PolymerElement {
 
   _openedChanged(opened, wasOpened) {
     if (opened) {
-      this._setOverlayWidth();
-
       this._scroller.style.maxHeight =
         getComputedStyle(this).getPropertyValue(`--${this.__hostTagName}-overlay-max-height`) || '65vh';
 
@@ -272,32 +269,6 @@ export class ComboBoxDropdown extends PolymerElement {
 
   _isOverlayHidden() {
     return !this.loading && !(this._items && this._items.length);
-  }
-
-  _positionTargetChanged(target) {
-    // We must update the overlay width when the positionTarget is set (or changes)
-    if (target) {
-      this._setOverlayWidth();
-    }
-  }
-
-  _setOverlayWidth() {
-    if (!this.positionTarget) {
-      return;
-    }
-    const inputWidth = `${this.positionTarget.clientWidth}px`;
-    const propPrefix = `${this.__hostTagName}-overlay`;
-    const customWidth = getComputedStyle(this).getPropertyValue(`--${propPrefix}-width`);
-
-    this.$.overlay.style.setProperty(`--_${propPrefix}-default-width`, inputWidth);
-
-    if (customWidth === '') {
-      this.$.overlay.style.removeProperty(`--${propPrefix}-width`);
-    } else {
-      this.$.overlay.style.setProperty(`--${propPrefix}-width`, customWidth);
-    }
-
-    this.$.overlay._updatePosition();
   }
 
   /**

--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -45,11 +45,17 @@ export class ComboBoxOverlay extends PositionMixin(OverlayElement) {
     return memoizedTemplate;
   }
 
+  static get observers() {
+    return ['_setOverlayWidth(positionTarget, opened)'];
+  }
+
   connectedCallback() {
     super.connectedCallback();
 
     const dropdown = this.__dataHost;
     const comboBox = dropdown && dropdown.getRootNode().host;
+    this._comboBox = comboBox;
+
     const hostDir = comboBox && comboBox.getAttribute('dir');
     if (hostDir) {
       this.setAttribute('dir', hostDir);
@@ -68,6 +74,23 @@ export class ComboBoxOverlay extends PositionMixin(OverlayElement) {
     const eventPath = event.composedPath();
     if (!eventPath.includes(this.positionTarget) && !eventPath.includes(this)) {
       this.close();
+    }
+  }
+
+  _setOverlayWidth(positionTarget, opened) {
+    if (positionTarget && opened) {
+      const propPrefix = this.localName;
+      this.style.setProperty(`--_${propPrefix}-default-width`, `${positionTarget.clientWidth}px`);
+
+      const customWidth = getComputedStyle(this._comboBox).getPropertyValue(`--${propPrefix}-width`);
+
+      if (customWidth === '') {
+        this.style.removeProperty(`--${propPrefix}-width`);
+      } else {
+        this.style.setProperty(`--${propPrefix}-width`, customWidth);
+      }
+
+      this._updatePosition();
     }
   }
 }


### PR DESCRIPTION
## Description

For historical reasons, the logic responsible for positioning `vaadin-combo-box-overlay` is currently placed in the `vaadin-combo-box-dropdown` component. Most of that logic was removed in #2497, the remaining part can be moved to the overlay itself.

This PR is a pre-requisite for the following one where the `vaadin-combo-box-dropdown` will be removed completely, with merging its logic into `ComboBoxMixin` to have less complex structure (that might be beneficial for moving to LitElement).

## Type of change

- Refactor