### PR TITLE
refactor: simplify selected item sync logic

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -192,10 +192,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
             filteredItems.splice(params.page * params.pageSize, items.length, ...items);
             this.filteredItems = filteredItems;
 
-            // Update selectedItem from filteredItems if value is set
-            if (this._isValidValue(this.value) && this._getItemValue(this.selectedItem) !== this.value) {
-              this._selectItemForValue(this.value);
-            }
             if (!this.opened && !this.hasAttribute('focused')) {
               this._commitValue();
             }

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -977,13 +977,13 @@ export const ComboBoxMixin = (subclass) =>
     _filteredItemsChanged(filteredItems, _itemValuePath, _itemLabelPath) {
       this._setOverlayItems(filteredItems);
 
-      // When the external filtering is used and `value` was provided before `filteredItems`,
-      // initialize the selected item with the current value here. This will also cause
-      // the input element value to sync. In other cases, the selected item is already initialized
-      // in other observers such as `valueChanged`, `_itemsChanged`.
+      // Try to sync `selectedItem` based on `value` once a new set of `filteredItems` is available
+      // (as a result of external filtering or when they have been loaded by the data provider).
+      // When `value` is specified but `selectedItem` is not, it means that there was no item
+      // matching `value` at the moment `value` was set, so `selectedItem` has remained unsynced.
       const valueIndex = this._indexOfValue(this.value, filteredItems);
-      if (this.selectedItem === null && valueIndex >= 0) {
-        this._selectItemForValue(this.value);
+      if ((this.selectedItem === null || this.selectedItem === undefined) && valueIndex >= 0) {
+        this.selectedItem = filteredItems[valueIndex];
       }
 
       const inputValue = this._inputElementValue;

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -993,23 +993,6 @@ describe('lazy loading', () => {
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('other value');
         });
-
-        it('should keep previous value if allow-custom-value is set', () => {
-          comboBox.allowCustomValue = true;
-          comboBox.open();
-          setInputValue(comboBox, 'other value');
-          comboBox.close();
-          expect(comboBox.value).to.eql('other value');
-
-          comboBox.focus();
-          // FIXME: fails when using `setInputValue()`
-          const filterValue = 'item 12';
-          comboBox.inputElement.value = filterValue;
-          comboBox.filter = filterValue;
-
-          expect(comboBox.value).to.eql('other value');
-          expect(comboBox.inputElement.value).to.eql('other value');
-        });
       });
 
       describe('after empty data set loaded', () => {


### PR DESCRIPTION
## Description

The PR simplifies the selected item synchronization by combining some conditions for the case when `value` is set before `filteredItems` which can be the case when the data provider has not yet loaded items or external filtering is implemented.

A preparation for https://github.com/vaadin/web-components/issues/3864

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
