### PR TITLE
fix: prevent an item focus reset after more items are loaded

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1107,6 +1107,9 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _filteredItemsChanged(filteredItems, oldFilteredItems) {
+      // Store the currently focused item if any. The focused index preserves
+      // in the case when more filtered items are loading but it is reset
+      // when the user types in a filter query.
       const focusedItem = oldFilteredItems ? oldFilteredItems[this._focusedIndex] : null;
 
       // Try to sync `selectedItem` based on `value` once a new set of `filteredItems` is available
@@ -1118,6 +1121,9 @@ export const ComboBoxMixin = (subclass) =>
         this.selectedItem = filteredItems[valueIndex];
       }
 
+      // Try to first set focus on the item that had been focused before `filteredItems` were updated
+      // if it is still present in the `filteredItems` array. Otherwise, set the focused index
+      // depending on the selected item or the filter query.
       const focusedItemIndex = this.__getItemIndexByValue(filteredItems, this._getItemValue(focusedItem));
       if (focusedItemIndex > -1) {
         this._focusedIndex = focusedItemIndex;

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -223,7 +223,7 @@ export class ComboBoxScroller extends PolymerElement {
 
   /** @private */
   __isItemFocused(focusedIndex, itemIndex) {
-    return focusedIndex === itemIndex;
+    return !this.loading && focusedIndex === itemIndex;
   }
 
   /** @private */
@@ -248,8 +248,8 @@ export class ComboBoxScroller extends PolymerElement {
   }
 
   /** @private */
-  __loadingChanged(loading) {
-    if (this.__virtualizer && !loading) {
+  __loadingChanged() {
+    if (this.__virtualizer) {
       this.requestContentUpdate();
     }
   }

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, enterKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { arrowDownKeyDown, aTimeout, enterKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
 import './not-animated-styles.js';
@@ -11,6 +11,7 @@ import {
   flushComboBox,
   getAllItems,
   getFirstItem,
+  getFocusedItemIndex,
   getSelectedItem,
   getViewportItems,
   getVisibleItemsCount,
@@ -414,6 +415,45 @@ describe('lazy loading', () => {
 
           enterKeyDown(comboBox.inputElement);
           expect(comboBox.value).to.eql('custom value');
+        });
+
+        it('should keep the focused item focused when loading more items', async () => {
+          comboBox.size = SIZE;
+          comboBox.dataProvider = spyAsyncDataProvider;
+          comboBox.opened = true;
+          // Wait for the async data provider to respond
+          await aTimeout(0);
+
+          arrowDownKeyDown(comboBox.inputElement);
+          expect(getFocusedItemIndex(comboBox)).to.equal(0);
+
+          comboBox._scrollIntoView(50);
+          // Wait for the async data provider to respond
+          await aTimeout(0);
+
+          comboBox._scrollIntoView(0);
+          expect(getFocusedItemIndex(comboBox)).to.equal(0);
+        });
+
+        it('should keep the focused item focused when loading more items including a selected item', async () => {
+          comboBox.size = SIZE;
+          comboBox.dataProvider = spyAsyncDataProvider;
+          comboBox.value = 'item 50';
+          comboBox.opened = true;
+          // Wait for the async data provider to respond
+          await aTimeout(0);
+          expect(comboBox.selectedItem).to.not.exist;
+
+          arrowDownKeyDown(comboBox.inputElement);
+          expect(getFocusedItemIndex(comboBox)).to.equal(0);
+
+          comboBox._scrollIntoView(50);
+          // Wait for the async data provider to respond
+          await aTimeout(0);
+          expect(comboBox.selectedItem).to.exist;
+
+          comboBox._scrollIntoView(0);
+          expect(getFocusedItemIndex(comboBox)).to.equal(0);
         });
 
         it('should not jump back to focused item after scroll', async () => {


### PR DESCRIPTION
## Description

The PR prevents a possible item focus reset after the data provider has loaded more items. The item focus preserves when more items are loading but it is reset when the user changes the filter query.

Fixes https://github.com/vaadin/web-components/issues/3864

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
