### PR TITLE
feat: add multi-select-combo-box Lit renderer

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -415,8 +415,13 @@ export const ComboBoxMixin = (subclass) =>
       });
     }
 
-    /** @private */
-    _initScroller() {
+    /**
+     * Create and initialize the scroller element.
+     * Override to provide custom host reference.
+     *
+     * @protected
+     */
+    _initScroller(host) {
       const scrollerTag = `${this._tagNamePrefix}-scroller`;
 
       const overlay = this.$.overlay;
@@ -434,7 +439,7 @@ export const ComboBoxMixin = (subclass) =>
 
       const scroller = overlay.querySelector(scrollerTag);
 
-      scroller.comboBox = this;
+      scroller.comboBox = host || this;
       scroller.getItemLabel = this._getItemLabel.bind(this);
       scroller.addEventListener('selection-changed', this._boundOverlaySelectedItemChanged);
 

--- a/packages/multi-select-combo-box/lit.d.ts
+++ b/packages/multi-select-combo-box/lit.d.ts
@@ -1,0 +1,1 @@
+export * from './src/lit/renderer-directives.js';

--- a/packages/multi-select-combo-box/lit.js
+++ b/packages/multi-select-combo-box/lit.js
@@ -1,0 +1,1 @@
+export * from './src/lit/renderer-directives.js';

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -19,6 +19,8 @@
   "main": "vaadin-multi-select-combo-box.js",
   "module": "vaadin-multi-select-combo-box.js",
   "files": [
+    "lit.js",
+    "lit.d.ts",
     "src",
     "theme",
     "vaadin-*.d.ts",
@@ -37,6 +39,7 @@
     "@vaadin/component-base": "^23.2.0-alpha0",
     "@vaadin/field-base": "^23.2.0-alpha0",
     "@vaadin/input-container": "^23.2.0-alpha0",
+    "@vaadin/lit-renderer": "^23.2.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "^23.2.0-alpha0",
     "@vaadin/vaadin-material-styles": "^23.2.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "^23.2.0-alpha0"

--- a/packages/multi-select-combo-box/src/lit/renderer-directives.d.ts
+++ b/packages/multi-select-combo-box/src/lit/renderer-directives.d.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { TemplateResult } from 'lit';
+import { DirectiveResult } from 'lit/directive.js';
+import { ComboBoxItemModel } from '@vaadin/combo-box/src/vaadin-combo-box.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+import { MultiSelectComboBox } from '../vaadin-multi-select-combo-box.js';
+
+export type MultiSelectComboBoxLitRenderer<TItem> = (
+  item: TItem,
+  model: ComboBoxItemModel<TItem>,
+  comboBox: MultiSelectComboBox<TItem>,
+) => TemplateResult;
+
+export class MultiSelectComboBoxRendererDirective<TItem> extends LitRendererDirective<
+  MultiSelectComboBox,
+  MultiSelectComboBoxLitRenderer<TItem>
+> {
+  /**
+   * Adds the renderer callback to the combo-box.
+   */
+  addRenderer(): void;
+
+  /**
+   * Runs the renderer callback on the combo-box.
+   */
+  runRenderer(): void;
+
+  /**
+   * Removes the renderer callback from the combo-box.
+   */
+  removeRenderer(): void;
+}
+
+/**
+ * A Lit directive for rendering the content of the `<vaadin-multi-select-combo-box-item>` elements.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the combo-box
+ * via the `renderer` property. The renderer is called for each combo-box item when assigned
+ * and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-multi-select-combo-box
+ *   ${multiSelectComboBoxRenderer((item, model, comboBox) => html`...`)}
+ * ></vaadin-multi-select-combo-box>`
+ * ```
+ *
+ * @param renderer the renderer callback that returns a Lit template.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export declare function multiSelectComboBoxRenderer<TItem>(
+  renderer: MultiSelectComboBoxLitRenderer<TItem>,
+  dependencies?: unknown,
+): DirectiveResult<typeof MultiSelectComboBoxRendererDirective>;

--- a/packages/multi-select-combo-box/src/lit/renderer-directives.js
+++ b/packages/multi-select-combo-box/src/lit/renderer-directives.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { directive } from 'lit/directive.js';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+
+export class MultiSelectComboBoxRendererDirective extends LitRendererDirective {
+  /**
+   * Adds the renderer callback to the combo-box.
+   */
+  addRenderer() {
+    this.element.renderer = (root, comboBox, model) => {
+      this.renderRenderer(root, model.item, model, comboBox);
+    };
+  }
+
+  /**
+   * Runs the renderer callback on the combo-box.
+   */
+  runRenderer() {
+    this.element.requestContentUpdate();
+  }
+
+  /**
+   * Removes the renderer callback from the combo-box.
+   */
+  removeRenderer() {
+    this.element.renderer = null;
+  }
+}
+
+/**
+ * A Lit directive for rendering the content of the `<vaadin-multi-select-combo-box-item>` elements.
+ *
+ * The directive accepts a renderer callback returning a Lit template and assigns it to the combo-box
+ * via the `renderer` property. The renderer is called for each combo-box item when assigned
+ * and whenever a single dependency or an array of dependencies changes.
+ * It is not guaranteed that the renderer will be called immediately (synchronously) in both cases.
+ *
+ * Dependencies can be a single value or an array of values.
+ * Values are checked against previous values with strict equality (`===`),
+ * so the check won't detect nested property changes inside objects or arrays.
+ * When dependencies are provided as an array, each item is checked against the previous value
+ * at the same index with strict equality. Nested arrays are also checked only by strict
+ * equality.
+ *
+ * Example of usage:
+ * ```js
+ * `<vaadin-multi-select-combo-box
+ *   ${multiSelectComboBoxRenderer((item, model, comboBox) => html`...`)}
+ * ></vaadin-multi-select-combo-box>`
+ * ```
+ *
+ * @param renderer the renderer callback that returns a Lit template.
+ * @param dependencies a single dependency or an array of dependencies
+ *                     which trigger a re-render when changed.
+ */
+export const multiSelectComboBoxRenderer = directive(MultiSelectComboBoxRendererDirective);

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -124,9 +124,20 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
 
     this._target = this;
     this._toggleElement = this.querySelector('.toggle-button');
+  }
 
-    // Set correct owner for using by item renderers
-    this._scroller.comboBox = this.getRootNode().host;
+  /**
+   * Override combo-box method to set correct owner for using by item renderers.
+   * This needs to be done before the scroller gets added to the DOM to ensure
+   * Lit directive works in case when combo-box is opened using attribute.
+   *
+   * @protected
+   * @override
+   */
+  _initScroller() {
+    const comboBox = this.getRootNode().host;
+
+    super._initScroller(comboBox);
   }
 
   /**

--- a/packages/multi-select-combo-box/test/lit-renderer-directives.test.js
+++ b/packages/multi-select-combo-box/test/lit-renderer-directives.test.js
@@ -1,0 +1,96 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './not-animated-styles.js';
+import '../vaadin-multi-select-combo-box.js';
+import { html, render } from 'lit';
+import { multiSelectComboBoxRenderer } from '../lit.js';
+
+async function renderComboBox(container, { items }) {
+  render(
+    html`
+      <vaadin-multi-select-combo-box
+        .items="${items}"
+        ${items ? multiSelectComboBoxRenderer((item) => html`${item}`, items) : null}
+      ></vaadin-multi-select-combo-box>
+    `,
+    container,
+  );
+  await nextFrame();
+  return container.querySelector('vaadin-multi-select-combo-box');
+}
+
+describe('lit renderer directives', () => {
+  let container, comboBox;
+
+  beforeEach(() => {
+    container = fixtureSync('<div></div>');
+  });
+
+  describe('multiSelectComboBoxRenderer', () => {
+    describe('basic', () => {
+      beforeEach(async () => {
+        comboBox = await renderComboBox(container, { items: ['Item'] });
+      });
+
+      it('should set `renderer` property when the directive is attached', () => {
+        expect(comboBox.renderer).to.exist;
+      });
+
+      it('should unset `renderer` property when the directive is detached', async () => {
+        await renderComboBox(container, {});
+        expect(comboBox.renderer).not.to.exist;
+      });
+
+      it('should render items with the renderer when the combo-box is opened', () => {
+        comboBox.opened = true;
+        const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+        expect(items[0].textContent).to.equal('Item');
+      });
+
+      it('should re-render items when the combo-box is opened and a renderer dependency changes', async () => {
+        comboBox.opened = true;
+        await renderComboBox(container, { items: ['New Item'] });
+        const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+        expect(items[0].textContent).to.equal('New Item');
+      });
+    });
+
+    describe('arguments', () => {
+      let rendererSpy;
+
+      beforeEach(async () => {
+        rendererSpy = sinon.spy();
+        render(
+          html`
+            <vaadin-multi-select-combo-box
+              opened
+              .items="${['Item']}"
+              ${multiSelectComboBoxRenderer(rendererSpy)}
+            ></vaadin-multi-select-combo-box>
+          `,
+          container,
+        );
+        await nextFrame();
+        comboBox = container.querySelector('vaadin-multi-select-combo-box');
+      });
+
+      it('should pass the item to the renderer', () => {
+        expect(rendererSpy.firstCall.args[0]).to.equal('Item');
+      });
+
+      it('should pass the model to the renderer', () => {
+        expect(rendererSpy.firstCall.args[1]).to.deep.equal({
+          item: 'Item',
+          index: 0,
+          focused: false,
+          selected: false,
+        });
+      });
+
+      it('should pass the combo-box instance to the renderer', () => {
+        expect(rendererSpy.firstCall.args[2]).to.equal(comboBox);
+      });
+    });
+  });
+});

--- a/packages/multi-select-combo-box/test/typings/lit.types.ts
+++ b/packages/multi-select-combo-box/test/typings/lit.types.ts
@@ -1,0 +1,19 @@
+import { DirectiveResult } from 'lit/directive.js';
+import {
+  MultiSelectComboBoxLitRenderer,
+  multiSelectComboBoxRenderer,
+  MultiSelectComboBoxRendererDirective,
+} from '../../lit.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+interface TestComboBoxItem {
+  testProperty: string;
+}
+
+assertType<
+  (
+    renderer: MultiSelectComboBoxLitRenderer<TestComboBoxItem>,
+    dependencies?: unknown,
+  ) => DirectiveResult<typeof MultiSelectComboBoxRendererDirective>
+>(multiSelectComboBoxRenderer);


### PR DESCRIPTION
## Description

Added the new Lit renderer directive copied from the `comboBoxRenderer`. 
Also, fixed the scroller initialization to be done before it gets attached.

Fixes #3981

## Type of change

- Feature