### PR TITLE
fix: accept boolean and numeric item values

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -659,8 +659,9 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
   /** @private */
   _updateSelectedItem(value, items) {
     if (items) {
+      const valueAsString = value === undefined || value === null ? value : value.toString();
       this._menuElement.selected = items.reduce((prev, item, idx) => {
-        return prev === undefined && item.value === value ? idx : prev;
+        return prev === undefined && item.value === valueAsString ? idx : prev;
       }, undefined);
       if (!this._selectedChanging) {
         this._valueChanging = true;

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -659,7 +659,7 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
   /** @private */
   _updateSelectedItem(value, items) {
     if (items) {
-      const valueAsString = value === undefined || value === null ? value : value.toString();
+      const valueAsString = value == null ? value : value.toString();
       this._menuElement.selected = items.reduce((prev, item, idx) => {
         return prev === undefined && item.value === valueAsString ? idx : prev;
       }, undefined);

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -89,6 +89,8 @@ describe('vaadin-select', () => {
               <vaadin-item></vaadin-item>
               <vaadin-item label="">Empty</vaadin-item>
               <vaadin-item value="v4" disabled>Disabled</vaadin-item>
+              <vaadin-item value="5">A number</vaadin-item>
+              <vaadin-item value="false">A boolean</vaadin-item>
             </vaadin-list-box>
           `,
           root,
@@ -192,6 +194,16 @@ describe('vaadin-select', () => {
         select.value = 'v2';
         select.value = 'foo';
         expect(menu.selected).to.be.undefined;
+      });
+
+      it('should select a value even if provided as a number', () => {
+        select.value = 5;
+        expect(menu.selected).to.be.equal(6);
+      });
+
+      it('should select a value even if provided as a boolean', () => {
+        select.value = false;
+        expect(menu.selected).to.be.equal(7);
       });
     });
 

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -196,12 +196,12 @@ describe('vaadin-select', () => {
         expect(menu.selected).to.be.undefined;
       });
 
-      it('should select a value even if provided as a number', () => {
+      it('should select a numeric value if a matching item is found', () => {
         select.value = 5;
         expect(menu.selected).to.be.equal(6);
       });
 
-      it('should select a value even if provided as a boolean', () => {
+      it('should select a boolean value if a matching item is found', () => {
         select.value = false;
         expect(menu.selected).to.be.equal(7);
       });


### PR DESCRIPTION
## Description

When the `vaadin-select` component receives a value which is not a string, it should be able to find the corresponding item anyway. This fix simply convert the new value to string before searching for it. This will also allow Hilla to bind `select`s to boolean and integers.

Fixes #4059

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
