### PR TITLE
fix: announce item label when removing chip with keyboard

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -762,7 +762,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     const itemsCopy = [...this.selectedItems];
     itemsCopy.splice(itemsCopy.indexOf(item), 1);
     this.__updateSelection(itemsCopy);
-    this.__announceItem(item, false, itemsCopy.length);
+    const itemLabel = this._getItemLabel(item);
+    this.__announceItem(itemLabel, false, itemsCopy.length);
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -112,6 +112,11 @@ describe('accessibility', () => {
   });
 
   describe('announcements', () => {
+    const apple = { id: 1, name: 'Apple' };
+    const banana = { id: 2, name: 'Banana' };
+    const lemon = { id: 3, name: 'Lemon' };
+    const orange = { id: 4, name: 'Orange' };
+    const fruits = [apple, banana, lemon, orange];
     let clock, region;
 
     before(() => {
@@ -120,7 +125,9 @@ describe('accessibility', () => {
 
     beforeEach(() => {
       comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
-      comboBox.items = ['Apple', 'Banana', 'Lemon', 'Orange'];
+      comboBox.itemIdPath = 'id';
+      comboBox.itemLabelPath = 'name';
+      comboBox.items = fruits;
       inputElement = comboBox.inputElement;
       clock = sinon.useFakeTimers();
     });
@@ -141,7 +148,7 @@ describe('accessibility', () => {
     });
 
     it('should announce when deselecting an item', () => {
-      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon'];
+      comboBox.selectedItems = [apple, banana, lemon];
       inputElement.click();
 
       const item = document.querySelector('vaadin-multi-select-combo-box-item');
@@ -153,7 +160,7 @@ describe('accessibility', () => {
     });
 
     it('should announce when clicking clear button', () => {
-      comboBox.selectedItems = ['Apple', 'Banana', 'Lemon'];
+      comboBox.selectedItems = [apple, banana, lemon];
       comboBox.clearButtonVisible = true;
 
       comboBox.$.clearButton.click();
@@ -164,7 +171,7 @@ describe('accessibility', () => {
     });
 
     it('should announce when focusing a chip with keyboard', async () => {
-      comboBox.selectedItems = ['Apple'];
+      comboBox.selectedItems = [apple];
 
       inputElement.focus();
       await sendKeys({ press: 'Backspace' });
@@ -172,6 +179,18 @@ describe('accessibility', () => {
       clock.tick(150);
 
       expect(region.textContent).to.equal('Apple focused. Press Backspace to remove');
+    });
+
+    it('should announce when removing a chip with keyboard', async () => {
+      comboBox.selectedItems = [apple];
+
+      inputElement.focus();
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('Apple removed from selection 0 items selected');
     });
   });
 });


### PR DESCRIPTION
## Description

Currenty removing a chip with backspace announces "[object Object] removed from selection" when using objects as items. This change fixes the announcement to use the item label.

Updated the announcement tests to use object items.

## Type of change

- Bugfix