### PR TITLE
fix: keep input value when data provider resolves callback

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -525,6 +525,11 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       this._focusedChipIndex = -1;
       this.validate();
     }
+
+    // Propagate focused attribute to internal combo box
+    if (this.$ && this.$.comboBox) {
+      this.$.comboBox.toggleAttribute('focused', focused);
+    }
   }
 
   /**

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -127,6 +127,14 @@ describe('basic', () => {
         combo.clearCache();
       }).to.not.throw(Error);
     });
+
+    it('should propagate focused attribute to combo-box', () => {
+      expect(internal.hasAttribute('focused')).to.be.false;
+      comboBox.focus();
+      expect(internal.hasAttribute('focused')).to.be.true;
+      comboBox.blur();
+      expect(internal.hasAttribute('focused')).to.be.false;
+    });
   });
 
   describe('selecting items', () => {


### PR DESCRIPTION
## Description

Prevent data provider mixin from clearing the input value when the data provider callback resolves. The data provider mixin relies on the `focused` attribute being present on the combo box to determine whether the component is actively used, however the `focused` attribute is never set on the internal combo box. This change propagates the `focused` attribute to the internal combo box to fix that.

Fixes #3969 

## Type of change

- Bugfix