### PR TITLE
fix: enable avatar size inheritance when in avatar group #1985

### DIFF
--- a/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js
+++ b/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js
@@ -101,3 +101,13 @@ registerStyles(
   `,
   { moduleId: 'lumo-avatar-group-item' },
 );
+
+registerStyles(
+  'vaadin-avatar',
+  css`
+    :host {
+      --vaadin-avatar-size: inherit;
+    }
+  `,
+  { moduleId: 'lumo-avatar' },
+);

--- a/packages/avatar-group/theme/material/vaadin-avatar-group-styles.js
+++ b/packages/avatar-group/theme/material/vaadin-avatar-group-styles.js
@@ -50,3 +50,13 @@ registerStyles(
   `,
   { moduleId: 'material-avatar-group-item' },
 );
+
+registerStyles(
+  'vaadin-avatar',
+  css`
+    :host {
+      --vaadin-avatar-size: inherit;
+    }
+  `,
+  { moduleId: 'material-avatar' },
+);


### PR DESCRIPTION
## Description
Sets the `--vaadin-avatar-size` property to inherit for avatars in an avatar group, which enables controlling the value through the avatar group. Fixes both Lumo and Material themes.

Fixes #1985 

## Type of change
- Bugfix