### PR TITLE
fix: pass the correct owner to item renderers

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-dropdown.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-dropdown.js
@@ -33,6 +33,15 @@ class MultiSelectComboBoxDropdown extends ComboBoxDropdown {
       ></vaadin-multi-select-combo-box-overlay>
     `;
   }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    // Set owner for using by item renderers
+    const comboBox = this.getRootNode().host;
+    this._scroller.comboBox = comboBox.getRootNode().host;
+  }
 }
 
 customElements.define(MultiSelectComboBoxDropdown.is, MultiSelectComboBoxDropdown);

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
@@ -40,8 +40,7 @@ class MultiSelectComboBoxScroller extends ComboBoxScroller {
       return false;
     }
 
-    const host = this.comboBox.getRootNode().host;
-    return host._findIndex(item, host.selectedItems, itemIdPath) > -1;
+    return this.comboBox._findIndex(item, this.comboBox.selectedItems, itemIdPath) > -1;
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -3,7 +3,11 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ComboBoxDataProvider, ComboBoxDefaultItem, ComboBoxRenderer } from '@vaadin/combo-box/src/vaadin-combo-box.js';
+import {
+  ComboBoxDataProvider,
+  ComboBoxDefaultItem,
+  ComboBoxItemModel,
+} from '@vaadin/combo-box/src/vaadin-combo-box.js';
 import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
@@ -19,6 +23,12 @@ import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export type MultiSelectComboBoxRenderer<TItem> = (
+  root: HTMLElement,
+  comboBox: MultiSelectComboBox<TItem>,
+  model: ComboBoxItemModel<TItem>,
+) => void;
 
 export interface MultiSelectComboBoxI18n {
   cleared: string;
@@ -254,13 +264,13 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
    * Receives three arguments:
    *
    * - `root` The `<vaadin-multi-select-combo-box-item>` internal container DOM element.
-   * - `comboBox` The reference to the `<vaadin-combo-box>` element.
+   * - `comboBox` The reference to the `<vaadin-multi-select-combo-box>` element.
    * - `model` The object with the properties related with the rendered
    *   item, contains:
    *   - `model.index` The index of the rendered item.
    *   - `model.item` The item.
    */
-  renderer: ComboBoxRenderer<TItem> | null | undefined;
+  renderer: MultiSelectComboBoxRenderer<TItem> | null | undefined;
 
   /**
    * The list of selected items.

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -387,7 +387,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        * Receives three arguments:
        *
        * - `root` The `<vaadin-multi-select-combo-box-item>` internal container DOM element.
-       * - `comboBox` The reference to the `<vaadin-combo-box>` element.
+       * - `comboBox` The reference to the `<vaadin-multi-select-combo-box>` element.
        * - `model` The object with the properties related with the rendered
        *   item, contains:
        *   - `model.index` The index of the rendered item.

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -917,6 +917,23 @@ describe('basic', () => {
       expect(internal.renderer).to.equal(renderer);
     });
 
+    it('should pass the "root", "owner", "model" arguments to the renderer', () => {
+      const spy = sinon.spy();
+      comboBox.renderer = spy;
+      comboBox.opened = true;
+
+      const [root, owner, model] = spy.firstCall.args;
+
+      expect(root.localName).to.equal('vaadin-multi-select-combo-box-item');
+      expect(owner).to.eql(comboBox);
+      expect(model).to.deep.equal({
+        item: 'apple',
+        index: 0,
+        focused: false,
+        selected: false,
+      });
+    });
+
     it('should use renderer when it is defined', () => {
       comboBox.renderer = (root, _, model) => {
         const textNode = document.createTextNode(`${model.item} ${model.index}`);

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -1,4 +1,3 @@
-import { ComboBoxRenderer } from '@vaadin/combo-box/src/vaadin-combo-box.js';
 import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
@@ -20,6 +19,7 @@ import {
   MultiSelectComboBoxFilterChangedEvent,
   MultiSelectComboBoxI18n,
   MultiSelectComboBoxInvalidChangedEvent,
+  MultiSelectComboBoxRenderer,
   MultiSelectComboBoxSelectedItemsChangedEvent,
 } from '../../vaadin-multi-select-combo-box.js';
 
@@ -72,7 +72,7 @@ assertType<string | null | undefined>(narrowedComboBox.itemIdPath);
 assertType<string>(narrowedComboBox.itemLabelPath);
 assertType<string>(narrowedComboBox.itemValuePath);
 assertType<MultiSelectComboBoxI18n>(narrowedComboBox.i18n);
-assertType<ComboBoxRenderer<TestComboBoxItem> | null | undefined>(narrowedComboBox.renderer);
+assertType<MultiSelectComboBoxRenderer<TestComboBoxItem> | null | undefined>(narrowedComboBox.renderer);
 assertType<boolean>(narrowedComboBox.invalid);
 assertType<HTMLElement | null | undefined>(narrowedComboBox.focusElement);
 assertType<boolean>(narrowedComboBox.disabled);


### PR DESCRIPTION
## Description

Depends on #3982 where the tests for `renderer` were added.

Fixes #3980

## Type of change

- Bugfix