### PR TITLE
chore: update license field for Pro components

### DIFF
--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "Polymer element to create flexible responsive layouts and build nice looking dashboard.",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/board/LICENSE.txt",
+  "license": "SEE LICENSE IN LICENSE.txt",
   "cvdlName": "vaadin-board",
   "repository": {
     "type": "git",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-charts",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/charts/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-chart",
   "repository": {
     "type": "git",

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-confirm-dialog",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/confirm-dialog/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-confirm-dialog",
   "repository": {
     "type": "git",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-cookie-consent",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/cookie-consent/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-cookie-consent",
   "repository": {
     "type": "git",

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-crud",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/crud/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-crud",
   "repository": {
     "type": "git",

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-grid-pro",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/grid-pro/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-grid-pro",
   "repository": {
     "type": "git",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-map",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/map/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-map",
   "repository": {
     "type": "git",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-rich-text-editor",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/rich-text-editor/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-rich-text-editor",
   "repository": {
     "type": "git",

--- a/packages/vaadin-board/package.json
+++ b/packages/vaadin-board/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "Polymer element to create flexible responsive layouts and build nice looking dashboard.",
-  "license": "https://raw.githubusercontent.com/vaadin/vaadin-board/master/LICENSE.txt",
+  "license": "SEE LICENSE IN LICENSE.txt",
   "cvdlName": "vaadin-board",
   "repository": {
     "type": "git",

--- a/packages/vaadin-charts/package.json
+++ b/packages/vaadin-charts/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-charts",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/vaadin-charts/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-chart",
   "repository": {
     "type": "git",

--- a/packages/vaadin-confirm-dialog/package.json
+++ b/packages/vaadin-confirm-dialog/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-confirm-dialog",
-  "license": "https://raw.githubusercontent.com/vaadin/vaadin-confirm-dialog/master/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-confirm-dialog",
   "repository": {
     "type": "git",

--- a/packages/vaadin-cookie-consent/package.json
+++ b/packages/vaadin-cookie-consent/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-cookie-consent",
-  "license": "https://raw.githubusercontent.com/vaadin/vaadin-cookie-consent/master/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-cookie-consent",
   "repository": {
     "type": "git",

--- a/packages/vaadin-crud/package.json
+++ b/packages/vaadin-crud/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-crud",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/vaadin-crud/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-crud",
   "repository": {
     "type": "git",

--- a/packages/vaadin-grid-pro/package.json
+++ b/packages/vaadin-grid-pro/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-grid-pro",
-  "license": "https://raw.githubusercontent.com/vaadin/web-components/master/packages/vaadin-grid-pro/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-grid-pro",
   "repository": {
     "type": "git",

--- a/packages/vaadin-rich-text-editor/package.json
+++ b/packages/vaadin-rich-text-editor/package.json
@@ -5,7 +5,7 @@
     "access": "public"
   },
   "description": "vaadin-rich-text-editor",
-  "license": "https://raw.githubusercontent.com/vaadin/vaadin-rich-text-editor/master/LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "cvdlName": "vaadin-rich-text-editor",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Currently, the `"license"` field in `package.json` does not adhere to [npm documentation](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license):

> If you are using a license that hasn't been assigned an SPDX identifier, or if you are using a custom license, use a string value like this one:
> ```
> {
>  "license" : "SEE LICENSE IN <filename>"
> }
> ```
 
This causes problems when using [`license-checker`](https://www.npmjs.com/package/license-checker) utility (not to be confused with Vaadin license checker), as it fails to recognize the `"license"` field and then falls back to [parsing `README` file](https://github.com/davglass/license-checker/blob/de6e9a42513aa38a58efc6b202ee5281ed61f486/lib/index.js#L139-L141), which ends up with a wrong link 😕 

```
├─ @vaadin/vaadin-charts@23.2.0-alpha2
│  ├─ licenses: Custom: https://www.npmjs.com/package/. <--- should be CVDL 4.0 
│  ├─ repository: https://github.com/vaadin/web-components
│  ├─ publisher: Vaadin Ltd
```

Updated all the Pro components to use `SEE LICENSE IN LICENSE` which is [correctly recognized](https://github.com/davglass/license-checker/blob/de6e9a42513aa38a58efc6b202ee5281ed61f486/lib/license.js#L19) by this tool.
As a result, the custom license would be [properly parsed](https://github.com/davglass/license-checker/blob/de6e9a42513aa38a58efc6b202ee5281ed61f486/lib/index.js#L170-L171) and reported as `licenses: Custom: cvdl-4.0`.
 
## Type of change

- Internal change