### PR TITLE
fix: ensure checkValidity returns false when date is invalid

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -529,7 +529,7 @@ export const DatePickerMixin = (subclass) =>
     checkValidity() {
       const inputValid =
         !this._inputValue ||
-        (this._selectedDate && this._inputValue === this._getFormattedDate(this.i18n.formatDate, this._selectedDate));
+        (!!this._selectedDate && this._inputValue === this._getFormattedDate(this.i18n.formatDate, this._selectedDate));
       const minMaxValid = !this._selectedDate || dateAllowed(this._selectedDate, this._minDate, this._maxDate);
 
       let inputValidity = true;

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -100,6 +100,7 @@ describe('keyboard', () => {
       await sendKeys({ type: 'foo' });
       await sendKeys({ press: 'Enter' });
       expect(datepicker.invalid).to.be.true;
+      expect(datepicker.checkValidity()).to.be.false;
       expect(datepicker.value).to.equal('');
       expect(input.value).to.equal('foo');
     });
@@ -110,6 +111,7 @@ describe('keyboard', () => {
       // Wait for overlay to finish closing
       await nextRender(datepicker);
       expect(datepicker.invalid).to.be.true;
+      expect(datepicker.checkValidity()).to.be.false;
 
       // Clear the invalid input
       input.select();
@@ -131,6 +133,7 @@ describe('keyboard', () => {
       datepicker.$.clearButton.click();
       expect(spy.callCount).to.equal(1);
       expect(datepicker.invalid).to.be.false;
+      expect(datepicker.checkValidity()).to.be.true;
     });
 
     it('should empty value with invalid input', async () => {
@@ -147,6 +150,7 @@ describe('keyboard', () => {
       await sendKeys({ type: 'foo' });
       await close(datepicker);
       expect(datepicker.invalid).to.be.true;
+      expect(datepicker.checkValidity()).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

Makes `checkValidity` return `false` when user enter invalid date on a `DatePicker`.

Fixes #4079

## Type of change

- [x] Bugfix
- [ ] Feature
