### PR TITLE
fix: use correct context-menu dependency

### DIFF
--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -37,7 +37,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/button": "23.2.0-alpha3",
     "@vaadin/component-base": "23.2.0-alpha3",
-    "@vaadin/vaadin-context-menu": "23.2.0-alpha3",
+    "@vaadin/context-menu": "23.2.0-alpha3",
     "@vaadin/vaadin-lumo-styles": "23.2.0-alpha3",
     "@vaadin/vaadin-material-styles": "23.2.0-alpha3",
     "@vaadin/vaadin-themable-mixin": "23.2.0-alpha3"


### PR DESCRIPTION
## Description

Looks like we missed to update this dependency while moving the package. Let's change it now.

## Type of change

- Bugfix