### PR TITLE
feat: expose loading property and attribute

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -51,6 +51,16 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   static get properties() {
     return {
       /**
+       * When set to `true`, "loading" attribute is set
+       * on the host and the overlay element.
+       * @type {boolean}
+       */
+      loading: {
+        type: Boolean,
+        notify: true,
+      },
+
+      /**
        * Total number of items.
        * @type {number | undefined}
        */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -122,6 +122,7 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
  * `invalid`              | Set when the element is invalid
  * `focused`              | Set when the element is focused
  * `focus-ring`           | Set when the element is keyboard focused
+ * `loading`              | Set when loading items from the data provider
  * `opened`               | Set when the dropdown is open
  * `readonly`             | Set to a readonly element
  *
@@ -240,6 +241,11 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
    * ```
    */
   i18n: MultiSelectComboBoxI18n;
+
+  /**
+   * True when loading items from the data provider, false otherwise.
+   */
+  loading: boolean;
 
   /**
    * True if the dropdown is open, false otherwise.

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -100,6 +100,7 @@ registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectCo
  * `invalid`              | Set when the element is invalid
  * `focused`              | Set when the element is focused
  * `focus-ring`           | Set when the element is keyboard focused
+ * `loading`              | Set when loading items from the data provider
  * `opened`               | Set when the dropdown is open
  * `readonly`             | Set to a readonly element
  *
@@ -162,6 +163,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           allow-custom-value="[[allowCustomValue]]"
           data-provider="[[dataProvider]]"
           filter="{{filter}}"
+          loading="{{loading}}"
           size="{{size}}"
           filtered-items="[[filteredItems]]"
           opened="{{opened}}"
@@ -296,6 +298,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
             total: '{count} items selected',
           };
         },
+      },
+
+      /**
+       * True when loading items from the data provider, false otherwise.
+       */
+      loading: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true,
       },
 
       /**

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -109,6 +109,24 @@ describe('basic', () => {
       expect(comboBox.size).to.equal(20);
     });
 
+    it('should propagate loading property to combo-box', () => {
+      comboBox.loading = true;
+      expect(internal.loading).to.be.true;
+    });
+
+    it('should update size when combo-box size changes', () => {
+      internal.loading = true;
+      expect(comboBox.loading).to.be.true;
+    });
+
+    it('should reflect loading property to attribute', () => {
+      comboBox.loading = true;
+      expect(comboBox.hasAttribute('loading')).to.be.true;
+
+      comboBox.loading = false;
+      expect(comboBox.hasAttribute('loading')).to.be.false;
+    });
+
     it('should call clearCache() method on the combo-box', () => {
       const spy = sinon.spy(internal, 'clearCache');
       comboBox.clearCache();


### PR DESCRIPTION
## Description

Follow-up to #3961, added a missing `loading` property and corresponding state attribute for styling.

## Type of change

- Feature