### PR TITLE
fix: remove not existing property observer

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -359,7 +359,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       dataProvider: {
         type: Object,
-        observer: '_dataProviderChanged',
       },
 
       /**


### PR DESCRIPTION
## Description

Fix a copy-pate leftover to eliminate warning about not existing observer:

![Screenshot 2022-06-06 at 10 25 47](https://user-images.githubusercontent.com/10589913/172115163-0d335a6a-5f36-4b9e-8fb1-79f07da74e71.png)

## Type of change

- Bugfix