### PR TITLE
fix: add hidden attribute styles to vaadin-tab

### DIFF
--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -40,7 +40,7 @@ class Tab extends ElementMixin(ThemableMixin(ItemMixin(PolymerElement))) {
     return html`
       <style>
         :host {
-          display: inline-flex;
+          display: block;
         }
 
         :host([hidden]) {

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -37,7 +37,18 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  */
 class Tab extends ElementMixin(ThemableMixin(ItemMixin(PolymerElement))) {
   static get template() {
-    return html`<slot></slot>`;
+    return html`
+      <style>
+        :host {
+          display: inline-flex;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+      </style>
+      <slot></slot>
+    `;
   }
 
   static get is() {

--- a/packages/tabs/test/tab.test.js
+++ b/packages/tabs/test/tab.test.js
@@ -17,6 +17,11 @@ describe('tab', () => {
     expect(tab.getAttribute('role')).to.be.equal('tab');
   });
 
+  it('should have display: none when hidden', () => {
+    tab.setAttribute('hidden', '');
+    expect(getComputedStyle(tab).display).to.equal('none');
+  });
+
   it('should have an unnamed slot for content', () => {
     const slot = tab.shadowRoot.querySelector('slot:not([name])');
     const content = slot.assignedNodes()[0];


### PR DESCRIPTION
## Description

For some reason, `vaadin-tab` was missing styles for `hidden` attribute 🙈 

## Type of change

- Bugfix