### PR TITLE
fix: render selectedItem as selected when setting it while loading items

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -91,6 +91,7 @@ export class ComboBoxScroller extends PolymerElement {
        */
       selectedItem: {
         type: Object,
+        observer: '__selectedItemChanged',
       },
 
       /**
@@ -247,9 +248,16 @@ export class ComboBoxScroller extends PolymerElement {
   }
 
   /** @private */
-  __loadingChanged(loading) {
-    if (this.__virtualizer && !loading) {
-      setTimeout(() => this.requestContentUpdate());
+  __loadingChanged() {
+    if (this.__virtualizer) {
+      this.requestContentUpdate();
+    }
+  }
+
+  /** @private */
+  __selectedItemChanged() {
+    if (this.__virtualizer) {
+      this.requestContentUpdate();
     }
   }
 

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -248,8 +248,8 @@ export class ComboBoxScroller extends PolymerElement {
   }
 
   /** @private */
-  __loadingChanged() {
-    if (this.__virtualizer) {
+  __loadingChanged(loading) {
+    if (this.__virtualizer && !loading) {
       this.requestContentUpdate();
     }
   }

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -15,6 +15,7 @@ import {
   getViewportItems,
   getVisibleItemsCount,
   makeItems,
+  scrollToIndex,
   setInputValue,
 } from './helpers.js';
 
@@ -56,6 +57,10 @@ describe('lazy loading', () => {
       return { id: i, value: `value ${i}`, label: `label ${i}` };
     });
     callback(dataProviderItems, SIZE);
+  };
+
+  const asyncObjectDataProvider = (params, callback) => {
+    setTimeout(() => objectDataProvider(params, callback));
   };
 
   before(() => {
@@ -430,9 +435,6 @@ describe('lazy loading', () => {
           // Wait for the async data provider to respond
           await aTimeout(0);
 
-          // Wait for the timeout in __loadingChanged
-          await aTimeout(0);
-
           expect(comboBox._focusedIndex).to.equal(8);
           const items = getViewportItems(comboBox);
           expect(items.some((item) => item.index === 50)).to.be.true;
@@ -686,7 +688,9 @@ describe('lazy loading', () => {
     });
 
     describe('selectedItem (string items)', () => {
-      beforeEach(() => (comboBox.dataProvider = dataProvider));
+      beforeEach(() => {
+        comboBox.dataProvider = asyncDataProvider;
+      });
 
       it('should allow setting initial selectedItem', () => {
         comboBox.selectedItem = 'item 0';
@@ -698,31 +702,41 @@ describe('lazy loading', () => {
         expect(comboBox.value).to.equal('item 0');
       });
 
-      it('should select value matching selectedItem when items are loading', () => {
-        comboBox.selectedItem = 'item 0';
-        comboBox.opened = true;
-        expect(comboBox.value).to.equal('item 0');
-        const selectedRenderedItemElements = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
-        expect(selectedRenderedItemElements).to.have.lengthOf(1);
-        expect(selectedRenderedItemElements[0].item).to.equal('item 0');
-      });
+      describe('some items are loaded', () => {
+        beforeEach(async () => {
+          comboBox.opened = true;
+          await aTimeout(0);
+        });
 
-      it('should select value matching selectedItem when items are loaded', () => {
-        comboBox.opened = true;
-        comboBox.selectedItem = 'item 0';
-        expect(comboBox.value).to.equal('item 0');
-        flushComboBox(comboBox);
-        const selectedRenderedItemElements = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
-        // Doesn't work when run on SauceLabs, work locally
-        // expect(selectedRenderedItemElements).to.have.lengthOf(1);
-        expect(selectedRenderedItemElements[0].item).to.equal('item 0');
+        it('should render selectedItem as selected when setting it', async () => {
+          const loadedItem = 'item 0';
+          comboBox.selectedItem = loadedItem;
+          flushComboBox(comboBox);
+          const items = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
+          expect(items).to.have.lengthOf(1);
+          expect(items[0].item).to.deep.equal(loadedItem);
+        });
+
+        it('should render selectedItem as selected when setting it while loading more items', async () => {
+          const alreadyLoadedItem = `item ${comboBox.pageSize - 1}`;
+
+          scrollToIndex(comboBox, comboBox.pageSize + 1);
+          expect(comboBox.loading).to.be.true;
+
+          comboBox.selectedItem = alreadyLoadedItem;
+          flushComboBox(comboBox);
+
+          const items = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
+          expect(items).to.have.lengthOf(1);
+          expect(items[0].item).to.deep.equal(alreadyLoadedItem);
+        });
       });
     });
 
     describe('selectedItem (object items)', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         comboBox.itemIdPath = 'id';
-        comboBox.dataProvider = objectDataProvider;
+        comboBox.dataProvider = asyncObjectDataProvider;
       });
 
       it('should allow setting initial selectedItem', () => {
@@ -735,26 +749,38 @@ describe('lazy loading', () => {
         expect(comboBox.value).to.equal('value 0');
       });
 
-      it('should select value matching selectedItem when items are loading', () => {
-        comboBox.selectedItem = { id: 0, value: 'value 0', label: 'label 0' };
-        comboBox.opened = true;
-        expect(comboBox.value).to.equal('value 0');
-        const selectedRenderedItemElements = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
-        expect(selectedRenderedItemElements).to.have.lengthOf(1);
-        expect(selectedRenderedItemElements[0].item).to.eql({ id: 0, value: 'value 0', label: 'label 0' });
-      });
+      describe('some items are loaded', () => {
+        beforeEach(async () => {
+          comboBox.opened = true;
+          await aTimeout(0);
+        });
 
-      it('should select value matching selectedItem when items are loaded', async () => {
-        comboBox.opened = true;
-        comboBox.selectedItem = { id: 0, value: 'value 0', label: 'label 0' };
-        expect(comboBox.value).to.equal('value 0');
-        flushComboBox(comboBox);
-        // Wait for the timeout in __loadingChanged to finish
-        await aTimeout(0);
-        const selectedRenderedItemElements = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
-        // Doesn't work when run on SauceLabs, work locally
-        // expect(selectedRenderedItemElements).to.have.lengthOf(1);
-        expect(selectedRenderedItemElements[0].item).to.eql({ id: 0, value: 'value 0', label: 'label 0' });
+        it('should render selectedItem as selected when setting it', async () => {
+          const loadedItem = { id: 0, value: 'value 0', label: 'label 0' };
+          comboBox.selectedItem = loadedItem;
+          flushComboBox(comboBox);
+          const items = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
+          expect(items).to.have.lengthOf(1);
+          expect(items[0].item).to.deep.equal(loadedItem);
+        });
+
+        it('should render selectedItem as selected when setting it while loading more items', async () => {
+          const alreadyLoadedItem = {
+            id: comboBox.pageSize - 1,
+            value: `value ${comboBox.pageSize - 1}`,
+            label: `label ${comboBox.pageSize - 1}`,
+          };
+
+          scrollToIndex(comboBox, comboBox.pageSize + 1);
+          expect(comboBox.loading).to.be.true;
+
+          comboBox.selectedItem = alreadyLoadedItem;
+          flushComboBox(comboBox);
+
+          const items = getAllItems(comboBox).filter((itemEl) => itemEl.selected);
+          expect(items).to.have.lengthOf(1);
+          expect(items[0].item).to.deep.equal(alreadyLoadedItem);
+        });
       });
     });
 


### PR DESCRIPTION
## Description

The main goal of the PR is to add a missing `selectedItem` property observer that should trigger the scroller to update whenever `selectedItem` changes. 

There was previously an assumption that when `selectedItem` changes, `focusedIndex` also changes which triggers the scroller to update afterward. However, that could not work when using a data provider and setting an item as selected whose reference is different from the reference of the identical item provided by the data provider. Because the strict comparison is used when identifying the index of the selected item, `focusedIndex` could remain `-1` and thus `focusedIndexObserver` would not be invoked:

https://github.com/vaadin/web-components/blob/ad1ad3d947c605dbe8d50f72e8348ac1de19688e/packages/combo-box/src/vaadin-combo-box-mixin.js#L1055-L1057

On the other hand, the corresponding tests used to pass just by coincidence because the `loading` observer was asynchronous, and thus the content update was anyway triggered after `selectedItem` was set in the tests. 

**What was done?**

- Added a `selectedItem` property observer.
- Removed `setTimeout` from the `loading` property observer.
- Moved setting the `loading` mode in `_loadPage` so that it would be after the request is marked as pending to avoid duplicate requests which were otherwise possible because of the synchronous nature of the `loading` observer.
- Updated tests so that they assert the correct behaviour now and fail even with `setTimeout` in the `loading` property observer on the `master` branch.

A finding from https://github.com/vaadin/web-components/issues/3864

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
