### PR TITLE
feat: add TS definitions for the `validated` event

### DIFF
--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -19,10 +19,17 @@ export type CheckboxGroupInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type CheckboxGroupValueChangedEvent = CustomEvent<{ value: string[] }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type CheckboxGroupValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface CheckboxGroupCustomEventMap {
   'invalid-changed': CheckboxGroupInvalidChangedEvent;
 
   'value-changed': CheckboxGroupValueChangedEvent;
+
+  validated: CheckboxGroupValidatedEvent;
 }
 
 export interface CheckboxGroupEventMap extends HTMLElementEventMap, CheckboxGroupCustomEventMap {}
@@ -66,6 +73,7 @@ export interface CheckboxGroupEventMap extends HTMLElementEventMap, CheckboxGrou
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(ThemableMixin(HTMLElement))))) {
   /**

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -51,6 +51,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ThemableMixin

--- a/packages/checkbox-group/test/typings/checkbox-group.types.ts
+++ b/packages/checkbox-group/test/typings/checkbox-group.types.ts
@@ -1,8 +1,8 @@
 import '../../vaadin-checkbox-group.js';
 import type {
   CheckboxGroupInvalidChangedEvent,
-  CheckboxGroupValueChangedEvent,
   CheckboxGroupValidatedEvent,
+  CheckboxGroupValueChangedEvent,
 } from '../../vaadin-checkbox-group.js';
 
 const assertType = <TExpected>(value: TExpected) => value;

--- a/packages/checkbox-group/test/typings/checkbox-group.types.ts
+++ b/packages/checkbox-group/test/typings/checkbox-group.types.ts
@@ -1,5 +1,9 @@
 import '../../vaadin-checkbox-group.js';
-import type { CheckboxGroupInvalidChangedEvent, CheckboxGroupValueChangedEvent } from '../../vaadin-checkbox-group.js';
+import type {
+  CheckboxGroupInvalidChangedEvent,
+  CheckboxGroupValueChangedEvent,
+  CheckboxGroupValidatedEvent,
+} from '../../vaadin-checkbox-group.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 
@@ -13,4 +17,9 @@ group.addEventListener('invalid-changed', (event) => {
 group.addEventListener('value-changed', (event) => {
   assertType<CheckboxGroupValueChangedEvent>(event);
   assertType<string[]>(event.detail.value);
+});
+
+group.addEventListener('validated', (event) => {
+  assertType<CheckboxGroupValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -54,6 +54,11 @@ export type ComboBoxLightFilterChangedEvent = CustomEvent<{ value: string }>;
  */
 export type ComboBoxLightSelectedItemChangedEvent<TItem> = CustomEvent<{ value: TItem | null | undefined }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type ComboBoxLightValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface ComboBoxLightEventMap<TItem> extends HTMLElementEventMap {
   change: ComboBoxLightChangeEvent<TItem>;
 
@@ -68,6 +73,8 @@ export interface ComboBoxLightEventMap<TItem> extends HTMLElementEventMap {
   'value-changed': ComboBoxLightValueChangedEvent;
 
   'selected-item-changed': ComboBoxLightSelectedItemChangedEvent<TItem>;
+
+  validated: ComboBoxLightValidatedEvent;
 }
 
 /**
@@ -114,6 +121,7 @@ export interface ComboBoxLightEventMap<TItem> extends HTMLElementEventMap {
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class ComboBoxLight<TItem = ComboBoxDefaultItem> extends HTMLElement {
   /**

--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -57,6 +57,7 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ComboBoxDataProviderMixin

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -65,6 +65,11 @@ export type ComboBoxFilterChangedEvent = CustomEvent<{ value: string }>;
  */
 export type ComboBoxSelectedItemChangedEvent<TItem> = CustomEvent<{ value: TItem | null | undefined }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type ComboBoxValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
   change: ComboBoxChangeEvent<TItem>;
 
@@ -79,6 +84,8 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
   'value-changed': ComboBoxValueChangedEvent;
 
   'selected-item-changed': ComboBoxSelectedItemChangedEvent<TItem>;
+
+  validated: ComboBoxValidatedEvent;
 }
 
 /**
@@ -208,6 +215,7 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class ComboBox<TItem = ComboBoxDefaultItem> extends HTMLElement {
   addEventListener<K extends keyof ComboBoxEventMap<TItem>>(

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -147,6 +147,7 @@ registerStyles('vaadin-combo-box', inputFieldShared, { moduleId: 'vaadin-combo-b
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -24,6 +24,7 @@ import type {
   ComboBoxOpenedChangedEvent,
   ComboBoxRenderer,
   ComboBoxSelectedItemChangedEvent,
+  ComboBoxValidatedEvent,
   ComboBoxValueChangedEvent,
 } from '../../vaadin-combo-box';
 import type {
@@ -34,6 +35,7 @@ import type {
   ComboBoxLightInvalidChangedEvent,
   ComboBoxLightOpenedChangedEvent,
   ComboBoxLightSelectedItemChangedEvent,
+  ComboBoxLightValidatedEvent,
   ComboBoxLightValueChangedEvent,
 } from '../../vaadin-combo-box-light';
 
@@ -82,6 +84,11 @@ narrowedComboBox.addEventListener('filter-changed', (event) => {
 narrowedComboBox.addEventListener('selected-item-changed', (event) => {
   assertType<ComboBoxSelectedItemChangedEvent<TestComboBoxItem>>(event);
   assertType<TestComboBoxItem | null | undefined>(event.detail.value);
+});
+
+narrowedComboBox.addEventListener('validated', (event) => {
+  assertType<ComboBoxValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });
 
 // ComboBox properties
@@ -178,6 +185,11 @@ narrowedComboBoxLight.addEventListener('filter-changed', (event) => {
 narrowedComboBoxLight.addEventListener('selected-item-changed', (event) => {
   assertType<ComboBoxLightSelectedItemChangedEvent<TestComboBoxItem>>(event);
   assertType<TestComboBoxItem | null | undefined>(event.detail.value);
+});
+
+narrowedComboBoxLight.addEventListener('validated', (event) => {
+  assertType<ComboBoxLightValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });
 
 // ComboBoxLight properties

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -36,6 +36,11 @@ export type CustomFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 export type CustomFieldValueChangedEvent = CustomEvent<{ value: string }>;
 
 /**
+ * Fired whenever the field is validated.
+ */
+export type CustomFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
+
+/**
  * Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
  */
 export type CustomFieldInternalTabEvent = Event & {
@@ -48,6 +53,8 @@ export interface CustomFieldCustomEventMap {
   'value-changed': CustomFieldValueChangedEvent;
 
   'internal-tab': CustomFieldInternalTabEvent;
+
+  validated: CustomFieldValidatedEvent;
 }
 
 export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCustomEventMap {
@@ -93,6 +100,7 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class CustomField extends FieldMixin(FocusMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
   /**

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -50,6 +50,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes FieldMixin

--- a/packages/custom-field/test/typings/custom-field.types.ts
+++ b/packages/custom-field/test/typings/custom-field.types.ts
@@ -4,6 +4,7 @@ import type {
   CustomFieldChangeEvent,
   CustomFieldInternalTabEvent,
   CustomFieldInvalidChangedEvent,
+  CustomFieldValidatedEvent,
   CustomFieldValueChangedEvent,
 } from '../../vaadin-custom-field.js';
 
@@ -29,4 +30,9 @@ customField.addEventListener('value-changed', (event) => {
 customField.addEventListener('internal-tab', (event) => {
   assertType<CustomFieldInternalTabEvent>(event);
   assertType<CustomField>(event.target);
+});
+
+customField.addEventListener('validated', (event) => {
+  assertType<CustomFieldValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/date-picker/src/vaadin-date-picker-light.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-light.d.ts
@@ -30,12 +30,19 @@ export type DatePickerLightInvalidChangedEvent = CustomEvent<{ value: boolean }>
  */
 export type DatePickerLightValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type DatePickerLightValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface DatePickerLightCustomEventMap {
   'opened-changed': DatePickerLightOpenedChangedEvent;
 
   'invalid-changed': DatePickerLightInvalidChangedEvent;
 
   'value-changed': DatePickerLightValueChangedEvent;
+
+  validated: DatePickerLightValidatedEvent;
 }
 
 export interface DatePickerLightEventMap extends HTMLElementEventMap, DatePickerLightCustomEventMap {
@@ -80,6 +87,7 @@ export interface DatePickerLightEventMap extends HTMLElementEventMap, DatePicker
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(HTMLElement))) {
   /**

--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -49,6 +49,7 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ThemableMixin

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -31,12 +31,19 @@ export type DatePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type DatePickerValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type DatePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface DatePickerCustomEventMap {
   'opened-changed': DatePickerOpenedChangedEvent;
 
   'invalid-changed': DatePickerInvalidChangedEvent;
 
   'value-changed': DatePickerValueChangedEvent;
+
+  validated: DatePickerValidatedEvent;
 }
 
 export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCustomEventMap {
@@ -133,6 +140,7 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
   addEventListener<K extends keyof DatePickerEventMap>(

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -108,6 +108,7 @@ registerStyles('vaadin-date-picker', [inputFieldShared, datePickerStyles], { mod
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -17,6 +17,7 @@ import type {
   DatePickerChangeEvent,
   DatePickerInvalidChangedEvent,
   DatePickerOpenedChangedEvent,
+  DatePickerValidatedEvent,
   DatePickerValueChangedEvent,
 } from '../../vaadin-date-picker.js';
 import type {
@@ -24,6 +25,7 @@ import type {
   DatePickerLightChangeEvent,
   DatePickerLightInvalidChangedEvent,
   DatePickerLightOpenedChangedEvent,
+  DatePickerLightValidatedEvent,
   DatePickerLightValueChangedEvent,
 } from '../../vaadin-date-picker-light.js';
 
@@ -51,6 +53,11 @@ datePicker.addEventListener('value-changed', (event) => {
 datePicker.addEventListener('change', (event) => {
   assertType<DatePickerChangeEvent>(event);
   assertType<DatePicker>(event.target);
+});
+
+datePicker.addEventListener('validated', (event) => {
+  assertType<DatePickerValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });
 
 // DatePicker properties
@@ -117,6 +124,11 @@ datePickerLight.addEventListener('value-changed', (event) => {
 datePickerLight.addEventListener('change', (event) => {
   assertType<DatePickerLightChangeEvent>(event);
   assertType<DatePickerLight>(event.target);
+});
+
+datePickerLight.addEventListener('validated', (event) => {
+  assertType<DatePickerLightValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });
 
 // DatePickerLight properties

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -31,10 +31,17 @@ export type DateTimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type DateTimePickerValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type DateTimePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface DateTimePickerCustomEventMap {
   'invalid-changed': DateTimePickerInvalidChangedEvent;
 
   'value-changed': DateTimePickerValueChangedEvent;
+
+  validated: DateTimePickerValidatedEvent;
 }
 
 export interface DateTimePickerEventMap extends DateTimePickerCustomEventMap, HTMLElementEventMap {
@@ -95,6 +102,7 @@ export interface DateTimePickerEventMap extends DateTimePickerCustomEventMap, HT
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class DateTimePicker extends FieldMixin(
   SlotMixin(DisabledMixin(FocusMixin(ThemableMixin(ElementMixin(HTMLElement))))),

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -97,6 +97,7 @@ const timePickerI18nProps = Object.keys(timePickerI18nDefaults);
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/date-time-picker/test/typings/date-time-picker.types.ts
+++ b/packages/date-time-picker/test/typings/date-time-picker.types.ts
@@ -3,6 +3,7 @@ import type {
   DateTimePicker,
   DateTimePickerChangeEvent,
   DateTimePickerInvalidChangedEvent,
+  DateTimePickerValidatedEvent,
   DateTimePickerValueChangedEvent,
 } from '../../vaadin-date-time-picker.js';
 
@@ -23,6 +24,11 @@ picker.addEventListener('invalid-changed', (event) => {
 picker.addEventListener('value-changed', (event) => {
   assertType<DateTimePickerValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+picker.addEventListener('validated', (event) => {
+  assertType<DateTimePickerValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });
 
 assertType<boolean>(picker.required);

--- a/packages/email-field/src/vaadin-email-field.d.ts
+++ b/packages/email-field/src/vaadin-email-field.d.ts
@@ -22,10 +22,17 @@ export type EmailFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type EmailFieldValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type EmailFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface EmailFieldCustomEventMap {
   'invalid-changed': EmailFieldInvalidChangedEvent;
 
   'value-changed': EmailFieldValueChangedEvent;
+
+  validated: EmailFieldValidatedEvent;
 }
 
 export interface EmailFieldEventMap extends HTMLElementEventMap, EmailFieldCustomEventMap {
@@ -50,6 +57,7 @@ export interface EmailFieldEventMap extends HTMLElementEventMap, EmailFieldCusto
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class EmailField extends TextField {
   addEventListener<K extends keyof EmailFieldEventMap>(

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -40,6 +40,7 @@ registerStyles(
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends TextField
  */

--- a/packages/email-field/test/typings/email-field.types.ts
+++ b/packages/email-field/test/typings/email-field.types.ts
@@ -3,6 +3,7 @@ import type {
   EmailField,
   EmailFieldChangeEvent,
   EmailFieldInvalidChangedEvent,
+  EmailFieldValidatedEvent,
   EmailFieldValueChangedEvent,
 } from '../../vaadin-email-field.js';
 
@@ -23,4 +24,9 @@ field.addEventListener('invalid-changed', (event) => {
 field.addEventListener('value-changed', (event) => {
   assertType<EmailFieldValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+field.addEventListener('validated', (event) => {
+  assertType<EmailFieldValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/integer-field/src/vaadin-integer-field.d.ts
+++ b/packages/integer-field/src/vaadin-integer-field.d.ts
@@ -22,10 +22,17 @@ export type IntegerFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type IntegerFieldValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type IntegerFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface IntegerFieldCustomEventMap {
   'invalid-changed': IntegerFieldInvalidChangedEvent;
 
   'value-changed': IntegerFieldValueChangedEvent;
+
+  validated: IntegerFieldValidatedEvent;
 }
 
 export interface IntegerFieldEventMap extends HTMLElementEventMap, IntegerFieldCustomEventMap {
@@ -57,6 +64,7 @@ export interface IntegerFieldEventMap extends HTMLElementEventMap, IntegerFieldC
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class IntegerField extends NumberField {
   addEventListener<K extends keyof IntegerFieldEventMap>(

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -30,6 +30,7 @@ import { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends NumberField
  */

--- a/packages/integer-field/test/typings/integer-field.types.ts
+++ b/packages/integer-field/test/typings/integer-field.types.ts
@@ -3,6 +3,7 @@ import type {
   IntegerField,
   IntegerFieldChangeEvent,
   IntegerFieldInvalidChangedEvent,
+  IntegerFieldValidatedEvent,
   IntegerFieldValueChangedEvent,
 } from '../../vaadin-integer-field.js';
 
@@ -23,4 +24,9 @@ field.addEventListener('invalid-changed', (event) => {
 field.addEventListener('value-changed', (event) => {
   assertType<IntegerFieldValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+field.addEventListener('validated', (event) => {
+  assertType<IntegerFieldValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -65,6 +65,11 @@ export type MultiSelectComboBoxInvalidChangedEvent = CustomEvent<{ value: boolea
  */
 export type MultiSelectComboBoxSelectedItemsChangedEvent<TItem> = CustomEvent<{ value: TItem[] }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type MultiSelectComboBoxValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap {
   change: MultiSelectComboBoxChangeEvent<TItem>;
 
@@ -75,6 +80,8 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
   'invalid-changed': MultiSelectComboBoxInvalidChangedEvent;
 
   'selected-items-changed': MultiSelectComboBoxSelectedItemsChangedEvent<TItem>;
+
+  validated: MultiSelectComboBoxValidatedEvent;
 }
 
 /**
@@ -154,6 +161,7 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
  * @fires {CustomEvent} filter-changed - Fired when the `filter` property changes.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLElement {
   /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -132,6 +132,7 @@ registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectCo
  * @fires {CustomEvent} filter-changed - Fired when the `filter` property changes.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -21,6 +21,7 @@ import type {
   MultiSelectComboBoxInvalidChangedEvent,
   MultiSelectComboBoxRenderer,
   MultiSelectComboBoxSelectedItemsChangedEvent,
+  MultiSelectComboBoxValidatedEvent,
 } from '../../vaadin-multi-select-combo-box.js';
 
 interface TestComboBoxItem {
@@ -58,6 +59,11 @@ narrowedComboBox.addEventListener('invalid-changed', (event) => {
 narrowedComboBox.addEventListener('selected-items-changed', (event) => {
   assertType<MultiSelectComboBoxSelectedItemsChangedEvent<TestComboBoxItem>>(event);
   assertType<TestComboBoxItem[]>(event.detail.value);
+});
+
+narrowedComboBox.addEventListener('validated', (event) => {
+  assertType<MultiSelectComboBoxValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });
 
 // Properties

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -25,10 +25,17 @@ export type NumberFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type NumberFieldValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type NumberFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface NumberFieldCustomEventMap {
   'invalid-changed': NumberFieldInvalidChangedEvent;
 
   'value-changed': NumberFieldValueChangedEvent;
+
+  validated: NumberFieldValidatedEvent;
 }
 
 export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCustomEventMap {
@@ -60,6 +67,7 @@ export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCus
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
   /**

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -42,6 +42,7 @@ registerStyles('vaadin-number-field', inputFieldShared, { moduleId: 'vaadin-numb
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes InputFieldMixin

--- a/packages/number-field/test/typings/number-field.types.ts
+++ b/packages/number-field/test/typings/number-field.types.ts
@@ -8,6 +8,7 @@ import type {
   NumberField,
   NumberFieldChangeEvent,
   NumberFieldInvalidChangedEvent,
+  NumberFieldValidatedEvent,
   NumberFieldValueChangedEvent,
 } from '../../vaadin-number-field.js';
 
@@ -36,4 +37,9 @@ field.addEventListener('invalid-changed', (event) => {
 field.addEventListener('value-changed', (event) => {
   assertType<NumberFieldValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+field.addEventListener('validated', (event) => {
+  assertType<NumberFieldValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -23,10 +23,17 @@ export type PasswordFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type PasswordFieldValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type PasswordFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface PasswordFieldCustomEventMap {
   'invalid-changed': PasswordFieldInvalidChangedEvent;
 
   'value-changed': PasswordFieldValueChangedEvent;
+
+  validated: PasswordFieldValidatedEvent;
 }
 
 export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFieldCustomEventMap {
@@ -63,6 +70,7 @@ export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFiel
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class PasswordField extends SlotStylesMixin(TextField) {
   /**

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -47,6 +47,7 @@ let memoizedTemplate;
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends TextField
  * @mixes SlotStylesMixin

--- a/packages/password-field/test/typings/password-field.types.ts
+++ b/packages/password-field/test/typings/password-field.types.ts
@@ -3,6 +3,7 @@ import type {
   PasswordField,
   PasswordFieldChangeEvent,
   PasswordFieldInvalidChangedEvent,
+  PasswordFieldValidatedEvent,
   PasswordFieldValueChangedEvent,
 } from '../../vaadin-password-field.js';
 
@@ -23,4 +24,9 @@ field.addEventListener('invalid-changed', (event) => {
 field.addEventListener('value-changed', (event) => {
   assertType<PasswordFieldValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+field.addEventListener('validated', (event) => {
+  assertType<PasswordFieldValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -20,10 +20,17 @@ export type RadioGroupInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type RadioGroupValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type RadioGroupValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface RadioGroupCustomEventMap {
   'invalid-changed': RadioGroupInvalidChangedEvent;
 
   'value-changed': RadioGroupValueChangedEvent;
+
+  validated: RadioGroupValidatedEvent;
 }
 
 export interface RadioGroupEventMap extends HTMLElementEventMap, RadioGroupCustomEventMap {}
@@ -68,6 +75,7 @@ export interface RadioGroupEventMap extends HTMLElementEventMap, RadioGroupCusto
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class RadioGroup extends FieldMixin(
   FocusMixin(DisabledMixin(KeyboardMixin(ElementMixin(ThemableMixin(HTMLElement))))),

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -54,6 +54,7 @@ import { RadioButton } from './vaadin-radio-button.js';
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ThemableMixin

--- a/packages/radio-group/test/typings/radio-button.types.ts
+++ b/packages/radio-group/test/typings/radio-button.types.ts
@@ -11,7 +11,11 @@ import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-fo
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { RadioButtonCheckedChangedEvent } from '../../vaadin-radio-button.js';
-import type { RadioGroupInvalidChangedEvent, RadioGroupValueChangedEvent, RadioGroupValidatedEvent } from '../../vaadin-radio-group.js';
+import type {
+  RadioGroupInvalidChangedEvent,
+  RadioGroupValidatedEvent,
+  RadioGroupValueChangedEvent,
+} from '../../vaadin-radio-group.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/radio-group/test/typings/radio-button.types.ts
+++ b/packages/radio-group/test/typings/radio-button.types.ts
@@ -11,7 +11,7 @@ import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-fo
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { RadioButtonCheckedChangedEvent } from '../../vaadin-radio-button.js';
-import type { RadioGroupInvalidChangedEvent, RadioGroupValueChangedEvent } from '../../vaadin-radio-group.js';
+import type { RadioGroupInvalidChangedEvent, RadioGroupValueChangedEvent, RadioGroupValidatedEvent } from '../../vaadin-radio-group.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -53,4 +53,9 @@ group.addEventListener('invalid-changed', (event) => {
 group.addEventListener('value-changed', (event) => {
   assertType<RadioGroupValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+group.addEventListener('validated', (event) => {
+  assertType<RadioGroupValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -47,12 +47,19 @@ export type SelectInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type SelectValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type SelectValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface SelectCustomEventMap {
   'opened-changed': SelectOpenedChangedEvent;
 
   'invalid-changed': SelectInvalidChangedEvent;
 
   'value-changed': SelectValueChangedEvent;
+
+  validated: SelectValidatedEvent;
 }
 
 export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMap {
@@ -162,6 +169,7 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(HTMLElement)))) {
   /**

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -125,6 +125,7 @@ registerStyles('vaadin-select', [fieldShared, inputFieldContainer], { moduleId: 
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -7,6 +7,7 @@ import type {
   SelectItem,
   SelectOpenedChangedEvent,
   SelectRenderer,
+  SelectValidatedEvent,
   SelectValueChangedEvent,
 } from '../../vaadin-select.js';
 
@@ -55,4 +56,9 @@ select.addEventListener('invalid-changed', (event) => {
 select.addEventListener('value-changed', (event) => {
   assertType<SelectValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+select.addEventListener('validated', (event) => {
+  assertType<SelectValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -26,10 +26,17 @@ export type TextAreaInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type TextAreaValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type TextAreaValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface TextAreaCustomEventMap {
   'invalid-changed': TextAreaInvalidChangedEvent;
 
   'value-changed': TextAreaValueChangedEvent;
+
+  validated: TextAreaValidatedEvent;
 }
 
 export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEventMap {
@@ -76,6 +83,7 @@ export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEve
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableMixin(ElementMixin(HTMLElement))))) {
   /**

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -54,6 +54,7 @@ registerStyles('vaadin-text-area', inputFieldShared, { moduleId: 'vaadin-text-ar
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes InputFieldMixin

--- a/packages/text-area/test/typings/text-area.types.ts
+++ b/packages/text-area/test/typings/text-area.types.ts
@@ -8,6 +8,7 @@ import type {
   TextArea,
   TextAreaChangeEvent,
   TextAreaInvalidChangedEvent,
+  TextAreaValidatedEvent,
   TextAreaValueChangedEvent,
 } from '../../vaadin-text-area.js';
 
@@ -36,4 +37,9 @@ area.addEventListener('invalid-changed', (event) => {
 area.addEventListener('value-changed', (event) => {
   assertType<TextAreaValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+area.addEventListener('validated', (event) => {
+  assertType<TextAreaValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -25,10 +25,17 @@ export type TextFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type TextFieldValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type TextFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface TextFieldCustomEventMap {
   'invalid-changed': TextFieldInvalidChangedEvent;
 
   'value-changed': TextFieldValueChangedEvent;
+
+  validated: TextFieldValidatedEvent;
 }
 
 export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomEventMap {
@@ -96,6 +103,7 @@ export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomE
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class TextField extends PatternMixin(InputFieldMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
   /**

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -76,7 +76,7 @@ registerStyles('vaadin-text-field', inputFieldShared, { moduleId: 'vaadin-text-f
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
- * @fires {CustomEvent} validated - Fired whenever the field is validated.*
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -76,6 +76,7 @@ registerStyles('vaadin-text-field', inputFieldShared, { moduleId: 'vaadin-text-f
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.*
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/text-field/test/typings/text-field.types.ts
+++ b/packages/text-field/test/typings/text-field.types.ts
@@ -8,6 +8,7 @@ import type {
   TextField,
   TextFieldChangeEvent,
   TextFieldInvalidChangedEvent,
+  TextFieldValidatedEvent,
   TextFieldValueChangedEvent,
 } from '../../vaadin-text-field.js';
 
@@ -36,4 +37,9 @@ field.addEventListener('invalid-changed', (event) => {
 field.addEventListener('value-changed', (event) => {
   assertType<TextFieldValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+field.addEventListener('validated', (event) => {
+  assertType<TextFieldValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -39,10 +39,17 @@ export type TimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type TimePickerValueChangedEvent = CustomEvent<{ value: string }>;
 
+/**
+ * Fired whenever the field is validated.
+ */
+export type TimePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface TimePickerCustomEventMap {
   'invalid-changed': TimePickerInvalidChangedEvent;
 
   'value-changed': TimePickerValueChangedEvent;
+
+  validated: TimePickerValidatedEvent;
 }
 
 export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCustomEventMap {
@@ -97,6 +104,7 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
   /**

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -64,6 +64,7 @@ registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/time-picker/test/typings/time-picker.types.ts
+++ b/packages/time-picker/test/typings/time-picker.types.ts
@@ -8,6 +8,7 @@ import type {
   TimePicker,
   TimePickerChangeEvent,
   TimePickerInvalidChangedEvent,
+  TimePickerValidatedEvent,
   TimePickerValueChangedEvent,
 } from '../../vaadin-time-picker.js';
 
@@ -36,4 +37,9 @@ timePicker.addEventListener('invalid-changed', (event) => {
 timePicker.addEventListener('value-changed', (event) => {
   assertType<TimePickerValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+timePicker.addEventListener('validated', (event) => {
+  assertType<TimePickerValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });


### PR DESCRIPTION
## Description

This PR adds TS definitions for the `validated` event to every component that extends `ValidateMixin`.

- [x] checkbox-group
- [x] combo-box
- [x] custom-field
- [x] date-picker
- [x] time-picker
- [x] date-time-picker
- [x] integer-field
- [x] number-field
- [x] password-field
- [x] radio-group
- [x] select
- [x] text-area
- [x] text-field
- [x] email-field

A follow-up to #4084

Part of https://github.com/vaadin/web-components/issues/4081

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
