### PR TITLE
refactor: remove a redundant call of _selectItemForValue

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -911,7 +911,6 @@ export const ComboBoxMixin = (subclass) =>
           });
           this.dispatchEvent(e);
           if (!e.defaultPrevented) {
-            this._selectItemForValue(customValue);
             this.value = customValue;
           }
         } else if (!this.allowCustomValue && !this.opened && itemMatchingInputValue) {


### PR DESCRIPTION
## Description

The PR removes a redundant call of the `_selectItemForValue` method from `_commitValue`. The call is redundant because `__valueChanged` already calls `_selectItemForValue`.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
