### PR TITLE
fix: prevent a filter reset on open after filtering when autoOpenDisabled (#4073) (CP: 23.1)

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -62,13 +62,17 @@ export const ComboBoxDataProviderMixin = (superClass) =>
         __placeHolder: {
           value: new ComboBoxPlaceholder(),
         },
+
+        /** @private */
+        __previousDataProviderFilter: {
+          type: String,
+        },
       };
     }
 
     static get observers() {
       return [
-        '_dataProviderFilterChanged(filter, dataProvider)',
-        '_dataProviderClearFilter(dataProvider, opened, value)',
+        '_dataProviderFilterChanged(filter)',
         '_warnDataProviderValue(dataProvider, value)',
         '_ensureFirstPage(opened)',
       ];
@@ -77,7 +81,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
     /** @protected */
     ready() {
       super.ready();
-      this.clearCache();
       this.$.dropdown.addEventListener('index-requested', (e) => {
         const index = e.detail.index;
         const currentScrollerPos = e.detail.currentScrollerPos;
@@ -101,38 +104,25 @@ export const ComboBoxDataProviderMixin = (superClass) =>
     }
 
     /** @private */
-    _dataProviderFilterChanged() {
-      if (!this._shouldFetchData()) {
+    _dataProviderFilterChanged(filter) {
+      if (this.__previousDataProviderFilter === undefined && filter === '') {
+        this.__previousDataProviderFilter = filter;
         return;
       }
 
-      this._refreshData();
-    }
+      if (this.__previousDataProviderFilter !== filter) {
+        this.__previousDataProviderFilter = filter;
 
-    /** @private */
-    _dataProviderClearFilter(dataProvider, opened, value) {
-      // Can't depend on filter in this observer as we don't want
-      // to clear the filter whenever it's set
-      if (dataProvider && !this.loading && this.filter && !(opened && this.autoOpenDisabled && value === this.filter)) {
-        this._refreshData(true);
-      }
-    }
+        this._pendingRequests = {};
+        // Immediately mark as loading if this refresh leads to re-fetching pages
+        // This prevents some issues with the properties below triggering
+        // observers that also rely on the loading state
+        this.loading = this._shouldFetchData();
+        // Reset size and internal loading state
+        this.size = undefined;
 
-    /** @private */
-    _refreshData(clearFilter) {
-      // Immediately mark as loading if this refresh leads to re-fetching pages
-      // This prevents some issues with the properties below triggering
-      // observers that also rely on the loading state
-      this.loading = this._shouldFetchData();
-      // Reset size and internal loading state
-      this.size = undefined;
-      this._pendingRequests = {};
-      // Clear filter if requested
-      if (clearFilter) {
-        this.filter = '';
+        this.clearCache();
       }
-      // Clear cached pages, and reload current page if we need the data
-      this.clearCache();
     }
 
     /** @private */
@@ -229,13 +219,16 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       if (!this.dataProvider) {
         return;
       }
+
       this._pendingRequests = {};
       const filteredItems = [];
       for (let i = 0; i < (this.size || 0); i++) {
         filteredItems.push(this.__placeHolder);
       }
       this.filteredItems = filteredItems;
+
       if (this._shouldFetchData()) {
+        this._forceNextRequest = false;
         this._loadPage(0);
       } else {
         this._forceNextRequest = true;
@@ -269,6 +262,8 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       this._ensureItemsOrDataProvider(() => {
         this.dataProvider = oldDataProvider;
       });
+
+      this.clearCache();
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -778,9 +778,7 @@ export const ComboBoxMixin = (subclass) =>
 
       this._clearSelectionRange();
 
-      if (!this.dataProvider) {
-        this.filter = '';
-      }
+      this.filter = '';
     }
 
     /**
@@ -938,6 +936,9 @@ export const ComboBoxMixin = (subclass) =>
       } else {
         this.selectedItem = null;
       }
+
+      this.filter = '';
+
       // In the next _detectAndDispatchChange() call, the change detection should pass
       this._lastCommittedValue = undefined;
     }

--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -248,6 +248,20 @@ describe('internal filtering', () => {
 
       expect(comboBox.opened && overlay.hidden).to.be.true;
     });
+
+    it('should reset the filter on value change', () => {
+      setInputValue(comboBox, 'bar');
+      expect(comboBox.filter).to.equal('bar');
+      comboBox.value = 'foo';
+      expect(comboBox.filter).to.be.empty;
+    });
+
+    it('should reset the filter on selected item change', () => {
+      setInputValue(comboBox, 'bar');
+      expect(comboBox.filter).to.equal('bar');
+      comboBox.selectedItem = 'foo';
+      expect(comboBox.filter).to.be.empty;
+    });
   });
 
   describe('setting items when opened', () => {

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -127,17 +127,31 @@ describe('lazy loading', () => {
       });
 
       (isComboBoxLight ? describe.skip : describe)('when autoOpenDisabled', () => {
-        beforeEach(() => (comboBox.autoOpenDisabled = true));
-
-        it('should not clear filter when loading first page', () => {
-          expect(comboBox.autoOpenDisabled).to.be.true;
-          expect(comboBox.opened).to.be.false;
+        beforeEach(() => {
+          comboBox.autoOpenDisabled = true;
+          comboBox.inputElement.focus();
           comboBox.dataProvider = spyDataProvider;
-          setInputValue(comboBox, 'item 1');
+          spyDataProvider.resetHistory();
+        });
+
+        it('should be invoked on open', () => {
           comboBox.opened = true;
+          expect(spyDataProvider.calledOnce).to.be.true;
+        });
+
+        it('should be invoked with the correct filter when filtering', () => {
+          setInputValue(comboBox, 'item 1');
           expect(comboBox.filter).to.equal('item 1');
+          expect(spyDataProvider.calledOnce).to.be.true;
           const { filter } = spyDataProvider.lastCall.args[0];
           expect(filter).to.equal('item 1');
+        });
+
+        it('should not be invoked on open after filtering', () => {
+          setInputValue(comboBox, 'item 1');
+          spyDataProvider.resetHistory();
+          comboBox.opened = true;
+          expect(spyDataProvider.called).to.be.false;
         });
       });
 
@@ -145,7 +159,10 @@ describe('lazy loading', () => {
       describe('when open', function () {
         // eslint-disable-next-line no-invalid-this
         this.timeout(15000);
-        beforeEach(() => (comboBox.opened = true));
+        beforeEach(() => {
+          comboBox.inputElement.focus();
+          comboBox.opened = true;
+        });
 
         it('should be invoked when set', () => {
           comboBox.dataProvider = spyDataProvider;
@@ -203,7 +220,7 @@ describe('lazy loading', () => {
         it('should request on filter change with user’s filter', () => {
           comboBox.dataProvider = spyDataProvider;
           spyDataProvider.resetHistory();
-          comboBox.filter = 'item 1';
+          setInputValue(comboBox, 'item 1');
           expect(spyDataProvider.called).to.be.true;
           const params = spyDataProvider.lastCall.args[0];
           expect(params.filter).to.equal('item 1');
@@ -211,7 +228,7 @@ describe('lazy loading', () => {
 
         it('should clear filter on value change', () => {
           comboBox.dataProvider = spyDataProvider;
-          comboBox.filter = 'item 1';
+          setInputValue(comboBox, 'item 1');
           spyDataProvider.resetHistory();
           comboBox.value = 'foo';
           const params = spyDataProvider.lastCall.args[0];
@@ -220,7 +237,7 @@ describe('lazy loading', () => {
 
         it('should clear filter on value clear', () => {
           comboBox.dataProvider = dataProvider;
-          comboBox.filter = 'item 1';
+          setInputValue(comboBox, 'item 1');
           comboBox.value = 'item 1';
           comboBox.value = '';
           expect(comboBox.filter).to.equal('');
@@ -228,7 +245,7 @@ describe('lazy loading', () => {
 
         it('should clear filter on opened change', () => {
           comboBox.dataProvider = dataProvider;
-          comboBox.filter = 'item 1';
+          setInputValue(comboBox, 'item 1');
           comboBox.opened = false;
           expect(comboBox.filter).to.equal('');
         });
@@ -261,7 +278,7 @@ describe('lazy loading', () => {
 
         it('should request page after partial filter & cancel & reopen', () => {
           comboBox.dataProvider = spyDataProvider;
-          comboBox.filter = 'it';
+          setInputValue(comboBox, 'it');
           spyDataProvider.resetHistory();
           comboBox.cancel();
           comboBox.opened = true;


### PR DESCRIPTION
## Description

A cherry-pick of the following fix to `23.1`:

- https://github.com/vaadin/web-components/pull/4073

Fixes https://github.com/vaadin/flow-components/issues/3321

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
