### PR TITLE
fix: set max-height on scroller when pre-opened

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -442,6 +442,11 @@ export const ComboBoxMixin = (subclass) =>
     // eslint-disable-next-line max-params
     _updateScroller(scroller, items, opened, loading, selectedItem, itemIdPath, focusedIndex, renderer, theme) {
       if (scroller) {
+        if (opened) {
+          scroller.style.maxHeight =
+            getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
+        }
+
         scroller.setProperties({
           items: opened ? items : [],
           opened,
@@ -849,10 +854,6 @@ export const ComboBoxMixin = (subclass) =>
     _onOpened() {
       // Defer scroll position adjustment to improve performance.
       requestAnimationFrame(() => {
-        // When opened is set as attribute, this logic needs to be delayed until scroller is created.
-        this._scroller.style.maxHeight =
-          getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
-
         this._scrollIntoView(this._focusedIndex);
 
         // Set attribute after the items are rendered when overlay is opened for the first time.

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -569,4 +569,15 @@ describe('pre-opened', () => {
     const actualOverlayWidth = comboBox.$.overlay.$.content.clientWidth;
     expect(actualOverlayWidth).to.eq(expectedOverlayWidth);
   });
+
+  it('should have overlay with correct width', () => {
+    const comboBox = fixtureSync(`
+      <vaadin-combo-box
+        opened
+        items="[0]"
+        style="--vaadin-combo-box-overlay-max-height: 200px"
+      ></vaadin-combo-box>`);
+    const scroller = comboBox.$.overlay.querySelector('vaadin-combo-box-scroller');
+    expect(scroller.style.maxHeight).to.equal('200px');
+  });
 });


### PR DESCRIPTION
## Description

This PR fixes a regression in #3944 that caused Flow component ITs to fail because of dataProvider requesting extra page.
After the refactoring, `max-height` was not set by the time when `scroller.requestContentUpdate()` was called.

## Type of change

- Bugfix