### PR TITLE
chore: fix lockfile change detection for 22.0

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -40,7 +40,7 @@ const hasAllParam = process.argv.indexOf('--all') !== -1;
  * Check if lockfile has changed.
  */
 const isLockfileChanged = () => {
-  const log = execSync('git diff --name-only origin/master HEAD').toString();
+  const log = execSync('git diff --name-only origin/22.0 HEAD').toString();
   return log.split('\n').some((line) => line.includes('yarn.lock'));
 };
 


### PR DESCRIPTION
## Description

Currently, all the cherry-picks to `22.0` branch run all tests due to `yarn.lock` compared against `master` 🤦‍♂️ 
This PR fixes that to use `origin/22.0` instead to ensure the correct file is checked.

## Type of change

- Internal change