### PR TITLE
refactor: don't use Polymer API internally in combo-box

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -188,13 +188,10 @@ export const ComboBoxDataProviderMixin = (superClass) =>
 
         const callback = (items, size) => {
           if (this._pendingRequests[page] === callback) {
-            if (!this.filteredItems) {
-              const filteredItems = [];
-              filteredItems.splice(params.page * params.pageSize, items.length, ...items);
-              this.filteredItems = filteredItems;
-            } else {
-              this.splice('filteredItems', params.page * params.pageSize, items.length, ...items);
-            }
+            const filteredItems = this.filteredItems ? [...this.filteredItems] : [];
+            filteredItems.splice(params.page * params.pageSize, items.length, ...items);
+            this.filteredItems = filteredItems;
+
             // Update selectedItem from filteredItems if value is set
             if (this._isValidValue(this.value) && this._getItemValue(this.selectedItem) !== this.value) {
               this._selectItemForValue(this.value);

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -203,8 +203,8 @@ export const ComboBoxMixin = (subclass) =>
     static get observers() {
       return [
         '_filterChanged(filter, itemValuePath, itemLabelPath)',
-        '_itemsOrPathsChanged(items, itemValuePath, itemLabelPath)',
-        '_filteredItemsChanged(filteredItems, itemValuePath, itemLabelPath)',
+        '_itemsChanged(items)',
+        '_filteredItemsChanged(filteredItems)',
         '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
       ];
     }
@@ -834,7 +834,7 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /** @private */
-    _filterChanged(filter, itemValuePath, itemLabelPath) {
+    _filterChanged(filter, _itemValuePath, _itemLabelPath) {
       if (filter === undefined) {
         return;
       }
@@ -848,7 +848,7 @@ export const ComboBoxMixin = (subclass) =>
         // With certain use cases (e. g., external filtering), `items` are
         // undefined. Filtering is unnecessary per se, but the filteredItems
         // observer should still be invoked to update focused item.
-        this._filteredItemsChanged(this.filteredItems, itemValuePath, itemLabelPath);
+        this._filteredItemsChanged(this.filteredItems);
       }
     }
 
@@ -956,10 +956,7 @@ export const ComboBoxMixin = (subclass) =>
       this._ensureItemsOrDataProvider(() => {
         this.items = oldItems;
       });
-    }
 
-    /** @private */
-    _itemsOrPathsChanged(items, _itemValuePath, _itemLabelPath) {
       if (items) {
         this.filteredItems = items.slice(0);
       } else if (this.__previousItems) {
@@ -984,7 +981,7 @@ export const ComboBoxMixin = (subclass) =>
       // When the external filtering is used and `value` was provided before `filteredItems`,
       // initialize the selected item with the current value here. This will also cause
       // the input element value to sync. In other cases, the selected item is already initialized
-      // in other observers such as `valueChanged`, `_itemsOrPathsChanged`.
+      // in other observers such as `valueChanged`, `_itemsChanged`.
       const valueIndex = this._indexOfValue(this.value, filteredItems);
       if (this.selectedItem === null && valueIndex >= 0) {
         this._selectItemForValue(this.value);

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -203,7 +203,6 @@ export const ComboBoxMixin = (subclass) =>
     static get observers() {
       return [
         '_filterChanged(filter, itemValuePath, itemLabelPath)',
-        '_itemsChanged(items)',
         '_filteredItemsChanged(filteredItems)',
         '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
       ];

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -203,8 +203,8 @@ export const ComboBoxMixin = (subclass) =>
     static get observers() {
       return [
         '_filterChanged(filter, itemValuePath, itemLabelPath)',
-        '_itemsOrPathsChanged(items.*, itemValuePath, itemLabelPath)',
-        '_filteredItemsChanged(filteredItems.*, itemValuePath, itemLabelPath)',
+        '_itemsOrPathsChanged(items, itemValuePath, itemLabelPath)',
+        '_filteredItemsChanged(filteredItems, itemValuePath, itemLabelPath)',
         '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
       ];
     }
@@ -848,7 +848,7 @@ export const ComboBoxMixin = (subclass) =>
         // With certain use cases (e. g., external filtering), `items` are
         // undefined. Filtering is unnecessary per se, but the filteredItems
         // observer should still be invoked to update focused item.
-        this._filteredItemsChanged({ path: 'filteredItems', value: this.filteredItems }, itemValuePath, itemLabelPath);
+        this._filteredItemsChanged(this.filteredItems, itemValuePath, itemLabelPath);
       }
     }
 
@@ -959,50 +959,46 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /** @private */
-    _itemsOrPathsChanged(e) {
-      if (e.path === 'items' || e.path === 'items.splices') {
-        if (this.items) {
-          this.filteredItems = this.items.slice(0);
-        } else if (this.__previousItems) {
-          // Only clear filteredItems if the component had items previously but got cleared
-          this.filteredItems = null;
-        }
-
-        const valueIndex = this._indexOfValue(this.value, this.items);
-        this._focusedIndex = valueIndex;
-
-        const item = valueIndex > -1 && this.items[valueIndex];
-        if (item) {
-          this.selectedItem = item;
-        }
+    _itemsOrPathsChanged(items, _itemValuePath, _itemLabelPath) {
+      if (items) {
+        this.filteredItems = items.slice(0);
+      } else if (this.__previousItems) {
+        // Only clear filteredItems if the component had items previously but got cleared
+        this.filteredItems = null;
       }
-      this.__previousItems = e.value;
+
+      const valueIndex = this._indexOfValue(this.value, items);
+      this._focusedIndex = valueIndex;
+
+      const item = valueIndex > -1 && items[valueIndex];
+      if (item) {
+        this.selectedItem = item;
+      }
+      this.__previousItems = items;
     }
 
     /** @private */
-    _filteredItemsChanged(e) {
-      if (e.path === 'filteredItems' || e.path === 'filteredItems.splices') {
-        this._setOverlayItems(this.filteredItems);
+    _filteredItemsChanged(filteredItems, _itemValuePath, _itemLabelPath) {
+      this._setOverlayItems(filteredItems);
 
-        // When the external filtering is used and `value` was provided before `filteredItems`,
-        // initialize the selected item with the current value here. This will also cause
-        // the input element value to sync. In other cases, the selected item is already initialized
-        // in other observers such as `valueChanged`, `_itemsOrPathsChanged`.
-        const valueIndex = this._indexOfValue(this.value, this.filteredItems);
-        if (this.selectedItem === null && valueIndex >= 0) {
-          this._selectItemForValue(this.value);
-        }
+      // When the external filtering is used and `value` was provided before `filteredItems`,
+      // initialize the selected item with the current value here. This will also cause
+      // the input element value to sync. In other cases, the selected item is already initialized
+      // in other observers such as `valueChanged`, `_itemsOrPathsChanged`.
+      const valueIndex = this._indexOfValue(this.value, filteredItems);
+      if (this.selectedItem === null && valueIndex >= 0) {
+        this._selectItemForValue(this.value);
+      }
 
-        const inputValue = this._inputElementValue;
-        if (inputValue === undefined || inputValue === this._getItemLabel(this.selectedItem)) {
-          // When the input element value is the same as the current value or not defined,
-          // set the focused index to the item that matches the value.
-          this._focusedIndex = this.$.dropdown.indexOfLabel(this._getItemLabel(this.selectedItem));
-        } else {
-          // When the user filled in something that is different from the current value = filtering is enabled,
-          // set the focused index to the item that matches the filter query.
-          this._focusedIndex = this.$.dropdown.indexOfLabel(this.filter);
-        }
+      const inputValue = this._inputElementValue;
+      if (inputValue === undefined || inputValue === this._getItemLabel(this.selectedItem)) {
+        // When the input element value is the same as the current value or not defined,
+        // set the focused index to the item that matches the value.
+        this._focusedIndex = this.$.dropdown.indexOfLabel(this._getItemLabel(this.selectedItem));
+      } else {
+        // When the user filled in something that is different from the current value = filtering is enabled,
+        // set the focused index to the item that matches the filter query.
+        this._focusedIndex = this.$.dropdown.indexOfLabel(this.filter);
       }
     }
 

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -34,15 +34,6 @@ describe('Properties', () => {
       expect(comboBox._focusedIndex).to.eql(1);
     });
 
-    it('should set focused index on mutation', () => {
-      comboBox.value = 'baz';
-      comboBox.items = ['foo', 'bar'];
-
-      comboBox.push('items', 'baz');
-
-      expect(comboBox._focusedIndex).to.eql(2);
-    });
-
     it('should support resetting items', () => {
       comboBox.items = ['foo', 'bar'];
       comboBox.items = undefined;


### PR DESCRIPTION
## Description

The PR removes the internal use of Polymer API from the combo-box to simplify the logic of observers.

A preparation for #3864 

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
