### PR TITLE
fix: restore timeout in scroller loading observer

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -250,7 +250,7 @@ export class ComboBoxScroller extends PolymerElement {
   /** @private */
   __loadingChanged() {
     if (this.__virtualizer) {
-      this.requestContentUpdate();
+      setTimeout(() => this.requestContentUpdate());
     }
   }
 

--- a/packages/combo-box/test/external-filtering.test.js
+++ b/packages/combo-box/test/external-filtering.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, enter, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
@@ -27,12 +27,13 @@ describe('external filtering', () => {
       expect(comboBox._scroller.items).to.eql(['foo', 'bar', 'baz']);
     });
 
-    it('should remove focus while loading', () => {
+    it('should remove focus while loading', async () => {
       setInputValue(comboBox, 'foo');
       comboBox.filteredItems = ['foo'];
       expect(getFocusedItemIndex(comboBox)).to.equal(0);
 
       comboBox.loading = true;
+      await aTimeout(0);
 
       expect(getFocusedItemIndex(comboBox)).to.equal(-1);
     });


### PR DESCRIPTION
## Description

This fixes part of the ITs that failed after upgrading Flow components to 23.2.0-alpha1:

- `ItemCountEstimateIncreaseComboBoxIT`
- `ItemCountCallbackComboBoxIT`
- `ComboBoxLitRendererIT`
- `FilterConverterComboBoxIT`

## Type of change

- Bugfix