### PR TITLE
docs: deprecate `preventInvalidInput` property

### DIFF
--- a/packages/field-base/src/pattern-mixin.d.ts
+++ b/packages/field-base/src/pattern-mixin.d.ts
@@ -34,6 +34,7 @@ export declare class PatternMixinClass {
    * When set to true, user is prevented from typing a value that
    * conflicts with the given `pattern`.
    * @attr {boolean} prevent-invalid-input
+   * @deprecated Please use `allowedCharPattern` instead.
    */
   preventInvalidInput: boolean | null | undefined;
 }

--- a/packages/field-base/src/pattern-mixin.js
+++ b/packages/field-base/src/pattern-mixin.js
@@ -29,9 +29,11 @@ export const PatternMixin = (superclass) =>
          * When set to true, user is prevented from typing a value that
          * conflicts with the given `pattern`.
          * @attr {boolean} prevent-invalid-input
+         * @deprecated Please use `allowedCharPattern` instead.
          */
         preventInvalidInput: {
           type: Boolean,
+          observer: '_preventInvalidInputChanged',
         },
       };
     }
@@ -67,5 +69,14 @@ export const PatternMixin = (superclass) =>
       this._checkInputValue();
 
       super._onInput(event);
+    }
+
+    /** @private */
+    _preventInvalidInputChanged(preventInvalidInput) {
+      if (preventInvalidInput) {
+        console.warn(
+          `WARNING: Since Vaadin 23.2, "preventInvalidInput" is deprecated. Please use "allowedCharPattern" instead.`,
+        );
+      }
     }
   };

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -70,15 +70,24 @@ const runTests = (baseClass) => {
 
   describe('prevent invalid input', () => {
     beforeEach(async () => {
+      sinon.stub(console, 'warn');
       element.preventInvalidInput = true;
       element.value = '1';
       await nextFrame();
+    });
+
+    afterEach(() => {
+      console.warn.restore();
     });
 
     function inputText(value) {
       input.value = value;
       input.dispatchEvent(new CustomEvent('input'));
     }
+
+    it('should warn about using preventInvalidInput', () => {
+      expect(console.warn.calledOnce).to.be.true;
+    });
 
     it('should prevent invalid pattern', async () => {
       element.pattern = '[0-9]*';


### PR DESCRIPTION
## Description

Added a deprecation warning to be shown when setting `preventInvalidInput` to `true`.

Part of #3837

## Type of change

- Documentation