### PR TITLE
test: speed up field highlighter unit tests

### DIFF
--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -10,9 +10,6 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 
-const DURATION = 200;
-const DELAY = 2000;
-
 const listenOnce = (elem, type) => {
   return new Promise((resolve) => {
     const listener = () => {
@@ -96,8 +93,18 @@ export class UserTags extends PolymerElement {
         value: () => [],
       },
 
+      duration: {
+        type: Number,
+        value: 200,
+      },
+
+      delay: {
+        type: Number,
+        value: 2000,
+      },
+
       /** @private */
-      _flashQueue: {
+      __flashQueue: {
         type: Array,
         value: () => [],
       },
@@ -217,12 +224,12 @@ export class UserTags extends PolymerElement {
     const changedTags = this.getChangedTags(addedUsers, removedUsers);
 
     // Check if flash queue contains pending tags for removed users
-    if (this._flashQueue.length > 0) {
+    if (this.__flashQueue.length > 0) {
       for (let i = 0; i < removedUsers.length; i++) {
         if (changedTags.removed[i] === null) {
-          for (let j = 0; j < this._flashQueue.length; j++) {
-            if (this._flashQueue[j].some((tag) => tag.uid === removedUsers[i].id)) {
-              this.splice('_flashQueue', i, 1);
+          for (let j = 0; j < this.__flashQueue.length; j++) {
+            if (this.__flashQueue[j].some((tag) => tag.uid === removedUsers[i].id)) {
+              this.splice('__flashQueue', i, 1);
             }
           }
         }
@@ -246,7 +253,7 @@ export class UserTags extends PolymerElement {
 
       if (this.flashing) {
         // Schedule next flash later
-        this.push('_flashQueue', addedTags);
+        this.push('__flashQueue', addedTags);
       } else {
         this.flashTags(addedTags);
       }
@@ -280,36 +287,40 @@ export class UserTags extends PolymerElement {
 
     this.flashPromise = new Promise((resolve) => {
       listenOnce(this.$.overlay, 'vaadin-overlay-open').then(() => {
-        this._debounceFlashStart = Debouncer.debounce(this._debounceFlashStart, timeOut.after(DURATION + DELAY), () => {
-          // Animate disappearing
-          if (!this.hasFocus) {
-            added.forEach((tag) => tag.classList.remove('show'));
-          }
-          this._debounceFlashEnd = Debouncer.debounce(this._debounceFlashEnd, timeOut.after(DURATION), () => {
-            // Show all tags
-            const finishFlash = () => {
-              hidden.forEach((tag) => (tag.style.display = 'block'));
-              this.flashing = false;
-              resolve();
-            };
-
-            if (this.hasFocus) {
-              finishFlash();
-            } else {
-              // Wait for overlay closing animation to complete
-              listenOnce(this.$.overlay, 'animationend').then(() => {
-                finishFlash();
-              });
-
-              this.opened = false;
+        this._debounceFlashStart = Debouncer.debounce(
+          this._debounceFlashStart,
+          timeOut.after(this.duration + this.delay),
+          () => {
+            // Animate disappearing
+            if (!this.hasFocus) {
+              added.forEach((tag) => tag.classList.remove('show'));
             }
-          });
-        });
+            this._debounceFlashEnd = Debouncer.debounce(this._debounceFlashEnd, timeOut.after(this.duration), () => {
+              // Show all tags
+              const finishFlash = () => {
+                hidden.forEach((tag) => (tag.style.display = 'block'));
+                this.flashing = false;
+                resolve();
+              };
+
+              if (this.hasFocus) {
+                finishFlash();
+              } else {
+                // Wait for overlay closing animation to complete
+                listenOnce(this.$.overlay, 'animationend').then(() => {
+                  finishFlash();
+                });
+
+                this.opened = false;
+              }
+            });
+          },
+        );
       });
     }).then(() => {
-      if (this._flashQueue.length > 0) {
-        const tags = this._flashQueue[0];
-        this.splice('_flashQueue', 0, 1);
+      if (this.__flashQueue.length > 0) {
+        const tags = this.__flashQueue[0];
+        this.splice('__flashQueue', 0, 1);
         this.flashTags(tags);
       }
     });
@@ -330,7 +341,7 @@ export class UserTags extends PolymerElement {
   updateTags(users, changed) {
     this.applyTagsStart(changed);
 
-    this._debounceRender = Debouncer.debounce(this._debounceRender, timeOut.after(DURATION), () => {
+    this._debounceRender = Debouncer.debounce(this._debounceRender, timeOut.after(this.duration), () => {
       this.set('users', users);
 
       this.applyTagsEnd(changed);

--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -37,6 +37,8 @@ describe('user-tags', () => {
       field = fixtureSync(`<vaadin-text-field></vaadin-text-field>`);
       FieldHighlighter.init(field);
       wrapper = field.shadowRoot.querySelector('vaadin-user-tags');
+      wrapper.duration = 0;
+      wrapper.delay = 0;
     });
 
     it('should create user tags for each added user', async () => {
@@ -62,6 +64,8 @@ describe('user-tags', () => {
       field = fixtureSync(`<vaadin-text-field></vaadin-text-field>`);
       FieldHighlighter.init(field);
       wrapper = field.shadowRoot.querySelector('vaadin-user-tags');
+      wrapper.duration = 0;
+      wrapper.delay = 0;
       wrapper.show();
     });
 
@@ -135,6 +139,8 @@ describe('user-tags', () => {
       field = fixtureSync(`<vaadin-text-field></vaadin-text-field>`);
       FieldHighlighter.init(field);
       wrapper = field.shadowRoot.querySelector('vaadin-user-tags');
+      wrapper.duration = 0;
+      wrapper.delay = 0;
       wrapper.show();
       setUsers([user2, user3]);
       wrapper.hide();


### PR DESCRIPTION
## Description

The PR speeds up field highlighter unit tests by decreasing the delay and duration of the flashing animation.

**Before:**

```
yarn run v1.22.18
$ web-test-runner --group field-highlighter

Chrome: |██████████████████████████████| 3/3 test files | 93 passed, 0 failed

Finished running tests in 11.3s, all tests passed! 🎉

✨  Done in 11.78s.
```

**After:**

```
yarn run v1.22.18
$ web-test-runner --group field-highlighter

Chrome: |██████████████████████████████| 3/3 test files | 93 passed, 0 failed

Finished running tests in 1.7s, all tests passed! 🎉

✨  Done in 2.22s.
```


## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
