### PR TITLE
refactor: remove license checker from Pro components

### DIFF
--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -38,8 +38,7 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@vaadin/component-base": "23.2.0-alpha2",
-    "@vaadin/vaadin-license-checker": "^2.1.0"
+    "@vaadin/component-base": "23.2.0-alpha2"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/board/src/vaadin-board.js
+++ b/packages/board/src/vaadin-board.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import '@vaadin/vaadin-license-checker/vaadin-license-checker.js';
 import './vaadin-board-row.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
@@ -49,20 +48,6 @@ class Board extends ElementMixin(PolymerElement) {
 
   static get cvdlName() {
     return 'vaadin-board';
-  }
-
-  /**
-   * @protected
-   */
-  static _finalizeClass() {
-    super._finalizeClass();
-
-    const devModeCallback = window.Vaadin.developmentModeCallback;
-    const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-    /* c8 ignore next 3 */
-    if (typeof licenseChecker === 'function') {
-      licenseChecker(Board);
-    }
   }
 
   /**

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.2.0-alpha2",
-    "@vaadin/vaadin-license-checker": "^2.1.0",
     "@vaadin/vaadin-themable-mixin": "23.2.0-alpha2",
     "highcharts": "9.2.2"
   },

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import '@vaadin/vaadin-license-checker/vaadin-license-checker.js';
 import 'highcharts/es-modules/masters/highstock.src.js';
 import 'highcharts/es-modules/masters/modules/accessibility.src.js';
 import 'highcharts/es-modules/masters/highcharts-more.src.js';
@@ -476,20 +475,6 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
       '__updateType(type, configuration)',
       '__updateAdditionalOptions(additionalOptions.*)',
     ];
-  }
-
-  /**
-   * @protected
-   */
-  static _finalizeClass() {
-    super._finalizeClass();
-
-    const devModeCallback = window.Vaadin.developmentModeCallback;
-    const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-    /* c8 ignore next 3 */
-    if (typeof licenseChecker === 'function') {
-      licenseChecker(Chart);
-    }
   }
 
   constructor() {

--- a/packages/component-base/custom_typings/vaadin.d.ts
+++ b/packages/component-base/custom_typings/vaadin.d.ts
@@ -1,7 +1,6 @@
 interface Vaadin {
   developmentModeCallback?: {
     'usage-statistics'?(): void;
-    'vaadin-license-checker'?(): void;
   };
   registrations?: Array<{ is: string; version: string }>;
   usageStatsChecker?: {

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -38,7 +38,6 @@
     "@vaadin/button": "23.2.0-alpha2",
     "@vaadin/component-base": "23.2.0-alpha2",
     "@vaadin/dialog": "23.2.0-alpha2",
-    "@vaadin/vaadin-license-checker": "^2.1.0",
     "@vaadin/vaadin-lumo-styles": "23.2.0-alpha2",
     "@vaadin/vaadin-material-styles": "23.2.0-alpha2",
     "@vaadin/vaadin-overlay": "23.2.0-alpha2",

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import '@vaadin/vaadin-license-checker/vaadin-license-checker.js';
 import './vaadin-confirm-dialog-overlay.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -269,18 +268,6 @@ class ConfirmDialog extends SlotMixin(ElementMixin(ThemePropertyMixin(PolymerEle
         observer: '_rejectButtonChanged',
       },
     };
-  }
-
-  /** @protected */
-  static _finalizeClass() {
-    super._finalizeClass();
-
-    const devModeCallback = window.Vaadin.developmentModeCallback;
-    const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-    /* c8 ignore next 3 */
-    if (typeof licenseChecker === 'function') {
-      licenseChecker(ConfirmDialog);
-    }
   }
 
   static get observers() {

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.2.0-alpha2",
-    "@vaadin/vaadin-license-checker": "^2.1.0",
     "@vaadin/vaadin-lumo-styles": "23.2.0-alpha2",
     "@vaadin/vaadin-material-styles": "23.2.0-alpha2",
     "cookieconsent": "^3.0.6"

--- a/packages/cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import '@vaadin/vaadin-license-checker/vaadin-license-checker.js';
 import 'cookieconsent/build/cookieconsent.min.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
@@ -132,18 +131,6 @@ class CookieConsent extends ElementMixin(PolymerElement) {
         type: Object,
       },
     };
-  }
-
-  /** @protected */
-  static _finalizeClass() {
-    super._finalizeClass();
-
-    const devModeCallback = window.Vaadin.developmentModeCallback;
-    const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-    /* c8 ignore next 3 */
-    if (typeof licenseChecker === 'function') {
-      licenseChecker(CookieConsent);
-    }
   }
 
   /** @private */

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -43,7 +43,6 @@
     "@vaadin/form-layout": "23.2.0-alpha2",
     "@vaadin/grid": "23.2.0-alpha2",
     "@vaadin/text-field": "23.2.0-alpha2",
-    "@vaadin/vaadin-license-checker": "^2.1.0",
     "@vaadin/vaadin-lumo-styles": "23.2.0-alpha2",
     "@vaadin/vaadin-material-styles": "23.2.0-alpha2",
     "@vaadin/vaadin-themable-mixin": "23.2.0-alpha2"

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -6,7 +6,6 @@
 import '@vaadin/button/src/vaadin-button.js';
 import '@vaadin/dialog/src/vaadin-dialog.js';
 import '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
-import '@vaadin/vaadin-license-checker/vaadin-license-checker.js';
 import './vaadin-crud-dialog.js';
 import './vaadin-crud-grid.js';
 import './vaadin-crud-form.js';
@@ -613,17 +612,6 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
       '__cancelButtonPropsChanged(_cancelButton, i18n.cancel)',
       '__deleteButtonPropsChanged(_deleteButton, i18n.deleteItem, __isNew)',
     ];
-  }
-
-  /** @protected */
-  static _finalizeClass() {
-    super._finalizeClass();
-
-    const devModeCallback = window.Vaadin.developmentModeCallback;
-    const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-    if (typeof licenseChecker === 'function') {
-      licenseChecker(Crud);
-    }
   }
 
   /** @private */

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -46,7 +46,6 @@
     "@vaadin/lit-renderer": "23.2.0-alpha2",
     "@vaadin/select": "23.2.0-alpha2",
     "@vaadin/text-field": "23.2.0-alpha2",
-    "@vaadin/vaadin-license-checker": "^2.1.0",
     "@vaadin/vaadin-lumo-styles": "23.2.0-alpha2",
     "@vaadin/vaadin-material-styles": "23.2.0-alpha2",
     "@vaadin/vaadin-themable-mixin": "23.2.0-alpha2"

--- a/packages/grid-pro/src/vaadin-grid-pro.js
+++ b/packages/grid-pro/src/vaadin-grid-pro.js
@@ -4,7 +4,6 @@
  * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
  * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
-import '@vaadin/vaadin-license-checker/vaadin-license-checker.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
 
@@ -53,18 +52,6 @@ class GridPro extends InlineEditingMixin(Grid) {
     return 'vaadin-grid-pro';
   }
 
-  /**
-   * @protected
-   */
-  static _finalizeClass() {
-    super._finalizeClass();
-
-    const devModeCallback = window.Vaadin.developmentModeCallback;
-    const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-    if (typeof licenseChecker === 'function') {
-      licenseChecker(GridPro);
-    }
-  }
 }
 
 customElements.define(GridPro.is, GridPro);

--- a/packages/grid-pro/src/vaadin-grid-pro.js
+++ b/packages/grid-pro/src/vaadin-grid-pro.js
@@ -51,7 +51,6 @@ class GridPro extends InlineEditingMixin(Grid) {
   static get cvdlName() {
     return 'vaadin-grid-pro';
   }
-
 }
 
 customElements.define(GridPro.is, GridPro);

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.2.0-alpha2",
-    "@vaadin/vaadin-license-checker": "^2.1.0",
     "@vaadin/vaadin-themable-mixin": "23.2.0-alpha2",
     "ol": "6.13.0"
   },

--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2022 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import '@vaadin/vaadin-license-checker/vaadin-license-checker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { defaults as defaultControls } from 'ol/control';
 import { defaults as defaultInteractions } from 'ol/interaction';
@@ -378,17 +377,6 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
 
   static get cvdlName() {
     return 'vaadin-map';
-  }
-
-  /** @protected */
-  static _finalizeClass() {
-    super._finalizeClass();
-
-    const devModeCallback = window.Vaadin.developmentModeCallback;
-    const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-    if (typeof licenseChecker === 'function') {
-      licenseChecker(Map);
-    }
   }
 
   /**

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -43,7 +43,6 @@
     "@vaadin/component-base": "23.2.0-alpha2",
     "@vaadin/confirm-dialog": "23.2.0-alpha2",
     "@vaadin/text-field": "23.2.0-alpha2",
-    "@vaadin/vaadin-license-checker": "^2.1.0",
     "@vaadin/vaadin-lumo-styles": "23.2.0-alpha2",
     "@vaadin/vaadin-material-styles": "23.2.0-alpha2",
     "@vaadin/vaadin-themable-mixin": "23.2.0-alpha2"

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -6,7 +6,6 @@
 import '@vaadin/button/src/vaadin-button.js';
 import '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
 import '@vaadin/text-field/src/vaadin-text-field.js';
-import '@vaadin/vaadin-license-checker/vaadin-license-checker.js';
 import '../vendor/vaadin-quill.js';
 import './vaadin-rich-text-editor-toolbar-styles.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -502,17 +501,6 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
 
   static get observers() {
     return ['_valueChanged(value, _editor)', '_disabledChanged(disabled, readonly, _editor)'];
-  }
-
-  /** @protected */
-  static _finalizeClass() {
-    super._finalizeClass();
-
-    const devModeCallback = window.Vaadin.developmentModeCallback;
-    const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-    if (typeof licenseChecker === 'function') {
-      licenseChecker(RichTextEditor);
-    }
   }
 
   /**

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -191,16 +191,6 @@ const getTestRunnerHtml = (theme) => (testFramework) =>
 
         /* Force development mode for element-mixin */
         localStorage.setItem('vaadin.developmentmode.force', true);
-
-        /* Prevent license checker popup for Pro */
-        const now = new Date().getTime();
-        localStorage.setItem('vaadin.licenses.vaadin-board.lastCheck', now);
-        localStorage.setItem('vaadin.licenses.vaadin-charts.lastCheck', now);
-        localStorage.setItem('vaadin.licenses.vaadin-confirm-dialog.lastCheck', now);
-        localStorage.setItem('vaadin.licenses.vaadin-cookie-consent.lastCheck', now);
-        localStorage.setItem('vaadin.licenses.vaadin-crud.lastCheck', now);
-        localStorage.setItem('vaadin.licenses.vaadin-grid-pro.lastCheck', now);
-        localStorage.setItem('vaadin.licenses.vaadin-rich-text-editor.lastCheck', now);
       </script>
       <script type="module" src="${testFramework}"></script>
     </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,13 +1956,6 @@
   resolved "https://registry.yarnpkg.com/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.5.tgz#5098216dae30d8eeabe46c7cbe494a352fe09691"
   integrity sha512-miirBQw10UHjKwRv29iZniXCo41cLg3wFotoyTeUZ2PTGIDk/fZVFr4Q4WVKZrp3D15878vz94nNQROSmPLjdg==
 
-"@vaadin/vaadin-license-checker@^2.1.0":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@vaadin/vaadin-license-checker/-/vaadin-license-checker-2.1.2.tgz#a255bed26291a4937106846690455b9e6e59ee39"
-  integrity sha512-oD6/MoavXyIZp6NWhkbJD5RKrpiWohhaQpgqjM0bFIthRr+1NoiG5R1w0uY3NIdMDuaXlsUFSQJ/Viz1v7F/jQ==
-  dependencies:
-    "@vaadin/vaadin-development-mode-detector" "^2.0.0"
-
 "@vaadin/vaadin-usage-statistics@^2.1.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz#a0a211b298e647742b60c6d4d1d8834381e3c77f"


### PR DESCRIPTION
License checking is now handled in Flow + Hilla
