### PR TITLE
refactor: add ValidateMixin to combo-box-light

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -6,6 +6,7 @@
 import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
 import { ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
@@ -142,7 +143,8 @@ interface ComboBoxLight<TItem = ComboBoxDefaultItem>
     KeyboardMixinClass,
     InputMixinClass,
     DisabledMixinClass,
-    ThemableMixinClass {}
+    ThemableMixinClass,
+    ValidateMixinClass {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -8,6 +8,7 @@ import './vaadin-combo-box-overlay.js';
 import './vaadin-combo-box-scroller.js';
 import { dashToCamelCase } from '@polymer/polymer/lib/utils/case-map.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ValidateMixin } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixin.js';
 import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
@@ -61,8 +62,9 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  * @mixes ComboBoxDataProviderMixin
  * @mixes ComboBoxMixin
  * @mixes ThemableMixin
+ * @mixes ValidateMixin
  */
-class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixin(PolymerElement))) {
+class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixin(ThemableMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-combo-box-light';
   }

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -138,11 +138,6 @@ export declare class ComboBoxMixinClass<TItem> {
    */
   itemIdPath: string | null | undefined;
 
-  /**
-   * Set to true if the value is invalid.
-   */
-  invalid: boolean;
-
   protected readonly _propertyForValue: string;
 
   protected _inputElementValue: string | undefined;

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1301,29 +1301,6 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /**
-     * Returns true if `value` is valid, and sets the `invalid` flag appropriately.
-     *
-     * @return {boolean} True if the value is valid and sets the `invalid` flag appropriately
-     */
-    validate() {
-      return !(this.invalid = !this.checkValidity());
-    }
-
-    /**
-     * Returns true if the current input value satisfies all constraints (if any).
-     * You can override this method for custom validations.
-     *
-     * @return {boolean}
-     */
-    checkValidity() {
-      if (super.checkValidity) {
-        return super.checkValidity();
-      }
-
-      return !this.required || !!this.value;
-    }
-
-    /**
      * Fired when the value changes.
      *
      * @event value-changed

--- a/packages/combo-box/test/form-input.test.js
+++ b/packages/combo-box/test/form-input.test.js
@@ -30,21 +30,25 @@ describe('form field', () => {
     expect(input.readOnly).to.be.true;
   });
 
-  it('should validate correctly when input value is invalid', () => {
-    comboBox.name = 'foo';
-    comboBox.required = true;
-
-    expect(comboBox.validate()).to.equal(false);
-    expect(comboBox.invalid).to.be.equal(true);
+  it('should pass the validation when the field is valid', () => {
+    expect(comboBox.checkValidity()).to.be.true;
+    expect(comboBox.validate()).to.be.true;
+    expect(comboBox.invalid).to.be.false;
   });
 
-  it('should validate correctly when input value is valid', () => {
-    comboBox.name = 'foo';
+  it('should not pass the validation when the field is required and has no value', () => {
+    comboBox.required = true;
+    expect(comboBox.checkValidity()).to.be.false;
+    expect(comboBox.validate()).to.be.false;
+    expect(comboBox.invalid).to.be.true;
+  });
+
+  it('should pass the validation when the field is required and has a value', () => {
     comboBox.required = true;
     comboBox.value = 'foo';
-
-    expect(comboBox.validate()).to.equal(true);
-    expect(comboBox.invalid).to.be.equal(false);
+    expect(comboBox.checkValidity()).to.be.true;
+    expect(comboBox.validate()).to.be.true;
+    expect(comboBox.invalid).to.be.false;
   });
 
   describe('enter key behavior', () => {

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -199,3 +199,4 @@ assertType<DisabledMixinClass>(narrowedComboBoxLight);
 assertType<InputMixinClass>(narrowedComboBoxLight);
 assertType<KeyboardMixinClass>(narrowedComboBoxLight);
 assertType<ThemableMixinClass>(narrowedComboBoxLight);
+assertType<ValidateMixinClass>(narrowedComboBoxLight);


### PR DESCRIPTION
## Description

This PR extends `combo-box-light` from `ValidateMixin` to make it possible to get rid of the `validate()` method in `combo-box-mixin`.

Part of #4081 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
