### PR TITLE
fix: ensure filteredItems is correctly updated

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -626,7 +626,10 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
    * @private
    */
   _onFilteredItemsChanged(event) {
-    this.filteredItems = event.detail.value;
+    const { value } = event.detail;
+    if (Array.isArray(value) || value == null) {
+      this.filteredItems = value;
+    }
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -132,6 +132,11 @@ describe('basic', () => {
       expect(comboBox.filteredItems).to.deep.equal(['apple']);
     });
 
+    it('should update filteredItems on combo-box filteredItems splice', () => {
+      internal.splice('filteredItems', 0, 2);
+      expect(comboBox.filteredItems).to.deep.equal(['lemon', 'orange']);
+    });
+
     it('should call clearCache() method on the combo-box', () => {
       const spy = sinon.spy(internal, 'clearCache');
       comboBox.clearCache();


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in #4028 where `filteredItems` could be incorrectly set to a number 🤦‍♂️ 

The reason for this behavior is the fact that Polymer dispatches notify events when calling Polymer `.splice()` API.
In this case, there are two events fired and one of them is for `length` - see [related logic](https://github.com/Polymer/polymer/blob/1e8b246d01ea99adba305ea04c45d26da31f68f1/lib/mixins/property-effects.js#L1227-L1228).

Note: the problem shouldn't happen on `master` as we removed usage of Polymer `splice()` in #4008.
Unfortunately, this code was not cherry-picked to `23.1` branch so the problem exists there.

## Type of change

- Bugfix