### PR TITLE
fix: do not fire change event on native input change

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -864,6 +864,18 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /**
+   * Override an event listener from `InputControlMixin` to
+   * stop the change event re-targeted from the input.
+   *
+   * @param {!Event} event
+   * @protected
+   * @override
+   */
+  _onChange(event) {
+    event.stopPropagation();
+  }
+
+  /**
    * Override an event listener from `KeyboardMixin`.
    * Do not call `super` in order to override clear
    * button logic defined in `InputControlMixin`.

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -708,6 +708,11 @@ describe('basic', () => {
       chip.shadowRoot.querySelector('[part="remove-button"]').click();
       expect(spy.calledOnce).to.be.true;
     });
+
+    it('should stop change event on the native input', () => {
+      inputElement.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+      expect(spy.called).to.be.false;
+    });
   });
 
   describe('allowCustomValue', () => {


### PR DESCRIPTION
## Description

Copied the logic that is present in `ComboBoxMixin` to make sure it works in `vaadin-multi-select-combo-box`:

https://github.com/vaadin/web-components/blob/9d50b856b3b9a839d3456b066f0bee41293bd281/packages/combo-box/src/vaadin-combo-box-mixin.js#L822-L826

In case of regular combo-box, the `ComboBoxMixin` is applied on top of `InputControlMixin` and overriding works.
This is not the case with `vaadin-multi-select-combo-box` which does not apply mixins in this order.

Fixes #4011

## Type of change

- Bugfix