### PR TITLE
fix: ensure checkValidity() returns the correct result

### DIFF
--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -244,13 +244,6 @@ declare class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(Themable
    */
   requestContentUpdate(): void;
 
-  /**
-   * Returns true if `value` is valid, and sets the `invalid` flag appropriately.
-   *
-   * @returns True if the value is valid and sets the `invalid` flag appropriately
-   */
-  validate(): boolean;
-
   addEventListener<K extends keyof SelectEventMap>(
     type: K,
     listener: (this: Select, ev: SelectEventMap[K]) => void,

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -697,7 +697,7 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
   }
 
   /**
-   * Returns true if the current input value satisfies all constraints (if any)
+   * Returns true if the current value satisfies all constraints (if any)
    *
    * @return {boolean}
    */

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -697,12 +697,12 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
   }
 
   /**
-   * Returns true if `value` is valid, and sets the `invalid` flag appropriately.
+   * Returns true if the current input value satisfies all constraints (if any)
    *
-   * @return {boolean} True if the value is valid and sets the `invalid` flag appropriately
+   * @return {boolean}
    */
-  validate() {
-    return !(this.invalid = !(this.disabled || !this.required || this.value));
+  checkValidity() {
+    return this.disabled || !this.required || !!this.value;
   }
 
   /**

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -538,7 +538,13 @@ describe('vaadin-select', () => {
     });
 
     describe('validation', () => {
-      it('should set invalid to true when is required but there is no value', () => {
+      it('should pass the validation when the field is valid', () => {
+        select.validate();
+        expect(select.checkValidity()).to.be.true;
+        expect(select.invalid).to.be.false;
+      });
+
+      it('should not pass the validation when the field is required and has no value', () => {
         expect(select.invalid).to.be.false;
         select.setAttribute('required', '');
 
@@ -548,7 +554,7 @@ describe('vaadin-select', () => {
         expect(select.invalid).to.be.true;
       });
 
-      it('should not set invalid to true when is required, there is no value, but is disabled', () => {
+      it('should pass the validation when the field is required and has no value but disabled', () => {
         expect(select.invalid).to.be.false;
         select.setAttribute('required', '');
         select.setAttribute('disabled', '');

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -544,6 +544,7 @@ describe('vaadin-select', () => {
 
         enterKeyDown(valueButton);
         escKeyDown(valueButton);
+        expect(select.checkValidity()).to.be.false;
         expect(select.invalid).to.be.true;
       });
 
@@ -553,6 +554,7 @@ describe('vaadin-select', () => {
         select.setAttribute('disabled', '');
 
         select.validate();
+        expect(select.checkValidity()).to.be.true;
         expect(select.invalid).to.be.false;
       });
 

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -1,4 +1,5 @@
 import '../../vaadin-select.js';
+import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import {
   Select,
   SelectChangeEvent,
@@ -20,8 +21,13 @@ assertType<SelectRenderer | undefined>(select.renderer);
 assertType<string>(select.value);
 assertType<string | null | undefined>(select.placeholder);
 assertType<boolean>(select.readonly);
+assertType<boolean>(select.invalid);
+assertType<boolean>(select.required);
 assertType<() => void>(select.requestContentUpdate);
 assertType<() => boolean>(select.validate);
+
+// Mixins
+assertType<ValidateMixinClass>(select);
 
 // Item properties
 const item: SelectItem = select.items ? select.items[0] : {};


### PR DESCRIPTION
## Description

- Moved the validatity checks from `validate()` to `checkValidity()`.
- Ensured `checkValidity()` always returns a boolean.
- Added the corresponding unit tests.

Part of #4081

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
