### PR TITLE
fix: make getEventContext() work with context-menu on iOS

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-event.js
+++ b/packages/context-menu/src/vaadin-contextmenu-event.js
@@ -41,12 +41,8 @@ register({
 
     // Calling `sourceEvent.composedPath()` after a timeout would return an empty array.
     // This is especially problematic on iOS where we configure the timer on touchstart.
-    // So we need this hack to make `grid.getEventContext(sourceEvent)` work properly.
-    Object.defineProperty(this.info.sourceEvent, 'composedPath', {
-      get: () => {
-        return () => path;
-      },
-    });
+    // Store the composed path to be used by `grid.getEventContext(event)` so it works.
+    this.info.sourceEvent.__composedPath = path;
   },
 
   touchstart(e) {

--- a/packages/context-menu/test/touch.test.js
+++ b/packages/context-menu/test/touch.test.js
@@ -71,6 +71,18 @@ describe('mobile support', () => {
     target.dispatchEvent(ev);
   });
 
+  it('should preserve `composedPath()` for the source event', (done) => {
+    const ev = new CustomEvent('contextmenu', { bubbles: true });
+    menu.listenOn.addEventListener('vaadin-contextmenu', (e) => {
+      setTimeout(() => {
+        const { sourceEvent } = e.detail;
+        expect(sourceEvent.composedPath()[0]).to.eql(target);
+        done();
+      });
+    });
+    target.dispatchEvent(ev);
+  });
+
   (isIOS ? describe : describe.skip)('iOS touch', () => {
     describe('timings', () => {
       let clock;

--- a/packages/context-menu/test/touch.test.js
+++ b/packages/context-menu/test/touch.test.js
@@ -74,11 +74,9 @@ describe('mobile support', () => {
   it('should preserve `composedPath()` for the source event', (done) => {
     const ev = new CustomEvent('contextmenu', { bubbles: true });
     menu.listenOn.addEventListener('vaadin-contextmenu', (e) => {
-      setTimeout(() => {
-        const { sourceEvent } = e.detail;
-        expect(sourceEvent.composedPath()[0]).to.eql(target);
-        done();
-      });
+      const { sourceEvent } = e.detail;
+      expect(sourceEvent.__composedPath[0]).to.eql(target);
+      done();
     });
     target.dispatchEvent(ev);
   });

--- a/packages/grid/src/vaadin-grid-event-context-mixin.js
+++ b/packages/grid/src/vaadin-grid-event-context-mixin.js
@@ -33,7 +33,9 @@ export const EventContextMixin = (superClass) =>
     getEventContext(event) {
       const context = {};
 
-      const path = event.composedPath();
+      // Use `composedPath()` stored by vaadin-context-menu gesture
+      // to avoid problem when accessing it after a timeout on iOS
+      const path = event.__composedPath || event.composedPath();
       const cell = path[path.indexOf(this.$.table) - 3];
 
       if (!cell) {

--- a/packages/grid/test/event-context.test.js
+++ b/packages/grid/test/event-context.test.js
@@ -133,4 +133,20 @@ describe('event context', () => {
   it('should return empty object when targeting grid element', (done) => {
     testEventContext(grid, {}, done);
   });
+
+  it('should use composedPath() stored on the event', (done) => {
+    grid.addEventListener('click', (e) => {
+      // Emulate the context-menu gesture
+      e.__composedPath = e.composedPath();
+
+      setTimeout(() => {
+        const context = grid.getEventContext(e);
+        expect(context.column).to.deep.equal(column);
+        done();
+      });
+    });
+
+    const cell = getContainerCell(grid.$.items, 0, 0);
+    click(cell);
+  });
 });


### PR DESCRIPTION
## Description

This PR addresses a problem that makes `grid.getEventContext()` broken when using `vaadin-contextmenu` event.
Note, this logic is quite fundamental for `vaadin-grid` context-menu feature, as you can see it's used in two places:

- [GridContextMenu](https://github.com/vaadin/flow-components/blob/90f440e15831ce1d6f6def44c91fa273f1d4b751/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.js#L1038-L1041)
- [TypeScript example](https://github.com/vaadin/docs/blob/ce9cf34c7a8b95adb16f90fa4b4c1114b91e385f/frontend/demo/component/grid/grid-context-menu.ts#L36-L39)

The actual problem is that `event.composedPath()` returns `[]` (empty array) as soon as you use `setTimeout()`.
This is exactly what we are doing for `touchstart` event by setting timer in our [`contextmenu` gesture](https://github.com/vaadin/web-components/blob/322bba42b83f908a78cd972b06acadc5da95a69d/packages/context-menu/src/vaadin-contextmenu-event.js#L48-L60).

Fixes https://github.com/vaadin/flow-components/issues/3296
Fixes https://github.com/vaadin/flow-components/issues/2951

Note: this needs an integration test, I'd like to add it in a separate PR to make cherry-picking easier.

Also note, the unit test that I added covers `contextmenu` event and not `touchstart`.
We do not currently run tests on iOS, so corresponding test suite is skipped 😕 

## Type of change

- Bugfix