### PR TITLE
docs: annotate protected methods correctly

### DIFF
--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -138,6 +138,7 @@ class Accordion extends ThemableMixin(ElementMixin(PolymerElement)) {
     }
   }
 
+  /** @protected */
   ready() {
     super.ready();
 

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -142,6 +142,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
     this.__onCheckboxCheckedChanged = this.__onCheckboxCheckedChanged.bind(this);
   }
 
+  /** @protected */
   ready() {
     super.ready();
 

--- a/packages/component-base/src/controller-mixin.js
+++ b/packages/component-base/src/controller-mixin.js
@@ -6,6 +6,11 @@
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
 /**
+ * @typedef ReactiveController
+ * @type {import('lit').ReactiveController}
+ */
+
+/**
  * A mixin for connecting controllers to the element.
  *
  * @polymerMixin
@@ -17,7 +22,7 @@ export const ControllerMixin = dedupingMixin(
         super();
 
         /**
-         * @type {Set<import('lit').ReactiveController>}
+         * @type {Set<ReactiveController>}
          */
         this.__controllers = new Set();
       }
@@ -47,7 +52,7 @@ export const ControllerMixin = dedupingMixin(
       /**
        * Registers a controller to participate in the element update cycle.
        *
-       * @param {import('lit').ReactiveController} controller
+       * @param {ReactiveController} controller
        * @protected
        */
       addController(controller) {
@@ -61,7 +66,7 @@ export const ControllerMixin = dedupingMixin(
       /**
        * Removes a controller from the element.
        *
-       * @param {import('lit').ReactiveController} controller
+       * @param {ReactiveController} controller
        * @protected
        */
       removeController(controller) {

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -131,6 +131,7 @@ class Details extends ShadowFocusMixin(ElementMixin(ThemableMixin(PolymerElement
     return this.shadowRoot.querySelector('[part="summary"]');
   }
 
+  /** @protected */
   ready() {
     super.ready();
     const uniqueId = (Details._uniqueId = 1 + Details._uniqueId || 0);

--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -24,6 +24,7 @@ export const ActiveItemMixin = (superClass) =>
       };
     }
 
+    /** @protected */
     ready() {
       super.ready();
 

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -35,6 +35,7 @@ export const ColumnReorderingMixin = (superClass) =>
       return ['_updateOrders(_columnTree, _columnTree.*)'];
     }
 
+    /** @protected */
     ready() {
       super.ready();
       addListener(this, 'track', this._onTrackEvent);

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -10,6 +10,7 @@ import { addListener } from '@vaadin/component-base/src/gestures.js';
  */
 export const ColumnResizingMixin = (superClass) =>
   class ColumnResizingMixin extends superClass {
+    /** @protected */
     ready() {
       super.ready();
       const scroller = this.$.scroller;

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -163,11 +163,13 @@ class Icon extends ThemableMixin(ElementMixin(PolymerElement)) {
     }
   }
 
+  /** @protected */
   connectedCallback() {
     super.connectedCallback();
     document.addEventListener('vaadin-iconset-registered', this.__onIconsetRegistered);
   }
 
+  /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
     document.removeEventListener('vaadin-iconset-registered', this.__onIconsetRegistered);

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -92,6 +92,7 @@ class ListBox extends ElementMixin(MultiSelectListMixin(ThemableMixin(Controller
     this.focused;
   }
 
+  /** @protected */
   ready() {
     super.ready();
     this.setAttribute('role', 'list');

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -101,6 +101,7 @@ class MessageList extends ElementMixin(ThemableMixin(PolymerElement)) {
     `;
   }
 
+  /** @protected */
   ready() {
     super.ready();
 

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -178,6 +178,7 @@ class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(PolymerEleme
     });
   }
 
+  /** @protected */
   ready() {
     super.ready();
     this._scrollerElement.addEventListener('scroll', () => this._updateOverflow());


### PR DESCRIPTION
## Description

1. Added missing `/** @protected */` JSDoc annotation to `ready()` and `connectedCallback()` callbacks,
2. Fixed the JSDoc annotations for `addController` and `removeController` methods to not mark them as public:

![Screenshot 2022-06-01 at 16 10 26](https://user-images.githubusercontent.com/10589913/171412246-fd21fc59-2e62-429b-9a96-a4511c4bab44.png)

## Type of change

- Documentation