### PR TITLE
fix: add ValidateMixin to date-picker-light

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-light.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-light.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ValidateMixin } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
 export { DatePickerDate, DatePickerI18n } from './vaadin-date-picker-mixin.js';
@@ -80,7 +81,7 @@ export interface DatePickerLightEventMap extends HTMLElementEventMap, DatePicker
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class DatePickerLight extends ThemableMixin(DatePickerMixin(HTMLElement)) {
+declare class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(HTMLElement))) {
   /**
    * Name of the two-way data-bindable property representing the
    * value of the custom input field.

--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -7,6 +7,7 @@ import './vaadin-date-picker-overlay.js';
 import './vaadin-date-picker-overlay-content.js';
 import { dashToCamelCase } from '@polymer/polymer/lib/utils/case-map.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ValidateMixin } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
 
@@ -53,7 +54,7 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * @mixes ThemableMixin
  * @mixes DatePickerMixin
  */
-class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
+class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(PolymerElement))) {
   static get template() {
     return html`
       <style>

--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -189,13 +189,6 @@ export declare class DatePickerMixinClass {
   close(): void;
 
   /**
-   * Returns true if `value` is valid, and sets the `invalid` flag appropriately.
-   *
-   * @returns True if the value is valid and sets the `invalid` flag appropriately
-   */
-  validate(): boolean;
-
-  /**
    * Returns true if the current input value satisfies all constraints (if any)
    *
    * Override the `checkValidity` method for custom validations.

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -511,15 +511,6 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /**
-     * Returns true if `value` is valid, and sets the `invalid` flag appropriately.
-     *
-     * @return {boolean} True if the value is valid and sets the `invalid` flag appropriately
-     */
-    validate() {
-      return !(this.invalid = !this.checkValidity());
-    }
-
-    /**
      * Returns true if the current input value satisfies all constraints (if any)
      *
      * Override the `checkValidity` method for custom validations.

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -97,6 +97,7 @@ assertType<DatePickerMixinClass>(datePicker);
 const datePickerLight = document.createElement('vaadin-date-picker-light');
 
 assertType<DatePickerLight>(datePickerLight);
+assertType<ValidateMixinClass>(datePickerLight);
 
 datePickerLight.addEventListener('opened-changed', (event) => {
   assertType<DatePickerLightOpenedChangedEvent>(event);
@@ -131,6 +132,8 @@ assertType<boolean | null | undefined>(datePickerLight.opened);
 assertType<HTMLElement | null | undefined>(datePickerLight.focusElement);
 assertType<boolean>(datePickerLight.disabled);
 assertType<string>(datePickerLight.value);
+assertType<boolean>(datePickerLight.invalid);
+assertType<boolean>(datePickerLight.required);
 assertType<string | null | undefined>(datePickerLight.initialPosition);
 
 // DatePickerLight mixins


### PR DESCRIPTION
## Description

This PR extends `date-picker-light` from `ValidateMixin` to add the missing `invalid`, `required` properties and make it possible to get rid of the `validate()` method in `combo-box-mixin`.

Part of #4081 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
