### PR TITLE
feat: add utilities for generating unique ids

### DIFF
--- a/packages/component-base/src/unique-id-utils.d.ts
+++ b/packages/component-base/src/unique-id-utils.d.ts
@@ -1,4 +1,10 @@
 /**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
  * Resets the unique id counter.
  */
 export function resetUniqueId(): void;

--- a/packages/component-base/src/unique-id-utils.d.ts
+++ b/packages/component-base/src/unique-id-utils.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Resets the unique id counter.
+ */
+export function resetUniqueId(): void;
+
+/**
+ * Returns a unique integer id.
+ */
+export function generateUniqueId(): number;

--- a/packages/component-base/src/unique-id-utils.js
+++ b/packages/component-base/src/unique-id-utils.js
@@ -1,0 +1,20 @@
+let uniqueId = 0;
+
+/**
+ * Resets the unique id counter.
+ *
+ * @return {void}
+ */
+export function resetUniqueId() {
+  uniqueId = 0;
+}
+
+/**
+ * Returns a unique integer id.
+ *
+ * @return {number}
+ */
+export function generateUniqueId() {
+  // eslint-disable-next-line no-plusplus
+  return uniqueId++;
+}

--- a/packages/component-base/src/unique-id-utils.js
+++ b/packages/component-base/src/unique-id-utils.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
 let uniqueId = 0;
 
 /**

--- a/packages/component-base/test/unique-id-utils.test.js
+++ b/packages/component-base/test/unique-id-utils.test.js
@@ -1,0 +1,25 @@
+import { expect } from '@esm-bundle/chai';
+import { generateUniqueId, resetUniqueId } from '../src/unique-id-utils.js';
+
+describe('unique-id-utils', () => {
+  describe('generateUniqueId', () => {
+    it('should generate a unique integer id on every call', () => {
+      expect(generateUniqueId()).to.equal(0);
+      expect(generateUniqueId()).to.equal(1);
+    });
+  });
+
+  describe('resetUniqueId', () => {
+    beforeEach(() => {
+      resetUniqueId();
+    });
+
+    it('should reset the unique id counter', () => {
+      expect(generateUniqueId()).to.equal(0);
+      expect(generateUniqueId()).to.equal(1);
+      resetUniqueId();
+      expect(generateUniqueId()).to.equal(0);
+      expect(generateUniqueId()).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
## Description

The PR introduces `generateUniqueId()` and `resetUniqueId()` utilities that cover common logic related to generating ids in components and mixins.

Note, `resetUniqueId()` is useful in snapshot tests as it makes the id generation stable and as a result we can get rid of the necessity to ignore a11y related attributes:

```diff
- const SNAPSHOT_CONFIG = {
-   ignoreAttributes: ['id', 'aria-describedby', 'aria-labelledby', 'for'],
- };
+ beforeEach(() => {
+   resetUniqueId();
+ }
```

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
