### PR TITLE
fix: allow passing array of styles with Lit

### DIFF
--- a/packages/vaadin-themable-mixin/test/lit-setup.js
+++ b/packages/vaadin-themable-mixin/test/lit-setup.js
@@ -11,6 +11,10 @@ window.defineCustomElementFunction = (name, parentName, content, styles, noIs) =
   const parentElement = parentName ? customElements.get(parentName) : LitElement;
   class CustomElement extends ThemableMixin(parentElement) {
     static get styles() {
+      if (Array.isArray(styles)) {
+        return styles.map((style) => unsafeCSS(style));
+      }
+
       return styles ? unsafeCSS(styles) : undefined;
     }
   }

--- a/packages/vaadin-themable-mixin/test/themable-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/themable-mixin.test.js
@@ -20,7 +20,8 @@ const defineCustomElement =
       Object.defineProperty(CustomElement, 'template', {
         get() {
           if (styles) {
-            content = `<style>${styles}</style>${content}`;
+            const cssText = Array.isArray(styles) ? styles.join('\n') : styles;
+            content = `<style>${cssText}</style>${content}`;
           }
 
           const template = document.createElement('template');
@@ -221,6 +222,19 @@ defineCustomElement(
   `,
 );
 
+defineCustomElement('test-own-styles-multiple', '', '<div part="text" id="text">text</div>', [
+  `
+    [part='text'] {
+      color: rgb(255, 0, 0);
+    }
+  `,
+  `
+    [part='text'] {
+      font-weight: 700;
+    }
+  `,
+]);
+
 function getText(element) {
   return element.shadowRoot.querySelector('#text');
 }
@@ -241,6 +255,7 @@ describe('ThemableMixin', () => {
         <test-inherited-no-content-no-is></test-inherited-no-content-no-is>
         <test-style-override></test-style-override>
         <test-own-styles></test-own-styles>
+        <test-own-styles-multiple></test-own-styles-multiple>
       </div>
     `);
 
@@ -362,5 +377,11 @@ describe('ThemableMixin', () => {
 
   it('should have own styles', async () => {
     expect(getComputedStyle(getText(components['test-own-styles'])).color).to.equal('rgb(255, 0, 0)');
+  });
+
+  it('should apply multiple own styles', () => {
+    const text = getText(components['test-own-styles-multiple']);
+    expect(getComputedStyle(text).color).to.equal('rgb(255, 0, 0)');
+    expect(getComputedStyle(text).fontWeight).to.equal('700');
   });
 });

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -227,7 +227,7 @@ export const ThemableMixin = (superClass) =>
       // a LitElement based component. The theme styles are added after it
       // so that they can override the component styles.
       const themeStyles = this.getStylesForThis();
-      return styles ? [styles, ...themeStyles] : themeStyles;
+      return styles ? [...super.finalizeStyles(styles), ...themeStyles] : themeStyles;
     }
 
     /**


### PR DESCRIPTION
## Description

Current implementation of `finalizeStyles` does not flatten the styles passed as an array e.g. like this:

```js
import { clearButton } from '@vaadin/field-base/src/styles/clear-button-styles.js';
import { fieldShared } from '@vaadin/field-base/src/styles/field-shared-styles.js';
import { inputFieldContainer } from '@vaadin/field-base/src/styles/input-field-container-styles.js';
import { css } from 'lit';

// ... inside a class:
static get styles() {
  return [
    fieldShared,
    inputFieldContainer,
    clearButton,
    css`
      .vaadin-text-area-container {
        flex: auto;
      }
    `,
  ];
}
```

This PR adds a call to `super.finalizeStyles(styles)` which performs [flattening](https://github.com/lit/lit/blob/7ba356c4795ddf2b2a69e69a4c3f78df1e6b56c5/packages/reactive-element/src/reactive-element.ts#L823-L831) for the `styles` array.

## Type of change

- Bugfix