### PR TITLE
fix: prevent default for click event on open

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -484,7 +484,11 @@ class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(Themab
    *
    * @private
    */
-  _onClick() {
+  _onClick(event) {
+    // Prevent parent components such as `vaadin-grid`
+    // from handling the click event after it bubbles.
+    event.preventDefault();
+
     this.opened = !this.readonly;
   }
 

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -6,6 +6,7 @@ import {
   enterKeyDown,
   enterKeyUp,
   escKeyDown,
+  fire,
   fixtureSync,
   keyboardEventFor,
   keyDownChar,
@@ -287,6 +288,11 @@ describe('vaadin-select', () => {
       it('should open the overlay on required indicator click', () => {
         select.shadowRoot.querySelector('[part=required-indicator]').click();
         expect(select.opened).to.be.true;
+      });
+
+      it('should prevent default for the handled click event', () => {
+        const event = fire(select._inputContainer, 'click');
+        expect(event.defaultPrevented).to.be.true;
       });
 
       it('should open the overlay on ArrowUp', () => {


### PR DESCRIPTION
## Description

There is a logic in `vaadin-grid` that ignores `click` events in case if they are prevented:

https://github.com/vaadin/web-components/blob/8e5b388efe5a17201298aae23a43e0136ba27105/packages/grid/src/vaadin-grid-active-item-mixin.js#L52-L56

We need to use this in `vaadin-select` which opens the overlay on `click` to inform parent `vaadin-grid` that the click is handled. This is somewhat related to #3885 where the same approach is proposed to be used for <kbd>Esc</kbd> press.

Part of https://github.com/vaadin/flow-components/issues/3177

Note: this PR alone is not enough to fix the original issue, as the `GridFlow` connector has another [`click` listener](https://github.com/vaadin/flow-components/blob/5a39682194b303fb0ee8209a8f0f281657b572ca/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js#L1056-L1059) that does not currently check for `event.defaultPrevented` 😞 I will submit a separate PR for Flow components to address that.

## Type of change

- Bugfix