### PR TITLE
refactor: remove _dropdownItems property

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -79,7 +79,7 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixi
 
       <vaadin-combo-box-overlay
         id="overlay"
-        hidden$="[[_isOverlayHidden(_dropdownItems, loading)]]"
+        hidden$="[[_isOverlayHidden(filteredItems, loading)]]"
         opened="[[_overlayOpened]]"
         loading$="[[loading]]"
         theme$="[[_theme]]"

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -145,11 +145,6 @@ export declare class ComboBoxMixinClass<TItem> {
 
   protected readonly _propertyForValue: string;
 
-  /**
-   * Set of items to be rendered in the dropdown.
-   */
-  protected _dropdownItems: TItem[];
-
   protected _inputElementValue: string | undefined;
 
   /**

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -221,14 +221,6 @@ export const ComboBoxMixin = (subclass) =>
           observer: '_toggleElementChanged',
         },
 
-        /**
-         * Set of items to be rendered in the dropdown.
-         * @protected
-         */
-        _dropdownItems: {
-          type: Array,
-        },
-
         /** @private */
         _closeOnBlurIsPrevented: Boolean,
 
@@ -247,8 +239,8 @@ export const ComboBoxMixin = (subclass) =>
       return [
         '_filterChanged(filter, itemValuePath, itemLabelPath)',
         '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
-        '_openedOrItemsChanged(opened, _dropdownItems, loading)',
-        '_updateScroller(_scroller, _dropdownItems, opened, loading, selectedItem, itemIdPath, _focusedIndex, renderer, theme)',
+        '_openedOrItemsChanged(opened, filteredItems, loading)',
+        '_updateScroller(_scroller, filteredItems, opened, loading, selectedItem, itemIdPath, _focusedIndex, renderer, theme)',
       ];
     }
 
@@ -477,7 +469,7 @@ export const ComboBoxMixin = (subclass) =>
         this.dispatchEvent(new CustomEvent('vaadin-combo-box-dropdown-opened', { bubbles: true, composed: true }));
 
         this._onOpened();
-      } else if (wasOpened && this._dropdownItems && this._dropdownItems.length) {
+      } else if (wasOpened && this.filteredItems && this.filteredItems.length) {
         this.close();
 
         this.dispatchEvent(new CustomEvent('vaadin-combo-box-dropdown-closed', { bubbles: true, composed: true }));
@@ -664,7 +656,7 @@ export const ComboBoxMixin = (subclass) =>
     /** @private */
     _onArrowDown() {
       if (this.opened) {
-        const items = this._dropdownItems;
+        const items = this.filteredItems;
         if (items) {
           this._focusedIndex = Math.min(items.length - 1, this._focusedIndex + 1);
           this._prefillFocusedItemLabel();
@@ -680,7 +672,7 @@ export const ComboBoxMixin = (subclass) =>
         if (this._focusedIndex > -1) {
           this._focusedIndex = Math.max(0, this._focusedIndex - 1);
         } else {
-          const items = this._dropdownItems;
+          const items = this.filteredItems;
           if (items) {
             this._focusedIndex = items.length - 1;
           }
@@ -695,7 +687,7 @@ export const ComboBoxMixin = (subclass) =>
     /** @private */
     _prefillFocusedItemLabel() {
       if (this._focusedIndex > -1) {
-        const focusedItem = this._dropdownItems[this._focusedIndex];
+        const focusedItem = this.filteredItems[this._focusedIndex];
         this._inputElementValue = this._getItemLabel(focusedItem);
         this._markAllSelectionRange();
       }
@@ -877,7 +869,7 @@ export const ComboBoxMixin = (subclass) =>
     /** @private */
     _commitValue() {
       if (this._focusedIndex > -1) {
-        const focusedItem = this._dropdownItems[this._focusedIndex];
+        const focusedItem = this.filteredItems[this._focusedIndex];
         if (this.selectedItem !== focusedItem) {
           this.selectedItem = focusedItem;
         }
@@ -1125,8 +1117,6 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _filteredItemsChanged(filteredItems) {
-      this._setDropdownItems(filteredItems);
-
       // Try to sync `selectedItem` based on `value` once a new set of `filteredItems` is available
       // (as a result of external filtering or when they have been loaded by the data provider).
       // When `value` is specified but `selectedItem` is not, it means that there was no item
@@ -1184,16 +1174,6 @@ export const ComboBoxMixin = (subclass) =>
     /** @private */
     _getItemElements() {
       return Array.from(this._scroller.querySelectorAll(`${this._tagNamePrefix}-item`));
-    }
-
-    /**
-     * Provide items to be rendered in the dropdown.
-     * Override this method to show custom items.
-     *
-     * @protected
-     */
-    _setDropdownItems(items) {
-      this._dropdownItems = items;
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -200,7 +200,7 @@ class ComboBox extends ComboBoxDataProviderMixin(
 
       <vaadin-combo-box-overlay
         id="overlay"
-        hidden$="[[_isOverlayHidden(_dropdownItems, loading)]]"
+        hidden$="[[_isOverlayHidden(filteredItems, loading)]]"
         opened="[[_overlayOpened]]"
         loading$="[[loading]]"
         theme$="[[_theme]]"

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -38,7 +38,7 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
 
       <vaadin-multi-select-combo-box-overlay
         id="overlay"
-        hidden$="[[_isOverlayHidden(_dropdownItems, loading)]]"
+        hidden$="[[_isOverlayHidden(filteredItems, loading)]]"
         opened="[[_overlayOpened]]"
         loading$="[[loading]]"
         theme$="[[_theme]]"
@@ -83,10 +83,6 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
         type: Object,
       },
     };
-  }
-
-  static get observers() {
-    return ['_readonlyItemsChanged(readonly, selectedItems)'];
   }
 
   /**
@@ -277,19 +273,6 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
 
   /**
    * Override method inherited from the combo-box
-   * to render only selected items when read-only,
-   * even if a different set of items is provided.
-   *
-   * @protected
-   * @override
-   */
-  _setDropdownItems(items) {
-    const effectiveItems = this.readonly ? this.selectedItems : items;
-    super._setDropdownItems(effectiveItems);
-  }
-
-  /**
-   * Override method inherited from the combo-box
    * to not request data provider when read-only.
    *
    * @param {number}
@@ -303,20 +286,6 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     }
 
     return super._shouldLoadPage(page);
-  }
-
-  /** @private */
-  _readonlyItemsChanged(readonly, selectedItems) {
-    if (readonly && selectedItems) {
-      this.__savedItems = this._dropdownItems;
-      this._dropdownItems = selectedItems;
-    }
-
-    // Restore the original dropdown items
-    if (readonly === false && this.__savedItems) {
-      this._dropdownItems = this.__savedItems;
-      this.__savedItems = null;
-    }
   }
 }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -422,6 +422,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       filteredItems: Array,
 
+      /** @private */
       __effectiveItems: {
         type: Array,
         computed: '__computeEffectiveItems(items, selectedItems, readonly, dataProvider)',

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -153,7 +153,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
         <vaadin-multi-select-combo-box-internal
           id="comboBox"
-          items="[[items]]"
+          items="[[__effectiveItems]]"
           item-id-path="[[itemIdPath]]"
           item-label-path="[[itemLabelPath]]"
           item-value-path="[[itemValuePath]]"
@@ -165,7 +165,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           filter="{{filter}}"
           loading="{{loading}}"
           size="{{size}}"
-          filtered-items="[[filteredItems]]"
+          filtered-items="[[__effectiveFilteredItems]]"
           selected-items="[[selectedItems]]"
           opened="{{opened}}"
           renderer="[[renderer]]"
@@ -421,6 +421,17 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        * The items can be of either `String` or `Object` type.
        */
       filteredItems: Array,
+
+      __effectiveItems: {
+        type: Array,
+        computed: '__computeEffectiveItems(items, selectedItems, readonly, dataProvider)',
+      },
+
+      /** @private */
+      __effectiveFilteredItems: {
+        type: Array,
+        computed: '__computeEffectiveFilteredItems(filteredItems, selectedItems, readonly, dataProvider)',
+      },
 
       /** @protected */
       _hasValue: {
@@ -1054,6 +1065,24 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     // Prevent mousedown event to keep the input focused
     // and keep the overlay opened when clicking a chip.
     event.preventDefault();
+  }
+
+  /** @private */
+  __computeEffectiveItems(items, selectedItems, readonly, dataProvider) {
+    if (dataProvider) {
+      return;
+    }
+
+    return readonly ? selectedItems : items;
+  }
+
+  /** @private */
+  __computeEffectiveFilteredItems(filteredItems, selectedItems, readonly, dataProvider) {
+    if (!dataProvider) {
+      return;
+    }
+
+    return readonly ? selectedItems : filteredItems;
   }
 }
 

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -878,48 +878,51 @@ describe('basic', () => {
       inputElement.click();
       expect(internal.opened).to.be.false;
     });
+  });
 
-    describe('dataProvider', () => {
-      let spyAsyncDataProvider;
+  describe('readonly + dataProvider', () => {
+    let spyAsyncDataProvider;
 
-      const ITEMS = ['apple', 'banana', 'lemon', 'orange', 'pear'];
+    const ITEMS = ['apple', 'banana', 'lemon', 'orange', 'pear'];
 
-      const getDataProvider = (allItems) => (params, callback) => {
-        const filteredItems = allItems.filter((item) => item.indexOf(params.filter) > -1);
-        const size = filteredItems.length;
-        const offset = params.page * params.pageSize;
-        const dataProviderItems = filteredItems.slice(offset, offset + params.pageSize);
-        callback(dataProviderItems, size);
-      };
+    const getDataProvider = (allItems) => (params, callback) => {
+      const filteredItems = allItems.filter((item) => item.indexOf(params.filter) > -1);
+      const size = filteredItems.length;
+      const offset = params.page * params.pageSize;
+      const dataProviderItems = filteredItems.slice(offset, offset + params.pageSize);
+      callback(dataProviderItems, size);
+    };
 
-      const dataProvider = getDataProvider(ITEMS);
+    const dataProvider = getDataProvider(ITEMS);
 
-      const asyncDataProvider = (params, callback) => {
-        setTimeout(() => dataProvider(params, callback));
-      };
+    const asyncDataProvider = (params, callback) => {
+      setTimeout(() => dataProvider(params, callback));
+    };
 
-      beforeEach(() => {
-        comboBox.items = undefined;
-        spyAsyncDataProvider = sinon.spy(asyncDataProvider);
-        comboBox.dataProvider = spyAsyncDataProvider;
-      });
+    beforeEach(() => {
+      comboBox.items = undefined;
+      spyAsyncDataProvider = sinon.spy(asyncDataProvider);
+      comboBox.dataProvider = spyAsyncDataProvider;
+      comboBox.selectedItems = ['apple', 'orange'];
+      comboBox.readonly = true;
+      inputElement.focus();
+    });
 
-      it('should not fetch items from the data-provider when readonly', async () => {
-        comboBox.opened = true;
-        // Wait for the async data provider timeout
-        await aTimeout(0);
-        expect(spyAsyncDataProvider.called).to.be.false;
-      });
+    it('should not fetch items from the data-provider when readonly', async () => {
+      comboBox.opened = true;
+      // Wait for the async data provider timeout
+      await aTimeout(0);
+      expect(spyAsyncDataProvider.called).to.be.false;
+    });
 
-      it('should not update the dropdown items from the data-provider', async () => {
-        comboBox.opened = true;
-        // Wait for the async data provider timeout
-        await aTimeout(0);
-        const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
-        expect(items.length).to.equal(2);
-        expect(items[0].textContent).to.equal('apple');
-        expect(items[1].textContent).to.equal('orange');
-      });
+    it('should not update the dropdown items from the data-provider', async () => {
+      comboBox.opened = true;
+      // Wait for the async data provider timeout
+      await aTimeout(0);
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items.length).to.equal(2);
+      expect(items[0].textContent).to.equal('apple');
+      expect(items[1].textContent).to.equal('orange');
     });
   });
 

--- a/packages/time-picker/src/vaadin-time-picker-combo-box.js
+++ b/packages/time-picker/src/vaadin-time-picker-combo-box.js
@@ -35,7 +35,7 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
 
       <vaadin-time-picker-overlay
         id="overlay"
-        hidden$="[[_isOverlayHidden(_dropdownItems, loading)]]"
+        hidden$="[[_isOverlayHidden(filteredItems, loading)]]"
         opened="[[_overlayOpened]]"
         loading$="[[loading]]"
         theme$="[[_theme]]"


### PR DESCRIPTION
## Description

The PR refactors the combo-box and multi-select-combo-box to get rid of a separate `dropdownItems` concept on top of `filteredItems`.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
