### PR TITLE
fix: prevent default for combo-box click on open

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -425,10 +425,27 @@ export const ComboBoxMixin = (subclass) =>
 
     /**
      * @param {Event} event
+     * @private
+     */
+    _onToggleButtonClick(event) {
+      // Prevent parent components such as `vaadin-grid`
+      // from handling the click event after it bubbles.
+      event.preventDefault();
+
+      if (this.opened) {
+        this.close();
+      } else {
+        this.open();
+      }
+    }
+
+    /**
+     * @param {Event} event
      * @protected
      */
-    _onHostClick(_event) {
+    _onHostClick(event) {
       if (!this.autoOpenDisabled) {
+        event.preventDefault();
         this.open();
       }
     }
@@ -442,11 +459,7 @@ export const ComboBoxMixin = (subclass) =>
       if (this._isClearButton(e)) {
         this._handleClearButtonClick(e);
       } else if (path.indexOf(this._toggleElement) > -1) {
-        if (this.opened) {
-          this.close();
-        } else {
-          this.open();
-        }
+        this._onToggleButtonClick(e);
       } else {
         this._onHostClick(e);
       }

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -83,6 +83,22 @@ describe('toggling dropdown', () => {
       expect(comboBox.opened).to.be.false;
     });
 
+    it('should prevent default for the handled toggle-button click', () => {
+      const event = click(comboBox._toggleElement);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should prevent default for the handled label element click', () => {
+      const event = click(comboBox.querySelector('[slot="label"]'));
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should not prevent default for click when autoOpenDisabled', () => {
+      comboBox.autoOpenDisabled = true;
+      const event = click(comboBox.querySelector('[slot="label"]'));
+      expect(event.defaultPrevented).to.be.false;
+    });
+
     it('should open on function call', () => {
       comboBox.open();
 


### PR DESCRIPTION
## Description

Same as #3954 but for `vaadin-combo-box`: tested the original issue and `ComboBox` in `Grid` editor has the same problem.
Updated to call `event.preventDefault()` for toggle button click (always) and for host click (when auto-open is enabled).

## Type of change

- Bugfix