### PR TITLE
feat: add missing API related to dataProvider

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -50,6 +50,15 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
 
   static get properties() {
     return {
+      /**
+       * Total number of items.
+       * @type {number | undefined}
+       */
+      size: {
+        type: Number,
+        notify: true,
+      },
+
       _target: {
         type: Object,
       },

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -268,6 +268,16 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
    */
   selectedItems: TItem[];
 
+  /**
+   * Total number of items.
+   */
+  size: number | undefined;
+
+  /**
+   * Clears the cached pages and reloads data from data provider when needed.
+   */
+  clearCache(): void;
+
   addEventListener<K extends keyof MultiSelectComboBoxEventMap<TItem>>(
     type: K,
     listener: (this: MultiSelectComboBox<TItem>, ev: MultiSelectComboBoxEventMap<TItem>[K]) => void,

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -162,6 +162,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           allow-custom-value="[[allowCustomValue]]"
           data-provider="[[dataProvider]]"
           filter="{{filter}}"
+          size="{{size}}"
           filtered-items="[[filteredItems]]"
           opened="{{opened}}"
           renderer="[[renderer]]"
@@ -328,6 +329,13 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       },
 
       /**
+       * Total number of items.
+       */
+      size: {
+        type: Number,
+      },
+
+      /**
        * Number of items fetched at a time from the data provider.
        * @attr {number} page-size
        */
@@ -468,6 +476,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
    */
   checkValidity() {
     return this.required && !this.readonly ? this._hasValue : true;
+  }
+
+  /**
+   * Clears the cached pages and reloads data from data provider when needed.
+   */
+  clearCache() {
+    if (this.$ && this.$.comboBox) {
+      this.$.comboBox.clearCache();
+    }
   }
 
   /**

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -104,6 +104,29 @@ describe('basic', () => {
       comboBox.itemValuePath = 'key';
       expect(internal.itemValuePath).to.equal('key');
     });
+
+    it('should propagate size property to combo-box', () => {
+      comboBox.size = 20;
+      expect(internal.size).to.equal(20);
+    });
+
+    it('should update size when combo-box size changes', () => {
+      internal.size = 20;
+      expect(comboBox.size).to.equal(20);
+    });
+
+    it('should call clearCache() method on the combo-box', () => {
+      const spy = sinon.spy(internal, 'clearCache');
+      comboBox.clearCache();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should not throw on clearCache() if not attached', () => {
+      const combo = document.createElement('vaadin-multi-select-combo-box');
+      expect(() => {
+        combo.clearCache();
+      }).to.not.throw(Error);
+    });
   });
 
   describe('selecting items', () => {


### PR DESCRIPTION
## Description

This PR adds the public APIs that are currently missing in `vaadin-multi-select-combo-box` but are present in the regular `vaadin-combo-box`, especially `size` property (we have some tests where it's configured) and `clearCache()` method.

## Type of change

- Feature