### PR TITLE
feat: support for @hilla/binder

### DIFF
--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -380,6 +380,11 @@ declare class Crud<Item> extends ControllerMixin(ElementMixin(ThemableMixin(HTML
    */
   i18n: CrudI18n;
 
+  /**
+   * An optional Hilla Binder in order to use validators and type safe models in Crud Forms.
+   */
+  binder: Binder<any, any>;
+
   addEventListener<K extends keyof CrudEventMap<Item>>(
     type: K,
     listener: (this: Crud<Item>, ev: CrudEventMap<Item>[K]) => void,


### PR DESCRIPTION
Fixes: https://github.com/vaadin/web-components/issues/3545

This adds support for an optional Hilla Binder to `vaadin-crud` web-component so as we can use server side validations 

