### PR TITLE
test: add ITs for active-item-changed grid event

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -10,6 +10,7 @@
     "@vaadin/accordion": "23.1.0-rc2",
     "@vaadin/combo-box": "23.1.0-rc2",
     "@vaadin/dialog": "23.1.0-rc2",
+    "@vaadin/grid": "23.1.0-rc2",
     "@vaadin/grid-pro": "23.1.0-rc2",
     "@vaadin/multi-select-combo-box": "23.1.0-rc2",
     "@vaadin/polymer-legacy-adapter": "23.1.0-rc2",

--- a/integration/tests/grid-combo-box.test.js
+++ b/integration/tests/grid-combo-box.test.js
@@ -1,0 +1,56 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '@vaadin/combo-box';
+import '@vaadin/grid';
+import { flushGrid, getBodyCellContent } from '@vaadin/grid/test/helpers.js';
+
+describe('combo-box in grid', () => {
+  let grid, column;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    grid.items = [{ value: '1' }, { value: '2' }];
+    column = grid.querySelector('vaadin-grid-column');
+    column.renderer = (root, _, model) => {
+      if (!root.firstChild) {
+        const comboBox = document.createElement('vaadin-combo-box');
+        comboBox.items = [
+          { label: 'Option 1', value: '1' },
+          { label: 'Option 2', value: '2' },
+        ];
+        root.appendChild(comboBox);
+        comboBox.label = 'Select an option';
+        comboBox.value = model.item.value;
+      }
+    };
+    flushGrid(grid);
+    await nextRender(grid);
+  });
+
+  it('should not activate item on combo-box toggle button click', () => {
+    const spy = sinon.spy();
+    grid.addEventListener('active-item-changed', spy);
+
+    const combo = getBodyCellContent(grid, 0, 0).firstElementChild;
+    const toggle = combo.shadowRoot.querySelector('[part="toggle-button"]');
+    toggle.click();
+
+    expect(spy.called).to.be.false;
+  });
+
+  it('should not activate item on combo-box label element click', () => {
+    const spy = sinon.spy();
+    grid.addEventListener('active-item-changed', spy);
+
+    const combo = getBodyCellContent(grid, 0, 0).firstElementChild;
+    const label = combo.querySelector('[slot="label"]');
+    label.click();
+
+    expect(spy.called).to.be.false;
+  });
+});

--- a/integration/tests/grid-select.test.js
+++ b/integration/tests/grid-select.test.js
@@ -1,0 +1,56 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '@vaadin/grid';
+import '@vaadin/select';
+import { flushGrid, getBodyCellContent } from '@vaadin/grid/test/helpers.js';
+
+describe('select in grid', () => {
+  let grid, column;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    grid.items = [{ value: '1' }, { value: '2' }];
+    column = grid.querySelector('vaadin-grid-column');
+    column.renderer = (root, _, model) => {
+      if (!root.firstChild) {
+        const select = document.createElement('vaadin-select');
+        select.items = [
+          { label: 'Option 1', value: '1' },
+          { label: 'Option 2', value: '2' },
+        ];
+        root.appendChild(select);
+        select.label = 'Select an option';
+        select.value = model.item.value;
+      }
+    };
+    flushGrid(grid);
+    await nextRender(grid);
+  });
+
+  it('should not activate item on select toggle button click', () => {
+    const spy = sinon.spy();
+    grid.addEventListener('active-item-changed', spy);
+
+    const select = getBodyCellContent(grid, 0, 0).firstElementChild;
+    const toggle = select.shadowRoot.querySelector('[part="toggle-button"]');
+    toggle.click();
+
+    expect(spy.called).to.be.false;
+  });
+
+  it('should not activate item on select label element click', () => {
+    const spy = sinon.spy();
+    grid.addEventListener('active-item-changed', spy);
+
+    const select = getBodyCellContent(grid, 0, 0).firstElementChild;
+    const label = select.querySelector('[slot="label"]');
+    label.click();
+
+    expect(spy.called).to.be.false;
+  });
+});


### PR DESCRIPTION
## Description

Added integration tests for `vaadin-select` and `vaadin-combo-box` fixes done in #3954 and #3957.

## Type of change

- Tests