### PR TITLE
fix: close drawer on touchend and prevent click

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -293,7 +293,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
       <div part="navbar" id="navbarTop">
         <slot name="navbar"></slot>
       </div>
-      <div part="backdrop" on-click="_close" on-touchstart="_close"></div>
+      <div part="backdrop" on-click="_onBackdropClick" on-touchend="_onBackdropTouchend"></div>
       <div part="drawer" id="drawer" on-keydown="__onDrawerKeyDown">
         <slot name="drawer" id="drawerSlot"></slot>
       </div>
@@ -725,6 +725,20 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     if (closeDrawerOn) {
       window.addEventListener(closeDrawerOn, this.__closeOverlayDrawerListener);
     }
+  }
+
+  /** @private */
+  _onBackdropClick() {
+    this._close();
+  }
+
+  /** @private */
+  _onBackdropTouchend(event) {
+    // Prevent the click event from being fired
+    // on clickable element behind the backdrop
+    event.preventDefault();
+
+    this._close();
   }
 
   /** @protected */

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -304,7 +304,7 @@ describe('vaadin-app-layout', () => {
           expect(layout.drawerOpened).to.be.false;
         });
 
-        it('should prevent touchend event on backdrop touchend', () => {
+        it('should close the drawer on backdrop touchend', () => {
           makeSoloTouchEvent('touchend', null, backdrop);
           expect(layout.drawerOpened).to.be.false;
         });

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -1,5 +1,13 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, esc, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import {
+  aTimeout,
+  esc,
+  fixtureSync,
+  makeSoloTouchEvent,
+  nextFrame,
+  nextRender,
+  oneEvent,
+} from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-app-layout.js';
 import '../vaadin-drawer-toggle.js';
@@ -294,6 +302,16 @@ describe('vaadin-app-layout', () => {
         it('should close the drawer on backdrop click', () => {
           backdrop.click();
           expect(layout.drawerOpened).to.be.false;
+        });
+
+        it('should prevent touchend event on backdrop touchend', () => {
+          makeSoloTouchEvent('touchend', null, backdrop);
+          expect(layout.drawerOpened).to.be.false;
+        });
+
+        it('should prevent touchend event on backdrop', () => {
+          const event = makeSoloTouchEvent('touchend', null, backdrop);
+          expect(event.defaultPrevented).to.be.true;
         });
 
         it('should close the drawer when calling helper method', () => {


### PR DESCRIPTION
## Description

Currently, on mobile devices the drawer is closed on `touchstart` and the following `touchend` event might result in dispatching a `click` event on the clickable element, such as `<button>` behind a backdrop - e.g. placed at the right corner of the navbar.

Up until Vaadin 23, this was apparently handled by Polymer ghost click prevention mechanism that we removed in #3169.
This PR changes the logic to close on `touchend` and adds `event.preventDefault()` call that actually prevents the click.

Fixes https://github.com/vaadin/flow-components/issues/3288

## Type of change

- Bugfix