### PR TITLE
refactor: move initialization to ready() callback

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -168,26 +168,25 @@ class Checkbox extends LabelMixin(
   }
 
   /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
+  ready() {
+    super.ready();
 
-    if (!this._inputController) {
-      this._inputController = new InputController(this, (input) => {
+    this.addController(
+      new InputController(this, (input) => {
         this._setInputElement(input);
         this._setFocusElement(input);
         this.stateTarget = input;
         this.ariaTarget = input;
-      });
-      this.addController(this._inputController);
-      this.addController(new LabelledInputController(this.inputElement, this._labelController));
-      this.addController(
-        new SlotTargetController(
-          this.$.noop,
-          () => this._labelController.node,
-          () => this.__warnDeprecated(),
-        ),
-      );
-    }
+      }),
+    );
+    this.addController(new LabelledInputController(this.inputElement, this._labelController));
+    this.addController(
+      new SlotTargetController(
+        this.$.noop,
+        () => this._labelController.node,
+        () => this.__warnDeprecated(),
+      ),
+    );
   }
 
   /** @private */

--- a/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
+++ b/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
@@ -3,6 +3,18 @@ export const snapshots = {};
 
 snapshots["vaadin-combo-box host placeholder"] = 
 `<vaadin-combo-box placeholder="Placeholder">
+  <label
+    for="input-vaadin-combo-box-4"
+    id="label-vaadin-combo-box-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-combo-box-2"
+    slot="error-message"
+  >
+  </div>
   <input
     aria-autocomplete="list"
     aria-expanded="false"
@@ -15,6 +27,12 @@ snapshots["vaadin-combo-box host placeholder"] =
     slot="input"
     spellcheck="false"
   >
+</vaadin-combo-box>
+`;
+/* end snapshot vaadin-combo-box host placeholder */
+
+snapshots["vaadin-combo-box host pattern"] = 
+`<vaadin-combo-box>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -27,12 +45,6 @@ snapshots["vaadin-combo-box host placeholder"] =
     slot="error-message"
   >
   </div>
-</vaadin-combo-box>
-`;
-/* end snapshot vaadin-combo-box host placeholder */
-
-snapshots["vaadin-combo-box host pattern"] = 
-`<vaadin-combo-box>
   <input
     aria-autocomplete="list"
     aria-expanded="false"
@@ -45,18 +57,6 @@ snapshots["vaadin-combo-box host pattern"] =
     slot="input"
     spellcheck="false"
   >
-  <label
-    for="input-vaadin-combo-box-4"
-    id="label-vaadin-combo-box-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-combo-box-2"
-    slot="error-message"
-  >
-  </div>
 </vaadin-combo-box>
 `;
 /* end snapshot vaadin-combo-box host pattern */
@@ -365,18 +365,7 @@ snapshots["vaadin-combo-box shadow theme"] =
 /* end snapshot vaadin-combo-box shadow theme */
 
 snapshots["vaadin-combo-box slots default"] = 
-`<input
-  aria-autocomplete="list"
-  aria-expanded="false"
-  autocapitalize="off"
-  autocomplete="off"
-  autocorrect="off"
-  id="input-vaadin-combo-box-4"
-  role="combobox"
-  slot="input"
-  spellcheck="false"
->
-<label
+`<label
   for="input-vaadin-combo-box-4"
   id="label-vaadin-combo-box-0"
   slot="label"
@@ -388,14 +377,9 @@ snapshots["vaadin-combo-box slots default"] =
   slot="error-message"
 >
 </div>
-`;
-/* end snapshot vaadin-combo-box slots default */
-
-snapshots["vaadin-combo-box slots label"] = 
-`<input
+<input
   aria-autocomplete="list"
   aria-expanded="false"
-  aria-labelledby="label-vaadin-combo-box-0"
   autocapitalize="off"
   autocomplete="off"
   autocorrect="off"
@@ -404,7 +388,11 @@ snapshots["vaadin-combo-box slots label"] =
   slot="input"
   spellcheck="false"
 >
-<label
+`;
+/* end snapshot vaadin-combo-box slots default */
+
+snapshots["vaadin-combo-box slots label"] = 
+`<label
   for="input-vaadin-combo-box-4"
   id="label-vaadin-combo-box-0"
   slot="label"
@@ -417,14 +405,10 @@ snapshots["vaadin-combo-box slots label"] =
   slot="error-message"
 >
 </div>
-`;
-/* end snapshot vaadin-combo-box slots label */
-
-snapshots["vaadin-combo-box slots helper"] = 
-`<input
+<input
   aria-autocomplete="list"
-  aria-describedby="helper-vaadin-combo-box-1"
   aria-expanded="false"
+  aria-labelledby="label-vaadin-combo-box-0"
   autocapitalize="off"
   autocomplete="off"
   autocorrect="off"
@@ -433,7 +417,11 @@ snapshots["vaadin-combo-box slots helper"] =
   slot="input"
   spellcheck="false"
 >
-<label
+`;
+/* end snapshot vaadin-combo-box slots label */
+
+snapshots["vaadin-combo-box slots helper"] = 
+`<label
   for="input-vaadin-combo-box-4"
   id="label-vaadin-combo-box-0"
   slot="label"
@@ -445,6 +433,18 @@ snapshots["vaadin-combo-box slots helper"] =
   slot="error-message"
 >
 </div>
+<input
+  aria-autocomplete="list"
+  aria-describedby="helper-vaadin-combo-box-1"
+  aria-expanded="false"
+  autocapitalize="off"
+  autocomplete="off"
+  autocorrect="off"
+  id="input-vaadin-combo-box-4"
+  role="combobox"
+  slot="input"
+  spellcheck="false"
+>
 <div
   id="helper-vaadin-combo-box-1"
   slot="helper"
@@ -455,20 +455,7 @@ snapshots["vaadin-combo-box slots helper"] =
 /* end snapshot vaadin-combo-box slots helper */
 
 snapshots["vaadin-combo-box slots error"] = 
-`<input
-  aria-autocomplete="list"
-  aria-expanded="false"
-  aria-invalid="true"
-  autocapitalize="off"
-  autocomplete="off"
-  autocorrect="off"
-  id="input-vaadin-combo-box-4"
-  invalid=""
-  role="combobox"
-  slot="input"
-  spellcheck="false"
->
-<label
+`<label
   for="input-vaadin-combo-box-4"
   id="label-vaadin-combo-box-0"
   slot="label"
@@ -481,6 +468,19 @@ snapshots["vaadin-combo-box slots error"] =
 >
   Error
 </div>
+<input
+  aria-autocomplete="list"
+  aria-expanded="false"
+  aria-invalid="true"
+  autocapitalize="off"
+  autocomplete="off"
+  autocorrect="off"
+  id="input-vaadin-combo-box-4"
+  invalid=""
+  role="combobox"
+  slot="input"
+  spellcheck="false"
+>
 `;
 /* end snapshot vaadin-combo-box slots error */
 

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -80,11 +80,6 @@ snapshots["vaadin-crud shadow default"] =
               style="width: 100%;"
               theme="small"
             >
-              <input
-                id="input-vaadin-text-field-10"
-                slot="input"
-                type="text"
-              >
               <label
                 for="input-vaadin-text-field-10"
                 id="label-vaadin-text-field-0"
@@ -97,6 +92,11 @@ snapshots["vaadin-crud shadow default"] =
                 slot="error-message"
               >
               </div>
+              <input
+                id="input-vaadin-text-field-10"
+                slot="input"
+                type="text"
+              >
             </vaadin-text-field>
           </vaadin-grid-filter>
         </vaadin-grid-cell-content>
@@ -112,11 +112,6 @@ snapshots["vaadin-crud shadow default"] =
               style="width: 100%;"
               theme="small"
             >
-              <input
-                id="input-vaadin-text-field-15"
-                slot="input"
-                type="text"
-              >
               <label
                 for="input-vaadin-text-field-15"
                 id="label-vaadin-text-field-3"
@@ -129,6 +124,11 @@ snapshots["vaadin-crud shadow default"] =
                 slot="error-message"
               >
               </div>
+              <input
+                id="input-vaadin-text-field-15"
+                slot="input"
+                type="text"
+              >
             </vaadin-text-field>
           </vaadin-grid-filter>
         </vaadin-grid-cell-content>

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -54,8 +54,8 @@ export class EmailField extends TextField {
   }
 
   /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
+  ready() {
+    super.ready();
 
     if (this.inputElement) {
       this.inputElement.autocapitalize = 'off';

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -234,13 +234,7 @@ snapshots["vaadin-email-field shadow theme"] =
 /* end snapshot vaadin-email-field shadow theme */
 
 snapshots["vaadin-email-field slots default"] = 
-`<input
-  autocapitalize="off"
-  id="input-vaadin-email-field-3"
-  slot="input"
-  type="email"
->
-<label
+`<label
   for="input-vaadin-email-field-3"
   id="label-vaadin-email-field-0"
   slot="label"
@@ -252,29 +246,35 @@ snapshots["vaadin-email-field slots default"] =
   slot="error-message"
 >
 </div>
+<input
+  autocapitalize="off"
+  id="input-vaadin-email-field-3"
+  slot="input"
+  type="email"
+>
 `;
 /* end snapshot vaadin-email-field slots default */
 
 snapshots["vaadin-email-field slots helper"] = 
-`<input
+`<label
+  for="input-vaadin-email-field-3"
+  id="label-vaadin-email-field-0"
+  slot="label"
+>
+</label>
+<div
+  hidden=""
+  id="error-message-vaadin-email-field-2"
+  slot="error-message"
+>
+</div>
+<input
   aria-describedby="helper-vaadin-email-field-1"
   autocapitalize="off"
   id="input-vaadin-email-field-3"
   slot="input"
   type="email"
 >
-<label
-  for="input-vaadin-email-field-3"
-  id="label-vaadin-email-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-email-field-2"
-  slot="error-message"
->
-</div>
 <div
   id="helper-vaadin-email-field-1"
   slot="helper"

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -89,10 +89,6 @@ export const FieldMixin = (superclass) =>
       this._helperController = new HelperController(this);
       this._errorController = new ErrorController(this);
 
-      this.addController(this._fieldAriaController);
-      this.addController(this._helperController);
-      this.addController(this._errorController);
-
       this._labelController.addEventListener('label-changed', (event) => {
         const { hasLabel, node } = event.detail;
         this.__labelChanged(hasLabel, node);
@@ -102,6 +98,15 @@ export const FieldMixin = (superclass) =>
         const { hasHelper, node } = event.detail;
         this.__helperChanged(hasHelper, node);
       });
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.addController(this._fieldAriaController);
+      this.addController(this._helperController);
+      this.addController(this._errorController);
     }
 
     /** @private */

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -43,6 +43,12 @@ export const LabelMixin = dedupingMixin(
         super();
 
         this._labelController = new LabelController(this);
+      }
+
+      /** @protected */
+      ready() {
+        super.ready();
+
         this.addController(this._labelController);
       }
 

--- a/packages/field-base/src/slot-target-controller.js
+++ b/packages/field-base/src/slot-target-controller.js
@@ -41,7 +41,11 @@ export class SlotTargetController {
 
     // Ensure the content is up to date when host is connected
     // to handle e.g. mutating text content while disconnected.
-    this.__checkAndCopyNodesToSlotTarget();
+    // Note, `hostConnected()` is called twice if the controller
+    // is initialized in `ready()` when using `ControllerMixin`.
+    if (!this.__copying) {
+      this.__checkAndCopyNodesToSlotTarget();
+    }
   }
 
   /**

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -360,15 +360,7 @@ snapshots["vaadin-integer-field shadow theme"] =
 /* end snapshot vaadin-integer-field shadow theme */
 
 snapshots["vaadin-integer-field slots default"] = 
-`<input
-  id="input-vaadin-integer-field-3"
-  max="undefined"
-  min="undefined"
-  slot="input"
-  step="any"
-  type="number"
->
-<label
+`<label
   for="input-vaadin-integer-field-3"
   id="label-vaadin-integer-field-0"
   slot="label"
@@ -380,11 +372,31 @@ snapshots["vaadin-integer-field slots default"] =
   slot="error-message"
 >
 </div>
+<input
+  id="input-vaadin-integer-field-3"
+  max="undefined"
+  min="undefined"
+  slot="input"
+  step="any"
+  type="number"
+>
 `;
 /* end snapshot vaadin-integer-field slots default */
 
 snapshots["vaadin-integer-field slots helper"] = 
-`<input
+`<label
+  for="input-vaadin-integer-field-3"
+  id="label-vaadin-integer-field-0"
+  slot="label"
+>
+</label>
+<div
+  hidden=""
+  id="error-message-vaadin-integer-field-2"
+  slot="error-message"
+>
+</div>
+<input
   aria-describedby="helper-vaadin-integer-field-1"
   id="input-vaadin-integer-field-3"
   max="undefined"
@@ -393,18 +405,6 @@ snapshots["vaadin-integer-field slots helper"] =
   step="any"
   type="number"
 >
-<label
-  for="input-vaadin-integer-field-3"
-  id="label-vaadin-integer-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-integer-field-2"
-  slot="error-message"
->
-</div>
 <div
   id="helper-vaadin-integer-field-1"
   slot="helper"

--- a/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
+++ b/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
@@ -3,15 +3,6 @@ export const snapshots = {};
 
 snapshots["vaadin-message-input default"] = 
 `<vaadin-message-input-text-area placeholder="Message">
-  <textarea
-    aria-label="Message"
-    id="textarea-vaadin-message-input-text-area-3"
-    placeholder="Message"
-    rows="1"
-    slot="textarea"
-    style="min-height: 0px;"
-  >
-  </textarea>
   <label
     for="textarea-vaadin-message-input-text-area-3"
     id="label-vaadin-message-input-text-area-0"
@@ -24,6 +15,15 @@ snapshots["vaadin-message-input default"] =
     slot="error-message"
   >
   </div>
+  <textarea
+    aria-label="Message"
+    id="textarea-vaadin-message-input-text-area-3"
+    placeholder="Message"
+    rows="1"
+    slot="textarea"
+    style="min-height: 0px;"
+  >
+  </textarea>
 </vaadin-message-input-text-area>
 <vaadin-message-input-button
   role="button"
@@ -41,17 +41,6 @@ snapshots["vaadin-message-input disabled"] =
   disabled=""
   placeholder="Message"
 >
-  <textarea
-    aria-label="Message"
-    disabled=""
-    id="textarea-vaadin-message-input-text-area-3"
-    placeholder="Message"
-    rows="1"
-    slot="textarea"
-    style="min-height: 0px;"
-    tabindex="-1"
-  >
-  </textarea>
   <label
     for="textarea-vaadin-message-input-text-area-3"
     id="label-vaadin-message-input-text-area-0"
@@ -64,6 +53,17 @@ snapshots["vaadin-message-input disabled"] =
     slot="error-message"
   >
   </div>
+  <textarea
+    aria-label="Message"
+    disabled=""
+    id="textarea-vaadin-message-input-text-area-3"
+    placeholder="Message"
+    rows="1"
+    slot="textarea"
+    style="min-height: 0px;"
+    tabindex="-1"
+  >
+  </textarea>
 </vaadin-message-input-text-area>
 <vaadin-message-input-button
   aria-disabled="true"

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -213,17 +213,6 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
   }
 
   /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-
-    if (this.inputElement) {
-      this.inputElement.min = this.min;
-      this.inputElement.max = this.max;
-      this.__applyStep(this.step);
-    }
-  }
-
-  /** @protected */
   ready() {
     super.ready();
 
@@ -235,6 +224,11 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
         this.ariaTarget = input;
       }),
     );
+
+    this.inputElement.min = this.min;
+    this.inputElement.max = this.max;
+    this.__applyStep(this.step);
+
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
   }
 

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -360,15 +360,7 @@ snapshots["vaadin-number-field shadow theme"] =
 /* end snapshot vaadin-number-field shadow theme */
 
 snapshots["vaadin-number-field slots default"] = 
-`<input
-  id="input-vaadin-number-field-3"
-  max="undefined"
-  min="undefined"
-  slot="input"
-  step="any"
-  type="number"
->
-<label
+`<label
   for="input-vaadin-number-field-3"
   id="label-vaadin-number-field-0"
   slot="label"
@@ -380,11 +372,31 @@ snapshots["vaadin-number-field slots default"] =
   slot="error-message"
 >
 </div>
+<input
+  id="input-vaadin-number-field-3"
+  max="undefined"
+  min="undefined"
+  slot="input"
+  step="any"
+  type="number"
+>
 `;
 /* end snapshot vaadin-number-field slots default */
 
 snapshots["vaadin-number-field slots helper"] = 
-`<input
+`<label
+  for="input-vaadin-number-field-3"
+  id="label-vaadin-number-field-0"
+  slot="label"
+>
+</label>
+<div
+  hidden=""
+  id="error-message-vaadin-number-field-2"
+  slot="error-message"
+>
+</div>
+<input
   aria-describedby="helper-vaadin-number-field-1"
   id="input-vaadin-number-field-3"
   max="undefined"
@@ -393,18 +405,6 @@ snapshots["vaadin-number-field slots helper"] =
   step="any"
   type="number"
 >
-<label
-  for="input-vaadin-number-field-3"
-  id="label-vaadin-number-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-number-field-2"
-  slot="error-message"
->
-</div>
 <div
   id="helper-vaadin-number-field-1"
   slot="helper"

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -269,7 +269,19 @@ snapshots["vaadin-password-field shadow theme"] =
 /* end snapshot vaadin-password-field shadow theme */
 
 snapshots["vaadin-password-field slots default"] = 
-`<input
+`<label
+  for="input-vaadin-password-field-3"
+  id="label-vaadin-password-field-0"
+  slot="label"
+>
+</label>
+<div
+  hidden=""
+  id="error-message-vaadin-password-field-2"
+  slot="error-message"
+>
+</div>
+<input
   autocapitalize="off"
   id="input-vaadin-password-field-3"
   slot="input"
@@ -283,7 +295,11 @@ snapshots["vaadin-password-field slots default"] =
   tabindex="0"
 >
 </vaadin-password-field-button>
-<label
+`;
+/* end snapshot vaadin-password-field slots default */
+
+snapshots["vaadin-password-field slots helper"] = 
+`<label
   for="input-vaadin-password-field-3"
   id="label-vaadin-password-field-0"
   slot="label"
@@ -295,11 +311,7 @@ snapshots["vaadin-password-field slots default"] =
   slot="error-message"
 >
 </div>
-`;
-/* end snapshot vaadin-password-field slots default */
-
-snapshots["vaadin-password-field slots helper"] = 
-`<input
+<input
   aria-describedby="helper-vaadin-password-field-1"
   autocapitalize="off"
   id="input-vaadin-password-field-3"
@@ -314,18 +326,6 @@ snapshots["vaadin-password-field slots helper"] =
   tabindex="0"
 >
 </vaadin-password-field-button>
-<label
-  for="input-vaadin-password-field-3"
-  id="label-vaadin-password-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-password-field-2"
-  slot="error-message"
->
-</div>
 <div
   id="helper-vaadin-password-field-1"
   slot="helper"

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -149,26 +149,25 @@ class RadioButton extends LabelMixin(
   }
 
   /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
+  ready() {
+    super.ready();
 
-    if (!this._inputController) {
-      this._inputController = new InputController(this, (input) => {
+    this.addController(
+      new InputController(this, (input) => {
         this._setInputElement(input);
         this._setFocusElement(input);
         this.stateTarget = input;
         this.ariaTarget = input;
-      });
-      this.addController(this._inputController);
-      this.addController(new LabelledInputController(this.inputElement, this._labelController));
-      this.addController(
-        new SlotTargetController(
-          this.$.noop,
-          () => this._labelController.node,
-          () => this.__warnDeprecated(),
-        ),
-      );
-    }
+      }),
+    );
+    this.addController(new LabelledInputController(this.inputElement, this._labelController));
+    this.addController(
+      new SlotTargetController(
+        this.$.noop,
+        () => this._labelController.node,
+        () => this.__warnDeprecated(),
+      ),
+    );
   }
 
   /** @private */

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -201,29 +201,6 @@ export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableM
     return this.$.clearButton;
   }
 
-  /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-
-    this._inputField = this.shadowRoot.querySelector('[part=input-field]');
-
-    // Wheel scrolling results in async scroll events. Preventing the wheel
-    // event, scrolling manually and then synchronously updating the scroll position CSS variable
-    // allows us to avoid some jumpy behavior that would occur on wheel otherwise.
-    this._inputField.addEventListener('wheel', (e) => {
-      const scrollTopBefore = this._inputField.scrollTop;
-      this._inputField.scrollTop += e.deltaY;
-
-      if (scrollTopBefore !== this._inputField.scrollTop) {
-        e.preventDefault();
-        this.__scrollPositionUpdated();
-      }
-    });
-
-    this._updateHeight();
-    this.__scrollPositionUpdated();
-  }
-
   /**
    * @protected
    * @override
@@ -246,6 +223,24 @@ export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableM
     );
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
     this.addEventListener('animationend', this._onAnimationEnd);
+
+    this._inputField = this.shadowRoot.querySelector('[part=input-field]');
+
+    // Wheel scrolling results in async scroll events. Preventing the wheel
+    // event, scrolling manually and then synchronously updating the scroll position CSS variable
+    // allows us to avoid some jumpy behavior that would occur on wheel otherwise.
+    this._inputField.addEventListener('wheel', (e) => {
+      const scrollTopBefore = this._inputField.scrollTop;
+      this._inputField.scrollTop += e.deltaY;
+
+      if (scrollTopBefore !== this._inputField.scrollTop) {
+        e.preventDefault();
+        this.__scrollPositionUpdated();
+      }
+    });
+
+    this._updateHeight();
+    this.__scrollPositionUpdated();
   }
 
   /** @private */

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -241,12 +241,7 @@ snapshots["vaadin-text-area shadow theme"] =
 /* end snapshot vaadin-text-area shadow theme */
 
 snapshots["vaadin-text-area slots default"] = 
-`<textarea
-  id="textarea-vaadin-text-area-3"
-  slot="textarea"
->
-</textarea>
-<label
+`<label
   for="textarea-vaadin-text-area-3"
   id="label-vaadin-text-area-0"
   slot="label"
@@ -258,28 +253,33 @@ snapshots["vaadin-text-area slots default"] =
   slot="error-message"
 >
 </div>
+<textarea
+  id="textarea-vaadin-text-area-3"
+  slot="textarea"
+>
+</textarea>
 `;
 /* end snapshot vaadin-text-area slots default */
 
 snapshots["vaadin-text-area slots helper"] = 
-`<textarea
+`<label
+  for="textarea-vaadin-text-area-3"
+  id="label-vaadin-text-area-0"
+  slot="label"
+>
+</label>
+<div
+  hidden=""
+  id="error-message-vaadin-text-area-2"
+  slot="error-message"
+>
+</div>
+<textarea
   aria-describedby="helper-vaadin-text-area-1"
   id="textarea-vaadin-text-area-3"
   slot="textarea"
 >
 </textarea>
-<label
-  for="textarea-vaadin-text-area-3"
-  id="label-vaadin-text-area-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-text-area-2"
-  slot="error-message"
->
-</div>
 <div
   id="helper-vaadin-text-area-1"
   slot="helper"

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -234,12 +234,7 @@ snapshots["vaadin-text-field shadow theme"] =
 /* end snapshot vaadin-text-field shadow theme */
 
 snapshots["vaadin-text-field slots default"] = 
-`<input
-  id="input-vaadin-text-field-3"
-  slot="input"
-  type="text"
->
-<label
+`<label
   for="input-vaadin-text-field-3"
   id="label-vaadin-text-field-0"
   slot="label"
@@ -251,28 +246,33 @@ snapshots["vaadin-text-field slots default"] =
   slot="error-message"
 >
 </div>
+<input
+  id="input-vaadin-text-field-3"
+  slot="input"
+  type="text"
+>
 `;
 /* end snapshot vaadin-text-field slots default */
 
 snapshots["vaadin-text-field slots helper"] = 
-`<input
+`<label
+  for="input-vaadin-text-field-3"
+  id="label-vaadin-text-field-0"
+  slot="label"
+>
+</label>
+<div
+  hidden=""
+  id="error-message-vaadin-text-field-2"
+  slot="error-message"
+>
+</div>
+<input
   aria-describedby="helper-vaadin-text-field-1"
   id="input-vaadin-text-field-3"
   slot="input"
   type="text"
 >
-<label
-  for="input-vaadin-text-field-3"
-  id="label-vaadin-text-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-text-field-2"
-  slot="error-message"
->
-</div>
 <div
   id="helper-vaadin-text-field-1"
   slot="helper"

--- a/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
+++ b/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
@@ -3,17 +3,6 @@ export const snapshots = {};
 
 snapshots["vaadin-time-picker host default"] = 
 `<vaadin-time-picker>
-  <input
-    aria-autocomplete="list"
-    aria-expanded="false"
-    autocapitalize="off"
-    autocomplete="off"
-    autocorrect="off"
-    id="input-vaadin-time-picker-4"
-    role="combobox"
-    slot="input"
-    spellcheck="false"
-  >
   <label
     for="input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
@@ -26,16 +15,9 @@ snapshots["vaadin-time-picker host default"] =
     slot="error-message"
   >
   </div>
-</vaadin-time-picker>
-`;
-/* end snapshot vaadin-time-picker host default */
-
-snapshots["vaadin-time-picker host label"] = 
-`<vaadin-time-picker has-label="">
   <input
     aria-autocomplete="list"
     aria-expanded="false"
-    aria-labelledby="label-vaadin-time-picker-0"
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
@@ -44,6 +26,12 @@ snapshots["vaadin-time-picker host label"] =
     slot="input"
     spellcheck="false"
   >
+</vaadin-time-picker>
+`;
+/* end snapshot vaadin-time-picker host default */
+
+snapshots["vaadin-time-picker host label"] = 
+`<vaadin-time-picker has-label="">
   <label
     for="input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
@@ -57,16 +45,10 @@ snapshots["vaadin-time-picker host label"] =
     slot="error-message"
   >
   </div>
-</vaadin-time-picker>
-`;
-/* end snapshot vaadin-time-picker host label */
-
-snapshots["vaadin-time-picker host helper"] = 
-`<vaadin-time-picker has-helper="">
   <input
     aria-autocomplete="list"
-    aria-describedby="helper-vaadin-time-picker-1"
     aria-expanded="false"
+    aria-labelledby="label-vaadin-time-picker-0"
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
@@ -75,6 +57,12 @@ snapshots["vaadin-time-picker host helper"] =
     slot="input"
     spellcheck="false"
   >
+</vaadin-time-picker>
+`;
+/* end snapshot vaadin-time-picker host label */
+
+snapshots["vaadin-time-picker host helper"] = 
+`<vaadin-time-picker has-helper="">
   <label
     for="input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
@@ -87,6 +75,18 @@ snapshots["vaadin-time-picker host helper"] =
     slot="error-message"
   >
   </div>
+  <input
+    aria-autocomplete="list"
+    aria-describedby="helper-vaadin-time-picker-1"
+    aria-expanded="false"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-time-picker-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
   <div
     id="helper-vaadin-time-picker-1"
     slot="helper"
@@ -102,19 +102,6 @@ snapshots["vaadin-time-picker host error"] =
   has-error-message=""
   invalid=""
 >
-  <input
-    aria-autocomplete="list"
-    aria-expanded="false"
-    aria-invalid="true"
-    autocapitalize="off"
-    autocomplete="off"
-    autocorrect="off"
-    id="input-vaadin-time-picker-4"
-    invalid=""
-    role="combobox"
-    slot="input"
-    spellcheck="false"
-  >
   <label
     for="input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
@@ -128,6 +115,19 @@ snapshots["vaadin-time-picker host error"] =
   >
     Error
   </div>
+  <input
+    aria-autocomplete="list"
+    aria-expanded="false"
+    aria-invalid="true"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-time-picker-4"
+    invalid=""
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
 </vaadin-time-picker>
 `;
 /* end snapshot vaadin-time-picker host error */
@@ -137,6 +137,18 @@ snapshots["vaadin-time-picker host disabled"] =
   aria-disabled="true"
   disabled=""
 >
+  <label
+    for="input-vaadin-time-picker-4"
+    id="label-vaadin-time-picker-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-time-picker-2"
+    slot="error-message"
+  >
+  </div>
   <input
     aria-autocomplete="list"
     aria-expanded="false"
@@ -150,6 +162,12 @@ snapshots["vaadin-time-picker host disabled"] =
     spellcheck="false"
     tabindex="-1"
   >
+</vaadin-time-picker>
+`;
+/* end snapshot vaadin-time-picker host disabled */
+
+snapshots["vaadin-time-picker host readonly"] = 
+`<vaadin-time-picker readonly="">
   <label
     for="input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
@@ -162,12 +180,6 @@ snapshots["vaadin-time-picker host disabled"] =
     slot="error-message"
   >
   </div>
-</vaadin-time-picker>
-`;
-/* end snapshot vaadin-time-picker host disabled */
-
-snapshots["vaadin-time-picker host readonly"] = 
-`<vaadin-time-picker readonly="">
   <input
     aria-autocomplete="list"
     aria-expanded="false"
@@ -180,6 +192,12 @@ snapshots["vaadin-time-picker host readonly"] =
     slot="input"
     spellcheck="false"
   >
+</vaadin-time-picker>
+`;
+/* end snapshot vaadin-time-picker host readonly */
+
+snapshots["vaadin-time-picker host placeholder"] = 
+`<vaadin-time-picker placeholder="Placeholder">
   <label
     for="input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
@@ -192,12 +210,6 @@ snapshots["vaadin-time-picker host readonly"] =
     slot="error-message"
   >
   </div>
-</vaadin-time-picker>
-`;
-/* end snapshot vaadin-time-picker host readonly */
-
-snapshots["vaadin-time-picker host placeholder"] = 
-`<vaadin-time-picker placeholder="Placeholder">
   <input
     aria-autocomplete="list"
     aria-expanded="false"
@@ -210,6 +222,12 @@ snapshots["vaadin-time-picker host placeholder"] =
     slot="input"
     spellcheck="false"
   >
+</vaadin-time-picker>
+`;
+/* end snapshot vaadin-time-picker host placeholder */
+
+snapshots["vaadin-time-picker host pattern"] = 
+`<vaadin-time-picker>
   <label
     for="input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
@@ -222,12 +240,6 @@ snapshots["vaadin-time-picker host placeholder"] =
     slot="error-message"
   >
   </div>
-</vaadin-time-picker>
-`;
-/* end snapshot vaadin-time-picker host placeholder */
-
-snapshots["vaadin-time-picker host pattern"] = 
-`<vaadin-time-picker>
   <input
     aria-autocomplete="list"
     aria-expanded="false"
@@ -240,18 +252,6 @@ snapshots["vaadin-time-picker host pattern"] =
     slot="input"
     spellcheck="false"
   >
-  <label
-    for="input-vaadin-time-picker-4"
-    id="label-vaadin-time-picker-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-time-picker-2"
-    slot="error-message"
-  >
-  </div>
 </vaadin-time-picker>
 `;
 /* end snapshot vaadin-time-picker host pattern */


### PR DESCRIPTION
## Description

Currently, some components initialize controllers in `connectedCallback()`, while others use `ready()`. This PR changes that.

Also, moving `addController()` calls to `ready()` is a first step for `LitElement` support through `PolylitMixin`.
This is due to the fact that in `SlotController` we need access to shadow DOM in order to observe a slot:

https://github.com/vaadin/web-components/blob/b4dec66f8a0f540bc4c0b3a16a9d099b954d74a7/packages/component-base/src/slot-controller.js#L137

## Type of change

- Refactor