### PR TITLE
fix: use always a boolean for the  `__isNew`  variable

### DIFF
--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -1141,7 +1141,7 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
         }
       });
 
-      this.__isNew = this.__isNew || (this.items && this.items.indexOf(item) < 0);
+      this.__isNew = !!(this.__isNew || (this.items && this.items.indexOf(item) < 0));
       this.editorOpened = true;
     }
   }


### PR DESCRIPTION
Fixes: #4022

