### PR TITLE
docs: document custom field internal-tab event

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -35,10 +35,19 @@ export type CustomFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type CustomFieldValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
+ */
+export type CustomFieldInternalTabEvent = Event & {
+  target: CustomField;
+};
+
 export interface CustomFieldCustomEventMap {
   'invalid-changed': CustomFieldInvalidChangedEvent;
 
   'value-changed': CustomFieldValueChangedEvent;
+
+  'internal-tab': CustomFieldInternalTabEvent;
 }
 
 export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCustomEventMap {

--- a/packages/custom-field/test/typings/custom-field.types.ts
+++ b/packages/custom-field/test/typings/custom-field.types.ts
@@ -2,6 +2,7 @@ import '../../vaadin-custom-field.js';
 import {
   CustomField,
   CustomFieldChangeEvent,
+  CustomFieldInternalTabEvent,
   CustomFieldInvalidChangedEvent,
   CustomFieldValueChangedEvent,
 } from '../../vaadin-custom-field.js';
@@ -23,4 +24,9 @@ customField.addEventListener('invalid-changed', (event) => {
 customField.addEventListener('value-changed', (event) => {
   assertType<CustomFieldValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+customField.addEventListener('internal-tab', (event) => {
+  assertType<CustomFieldInternalTabEvent>(event);
+  assertType<CustomField>(event.target);
 });


### PR DESCRIPTION
Add the missing type definitions for `<vaadin-custom-field>` "internal-tab" event