### PR TITLE
refactor: use SlotController for value button

### DIFF
--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';
 import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -164,7 +163,7 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class Select extends DelegateFocusMixin(FieldMixin(SlotMixin(ElementMixin(ThemableMixin(HTMLElement))))) {
+declare class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(HTMLElement)))) {
   /**
    * An array containing items that will be rendered as the options of the select.
    *

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -214,17 +214,7 @@ snapshots["vaadin-select shadow theme"] =
 /* end snapshot vaadin-select shadow theme */
 
 snapshots["vaadin-select slots default"] = 
-`<vaadin-select-value-button
-  aria-expanded="false"
-  aria-haspopup="listbox"
-  aria-labelledby="label-vaadin-select-0 vaadin-select-3"
-  aria-required="false"
-  role="button"
-  slot="value"
-  tabindex="0"
->
-</vaadin-select-value-button>
-<label
+`<label
   id="label-vaadin-select-0"
   slot="label"
 >
@@ -235,11 +225,32 @@ snapshots["vaadin-select slots default"] =
   slot="error-message"
 >
 </div>
+<vaadin-select-value-button
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-labelledby="label-vaadin-select-0 vaadin-select-3"
+  aria-required="false"
+  role="button"
+  slot="value"
+  tabindex="0"
+>
+</vaadin-select-value-button>
 `;
 /* end snapshot vaadin-select slots default */
 
 snapshots["vaadin-select slots helper"] = 
-`<vaadin-select-value-button
+`<label
+  id="label-vaadin-select-0"
+  slot="label"
+>
+</label>
+<div
+  hidden=""
+  id="error-message-vaadin-select-2"
+  slot="error-message"
+>
+</div>
+<vaadin-select-value-button
   aria-describedby="helper-vaadin-select-1"
   aria-expanded="false"
   aria-haspopup="listbox"
@@ -250,17 +261,6 @@ snapshots["vaadin-select slots helper"] =
   tabindex="0"
 >
 </vaadin-select-value-button>
-<label
-  id="label-vaadin-select-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-select-2"
-  slot="error-message"
->
-</div>
 <div
   id="helper-vaadin-select-1"
   slot="helper"


### PR DESCRIPTION
## Description

Same as #3492 but for `vaadin-select-value-button`. This also moves `vaadin-select` initialization to `ready()` callback.

## Type of change

- Refactor