### PR TITLE
fix: allow setting custom viewBox attribute

### DIFF
--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -83,7 +83,7 @@ class Icon extends ThemableMixin(ElementMixin(PolymerElement)) {
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
         xmlns:xlink="http://www.w3.org/1999/xlink"
-        viewBox="[[__computeViewBox(size)]]"
+        viewBox="[[__computeViewBox(size, __viewBox)]]"
         preserveAspectRatio="xMidYMid meet"
         aria-hidden="true"
       ></svg>
@@ -128,6 +128,12 @@ class Icon extends ThemableMixin(ElementMixin(PolymerElement)) {
 
       /** @private */
       __svgElement: Object,
+
+      /** @private */
+      __viewBox: {
+        type: String,
+        value: '',
+      },
     };
   }
 
@@ -181,7 +187,10 @@ class Icon extends ThemableMixin(ElementMixin(PolymerElement)) {
       this.__checkDeprecatedIcon(icon);
       const iconsetName = this.__getIconsetName(icon);
       const iconset = Iconset.getIconset(iconsetName);
-      const { svg, size } = iconset.applyIcon(icon);
+      const { svg, size, viewBox } = iconset.applyIcon(icon);
+      if (viewBox) {
+        this.__viewBox = viewBox;
+      }
       if (size !== this.size) {
         this.size = size;
       }
@@ -215,8 +224,8 @@ class Icon extends ThemableMixin(ElementMixin(PolymerElement)) {
   }
 
   /** @private */
-  __computeViewBox(size) {
-    return `0 0 ${size} ${size}`;
+  __computeViewBox(size, viewBox) {
+    return viewBox || `0 0 ${size} ${size}`;
   }
 }
 

--- a/packages/icon/src/vaadin-iconset.d.ts
+++ b/packages/icon/src/vaadin-iconset.d.ts
@@ -35,7 +35,7 @@ declare class Iconset extends ElementMixin(HTMLElement) {
    * Produce SVGTemplateResult for the element matching `name` in this
    * iconset, or `undefined` if there is no matching element.
    */
-  applyIcon(name: string): { svg: IconSvgLiteral; size: number };
+  applyIcon(name: string): { svg: IconSvgLiteral; size: number; viewBox: string | null };
 }
 
 declare global {

--- a/packages/icon/src/vaadin-iconset.js
+++ b/packages/icon/src/vaadin-iconset.js
@@ -82,7 +82,12 @@ class Iconset extends ElementMixin(PolymerElement) {
     // Create the icon map on-demand, since the iconset itself has no discrete
     // signal to know when it's children are fully parsed
     this._icons = this._icons || this.__createIconMap();
-    return { svg: cloneSvgNode(this._icons[this.__getIconId(name)]), size: this.size };
+    const icon = this._icons[this.__getIconId(name)];
+    return {
+      svg: cloneSvgNode(icon),
+      size: this.size,
+      viewBox: icon ? icon.getAttribute('viewBox') : null,
+    };
   }
 
   /**

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -6,6 +6,7 @@ import { unsafeSvgLiteral } from '../src/vaadin-icon-svg.js';
 
 const ANGLE_DOWN = '<path d="M13 4v2l-5 5-5-5v-2l5 5z"></path>';
 const ANGLE_UP = '<path d="M3 12v-2l5-5 5 5v2l-5-5z"></path>';
+const PLUS = '<path d="M3.5,7V0M0,3.5h7"></path>';
 
 describe('vaadin-icon', () => {
   let icon, svgElement;
@@ -124,6 +125,7 @@ describe('vaadin-icon', () => {
             <defs>
               <g id="vaadin:angle-down">${ANGLE_DOWN}</g>
               <g id="vaadin:angle-up">${ANGLE_UP}</g>
+              <g id="vaadin:plus" viewBox="0 0 7 7">${PLUS}</g>
             </defs>
           </svg>
         </vaadin-iconset>
@@ -167,6 +169,11 @@ describe('vaadin-icon', () => {
         icon.style.color = 'rgb(0, 0, 255)';
         icon.style.fill = 'rgb(0, 255, 0)';
         expect(getComputedStyle(icon).fill).to.equal('rgb(0, 255, 0)');
+      });
+
+      it('should preserve the viewBox attribute set on the icon', () => {
+        icon.icon = 'vaadin:plus';
+        expect(svgElement.getAttribute('viewBox')).to.equal('0 0 7 7');
       });
 
       it('should apply the icon once the set is registered', () => {

--- a/packages/icon/test/typings/iconset.types.ts
+++ b/packages/icon/test/typings/iconset.types.ts
@@ -6,4 +6,4 @@ const iconset = document.createElement('vaadin-iconset');
 assertType<Iconset>(iconset);
 
 const result = iconset.applyIcon('test');
-assertType<{ svg: IconSvgLiteral; size: number }>(result);
+assertType<{ svg: IconSvgLiteral; size: number; viewBox: string | null }>(result);


### PR DESCRIPTION
## Description

Currently, the `vaadin-iconset` does not take custom `viewBox` into account.
We missed to implement corresponding [logic](https://github.com/PolymerElements/iron-iconset-svg/blob/c575f7f30be3174607a76ccf15c16ce4c2416f4c/iron-iconset-svg.js#L237-L238) from `iron-iconset-svg`.

This PR fixes that by checking the attribute on the cloned `<g>` element.

Fixes #3992

## Type of change

- Bugfix