### PR TITLE
fix: update selectedItems when updating items

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -235,6 +235,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       items: {
         type: Array,
+        observer: '_itemsChanged',
       },
 
       /**
@@ -602,6 +603,13 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   _clearButtonVisibleChanged(visible, oldVisible) {
     if (visible || oldVisible) {
       this.__updateChips();
+    }
+  }
+
+  /** @private */
+  _itemsChanged(items) {
+    if (Array.isArray(items) && Array.isArray(this.selectedItems)) {
+      this.selectedItems = this.selectedItems.filter((item) => this._findIndex(item, items, this.itemIdPath) > -1);
     }
   }
 

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -237,6 +237,40 @@ describe('basic', () => {
       await sendKeys({ down: 'Tab' });
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
+
+    it('should clear selectedItems when items property is reset', () => {
+      comboBox.selectedItems = ['apple', 'banana'];
+      comboBox.items = [];
+      expect(comboBox.selectedItems).to.deep.equal([]);
+    });
+
+    it('should update selectedItems when items property is updated', () => {
+      comboBox.selectedItems = ['apple', 'banana'];
+      comboBox.items = ['apple', 'lemon'];
+      expect(comboBox.selectedItems).to.deep.equal(['apple']);
+    });
+
+    it('should update selectedItems when updating object items', () => {
+      comboBox.itemIdPath = 'key';
+
+      comboBox.items = [
+        { id: 'a', key: 'apple' },
+        { id: 'b', key: 'banana' },
+        { id: 'l', key: 'lemon' },
+      ];
+
+      comboBox.selectedItems = [
+        { id: 'a', key: 'apple' },
+        { id: 'b', key: 'banana' },
+      ];
+
+      comboBox.items = [
+        { id: 'a', key: 'apple' },
+        { id: 'l', key: 'lemon' },
+      ];
+
+      expect(comboBox.selectedItems).to.deep.equal([{ id: 'a', key: 'apple' }]);
+    });
   });
 
   describe('pageSize', () => {


### PR DESCRIPTION
## Description

Currently, when updating `items` property to empty array, or changing it, the `selectedItems` is not updated.
This PR changes that to filter out the items that are removed and exclude them from `selectedItems`.

## Type of change

- Bugfix