### PR TITLE
fix: do not request dataProvider when readonly

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -84,6 +84,10 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     };
   }
 
+  static get observers() {
+    return ['_readonlyItemsChanged(readonly, selectedItems)'];
+  }
+
   /**
    * Reference to the clear button element.
    * @protected
@@ -304,6 +308,13 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     } else if (oldReadonly) {
       this._setOverlayItems(this.__savedItems);
       this.__savedItems = null;
+    }
+  }
+
+  /** @private */
+  _readonlyItemsChanged(readonly, selectedItems) {
+    if (readonly && selectedItems) {
+      this._setOverlayItems(selectedItems);
     }
   }
 }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -164,6 +164,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           filter="{{filter}}"
           size="{{size}}"
           filtered-items="[[filteredItems]]"
+          selected-items="[[selectedItems]]"
           opened="{{opened}}"
           renderer="[[renderer]]"
           theme$="[[_theme]]"
@@ -595,13 +596,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   /** @private */
   _readonlyChanged(readonly, oldReadonly) {
-    if (readonly) {
-      this.__savedItems = this.$.comboBox._getOverlayItems();
-      this.$.comboBox._setOverlayItems(Array.from(this.selectedItems));
-      this.__updateChips();
-    } else if (oldReadonly) {
-      this.$.comboBox._setOverlayItems(this.__savedItems);
-      this.__savedItems = null;
+    if (readonly || oldReadonly) {
       this.__updateChips();
     }
   }
@@ -647,10 +642,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     // Re-render chips
     this.__updateChips();
-
-    if (this.readonly) {
-      this.$.comboBox._setOverlayItems(selectedItems);
-    }
 
     // Update selected for dropdown items
     this.requestContentUpdate();

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
@@ -845,6 +845,49 @@ describe('basic', () => {
       comboBox.readonly = true;
       inputElement.click();
       expect(internal.opened).to.be.false;
+    });
+
+    describe('dataProvider', () => {
+      let spyAsyncDataProvider;
+
+      const ITEMS = ['apple', 'banana', 'lemon', 'orange', 'pear'];
+
+      const getDataProvider = (allItems) => (params, callback) => {
+        const filteredItems = allItems.filter((item) => item.indexOf(params.filter) > -1);
+        const size = filteredItems.length;
+        const offset = params.page * params.pageSize;
+        const dataProviderItems = filteredItems.slice(offset, offset + params.pageSize);
+        callback(dataProviderItems, size);
+      };
+
+      const dataProvider = getDataProvider(ITEMS);
+
+      const asyncDataProvider = (params, callback) => {
+        setTimeout(() => dataProvider(params, callback));
+      };
+
+      beforeEach(() => {
+        comboBox.items = undefined;
+        spyAsyncDataProvider = sinon.spy(asyncDataProvider);
+        comboBox.dataProvider = spyAsyncDataProvider;
+      });
+
+      it('should not fetch items from the data-provider when readonly', async () => {
+        comboBox.opened = true;
+        // Wait for the async data provider timeout
+        await aTimeout(0);
+        expect(spyAsyncDataProvider.called).to.be.false;
+      });
+
+      it('should not update the dropdown items from the data-provider', async () => {
+        comboBox.opened = true;
+        // Wait for the async data provider timeout
+        await aTimeout(0);
+        const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+        expect(items.length).to.equal(2);
+        expect(items[0].textContent).to.equal('apple');
+        expect(items[1].textContent).to.equal('orange');
+      });
     });
   });
 

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -811,6 +811,15 @@ describe('basic', () => {
       expect(items[1].textContent).to.equal('orange');
     });
 
+    it('should render selected items updated while readonly', () => {
+      comboBox.selectedItems = [];
+      comboBox.selectedItems = ['lemon'];
+      inputElement.click();
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items.length).to.equal(1);
+      expect(items[0].textContent).to.equal('lemon');
+    });
+
     it('should not set selected attribute on the dropdown items', () => {
       inputElement.click();
       const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');


### PR DESCRIPTION
## Description

1. Added a check for `readonly` when requesting data provider to avoid spinner if opened in `readonly` mode
2. Refactored logic and added a test to cover the case when `selectedItems` is updated while `readonly`

Fixes #3984

## Type of change

- Bugfix