### PR TITLE
chore: disable yarn cache to fix CI builds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
@@ -34,7 +33,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
@@ -56,7 +54,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
@@ -49,7 +48,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
-          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive


### PR DESCRIPTION
## Description

Disabled caching `node_modules` for now to workaround failures in GitHub Actions.

See https://github.com/actions/setup-node/issues/516

## Type of change

- Internal change