### PR TITLE
docs: remove no longer used mixin from typings

### DIFF
--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';
 import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 
@@ -65,7 +64,7 @@ export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFiel
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class PasswordField extends SlotStylesMixin(SlotMixin(TextField)) {
+declare class PasswordField extends SlotStylesMixin(TextField) {
   /**
    * Set to true to hide the eye icon which toggles the password visibility.
    * @attr {boolean} reveal-button-hidden


### PR DESCRIPTION
## Description

The usage of `SlotMixin` was replaced with `SlotController` in #3492 but the mixin was not removed from the `d.ts` file.

## Type of change

- Docs