### PR TITLE
fix: prevent and stop propagation when clearing

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -915,7 +915,8 @@ export const DatePickerMixin = (subclass) =>
      * to validate and dispatch change on clear.
      * @protected
      */
-    _onClearButtonClick() {
+    _onClearButtonClick(event) {
+      event.preventDefault();
       this.value = '';
       this._inputValue = '';
       this.validate();
@@ -1006,19 +1007,25 @@ export const DatePickerMixin = (subclass) =>
      * Do not call `super` in order to override clear
      * button logic defined in `InputControlMixin`.
      *
-     * @param {!KeyboardEvent} _event
+     * @param {!KeyboardEvent} event
      * @protected
      * @override
      */
-    _onEscape(_event) {
+    _onEscape(event) {
       // Closing overlay is handled in vaadin-overlay-escape-press event listener.
       if (this.opened) {
         return;
       }
 
-      if (this.clearButtonVisible) {
-        this._onClearButtonClick();
-      } else if (this.autoOpenDisabled) {
+      if (this.clearButtonVisible && !!this.value) {
+        // Stop event from propagating to the host element
+        // to avoid closing dialog when clearing on Esc
+        event.stopPropagation();
+        this._onClearButtonClick(event);
+        return;
+      }
+
+      if (this.autoOpenDisabled) {
         // Do not restore selected date if Esc was pressed after clearing input field
         if (this.inputElement.value === '') {
           this._selectDate(null);

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -1,5 +1,14 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, click, fixtureSync, makeSoloTouchEvent, nextRender, oneEvent, tap } from '@vaadin/testing-helpers';
+import {
+  aTimeout,
+  click,
+  fixtureSync,
+  keyboardEventFor,
+  makeSoloTouchEvent,
+  nextRender,
+  oneEvent,
+  tap,
+} from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
@@ -588,6 +597,42 @@ describe('clear button', () => {
     datepicker.value = '2000-02-01';
     click(clearButton);
     expect(datepicker.hasAttribute('has-value')).to.be.false;
+  });
+
+  it('should prevent default on clear button click event', () => {
+    datepicker.value = '2000-02-01';
+    const event = click(clearButton);
+    expect(event.defaultPrevented).to.be.true;
+  });
+
+  it('should prevent default on Esc when clearing value', () => {
+    datepicker.value = '2000-02-01';
+    const event = keyboardEventFor('keydown', 27, [], 'Escape');
+    datepicker.inputElement.dispatchEvent(event);
+    expect(event.defaultPrevented).to.be.true;
+  });
+
+  it('should stop propagation on Esc when clearing value', () => {
+    datepicker.value = '2000-02-01';
+    const event = keyboardEventFor('keydown', 27, [], 'Escape');
+    const spy = sinon.spy(event, 'stopPropagation');
+    datepicker.inputElement.dispatchEvent(event);
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should not stop propagation on Esc when no value is set', () => {
+    const event = keyboardEventFor('keydown', 27, [], 'Escape');
+    const spy = sinon.spy(event, 'stopPropagation');
+    datepicker.inputElement.dispatchEvent(event);
+    expect(spy.called).to.be.false;
+  });
+
+  it('should not stop propagation on Esc when clearButtonVisible is false', () => {
+    datepicker.clearButtonVisible = false;
+    const event = keyboardEventFor('keydown', 27, [], 'Escape');
+    const spy = sinon.spy(event, 'stopPropagation');
+    datepicker.inputElement.dispatchEvent(event);
+    expect(spy.called).to.be.false;
   });
 });
 


### PR DESCRIPTION
## Description

Added the same fix as in #3883 but for `vaadin-date-picker` that has `clearButtonVisible` set to `true`.
Note: also added `preventDefault()` for forwards compatibility with the approach suggested in #3885

The integration test for this fix will be added in a separate PR to make cherry-picking possible.

## Type of change

- Bugfix