### PR TITLE
refactor: add more rules to ESLint config, fix warnings (2)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,7 @@
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/consistent-type-imports": ["error", { "prefer": "type-imports" }],
     "@typescript-eslint/member-ordering": [
       "error",
       {

--- a/packages/accordion/src/vaadin-accordion.d.ts
+++ b/packages/accordion/src/vaadin-accordion.d.ts
@@ -5,7 +5,7 @@
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { AccordionPanel } from './vaadin-accordion-panel.js';
+import type { AccordionPanel } from './vaadin-accordion-panel.js';
 
 /**
  * Fired when the `items` property changes.

--- a/packages/accordion/test/typings/accordion.types.ts
+++ b/packages/accordion/test/typings/accordion.types.ts
@@ -1,6 +1,6 @@
 import '../../vaadin-accordion.js';
-import { AccordionItemsChangedEvent, AccordionOpenedChangedEvent } from '../../vaadin-accordion.js';
-import { AccordionPanel } from '../../vaadin-accordion-panel';
+import type { AccordionItemsChangedEvent, AccordionOpenedChangedEvent } from '../../vaadin-accordion.js';
+import type { AccordionPanel } from '../../vaadin-accordion-panel';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/app-layout/test/typings/app-layout.types.ts
+++ b/packages/app-layout/test/typings/app-layout.types.ts
@@ -1,8 +1,8 @@
 import '../../vaadin-app-layout.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import {
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type {
   AppLayoutDrawerOpenedChangedEvent,
   AppLayoutI18n,
   AppLayoutOverlayChangedEvent,

--- a/packages/button/src/vaadin-button-mixin.d.ts
+++ b/packages/button/src/vaadin-button-mixin.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mixin.js';
 
 /**
  * A mixin providing common button functionality.

--- a/packages/charts/src/vaadin-chart-series.d.ts
+++ b/packages/charts/src/vaadin-chart-series.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { PointOptionsObject, Series, SeriesOptionsType } from 'highcharts';
+import type { PointOptionsObject, Series, SeriesOptionsType } from 'highcharts';
 
 export type ChartSeriesMarkers = 'shown' | 'hidden' | 'auto';
 

--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { Axis, Chart as HighchartsChart, ExtremesObject, Options, Point, Series } from 'highcharts';
+import type { Axis, Chart as HighchartsChart, ExtremesObject, Options, Point, Series } from 'highcharts';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

--- a/packages/charts/test/typings/chart.types.ts
+++ b/packages/charts/test/typings/chart.types.ts
@@ -1,6 +1,6 @@
 import '../../vaadin-chart.js';
-import { Axis, Chart as HighchartsChart, Point, Series } from 'highcharts';
-import {
+import type { Axis, Chart as HighchartsChart, Point, Series } from 'highcharts';
+import type {
   ChartAddSeriesEvent,
   ChartAfterExportEvent,
   ChartAfterPrintEvent,

--- a/packages/checkbox-group/test/typings/checkbox-group.types.ts
+++ b/packages/checkbox-group/test/typings/checkbox-group.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-checkbox-group.js';
-import { CheckboxGroupInvalidChangedEvent, CheckboxGroupValueChangedEvent } from '../../vaadin-checkbox-group.js';
+import type { CheckboxGroupInvalidChangedEvent, CheckboxGroupValueChangedEvent } from '../../vaadin-checkbox-group.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 

--- a/packages/checkbox/test/typings/checkbox.types.ts
+++ b/packages/checkbox/test/typings/checkbox.types.ts
@@ -1,15 +1,15 @@
 import '../../vaadin-checkbox.js';
-import { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { CheckedMixinClass } from '@vaadin/field-base/src/checked-mixin.js';
-import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { CheckboxCheckedChangedEvent, CheckboxIndeterminateChangedEvent } from '../../vaadin-checkbox.js';
+import type { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { CheckedMixinClass } from '@vaadin/field-base/src/checked-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { CheckboxCheckedChangedEvent, CheckboxIndeterminateChangedEvent } from '../../vaadin-checkbox.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 

--- a/packages/combo-box/src/lit/renderer-directives.d.ts
+++ b/packages/combo-box/src/lit/renderer-directives.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive.js';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive.js';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
-import { ComboBox, ComboBoxItemModel } from '../vaadin-combo-box.js';
+import type { ComboBox, ComboBoxItemModel } from '../vaadin-combo-box.js';
 
 export type ComboBoxLitRenderer<TItem> = (
   item: TItem,

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export type ComboBoxDataProviderCallback<TItem> = (items: TItem[], size: number) => void;
 

--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -3,14 +3,13 @@
  * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
-import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
-import { ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
-import { ComboBoxDefaultItem } from './vaadin-combo-box-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
+import type { ComboBoxDefaultItem, ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
 export {
   ComboBoxDataProvider,
   ComboBoxDataProviderCallback,

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
-import { ComboBox } from './vaadin-combo-box.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { ComboBox } from './vaadin-combo-box.js';
 
 export type ComboBoxDefaultItem = any;
 

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -3,24 +3,24 @@
  * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
-import { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
-import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
-import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
-import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
-import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
-import { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
-import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
-import { ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
-import { ComboBoxDefaultItem } from './vaadin-combo-box-mixin.js';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import type { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
+import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
+import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
+import type { ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
+import type { ComboBoxDefaultItem } from './vaadin-combo-box-mixin.js';
 export {
   ComboBoxDataProvider,
   ComboBoxDataProviderCallback,

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -1,21 +1,21 @@
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
-import { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
-import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
-import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
-import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
-import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
-import { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
-import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
-import { ComboBoxDataProviderMixinClass } from '../../src/vaadin-combo-box-data-provider-mixin';
-import { ComboBoxMixinClass } from '../../src/vaadin-combo-box-mixin';
-import {
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import type { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
+import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
+import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
+import type { ComboBoxDataProviderMixinClass } from '../../src/vaadin-combo-box-data-provider-mixin';
+import type { ComboBoxMixinClass } from '../../src/vaadin-combo-box-mixin';
+import type {
   ComboBox,
   ComboBoxChangeEvent,
   ComboBoxCustomValueSetEvent,
@@ -26,7 +26,7 @@ import {
   ComboBoxSelectedItemChangedEvent,
   ComboBoxValueChangedEvent,
 } from '../../vaadin-combo-box';
-import {
+import type {
   ComboBoxLight,
   ComboBoxLightChangeEvent,
   ComboBoxLightCustomValueSetEvent,

--- a/packages/combo-box/test/typings/lit.types.ts
+++ b/packages/combo-box/test/typings/lit.types.ts
@@ -1,5 +1,6 @@
-import { DirectiveResult } from 'lit/directive.js';
-import { ComboBoxLitRenderer, comboBoxRenderer, ComboBoxRendererDirective } from '../../lit.js';
+import type { DirectiveResult } from 'lit/directive.js';
+import type { ComboBoxLitRenderer, ComboBoxRendererDirective } from '../../lit.js';
+import { comboBoxRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/component-base/src/active-mixin.d.ts
+++ b/packages/component-base/src/active-mixin.d.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DisabledMixinClass } from './disabled-mixin.js';
-import { KeyboardMixinClass } from './keyboard-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DisabledMixinClass } from './disabled-mixin.js';
+import type { KeyboardMixinClass } from './keyboard-mixin.js';
 
 /**
  * A mixin to toggle the `active` attribute.

--- a/packages/component-base/src/controller-mixin.d.ts
+++ b/packages/component-base/src/controller-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { ReactiveController, ReactiveControllerHost } from 'lit';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
 /**
  * A mixin for connecting controllers to the element.

--- a/packages/component-base/src/debounce.d.ts
+++ b/packages/component-base/src/debounce.d.ts
@@ -7,7 +7,7 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
-import { AsyncInterface } from './async.js';
+import type { AsyncInterface } from './async.js';
 
 export declare class Debouncer {
   /**

--- a/packages/component-base/src/dir-mixin.d.ts
+++ b/packages/component-base/src/dir-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to handle `dir` attribute based on the one set on the `<html>` element.

--- a/packages/component-base/src/disabled-mixin.d.ts
+++ b/packages/component-base/src/disabled-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to provide disabled property for field components.

--- a/packages/component-base/src/element-mixin.d.ts
+++ b/packages/component-base/src/element-mixin.d.ts
@@ -5,8 +5,8 @@
  */
 import '../custom_typings/vaadin-usage-statistics.js';
 import '../custom_typings/vaadin.js';
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DirMixinClass } from './dir-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DirMixinClass } from './dir-mixin.js';
 
 /**
  * A mixin providing common logic for Vaadin components.

--- a/packages/component-base/src/focus-mixin.d.ts
+++ b/packages/component-base/src/focus-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to handle `focused` and `focus-ring` attributes based on focus.

--- a/packages/component-base/src/focus-trap-controller.d.ts
+++ b/packages/component-base/src/focus-trap-controller.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ReactiveController } from 'lit';
+import type { ReactiveController } from 'lit';
 
 /**
  * A controller for trapping focus within a DOM node.

--- a/packages/component-base/src/keyboard-mixin.d.ts
+++ b/packages/component-base/src/keyboard-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin that manages keyboard handling.

--- a/packages/component-base/src/media-query-controller.d.ts
+++ b/packages/component-base/src/media-query-controller.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ReactiveController } from 'lit';
+import type { ReactiveController } from 'lit';
 
 /**
  * A controller for listening on media query changes.

--- a/packages/component-base/src/polylit-mixin.d.ts
+++ b/packages/component-base/src/polylit-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { LitElement } from 'lit';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { LitElement } from 'lit';
 
 export declare function PolylitMixin<T extends Constructor<LitElement>>(base: T): T & Constructor<PolylitMixinClass>;
 

--- a/packages/component-base/src/resize-mixin.d.ts
+++ b/packages/component-base/src/resize-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin that uses a ResizeObserver to listen to host size changes.

--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ReactiveController } from 'lit';
+import type { ReactiveController } from 'lit';
 
 export class SlotController extends EventTarget implements ReactiveController {
   /**

--- a/packages/component-base/src/slot-mixin.d.ts
+++ b/packages/component-base/src/slot-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to provide content for named slots defined by component.

--- a/packages/component-base/src/tabindex-mixin.d.ts
+++ b/packages/component-base/src/tabindex-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DisabledMixinClass } from './disabled-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DisabledMixinClass } from './disabled-mixin.js';
 
 /**
  * A mixin to toggle the `tabindex` attribute.

--- a/packages/confirm-dialog/test/typings/confirm-dialog.types.ts
+++ b/packages/confirm-dialog/test/typings/confirm-dialog.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-confirm-dialog.js';
-import { ConfirmDialogOpenedChangedEvent } from '../../vaadin-confirm-dialog.js';
+import type { ConfirmDialogOpenedChangedEvent } from '../../vaadin-confirm-dialog.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/context-menu/src/lit/renderer-directives.d.ts
+++ b/packages/context-menu/src/lit/renderer-directives.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive.js';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive.js';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
-import { ContextMenu, ContextMenuRendererContext } from '../vaadin-context-menu.js';
+import type { ContextMenu, ContextMenuRendererContext } from '../vaadin-context-menu.js';
 
 export type ContextMenuLitRenderer = (context: ContextMenuRendererContext, menu: ContextMenu) => TemplateResult;
 

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 import { Item } from '@vaadin/item/src/vaadin-item.js';
 import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
 

--- a/packages/context-menu/test/typings/context-menu.types.ts
+++ b/packages/context-menu/test/typings/context-menu.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-context-menu.js';
-import {
+import type {
   ContextMenuItem,
   ContextMenuItemSelectedEvent,
   ContextMenuOpenedChangedEvent,

--- a/packages/context-menu/test/typings/lit.types.ts
+++ b/packages/context-menu/test/typings/lit.types.ts
@@ -1,5 +1,6 @@
-import { DirectiveResult } from 'lit/directive.js';
-import { ContextMenuLitRenderer, contextMenuRenderer, ContextMenuRendererDirective } from '../../lit.js';
+import type { DirectiveResult } from 'lit/directive.js';
+import type { ContextMenuLitRenderer, ContextMenuRendererDirective } from '../../lit.js';
+import { contextMenuRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/crud/src/vaadin-crud-include-mixin.d.ts
+++ b/packages/crud/src/vaadin-crud-include-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function IncludedMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<IncludedMixinClass>;
 

--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -5,7 +5,7 @@
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { GridFilterDefinition, GridSorterDefinition } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridFilterDefinition, GridSorterDefinition } from '@vaadin/grid/src/vaadin-grid.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export type CrudDataProviderCallback<T> = (items: T[], size?: number) => void;

--- a/packages/crud/test/typings/crud.types.ts
+++ b/packages/crud/test/typings/crud.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-crud.js';
-import {
+import type {
   Crud,
   CrudCancelEvent,
   CrudDeleteEvent,

--- a/packages/custom-field/test/typings/custom-field.types.ts
+++ b/packages/custom-field/test/typings/custom-field.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-custom-field.js';
-import {
+import type {
   CustomField,
   CustomFieldChangeEvent,
   CustomFieldInternalTabEvent,

--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 
 export interface DatePickerDate {
   day: number;

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -3,8 +3,7 @@ import { aTimeout, click, down, fixtureSync, isIOS, touchstart } from '@vaadin/t
 import { sendKeys } from '@web/test-runner-commands';
 import '../src/vaadin-date-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { open, outsideClick } from './common.js';
-import { isFullscreen } from './common.js';
+import { isFullscreen, open, outsideClick } from './common.js';
 
 describe('dropdown', () => {
   let datepicker, input;

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -1,25 +1,25 @@
 import '../../vaadin-date-picker.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
-import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
-import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
-import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
-import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { DatePickerMixinClass } from '../../src/vaadin-date-picker-mixin.js';
-import {
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
+import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { DatePickerMixinClass } from '../../src/vaadin-date-picker-mixin.js';
+import type {
   DatePicker,
   DatePickerChangeEvent,
   DatePickerInvalidChangedEvent,
   DatePickerOpenedChangedEvent,
   DatePickerValueChangedEvent,
 } from '../../vaadin-date-picker.js';
-import {
+import type {
   DatePickerLight,
   DatePickerLightChangeEvent,
   DatePickerLightInvalidChangedEvent,

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -7,9 +7,9 @@ import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';
-import { DatePickerI18n } from '@vaadin/date-picker/src/vaadin-date-picker.js';
+import type { DatePickerI18n } from '@vaadin/date-picker/src/vaadin-date-picker.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
-import { TimePickerI18n } from '@vaadin/time-picker/src/vaadin-time-picker.js';
+import type { TimePickerI18n } from '@vaadin/time-picker/src/vaadin-time-picker.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export interface DateTimePickerI18n extends DatePickerI18n, TimePickerI18n {}

--- a/packages/date-time-picker/test/typings/date-time-picker.types.ts
+++ b/packages/date-time-picker/test/typings/date-time-picker.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-date-time-picker.js';
-import {
+import type {
   DateTimePicker,
   DateTimePickerChangeEvent,
   DateTimePickerInvalidChangedEvent,

--- a/packages/details/test/typings/details.types.ts
+++ b/packages/details/test/typings/details.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-details.js';
-import { DetailsOpenedChangedEvent } from '../../vaadin-details.js';
+import type { DetailsOpenedChangedEvent } from '../../vaadin-details.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/dialog/src/lit/renderer-directives.d.ts
+++ b/packages/dialog/src/lit/renderer-directives.d.ts
@@ -4,10 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 /* eslint-disable max-classes-per-file */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive.js';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive.js';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
-import { Dialog } from '../vaadin-dialog.js';
+import type { Dialog } from '../vaadin-dialog.js';
 
 export type DialogLitRenderer = (dialog: Dialog) => TemplateResult;
 

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function DialogDraggableMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function DialogResizableMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/dialog/test/typings/dialog.types.ts
+++ b/packages/dialog/test/typings/dialog.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-dialog.js';
-import {
+import type {
   DialogOpenedChangedEvent,
   DialogRenderer,
   DialogResizeDimensions,

--- a/packages/dialog/test/typings/lit.types.ts
+++ b/packages/dialog/test/typings/lit.types.ts
@@ -1,13 +1,11 @@
-import { DirectiveResult } from 'lit/directive.js';
-import {
-  dialogFooterRenderer,
+import type { DirectiveResult } from 'lit/directive.js';
+import type {
   DialogFooterRendererDirective,
-  dialogHeaderRenderer,
   DialogHeaderRendererDirective,
   DialogLitRenderer,
-  dialogRenderer,
   DialogRendererDirective,
 } from '../../lit.js';
+import { dialogFooterRenderer, dialogHeaderRenderer, dialogRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/email-field/test/typings/email-field.types.ts
+++ b/packages/email-field/test/typings/email-field.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-email-field.js';
-import {
+import type {
   EmailField,
   EmailFieldChangeEvent,
   EmailFieldInvalidChangedEvent,

--- a/packages/field-base/src/checked-mixin.d.ts
+++ b/packages/field-base/src/checked-mixin.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { DelegateStateMixinClass } from './delegate-state-mixin.js';
-import { InputMixinClass } from './input-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { DelegateStateMixinClass } from './delegate-state-mixin.js';
+import type { InputMixinClass } from './input-mixin.js';
 
 /**
  * A mixin to manage the checked state.

--- a/packages/field-base/src/delegate-focus-mixin.d.ts
+++ b/packages/field-base/src/delegate-focus-mixin.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mixin.js';
 
 /**
  * A mixin to forward focus to an element in the light DOM.

--- a/packages/field-base/src/delegate-state-mixin.d.ts
+++ b/packages/field-base/src/delegate-state-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to delegate properties and attributes to a target element.

--- a/packages/field-base/src/field-mixin.d.ts
+++ b/packages/field-base/src/field-mixin.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { LabelMixinClass } from './label-mixin.js';
-import { ValidateMixinClass } from './validate-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { LabelMixinClass } from './label-mixin.js';
+import type { ValidateMixinClass } from './validate-mixin.js';
 
 /**
  * A mixin to provide common field logic: label, error message and helper text.

--- a/packages/field-base/src/input-constraints-mixin.d.ts
+++ b/packages/field-base/src/input-constraints-mixin.d.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { DelegateStateMixinClass } from './delegate-state-mixin.js';
-import { InputMixinClass } from './input-mixin.js';
-import { ValidateMixinClass } from './validate-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { DelegateStateMixinClass } from './delegate-state-mixin.js';
+import type { InputMixinClass } from './input-mixin.js';
+import type { ValidateMixinClass } from './validate-mixin.js';
 
 /**
  * A mixin to combine multiple input validation constraints.

--- a/packages/field-base/src/input-control-mixin.d.ts
+++ b/packages/field-base/src/input-control-mixin.d.ts
@@ -3,18 +3,18 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { DelegateFocusMixinClass } from './delegate-focus-mixin.js';
-import { DelegateStateMixinClass } from './delegate-state-mixin.js';
-import { FieldMixinClass } from './field-mixin.js';
-import { InputConstraintsMixinClass } from './input-constraints-mixin.js';
-import { InputMixinClass } from './input-mixin.js';
-import { LabelMixinClass } from './label-mixin.js';
-import { ValidateMixinClass } from './validate-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { DelegateFocusMixinClass } from './delegate-focus-mixin.js';
+import type { DelegateStateMixinClass } from './delegate-state-mixin.js';
+import type { FieldMixinClass } from './field-mixin.js';
+import type { InputConstraintsMixinClass } from './input-constraints-mixin.js';
+import type { InputMixinClass } from './input-mixin.js';
+import type { LabelMixinClass } from './label-mixin.js';
+import type { ValidateMixinClass } from './validate-mixin.js';
 
 /**
  * A mixin to provide shared logic for the editable form input controls.

--- a/packages/field-base/src/input-field-mixin.d.ts
+++ b/packages/field-base/src/input-field-mixin.d.ts
@@ -3,19 +3,19 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { DelegateFocusMixinClass } from './delegate-focus-mixin.js';
-import { DelegateStateMixinClass } from './delegate-state-mixin.js';
-import { FieldMixinClass } from './field-mixin.js';
-import { InputConstraintsMixinClass } from './input-constraints-mixin.js';
-import { InputControlMixinClass } from './input-control-mixin.js';
-import { InputMixinClass } from './input-mixin.js';
-import { LabelMixinClass } from './label-mixin.js';
-import { ValidateMixinClass } from './validate-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { DelegateFocusMixinClass } from './delegate-focus-mixin.js';
+import type { DelegateStateMixinClass } from './delegate-state-mixin.js';
+import type { FieldMixinClass } from './field-mixin.js';
+import type { InputConstraintsMixinClass } from './input-constraints-mixin.js';
+import type { InputControlMixinClass } from './input-control-mixin.js';
+import type { InputMixinClass } from './input-mixin.js';
+import type { LabelMixinClass } from './label-mixin.js';
+import type { ValidateMixinClass } from './validate-mixin.js';
 
 /**
  * A mixin to provide logic for vaadin-text-field and related components.

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to store the reference to an input element

--- a/packages/field-base/src/label-mixin.d.ts
+++ b/packages/field-base/src/label-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { LabelController } from './label-controller.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { LabelController } from './label-controller.js';
 
 /**
  * A mixin to provide label via corresponding property or named slot.

--- a/packages/field-base/src/labelled-input-controller.d.ts
+++ b/packages/field-base/src/labelled-input-controller.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ReactiveController } from 'lit';
+import type { ReactiveController } from 'lit';
 
 /**
  * A controller for linking a `<label>` element with an `<input>` element.

--- a/packages/field-base/src/pattern-mixin.d.ts
+++ b/packages/field-base/src/pattern-mixin.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { DelegateStateMixinClass } from './delegate-state-mixin.js';
-import { InputConstraintsMixinClass } from './input-constraints-mixin.js';
-import { InputMixinClass } from './input-mixin.js';
-import { ValidateMixinClass } from './validate-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { DelegateStateMixinClass } from './delegate-state-mixin.js';
+import type { InputConstraintsMixinClass } from './input-constraints-mixin.js';
+import type { InputMixinClass } from './input-mixin.js';
+import type { ValidateMixinClass } from './validate-mixin.js';
 
 /**
  * A mixin to provide `pattern` and `preventInvalidInput` properties.

--- a/packages/field-base/src/shadow-focus-mixin.d.ts
+++ b/packages/field-base/src/shadow-focus-mixin.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mixin.js';
-import { DelegateFocusMixinClass } from './delegate-focus-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mixin.js';
+import type { DelegateFocusMixinClass } from './delegate-focus-mixin.js';
 
 /**
  * A mixin to forward focus to an element in the shadow DOM.

--- a/packages/field-base/src/slot-styles-mixin.d.ts
+++ b/packages/field-base/src/slot-styles-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * Mixin to insert styles into the outer scope to handle slotted components.

--- a/packages/field-base/src/slot-target-controller.d.ts
+++ b/packages/field-base/src/slot-target-controller.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ReactiveController } from 'lit';
+import type { ReactiveController } from 'lit';
 
 export class SlotTargetController implements ReactiveController {
   /**

--- a/packages/field-base/src/styles/clear-button-styles.d.ts
+++ b/packages/field-base/src/styles/clear-button-styles.d.ts
@@ -3,6 +3,6 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd..
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const clearButton: CSSResult;

--- a/packages/field-base/src/styles/field-shared-styles.d.ts
+++ b/packages/field-base/src/styles/field-shared-styles.d.ts
@@ -3,6 +3,6 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd..
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const fieldShared: CSSResult;

--- a/packages/field-base/src/styles/input-field-container-styles.d.ts
+++ b/packages/field-base/src/styles/input-field-container-styles.d.ts
@@ -3,6 +3,6 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd..
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const inputFieldContainer: CSSResult;

--- a/packages/field-base/src/styles/input-field-shared-styles.d.ts
+++ b/packages/field-base/src/styles/input-field-shared-styles.d.ts
@@ -3,6 +3,6 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd..
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const inputFieldShared: CSSResult;

--- a/packages/field-base/src/validate-mixin.d.ts
+++ b/packages/field-base/src/validate-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to provide required state and validation logic.

--- a/packages/field-base/src/virtual-keyboard-controller.d.ts
+++ b/packages/field-base/src/virtual-keyboard-controller.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ReactiveController } from 'lit';
+import type { ReactiveController } from 'lit';
 
 /**
  * A controller which prevents the virtual keyboard from showing up on mobile devices

--- a/packages/field-highlighter/src/vaadin-field-highlighter.d.ts
+++ b/packages/field-highlighter/src/vaadin-field-highlighter.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ReactiveController } from 'lit';
+import type { ReactiveController } from 'lit';
 
 export interface FieldHighlighterUser {
   id: number;

--- a/packages/grid-pro/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid-pro/src/lit/column-renderer-directives.d.ts
@@ -4,11 +4,11 @@
  * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
  * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive';
-import { GridItemModel } from '@vaadin/grid';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive';
+import type { GridItemModel } from '@vaadin/grid';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
-import { GridProEditColumn } from '../vaadin-grid-pro-edit-column.js';
+import type { GridProEditColumn } from '../vaadin-grid-pro-edit-column.js';
 
 export type GridProColumnEditModeLitRenderer<TItem> = (
   item: TItem,

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -4,7 +4,7 @@
  * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
  * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
-import { GridBodyRenderer, GridDefaultItem, GridItemModel } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridBodyRenderer, GridDefaultItem, GridItemModel } from '@vaadin/grid/src/vaadin-grid.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 
 export type GridProEditorType = 'text' | 'checkbox' | 'select' | 'custom';

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
@@ -4,7 +4,7 @@
  * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
  * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function InlineEditingMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro.d.ts
@@ -4,8 +4,9 @@
  * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
  * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
-import { Grid, GridCustomEventMap, GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { InlineEditingMixinClass } from './vaadin-grid-pro-inline-editing-mixin.js';
+import type { GridCustomEventMap, GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
+import type { InlineEditingMixinClass } from './vaadin-grid-pro-inline-editing-mixin.js';
 export { GridProEditorType } from './vaadin-grid-pro-edit-column.js';
 
 /**

--- a/packages/grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/grid-pro/test/typings/grid-pro.types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Grid,
   GridActiveItemChangedEvent,
   GridCellActivateEvent,
@@ -12,10 +12,10 @@ import {
   GridLoadingChangedEvent,
   GridSelectedItemsChangedEvent,
 } from '@vaadin/grid';
-import { GridColumn } from '@vaadin/grid/vaadin-grid-column';
-import { InlineEditingMixinClass } from '../../src/vaadin-grid-pro-inline-editing-mixin';
-import { GridPro } from '../../vaadin-grid-pro';
-import { GridProEditColumn } from '../../vaadin-grid-pro-edit-column';
+import type { GridColumn } from '@vaadin/grid/vaadin-grid-column';
+import type { InlineEditingMixinClass } from '../../src/vaadin-grid-pro-inline-editing-mixin';
+import type { GridPro } from '../../vaadin-grid-pro';
+import type { GridProEditColumn } from '../../vaadin-grid-pro-edit-column';
 
 interface TestGridItem {
   testProperty: string;

--- a/packages/grid-pro/test/typings/lit-renderer-directives.types.ts
+++ b/packages/grid-pro/test/typings/lit-renderer-directives.types.ts
@@ -1,9 +1,6 @@
-import { DirectiveResult } from 'lit/directive';
-import {
-  columnEditModeRenderer,
-  GridProColumnEditModeLitRenderer,
-  GridProColumnEditModeRendererDirective,
-} from '../../lit.js';
+import type { DirectiveResult } from 'lit/directive';
+import type { GridProColumnEditModeLitRenderer, GridProColumnEditModeRendererDirective } from '../../lit.js';
+import { columnEditModeRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/grid/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid/src/lit/column-renderer-directives.d.ts
@@ -4,11 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 /* eslint-disable max-classes-per-file */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive';
-import { LitRenderer, LitRendererDirective } from '@vaadin/lit-renderer';
-import { GridItemModel } from '../vaadin-grid.js';
-import { GridColumn } from '../vaadin-grid-column.js';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive';
+import type { LitRenderer } from '@vaadin/lit-renderer';
+import { LitRendererDirective } from '@vaadin/lit-renderer';
+import type { GridItemModel } from '../vaadin-grid.js';
+import type { GridColumn } from '../vaadin-grid-column.js';
 
 export type GridColumnBodyLitRenderer<TItem> = (
   item: TItem,

--- a/packages/grid/src/lit/renderer-directives.d.ts
+++ b/packages/grid/src/lit/renderer-directives.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
-import { Grid, GridItemModel } from '../vaadin-grid.js';
+import type { Grid, GridItemModel } from '../vaadin-grid.js';
 
 export type GridRowDetailsLitRenderer<TItem> = (item: TItem, model: GridItemModel<TItem>, grid: Grid) => TemplateResult;
 

--- a/packages/grid/src/vaadin-grid-active-item-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ActiveItemMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/grid/src/vaadin-grid-array-data-provider-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-array-data-provider-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ArrayDataProviderMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/grid/src/vaadin-grid-column-group.d.ts
+++ b/packages/grid/src/vaadin-grid-column-group.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from './vaadin-grid.js';
-import { ColumnBaseMixinClass } from './vaadin-grid-column.js';
+import type { GridDefaultItem } from './vaadin-grid.js';
+import type { ColumnBaseMixinClass } from './vaadin-grid-column.js';
 
 /**
  * A `<vaadin-grid-column-group>` is used to make groups of columns in `<vaadin-grid>` and

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ColumnReorderingMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/grid/src/vaadin-grid-column.d.ts
+++ b/packages/grid/src/vaadin-grid-column.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { GridDefaultItem, GridItemModel } from './vaadin-grid.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { GridDefaultItem, GridItemModel } from './vaadin-grid.js';
 
 export type GridBodyRenderer<TItem> = (
   root: HTMLElement,

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 import { GridSorterDirection } from './vaadin-grid-sorter.js';
 
 export { GridSorterDirection };

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { GridItemModel } from './vaadin-grid.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { GridItemModel } from './vaadin-grid.js';
 
 export type GridDragAndDropFilter<TItem> = (model: GridItemModel<TItem>) => boolean;
 

--- a/packages/grid/src/vaadin-grid-event-context-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-event-context-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { GridColumn } from './vaadin-grid-column.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { GridColumn } from './vaadin-grid-column.js';
 
 export interface GridEventContext<TItem> {
   section?: 'body' | 'header' | 'footer' | 'details';

--- a/packages/grid/src/vaadin-grid-filter-column.d.ts
+++ b/packages/grid/src/vaadin-grid-filter-column.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from './vaadin-grid.js';
+import type { GridDefaultItem } from './vaadin-grid.js';
 import { GridColumn } from './vaadin-grid-column.js';
 
 /**

--- a/packages/grid/src/vaadin-grid-row-details-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { Grid, GridItemModel } from './vaadin-grid.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { Grid, GridItemModel } from './vaadin-grid.js';
 
 export type GridRowDetailsRenderer<TItem> = (
   root: HTMLElement,

--- a/packages/grid/src/vaadin-grid-scroll-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ScrollMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ScrollMixinClass>;
 

--- a/packages/grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from './vaadin-grid.js';
+import type { GridDefaultItem } from './vaadin-grid.js';
 import { GridColumn } from './vaadin-grid-column.js';
 
 /**

--- a/packages/grid/src/vaadin-grid-selection-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function SelectionMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-column.d.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from './vaadin-grid.js';
+import type { GridDefaultItem } from './vaadin-grid.js';
 import { GridColumn } from './vaadin-grid-column.js';
-import { GridSorterDirection } from './vaadin-grid-sorter.js';
+import type { GridSorterDirection } from './vaadin-grid-sorter.js';
 
 /**
  * Fired when the `direction` property changes.

--- a/packages/grid/src/vaadin-grid-sort-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function SortMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<SortMixinClass>;
 

--- a/packages/grid/src/vaadin-grid-styling-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-styling-mixin.d.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { GridItemModel } from './vaadin-grid.js';
-import { GridColumn } from './vaadin-grid-column.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { GridItemModel } from './vaadin-grid.js';
+import type { GridColumn } from './vaadin-grid-column.js';
 
 export type GridCellClassNameGenerator<TItem> = (column: GridColumn<TItem>, model: GridItemModel<TItem>) => string;
 

--- a/packages/grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-column.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from './vaadin-grid.js';
+import type { GridDefaultItem } from './vaadin-grid.js';
 import { GridColumn } from './vaadin-grid-column.js';
 
 /**

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -3,15 +3,16 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { ActiveItemMixinClass } from './vaadin-grid-active-item-mixin.js';
-import { ArrayDataProviderMixinClass } from './vaadin-grid-array-data-provider-mixin.js';
-import { GridBodyRenderer, GridColumn, GridHeaderFooterRenderer } from './vaadin-grid-column.js';
-import { ColumnReorderingMixinClass } from './vaadin-grid-column-reordering-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ActiveItemMixinClass } from './vaadin-grid-active-item-mixin.js';
+import type { ArrayDataProviderMixinClass } from './vaadin-grid-array-data-provider-mixin.js';
+import type { GridColumn } from './vaadin-grid-column.js';
+import { GridBodyRenderer, GridHeaderFooterRenderer } from './vaadin-grid-column.js';
+import type { ColumnReorderingMixinClass } from './vaadin-grid-column-reordering-mixin.js';
+import type { DataProviderMixinClass } from './vaadin-grid-data-provider-mixin.js';
 import {
-  DataProviderMixinClass,
   GridDataProvider,
   GridDataProviderCallback,
   GridDataProviderParams,
@@ -19,18 +20,17 @@ import {
   GridSorterDefinition,
   GridSorterDirection,
 } from './vaadin-grid-data-provider-mixin.js';
-import {
-  DragAndDropMixinClass,
-  GridDragAndDropFilter,
-  GridDropLocation,
-  GridDropMode,
-} from './vaadin-grid-drag-and-drop-mixin.js';
-import { EventContextMixinClass, GridEventContext } from './vaadin-grid-event-context-mixin.js';
-import { GridRowDetailsRenderer, RowDetailsMixinClass } from './vaadin-grid-row-details-mixin.js';
-import { ScrollMixinClass } from './vaadin-grid-scroll-mixin.js';
-import { SelectionMixinClass } from './vaadin-grid-selection-mixin.js';
-import { SortMixinClass } from './vaadin-grid-sort-mixin.js';
-import { GridCellClassNameGenerator, StylingMixinClass } from './vaadin-grid-styling-mixin.js';
+import type { DragAndDropMixinClass } from './vaadin-grid-drag-and-drop-mixin.js';
+import { GridDragAndDropFilter, GridDropLocation, GridDropMode } from './vaadin-grid-drag-and-drop-mixin.js';
+import type { EventContextMixinClass } from './vaadin-grid-event-context-mixin.js';
+import { GridEventContext } from './vaadin-grid-event-context-mixin.js';
+import type { RowDetailsMixinClass } from './vaadin-grid-row-details-mixin.js';
+import { GridRowDetailsRenderer } from './vaadin-grid-row-details-mixin.js';
+import type { ScrollMixinClass } from './vaadin-grid-scroll-mixin.js';
+import type { SelectionMixinClass } from './vaadin-grid-selection-mixin.js';
+import type { SortMixinClass } from './vaadin-grid-sort-mixin.js';
+import type { StylingMixinClass } from './vaadin-grid-styling-mixin.js';
+import { GridCellClassNameGenerator } from './vaadin-grid-styling-mixin.js';
 
 export {
   GridBodyRenderer,

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -1,18 +1,18 @@
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
-import { ActiveItemMixinClass } from '../../src/vaadin-grid-active-item-mixin';
-import { ArrayDataProviderMixinClass } from '../../src/vaadin-grid-array-data-provider-mixin';
-import { ColumnReorderingMixinClass } from '../../src/vaadin-grid-column-reordering-mixin';
-import { DataProviderMixinClass } from '../../src/vaadin-grid-data-provider-mixin';
-import { DragAndDropMixinClass } from '../../src/vaadin-grid-drag-and-drop-mixin';
-import { EventContextMixinClass } from '../../src/vaadin-grid-event-context-mixin';
-import { RowDetailsMixinClass } from '../../src/vaadin-grid-row-details-mixin';
-import { ScrollMixinClass } from '../../src/vaadin-grid-scroll-mixin';
-import { SelectionMixinClass } from '../../src/vaadin-grid-selection-mixin';
-import { SortMixinClass } from '../../src/vaadin-grid-sort-mixin';
-import { StylingMixinClass } from '../../src/vaadin-grid-styling-mixin';
-import {
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
+import type { ActiveItemMixinClass } from '../../src/vaadin-grid-active-item-mixin';
+import type { ArrayDataProviderMixinClass } from '../../src/vaadin-grid-array-data-provider-mixin';
+import type { ColumnReorderingMixinClass } from '../../src/vaadin-grid-column-reordering-mixin';
+import type { DataProviderMixinClass } from '../../src/vaadin-grid-data-provider-mixin';
+import type { DragAndDropMixinClass } from '../../src/vaadin-grid-drag-and-drop-mixin';
+import type { EventContextMixinClass } from '../../src/vaadin-grid-event-context-mixin';
+import type { RowDetailsMixinClass } from '../../src/vaadin-grid-row-details-mixin';
+import type { ScrollMixinClass } from '../../src/vaadin-grid-scroll-mixin';
+import type { SelectionMixinClass } from '../../src/vaadin-grid-selection-mixin';
+import type { SortMixinClass } from '../../src/vaadin-grid-sort-mixin';
+import type { StylingMixinClass } from '../../src/vaadin-grid-styling-mixin';
+import type {
   ColumnBaseMixinClass,
   Grid,
   GridActiveItemChangedEvent,
@@ -40,14 +40,17 @@ import {
   GridSorterDefinition,
   GridSorterDirection,
 } from '../../vaadin-grid.js';
-import { GridColumnGroup } from '../../vaadin-grid-column-group';
-import { GridFilter, GridFilterValueChangedEvent } from '../../vaadin-grid-filter.js';
-import { GridFilterColumn } from '../../vaadin-grid-filter-column';
-import { GridSelectionColumn, GridSelectionColumnSelectAllChangedEvent } from '../../vaadin-grid-selection-column.js';
-import { GridSortColumn, GridSortColumnDirectionChangedEvent } from '../../vaadin-grid-sort-column.js';
-import { GridSorter, GridSorterDirectionChangedEvent } from '../../vaadin-grid-sorter.js';
-import { GridTreeColumn } from '../../vaadin-grid-tree-column';
-import { GridTreeToggle, GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
+import type { GridColumnGroup } from '../../vaadin-grid-column-group';
+import type { GridFilter, GridFilterValueChangedEvent } from '../../vaadin-grid-filter.js';
+import type { GridFilterColumn } from '../../vaadin-grid-filter-column';
+import type {
+  GridSelectionColumn,
+  GridSelectionColumnSelectAllChangedEvent,
+} from '../../vaadin-grid-selection-column.js';
+import type { GridSortColumn, GridSortColumnDirectionChangedEvent } from '../../vaadin-grid-sort-column.js';
+import type { GridSorter, GridSorterDirectionChangedEvent } from '../../vaadin-grid-sorter.js';
+import type { GridTreeColumn } from '../../vaadin-grid-tree-column';
+import type { GridTreeToggle, GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
 
 interface TestGridItem {
   testProperty: string;

--- a/packages/grid/test/typings/lit-renderer-directives.types.ts
+++ b/packages/grid/test/typings/lit-renderer-directives.types.ts
@@ -1,8 +1,5 @@
-import { DirectiveResult } from 'lit/directive';
-import {
-  columnBodyRenderer,
-  columnFooterRenderer,
-  columnHeaderRenderer,
+import type { DirectiveResult } from 'lit/directive';
+import type {
   GridColumnBodyLitRenderer,
   GridColumnBodyRendererDirective,
   GridColumnFooterLitRenderer,
@@ -10,9 +7,9 @@ import {
   GridColumnHeaderLitRenderer,
   GridColumnHeaderRendererDirective,
   GridRowDetailsLitRenderer,
-  gridRowDetailsRenderer,
   GridRowDetailsRendererDirective,
 } from '../../lit.js';
+import { columnBodyRenderer, columnFooterRenderer, columnHeaderRenderer, gridRowDetailsRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/icon/src/vaadin-icon-svg.d.ts
+++ b/packages/icon/src/vaadin-icon-svg.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { nothing, SVGTemplateResult } from 'lit';
+import type { nothing, SVGTemplateResult } from 'lit';
 
 export type IconSvgLiteral = SVGTemplateResult | typeof nothing;
 

--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -5,7 +5,7 @@
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { IconSvgLiteral } from './vaadin-icon-svg.js';
+import type { IconSvgLiteral } from './vaadin-icon-svg.js';
 
 /**
  * `<vaadin-icon>` is a Web Component for displaying SVG icons.

--- a/packages/icon/src/vaadin-iconset.d.ts
+++ b/packages/icon/src/vaadin-iconset.d.ts
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { IconSvgLiteral } from './vaadin-icon-svg.js';
+import type { IconSvgLiteral } from './vaadin-icon-svg.js';
 
 /**
  * `<vaadin-iconset>` is a Web Component for creating SVG icon collections.

--- a/packages/icon/test/typings/icon.types.ts
+++ b/packages/icon/test/typings/icon.types.ts
@@ -1,4 +1,4 @@
-import { Icon, IconSvgLiteral } from '../../vaadin-icon';
+import type { Icon, IconSvgLiteral } from '../../vaadin-icon';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/icon/test/typings/iconset.types.ts
+++ b/packages/icon/test/typings/iconset.types.ts
@@ -1,4 +1,4 @@
-import { Iconset, IconSvgLiteral } from '../../vaadin-iconset';
+import type { Iconset, IconSvgLiteral } from '../../vaadin-iconset';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/integer-field/test/typings/integer-field.types.ts
+++ b/packages/integer-field/test/typings/integer-field.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-integer-field.js';
-import {
+import type {
   IntegerField,
   IntegerFieldChangeEvent,
   IntegerFieldInvalidChangedEvent,

--- a/packages/item/src/vaadin-item-mixin.d.ts
+++ b/packages/item/src/vaadin-item-mixin.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 
 /**
  * A mixin providing `focused`, `focus-ring`, `active`, `disabled` and `selected`.

--- a/packages/list-box/test/typings/list-box.types.ts
+++ b/packages/list-box/test/typings/list-box.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-list-box.js';
-import {
+import type {
   ListBoxItemsChangedEvent,
   ListBoxSelectedChangedEvent,
   ListBoxSelectedValuesChangedEvent,

--- a/packages/lit-renderer/src/lit-renderer.d.ts
+++ b/packages/lit-renderer/src/lit-renderer.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ElementPart, nothing, RenderOptions, TemplateResult } from 'lit';
+import type { ElementPart, nothing, RenderOptions, TemplateResult } from 'lit';
 import { AsyncDirective } from 'lit/async-directive.js';
 
 export type LitRenderer = (...args: any[]) => TemplateResult;

--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export interface LoginI18n {
   form: {

--- a/packages/login/test/typings/login.types.ts
+++ b/packages/login/test/typings/login.types.ts
@@ -1,6 +1,6 @@
 import '../../vaadin-login-form.js';
-import { LoginFormLoginEvent } from '../../vaadin-login-form.js';
-import { LoginOverlayLoginEvent } from '../../vaadin-login-overlay.js';
+import type { LoginFormLoginEvent } from '../../vaadin-login-form.js';
+import type { LoginOverlayLoginEvent } from '../../vaadin-login-overlay.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/map/src/vaadin-map.d.ts
+++ b/packages/map/src/vaadin-map.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2022 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import OpenLayersMap from 'ol/Map.js';
+import type OpenLayersMap from 'ol/Map.js';
 import { ElementMixin, FocusMixin, ResizeMixin } from '@vaadin/component-base';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
 

--- a/packages/map/test/typings/map.types.ts
+++ b/packages/map/test/typings/map.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-map.js';
-import Map from 'ol/Map';
+import type Map from 'ol/Map';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/map/test/typings/map.types.ts
+++ b/packages/map/test/typings/map.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-map.js';
-import type Map from 'ol/Map';
+import type Map from 'ol/Map.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 
 export declare function ButtonsMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function InteractionsMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/menu-bar/test/typings/menu-bar.types.ts
+++ b/packages/menu-bar/test/typings/menu-bar.types.ts
@@ -1,6 +1,6 @@
 import '../../vaadin-menu-bar.js';
-import { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
-import { MenuBarItem, MenuBarItemSelectedEvent } from '../../vaadin-menu-bar.js';
+import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+import type { MenuBarItem, MenuBarItemSelectedEvent } from '../../vaadin-menu-bar.js';
 
 const menu = document.createElement('vaadin-menu-bar');
 

--- a/packages/message-input/test/typings/message-input.types.ts
+++ b/packages/message-input/test/typings/message-input.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-message-input.js';
-import { MessageInputSubmitEvent } from '../../vaadin-message-input.js';
+import type { MessageInputSubmitEvent } from '../../vaadin-message-input.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/multi-select-combo-box/src/lit/renderer-directives.d.ts
+++ b/packages/multi-select-combo-box/src/lit/renderer-directives.d.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive.js';
-import { ComboBoxItemModel } from '@vaadin/combo-box/src/vaadin-combo-box.js';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive.js';
+import type { ComboBoxItemModel } from '@vaadin/combo-box/src/vaadin-combo-box.js';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
-import { MultiSelectComboBox } from '../vaadin-multi-select-combo-box.js';
+import type { MultiSelectComboBox } from '../vaadin-multi-select-combo-box.js';
 
 export type MultiSelectComboBoxLitRenderer<TItem> = (
   item: TItem,

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -3,26 +3,26 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import {
+import type {
   ComboBoxDataProvider,
   ComboBoxDefaultItem,
   ComboBoxItemModel,
 } from '@vaadin/combo-box/src/vaadin-combo-box.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
-import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
-import { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
-import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
-import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
-import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
-import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
-import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import type { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
+import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
+import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export type MultiSelectComboBoxRenderer<TItem> = (
   root: HTMLElement,

--- a/packages/multi-select-combo-box/test/typings/lit.types.ts
+++ b/packages/multi-select-combo-box/test/typings/lit.types.ts
@@ -1,9 +1,6 @@
-import { DirectiveResult } from 'lit/directive.js';
-import {
-  MultiSelectComboBoxLitRenderer,
-  multiSelectComboBoxRenderer,
-  MultiSelectComboBoxRendererDirective,
-} from '../../lit.js';
+import type { DirectiveResult } from 'lit/directive.js';
+import type { MultiSelectComboBoxLitRenderer, MultiSelectComboBoxRendererDirective } from '../../lit.js';
+import { multiSelectComboBoxRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -1,18 +1,18 @@
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
-import { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
-import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
-import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
-import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
-import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
-import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
-import {
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import type { DelegateStateMixinClass } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
+import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
+import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
+import type {
   MultiSelectComboBox,
   MultiSelectComboBoxChangeEvent,
   MultiSelectComboBoxCustomValueSetEvent,

--- a/packages/notification/src/lit/renderer-directives.d.ts
+++ b/packages/notification/src/lit/renderer-directives.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive.js';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive.js';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
-import { Notification } from '../vaadin-notification.js';
+import type { Notification } from '../vaadin-notification.js';
 
 export type NotificationLitRenderer = (notification: Notification) => TemplateResult;
 

--- a/packages/notification/src/vaadin-notification.d.ts
+++ b/packages/notification/src/vaadin-notification.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TemplateResult } from 'lit';
+import type { TemplateResult } from 'lit';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';

--- a/packages/notification/test/typings/lit.types.ts
+++ b/packages/notification/test/typings/lit.types.ts
@@ -1,5 +1,6 @@
-import { DirectiveResult } from 'lit/directive.js';
-import { NotificationLitRenderer, notificationRenderer, NotificationRendererDirective } from '../../lit.js';
+import type { DirectiveResult } from 'lit/directive.js';
+import type { NotificationLitRenderer, NotificationRendererDirective } from '../../lit.js';
+import { notificationRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/notification/test/typings/notification.types.ts
+++ b/packages/notification/test/typings/notification.types.ts
@@ -1,5 +1,6 @@
 import '../../vaadin-notification.js';
-import { Notification, NotificationOpenedChangedEvent } from '../../vaadin-notification.js';
+import type { NotificationOpenedChangedEvent } from '../../vaadin-notification.js';
+import { Notification } from '../../vaadin-notification.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 

--- a/packages/number-field/test/typings/number-field.types.ts
+++ b/packages/number-field/test/typings/number-field.types.ts
@@ -1,10 +1,10 @@
 import '../../vaadin-number-field.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
-import { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import {
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
+import type { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type {
   NumberField,
   NumberFieldChangeEvent,
   NumberFieldInvalidChangedEvent,

--- a/packages/password-field/test/typings/password-field.types.ts
+++ b/packages/password-field/test/typings/password-field.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-password-field.js';
-import {
+import type {
   PasswordField,
   PasswordFieldChangeEvent,
   PasswordFieldInvalidChangedEvent,

--- a/packages/progress-bar/src/vaadin-progress-mixin.d.ts
+++ b/packages/progress-bar/src/vaadin-progress-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ProgressMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ProgressMixinClass>;
 

--- a/packages/radio-group/test/typings/radio-button.types.ts
+++ b/packages/radio-group/test/typings/radio-button.types.ts
@@ -1,17 +1,17 @@
 import '../../vaadin-radio-button.js';
 import '../../vaadin-radio-group.js';
-import { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
-import { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
-import { CheckedMixinClass } from '@vaadin/field-base/src/checked-mixin.js';
-import { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { RadioButtonCheckedChangedEvent } from '../../vaadin-radio-button.js';
-import { RadioGroupInvalidChangedEvent, RadioGroupValueChangedEvent } from '../../vaadin-radio-group.js';
+import type { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { CheckedMixinClass } from '@vaadin/field-base/src/checked-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { RadioButtonCheckedChangedEvent } from '../../vaadin-radio-button.js';
+import type { RadioGroupInvalidChangedEvent, RadioGroupValueChangedEvent } from '../../vaadin-radio-group.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/rich-text-editor/test/typings/rich-text-editor.types.ts
+++ b/packages/rich-text-editor/test/typings/rich-text-editor.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-rich-text-editor.js';
-import {
+import type {
   RichTextEditor,
   RichTextEditorChangeEvent,
   RichTextEditorHtmlValueChangedEvent,

--- a/packages/scroller/test/typings/scroller.types.ts
+++ b/packages/scroller/test/typings/scroller.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-scroller.js';
-import { Scroller } from '../../vaadin-scroller.js';
+import type { Scroller } from '../../vaadin-scroller.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/select/src/lit/renderer-directives.d.ts
+++ b/packages/select/src/lit/renderer-directives.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive.js';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive.js';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
-import { Select } from '../vaadin-select.js';
+import type { Select } from '../vaadin-select.js';
 
 export type SelectLitRenderer = (select: Select) => TemplateResult;
 

--- a/packages/select/test/typings/lit.types.ts
+++ b/packages/select/test/typings/lit.types.ts
@@ -1,5 +1,6 @@
-import { DirectiveResult } from 'lit/directive.js';
-import { SelectLitRenderer, selectRenderer, SelectRendererDirective } from '../../lit.js';
+import type { DirectiveResult } from 'lit/directive.js';
+import type { SelectLitRenderer, SelectRendererDirective } from '../../lit.js';
+import { selectRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -1,6 +1,6 @@
 import '../../vaadin-select.js';
-import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
-import {
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+import type {
   Select,
   SelectChangeEvent,
   SelectInvalidChangedEvent,

--- a/packages/tabs/test/typings/tabs.types.ts
+++ b/packages/tabs/test/typings/tabs.types.ts
@@ -1,6 +1,6 @@
 import '../../vaadin-tabs.js';
-import { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
-import { TabsItemsChangedEvent, TabsSelectedChangedEvent } from '../../vaadin-tabs.js';
+import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+import type { TabsItemsChangedEvent, TabsSelectedChangedEvent } from '../../vaadin-tabs.js';
 
 const tabs = document.createElement('vaadin-tabs');
 

--- a/packages/text-area/test/typings/text-area.types.ts
+++ b/packages/text-area/test/typings/text-area.types.ts
@@ -1,10 +1,10 @@
 import '../../vaadin-text-area.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
-import { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import {
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
+import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type {
   TextArea,
   TextAreaChangeEvent,
   TextAreaInvalidChangedEvent,

--- a/packages/text-field/test/typings/text-field.types.ts
+++ b/packages/text-field/test/typings/text-field.types.ts
@@ -1,10 +1,10 @@
 import '../../vaadin-text-field.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
-import { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import {
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
+import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type {
   TextField,
   TextFieldChangeEvent,
   TextFieldInvalidChangedEvent,

--- a/packages/time-picker/test/typings/time-picker.types.ts
+++ b/packages/time-picker/test/typings/time-picker.types.ts
@@ -1,10 +1,10 @@
 import '../../vaadin-time-picker.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
-import { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import {
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
+import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type {
   TimePicker,
   TimePickerChangeEvent,
   TimePickerInvalidChangedEvent,

--- a/packages/upload/test/typings/upload.types.ts
+++ b/packages/upload/test/typings/upload.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-upload.js';
-import {
+import type {
   UploadAbortEvent,
   UploadBeforeEvent,
   UploadErrorEvent,

--- a/packages/vaadin-accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/vaadin-accordion/src/vaadin-accordion-panel.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { AccordionPanel } from '@vaadin/accordion/src/vaadin-accordion-panel.js';
+import type { AccordionPanel } from '@vaadin/accordion/src/vaadin-accordion-panel.js';
 
 /**
  * @deprecated Import `AccordionPanel` from `@vaadin/accordion/vaadin-accordion-panel` instead.

--- a/packages/vaadin-accordion/src/vaadin-accordion.d.ts
+++ b/packages/vaadin-accordion/src/vaadin-accordion.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Accordion } from '@vaadin/accordion/src/vaadin-accordion.js';
+import type { Accordion } from '@vaadin/accordion/src/vaadin-accordion.js';
 
 /**
  * @deprecated Import `Accordion` from `@vaadin/accordion` instead.

--- a/packages/vaadin-app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/vaadin-app-layout/src/vaadin-app-layout.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { AppLayout } from '@vaadin/app-layout/src/vaadin-app-layout.js';
+import type { AppLayout } from '@vaadin/app-layout/src/vaadin-app-layout.js';
 
 /**
  * @deprecated Import `AppLayout` from `@vaadin/app-layout` instead.

--- a/packages/vaadin-app-layout/src/vaadin-drawer-toggle.d.ts
+++ b/packages/vaadin-app-layout/src/vaadin-drawer-toggle.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DrawerToggle } from '@vaadin/app-layout/src/vaadin-drawer-toggle.js';
+import type { DrawerToggle } from '@vaadin/app-layout/src/vaadin-drawer-toggle.js';
 
 /**
  * @deprecated Import `DrawerToggle` from `@vaadin/app-layout/vaadin-drawer-toggle` instead.

--- a/packages/vaadin-avatar/src/vaadin-avatar-group.d.ts
+++ b/packages/vaadin-avatar/src/vaadin-avatar-group.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2020 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { AvatarGroup } from '@vaadin/avatar-group/src/vaadin-avatar-group.js';
+import type { AvatarGroup } from '@vaadin/avatar-group/src/vaadin-avatar-group.js';
 
 /**
  * @deprecated Import `AvatarGroup` from `@vaadin/avatar-group` instead.

--- a/packages/vaadin-avatar/src/vaadin-avatar.d.ts
+++ b/packages/vaadin-avatar/src/vaadin-avatar.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2020 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Avatar } from '@vaadin/avatar/src/vaadin-avatar.js';
+import type { Avatar } from '@vaadin/avatar/src/vaadin-avatar.js';
 
 /**
  * @deprecated Import `Avatar` from `@vaadin/avatar` instead.

--- a/packages/vaadin-board/src/vaadin-board-row.d.ts
+++ b/packages/vaadin-board/src/vaadin-board-row.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { BoardRow } from '@vaadin/board/src/vaadin-board-row.js';
+import type { BoardRow } from '@vaadin/board/src/vaadin-board-row.js';
 
 /**
  * @deprecated Import `BoardRow` from `@vaadin/board/vaadin-board-row` instead.

--- a/packages/vaadin-board/src/vaadin-board.d.ts
+++ b/packages/vaadin-board/src/vaadin-board.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { Board } from '@vaadin/board/src/vaadin-board.js';
+import type { Board } from '@vaadin/board/src/vaadin-board.js';
 
 /**
  * @deprecated Import `Board` from `@vaadin/board` instead.

--- a/packages/vaadin-button/src/vaadin-button.d.ts
+++ b/packages/vaadin-button/src/vaadin-button.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Button } from '@vaadin/button/src/vaadin-button.js';
+import type { Button } from '@vaadin/button/src/vaadin-button.js';
 
 /**
  * @deprecated Import `Button` from `@vaadin/button` instead.

--- a/packages/vaadin-charts/src/vaadin-chart-series.d.ts
+++ b/packages/vaadin-charts/src/vaadin-chart-series.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2015 - 2021 Vaadin Ltd
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { ChartSeries } from '@vaadin/charts/src/vaadin-chart-series.js';
+import type { ChartSeries } from '@vaadin/charts/src/vaadin-chart-series.js';
 
 /**
  * @deprecated Import `ChartSeries` from `@vaadin/charts/src/vaadin-chart-series` instead.

--- a/packages/vaadin-charts/src/vaadin-chart.d.ts
+++ b/packages/vaadin-charts/src/vaadin-chart.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2015 - 2021 Vaadin Ltd
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { Chart } from '@vaadin/charts/src/vaadin-chart.js';
+import type { Chart } from '@vaadin/charts/src/vaadin-chart.js';
 
 /**
  * @deprecated Import `Chart` from `@vaadin/charts` instead.

--- a/packages/vaadin-checkbox/src/vaadin-checkbox-group.d.ts
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox-group.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CheckboxGroup } from '@vaadin/checkbox-group/src/vaadin-checkbox-group.js';
+import type { CheckboxGroup } from '@vaadin/checkbox-group/src/vaadin-checkbox-group.js';
 
 /**
  * @deprecated Import `CheckboxGroup` from `@vaadin/checkbox-group` instead.

--- a/packages/vaadin-checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
+import type { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
 
 /**
  * @deprecated Import `Checkbox` from `@vaadin/checkbox` instead.

--- a/packages/vaadin-combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box-light.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ComboBoxDefaultItem } from '@vaadin/combo-box';
-import { ComboBoxLight } from '@vaadin/combo-box/src/vaadin-combo-box-light.js';
+import type { ComboBoxDefaultItem } from '@vaadin/combo-box';
+import type { ComboBoxLight } from '@vaadin/combo-box/src/vaadin-combo-box-light.js';
 
 /**
  * @deprecated Import `ComboBoxLight` from `@vaadin/combo-box/vaadin-combo-box-light` instead.

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ComboBoxDefaultItem } from '@vaadin/combo-box';
-import { ComboBox } from '@vaadin/combo-box/src/vaadin-combo-box.js';
+import type { ComboBoxDefaultItem } from '@vaadin/combo-box';
+import type { ComboBox } from '@vaadin/combo-box/src/vaadin-combo-box.js';
 
 /**
  * @deprecated Import `ComboBox` from `@vaadin/combo-box` instead.

--- a/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2021 Vaadin Ltd
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { ConfirmDialog } from '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
+import type { ConfirmDialog } from '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
 
 /**
  * @deprecated Import `ConfirmDialog` from `@vaadin/confirm-dialog` instead.

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ContextMenu } from '@vaadin/context-menu/src/vaadin-context-menu.js';
+import type { ContextMenu } from '@vaadin/context-menu/src/vaadin-context-menu.js';
 
 /**
  * @deprecated Import `ContextMenu` from `@vaadin/context-menu` instead.

--- a/packages/vaadin-cookie-consent/src/vaadin-cookie-consent.d.ts
+++ b/packages/vaadin-cookie-consent/src/vaadin-cookie-consent.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { CookieConsent } from '@vaadin/cookie-consent/src/vaadin-cookie-consent.js';
+import type { CookieConsent } from '@vaadin/cookie-consent/src/vaadin-cookie-consent.js';
 
 /**
  * @deprecated Import `CookieConsent` from `@vaadin/cookie-consent` instead.

--- a/packages/vaadin-crud/src/vaadin-crud.d.ts
+++ b/packages/vaadin-crud/src/vaadin-crud.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { Crud } from '@vaadin/crud/src/vaadin-crud.js';
+import type { Crud } from '@vaadin/crud/src/vaadin-crud.js';
 
 /**
  * @deprecated Import `Crud` from `@vaadin/crud` instead.

--- a/packages/vaadin-custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/vaadin-custom-field/src/vaadin-custom-field.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CustomField } from '@vaadin/custom-field/src/vaadin-custom-field.js';
+import type { CustomField } from '@vaadin/custom-field/src/vaadin-custom-field.js';
 
 /**
  * @deprecated Import `CustomField` from `@vaadin/custom-field` instead.

--- a/packages/vaadin-date-picker/src/vaadin-date-picker-light.d.ts
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker-light.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DatePickerLight } from '@vaadin/date-picker/src/vaadin-date-picker-light.js';
+import type { DatePickerLight } from '@vaadin/date-picker/src/vaadin-date-picker-light.js';
 
 /**
  * @deprecated Import `DatePickerLight` from `@vaadin/date-picker` instead.

--- a/packages/vaadin-date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DatePicker } from '@vaadin/date-picker/src/vaadin-date-picker.js';
+import type { DatePicker } from '@vaadin/date-picker/src/vaadin-date-picker.js';
 
 /**
  * @deprecated Import `DatePicker` from `@vaadin/date-picker` instead.

--- a/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DateTimePicker } from '@vaadin/date-time-picker/src/vaadin-date-time-picker.js';
+import type { DateTimePicker } from '@vaadin/date-time-picker/src/vaadin-date-time-picker.js';
 
 /**
  * @deprecated Import `DateTimePicker` from `@vaadin/date-time-picker` instead.

--- a/packages/vaadin-details/src/vaadin-details.d.ts
+++ b/packages/vaadin-details/src/vaadin-details.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Details } from '@vaadin/details/src/vaadin-details.js';
+import type { Details } from '@vaadin/details/src/vaadin-details.js';
 
 /**
  * @deprecated Import `Details` from `@vaadin/details` instead.

--- a/packages/vaadin-dialog/src/vaadin-dialog.d.ts
+++ b/packages/vaadin-dialog/src/vaadin-dialog.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Dialog } from '@vaadin/dialog/src/vaadin-dialog.js';
+import type { Dialog } from '@vaadin/dialog/src/vaadin-dialog.js';
 
 /**
  * @deprecated Import `Dialog` from `@vaadin/dialog` instead.

--- a/packages/vaadin-form-layout/src/vaadin-form-item.d.ts
+++ b/packages/vaadin-form-layout/src/vaadin-form-item.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { FormItem } from '@vaadin/form-layout/src/vaadin-form-item.js';
+import type { FormItem } from '@vaadin/form-layout/src/vaadin-form-item.js';
 
 /**
  * @deprecated Import `FormItem` from `@vaadin/form-layout/vaadin-form-item` instead.

--- a/packages/vaadin-form-layout/src/vaadin-form-layout.d.ts
+++ b/packages/vaadin-form-layout/src/vaadin-form-layout.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { FormLayout } from '@vaadin/form-layout/src/vaadin-form-layout.js';
+import type { FormLayout } from '@vaadin/form-layout/src/vaadin-form-layout.js';
 
 /**
  * @deprecated Import `FormLayout` from `@vaadin/form-layout` instead.

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -4,8 +4,8 @@
  * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
  * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
-import { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { GridProEditColumn } from '@vaadin/grid-pro/src/vaadin-grid-pro-edit-column.js';
+import type { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridProEditColumn } from '@vaadin/grid-pro/src/vaadin-grid-pro-edit-column.js';
 
 /**
  * @deprecated Import `GridProEditColumn` from `@vaadin/grid-pro/vaadin-grid-pro-edit-column` instead.

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.d.ts
@@ -4,8 +4,8 @@
  * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
  * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
  */
-import { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { GridPro } from '@vaadin/grid-pro/src/vaadin-grid-pro.js';
+import type { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridPro } from '@vaadin/grid-pro/src/vaadin-grid-pro.js';
 
 /**
  * @deprecated Import `GridPro` from `@vaadin/grid-pro` instead.

--- a/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column-group.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { GridColumnGroup } from '@vaadin/grid/src/vaadin-grid-column-group.js';
+import type { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridColumnGroup } from '@vaadin/grid/src/vaadin-grid-column-group.js';
 
 /**
  * @deprecated Import `GridColumnGroup` from `@vaadin/grid/vaadin-grid-column-group` instead.

--- a/packages/vaadin-grid/src/vaadin-grid-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-column.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
+import type { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 
 /**
  * @deprecated Import `GridColumn` from `@vaadin/grid/vaadin-grid-column` instead.

--- a/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-filter-column.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { GridFilterColumn } from '@vaadin/grid/src/vaadin-grid-filter-column.js';
+import type { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridFilterColumn } from '@vaadin/grid/src/vaadin-grid-filter-column.js';
 
 /**
  * @deprecated Import `GridFilterColumn` from `@vaadin/grid/vaadin-grid-filter-column` instead.

--- a/packages/vaadin-grid/src/vaadin-grid-filter.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-filter.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridFilter } from '@vaadin/grid/src/vaadin-grid-filter.js';
+import type { GridFilter } from '@vaadin/grid/src/vaadin-grid-filter.js';
 
 /**
  * @deprecated Import `GridFilter` from `@vaadin/grid/vaadin-grid-filter` instead.

--- a/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-selection-column.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { GridSelectionColumn } from '@vaadin/grid/src/vaadin-grid-selection-column.js';
+import type { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridSelectionColumn } from '@vaadin/grid/src/vaadin-grid-selection-column.js';
 
 /**
  * @deprecated Import `GridSelectionColumn` from `@vaadin/grid/vaadin-grid-selection-column` instead.

--- a/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sort-column.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { GridSortColumn } from '@vaadin/grid/src/vaadin-grid-sort-column.js';
+import type { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridSortColumn } from '@vaadin/grid/src/vaadin-grid-sort-column.js';
 
 /**
  * @deprecated Import `GridSortColumn` from `@vaadin/grid/vaadin-grid-sort-column` instead.

--- a/packages/vaadin-grid/src/vaadin-grid-sorter.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-sorter.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridSorter } from '@vaadin/grid/src/vaadin-grid-sorter.js';
+import type { GridSorter } from '@vaadin/grid/src/vaadin-grid-sorter.js';
 
 /**
  * @deprecated Import `GridSorter` from `@vaadin/grid/vaadin-grid-sorter` instead.

--- a/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-column.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { GridTreeColumn } from '@vaadin/grid/src/vaadin-grid-tree-column.js';
+import type { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridTreeColumn } from '@vaadin/grid/src/vaadin-grid-tree-column.js';
 
 /**
  * @deprecated Import `GridTreeColumn` from `@vaadin/grid/vaadin-grid-tree-column` instead.

--- a/packages/vaadin-grid/src/vaadin-grid-tree-toggle.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid-tree-toggle.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridTreeToggle } from '@vaadin/grid/src/vaadin-grid-tree-toggle.js';
+import type { GridTreeToggle } from '@vaadin/grid/src/vaadin-grid-tree-toggle.js';
 
 /**
  * @deprecated Import `GridTreeToggle` from `@vaadin/grid/vaadin-grid-tree-toggle` instead.

--- a/packages/vaadin-grid/src/vaadin-grid.d.ts
+++ b/packages/vaadin-grid/src/vaadin-grid.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
-import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
+import type { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 
 /**
  * @deprecated Import `Grid` from `@vaadin/grid` instead.

--- a/packages/vaadin-icon/src/vaadin-icon.d.ts
+++ b/packages/vaadin-icon/src/vaadin-icon.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Icon } from '@vaadin/icon/src/vaadin-icon.js';
+import type { Icon } from '@vaadin/icon/src/vaadin-icon.js';
 
 /**
  * @deprecated Import `Icon` from `@vaadin/icon` instead.

--- a/packages/vaadin-icon/src/vaadin-iconset.d.ts
+++ b/packages/vaadin-icon/src/vaadin-iconset.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Iconset } from '@vaadin/icon/src/vaadin-iconset.js';
+import type { Iconset } from '@vaadin/icon/src/vaadin-iconset.js';
 
 /**
  * @deprecated Import `Iconset` from `@vaadin/icon/vaadin-iconset` instead.

--- a/packages/vaadin-item/src/vaadin-item.d.ts
+++ b/packages/vaadin-item/src/vaadin-item.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Item } from '@vaadin/item/src/vaadin-item.js';
+import type { Item } from '@vaadin/item/src/vaadin-item.js';
 
 /**
  * @deprecated Import `Item` from `@vaadin/item` instead.

--- a/packages/vaadin-list-box/src/vaadin-list-box.d.ts
+++ b/packages/vaadin-list-box/src/vaadin-list-box.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
+import type { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
 
 /**
  * @deprecated Import `ListBox` from `@vaadin/list-box` instead.

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.d.ts
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin for `nav` elements, facilitating navigation and selection of childNodes.

--- a/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.d.ts
+++ b/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { ListMixinClass } from './vaadin-list-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ListMixinClass } from './vaadin-list-mixin.js';
 
 /**
  * A mixin for `nav` elements, facilitating multiple selection of childNodes.

--- a/packages/vaadin-login/src/vaadin-login-form.d.ts
+++ b/packages/vaadin-login/src/vaadin-login-form.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LoginForm } from '@vaadin/login/src/vaadin-login-form.js';
+import type { LoginForm } from '@vaadin/login/src/vaadin-login-form.js';
 
 /**
  * @deprecated Import `LoginForm` from `@vaadin/login/vaadin-login-form` instead.

--- a/packages/vaadin-login/src/vaadin-login-overlay.d.ts
+++ b/packages/vaadin-login/src/vaadin-login-overlay.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LoginOverlay } from '@vaadin/login/src/vaadin-login-overlay.js';
+import type { LoginOverlay } from '@vaadin/login/src/vaadin-login-overlay.js';
 
 /**
  * @deprecated Import `LoginOverlay` from `@vaadin/login` instead.

--- a/packages/vaadin-lumo-styles/badge.d.ts
+++ b/packages/vaadin-lumo-styles/badge.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const badge: CSSResult;

--- a/packages/vaadin-lumo-styles/color.d.ts
+++ b/packages/vaadin-lumo-styles/color.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const colorBase: CSSResult;
 

--- a/packages/vaadin-lumo-styles/mixins/field-button.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/field-button.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const fieldButton: CSSResult;

--- a/packages/vaadin-lumo-styles/mixins/helper.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/helper.d.ts
@@ -3,6 +3,6 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const helper: CSSResult;

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const inputField: CSSResult;
 

--- a/packages/vaadin-lumo-styles/mixins/menu-overlay.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/menu-overlay.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const menuOverlay: CSSResult[];
 

--- a/packages/vaadin-lumo-styles/mixins/overlay.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/overlay.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const overlay: CSSResult;

--- a/packages/vaadin-lumo-styles/mixins/required-field.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/required-field.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const requiredField: CSSResult;

--- a/packages/vaadin-lumo-styles/sizing.d.ts
+++ b/packages/vaadin-lumo-styles/sizing.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const sizing: CSSResult;

--- a/packages/vaadin-lumo-styles/spacing.d.ts
+++ b/packages/vaadin-lumo-styles/spacing.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const spacing: CSSResult;

--- a/packages/vaadin-lumo-styles/style.d.ts
+++ b/packages/vaadin-lumo-styles/style.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const style: CSSResult;

--- a/packages/vaadin-lumo-styles/typography.d.ts
+++ b/packages/vaadin-lumo-styles/typography.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const font: CSSResult;
 

--- a/packages/vaadin-lumo-styles/user-colors.d.ts
+++ b/packages/vaadin-lumo-styles/user-colors.d.ts
@@ -3,6 +3,6 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const userColors: CSSResult;

--- a/packages/vaadin-lumo-styles/utility.d.ts
+++ b/packages/vaadin-lumo-styles/utility.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const utility: CSSResult;

--- a/packages/vaadin-material-styles/color.d.ts
+++ b/packages/vaadin-material-styles/color.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const colorLight: CSSResult;
 

--- a/packages/vaadin-material-styles/mixins/field-button.d.ts
+++ b/packages/vaadin-material-styles/mixins/field-button.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const fieldButton: CSSResult;

--- a/packages/vaadin-material-styles/mixins/helper.d.ts
+++ b/packages/vaadin-material-styles/mixins/helper.d.ts
@@ -3,6 +3,6 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const helper: CSSResult;

--- a/packages/vaadin-material-styles/mixins/input-field-shared.d.ts
+++ b/packages/vaadin-material-styles/mixins/input-field-shared.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const inputField: CSSResult;
 

--- a/packages/vaadin-material-styles/mixins/menu-overlay.d.ts
+++ b/packages/vaadin-material-styles/mixins/menu-overlay.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const menuOverlay: CSSResult;

--- a/packages/vaadin-material-styles/mixins/overlay.d.ts
+++ b/packages/vaadin-material-styles/mixins/overlay.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const overlay: CSSResult;

--- a/packages/vaadin-material-styles/mixins/required-field.d.ts
+++ b/packages/vaadin-material-styles/mixins/required-field.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const requiredField: CSSResult;

--- a/packages/vaadin-material-styles/shadow.d.ts
+++ b/packages/vaadin-material-styles/shadow.d.ts
@@ -1,3 +1,3 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const shadow: CSSResult;

--- a/packages/vaadin-material-styles/typography.d.ts
+++ b/packages/vaadin-material-styles/typography.d.ts
@@ -1,4 +1,4 @@
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const font: CSSResult;
 

--- a/packages/vaadin-material-styles/user-colors.d.ts
+++ b/packages/vaadin-material-styles/user-colors.d.ts
@@ -3,6 +3,6 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { CSSResult } from 'lit';
+import type { CSSResult } from 'lit';
 
 export const userColors: CSSResult;

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { MenuBar } from '@vaadin/menu-bar/src/vaadin-menu-bar.js';
+import type { MenuBar } from '@vaadin/menu-bar/src/vaadin-menu-bar.js';
 
 /**
  * @deprecated Import `MenuBar` from `@vaadin/menu-bar` instead.

--- a/packages/vaadin-messages/src/vaadin-message-input.d.ts
+++ b/packages/vaadin-messages/src/vaadin-message-input.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { MessageInput } from '@vaadin/message-input/src/vaadin-message-input.js';
+import type { MessageInput } from '@vaadin/message-input/src/vaadin-message-input.js';
 
 /**
  * @deprecated Import `MessageInput` from `@vaadin/message-input` instead.

--- a/packages/vaadin-messages/src/vaadin-message-list.d.ts
+++ b/packages/vaadin-messages/src/vaadin-message-list.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { MessageList } from '@vaadin/message-list/src/vaadin-message-list.js';
+import type { MessageList } from '@vaadin/message-list/src/vaadin-message-list.js';
 
 /**
  * @deprecated Import `MessageList` from `@vaadin/message-list` instead.

--- a/packages/vaadin-messages/src/vaadin-message.d.ts
+++ b/packages/vaadin-messages/src/vaadin-message.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Message } from '@vaadin/message-list/src/vaadin-message.js';
+import type { Message } from '@vaadin/message-list/src/vaadin-message.js';
 
 /**
  * @deprecated Import `Message` from `@vaadin/message-list/vaadin-message` instead.

--- a/packages/vaadin-notification/src/vaadin-notification.d.ts
+++ b/packages/vaadin-notification/src/vaadin-notification.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Notification } from '@vaadin/notification/src/vaadin-notification.js';
+import type { Notification } from '@vaadin/notification/src/vaadin-notification.js';
 
 /**
  * @deprecated Import `Notification` from `@vaadin/notification` instead.

--- a/packages/vaadin-ordered-layout/src/vaadin-horizontal-layout.d.ts
+++ b/packages/vaadin-ordered-layout/src/vaadin-horizontal-layout.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { HorizontalLayout } from '@vaadin/horizontal-layout/src/vaadin-horizontal-layout.js';
+import type { HorizontalLayout } from '@vaadin/horizontal-layout/src/vaadin-horizontal-layout.js';
 
 /**
  * @deprecated Import `HorizontalLayout` from `@vaadin/horizontal-layout` instead.

--- a/packages/vaadin-ordered-layout/src/vaadin-scroller.d.ts
+++ b/packages/vaadin-ordered-layout/src/vaadin-scroller.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Scroller } from '@vaadin/scroller/src/vaadin-scroller.js';
+import type { Scroller } from '@vaadin/scroller/src/vaadin-scroller.js';
 
 /**
  * @deprecated Import `Scroller` from `@vaadin/scroller` instead.

--- a/packages/vaadin-ordered-layout/src/vaadin-vertical-layout.d.ts
+++ b/packages/vaadin-ordered-layout/src/vaadin-vertical-layout.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { VerticalLayout } from '@vaadin/vertical-layout/src/vaadin-vertical-layout.js';
+import type { VerticalLayout } from '@vaadin/vertical-layout/src/vaadin-vertical-layout.js';
 
 /**
  * @deprecated Import `VerticalLayout` from `@vaadin/vertical-layout` instead.

--- a/packages/vaadin-overlay/test/typings/overlay.types.ts
+++ b/packages/vaadin-overlay/test/typings/overlay.types.ts
@@ -1,8 +1,8 @@
 import '../../vaadin-overlay.js';
-import { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
-import { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
-import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import {
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type {
   OverlayCloseEvent,
   OverlayClosingEvent,
   OverlayEscapePressEvent,

--- a/packages/vaadin-progress-bar/src/vaadin-progress-bar.d.ts
+++ b/packages/vaadin-progress-bar/src/vaadin-progress-bar.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ProgressBar } from '@vaadin/progress-bar/src/vaadin-progress-bar.js';
+import type { ProgressBar } from '@vaadin/progress-bar/src/vaadin-progress-bar.js';
 
 /**
  * @deprecated Import `ProgressBar` from `@vaadin/progress-bar` instead.

--- a/packages/vaadin-radio-button/src/vaadin-radio-button.d.ts
+++ b/packages/vaadin-radio-button/src/vaadin-radio-button.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { RadioButton } from '@vaadin/radio-group/src/vaadin-radio-button.js';
+import type { RadioButton } from '@vaadin/radio-group/src/vaadin-radio-button.js';
 
 /**
  * @deprecated Import `RadioButton` from `@vaadin/radio-group/vaadin-radio-button` instead.

--- a/packages/vaadin-radio-button/src/vaadin-radio-group.d.ts
+++ b/packages/vaadin-radio-button/src/vaadin-radio-group.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { RadioGroup } from '@vaadin/radio-group/src/vaadin-radio-group.js';
+import type { RadioGroup } from '@vaadin/radio-group/src/vaadin-radio-group.js';
 
 /**
  * @deprecated Import `RadioGroup` from `@vaadin/radio-group` instead.

--- a/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.d.ts
+++ b/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
-import { RichTextEditor } from '@vaadin/rich-text-editor/src/vaadin-rich-text-editor.js';
+import type { RichTextEditor } from '@vaadin/rich-text-editor/src/vaadin-rich-text-editor.js';
 
 /**
  * @deprecated Import `RichTextEditor` from `@vaadin/rich-text-editor` instead.

--- a/packages/vaadin-select/src/vaadin-select.d.ts
+++ b/packages/vaadin-select/src/vaadin-select.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Select } from '@vaadin/select/src/vaadin-select.js';
+import type { Select } from '@vaadin/select/src/vaadin-select.js';
 
 /**
  * @deprecated Import `Select` from `@vaadin/select` instead.

--- a/packages/vaadin-split-layout/src/vaadin-split-layout.d.ts
+++ b/packages/vaadin-split-layout/src/vaadin-split-layout.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SplitLayout } from '@vaadin/split-layout/src/vaadin-split-layout.js';
+import type { SplitLayout } from '@vaadin/split-layout/src/vaadin-split-layout.js';
 
 /**
  * @deprecated Import `SplitLayout` from `@vaadin/split-layout` instead.

--- a/packages/vaadin-tabs/src/vaadin-tab.d.ts
+++ b/packages/vaadin-tabs/src/vaadin-tab.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Tab } from '@vaadin/tabs/src/vaadin-tab.js';
+import type { Tab } from '@vaadin/tabs/src/vaadin-tab.js';
 
 /**
  * @deprecated Import `Tab` from `@vaadin/tabs/vaadin-tab` instead.

--- a/packages/vaadin-tabs/src/vaadin-tabs.d.ts
+++ b/packages/vaadin-tabs/src/vaadin-tabs.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Tabs } from '@vaadin/tabs/src/vaadin-tabs.js';
+import type { Tabs } from '@vaadin/tabs/src/vaadin-tabs.js';
 
 /**
  * @deprecated Import `Tabs` from `@vaadin/tabs` instead.

--- a/packages/vaadin-text-field/src/vaadin-email-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-email-field.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { EmailField } from '@vaadin/email-field/src/vaadin-email-field.js';
+import type { EmailField } from '@vaadin/email-field/src/vaadin-email-field.js';
 
 /**
  * @deprecated Import `EmailField` from `@vaadin/email-field` instead.

--- a/packages/vaadin-text-field/src/vaadin-integer-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-integer-field.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { IntegerField } from '@vaadin/integer-field/src/vaadin-integer-field.js';
+import type { IntegerField } from '@vaadin/integer-field/src/vaadin-integer-field.js';
 
 /**
  * @deprecated Import `IntegerField` from `@vaadin/integer-field` instead.

--- a/packages/vaadin-text-field/src/vaadin-number-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-number-field.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
+import type { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
 
 /**
  * @deprecated Import `NumberField` from `@vaadin/number-field` instead.

--- a/packages/vaadin-text-field/src/vaadin-password-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-password-field.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { PasswordField } from '@vaadin/password-field/src/vaadin-password-field.js';
+import type { PasswordField } from '@vaadin/password-field/src/vaadin-password-field.js';
 
 /**
  * @deprecated Import `PasswordField` from `@vaadin/password-field` instead.

--- a/packages/vaadin-text-field/src/vaadin-text-area.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-text-area.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TextArea } from '@vaadin/text-area/src/vaadin-text-area.js';
+import type { TextArea } from '@vaadin/text-area/src/vaadin-text-area.js';
 
 /**
  * @deprecated Import `TextArea` from `@vaadin/text-area` instead.

--- a/packages/vaadin-text-field/src/vaadin-text-field.d.ts
+++ b/packages/vaadin-text-field/src/vaadin-text-field.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
+import type { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 
 /**
  * @deprecated Import `TextField` from `@vaadin/text-field` instead.

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.d.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
-import { CSSResult, CSSResultGroup } from 'lit';
-import { ThemePropertyMixinClass } from './vaadin-theme-property-mixin.js';
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { CSSResult, CSSResultGroup } from 'lit';
+import type { ThemePropertyMixinClass } from './vaadin-theme-property-mixin.js';
 
 /**
  * A mixin for `nav` elements, facilitating navigation and selection of childNodes.

--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Constructor } from '@open-wc/dedupe-mixin';
+import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ThemePropertyMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/vaadin-time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TimePicker } from '@vaadin/time-picker';
+import type { TimePicker } from '@vaadin/time-picker';
 
 export * from '@vaadin/time-picker/src/vaadin-time-picker.js';
 /**

--- a/packages/vaadin-upload/src/vaadin-upload.d.ts
+++ b/packages/vaadin-upload/src/vaadin-upload.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Upload } from '@vaadin/upload/src/vaadin-upload.js';
+import type { Upload } from '@vaadin/upload/src/vaadin-upload.js';
 
 /**
  * @deprecated Import `Upload` from `@vaadin/upload` instead.

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.d.ts
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { VirtualList, VirtualListDefaultItem } from '@vaadin/virtual-list/src/vaadin-virtual-list.js';
+import type { VirtualList, VirtualListDefaultItem } from '@vaadin/virtual-list/src/vaadin-virtual-list.js';
 
 /**
  * @deprecated Import `VirtualList` from `@vaadin/virtual-list` instead.

--- a/packages/virtual-list/src/lit/renderer-directives.d.ts
+++ b/packages/virtual-list/src/lit/renderer-directives.d.ts
@@ -3,10 +3,10 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TemplateResult } from 'lit';
-import { DirectiveResult } from 'lit/directive.js';
+import type { TemplateResult } from 'lit';
+import type { DirectiveResult } from 'lit/directive.js';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
-import { VirtualList, VirtualListItemModel } from '../vaadin-virtual-list.js';
+import type { VirtualList, VirtualListItemModel } from '../vaadin-virtual-list.js';
 
 export type VirtualListLitRenderer<TItem> = (
   item: TItem,

--- a/packages/virtual-list/test/typings/lit.types.ts
+++ b/packages/virtual-list/test/typings/lit.types.ts
@@ -1,5 +1,6 @@
-import { DirectiveResult } from 'lit/directive.js';
-import { VirtualListLitRenderer, virtualListRenderer, VirtualListRendererDirective } from '../../lit.js';
+import type { DirectiveResult } from 'lit/directive.js';
+import type { VirtualListLitRenderer, VirtualListRendererDirective } from '../../lit.js';
+import { virtualListRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/virtual-list/test/typings/virtual-list.types.ts
+++ b/packages/virtual-list/test/typings/virtual-list.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-virtual-list.js';
-import { VirtualList, VirtualListItemModel, VirtualListRenderer } from '../../vaadin-virtual-list.js';
+import type { VirtualList, VirtualListItemModel, VirtualListRenderer } from '../../vaadin-virtual-list.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 


### PR DESCRIPTION
## Description

The PR adds the following rules to the project's ESLint config:

- [x] @typescript-eslint/consistent-type-imports

Part of https://github.com/vaadin/eslint-config-vaadin/issues/16

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
