### PR TITLE
Revert "fix: update selectedItems when updating items (#4016)"

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -235,7 +235,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       items: {
         type: Array,
-        observer: '_itemsChanged',
       },
 
       /**
@@ -603,13 +602,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   _clearButtonVisibleChanged(visible, oldVisible) {
     if (visible || oldVisible) {
       this.__updateChips();
-    }
-  }
-
-  /** @private */
-  _itemsChanged(items) {
-    if (Array.isArray(items) && Array.isArray(this.selectedItems)) {
-      this.selectedItems = this.selectedItems.filter((item) => this._findIndex(item, items, this.itemIdPath) > -1);
     }
   }
 

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -237,40 +237,6 @@ describe('basic', () => {
       await sendKeys({ down: 'Tab' });
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
-
-    it('should clear selectedItems when items property is reset', () => {
-      comboBox.selectedItems = ['apple', 'banana'];
-      comboBox.items = [];
-      expect(comboBox.selectedItems).to.deep.equal([]);
-    });
-
-    it('should update selectedItems when items property is updated', () => {
-      comboBox.selectedItems = ['apple', 'banana'];
-      comboBox.items = ['apple', 'lemon'];
-      expect(comboBox.selectedItems).to.deep.equal(['apple']);
-    });
-
-    it('should update selectedItems when updating object items', () => {
-      comboBox.itemIdPath = 'key';
-
-      comboBox.items = [
-        { id: 'a', key: 'apple' },
-        { id: 'b', key: 'banana' },
-        { id: 'l', key: 'lemon' },
-      ];
-
-      comboBox.selectedItems = [
-        { id: 'a', key: 'apple' },
-        { id: 'b', key: 'banana' },
-      ];
-
-      comboBox.items = [
-        { id: 'a', key: 'apple' },
-        { id: 'l', key: 'lemon' },
-      ];
-
-      expect(comboBox.selectedItems).to.deep.equal([{ id: 'a', key: 'apple' }]);
-    });
   });
 
   describe('pageSize', () => {


### PR DESCRIPTION
This reverts commit 0064ec46f0fffd3a7baa5a25731c879ad27f3dba.

## Description

Revert the previous PR based on discussion, see #https://github.com/vaadin/web-components/pull/4016#issuecomment-1150974114

## Type of change

- Revert