### PR TITLE
refactor: add methods to make setting invalid overridable

### DIFF
--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -88,7 +88,7 @@ export const InputConstraintsMixin = dedupingMixin(
         if (this._hasValidConstraints(constraints)) {
           this.validate();
         } else {
-          this._commitValidationResult(true);
+          this._setInvalid(false);
         }
       }
 

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -88,7 +88,7 @@ export const InputConstraintsMixin = dedupingMixin(
         if (this._hasValidConstraints(constraints)) {
           this.validate();
         } else {
-          this.invalid = false;
+          this._commitValidationResult(true);
         }
       }
 

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -44,7 +44,7 @@ export const ValidateMixin = dedupingMixin(
        */
       validate() {
         const isValid = this.checkValidity();
-        this._commitValidationResult(isValid);
+        this._setInvalid(!isValid);
         this.dispatchEvent(new CustomEvent('validated', { detail: { valid: isValid } }));
         return isValid;
       }
@@ -59,26 +59,23 @@ export const ValidateMixin = dedupingMixin(
       }
 
       /**
-       * Sets the `invalid` property according to the given validation result
-       * if the result passes `_shouldCommitValidationResult`.
-       *
-       * @param {boolean} isValid
+       * @param {boolean} invalid
        * @protected
        */
-      _commitValidationResult(isValid) {
-        if (this._shouldCommitValidationResult(isValid)) {
-          this.invalid = !isValid;
+      _setInvalid(invalid) {
+        if (this._shouldSetInvalid(invalid)) {
+          this.invalid = invalid;
         }
       }
 
       /**
-       * Override this method to control which validation results should be committed.
+       * Override this method to define whether the given `invalid` state should be set.
        *
-       * @param {boolean} isValid
+       * @param {boolean} _invalid
        * @return {boolean}
        * @protected
        */
-      _shouldCommitValidationResult(_isValid) {
+      _shouldSetInvalid(_invalid) {
         return true;
       }
 

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -44,7 +44,7 @@ export const ValidateMixin = dedupingMixin(
        */
       validate() {
         const isValid = this.checkValidity();
-        this.invalid = !isValid;
+        this._commitValidationResult(isValid);
         this.dispatchEvent(new CustomEvent('validated', { detail: { valid: isValid } }));
         return isValid;
       }
@@ -56,6 +56,32 @@ export const ValidateMixin = dedupingMixin(
        */
       checkValidity() {
         return !this.required || !!this.value;
+      }
+
+      /**
+       * Sets the `invalid` property according to the given validation result
+       * if the result passes `_shouldCommitValidationResult`.
+       *
+       * @param {boolean} isValid
+       * @protected
+       */
+      _commitValidationResult(isValid) {
+        if (!this._shouldCommitValidationResult(isValid)) {
+          return;
+        }
+
+        this.invalid = !isValid;
+      }
+
+      /**
+       * Override this method to control which validation results should be committed.
+       *
+       * @param {boolean} isValid
+       * @return {boolean}
+       * @protected
+       */
+      _shouldCommitValidationResult(_isValid) {
+        return true;
       }
 
       /**

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -66,11 +66,9 @@ export const ValidateMixin = dedupingMixin(
        * @protected
        */
       _commitValidationResult(isValid) {
-        if (!this._shouldCommitValidationResult(isValid)) {
-          return;
+        if (this._shouldCommitValidationResult(isValid)) {
+          this.invalid = !isValid;
         }
-
-        this.invalid = !isValid;
       }
 
       /**

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -123,6 +123,34 @@ const runTests = (baseClass) => {
       expect(event.detail.valid).to.be.false;
     });
   });
+
+  describe('only validation failure is committed', () => {
+    const tagWithOnlyFailureCommitted = define[baseClass](
+      'validate-mixin-with-only-failure-committed',
+      '<input>',
+      (Base) =>
+        class extends ValidateMixin(Base) {
+          _shouldCommitValidationResult(isValid) {
+            return !isValid;
+          }
+        },
+    );
+
+    beforeEach(async () => {
+      element = fixtureSync(`<${tagWithOnlyFailureCommitted}></${tagWithOnlyFailureCommitted}>`);
+      await nextRender();
+    });
+
+    it('should not commit validation success', () => {
+      element.required = true;
+      element.validate();
+      expect(element.invalid).to.be.true;
+
+      element.value = 'value';
+      element.validate();
+      expect(element.invalid).to.be.true;
+    });
+  });
 };
 
 describe('ValidateMixin + Polymer', () => {

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -124,28 +124,27 @@ const runTests = (baseClass) => {
     });
   });
 
-  describe('only validation failure is committed', () => {
-    const tagWithOnlyFailureCommitted = define[baseClass](
-      'validate-mixin-with-only-failure-committed',
+  describe('invalid cannot be set to false', () => {
+    const tagWithShouldSetInvalid = define[baseClass](
+      'validate-mixin-with-should-set-invalid',
       '<input>',
       (Base) =>
         class extends ValidateMixin(Base) {
-          _shouldCommitValidationResult(isValid) {
-            return !isValid;
+          _shouldSetInvalid(invalid) {
+            return invalid;
           }
         },
     );
 
     beforeEach(async () => {
-      element = fixtureSync(`<${tagWithOnlyFailureCommitted}></${tagWithOnlyFailureCommitted}>`);
+      element = fixtureSync(`<${tagWithShouldSetInvalid}></${tagWithShouldSetInvalid}>`);
       await nextRender();
     });
 
-    it('should not commit validation success', () => {
+    it('should set invalid only when it is true', () => {
       element.required = true;
       element.validate();
       expect(element.invalid).to.be.true;
-
       element.value = 'value';
       element.validate();
       expect(element.invalid).to.be.true;

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -259,7 +259,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
     if (!isNumUnset(min) || !isNumUnset(max)) {
       this.validate();
     } else if (!required) {
-      this.invalid = false;
+      this._commitValidationResult(true);
     }
   }
 

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -259,7 +259,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
     if (!isNumUnset(min) || !isNumUnset(max)) {
       this.validate();
     } else if (!required) {
-      this._commitValidationResult(true);
+      this._setInvalid(false);
     }
   }
 


### PR DESCRIPTION
## Description

- Added a protected method `_shouldSetInvalid(invalid)` that determines whether the `invalid` property should be updated to the given `invalid` state (by default: always `true`).
- Added a protected method `_setInvalid(invalid)` that updates the `invalid` property to the given `invalid` state if it passes `_shouldSetInvalid`. This method is supposed to be used by the web components wherever they need to update `invalid` internally instead of manipulating the property directly.

The main purpose of `_shouldSetInvalid` is to make it possible later for Flow to prevent the web components from committing client-side validation success: the final decision on whether a component is valid will be made by the server.

Part of #4081 

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
