### PR TITLE
fix: show user tags overlay only when the field is fully visible

### DIFF
--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -165,8 +165,8 @@ export class UserTags extends PolymerElement {
   __onTargetVisibilityChange(isVisible) {
     this.__isTargetVisible = isVisible;
 
-    if (isVisible && this._flashQueue.length > 0 && !this.flashing) {
-      this.flashTags(this._flashQueue.shift());
+    if (isVisible && this.__flashQueue.length > 0 && !this.flashing) {
+      this.flashTags(this.__flashQueue.shift());
       return;
     }
 

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -165,16 +165,24 @@ export class UserTags extends PolymerElement {
   __onTargetVisibilityChange(isVisible) {
     this.__isTargetVisible = isVisible;
 
+    // Open the overlay and run the flashing animation for the user tags
+    // that have been enqueued (if any) during a `.setUsers()` call
+    // because the field was not visible at that point.
     if (isVisible && this.__flashQueue.length > 0 && !this.flashing) {
       this.flashTags(this.__flashQueue.shift());
       return;
     }
 
+    // Open the overlay when the field is visible and focused.
+    // - opens the overlay in the case it was not opened during a `.show()` call because the field was not visible at that point.
+    // - re-opens the overlay in the case it was closed because the focused field became not visible for a while (see the below check).
     if (isVisible && this.hasFocus) {
       this.opened = true;
       return;
     }
 
+    // Close the overlay when the field is not visible.
+    // The focused field will be re-opened once it becomes visible again (see the above check).
     if (!isVisible && this.opened) {
       this.opened = false;
     }

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -170,7 +170,7 @@ export class UserTags extends PolymerElement {
       return;
     }
 
-    if (isVisible && this.users.length > 0 && this.hasFocus) {
+    if (isVisible && this.hasFocus) {
       this.opened = true;
       return;
     }

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -417,7 +417,9 @@ export class UserTags extends PolymerElement {
 
   show() {
     this.hasFocus = true;
-    this.opened = true;
+    if (this.__isTargetVisible) {
+      this.opened = true;
+    }
   }
 
   hide() {

--- a/packages/field-highlighter/test/field-components.test.js
+++ b/packages/field-highlighter/test/field-components.test.js
@@ -14,6 +14,11 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, render } from 'lit';
 import { FieldHighlighter } from '../src/vaadin-field-highlighter.js';
 
+async function waitForIntersectionObserver() {
+  await nextFrame();
+  await nextFrame();
+}
+
 describe('field components', () => {
   let field;
   let overlay;
@@ -31,13 +36,14 @@ describe('field components', () => {
   }
 
   describe('text field', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync(`<vaadin-text-field></vaadin-text-field>`);
       FieldHighlighter.init(field);
       showSpy = sinon.spy();
       hideSpy = sinon.spy();
       field.addEventListener('vaadin-highlight-show', showSpy);
       field.addEventListener('vaadin-highlight-hide', hideSpy);
+      await waitForIntersectionObserver();
     });
 
     it('should dispatch vaadin-highlight-show event on focus', () => {
@@ -53,7 +59,7 @@ describe('field components', () => {
   });
 
   describe('date picker', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
       FieldHighlighter.init(field);
       overlay = field.$.overlay;
@@ -61,6 +67,7 @@ describe('field components', () => {
       hideSpy = sinon.spy();
       field.addEventListener('vaadin-highlight-show', showSpy);
       field.addEventListener('vaadin-highlight-hide', hideSpy);
+      await waitForIntersectionObserver();
     });
 
     afterEach(() => {
@@ -182,7 +189,7 @@ describe('field components', () => {
   });
 
   describe('select', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync(`<vaadin-select></vaadin-select>`);
       field.renderer = (root) => {
         if (root.firstChild) {
@@ -206,6 +213,7 @@ describe('field components', () => {
       hideSpy = sinon.spy();
       field.addEventListener('vaadin-highlight-show', showSpy);
       field.addEventListener('vaadin-highlight-hide', hideSpy);
+      await waitForIntersectionObserver();
     });
 
     describe('default', () => {
@@ -296,7 +304,7 @@ describe('field components', () => {
   describe('checkbox group', () => {
     let checkboxes;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync(`
         <vaadin-checkbox-group>
           <vaadin-checkbox value="1" label="Checkbox 1"></vaadin-checkbox>
@@ -310,6 +318,7 @@ describe('field components', () => {
       field.addEventListener('vaadin-highlight-show', showSpy);
       field.addEventListener('vaadin-highlight-hide', hideSpy);
       checkboxes = Array.from(field.children);
+      await waitForIntersectionObserver();
     });
 
     it('should dispatch vaadin-highlight-show event on checkbox focus', () => {
@@ -352,7 +361,7 @@ describe('field components', () => {
   describe('radio group', () => {
     let radios;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync(`
         <vaadin-radio-group>
           <vaadin-radio-button value="1" label="Radio 1"></vaadin-radio-button>
@@ -366,6 +375,7 @@ describe('field components', () => {
       field.addEventListener('vaadin-highlight-show', showSpy);
       field.addEventListener('vaadin-highlight-hide', hideSpy);
       radios = Array.from(field.children);
+      await waitForIntersectionObserver();
     });
 
     it('should dispatch vaadin-highlight-show event on checkbox focus', () => {
@@ -409,7 +419,7 @@ describe('field components', () => {
     let date;
     let time;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync(`<vaadin-date-time-picker></vaadin-date-time-picker>`);
       FieldHighlighter.init(field);
       date = field.__inputs[0];
@@ -419,6 +429,7 @@ describe('field components', () => {
       hideSpy = sinon.spy();
       field.addEventListener('vaadin-highlight-show', showSpy);
       field.addEventListener('vaadin-highlight-hide', hideSpy);
+      await waitForIntersectionObserver();
     });
 
     afterEach(() => {
@@ -520,6 +531,7 @@ describe('field components', () => {
       hideSpy = sinon.spy();
       field.addEventListener('vaadin-highlight-show', showSpy);
       field.addEventListener('vaadin-highlight-hide', hideSpy);
+      await waitForIntersectionObserver();
     });
 
     it('should dispatch vaadin-highlight-show event on item focus', () => {

--- a/packages/field-highlighter/test/field-highlighter.test.js
+++ b/packages/field-highlighter/test/field-highlighter.test.js
@@ -4,6 +4,11 @@ import sinon from 'sinon';
 import '@vaadin/vaadin-text-field/vaadin-text-field.js';
 import { FieldHighlighter } from '../src/vaadin-field-highlighter.js';
 
+async function waitForIntersectionObserver() {
+  await nextFrame();
+  await nextFrame();
+}
+
 describe('field highlighter', () => {
   let field;
   let highlighter;
@@ -11,12 +16,13 @@ describe('field highlighter', () => {
   let wrapper;
   let overlay;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     field = fixtureSync(`<vaadin-text-field></vaadin-text-field>`);
     highlighter = FieldHighlighter.init(field);
     outline = field.shadowRoot.querySelector('[part="outline"]');
     wrapper = field.shadowRoot.querySelector('vaadin-user-tags');
     overlay = wrapper.$.overlay;
+    await waitForIntersectionObserver();
   });
 
   describe('initialization', () => {

--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -148,6 +148,7 @@ describe('user-tags', () => {
       wrapper = field.shadowRoot.querySelector('vaadin-user-tags');
       wrapper.duration = 0;
       wrapper.delay = 0;
+      await waitForIntersectionObserver();
       wrapper.show();
       setUsers([user2, user3]);
       wrapper.hide();
@@ -237,6 +238,36 @@ describe('user-tags', () => {
       });
     });
 
+    describe('adding users when the field is partially visible and focused', () => {
+      beforeEach(async () => {
+        container.scrollTop = 220;
+        field.inputElement.focus();
+        await waitForIntersectionObserver();
+        addUser(user1);
+        addUser(user2);
+      });
+
+      it('should postpone opening the overlay until the field is fully visible', async () => {
+        expect(wrapper.opened).to.be.false;
+
+        field.scrollIntoView({ block: 'center' });
+        await waitForIntersectionObserver();
+        expect(wrapper.opened).to.be.true;
+      });
+
+      it('should keep the overlay open as long as the field is fully visible', async () => {
+        expect(wrapper.opened).to.be.false;
+
+        field.scrollIntoView({ block: 'center' });
+        await waitForIntersectionObserver();
+        expect(wrapper.opened).to.be.true;
+
+        container.scrollTop = 0;
+        await waitForIntersectionObserver();
+        expect(wrapper.opened).to.be.false;
+      });
+    });
+
     describe('adding users when the field is visible', () => {
       beforeEach(async () => {
         field.scrollIntoView({ block: 'center' });
@@ -253,23 +284,10 @@ describe('user-tags', () => {
         expect(wrapper.flashing).to.be.true;
       });
 
-      it('should hide the overlay when the field is not visible', async () => {
+      it('should hide the overlay once the field is not visible', async () => {
         container.scrollTop = 0;
         await waitForIntersectionObserver();
         expect(wrapper.opened).to.be.false;
-      });
-
-      it('should only hide the overlay as long as the field is not visible when it is focused', async () => {
-        field.inputElement.focus();
-        expect(wrapper.opened).to.be.true;
-
-        container.scrollTop = 0;
-        await waitForIntersectionObserver();
-        expect(wrapper.opened).to.be.false;
-
-        field.scrollIntoView({ block: 'center' });
-        await waitForIntersectionObserver();
-        expect(wrapper.opened).to.be.true;
       });
     });
   });

--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -200,6 +200,7 @@ describe('user-tags', () => {
       field = container.querySelector('vaadin-text-field');
       FieldHighlighter.init(field);
       wrapper = field.shadowRoot.querySelector('vaadin-user-tags');
+      wrapper.duration = 1000;
       await waitForIntersectionObserver();
     });
 
@@ -247,15 +248,7 @@ describe('user-tags', () => {
         addUser(user2);
       });
 
-      it('should postpone opening the overlay until the field is fully visible', async () => {
-        expect(wrapper.opened).to.be.false;
-
-        field.scrollIntoView({ block: 'center' });
-        await waitForIntersectionObserver();
-        expect(wrapper.opened).to.be.true;
-      });
-
-      it('should keep the overlay open as long as the field is fully visible', async () => {
+      it('should open the overlay when the field is fully visible and hide otherwise', async () => {
         expect(wrapper.opened).to.be.false;
 
         field.scrollIntoView({ block: 'center' });
@@ -288,6 +281,20 @@ describe('user-tags', () => {
         container.scrollTop = 0;
         await waitForIntersectionObserver();
         expect(wrapper.opened).to.be.false;
+      });
+
+      it('should not run extra flashing when the field changes visibility', async () => {
+        const spy = sinon.spy(wrapper, 'flashTags');
+
+        // Make the field not visible.
+        container.scrollTop = 0;
+        await waitForIntersectionObserver();
+
+        // Make the field visible again.
+        field.scrollIntoView({ block: 'center' });
+        await waitForIntersectionObserver();
+
+        expect(spy.called).to.be.false;
       });
     });
   });

--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -8,7 +8,7 @@ const user1 = { id: 'a', name: 'foo', colorIndex: 0 };
 const user2 = { id: 'b', name: 'var', colorIndex: 1 };
 const user3 = { id: 'c', name: 'baz', colorIndex: 2 };
 
-async function nextIntersection() {
+async function waitForIntersectionObserver() {
   await nextFrame();
   await nextFrame();
 }
@@ -44,7 +44,7 @@ describe('user-tags', () => {
       wrapper = field.shadowRoot.querySelector('vaadin-user-tags');
       wrapper.duration = 0;
       wrapper.delay = 0;
-      await nextIntersection();
+      await waitForIntersectionObserver();
     });
 
     it('should create user tags for each added user', async () => {
@@ -73,7 +73,7 @@ describe('user-tags', () => {
       wrapper.duration = 0;
       wrapper.delay = 0;
       wrapper.show();
-      await nextIntersection();
+      await waitForIntersectionObserver();
     });
 
     it('should create user tags for each added user', () => {
@@ -152,7 +152,7 @@ describe('user-tags', () => {
       setUsers([user2, user3]);
       wrapper.hide();
       wrapper.$.overlay._flushAnimation('closing');
-      await nextIntersection();
+      await waitForIntersectionObserver();
     });
 
     it('should render and hide all tags except new ones', async () => {
@@ -199,7 +199,7 @@ describe('user-tags', () => {
       field = container.querySelector('vaadin-text-field');
       FieldHighlighter.init(field);
       wrapper = field.shadowRoot.querySelector('vaadin-user-tags');
-      await nextIntersection();
+      await waitForIntersectionObserver();
     });
 
     describe('adding users when the field is not visible', () => {
@@ -212,7 +212,7 @@ describe('user-tags', () => {
         expect(wrapper.opened).to.be.false;
 
         field.scrollIntoView({ block: 'center' });
-        await nextIntersection();
+        await waitForIntersectionObserver();
         expect(wrapper.opened).to.be.true;
       });
 
@@ -220,7 +220,7 @@ describe('user-tags', () => {
         expect(wrapper.flashing).to.be.false;
 
         field.scrollIntoView({ block: 'center' });
-        await nextIntersection();
+        await waitForIntersectionObserver();
         expect(wrapper.flashing).to.be.true;
       });
     });
@@ -228,7 +228,7 @@ describe('user-tags', () => {
     describe('adding users when the field is visible', () => {
       beforeEach(async () => {
         field.scrollIntoView({ block: 'center' });
-        await nextIntersection();
+        await waitForIntersectionObserver();
         addUser(user1);
         addUser(user2);
       });
@@ -243,7 +243,7 @@ describe('user-tags', () => {
 
       it('should hide the overlay when the field is not visible', async () => {
         container.scrollTop = 0;
-        await nextIntersection();
+        await waitForIntersectionObserver();
         expect(wrapper.opened).to.be.false;
       });
 
@@ -252,11 +252,11 @@ describe('user-tags', () => {
         expect(wrapper.opened).to.be.true;
 
         container.scrollTop = 0;
-        await nextIntersection();
+        await waitForIntersectionObserver();
         expect(wrapper.opened).to.be.false;
 
         field.scrollIntoView({ block: 'center' });
-        await nextIntersection();
+        await waitForIntersectionObserver();
         expect(wrapper.opened).to.be.true;
       });
     });

--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -208,17 +208,29 @@ describe('user-tags', () => {
         addUser(user2);
       });
 
-      it('should postpone opening the overlay until the field is visible', async () => {
+      it('should postpone opening the overlay until the field is fully visible', async () => {
         expect(wrapper.opened).to.be.false;
 
+        // The field is partially visible.
+        container.scrollTop = 220;
+        await waitForIntersectionObserver();
+        expect(wrapper.opened).to.be.false;
+
+        // The field is fully visible.
         field.scrollIntoView({ block: 'center' });
         await waitForIntersectionObserver();
         expect(wrapper.opened).to.be.true;
       });
 
-      it('should postpone flashing until the field is visible', async () => {
+      it('should postpone flashing until the field is fully visible', async () => {
         expect(wrapper.flashing).to.be.false;
 
+        // The field is partially visible.
+        container.scrollTop = 220;
+        await waitForIntersectionObserver();
+        expect(wrapper.flashing).to.be.false;
+
+        // The field is fully visible.
         field.scrollIntoView({ block: 'center' });
         await waitForIntersectionObserver();
         expect(wrapper.flashing).to.be.true;


### PR DESCRIPTION
## Description

The PR introduces `IntersectionObserver` to `vaadin-user-tags` in order to watch for visibility changes of the target field and hide the overlay when the field is not visible.

- When adding users, the `user-tags` waits for the field to become fully visible before opening the overlay and beginning the flashing animation.
- The overlay is closed as soon as the field becomes not fully visible.
- If the field has focus, the overlay is re-opened as soon as the field becomes fully visible again.

A part of https://github.com/vaadin/web-components/issues/3540

Based on the prototype: https://github.com/vaadin/web-components/pull/3841

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
