### PR TITLE
feat: add property to control multi-sort priority

### DIFF
--- a/packages/grid/src/vaadin-grid-sort-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-mixin.d.ts
@@ -15,8 +15,8 @@ export declare class SortMixinClass {
   multiSort: boolean;
 
   /**
-    * Controls how columns are added to the sort order when using multi-sort.
-    * The sort order is visually indicated by numbers in grid sorters placed in column headers.
+   * Controls how columns are added to the sort order when using multi-sort.
+   * The sort order is visually indicated by numbers in grid sorters placed in column headers.
    *
    * By default, whenever an unsorted column is sorted, or the sort-direction of a column is
    * changed, that column gets sort priority 1, thus affecting the priority for all the other

--- a/packages/grid/src/vaadin-grid-sort-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-mixin.d.ts
@@ -15,8 +15,8 @@ export declare class SortMixinClass {
   multiSort: boolean;
 
   /**
-   * Use this property to determine the order in which the grid rows are sorted.
-   * It's visually indicated by numbers in grid sorters placed in column headers.
+    * Controls how columns are added to the sort order when using multi-sort.
+    * The sort order is visually indicated by numbers in grid sorters placed in column headers.
    *
    * By default, whenever an unsorted column is sorted, or the sort-direction of a column is
    * changed, that column gets sort priority 1, thus affecting the priority for all the other

--- a/packages/grid/src/vaadin-grid-sort-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-mixin.d.ts
@@ -13,4 +13,20 @@ export declare class SortMixinClass {
    * @attr {boolean} multi-sort
    */
   multiSort: boolean;
+
+  /**
+   * Use this property to determine the order in which the grid rows are sorted.
+   * It's visually indicated by numbers in grid sorters placed in column headers.
+   *
+   * By default, whenever an unsorted column is sorted, or the sort-direction of a column is
+   * changed, that column gets sort priority 1, thus affecting the priority for all the other
+   * sorted columns. This is identical to using `multi-sort-priority="prepend"`.
+   *
+   * Using this property allows to change this behavior so that sorting an unsorted column
+   * would add it to the "end" of the sort, and changing column's sort direction would retain
+   * it's previous priority. To set this, use `multi-sort-priority="append"`.
+   *
+   * @attr {string} multi-sort-priority
+   */
+  multiSortPriority: 'prepend' | 'append';
 }

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -22,8 +22,8 @@ export const SortMixin = (superClass) =>
         },
 
         /**
-         * Use this property to determine the order in which the grid rows are sorted.
-         * It's visually indicated by numbers in grid sorters placed in column headers.
+         * Controls how columns are added to the sort order when using multi-sort.
+         * The sort order is visually indicated by numbers in grid sorters placed in column headers.
          *
          * By default, whenever an unsorted column is sorted, or the sort-direction of a column is
          * changed, that column gets sort priority 1, thus affecting the priority for all the other

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -351,6 +351,41 @@ describe('sorting', () => {
       });
     });
 
+    describe('multi-sort priority', () => {
+      beforeEach(() => {
+        grid.multiSortPriority = 'append';
+      });
+
+      it('should append sort order when setting sort direction', () => {
+        sorterLast.direction = null;
+
+        sorterLast.direction = 'asc';
+        expect(sorterFirst._order).to.equal(0);
+        expect(sorterLast._order).to.equal(1);
+      });
+
+      it('should retain sort order when changing sort direction', () => {
+        sorterFirst.direction = 'desc';
+        expect(sorterFirst._order).to.equal(1);
+        expect(sorterLast._order).to.equal(0);
+      });
+
+      it('should remove sorter when clearing sort direction', () => {
+        sorterLast.direction = null;
+
+        const sortOrders = grid._mapSorters();
+        expect(sortOrders).to.have.length(1);
+        expect(sortOrders[0].path).to.equal('first');
+        expect(sortOrders[0].direction).to.equal('asc');
+      });
+
+      it('should update order when clearing sort direction', () => {
+        sorterLast.direction = null;
+
+        expect(sorterFirst._order).to.be.null;
+      });
+    });
+
     describe('single column sorting', () => {
       beforeEach(() => {
         grid.multiSort = false;

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -351,7 +351,7 @@ describe('sorting', () => {
       });
     });
 
-    describe('multi-sort priority', () => {
+    describe('multi-sort-priority="append"', () => {
       beforeEach(() => {
         grid.multiSortPriority = 'append';
       });

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -173,6 +173,7 @@ assertType<(arg0: TestGridItem) => void>(narrowedGrid.selectItem);
 assertType<(arg0: TestGridItem) => void>(narrowedGrid.deselectItem);
 
 assertType<boolean>(narrowedGrid.multiSort);
+assertType<'prepend' | 'append'>(narrowedGrid.multiSortPriority);
 
 assertType<GridCellClassNameGenerator<TestGridItem> | null | undefined>(narrowedGrid.cellClassNameGenerator);
 assertType<() => void>(narrowedGrid.generateCellClassNames);


### PR DESCRIPTION
## Description

Added `multiSortPriority` property that can be used to update sorting behavior as follows:

1. Clicking a sorter for a not yet sorted column "appends" it by applying at the end of the existing sorters,
2. Clicking a sorter for an already column sorted does not update order in which columns are sorted.

Fixes #1281

Part of https://github.com/vaadin/platform/issues/3052
Related to https://github.com/vaadin/flow-components/issues/1197

## Type of change

- Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
