### PR TITLE
fix: add aria-hidden to clear and toggle buttons

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -190,8 +190,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
             ></vaadin-multi-select-combo-box-chip>
             <div id="chips" part="chips" slot="prefix"></div>
             <slot name="input"></slot>
-            <div id="clearButton" part="clear-button" slot="suffix"></div>
-            <div id="toggleButton" class="toggle-button" part="toggle-button" slot="suffix"></div>
+            <div id="clearButton" part="clear-button" slot="suffix" aria-hidden="true"></div>
+            <div id="toggleButton" class="toggle-button" part="toggle-button" slot="suffix" aria-hidden="true"></div>
           </vaadin-multi-select-combo-box-container>
         </vaadin-multi-select-combo-box-internal>
 


### PR DESCRIPTION
## Description

Applied the a11y change that was implemented in #3375 to `vaadin-multi-select-combo-box`.
Note: this will be covered with snapshot tests, I'm going to add them in a separate PR.

## Type of change

- Bugfix