### PR TITLE
test: re-organize and add more snapshot tests

### DIFF
--- a/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
+++ b/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
@@ -1,6 +1,35 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-combo-box host default"] = 
+`<vaadin-combo-box>
+  <label
+    for="input-vaadin-combo-box-4"
+    id="label-vaadin-combo-box-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-combo-box-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-expanded="false"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-combo-box-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+</vaadin-combo-box>
+`;
+/* end snapshot vaadin-combo-box host default */
+
 snapshots["vaadin-combo-box host placeholder"] = 
 `<vaadin-combo-box placeholder="Placeholder">
   <label
@@ -60,6 +89,109 @@ snapshots["vaadin-combo-box host pattern"] =
 </vaadin-combo-box>
 `;
 /* end snapshot vaadin-combo-box host pattern */
+
+snapshots["vaadin-combo-box host label"] = 
+`<vaadin-combo-box has-label="">
+  <label
+    for="input-vaadin-combo-box-4"
+    id="label-vaadin-combo-box-0"
+    slot="label"
+  >
+    Label
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-combo-box-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-expanded="false"
+    aria-labelledby="label-vaadin-combo-box-0"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-combo-box-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+</vaadin-combo-box>
+`;
+/* end snapshot vaadin-combo-box host label */
+
+snapshots["vaadin-combo-box host helper"] = 
+`<vaadin-combo-box has-helper="">
+  <label
+    for="input-vaadin-combo-box-4"
+    id="label-vaadin-combo-box-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-combo-box-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-describedby="helper-vaadin-combo-box-1"
+    aria-expanded="false"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-combo-box-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+  <div
+    id="helper-vaadin-combo-box-1"
+    slot="helper"
+  >
+    Helper
+  </div>
+</vaadin-combo-box>
+`;
+/* end snapshot vaadin-combo-box host helper */
+
+snapshots["vaadin-combo-box host error"] = 
+`<vaadin-combo-box
+  has-error-message=""
+  invalid=""
+>
+  <label
+    for="input-vaadin-combo-box-4"
+    id="label-vaadin-combo-box-0"
+    slot="label"
+  >
+  </label>
+  <div
+    id="error-message-vaadin-combo-box-2"
+    role="alert"
+    slot="error-message"
+  >
+    Error
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-describedby="error-message-vaadin-combo-box-2"
+    aria-expanded="false"
+    aria-invalid="true"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-combo-box-4"
+    invalid=""
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+</vaadin-combo-box>
+`;
+/* end snapshot vaadin-combo-box host error */
 
 snapshots["vaadin-combo-box shadow default"] = 
 `<div class="vaadin-combo-box-container">
@@ -363,124 +495,4 @@ snapshots["vaadin-combo-box shadow theme"] =
 </vaadin-combo-box-overlay>
 `;
 /* end snapshot vaadin-combo-box shadow theme */
-
-snapshots["vaadin-combo-box slots default"] = 
-`<label
-  for="input-vaadin-combo-box-4"
-  id="label-vaadin-combo-box-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-combo-box-2"
-  slot="error-message"
->
-</div>
-<input
-  aria-autocomplete="list"
-  aria-expanded="false"
-  autocapitalize="off"
-  autocomplete="off"
-  autocorrect="off"
-  id="input-vaadin-combo-box-4"
-  role="combobox"
-  slot="input"
-  spellcheck="false"
->
-`;
-/* end snapshot vaadin-combo-box slots default */
-
-snapshots["vaadin-combo-box slots label"] = 
-`<label
-  for="input-vaadin-combo-box-4"
-  id="label-vaadin-combo-box-0"
-  slot="label"
->
-  Label
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-combo-box-2"
-  slot="error-message"
->
-</div>
-<input
-  aria-autocomplete="list"
-  aria-expanded="false"
-  aria-labelledby="label-vaadin-combo-box-0"
-  autocapitalize="off"
-  autocomplete="off"
-  autocorrect="off"
-  id="input-vaadin-combo-box-4"
-  role="combobox"
-  slot="input"
-  spellcheck="false"
->
-`;
-/* end snapshot vaadin-combo-box slots label */
-
-snapshots["vaadin-combo-box slots helper"] = 
-`<label
-  for="input-vaadin-combo-box-4"
-  id="label-vaadin-combo-box-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-combo-box-2"
-  slot="error-message"
->
-</div>
-<input
-  aria-autocomplete="list"
-  aria-describedby="helper-vaadin-combo-box-1"
-  aria-expanded="false"
-  autocapitalize="off"
-  autocomplete="off"
-  autocorrect="off"
-  id="input-vaadin-combo-box-4"
-  role="combobox"
-  slot="input"
-  spellcheck="false"
->
-<div
-  id="helper-vaadin-combo-box-1"
-  slot="helper"
->
-  Helper
-</div>
-`;
-/* end snapshot vaadin-combo-box slots helper */
-
-snapshots["vaadin-combo-box slots error"] = 
-`<label
-  for="input-vaadin-combo-box-4"
-  id="label-vaadin-combo-box-0"
-  slot="label"
->
-</label>
-<div
-  id="error-message-vaadin-combo-box-2"
-  role="alert"
-  slot="error-message"
->
-  Error
-</div>
-<input
-  aria-autocomplete="list"
-  aria-expanded="false"
-  aria-invalid="true"
-  autocapitalize="off"
-  autocomplete="off"
-  autocorrect="off"
-  id="input-vaadin-combo-box-4"
-  invalid=""
-  role="combobox"
-  slot="input"
-  spellcheck="false"
->
-`;
-/* end snapshot vaadin-combo-box slots error */
 

--- a/packages/combo-box/test/dom/combo-box.test.js
+++ b/packages/combo-box/test/dom/combo-box.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-combo-box.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -12,6 +12,10 @@ describe('vaadin-combo-box', () => {
   });
 
   describe('host', () => {
+    it('default', async () => {
+      await expect(comboBox).dom.to.equalSnapshot();
+    });
+
     it('placeholder', async () => {
       comboBox.placeholder = 'Placeholder';
       await expect(comboBox).dom.to.equalSnapshot();
@@ -19,6 +23,23 @@ describe('vaadin-combo-box', () => {
 
     it('pattern', async () => {
       comboBox.pattern = '[0-9]*';
+      await expect(comboBox).dom.to.equalSnapshot();
+    });
+
+    it('label', async () => {
+      comboBox.label = 'Label';
+      await expect(comboBox).dom.to.equalSnapshot();
+    });
+
+    it('helper', async () => {
+      comboBox.helperText = 'Helper';
+      await expect(comboBox).dom.to.equalSnapshot();
+    });
+
+    it('error', async () => {
+      comboBox.errorMessage = 'Error';
+      comboBox.invalid = true;
+      await aTimeout(0);
       await expect(comboBox).dom.to.equalSnapshot();
     });
   });
@@ -46,28 +67,6 @@ describe('vaadin-combo-box', () => {
     it('theme', async () => {
       comboBox.setAttribute('theme', 'align-right');
       await expect(comboBox).shadowDom.to.equalSnapshot();
-    });
-  });
-
-  describe('slots', () => {
-    it('default', async () => {
-      await expect(comboBox).lightDom.to.equalSnapshot();
-    });
-
-    it('label', async () => {
-      comboBox.label = 'Label';
-      await expect(comboBox).lightDom.to.equalSnapshot();
-    });
-
-    it('helper', async () => {
-      comboBox.helperText = 'Helper';
-      await expect(comboBox).lightDom.to.equalSnapshot();
-    });
-
-    it('error', async () => {
-      comboBox.errorMessage = 'Error';
-      comboBox.invalid = true;
-      await expect(comboBox).lightDom.to.equalSnapshot();
     });
   });
 });

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -307,6 +307,7 @@ snapshots["vaadin-email-field host error"] =
     Error
   </div>
   <input
+    aria-describedby="error-message-vaadin-email-field-2"
     aria-invalid="true"
     id="input-vaadin-email-field-3"
     invalid=""

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -1,6 +1,61 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-email-field host default"] = 
+`<vaadin-email-field>
+  <label
+    for="input-vaadin-email-field-3"
+    id="label-vaadin-email-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-email-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    autocapitalize="off"
+    id="input-vaadin-email-field-3"
+    slot="input"
+    type="email"
+  >
+</vaadin-email-field>
+`;
+/* end snapshot vaadin-email-field host default */
+
+snapshots["vaadin-email-field host helper"] = 
+`<vaadin-email-field has-helper="">
+  <label
+    for="input-vaadin-email-field-3"
+    id="label-vaadin-email-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-email-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="helper-vaadin-email-field-1"
+    autocapitalize="off"
+    id="input-vaadin-email-field-3"
+    slot="input"
+    type="email"
+  >
+  <div
+    id="helper-vaadin-email-field-1"
+    slot="helper"
+  >
+    Helper
+  </div>
+</vaadin-email-field>
+`;
+/* end snapshot vaadin-email-field host helper */
+
 snapshots["vaadin-email-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -233,54 +288,32 @@ snapshots["vaadin-email-field shadow theme"] =
 `;
 /* end snapshot vaadin-email-field shadow theme */
 
-snapshots["vaadin-email-field slots default"] = 
-`<label
-  for="input-vaadin-email-field-3"
-  id="label-vaadin-email-field-0"
-  slot="label"
+snapshots["vaadin-email-field host error"] = 
+`<vaadin-email-field
+  has-error-message=""
+  invalid=""
 >
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-email-field-2"
-  slot="error-message"
->
-</div>
-<input
-  autocapitalize="off"
-  id="input-vaadin-email-field-3"
-  slot="input"
-  type="email"
->
+  <label
+    for="input-vaadin-email-field-3"
+    id="label-vaadin-email-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    id="error-message-vaadin-email-field-2"
+    role="alert"
+    slot="error-message"
+  >
+    Error
+  </div>
+  <input
+    aria-invalid="true"
+    id="input-vaadin-email-field-3"
+    invalid=""
+    slot="input"
+    type="email"
+  >
+</vaadin-email-field>
 `;
-/* end snapshot vaadin-email-field slots default */
-
-snapshots["vaadin-email-field slots helper"] = 
-`<label
-  for="input-vaadin-email-field-3"
-  id="label-vaadin-email-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-email-field-2"
-  slot="error-message"
->
-</div>
-<input
-  aria-describedby="helper-vaadin-email-field-1"
-  autocapitalize="off"
-  id="input-vaadin-email-field-3"
-  slot="input"
-  type="email"
->
-<div
-  id="helper-vaadin-email-field-1"
-  slot="helper"
->
-  Helper
-</div>
-`;
-/* end snapshot vaadin-email-field slots helper */
+/* end snapshot vaadin-email-field host error */
 

--- a/packages/email-field/test/dom/email-field.test.js
+++ b/packages/email-field/test/dom/email-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-email-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -14,6 +14,24 @@ describe('vaadin-email-field', () => {
   beforeEach(() => {
     resetUniqueId();
     field = fixtureSync('<vaadin-email-field></vaadin-email-field>');
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(field).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
+
+    it('helper', async () => {
+      field.helperText = 'Helper';
+      await expect(field).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
+
+    it('error', async () => {
+      field.errorMessage = 'Error';
+      field.invalid = true;
+      await aTimeout(0);
+      await expect(field).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
   });
 
   describe('shadow', () => {
@@ -39,17 +57,6 @@ describe('vaadin-email-field', () => {
     it('theme', async () => {
       field.setAttribute('theme', 'align-right');
       await expect(field).shadowDom.to.equalSnapshot();
-    });
-  });
-
-  describe('slots', () => {
-    it('default', async () => {
-      await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
-    });
-
-    it('helper', async () => {
-      field.helperText = 'Helper';
-      await expect(field).lightDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
   });
 });

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -1,6 +1,102 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-integer-field host default"] = 
+`<vaadin-integer-field step="1">
+  <label
+    for="input-vaadin-integer-field-3"
+    id="label-vaadin-integer-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-integer-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    id="input-vaadin-integer-field-3"
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-integer-field>
+`;
+/* end snapshot vaadin-integer-field host default */
+
+snapshots["vaadin-integer-field host helper"] = 
+`<vaadin-integer-field
+  has-helper=""
+  step="1"
+>
+  <label
+    for="input-vaadin-integer-field-3"
+    id="label-vaadin-integer-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-integer-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="helper-vaadin-integer-field-1"
+    id="input-vaadin-integer-field-3"
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+  <div
+    id="helper-vaadin-integer-field-1"
+    slot="helper"
+  >
+    Helper
+  </div>
+</vaadin-integer-field>
+`;
+/* end snapshot vaadin-integer-field host helper */
+
+snapshots["vaadin-integer-field host error"] = 
+`<vaadin-integer-field
+  has-error-message=""
+  invalid=""
+  step="1"
+>
+  <label
+    for="input-vaadin-integer-field-3"
+    id="label-vaadin-integer-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    id="error-message-vaadin-integer-field-2"
+    role="alert"
+    slot="error-message"
+  >
+    Error
+  </div>
+  <input
+    aria-describedby="error-message-vaadin-integer-field-2"
+    aria-invalid="true"
+    id="input-vaadin-integer-field-3"
+    invalid=""
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-integer-field>
+`;
+/* end snapshot vaadin-integer-field host error */
+
 snapshots["vaadin-integer-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -358,59 +454,4 @@ snapshots["vaadin-integer-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-integer-field shadow theme */
-
-snapshots["vaadin-integer-field slots default"] = 
-`<label
-  for="input-vaadin-integer-field-3"
-  id="label-vaadin-integer-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-integer-field-2"
-  slot="error-message"
->
-</div>
-<input
-  id="input-vaadin-integer-field-3"
-  max="undefined"
-  min="undefined"
-  slot="input"
-  step="any"
-  type="number"
->
-`;
-/* end snapshot vaadin-integer-field slots default */
-
-snapshots["vaadin-integer-field slots helper"] = 
-`<label
-  for="input-vaadin-integer-field-3"
-  id="label-vaadin-integer-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-integer-field-2"
-  slot="error-message"
->
-</div>
-<input
-  aria-describedby="helper-vaadin-integer-field-1"
-  id="input-vaadin-integer-field-3"
-  max="undefined"
-  min="undefined"
-  slot="input"
-  step="any"
-  type="number"
->
-<div
-  id="helper-vaadin-integer-field-1"
-  slot="helper"
->
-  Helper
-</div>
-`;
-/* end snapshot vaadin-integer-field slots helper */
 

--- a/packages/integer-field/test/dom/integer-field.test.js
+++ b/packages/integer-field/test/dom/integer-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-integer-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -9,6 +9,24 @@ describe('vaadin-integer-field', () => {
   beforeEach(() => {
     resetUniqueId();
     field = fixtureSync('<vaadin-integer-field></vaadin-integer-field>');
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(field).dom.to.equalSnapshot();
+    });
+
+    it('helper', async () => {
+      field.helperText = 'Helper';
+      await expect(field).dom.to.equalSnapshot();
+    });
+
+    it('error', async () => {
+      field.errorMessage = 'Error';
+      field.invalid = true;
+      await aTimeout(0);
+      await expect(field).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {
@@ -39,17 +57,6 @@ describe('vaadin-integer-field', () => {
     it('theme', async () => {
       field.setAttribute('theme', 'align-right');
       await expect(field).shadowDom.to.equalSnapshot();
-    });
-  });
-
-  describe('slots', () => {
-    it('default', async () => {
-      await expect(field).lightDom.to.equalSnapshot();
-    });
-
-    it('helper', async () => {
-      field.helperText = 'Helper';
-      await expect(field).lightDom.to.equalSnapshot();
     });
   });
 });

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -1,6 +1,102 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-number-field host default"] = 
+`<vaadin-number-field step="1">
+  <label
+    for="input-vaadin-number-field-3"
+    id="label-vaadin-number-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-number-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    id="input-vaadin-number-field-3"
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-number-field>
+`;
+/* end snapshot vaadin-number-field host default */
+
+snapshots["vaadin-number-field host helper"] = 
+`<vaadin-number-field
+  has-helper=""
+  step="1"
+>
+  <label
+    for="input-vaadin-number-field-3"
+    id="label-vaadin-number-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-number-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="helper-vaadin-number-field-1"
+    id="input-vaadin-number-field-3"
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+  <div
+    id="helper-vaadin-number-field-1"
+    slot="helper"
+  >
+    Helper
+  </div>
+</vaadin-number-field>
+`;
+/* end snapshot vaadin-number-field host helper */
+
+snapshots["vaadin-number-field host error"] = 
+`<vaadin-number-field
+  has-error-message=""
+  invalid=""
+  step="1"
+>
+  <label
+    for="input-vaadin-number-field-3"
+    id="label-vaadin-number-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    id="error-message-vaadin-number-field-2"
+    role="alert"
+    slot="error-message"
+  >
+    Error
+  </div>
+  <input
+    aria-describedby="error-message-vaadin-number-field-2"
+    aria-invalid="true"
+    id="input-vaadin-number-field-3"
+    invalid=""
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-number-field>
+`;
+/* end snapshot vaadin-number-field host error */
+
 snapshots["vaadin-number-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -358,59 +454,4 @@ snapshots["vaadin-number-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-number-field shadow theme */
-
-snapshots["vaadin-number-field slots default"] = 
-`<label
-  for="input-vaadin-number-field-3"
-  id="label-vaadin-number-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-number-field-2"
-  slot="error-message"
->
-</div>
-<input
-  id="input-vaadin-number-field-3"
-  max="undefined"
-  min="undefined"
-  slot="input"
-  step="any"
-  type="number"
->
-`;
-/* end snapshot vaadin-number-field slots default */
-
-snapshots["vaadin-number-field slots helper"] = 
-`<label
-  for="input-vaadin-number-field-3"
-  id="label-vaadin-number-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-number-field-2"
-  slot="error-message"
->
-</div>
-<input
-  aria-describedby="helper-vaadin-number-field-1"
-  id="input-vaadin-number-field-3"
-  max="undefined"
-  min="undefined"
-  slot="input"
-  step="any"
-  type="number"
->
-<div
-  id="helper-vaadin-number-field-1"
-  slot="helper"
->
-  Helper
-</div>
-`;
-/* end snapshot vaadin-number-field slots helper */
 

--- a/packages/number-field/test/dom/number-field.test.js
+++ b/packages/number-field/test/dom/number-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-number-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -9,6 +9,24 @@ describe('vaadin-number-field', () => {
   beforeEach(() => {
     resetUniqueId();
     field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(field).dom.to.equalSnapshot();
+    });
+
+    it('helper', async () => {
+      field.helperText = 'Helper';
+      await expect(field).dom.to.equalSnapshot();
+    });
+
+    it('error', async () => {
+      field.errorMessage = 'Error';
+      field.invalid = true;
+      await aTimeout(0);
+      await expect(field).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {
@@ -39,17 +57,6 @@ describe('vaadin-number-field', () => {
     it('theme', async () => {
       field.setAttribute('theme', 'align-right');
       await expect(field).shadowDom.to.equalSnapshot();
-    });
-  });
-
-  describe('slots', () => {
-    it('default', async () => {
-      await expect(field).lightDom.to.equalSnapshot();
-    });
-
-    it('helper', async () => {
-      field.helperText = 'Helper';
-      await expect(field).lightDom.to.equalSnapshot();
     });
   });
 });

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -1,6 +1,115 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-password-field host default"] = 
+`<vaadin-password-field>
+  <label
+    for="input-vaadin-password-field-3"
+    id="label-vaadin-password-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-password-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    autocapitalize="off"
+    id="input-vaadin-password-field-3"
+    slot="input"
+    type="password"
+  >
+  <vaadin-password-field-button
+    aria-label="Show password"
+    aria-pressed="false"
+    role="button"
+    slot="reveal"
+    tabindex="0"
+  >
+  </vaadin-password-field-button>
+</vaadin-password-field>
+`;
+/* end snapshot vaadin-password-field host default */
+
+snapshots["vaadin-password-field host helper"] = 
+`<vaadin-password-field has-helper="">
+  <label
+    for="input-vaadin-password-field-3"
+    id="label-vaadin-password-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-password-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="helper-vaadin-password-field-1"
+    autocapitalize="off"
+    id="input-vaadin-password-field-3"
+    slot="input"
+    type="password"
+  >
+  <vaadin-password-field-button
+    aria-label="Show password"
+    aria-pressed="false"
+    role="button"
+    slot="reveal"
+    tabindex="0"
+  >
+  </vaadin-password-field-button>
+  <div
+    id="helper-vaadin-password-field-1"
+    slot="helper"
+  >
+    Helper
+  </div>
+</vaadin-password-field>
+`;
+/* end snapshot vaadin-password-field host helper */
+
+snapshots["vaadin-password-field host error"] = 
+`<vaadin-password-field
+  has-error-message=""
+  invalid=""
+>
+  <label
+    for="input-vaadin-password-field-3"
+    id="label-vaadin-password-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    id="error-message-vaadin-password-field-2"
+    role="alert"
+    slot="error-message"
+  >
+    Error
+  </div>
+  <input
+    aria-describedby="error-message-vaadin-password-field-2"
+    aria-invalid="true"
+    id="input-vaadin-password-field-3"
+    invalid=""
+    slot="input"
+    type="password"
+  >
+  <vaadin-password-field-button
+    aria-label="Show password"
+    aria-pressed="false"
+    role="button"
+    slot="reveal"
+    tabindex="0"
+  >
+  </vaadin-password-field-button>
+</vaadin-password-field>
+`;
+/* end snapshot vaadin-password-field host error */
+
 snapshots["vaadin-password-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -267,71 +376,4 @@ snapshots["vaadin-password-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-password-field shadow theme */
-
-snapshots["vaadin-password-field slots default"] = 
-`<label
-  for="input-vaadin-password-field-3"
-  id="label-vaadin-password-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-password-field-2"
-  slot="error-message"
->
-</div>
-<input
-  autocapitalize="off"
-  id="input-vaadin-password-field-3"
-  slot="input"
-  type="password"
->
-<vaadin-password-field-button
-  aria-label="Show password"
-  aria-pressed="false"
-  role="button"
-  slot="reveal"
-  tabindex="0"
->
-</vaadin-password-field-button>
-`;
-/* end snapshot vaadin-password-field slots default */
-
-snapshots["vaadin-password-field slots helper"] = 
-`<label
-  for="input-vaadin-password-field-3"
-  id="label-vaadin-password-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-password-field-2"
-  slot="error-message"
->
-</div>
-<input
-  aria-describedby="helper-vaadin-password-field-1"
-  autocapitalize="off"
-  id="input-vaadin-password-field-3"
-  slot="input"
-  type="password"
->
-<vaadin-password-field-button
-  aria-label="Show password"
-  aria-pressed="false"
-  role="button"
-  slot="reveal"
-  tabindex="0"
->
-</vaadin-password-field-button>
-<div
-  id="helper-vaadin-password-field-1"
-  slot="helper"
->
-  Helper
-</div>
-`;
-/* end snapshot vaadin-password-field slots helper */
 

--- a/packages/password-field/test/dom/password-field.test.js
+++ b/packages/password-field/test/dom/password-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-password-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -9,6 +9,24 @@ describe('vaadin-password-field', () => {
   beforeEach(() => {
     resetUniqueId();
     field = fixtureSync('<vaadin-password-field></vaadin-password-field>');
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(field).dom.to.equalSnapshot();
+    });
+
+    it('helper', async () => {
+      field.helperText = 'Helper';
+      await expect(field).dom.to.equalSnapshot();
+    });
+
+    it('error', async () => {
+      field.errorMessage = 'Error';
+      field.invalid = true;
+      await aTimeout(0);
+      await expect(field).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {
@@ -34,17 +52,6 @@ describe('vaadin-password-field', () => {
     it('theme', async () => {
       field.setAttribute('theme', 'align-right');
       await expect(field).shadowDom.to.equalSnapshot();
-    });
-  });
-
-  describe('slots', () => {
-    it('default', async () => {
-      await expect(field).lightDom.to.equalSnapshot();
-    });
-
-    it('helper', async () => {
-      field.helperText = 'Helper';
-      await expect(field).lightDom.to.equalSnapshot();
     });
   });
 });

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -1,6 +1,99 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-select host default"] = 
+`<vaadin-select>
+  <label
+    id="label-vaadin-select-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-select-2"
+    slot="error-message"
+  >
+  </div>
+  <vaadin-select-value-button
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-labelledby="label-vaadin-select-0 vaadin-select-3"
+    aria-required="false"
+    role="button"
+    slot="value"
+    tabindex="0"
+  >
+  </vaadin-select-value-button>
+</vaadin-select>
+`;
+/* end snapshot vaadin-select host default */
+
+snapshots["vaadin-select host helper"] = 
+`<vaadin-select has-helper="">
+  <label
+    id="label-vaadin-select-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-select-2"
+    slot="error-message"
+  >
+  </div>
+  <vaadin-select-value-button
+    aria-describedby="helper-vaadin-select-1"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-labelledby="label-vaadin-select-0 vaadin-select-3"
+    aria-required="false"
+    role="button"
+    slot="value"
+    tabindex="0"
+  >
+  </vaadin-select-value-button>
+  <div
+    id="helper-vaadin-select-1"
+    slot="helper"
+  >
+    Helper
+  </div>
+</vaadin-select>
+`;
+/* end snapshot vaadin-select host helper */
+
+snapshots["vaadin-select host error"] = 
+`<vaadin-select
+  has-error-message=""
+  invalid=""
+>
+  <label
+    id="label-vaadin-select-0"
+    slot="label"
+  >
+  </label>
+  <div
+    id="error-message-vaadin-select-2"
+    role="alert"
+    slot="error-message"
+  >
+    Error
+  </div>
+  <vaadin-select-value-button
+    aria-describedby="error-message-vaadin-select-2"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-labelledby="label-vaadin-select-0 vaadin-select-3"
+    aria-required="false"
+    role="button"
+    slot="value"
+    tabindex="0"
+  >
+  </vaadin-select-value-button>
+</vaadin-select>
+`;
+/* end snapshot vaadin-select host error */
+
 snapshots["vaadin-select shadow default"] = 
 `<div class="vaadin-select-container">
   <div part="label">
@@ -212,61 +305,4 @@ snapshots["vaadin-select shadow theme"] =
 </vaadin-select-overlay>
 `;
 /* end snapshot vaadin-select shadow theme */
-
-snapshots["vaadin-select slots default"] = 
-`<label
-  id="label-vaadin-select-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-select-2"
-  slot="error-message"
->
-</div>
-<vaadin-select-value-button
-  aria-expanded="false"
-  aria-haspopup="listbox"
-  aria-labelledby="label-vaadin-select-0 vaadin-select-3"
-  aria-required="false"
-  role="button"
-  slot="value"
-  tabindex="0"
->
-</vaadin-select-value-button>
-`;
-/* end snapshot vaadin-select slots default */
-
-snapshots["vaadin-select slots helper"] = 
-`<label
-  id="label-vaadin-select-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-select-2"
-  slot="error-message"
->
-</div>
-<vaadin-select-value-button
-  aria-describedby="helper-vaadin-select-1"
-  aria-expanded="false"
-  aria-haspopup="listbox"
-  aria-labelledby="label-vaadin-select-0 vaadin-select-3"
-  aria-required="false"
-  role="button"
-  slot="value"
-  tabindex="0"
->
-</vaadin-select-value-button>
-<div
-  id="helper-vaadin-select-1"
-  slot="helper"
->
-  Helper
-</div>
-`;
-/* end snapshot vaadin-select slots helper */
 

--- a/packages/select/test/dom/select.test.js
+++ b/packages/select/test/dom/select.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-select.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -9,6 +9,24 @@ describe('vaadin-select', () => {
   beforeEach(() => {
     resetUniqueId();
     select = fixtureSync('<vaadin-select></vaadin-select>');
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(select).dom.to.equalSnapshot();
+    });
+
+    it('helper', async () => {
+      select.helperText = 'Helper';
+      await expect(select).dom.to.equalSnapshot();
+    });
+
+    it('error', async () => {
+      select.errorMessage = 'Error';
+      select.invalid = true;
+      await aTimeout(0);
+      await expect(select).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {
@@ -34,17 +52,6 @@ describe('vaadin-select', () => {
     it('theme', async () => {
       select.setAttribute('theme', 'align-right');
       await expect(select).shadowDom.to.equalSnapshot();
-    });
-  });
-
-  describe('slots', () => {
-    it('default', async () => {
-      await expect(select).lightDom.to.equalSnapshot();
-    });
-
-    it('helper', async () => {
-      select.helperText = 'Helper';
-      await expect(select).lightDom.to.equalSnapshot();
     });
   });
 });

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -1,6 +1,89 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-text-area host default"] = 
+`<vaadin-text-area>
+  <label
+    for="textarea-vaadin-text-area-3"
+    id="label-vaadin-text-area-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-area-2"
+    slot="error-message"
+  >
+  </div>
+  <textarea
+    id="textarea-vaadin-text-area-3"
+    slot="textarea"
+  >
+  </textarea>
+</vaadin-text-area>
+`;
+/* end snapshot vaadin-text-area host default */
+
+snapshots["vaadin-text-area host helper"] = 
+`<vaadin-text-area has-helper="">
+  <label
+    for="textarea-vaadin-text-area-3"
+    id="label-vaadin-text-area-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-area-2"
+    slot="error-message"
+  >
+  </div>
+  <textarea
+    aria-describedby="helper-vaadin-text-area-1"
+    id="textarea-vaadin-text-area-3"
+    slot="textarea"
+  >
+  </textarea>
+  <div
+    id="helper-vaadin-text-area-1"
+    slot="helper"
+  >
+    Helper
+  </div>
+</vaadin-text-area>
+`;
+/* end snapshot vaadin-text-area host helper */
+
+snapshots["vaadin-text-area host error"] = 
+`<vaadin-text-area
+  has-error-message=""
+  invalid=""
+>
+  <label
+    for="textarea-vaadin-text-area-3"
+    id="label-vaadin-text-area-0"
+    slot="label"
+  >
+  </label>
+  <div
+    id="error-message-vaadin-text-area-2"
+    role="alert"
+    slot="error-message"
+  >
+    Error
+  </div>
+  <textarea
+    aria-describedby="error-message-vaadin-text-area-2"
+    aria-invalid="true"
+    id="textarea-vaadin-text-area-3"
+    invalid=""
+    slot="textarea"
+  >
+  </textarea>
+</vaadin-text-area>
+`;
+/* end snapshot vaadin-text-area host error */
+
 snapshots["vaadin-text-area shadow default"] = 
 `<div class="vaadin-text-area-container">
   <div part="label">
@@ -239,53 +322,4 @@ snapshots["vaadin-text-area shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-text-area shadow theme */
-
-snapshots["vaadin-text-area slots default"] = 
-`<label
-  for="textarea-vaadin-text-area-3"
-  id="label-vaadin-text-area-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-text-area-2"
-  slot="error-message"
->
-</div>
-<textarea
-  id="textarea-vaadin-text-area-3"
-  slot="textarea"
->
-</textarea>
-`;
-/* end snapshot vaadin-text-area slots default */
-
-snapshots["vaadin-text-area slots helper"] = 
-`<label
-  for="textarea-vaadin-text-area-3"
-  id="label-vaadin-text-area-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-text-area-2"
-  slot="error-message"
->
-</div>
-<textarea
-  aria-describedby="helper-vaadin-text-area-1"
-  id="textarea-vaadin-text-area-3"
-  slot="textarea"
->
-</textarea>
-<div
-  id="helper-vaadin-text-area-1"
-  slot="helper"
->
-  Helper
-</div>
-`;
-/* end snapshot vaadin-text-area slots helper */
 

--- a/packages/text-area/test/dom/text-area.test.js
+++ b/packages/text-area/test/dom/text-area.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-text-area.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -9,6 +9,24 @@ describe('vaadin-text-area', () => {
   beforeEach(() => {
     resetUniqueId();
     textArea = fixtureSync('<vaadin-text-area></vaadin-text-area>');
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(textArea).dom.to.equalSnapshot();
+    });
+
+    it('helper', async () => {
+      textArea.helperText = 'Helper';
+      await expect(textArea).dom.to.equalSnapshot();
+    });
+
+    it('error', async () => {
+      textArea.errorMessage = 'Error';
+      textArea.invalid = true;
+      await aTimeout(0);
+      await expect(textArea).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {
@@ -34,17 +52,6 @@ describe('vaadin-text-area', () => {
     it('theme', async () => {
       textArea.setAttribute('theme', 'align-right');
       await expect(textArea).shadowDom.to.equalSnapshot();
-    });
-  });
-
-  describe('slots', () => {
-    it('default', async () => {
-      await expect(textArea).lightDom.to.equalSnapshot();
-    });
-
-    it('helper', async () => {
-      textArea.helperText = 'Helper';
-      await expect(textArea).lightDom.to.equalSnapshot();
     });
   });
 });

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -1,6 +1,89 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-text-field host default"] = 
+`<vaadin-text-field>
+  <label
+    for="input-vaadin-text-field-3"
+    id="label-vaadin-text-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    id="input-vaadin-text-field-3"
+    slot="input"
+    type="text"
+  >
+</vaadin-text-field>
+`;
+/* end snapshot vaadin-text-field host default */
+
+snapshots["vaadin-text-field host helper"] = 
+`<vaadin-text-field has-helper="">
+  <label
+    for="input-vaadin-text-field-3"
+    id="label-vaadin-text-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="helper-vaadin-text-field-1"
+    id="input-vaadin-text-field-3"
+    slot="input"
+    type="text"
+  >
+  <div
+    id="helper-vaadin-text-field-1"
+    slot="helper"
+  >
+    Helper
+  </div>
+</vaadin-text-field>
+`;
+/* end snapshot vaadin-text-field host helper */
+
+snapshots["vaadin-text-field host error"] = 
+`<vaadin-text-field
+  has-error-message=""
+  invalid=""
+>
+  <label
+    for="input-vaadin-text-field-3"
+    id="label-vaadin-text-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    id="error-message-vaadin-text-field-2"
+    role="alert"
+    slot="error-message"
+  >
+    Error
+  </div>
+  <input
+    aria-describedby="error-message-vaadin-text-field-2"
+    aria-invalid="true"
+    id="input-vaadin-text-field-3"
+    invalid=""
+    slot="input"
+    type="text"
+  >
+</vaadin-text-field>
+`;
+/* end snapshot vaadin-text-field host error */
+
 snapshots["vaadin-text-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -232,53 +315,4 @@ snapshots["vaadin-text-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-text-field shadow theme */
-
-snapshots["vaadin-text-field slots default"] = 
-`<label
-  for="input-vaadin-text-field-3"
-  id="label-vaadin-text-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-text-field-2"
-  slot="error-message"
->
-</div>
-<input
-  id="input-vaadin-text-field-3"
-  slot="input"
-  type="text"
->
-`;
-/* end snapshot vaadin-text-field slots default */
-
-snapshots["vaadin-text-field slots helper"] = 
-`<label
-  for="input-vaadin-text-field-3"
-  id="label-vaadin-text-field-0"
-  slot="label"
->
-</label>
-<div
-  hidden=""
-  id="error-message-vaadin-text-field-2"
-  slot="error-message"
->
-</div>
-<input
-  aria-describedby="helper-vaadin-text-field-1"
-  id="input-vaadin-text-field-3"
-  slot="input"
-  type="text"
->
-<div
-  id="helper-vaadin-text-field-1"
-  slot="helper"
->
-  Helper
-</div>
-`;
-/* end snapshot vaadin-text-field slots helper */
 

--- a/packages/text-field/test/dom/text-field.test.js
+++ b/packages/text-field/test/dom/text-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-text-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -9,6 +9,24 @@ describe('vaadin-text-field', () => {
   beforeEach(() => {
     resetUniqueId();
     field = fixtureSync('<vaadin-text-field></vaadin-text-field>');
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(field).dom.to.equalSnapshot();
+    });
+
+    it('helper', async () => {
+      field.helperText = 'Helper';
+      await expect(field).dom.to.equalSnapshot();
+    });
+
+    it('error', async () => {
+      field.errorMessage = 'Error';
+      field.invalid = true;
+      await aTimeout(0);
+      await expect(field).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {
@@ -34,17 +52,6 @@ describe('vaadin-text-field', () => {
     it('theme', async () => {
       field.setAttribute('theme', 'align-right');
       await expect(field).shadowDom.to.equalSnapshot();
-    });
-  });
-
-  describe('slots', () => {
-    it('default', async () => {
-      await expect(field).lightDom.to.equalSnapshot();
-    });
-
-    it('helper', async () => {
-      field.helperText = 'Helper';
-      await expect(field).lightDom.to.equalSnapshot();
     });
   });
 });


### PR DESCRIPTION
## Description

- Re-organized snapshot tests so that there is now a common `host` suite that tests both the host element and slots at the same time.
- Added tests verifying that the error message id is associated with the input when the field is invalid.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
