### PR TITLE
fix: remove disconnected sorters with no parent

### DIFF
--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -48,6 +48,7 @@ export const SortMixin = (superClass) =>
     _onSorterChanged(e) {
       const sorter = e.target;
       e.stopPropagation();
+      sorter._grid = this;
       this.__updateSorter(sorter);
       this.__applySorters();
     }

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -170,12 +170,28 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
   connectedCallback() {
     super.connectedCallback();
     this._isConnected = true;
+    this._grid = this._findHostGrid();
   }
 
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
     this._isConnected = false;
+
+    if (!this.parentNode && this._grid && this.direction) {
+      this._grid.__removeSorters([this]);
+    }
+  }
+
+  /** @private */
+  _findHostGrid() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias, consistent-this
+    let el = this;
+    // Custom elements extending grid must have a specific localName
+    while (el && !/^vaadin.*grid(-pro)?$/.test(el.localName)) {
+      el = el.parentNode;
+    }
+    return el || undefined;
   }
 
   /** @private */

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -170,7 +170,6 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
   connectedCallback() {
     super.connectedCallback();
     this._isConnected = true;
-    this._grid = this._findHostGrid();
   }
 
   /** @protected */
@@ -178,20 +177,9 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
     super.disconnectedCallback();
     this._isConnected = false;
 
-    if (!this.parentNode && this._grid && this.direction) {
+    if (!this.parentNode && this._grid) {
       this._grid.__removeSorters([this]);
     }
-  }
-
-  /** @private */
-  _findHostGrid() {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias, consistent-this
-    let el = this;
-    // Custom elements extending grid must have a specific localName
-    while (el && !/^vaadin.*grid(-pro)?$/.test(el.localName)) {
-      el = el.parentNode;
-    }
-    return el || undefined;
   }
 
   /** @private */


### PR DESCRIPTION
## Description

This PR is based on a suggestion from https://github.com/vaadin/flow-components/pull/3343#discussion_r897915797.
Note: I simplified the test case as the underlying issue is not specific to moving columns in the DOM.

Fixes https://github.com/vaadin/flow-components/issues/2102

## Type of change

- Bugfix