### PR TITLE
fix: make ComboBoxDataProviderCallback size optional

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
@@ -5,7 +5,7 @@
  */
 import { Constructor } from '@open-wc/dedupe-mixin';
 
-export type ComboBoxDataProviderCallback<TItem> = (items: TItem[], size: number) => void;
+export type ComboBoxDataProviderCallback<TItem> = (items: TItem[], size?: number) => void;
 
 export interface ComboBoxDataProviderParams {
   page: number;

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -189,7 +189,10 @@ export const ComboBoxDataProviderMixin = (superClass) =>
         if (!this.opened && !this.hasAttribute('focused')) {
           this._commitValue();
         }
-        this.size = size;
+
+        if (size !== undefined) {
+          this.size = size;
+        }
 
         delete this._pendingRequests[page];
 

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -595,6 +595,15 @@ describe('lazy loading', () => {
         expect(comboBox.filteredItems).to.eql(['foo']);
       });
 
+      it('should not reset when dataProvider callback has undefined size', () => {
+        comboBox.size = SIZE;
+        comboBox.dataProvider = (params, callback) => {
+          callback(allItems);
+        };
+        comboBox.opened = true;
+        expect(comboBox.size).to.equal(SIZE);
+      });
+
       it('should not show the loading on size change while pending the data provider', () => {
         const allItems = makeItems(200);
 


### PR DESCRIPTION
## Description

Updated the type definition as requested by https://github.com/vaadin/web-components/issues/4099#issuecomment-1167249564 and to align with corresponding type in `vaadin-grid`:

https://github.com/vaadin/web-components/blob/48e5e39670645eba5b9d0f9be91e29b134b93bf8/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts#L21

Fixes #4099

## Type of change

- Bugfix