### PR TITLE
fix: avoid extra request when opened on input

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1007,11 +1007,7 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /** @private */
-    _filterChanged(filter, _itemValuePath, _itemLabelPath) {
-      if (filter === undefined) {
-        return;
-      }
-
+    _filterChanged(filter) {
       // Scroll to the top of the list whenever the filter changes.
       this._scrollIntoView(0);
 

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -366,6 +366,15 @@ describe('lazy loading', () => {
           expect(spyAsyncDataProvider.calledOnce).to.be.true;
         });
 
+        it('should be invoked with correct filter parameter', async () => {
+          comboBox.dataProvider = spyAsyncDataProvider;
+          setInputValue(comboBox, '1');
+          // Wait for the async data provider to respond
+          await aTimeout(0);
+          expect(spyAsyncDataProvider.calledOnce).to.be.true;
+          expect(spyAsyncDataProvider.firstCall.args[0].filter).to.equal('1');
+        });
+
         it('should be invoked on open with pre-defined size', () => {
           comboBox.size = SIZE;
           comboBox.dataProvider = spyAsyncDataProvider;


### PR DESCRIPTION
## Description

Updated the logic related to opening combo-box dropdown on `input` event to perform a [batched property update](https://polymer-library.polymer-project.org/2.0/docs/devguide/data-system#batched-property-changes).
This avoids an extra request by making sure `this.filter` contains correct input when requesting data-provider.

Fixes #1215

### Before

https://user-images.githubusercontent.com/10589913/174742070-480ce3a0-9cfc-43bc-945a-19d50b1f3f28.mp4

### After

https://user-images.githubusercontent.com/10589913/174742052-ca94d594-900a-4968-876b-57ea7080d8e5.mp4

## Type of change

- Bugfix