### PR TITLE
feat: respect reduce motion setting on App Layout

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -289,6 +289,12 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
             width: 20em;
           }
         }
+
+        @media (prefers-reduced-motion: reduce) {
+          :host {
+            --vaadin-app-layout-transition: none !important;
+          }
+        }
       </style>
       <div part="navbar" id="navbarTop">
         <slot name="navbar"></slot>


### PR DESCRIPTION
## Description

Add media query to disable App Layout animations if `prefers-reduce-motion` is set to `reduce`:


https://user-images.githubusercontent.com/262432/174613132-14ddfd35-5603-4539-ad02-5afd50454535.mp4

Part of #1727
