### PR TITLE
refactor: remove duplicate logic from the items observer

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1113,13 +1113,6 @@ export const ComboBoxMixin = (subclass) =>
         this.filteredItems = null;
       }
 
-      const valueIndex = this.__getItemIndexByValue(items, this.value);
-      this._focusedIndex = valueIndex;
-
-      const item = valueIndex > -1 && items[valueIndex];
-      if (item) {
-        this.selectedItem = item;
-      }
       this.__previousItems = items;
     }
 

--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -9,6 +9,21 @@ import { getAllItems, getFocusedItemIndex, makeItems, onceOpened, setInputValue 
 describe('internal filtering', () => {
   let comboBox;
 
+  describe('value is set before', () => {
+    beforeEach(() => {
+      comboBox = fixtureSync(`<vaadin-combo-box value="foo"></vaadin-combo-box>`);
+      comboBox.items = ['foo', 'bar'];
+    });
+
+    it('should have the selected item', () => {
+      expect(comboBox.selectedItem).to.equal('foo');
+    });
+
+    it('should have the input value', () => {
+      expect(comboBox.inputElement.value).to.equal('foo');
+    });
+  });
+
   describe('setting the input field value', () => {
     beforeEach(() => {
       comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');


### PR DESCRIPTION
## Description

The PR removes the duplicate logic related to setting `selectedItem` from the `items` observer as this case is already covered in the `filteredItems` observer.

A preparation for https://github.com/vaadin/web-components/issues/3864

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
