### PR TITLE
test: wait for the loading observer in combo-box tests

### DIFF
--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -439,6 +439,8 @@ describe('lazy loading', () => {
           comboBox._scrollIntoView(50);
           // Wait for the async data provider to respond
           await aTimeout(0);
+          // Wait for the __loadingChanged observer
+          await aTimeout(0);
 
           comboBox._scrollIntoView(0);
           expect(getFocusedItemIndex(comboBox)).to.equal(0);
@@ -458,6 +460,8 @@ describe('lazy loading', () => {
 
           comboBox._scrollIntoView(50);
           // Wait for the async data provider to respond
+          await aTimeout(0);
+          // Wait for the __loadingChanged observer
           await aTimeout(0);
           expect(comboBox.selectedItem).to.exist;
 
@@ -482,6 +486,8 @@ describe('lazy loading', () => {
           await nextFrame();
           comboBox._scrollIntoView(50);
           // Wait for the async data provider to respond
+          await aTimeout(0);
+          // Wait for the __loadingChanged observer
           await aTimeout(0);
 
           expect(comboBox._focusedIndex).to.equal(8);


### PR DESCRIPTION
## Description

After restoring `setTimeout` in `combo-box-scroller`, we forgot to restore waiting for that `setTimeout` in combo-box tests which made some of them flaky.

A follow-up to https://github.com/vaadin/web-components/pull/4049

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
