### PR TITLE
docs: update links to chart styling guide

### DIFF
--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -346,7 +346,7 @@ export type ChartEventMap = HTMLElementEventMap & ChartCustomEventMap;
  * A comprehensive list of the supported style classes can be found at
  * https://www.highcharts.com/docs/chart-design-and-style/style-by-css
  *
- * See also [Chart Styling](https://vaadin.com/docs/latest/components/charts/css-styling) documentation.
+ * See also the [Chart Styling](https://vaadin.com/docs/latest/components/charts/css-styling) documentation.
  *
  * ### RTL support
  *

--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -346,8 +346,7 @@ export type ChartEventMap = HTMLElementEventMap & ChartCustomEventMap;
  * A comprehensive list of the supported style classes can be found at
  * https://www.highcharts.com/docs/chart-design-and-style/style-by-css
  *
- * See also the documentation for styling Vaadin components at
- * https://vaadin.com/docs/v14/themes/themes-and-styling-overview.html
+ * See also [Chart Styling](https://vaadin.com/docs/latest/components/charts/css-styling) documentation.
  *
  * ### RTL support
  *

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -164,8 +164,7 @@ Highcharts.setOptions({ lang: { noData: '' } });
  * A comprehensive list of the supported style classes can be found at
  * https://www.highcharts.com/docs/chart-design-and-style/style-by-css
  *
- * See also the documentation for styling Vaadin components at
- * https://vaadin.com/docs/v14/themes/themes-and-styling-overview.html
+ * See also [Chart Styling](https://vaadin.com/docs/latest/components/charts/css-styling) documentation.
  *
  * ### RTL support
  *

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -164,7 +164,7 @@ Highcharts.setOptions({ lang: { noData: '' } });
  * A comprehensive list of the supported style classes can be found at
  * https://www.highcharts.com/docs/chart-design-and-style/style-by-css
  *
- * See also [Chart Styling](https://vaadin.com/docs/latest/components/charts/css-styling) documentation.
+ * See also the [Chart Styling](https://vaadin.com/docs/latest/components/charts/css-styling) documentation.
  *
  * ### RTL support
  *


### PR DESCRIPTION
## Description

Replaced old links to Vaadin 14 docs with the latest Chart styling guide.

## Type of change

- Documentation