### PR TITLE
refactor!: remove the default value for step

### DIFF
--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -71,7 +71,7 @@ export class IntegerField extends NumberField {
   _stepChanged(step, inputElement) {
     if (step && !this.__hasOnlyDigits(step)) {
       console.warn(
-        `Trying to set invalid step size "${step}", which is not a positive integer, to <vaadin-integer-field>. Resetting the default value to "null".`,
+        `<vaadin-integer-field> The \`step\` property must be a positive integer but \`${step}\` was provided, so the property was reset to \`null\`.`,
       );
       this.step = null;
       return;

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -65,6 +65,7 @@ export class IntegerField extends NumberField {
    * Override an observer from `NumberField` to reset the step
    * property when an invalid step is set.
    * @param {number} newVal
+   * @param {HTMLElement | undefined} inputElement
    * @protected
    * @override
    */

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -65,20 +65,19 @@ export class IntegerField extends NumberField {
    * Override an observer from `NumberField` to reset the step
    * property when an invalid step is set.
    * @param {number} newVal
-   * @param {number | undefined} oldVal
    * @protected
    * @override
    */
-  _stepChanged(newVal, oldVal) {
-    if (!this.__hasOnlyDigits(newVal)) {
+  _stepChanged(step, inputElement) {
+    if (step && !this.__hasOnlyDigits(step)) {
       console.warn(
-        `Trying to set invalid step size "${newVal}", which is not a positive integer, to <vaadin-integer-field>. Resetting the default value 1.`,
+        `Trying to set invalid step size "${step}", which is not a positive integer, to <vaadin-integer-field>. Resetting the default value 1.`,
       );
-      this.step = 1;
+      this.step = null;
       return;
     }
 
-    super._stepChanged(newVal, oldVal);
+    super._stepChanged(step, inputElement);
   }
 
   /** @private */

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -70,7 +70,7 @@ export class IntegerField extends NumberField {
    * @override
    */
   _stepChanged(step, inputElement) {
-    if (step && !this.__hasOnlyDigits(step)) {
+    if (step != null && !this.__hasOnlyDigits(step)) {
       console.warn(
         `<vaadin-integer-field> The \`step\` property must be a positive integer but \`${step}\` was provided, so the property was reset to \`null\`.`,
       );
@@ -88,7 +88,7 @@ export class IntegerField extends NumberField {
 
   /** @private */
   __hasOnlyDigits(value) {
-    return /^\d*$/.test(String(value));
+    return /^\d+$/.test(String(value));
   }
 }
 

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -71,7 +71,7 @@ export class IntegerField extends NumberField {
   _stepChanged(step, inputElement) {
     if (step && !this.__hasOnlyDigits(step)) {
       console.warn(
-        `Trying to set invalid step size "${step}", which is not a positive integer, to <vaadin-integer-field>. Resetting the default value 1.`,
+        `Trying to set invalid step size "${step}", which is not a positive integer, to <vaadin-integer-field>. Resetting the default value to "null".`,
       );
       this.step = null;
       return;

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["vaadin-integer-field host default"] = 
-`<vaadin-integer-field step="1">
+`<vaadin-integer-field>
   <label
     for="input-vaadin-integer-field-3"
     id="label-vaadin-integer-field-0"
@@ -28,10 +28,7 @@ snapshots["vaadin-integer-field host default"] =
 /* end snapshot vaadin-integer-field host default */
 
 snapshots["vaadin-integer-field host helper"] = 
-`<vaadin-integer-field
-  has-helper=""
-  step="1"
->
+`<vaadin-integer-field has-helper="">
   <label
     for="input-vaadin-integer-field-3"
     id="label-vaadin-integer-field-0"
@@ -67,7 +64,6 @@ snapshots["vaadin-integer-field host error"] =
 `<vaadin-integer-field
   has-error-message=""
   invalid=""
-  step="1"
 >
   <label
     for="input-vaadin-integer-field-3"

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -208,7 +208,7 @@ describe('integer-field', () => {
       });
 
       ['foo', '-1', -1, '1.2', 1.2, '+1', '1e1', {}].forEach((invalidStep) => {
-        it(`should reset default step when setting ${typeof invalidStep} value: ${invalidStep}`, () => {
+        it(`should reset default step when setting ${typeof invalidStep} value: "${invalidStep}"`, () => {
           integerField.step = invalidStep;
           expect(integerField.step).to.be.null;
           expect(console.warn.called).to.be.true;
@@ -229,7 +229,7 @@ describe('integer-field', () => {
 
       it('should not show the warning when setting step to an empty string', () => {
         integerField.step = '';
-        expect(integerField.step).to.equal('');
+        expect(integerField.step).to.be.null;
         expect(console.warn.called).to.be.false;
       });
     });

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -207,12 +207,30 @@ describe('integer-field', () => {
         console.warn.restore();
       });
 
-      ['foo', '-1', -1, '1.2', 1.2, '+1', '1e1', undefined, null, {}].forEach((invalidStep) => {
+      ['foo', '-1', -1, '1.2', 1.2, '+1', '1e1', {}].forEach((invalidStep) => {
         it(`should reset default step when setting ${typeof invalidStep} value: ${invalidStep}`, () => {
           integerField.step = invalidStep;
-          expect(integerField.step).to.eql(1);
+          expect(integerField.step).to.be.null;
           expect(console.warn.called).to.be.true;
         });
+      });
+
+      it('should not show the warning when setting step to undefined', () => {
+        integerField.step = undefined;
+        expect(integerField.step).to.be.undefined;
+        expect(console.warn.called).to.be.false;
+      });
+
+      it('should not show the warning when setting step to null', () => {
+        integerField.step = null;
+        expect(integerField.step).to.be.null;
+        expect(console.warn.called).to.be.false;
+      });
+
+      it('should not show the warning when setting step to an empty string', () => {
+        integerField.step = '';
+        expect(integerField.step).to.equal('');
+        expect(console.warn.called).to.be.false;
       });
     });
   });

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -193,11 +193,6 @@ describe('integer-field', () => {
       expect(integerField.step).to.eql(initialStep);
     });
 
-    it('should allow setting positive integer as string', () => {
-      integerField.step = '5';
-      expect(integerField.step).to.eql(5);
-    });
-
     describe('invalid step', () => {
       beforeEach(() => {
         sinon.stub(console, 'warn');
@@ -207,7 +202,7 @@ describe('integer-field', () => {
         console.warn.restore();
       });
 
-      ['foo', '-1', -1, '1.2', 1.2, '+1', '1e1', {}].forEach((invalidStep) => {
+      ['foo', '-1', -1, '1.2', 1.2, '+1', '1e1', {}, ''].forEach((invalidStep) => {
         it(`should reset default step when setting ${typeof invalidStep} value: "${invalidStep}"`, () => {
           integerField.step = invalidStep;
           expect(integerField.step).to.be.null;
@@ -223,12 +218,6 @@ describe('integer-field', () => {
 
       it('should not show the warning when setting step to null', () => {
         integerField.step = null;
-        expect(integerField.step).to.be.null;
-        expect(console.warn.called).to.be.false;
-      });
-
-      it('should not show the warning when setting step to an empty string', () => {
-        integerField.step = '';
         expect(integerField.step).to.be.null;
         expect(console.warn.called).to.be.false;
       });

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -81,7 +81,7 @@ declare class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(
   /**
    * Specifies the allowed number intervals of the field.
    */
-  step: number;
+  step: number | null | undefined;
 
   addEventListener<K extends keyof NumberFieldEventMap>(
     type: K,

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -246,23 +246,6 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
     this._increaseValue();
   }
 
-  /**
-   * @protected
-   * @override
-   */
-  _constraintsChanged(required, min, max, _step) {
-    if (!this.invalid) {
-      return;
-    }
-
-    const isNumUnset = (n) => !n && n !== 0;
-    if (!isNumUnset(min) || !isNumUnset(max)) {
-      this.validate();
-    } else if (!required) {
-      this._setInvalid(false);
-    }
-  }
-
   /** @private */
   _decreaseValue() {
     this._incrementValue(-1);

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -379,8 +379,9 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
    * @protected
    */
   _stepChanged(step, inputElement) {
-    if (typeof step === 'string' && step) {
-      this.step = parseFloat(step);
+    if (typeof step === 'string') {
+      const stepNumber = parseFloat(step);
+      this.step = isNaN(stepNumber) ? null : stepNumber;
       return;
     }
 

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -379,12 +379,6 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
    * @protected
    */
   _stepChanged(step, inputElement) {
-    if (typeof step === 'string') {
-      const stepNumber = parseFloat(step);
-      this.step = isNaN(stepNumber) ? null : stepNumber;
-      return;
-    }
-
     if (inputElement) {
       inputElement.step = step || 'any';
     }

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -363,6 +363,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
 
   /**
    * @param {number} step
+   * @param {HTMLElement | undefined} inputElement
    * @protected
    */
   _stepChanged(step, inputElement) {

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -166,7 +166,11 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
   }
 
   static get observers() {
-    return ['_minChanged(min, inputElement)', '_maxChanged(max, inputElement)', '_stepChanged(step, inputElement)'];
+    return ['_stepChanged(step, inputElement)'];
+  }
+
+  static get delegateProps() {
+    return [...super.delegateProps, 'min', 'max'];
   }
 
   static get constraints() {
@@ -381,20 +385,6 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
   _stepChanged(step, inputElement) {
     if (inputElement) {
       inputElement.step = step || 'any';
-    }
-  }
-
-  /** @private */
-  _minChanged(min, inputElement) {
-    if (inputElement) {
-      inputElement.min = min;
-    }
-  }
-
-  /** @private */
-  _maxChanged(max, inputElement) {
-    if (inputElement) {
-      inputElement.max = max;
     }
   }
 

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["vaadin-number-field host default"] = 
-`<vaadin-number-field step="1">
+`<vaadin-number-field>
   <label
     for="input-vaadin-number-field-3"
     id="label-vaadin-number-field-0"
@@ -28,10 +28,7 @@ snapshots["vaadin-number-field host default"] =
 /* end snapshot vaadin-number-field host default */
 
 snapshots["vaadin-number-field host helper"] = 
-`<vaadin-number-field
-  has-helper=""
-  step="1"
->
+`<vaadin-number-field has-helper="">
   <label
     for="input-vaadin-number-field-3"
     id="label-vaadin-number-field-0"
@@ -67,7 +64,6 @@ snapshots["vaadin-number-field host error"] =
 `<vaadin-number-field
   has-error-message=""
   invalid=""
-  step="1"
 >
   <label
     for="input-vaadin-number-field-3"

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -452,7 +452,7 @@ snapshots["vaadin-number-field shadow theme"] =
 /* end snapshot vaadin-number-field shadow theme */
 
 snapshots["vaadin-number-field host min"] = 
-`<vaadin-number-field step="1">
+`<vaadin-number-field>
   <label
     for="input-vaadin-number-field-3"
     id="label-vaadin-number-field-0"
@@ -478,7 +478,7 @@ snapshots["vaadin-number-field host min"] =
 /* end snapshot vaadin-number-field host min */
 
 snapshots["vaadin-number-field host max"] = 
-`<vaadin-number-field step="1">
+`<vaadin-number-field>
   <label
     for="input-vaadin-number-field-3"
     id="label-vaadin-number-field-0"
@@ -504,7 +504,7 @@ snapshots["vaadin-number-field host max"] =
 /* end snapshot vaadin-number-field host max */
 
 snapshots["vaadin-number-field host step"] = 
-`<vaadin-number-field step="2">
+`<vaadin-number-field>
   <label
     for="input-vaadin-number-field-3"
     id="label-vaadin-number-field-0"

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -55,6 +55,18 @@ describe('number-field', () => {
     });
   });
 
+  describe('step property', () => {
+    it('should reset the step property when setting not a number', () => {
+      numberField.step = 'not a number';
+      expect(numberField.step).to.be.null;
+    });
+
+    it('should cast the step property to a number when setting a number as a string', () => {
+      numberField.step = '100';
+      expect(numberField.step).to.equal(100);
+    });
+  });
+
   describe('value control buttons', () => {
     it('should increase value by 1 on plus button click', () => {
       numberField.value = 0;

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -55,18 +55,6 @@ describe('number-field', () => {
     });
   });
 
-  describe('step property', () => {
-    it('should reset the step property when setting not a number', () => {
-      numberField.step = 'not a number';
-      expect(numberField.step).to.be.null;
-    });
-
-    it('should cast the step property to a number when setting a number as a string', () => {
-      numberField.step = '100';
-      expect(numberField.step).to.equal(100);
-    });
-  });
-
   describe('value control buttons', () => {
     it('should increase value by 1 on plus button click', () => {
       numberField.value = 0;

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -262,7 +262,7 @@ describe('validation', () => {
       field.validate();
       expect(field.invalid).to.be.true;
 
-      field.step = '';
+      field.step = null;
       expect(field.invalid).to.be.false;
     });
 
@@ -272,7 +272,7 @@ describe('validation', () => {
       field.validate();
       expect(field.invalid).to.be.true;
 
-      field.step = '';
+      field.step = null;
       expect(field.invalid).to.be.true;
     });
 


### PR DESCRIPTION
## Description

This PR removes the default value for the `step` property of `number-field` which makes it possible to throw away the custom validation logic entirely relying on the `InputConstraintsMixin` validation logic instead.

**Breaking changes:**

1. The `step` property no longer has a default value and therefore `undefined` and `null` values are now allowed.
3. Setting the `step` property no longer leads to setting the `step` attribute on the `number-field` host.

Related to https://github.com/vaadin/web-components/issues/1224

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
