### PR TITLE
feat: fire a `validated` event on validation

### DIFF
--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -541,6 +541,27 @@ describe('vaadin-checkbox-group', () => {
 
       expect(spy.called).to.be.false;
     });
+
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      group.addEventListener('validated', validatedSpy);
+      group.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      group.addEventListener('validated', validatedSpy);
+      group.required = true;
+      group.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
+    });
   });
 
   describe('array mutation methods', () => {

--- a/packages/combo-box/test/form-input.test.js
+++ b/packages/combo-box/test/form-input.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, keyboardEventFor } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
 
@@ -49,6 +50,27 @@ describe('form field', () => {
     expect(comboBox.checkValidity()).to.be.true;
     expect(comboBox.validate()).to.be.true;
     expect(comboBox.invalid).to.be.false;
+  });
+
+  it('should fire a validated event on validation success', () => {
+    const validatedSpy = sinon.spy();
+    comboBox.addEventListener('validated', validatedSpy);
+    comboBox.validate();
+
+    expect(validatedSpy.calledOnce).to.be.true;
+    const event = validatedSpy.firstCall.args[0];
+    expect(event.detail.valid).to.be.true;
+  });
+
+  it('should fire a validated event on validation failure', () => {
+    const validatedSpy = sinon.spy();
+    comboBox.addEventListener('validated', validatedSpy);
+    comboBox.required = true;
+    comboBox.validate();
+
+    expect(validatedSpy.calledOnce).to.be.true;
+    const event = validatedSpy.firstCall.args[0];
+    expect(event.detail.valid).to.be.false;
   });
 
   describe('enter key behavior', () => {

--- a/packages/custom-field/test/custom-field.test.js
+++ b/packages/custom-field/test/custom-field.test.js
@@ -215,7 +215,7 @@ describe('custom field', () => {
     });
   });
 
-  describe('checkValidity', () => {
+  describe('validation', () => {
     it('should check validity on validate', () => {
       const spy = sinon.spy(customField, 'checkValidity');
       customField.validate();
@@ -227,6 +227,27 @@ describe('custom field', () => {
       customField.inputs[0].value = 'foo';
       dispatchChange(customField.inputs[0]);
       expect(spy.called).to.be.true;
+    });
+
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      customField.addEventListener('validated', validatedSpy);
+      customField.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      customField.addEventListener('validated', validatedSpy);
+      customField.required = true;
+      customField.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
     });
   });
 

--- a/packages/date-picker/test/form-input.test.js
+++ b/packages/date-picker/test/form-input.test.js
@@ -149,6 +149,27 @@ describe('form input', () => {
       expect(datepicker.validate()).to.equal(false);
       expect(datepicker.invalid).to.be.equal(true);
     });
+
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      datepicker.addEventListener('validated', validatedSpy);
+      datepicker.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      datepicker.addEventListener('validated', validatedSpy);
+      datepicker.required = true;
+      datepicker.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
+    });
   });
 
   describe('required', () => {

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -80,6 +80,27 @@ const fixtures = {
       expect(dateTimePicker.invalid).to.equal(false);
     });
 
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      dateTimePicker.addEventListener('validated', validatedSpy);
+      dateTimePicker.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      dateTimePicker.addEventListener('validated', validatedSpy);
+      dateTimePicker.required = true;
+      dateTimePicker.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
+    });
+
     describe('required', () => {
       beforeEach(() => {
         dateTimePicker.required = true;

--- a/packages/email-field/test/email-field.test.js
+++ b/packages/email-field/test/email-field.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../src/vaadin-email-field.js';
 
 const validAddresses = [
@@ -92,6 +93,35 @@ describe('email-field', () => {
 
     it('should not remove "invalid" state when ready', () => {
       expect(field.invalid).to.be.true;
+    });
+  });
+
+  describe('validation', () => {
+    let field;
+
+    beforeEach(() => {
+      field = fixtureSync('<vaadin-email-field></vaadin-email-field>');
+    });
+
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      field.addEventListener('validated', validatedSpy);
+      field.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      field.addEventListener('validated', validatedSpy);
+      field.required = true;
+      field.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
     });
   });
 });

--- a/packages/field-base/src/validate-mixin.d.ts
+++ b/packages/field-base/src/validate-mixin.d.ts
@@ -30,4 +30,12 @@ export declare class ValidateMixinClass {
    * Returns true if the field value satisfies all constraints (if any).
    */
   checkValidity(): boolean;
+
+  /**
+   * Fired whenever the field is validated.
+   *
+   * @event validated
+   * @param {Object} detail
+   * @param {boolean} detail.valid the result of the validation.
+   */
 }

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -36,12 +36,17 @@ export const ValidateMixin = dedupingMixin(
       }
 
       /**
-       * Returns true if field is valid, and sets `invalid` based on the field validity.
+       * Validates the field and sets the `invalid` property based on the result.
+       *
+       * The method fires a `validated` event with the result of the validation.
        *
        * @return {boolean} True if the value is valid.
        */
       validate() {
-        return !(this.invalid = !this.checkValidity());
+        const isValid = this.checkValidity();
+        this.invalid = !isValid;
+        this.dispatchEvent(new CustomEvent('validated', { detail: { valid: isValid } }));
+        return isValid;
       }
 
       /**
@@ -52,5 +57,13 @@ export const ValidateMixin = dedupingMixin(
       checkValidity() {
         return !this.required || !!this.value;
       }
+
+      /**
+       * Fired whenever the field is validated.
+       *
+       * @event validated
+       * @param {Object} detail
+       * @param {boolean} detail.valid the result of the validation.
+       */
     },
 );

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import { ValidateMixin } from '../src/validate-mixin.js';
 import { define } from './helpers.js';
 
@@ -99,6 +100,27 @@ const runTests = (baseClass) => {
       element.value = 'value';
       element.validate();
       expect(element.invalid).to.be.false;
+    });
+
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      element.addEventListener('validated', validatedSpy);
+      element.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      element.addEventListener('validated', validatedSpy);
+      element.required = true;
+      element.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
     });
   });
 };

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -216,6 +216,29 @@ describe('integer-field', () => {
       });
     });
   });
+
+  describe('validation', () => {
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      integerField.addEventListener('validated', validatedSpy);
+      integerField.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      integerField.addEventListener('validated', validatedSpy);
+      integerField.required = true;
+      integerField.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
+    });
+  });
 });
 
 describe('mixed', () => {

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -114,6 +114,27 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
       expect(changeSpy.calledAfter(validateSpy)).to.be.true;
     });
+
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      field.addEventListener('validated', validatedSpy);
+      field.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      field.addEventListener('validated', validatedSpy);
+      field.required = true;
+      field.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
+    });
   });
 
   describe('step', () => {

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -179,6 +179,29 @@ describe('password-field', () => {
       expect(revealButton.hasAttribute('aria-hidden')).to.be.false;
     });
   });
+
+  describe('validation', () => {
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      passwordField.addEventListener('validated', validatedSpy);
+      passwordField.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      passwordField.addEventListener('validated', validatedSpy);
+      passwordField.required = true;
+      passwordField.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
+    });
+  });
 });
 
 describe('invalid', () => {

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -548,6 +548,27 @@ describe('radio-group', () => {
       group.invalid = false;
       expect(group.hasAttribute('invalid')).to.be.false;
     });
+
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      group.addEventListener('validated', validatedSpy);
+      group.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      group.addEventListener('validated', validatedSpy);
+      group.required = true;
+      group.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
+    });
   });
 
   describe('aria-labelledby', () => {

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -589,6 +589,27 @@ describe('vaadin-select', () => {
         select.value = '';
         expect(spy.callCount).to.be.equal(2);
       });
+
+      it('should fire a validated event on validation success', () => {
+        const validatedSpy = sinon.spy();
+        select.addEventListener('validated', validatedSpy);
+        select.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.true;
+      });
+
+      it('should fire a validated event on validation failure', () => {
+        const validatedSpy = sinon.spy();
+        select.addEventListener('validated', validatedSpy);
+        select.required = true;
+        select.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.false;
+      });
     });
 
     describe('initial validation', () => {

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -140,6 +140,27 @@ describe('text-area', () => {
         textArea.maxlength = 6;
         expect(spy.calledOnce).to.be.true;
       });
+
+      it('should fire a validated event on validation success', () => {
+        const validatedSpy = sinon.spy();
+        textArea.addEventListener('validated', validatedSpy);
+        textArea.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.true;
+      });
+
+      it('should fire a validated event on validation failure', () => {
+        const validatedSpy = sinon.spy();
+        textArea.addEventListener('validated', validatedSpy);
+        textArea.required = true;
+        textArea.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.false;
+      });
     });
   });
 

--- a/packages/text-field/test/text-field.test.js
+++ b/packages/text-field/test/text-field.test.js
@@ -167,6 +167,29 @@ describe('text-field', () => {
       });
     });
 
+    describe('validation', () => {
+      it('should fire a validated event on validation success', () => {
+        const validatedSpy = sinon.spy();
+        textField.addEventListener('validated', validatedSpy);
+        textField.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.true;
+      });
+
+      it('should fire a validated event on validation failure', () => {
+        const validatedSpy = sinon.spy();
+        textField.addEventListener('validated', validatedSpy);
+        textField.required = true;
+        textField.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.false;
+      });
+    });
+
     describe('validation constraints', () => {
       it('should not validate the field when minlength is set', () => {
         textField.minlength = 2;

--- a/packages/time-picker/test/form-input.test.js
+++ b/packages/time-picker/test/form-input.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, focusout } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import { TimePicker } from '../src/vaadin-time-picker.js';
 
 class TimePicker20Element extends TimePicker {
@@ -165,6 +166,27 @@ describe('form input', () => {
       expect(timePicker.invalid).to.be.equal(false);
       focusout(comboBox);
       expect(timePicker.invalid).to.be.equal(true);
+    });
+
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      timePicker.addEventListener('validated', validatedSpy);
+      timePicker.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      timePicker.addEventListener('validated', validatedSpy);
+      timePicker.required = true;
+      timePicker.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

This PR introduces a `validated` event that will be fired whenever a field is validated.

- [x] Implementation
- [x] Unit tests for `ValidateMixin`
- [x] Unit tests for components

Part of https://github.com/vaadin/web-components/issues/4081

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
