### PR TITLE
docs: update input-prevented attribute docs

### DIFF
--- a/packages/integer-field/src/vaadin-integer-field.d.ts
+++ b/packages/integer-field/src/vaadin-integer-field.d.ts
@@ -51,8 +51,6 @@ export interface IntegerFieldEventMap extends HTMLElementEventMap, IntegerFieldC
  * `increase-button` | Increase ("plus") button
  * `decrease-button` | Decrease ("minus") button
  *
- * Note, the `input-prevented` state attribute is not supported by `<vaadin-integer-field>`.
- *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -24,8 +24,6 @@ import { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
  * `increase-button` | Increase ("plus") button
  * `decrease-button` | Decrease ("minus") button
  *
- * Note, the `input-prevented` state attribute is not supported by `<vaadin-integer-field>`.
- *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -54,7 +54,7 @@ export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCus
  * `increase-button` | Increase ("plus") button
  * `decrease-button` | Decrease ("minus") button
  *
- * Note, the `input-prevented` state attribute is not supported by `<vaadin-number-field>`.
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -34,7 +34,7 @@ registerStyles('vaadin-number-field', inputFieldShared, { moduleId: 'vaadin-numb
  * `increase-button` | Increase ("plus") button
  * `decrease-button` | Decrease ("minus") button
  *
- * Note, the `input-prevented` state attribute is not supported by `<vaadin-number-field>`.
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Updated API docs for numeric fields to fix no longer valid statements about `input-prevented` state attribute.

## Type of change

- Docs