### PR TITLE
fix: prevent default for date-picker click on open

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -370,6 +370,7 @@ export const DatePickerMixin = (subclass) =>
     constructor() {
       super();
 
+      this._boundOnClick = this._onClick.bind(this);
       this._boundOnScroll = this._onScroll.bind(this);
     }
 
@@ -414,11 +415,7 @@ export const DatePickerMixin = (subclass) =>
     ready() {
       super.ready();
 
-      this.addEventListener('click', (e) => {
-        if (!this._isClearButton(e) && (!this.autoOpenDisabled || this._noInput)) {
-          this.open();
-        }
-      });
+      this.addEventListener('click', this._boundOnClick);
 
       this.addController(
         new MediaQueryController(this._fullscreenMediaQuery, (matches) => {
@@ -908,6 +905,29 @@ export const DatePickerMixin = (subclass) =>
       }
 
       event.stopPropagation();
+    }
+
+    /**
+     * @param {Event} event
+     * @private
+     */
+    _onClick(event) {
+      // Clear button click is handled in separate listener
+      // but bubbles to the host, so we need to ignore it.
+      if (!this._isClearButton(event)) {
+        this._onHostClick(event);
+      }
+    }
+
+    /**
+     * @param {Event} event
+     * @private
+     */
+    _onHostClick(event) {
+      if (!this.autoOpenDisabled || this._noInput) {
+        event.preventDefault();
+        this.open();
+      }
     }
 
     /**

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -113,6 +113,13 @@ describe('basic features', () => {
     expect(event.defaultPrevented).to.be.true;
   });
 
+  it('should not prevent default for click when autoOpenDisabled', () => {
+    datepicker.autoOpenDisabled = true;
+    const inputField = datepicker.shadowRoot.querySelector('[part="input-field"]');
+    const event = click(inputField);
+    expect(event.defaultPrevented).to.be.false;
+  });
+
   it('should pass the placeholder attribute to the input tag', () => {
     const placeholder = 'Pick a date';
     datepicker.set('placeholder', placeholder);

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -101,6 +101,18 @@ describe('basic features', () => {
     expect(isFocused(input)).to.be.true;
   });
 
+  it('should open on input container element click', () => {
+    const inputField = datepicker.shadowRoot.querySelector('[part="input-field"]');
+    click(inputField);
+    expect(datepicker.opened).to.be.true;
+  });
+
+  it('should prevent default for the handled click event', () => {
+    const inputField = datepicker.shadowRoot.querySelector('[part="input-field"]');
+    const event = click(inputField);
+    expect(event.defaultPrevented).to.be.true;
+  });
+
   it('should pass the placeholder attribute to the input tag', () => {
     const placeholder = 'Pick a date';
     datepicker.set('placeholder', placeholder);


### PR DESCRIPTION
## Description

Same as #3954 but for `vaadin-date-picker` which is affected by the same issue, see the recording:

https://user-images.githubusercontent.com/10589913/171132701-5e8e1f49-539d-4ff2-b64f-481609b57bbf.mp4

Note: click on the toggle button is not affected because we use `stopPropagation()` for it:

https://github.com/vaadin/web-components/blob/51a1a42a6f2a825e13803a6f8c5c3705e2036c88/packages/date-picker/src/vaadin-date-picker.js#L235-L238

Also, clicks on `<input>` and `<label>` are ignored by `GridFlow` as both pass the `isFocused` check.

Integration test for this fix will be added in a separate PR to make cherry-picks possible.

## Type of change

- Bugfix