### PR TITLE
refactor: add more rules to ESLint config, fix warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,6 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/prefer-function-type": "error",
     "@typescript-eslint/consistent-type-imports": ["error", { "prefer": "type-imports" }],
-    "@typescript-eslint/sort-type-union-intersection-members": "error",
     "@typescript-eslint/member-ordering": [
       "error",
       {
@@ -112,6 +111,7 @@
         "typeLiterals": ["field", "constructor", "method"]
       }
     ],
+    "@typescript-eslint/sort-type-union-intersection-members": "error",
     "accessor-pairs": "error",
     "array-callback-return": "error",
     "capitalized-comments": ["error", "always", {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,6 +58,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/prefer-function-type": "error",
     "@typescript-eslint/consistent-type-imports": ["error", { "prefer": "type-imports" }],
+    "@typescript-eslint/sort-type-union-intersection-members": "error",
     "@typescript-eslint/member-ordering": [
       "error",
       {

--- a/packages/accordion/src/vaadin-accordion.d.ts
+++ b/packages/accordion/src/vaadin-accordion.d.ts
@@ -23,7 +23,7 @@ export interface AccordionCustomEventMap {
   'opened-changed': AccordionOpenedChangedEvent;
 }
 
-export type AccordionEventMap = HTMLElementEventMap & AccordionCustomEventMap;
+export type AccordionEventMap = AccordionCustomEventMap & HTMLElementEventMap;
 
 /**
  * `<vaadin-accordion>` is a Web Component implementing accordion widget —
@@ -87,13 +87,13 @@ declare class Accordion extends ElementMixin(ThemableMixin(HTMLElement)) {
   addEventListener<K extends keyof AccordionEventMap>(
     type: K,
     listener: (this: Accordion, ev: AccordionEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof AccordionEventMap>(
     type: K,
     listener: (this: Accordion, ev: AccordionEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -24,7 +24,7 @@ export type AppLayoutOverlayChangedEvent = CustomEvent<{ value: boolean }>;
 /**
  * Fired when the `primarySection` property changes.
  */
-export type AppLayoutPrimarySectionChangedEvent = CustomEvent<{ value: 'navbar' | 'drawer' }>;
+export type AppLayoutPrimarySectionChangedEvent = CustomEvent<{ value: 'drawer' | 'navbar' }>;
 
 export interface AppLayoutCustomEventMap {
   'drawer-opened-changed': AppLayoutDrawerOpenedChangedEvent;
@@ -34,7 +34,7 @@ export interface AppLayoutCustomEventMap {
   'primary-section-changed': AppLayoutPrimarySectionChangedEvent;
 }
 
-export type AppLayoutEventMap = HTMLElementEventMap & AppLayoutCustomEventMap;
+export type AppLayoutEventMap = AppLayoutCustomEventMap & HTMLElementEventMap;
 
 /**
  * `<vaadin-app-layout>` is a Web Component providing a quick and easy way to get a common application layout structure done.
@@ -157,7 +157,7 @@ declare class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(HTMLE
    * - If `primary-section="drawer"` is set, then the drawer will move the navbar, taking the full available height.
    * @attr {navbar|drawer} primary-section
    */
-  primarySection: 'navbar' | 'drawer';
+  primarySection: 'drawer' | 'navbar';
 
   /**
    * Controls whether the drawer is opened (visible) or not.
@@ -185,13 +185,13 @@ declare class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(HTMLE
   addEventListener<K extends keyof AppLayoutEventMap>(
     type: K,
     listener: (this: AppLayout, ev: AppLayoutEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof AppLayoutEventMap>(
     type: K,
     listener: (this: AppLayout, ev: AppLayoutEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/app-layout/test/typings/app-layout.types.ts
+++ b/packages/app-layout/test/typings/app-layout.types.ts
@@ -19,7 +19,7 @@ assertType<ThemableMixinClass>(layout);
 assertType<ControllerMixinClass>(layout);
 
 // Properties
-assertType<'navbar' | 'drawer'>(layout.primarySection);
+assertType<'drawer' | 'navbar'>(layout.primarySection);
 assertType<boolean>(layout.drawerOpened);
 assertType<boolean>(layout.overlay);
 assertType<string>(layout.closeDrawerOn);
@@ -38,5 +38,5 @@ layout.addEventListener('overlay-changed', (event) => {
 
 layout.addEventListener('primary-section-changed', (event) => {
   assertType<AppLayoutPrimarySectionChangedEvent>(event);
-  assertType<'navbar' | 'drawer'>(event.detail.value);
+  assertType<'drawer' | 'navbar'>(event.detail.value);
 });

--- a/packages/button/src/vaadin-button-mixin.d.ts
+++ b/packages/button/src/vaadin-button-mixin.d.ts
@@ -15,9 +15,9 @@ import type { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mix
  */
 export declare function ButtonMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<ActiveMixinClass> &
+): Constructor<ActiveMixinClass> &
   Constructor<DisabledMixinClass> &
   Constructor<FocusMixinClass> &
   Constructor<KeyboardMixinClass> &
-  Constructor<TabindexMixinClass>;
+  Constructor<TabindexMixinClass> &
+  T;

--- a/packages/charts/src/vaadin-chart-series.d.ts
+++ b/packages/charts/src/vaadin-chart-series.d.ts
@@ -5,7 +5,7 @@
  */
 import type { PointOptionsObject, Series, SeriesOptionsType } from 'highcharts';
 
-export type ChartSeriesMarkers = 'shown' | 'hidden' | 'auto';
+export type ChartSeriesMarkers = 'auto' | 'hidden' | 'shown';
 
 export interface ChartSeriesConfig {
   data?: ChartSeriesValues;
@@ -22,7 +22,7 @@ export interface ChartSeriesConfig {
 
 export type ChartSeriesOptions = ChartSeriesConfig & SeriesOptionsType;
 
-export type ChartSeriesValues = Array<number | number[] | PointOptionsObject>;
+export type ChartSeriesValues = Array<number[] | PointOptionsObject | number>;
 
 /**
  * `<vaadin-chart-series>` is a custom element for creating series for Vaadin Charts.

--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -10,7 +10,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 
 export type ChartCategories = string[] | { [key: number]: string };
 
-export type ChartCategoryPosition = 'left' | 'right' | 'top' | 'bottom';
+export type ChartCategoryPosition = 'bottom' | 'left' | 'right' | 'top';
 
 export type ChartStacking = 'normal' | 'percent' | null;
 
@@ -245,7 +245,7 @@ export interface ChartCustomEventMap {
   'yaxes-extremes-set': ChartYaxesExtremesSetEvent;
 }
 
-export type ChartEventMap = HTMLElementEventMap & ChartCustomEventMap;
+export type ChartEventMap = ChartCustomEventMap & HTMLElementEventMap;
 
 /**
  * `<vaadin-chart>` is a Web Component for creating high quality charts.
@@ -582,13 +582,13 @@ declare class Chart extends ResizeMixin(ThemableMixin(ElementMixin(HTMLElement))
   addEventListener<K extends keyof ChartEventMap>(
     type: K,
     listener: (this: Chart, ev: ChartEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof ChartEventMap>(
     type: K,
     listener: (this: Chart, ev: ChartEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -87,13 +87,13 @@ declare class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementM
   addEventListener<K extends keyof CheckboxGroupEventMap>(
     type: K,
     listener: (this: CheckboxGroup, ev: CheckboxGroupEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof CheckboxGroupEventMap>(
     type: K,
     listener: (this: CheckboxGroup, ev: CheckboxGroupEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -81,13 +81,13 @@ declare class Checkbox extends LabelMixin(
   addEventListener<K extends keyof CheckboxEventMap>(
     type: K,
     listener: (this: Checkbox, ev: CheckboxEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof CheckboxEventMap>(
     type: K,
     listener: (this: Checkbox, ev: CheckboxEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
@@ -20,7 +20,7 @@ export type ComboBoxDataProvider<TItem> = (
 
 export declare function ComboBoxDataProviderMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ComboBoxDataProviderMixinClass<TItem>>;
+): Constructor<ComboBoxDataProviderMixinClass<TItem>> & T;
 
 export declare class ComboBoxDataProviderMixinClass<TItem> {
   /**

--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -134,13 +134,13 @@ declare class ComboBoxLight<TItem = ComboBoxDefaultItem> extends HTMLElement {
   addEventListener<K extends keyof ComboBoxLightEventMap<TItem>>(
     type: K,
     listener: (this: ComboBoxLight<TItem>, ev: ComboBoxLightEventMap<TItem>[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof ComboBoxLightEventMap<TItem>>(
     type: K,
     listener: (this: ComboBoxLight<TItem>, ev: ComboBoxLightEventMap<TItem>[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -24,11 +24,11 @@ export type ComboBoxRenderer<TItem> = (
 
 export declare function ComboBoxMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<ComboBoxMixinClass<TItem>> &
+): Constructor<ComboBoxMixinClass<TItem>> &
   Constructor<DisabledMixinClass> &
   Constructor<InputMixinClass> &
-  Constructor<KeyboardMixinClass>;
+  Constructor<KeyboardMixinClass> &
+  T;
 
 export declare class ComboBoxMixinClass<TItem> {
   /**

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -221,13 +221,13 @@ declare class ComboBox<TItem = ComboBoxDefaultItem> extends HTMLElement {
   addEventListener<K extends keyof ComboBoxEventMap<TItem>>(
     type: K,
     listener: (this: ComboBox<TItem>, ev: ComboBoxEventMap<TItem>[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof ComboBoxEventMap<TItem>>(
     type: K,
     listener: (this: ComboBox<TItem>, ev: ComboBoxEventMap<TItem>[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/component-base/src/a11y-announcer.d.ts
+++ b/packages/component-base/src/a11y-announcer.d.ts
@@ -7,4 +7,4 @@
 /**
  * Cause a text string to be announced by screen readers.
  */
-export function announce(text: string, options?: { mode?: 'polite' | 'assertive' | 'alert'; timeout?: number }): void;
+export function announce(text: string, options?: { mode?: 'alert' | 'assertive' | 'polite'; timeout?: number }): void;

--- a/packages/component-base/src/active-mixin.d.ts
+++ b/packages/component-base/src/active-mixin.d.ts
@@ -18,7 +18,7 @@ import type { KeyboardMixinClass } from './keyboard-mixin.js';
  */
 export declare function ActiveMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ActiveMixinClass> & Constructor<DisabledMixinClass> & Constructor<KeyboardMixinClass>;
+): Constructor<ActiveMixinClass> & Constructor<DisabledMixinClass> & Constructor<KeyboardMixinClass> & T;
 
 export declare class ActiveMixinClass {
   /**

--- a/packages/component-base/src/controller-mixin.d.ts
+++ b/packages/component-base/src/controller-mixin.d.ts
@@ -11,7 +11,7 @@ import type { ReactiveController, ReactiveControllerHost } from 'lit';
  */
 export declare function ControllerMixin<T extends Constructor<HTMLElement>>(
   superclass: T,
-): T & Constructor<ControllerMixinClass>;
+): Constructor<ControllerMixinClass> & T;
 
 export declare class ControllerMixinClass
   implements Pick<ReactiveControllerHost, 'addController' | 'removeController'>

--- a/packages/component-base/src/dir-mixin.d.ts
+++ b/packages/component-base/src/dir-mixin.d.ts
@@ -8,7 +8,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 /**
  * A mixin to handle `dir` attribute based on the one set on the `<html>` element.
  */
-export declare function DirMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<DirMixinClass>;
+export declare function DirMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<DirMixinClass> & T;
 
 export declare class DirMixinClass {
   protected __getNormalizedScrollLeft(element: Element | null): number;

--- a/packages/component-base/src/element-mixin.d.ts
+++ b/packages/component-base/src/element-mixin.d.ts
@@ -13,7 +13,7 @@ import type { DirMixinClass } from './dir-mixin.js';
  */
 export declare function ElementMixin<T extends Constructor<HTMLElement>>(
   superclass: T,
-): T & Constructor<DirMixinClass> & Constructor<ElementMixinClass>;
+): Constructor<DirMixinClass> & Constructor<ElementMixinClass> & T;
 
 export declare class ElementMixinClass {
   static version: string;

--- a/packages/component-base/src/focus-mixin.d.ts
+++ b/packages/component-base/src/focus-mixin.d.ts
@@ -8,7 +8,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 /**
  * A mixin to handle `focused` and `focus-ring` attributes based on focus.
  */
-export declare function FocusMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<FocusMixinClass>;
+export declare function FocusMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<FocusMixinClass> & T;
 
 export declare class FocusMixinClass {
   protected readonly _keyboardActive: boolean;

--- a/packages/component-base/src/keyboard-mixin.d.ts
+++ b/packages/component-base/src/keyboard-mixin.d.ts
@@ -10,7 +10,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
  * The mixin subscribes to the keyboard events while an actual implementation
  * for the event handlers is left to the client (a component or another mixin).
  */
-export declare function KeyboardMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<KeyboardMixinClass>;
+export declare function KeyboardMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<KeyboardMixinClass> & T;
 
 export declare class KeyboardMixinClass {
   /**

--- a/packages/component-base/src/polylit-mixin.d.ts
+++ b/packages/component-base/src/polylit-mixin.d.ts
@@ -6,7 +6,7 @@
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { LitElement } from 'lit';
 
-export declare function PolylitMixin<T extends Constructor<LitElement>>(base: T): T & Constructor<PolylitMixinClass>;
+export declare function PolylitMixin<T extends Constructor<LitElement>>(base: T): Constructor<PolylitMixinClass> & T;
 
 export declare class PolylitMixinClass {
   ready(): void;

--- a/packages/component-base/src/resize-mixin.d.ts
+++ b/packages/component-base/src/resize-mixin.d.ts
@@ -8,7 +8,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 /**
  * A mixin that uses a ResizeObserver to listen to host size changes.
  */
-export declare function ResizeMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ResizeMixinClass>;
+export declare function ResizeMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<ResizeMixinClass> & T;
 
 export declare class ResizeMixinClass {
   /**

--- a/packages/component-base/src/slot-mixin.d.ts
+++ b/packages/component-base/src/slot-mixin.d.ts
@@ -8,7 +8,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 /**
  * A mixin to provide content for named slots defined by component.
  */
-export declare function SlotMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<SlotMixinClass>;
+export declare function SlotMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<SlotMixinClass> & T;
 
 export declare class SlotMixinClass {
   /**

--- a/packages/component-base/src/tabindex-mixin.d.ts
+++ b/packages/component-base/src/tabindex-mixin.d.ts
@@ -14,23 +14,23 @@ import type { DisabledMixinClass } from './disabled-mixin.js';
  */
 export declare function TabindexMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<DisabledMixinClass> & Constructor<TabindexMixinClass>;
+): Constructor<DisabledMixinClass> & Constructor<TabindexMixinClass> & T;
 
 export declare class TabindexMixinClass {
   /**
    * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
    */
-  tabindex: number | undefined | null;
+  tabindex: number | null | undefined;
 
   /**
    * Stores the last known tabindex since the element has been disabled.
    */
-  protected _lastTabIndex: number | undefined | null;
+  protected _lastTabIndex: number | null | undefined;
 
   /**
    * When the user has changed tabindex while the element is disabled,
    * the observer reverts tabindex to -1 and rather saves the new tabindex value to apply it later.
    * The new value will be applied as soon as the element becomes enabled.
    */
-  protected _tabindexChanged(tabindex: number | undefined | null): void;
+  protected _tabindexChanged(tabindex: number | null | undefined): void;
 }

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -22,7 +22,7 @@ export interface ConfirmDialogCustomEventMap {
   reject: Event;
 }
 
-export type ConfirmDialogEventMap = HTMLElementEventMap & ConfirmDialogCustomEventMap;
+export type ConfirmDialogEventMap = ConfirmDialogCustomEventMap & HTMLElementEventMap;
 
 /**
  * `<vaadin-confirm-dialog>` is a Web Component for showing alerts and asking for user confirmation.
@@ -149,13 +149,13 @@ declare class ConfirmDialog extends SlotMixin(ElementMixin(ThemePropertyMixin(HT
   addEventListener<K extends keyof ConfirmDialogEventMap>(
     type: K,
     listener: (this: ConfirmDialog, ev: ConfirmDialogEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof ConfirmDialogEventMap>(
     type: K,
     listener: (this: ConfirmDialog, ev: ConfirmDialogEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -289,13 +289,13 @@ declare class ContextMenu extends ElementMixin(ThemePropertyMixin(ItemsMixin(HTM
   addEventListener<K extends keyof ContextMenuEventMap>(
     type: K,
     listener: (this: ContextMenu, ev: ContextMenuEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof ContextMenuEventMap>(
     type: K,
     listener: (this: ContextMenu, ev: ContextMenuEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -9,10 +9,10 @@ import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
 
 export interface ContextMenuItem {
   text?: string;
-  component?: string | HTMLElement;
+  component?: HTMLElement | string;
   disabled?: boolean;
   checked?: boolean;
-  theme?: string | string[];
+  theme?: string[] | string;
   children?: ContextMenuItem[];
 }
 
@@ -37,7 +37,7 @@ declare global {
  */
 declare class ContextMenuListBox extends ListBox {}
 
-export declare function ItemsMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ItemsMixinClass>;
+export declare function ItemsMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<ItemsMixinClass> & T;
 
 export declare class ItemsMixinClass {
   /**

--- a/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
@@ -61,7 +61,7 @@ declare class CookieConsent extends ElementMixin(HTMLElement) {
    * For `top` and `bottom`, the banner is shown with full width. For the corner positions,
    * it is shown as a smaller popup.
    */
-  position: 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  position: 'bottom-left' | 'bottom-right' | 'bottom' | 'top-left' | 'top-right' | 'top';
 
   /**
    * The name of the cookie to set to remember that the user has consented.

--- a/packages/crud/src/vaadin-crud-include-mixin.d.ts
+++ b/packages/crud/src/vaadin-crud-include-mixin.d.ts
@@ -5,7 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
-export declare function IncludedMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<IncludedMixinClass>;
+export declare function IncludedMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<IncludedMixinClass> & T;
 
 export declare class IncludedMixinClass {
   /**
@@ -15,12 +15,12 @@ export declare class IncludedMixinClass {
    *
    * Default is to exclude any private property.
    */
-  exclude: string | RegExp | null;
+  exclude: RegExp | string | null;
 
   /**
    * A list of item properties that should be mapped to form fields.
    *
    * When it is defined [`exclude`](#/elements/vaadin-crud-form#property-exclude) is ignored.
    */
-  include: string | string[] | undefined;
+  include: string[] | string | undefined;
 }

--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -19,7 +19,7 @@ export type CrudDataProviderParams = {
 
 export type CrudDataProvider<T> = (params: CrudDataProviderParams, callback: CrudDataProviderCallback<T>) => void;
 
-export type CrudEditorPosition = '' | 'bottom' | 'aside';
+export type CrudEditorPosition = '' | 'aside' | 'bottom';
 
 export interface CrudI18n {
   newItem: string;
@@ -113,7 +113,7 @@ export type CrudCustomEventMap<T> = {
   save: CrudSaveEvent<T>;
 };
 
-export type CrudEventMap<T> = HTMLElementEventMap & CrudCustomEventMap<T>;
+export type CrudEventMap<T> = CrudCustomEventMap<T> & HTMLElementEventMap;
 
 /**
  * `<vaadin-crud>` is a Web Component for [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operations.
@@ -383,13 +383,13 @@ declare class Crud<Item> extends ControllerMixin(ElementMixin(ThemableMixin(HTML
   addEventListener<K extends keyof CrudEventMap<Item>>(
     type: K,
     listener: (this: Crud<Item>, ev: CrudEventMap<Item>[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof CrudEventMap<Item>>(
     type: K,
     listener: (this: Crud<Item>, ev: CrudEventMap<Item>[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -161,13 +161,13 @@ declare class CustomField extends FieldMixin(FocusMixin(ThemableMixin(ElementMix
   addEventListener<K extends keyof CustomFieldEventMap>(
     type: K,
     listener: (this: CustomField, ev: CustomFieldEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof CustomFieldEventMap>(
     type: K,
     listener: (this: CustomField, ev: CustomFieldEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/date-picker/src/vaadin-date-picker-light.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-light.d.ts
@@ -99,13 +99,13 @@ declare class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixi
   addEventListener<K extends keyof DatePickerLightEventMap>(
     type: K,
     listener: (this: DatePickerLight, ev: DatePickerLightEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof DatePickerLightEventMap>(
     type: K,
     listener: (this: DatePickerLight, ev: DatePickerLightEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -33,13 +33,13 @@ export interface DatePickerI18n {
 
 export declare function DatePickerMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<DatePickerMixinClass> &
+): Constructor<DatePickerMixinClass> &
   Constructor<DelegateFocusMixinClass> &
   Constructor<DisabledMixinClass> &
   Constructor<FocusMixinClass> &
   Constructor<InputMixinClass> &
-  Constructor<KeyboardMixinClass>;
+  Constructor<KeyboardMixinClass> &
+  T;
 
 export declare class DatePickerMixinClass {
   /**

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -146,13 +146,13 @@ declare class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin
   addEventListener<K extends keyof DatePickerEventMap>(
     type: K,
     listener: (this: DatePicker, ev: DatePickerEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof DatePickerEventMap>(
     type: K,
     listener: (this: DatePicker, ev: DatePickerEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -218,13 +218,13 @@ declare class DateTimePicker extends FieldMixin(
   addEventListener<K extends keyof DateTimePickerEventMap>(
     type: K,
     listener: (this: DateTimePicker, ev: DateTimePickerEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof DateTimePickerEventMap>(
     type: K,
     listener: (this: DateTimePicker, ev: DateTimePickerEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -16,7 +16,7 @@ export interface DetailsCustomEventMap {
   'opened-changed': DetailsOpenedChangedEvent;
 }
 
-export type DetailsEventMap = HTMLElementEventMap & DetailsCustomEventMap;
+export type DetailsEventMap = DetailsCustomEventMap & HTMLElementEventMap;
 
 /**
  * `<vaadin-details>` is a Web Component which the creates an
@@ -62,13 +62,13 @@ declare class Details extends ShadowFocusMixin(ElementMixin(ThemableMixin(HTMLEl
   addEventListener<K extends keyof DetailsEventMap>(
     type: K,
     listener: (this: Details, ev: DetailsEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof DetailsEventMap>(
     type: K,
     listener: (this: Details, ev: DetailsEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/dialog/src/lit/renderer-directives.d.ts
+++ b/packages/dialog/src/lit/renderer-directives.d.ts
@@ -15,7 +15,7 @@ declare abstract class AbstractDialogRendererDirective extends LitRendererDirect
   /**
    * A property to that the renderer callback will be assigned.
    */
-  abstract rendererProperty: 'renderer' | 'headerRenderer' | 'footerRenderer';
+  abstract rendererProperty: 'footerRenderer' | 'headerRenderer' | 'renderer';
 
   /**
    * Adds the renderer callback to the dialog.

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function DialogDraggableMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<DialogDraggableMixinClass>;
+): Constructor<DialogDraggableMixinClass> & T;
 
 export declare class DialogDraggableMixinClass {
   /**

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function DialogResizableMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<DialogResizableMixinClass>;
+): Constructor<DialogResizableMixinClass> & T;
 
 export declare class DialogResizableMixinClass {
   /**

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -16,7 +16,7 @@ export class DialogOverlay extends OverlayElement {}
 
 export type DialogRenderer = (root: HTMLElement, dialog?: Dialog) => void;
 
-export type DialogResizableDirection = 'n' | 'e' | 's' | 'w' | 'nw' | 'ne' | 'se' | 'sw';
+export type DialogResizableDirection = 'e' | 'n' | 'ne' | 'nw' | 's' | 'se' | 'sw' | 'w';
 
 export type DialogResizeDimensions = {
   width: string;
@@ -35,10 +35,10 @@ export type DialogOverlayBounds = {
 export type DialogOverlayBoundsParam =
   | DialogOverlayBounds
   | {
-      top?: string | number;
-      left?: string | number;
-      width?: string | number;
-      height?: string | number;
+      top?: number | string;
+      left?: number | string;
+      width?: number | string;
+      height?: number | string;
     };
 
 /**
@@ -57,7 +57,7 @@ export interface DialogCustomEventMap {
   resize: DialogResizeEvent;
 }
 
-export type DialogEventMap = HTMLElementEventMap & DialogCustomEventMap;
+export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
 
 /**
  * `<vaadin-dialog>` is a Web Component for creating customized modal dialogs.
@@ -208,13 +208,13 @@ declare class Dialog extends ThemePropertyMixin(ElementMixin(DialogDraggableMixi
   addEventListener<K extends keyof DialogEventMap>(
     type: K,
     listener: (this: Dialog, ev: DialogEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof DialogEventMap>(
     type: K,
     listener: (this: Dialog, ev: DialogEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/email-field/src/vaadin-email-field.d.ts
+++ b/packages/email-field/src/vaadin-email-field.d.ts
@@ -63,13 +63,13 @@ declare class EmailField extends TextField {
   addEventListener<K extends keyof EmailFieldEventMap>(
     type: K,
     listener: (this: EmailField, ev: EmailFieldEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof EmailFieldEventMap>(
     type: K,
     listener: (this: EmailField, ev: EmailFieldEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/field-base/src/checked-mixin.d.ts
+++ b/packages/field-base/src/checked-mixin.d.ts
@@ -13,11 +13,11 @@ import type { InputMixinClass } from './input-mixin.js';
  */
 export declare function CheckedMixin<T extends Constructor<object>>(
   base: T,
-): T &
-  Constructor<CheckedMixinClass> &
+): Constructor<CheckedMixinClass> &
   Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &
-  Constructor<InputMixinClass>;
+  Constructor<InputMixinClass> &
+  T;
 
 export declare class CheckedMixinClass {
   /**

--- a/packages/field-base/src/delegate-focus-mixin.d.ts
+++ b/packages/field-base/src/delegate-focus-mixin.d.ts
@@ -13,11 +13,11 @@ import type { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mix
  */
 export declare function DelegateFocusMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<DelegateFocusMixinClass> &
+): Constructor<DelegateFocusMixinClass> &
   Constructor<DisabledMixinClass> &
   Constructor<FocusMixinClass> &
-  Constructor<TabindexMixinClass>;
+  Constructor<TabindexMixinClass> &
+  T;
 
 export declare class DelegateFocusMixinClass {
   /**

--- a/packages/field-base/src/delegate-state-mixin.d.ts
+++ b/packages/field-base/src/delegate-state-mixin.d.ts
@@ -10,7 +10,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
  */
 export declare function DelegateStateMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<DelegateStateMixinClass>;
+): Constructor<DelegateStateMixinClass> & T;
 
 export declare class DelegateStateMixinClass {
   /**

--- a/packages/field-base/src/field-mixin.d.ts
+++ b/packages/field-base/src/field-mixin.d.ts
@@ -13,11 +13,11 @@ import type { ValidateMixinClass } from './validate-mixin.js';
  */
 export declare function FieldMixin<T extends Constructor<HTMLElement>>(
   superclass: T,
-): T &
-  Constructor<ControllerMixinClass> &
+): Constructor<ControllerMixinClass> &
   Constructor<FieldMixinClass> &
   Constructor<LabelMixinClass> &
-  Constructor<ValidateMixinClass>;
+  Constructor<ValidateMixinClass> &
+  T;
 
 export declare class FieldMixinClass {
   /**

--- a/packages/field-base/src/input-constraints-mixin.d.ts
+++ b/packages/field-base/src/input-constraints-mixin.d.ts
@@ -14,12 +14,12 @@ import type { ValidateMixinClass } from './validate-mixin.js';
  */
 export declare function InputConstraintsMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<DelegateStateMixinClass> &
+): Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &
   Constructor<InputConstraintsMixinClass> &
   Constructor<InputMixinClass> &
-  Constructor<ValidateMixinClass>;
+  Constructor<ValidateMixinClass> &
+  T;
 
 export declare class InputConstraintsMixinClass {
   /**

--- a/packages/field-base/src/input-control-mixin.d.ts
+++ b/packages/field-base/src/input-control-mixin.d.ts
@@ -21,8 +21,7 @@ import type { ValidateMixinClass } from './validate-mixin.js';
  */
 export declare function InputControlMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<ControllerMixinClass> &
+): Constructor<ControllerMixinClass> &
   Constructor<DelegateFocusMixinClass> &
   Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &
@@ -33,7 +32,8 @@ export declare function InputControlMixin<T extends Constructor<HTMLElement>>(
   Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<LabelMixinClass> &
-  Constructor<ValidateMixinClass>;
+  Constructor<ValidateMixinClass> &
+  T;
 
 export declare class InputControlMixinClass {
   /**

--- a/packages/field-base/src/input-field-mixin.d.ts
+++ b/packages/field-base/src/input-field-mixin.d.ts
@@ -22,8 +22,7 @@ import type { ValidateMixinClass } from './validate-mixin.js';
  */
 export declare function InputFieldMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<ControllerMixinClass> &
+): Constructor<ControllerMixinClass> &
   Constructor<DelegateFocusMixinClass> &
   Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &
@@ -35,7 +34,8 @@ export declare function InputFieldMixin<T extends Constructor<HTMLElement>>(
   Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<LabelMixinClass> &
-  Constructor<ValidateMixinClass>;
+  Constructor<ValidateMixinClass> &
+  T;
 
 export declare class InputFieldMixinClass {
   /**
@@ -52,7 +52,7 @@ export declare class InputFieldMixinClass {
    * on: Enable autocorrection.
    * off: Disable autocorrection.
    */
-  autocorrect: 'on' | 'off' | undefined;
+  autocorrect: 'off' | 'on' | undefined;
 
   /**
    * This is a property supported by Safari and Chrome that is used to control whether
@@ -63,5 +63,5 @@ export declare class InputFieldMixinClass {
    * sentences: Sentences capitalization.
    * none: No capitalization.
    */
-  autocapitalize: 'on' | 'off' | 'none' | 'characters' | 'words' | 'sentences' | undefined;
+  autocapitalize: 'characters' | 'none' | 'off' | 'on' | 'sentences' | 'words' | undefined;
 }

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -9,7 +9,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
  * A mixin to store the reference to an input element
  * and add input and change event listeners to it.
  */
-export declare function InputMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<InputMixinClass>;
+export declare function InputMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<InputMixinClass> & T;
 
 export declare class InputMixinClass {
   /**

--- a/packages/field-base/src/label-mixin.d.ts
+++ b/packages/field-base/src/label-mixin.d.ts
@@ -9,7 +9,7 @@ import type { LabelController } from './label-controller.js';
 /**
  * A mixin to provide label via corresponding property or named slot.
  */
-export declare function LabelMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<LabelMixinClass>;
+export declare function LabelMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<LabelMixinClass> & T;
 
 export declare class LabelMixinClass {
   /**

--- a/packages/field-base/src/pattern-mixin.d.ts
+++ b/packages/field-base/src/pattern-mixin.d.ts
@@ -15,13 +15,13 @@ import type { ValidateMixinClass } from './validate-mixin.js';
  */
 export declare function PatternMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<DelegateStateMixinClass> &
+): Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &
   Constructor<InputConstraintsMixinClass> &
   Constructor<InputMixinClass> &
   Constructor<PatternMixinClass> &
-  Constructor<ValidateMixinClass>;
+  Constructor<ValidateMixinClass> &
+  T;
 
 export declare class PatternMixinClass {
   /**

--- a/packages/field-base/src/shadow-focus-mixin.d.ts
+++ b/packages/field-base/src/shadow-focus-mixin.d.ts
@@ -15,9 +15,9 @@ import type { DelegateFocusMixinClass } from './delegate-focus-mixin.js';
  */
 export declare function ShadowFocusMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<DelegateFocusMixinClass> &
+): Constructor<DelegateFocusMixinClass> &
   Constructor<DisabledMixinClass> &
   Constructor<FocusMixinClass> &
   Constructor<KeyboardMixinClass> &
-  Constructor<TabindexMixinClass>;
+  Constructor<TabindexMixinClass> &
+  T;

--- a/packages/field-base/src/slot-styles-mixin.d.ts
+++ b/packages/field-base/src/slot-styles-mixin.d.ts
@@ -11,7 +11,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
  */
 export declare function SlotStylesMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<SlotStylesMixinClass>;
+): Constructor<SlotStylesMixinClass> & T;
 
 export declare class SlotStylesMixinClass {
   /**

--- a/packages/field-base/src/validate-mixin.d.ts
+++ b/packages/field-base/src/validate-mixin.d.ts
@@ -8,7 +8,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 /**
  * A mixin to provide required state and validation logic.
  */
-export declare function ValidateMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ValidateMixinClass>;
+export declare function ValidateMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<ValidateMixinClass> & T;
 
 export declare class ValidateMixinClass {
   /**

--- a/packages/field-base/src/virtual-keyboard-controller.d.ts
+++ b/packages/field-base/src/virtual-keyboard-controller.d.ts
@@ -10,5 +10,5 @@ import type { ReactiveController } from 'lit';
  * when the field's overlay is closed.
  */
 export class VirtualKeyboardController implements ReactiveController {
-  constructor(host: { inputElement?: HTMLElement; opened: boolean } & HTMLElement);
+  constructor(host: HTMLElement & { inputElement?: HTMLElement; opened: boolean });
 }

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -7,7 +7,7 @@
 import type { GridBodyRenderer, GridDefaultItem, GridItemModel } from '@vaadin/grid/src/vaadin-grid.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 
-export type GridProEditorType = 'text' | 'checkbox' | 'select' | 'custom';
+export type GridProEditorType = 'checkbox' | 'custom' | 'select' | 'text';
 
 /**
  * `<vaadin-grid-pro-edit-column>` is a helper element for the `<vaadin-grid-pro>`

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
@@ -8,7 +8,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function InlineEditingMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<InlineEditingMixinClass>;
+): Constructor<InlineEditingMixinClass> & T;
 
 export declare class InlineEditingMixinClass {
   /**

--- a/packages/grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro.d.ts
@@ -25,7 +25,7 @@ export type GridProItemPropertyChangedEvent<TItem> = CustomEvent<{
   index: number;
   item: TItem;
   path: string;
-  value: string | boolean;
+  value: boolean | string;
 }>;
 
 export interface GridProCustomEventMap<TItem> {
@@ -75,13 +75,13 @@ declare class GridPro<TItem = GridDefaultItem> extends Grid<TItem> {
   addEventListener<K extends keyof GridProEventMap<TItem>>(
     type: K,
     listener: (this: GridPro<TItem>, ev: GridProEventMap<TItem>[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof GridProEventMap<TItem>>(
     type: K,
     listener: (this: GridPro<TItem>, ev: GridProEventMap<TItem>[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/grid-pro/test/typings/grid-pro.types.ts
@@ -41,7 +41,7 @@ narrowedGrid.addEventListener('item-property-changed', (event) => {
   assertType<string>(event.detail.path);
   assertType<number>(event.detail.index);
   assertType<TestGridItem>(event.detail.item);
-  assertType<string | boolean>(event.detail.value);
+  assertType<boolean | string>(event.detail.value);
 });
 
 narrowedGrid.addEventListener('active-item-changed', (event) => {

--- a/packages/grid/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid/src/lit/column-renderer-directives.d.ts
@@ -27,7 +27,7 @@ declare abstract class AbstractGridColumnRendererDirective<R extends LitRenderer
   /**
    * A property to that the renderer callback will be assigned.
    */
-  abstract rendererProperty: 'renderer' | 'headerRenderer' | 'footerRenderer';
+  abstract rendererProperty: 'footerRenderer' | 'headerRenderer' | 'renderer';
 
   /**
    * Adds the renderer callback to the grid column.

--- a/packages/grid/src/vaadin-grid-active-item-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ActiveItemMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ActiveItemMixinClass<TItem>>;
+): Constructor<ActiveItemMixinClass<TItem>> & T;
 
 export declare class ActiveItemMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-array-data-provider-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-array-data-provider-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ArrayDataProviderMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ArrayDataProviderMixinClass<TItem>>;
+): Constructor<ArrayDataProviderMixinClass<TItem>> & T;
 
 export declare class ArrayDataProviderMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ColumnReorderingMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ColumnReorderingMixinClass>;
+): Constructor<ColumnReorderingMixinClass> & T;
 
 export declare class ColumnReorderingMixinClass {
   /**

--- a/packages/grid/src/vaadin-grid-column.d.ts
+++ b/packages/grid/src/vaadin-grid-column.d.ts
@@ -12,13 +12,13 @@ export type GridBodyRenderer<TItem> = (
   model: GridItemModel<TItem>,
 ) => void;
 
-export type GridColumnTextAlign = 'start' | 'center' | 'end' | null;
+export type GridColumnTextAlign = 'center' | 'end' | 'start' | null;
 
 export type GridHeaderFooterRenderer<TItem> = (root: HTMLElement, column: GridColumn<TItem>) => void;
 
 export declare function ColumnBaseMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ColumnBaseMixinClass<TItem>>;
+): Constructor<ColumnBaseMixinClass<TItem>> & T;
 
 export declare class ColumnBaseMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
@@ -58,7 +58,7 @@ export declare class ItemCache<TItem> {
 
 export declare function DataProviderMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<DataProviderMixinClass<TItem>>;
+): Constructor<DataProviderMixinClass<TItem>> & T;
 
 export declare class DataProviderMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.d.ts
@@ -8,13 +8,13 @@ import type { GridItemModel } from './vaadin-grid.js';
 
 export type GridDragAndDropFilter<TItem> = (model: GridItemModel<TItem>) => boolean;
 
-export type GridDropLocation = 'above' | 'on-top' | 'below' | 'empty';
+export type GridDropLocation = 'above' | 'below' | 'empty' | 'on-top';
 
-export type GridDropMode = 'between' | 'on-top' | 'on-top-or-between' | 'on-grid';
+export type GridDropMode = 'between' | 'on-grid' | 'on-top-or-between' | 'on-top';
 
 export declare function DragAndDropMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<DragAndDropMixinClass<TItem>>;
+): Constructor<DragAndDropMixinClass<TItem>> & T;
 
 export declare class DragAndDropMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-event-context-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-event-context-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { GridColumn } from './vaadin-grid-column.js';
 
 export interface GridEventContext<TItem> {
-  section?: 'body' | 'header' | 'footer' | 'details';
+  section?: 'body' | 'details' | 'footer' | 'header';
   item?: TItem;
   column?: GridColumn<TItem>;
   index?: number;
@@ -19,7 +19,7 @@ export interface GridEventContext<TItem> {
 
 export declare function EventContextMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<EventContextMixinClass<TItem>>;
+): Constructor<EventContextMixinClass<TItem>> & T;
 
 export declare class EventContextMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-filter.d.ts
+++ b/packages/grid/src/vaadin-grid-filter.d.ts
@@ -54,13 +54,13 @@ declare class GridFilter extends HTMLElement {
   addEventListener<K extends keyof GridFilterEventMap>(
     type: K,
     listener: (this: GridFilter, ev: GridFilterEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof GridFilterEventMap>(
     type: K,
     listener: (this: GridFilter, ev: GridFilterEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/grid/src/vaadin-grid-row-details-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.d.ts
@@ -14,7 +14,7 @@ export type GridRowDetailsRenderer<TItem> = (
 
 export declare function RowDetailsMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<RowDetailsMixinClass<TItem>>;
+): Constructor<RowDetailsMixinClass<TItem>> & T;
 
 export declare class RowDetailsMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-scroll-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.d.ts
@@ -5,7 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
-export declare function ScrollMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ScrollMixinClass>;
+export declare function ScrollMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<ScrollMixinClass> & T;
 
 export declare class ScrollMixinClass {
   /**

--- a/packages/grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column.d.ts
@@ -57,13 +57,13 @@ declare class GridSelectionColumn<TItem = GridDefaultItem> extends GridColumn<TI
   addEventListener<K extends keyof GridSelectionColumnEventMap>(
     type: K,
     listener: (this: GridSelectionColumn<TItem>, ev: GridSelectionColumnEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof GridSelectionColumnEventMap>(
     type: K,
     listener: (this: GridSelectionColumn<TItem>, ev: GridSelectionColumnEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/grid/src/vaadin-grid-selection-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function SelectionMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<SelectionMixinClass<TItem>>;
+): Constructor<SelectionMixinClass<TItem>> & T;
 
 export declare class SelectionMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-column.d.ts
@@ -49,13 +49,13 @@ declare class GridSortColumn<TItem = GridDefaultItem> extends GridColumn<TItem> 
   addEventListener<K extends keyof GridSortColumnEventMap>(
     type: K,
     listener: (this: GridSortColumn<TItem>, ev: GridSortColumnEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof GridSortColumnEventMap>(
     type: K,
     listener: (this: GridSortColumn<TItem>, ev: GridSortColumnEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/grid/src/vaadin-grid-sort-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-mixin.d.ts
@@ -5,7 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
-export declare function SortMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<SortMixinClass>;
+export declare function SortMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<SortMixinClass> & T;
 
 export declare class SortMixinClass {
   /**
@@ -28,5 +28,5 @@ export declare class SortMixinClass {
    *
    * @attr {string} multi-sort-priority
    */
-  multiSortPriority: 'prepend' | 'append';
+  multiSortPriority: 'append' | 'prepend';
 }

--- a/packages/grid/src/vaadin-grid-sorter.d.ts
+++ b/packages/grid/src/vaadin-grid-sorter.d.ts
@@ -76,13 +76,13 @@ declare class GridSorter extends ThemableMixin(DirMixin(HTMLElement)) {
   addEventListener<K extends keyof GridSorterEventMap>(
     type: K,
     listener: (this: GridSorter, ev: GridSorterEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof GridSorterEventMap>(
     type: K,
     listener: (this: GridSorter, ev: GridSorterEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/grid/src/vaadin-grid-styling-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-styling-mixin.d.ts
@@ -11,7 +11,7 @@ export type GridCellClassNameGenerator<TItem> = (column: GridColumn<TItem>, mode
 
 export declare function StylingMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<StylingMixinClass<TItem>>;
+): Constructor<StylingMixinClass<TItem>> & T;
 
 export declare class StylingMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-tree-toggle.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-toggle.d.ts
@@ -85,13 +85,13 @@ declare class GridTreeToggle extends ThemableMixin(DirMixin(HTMLElement)) {
   addEventListener<K extends keyof GridTreeToggleEventMap>(
     type: K,
     listener: (this: GridTreeToggle, ev: GridTreeToggleEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof GridTreeToggleEventMap>(
     type: K,
     listener: (this: GridTreeToggle, ev: GridTreeToggleEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -379,13 +379,13 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
   addEventListener<K extends keyof GridEventMap<TItem>>(
     type: K,
     listener: (this: Grid<TItem>, ev: GridEventMap<TItem>[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof GridEventMap<TItem>>(
     type: K,
     listener: (this: Grid<TItem>, ev: GridEventMap<TItem>[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -146,7 +146,7 @@ assertType<boolean | null | undefined>(narrowedGrid.loading);
 assertType<string | null | undefined>(narrowedGrid.itemIdPath);
 assertType<string>(narrowedGrid.itemHasChildrenPath);
 
-assertType<TestGridItem[] | undefined | null>(narrowedGrid.items);
+assertType<TestGridItem[] | null | undefined>(narrowedGrid.items);
 assertType<TestGridItem | null>(narrowedGrid.activeItem);
 assertType<boolean>(narrowedGrid.columnReorderingAllowed);
 
@@ -176,7 +176,7 @@ assertType<(arg0: TestGridItem) => void>(narrowedGrid.selectItem);
 assertType<(arg0: TestGridItem) => void>(narrowedGrid.deselectItem);
 
 assertType<boolean>(narrowedGrid.multiSort);
-assertType<'prepend' | 'append'>(narrowedGrid.multiSortPriority);
+assertType<'append' | 'prepend'>(narrowedGrid.multiSortPriority);
 
 assertType<GridCellClassNameGenerator<TestGridItem> | null | undefined>(narrowedGrid.cellClassNameGenerator);
 assertType<() => void>(narrowedGrid.generateCellClassNames);

--- a/packages/integer-field/src/vaadin-integer-field.d.ts
+++ b/packages/integer-field/src/vaadin-integer-field.d.ts
@@ -70,13 +70,13 @@ declare class IntegerField extends NumberField {
   addEventListener<K extends keyof IntegerFieldEventMap>(
     type: K,
     listener: (this: IntegerField, ev: IntegerFieldEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof IntegerFieldEventMap>(
     type: K,
     listener: (this: IntegerField, ev: IntegerFieldEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/item/src/vaadin-item-mixin.d.ts
+++ b/packages/item/src/vaadin-item-mixin.d.ts
@@ -15,11 +15,11 @@ import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js'
  */
 export declare function ItemMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T &
-  Constructor<ItemMixinClass> &
-  Constructor<ActiveMixinClass> &
+): Constructor<ActiveMixinClass> &
   Constructor<DisabledMixinClass> &
-  Constructor<FocusMixinClass>;
+  Constructor<FocusMixinClass> &
+  Constructor<ItemMixinClass> &
+  T;
 
 export declare class ItemMixinClass {
   value: string;

--- a/packages/list-box/src/vaadin-list-box.d.ts
+++ b/packages/list-box/src/vaadin-list-box.d.ts
@@ -65,13 +65,13 @@ declare class ListBox extends MultiSelectListMixin(ThemableMixin(ElementMixin(Co
   addEventListener<K extends keyof ListBoxEventMap>(
     type: K,
     listener: (this: ListBox, ev: ListBoxEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof ListBoxEventMap>(
     type: K,
     listener: (this: ListBox, ev: ListBoxEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/login/src/vaadin-login-form.d.ts
+++ b/packages/login/src/vaadin-login-form.d.ts
@@ -60,13 +60,13 @@ declare class LoginForm extends ElementMixin(ThemableMixin(LoginMixin(HTMLElemen
   addEventListener<K extends keyof LoginFormEventMap>(
     type: K,
     listener: (this: LoginForm, ev: LoginFormEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof LoginFormEventMap>(
     type: K,
     listener: (this: LoginForm, ev: LoginFormEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -24,7 +24,7 @@ export interface LoginI18n {
   additionalInformation?: string;
 }
 
-export declare function LoginMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<LoginMixinClass>;
+export declare function LoginMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<LoginMixinClass> & T;
 
 export declare class LoginMixinClass {
   /**

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -70,13 +70,13 @@ declare class LoginOverlay extends ElementMixin(ThemableMixin(LoginMixin(HTMLEle
   addEventListener<K extends keyof LoginOverlayEventMap>(
     type: K,
     listener: (this: LoginOverlay, ev: LoginOverlayEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof LoginOverlayEventMap>(
     type: K,
     listener: (this: LoginOverlay, ev: LoginOverlayEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.d.ts
@@ -8,7 +8,7 @@ import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.j
 
 export declare function ButtonsMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ButtonsMixinClass> & Constructor<ResizeMixinClass>;
+): Constructor<ButtonsMixinClass> & Constructor<ResizeMixinClass> & T;
 
 export declare class ButtonsMixinClass {
   protected readonly _buttons: HTMLElement[];

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function InteractionsMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<InteractionsMixinClass>;
+): Constructor<InteractionsMixinClass> & T;
 
 export declare class InteractionsMixinClass {
   /**

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -11,17 +11,17 @@ import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
 
 export interface MenuBarItem {
   text?: string;
-  component?: string | HTMLElement;
+  component?: HTMLElement | string;
   disabled?: boolean;
-  theme?: string | string[];
+  theme?: string[] | string;
   children?: SubMenuItem[];
 }
 
 export interface SubMenuItem {
   text?: string;
-  component?: string | HTMLElement;
+  component?: HTMLElement | string;
   disabled?: boolean;
-  theme?: string | string[];
+  theme?: string[] | string;
   checked?: boolean;
   children?: SubMenuItem[];
 }
@@ -138,13 +138,13 @@ declare class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(Eleme
   addEventListener<K extends keyof MenuBarEventMap>(
     type: K,
     listener: (this: MenuBar, ev: MenuBarEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof MenuBarEventMap>(
     type: K,
     listener: (this: MenuBar, ev: MenuBarEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 
   /**

--- a/packages/message-input/src/vaadin-message-input.d.ts
+++ b/packages/message-input/src/vaadin-message-input.d.ts
@@ -68,13 +68,13 @@ declare class MessageInput extends ThemableMixin(ElementMixin(HTMLElement)) {
   addEventListener<K extends keyof MessageInputEventMap>(
     type: K,
     listener: (this: MessageInput, ev: MessageInputEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof MessageInputEventMap>(
     type: K,
     listener: (this: MessageInput, ev: MessageInputEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -314,13 +314,13 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
   addEventListener<K extends keyof MultiSelectComboBoxEventMap<TItem>>(
     type: K,
     listener: (this: MultiSelectComboBox<TItem>, ev: MultiSelectComboBoxEventMap<TItem>[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof MultiSelectComboBoxEventMap<TItem>>(
     type: K,
     listener: (this: MultiSelectComboBox<TItem>, ev: MultiSelectComboBoxEventMap<TItem>[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/notification/src/vaadin-notification.d.ts
+++ b/packages/notification/src/vaadin-notification.d.ts
@@ -9,15 +9,15 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
 export type NotificationPosition =
-  | 'top-stretch'
-  | 'top-start'
-  | 'top-center'
-  | 'top-end'
-  | 'middle'
-  | 'bottom-start'
   | 'bottom-center'
   | 'bottom-end'
-  | 'bottom-stretch';
+  | 'bottom-start'
+  | 'bottom-stretch'
+  | 'middle'
+  | 'top-center'
+  | 'top-end'
+  | 'top-start'
+  | 'top-stretch';
 
 export type NotificationRenderer = (root: HTMLElement, notification?: Notification) => void;
 
@@ -121,7 +121,7 @@ declare class Notification extends ThemePropertyMixin(ElementMixin(HTMLElement))
    * @param contents the contents to show, either as a string or a Lit template.
    * @param options optional options for customizing the notification.
    */
-  static show(contents: string | TemplateResult, options?: ShowOptions): Notification;
+  static show(contents: TemplateResult | string, options?: ShowOptions): Notification;
 
   /**
    * The duration in milliseconds to show the notification.
@@ -171,13 +171,13 @@ declare class Notification extends ThemePropertyMixin(ElementMixin(HTMLElement))
   addEventListener<K extends keyof NotificationEventMap>(
     type: K,
     listener: (this: Notification, ev: NotificationEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof NotificationEventMap>(
     type: K,
     listener: (this: Notification, ev: NotificationEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -94,13 +94,13 @@ declare class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(
   addEventListener<K extends keyof NumberFieldEventMap>(
     type: K,
     listener: (this: NumberField, ev: NumberFieldEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof NumberFieldEventMap>(
     type: K,
     listener: (this: NumberField, ev: NumberFieldEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -101,13 +101,13 @@ declare class PasswordField extends SlotStylesMixin(TextField) {
   addEventListener<K extends keyof PasswordFieldEventMap>(
     type: K,
     listener: (this: PasswordField, ev: PasswordFieldEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof PasswordFieldEventMap>(
     type: K,
     listener: (this: PasswordField, ev: PasswordFieldEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/progress-bar/src/vaadin-progress-mixin.d.ts
+++ b/packages/progress-bar/src/vaadin-progress-mixin.d.ts
@@ -5,7 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
-export declare function ProgressMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ProgressMixinClass>;
+export declare function ProgressMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<ProgressMixinClass> & T;
 
 export declare class ProgressMixinClass {
   /**

--- a/packages/radio-group/src/vaadin-radio-button.d.ts
+++ b/packages/radio-group/src/vaadin-radio-button.d.ts
@@ -68,13 +68,13 @@ declare class RadioButton extends LabelMixin(
   addEventListener<K extends keyof RadioButtonEventMap>(
     type: K,
     listener: (this: RadioButton, ev: RadioButtonEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof RadioButtonEventMap>(
     type: K,
     listener: (this: RadioButton, ev: RadioButtonEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -96,13 +96,13 @@ declare class RadioGroup extends FieldMixin(
   addEventListener<K extends keyof RadioGroupEventMap>(
     type: K,
     listener: (this: RadioGroup, ev: RadioGroupEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof RadioGroupEventMap>(
     type: K,
     listener: (this: RadioGroup, ev: RadioGroupEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
@@ -181,13 +181,13 @@ declare class RichTextEditor extends ElementMixin(ThemableMixin(HTMLElement)) {
   addEventListener<K extends keyof RichTextEditorEventMap>(
     type: K,
     listener: (this: RichTextEditor, ev: RichTextEditorEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof RichTextEditorEventMap>(
     type: K,
     listener: (this: RichTextEditor, ev: RichTextEditorEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/scroller/src/vaadin-scroller.d.ts
+++ b/packages/scroller/src/vaadin-scroller.d.ts
@@ -27,7 +27,7 @@ declare class Scroller extends FocusMixin(ThemableMixin(ElementMixin(HTMLElement
    * This property indicates the scroll direction. Supported values are `vertical`, `horizontal`, `none`.
    * When `scrollDirection` is undefined scrollbars will be shown in both directions.
    */
-  scrollDirection: 'horizontal' | 'vertical' | 'none' | undefined;
+  scrollDirection: 'horizontal' | 'none' | 'vertical' | undefined;
 
   /**
    * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -255,13 +255,13 @@ declare class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(Themable
   addEventListener<K extends keyof SelectEventMap>(
     type: K,
     listener: (this: Select, ev: SelectEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof SelectEventMap>(
     type: K,
     listener: (this: Select, ev: SelectEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/split-layout/src/vaadin-split-layout.d.ts
+++ b/packages/split-layout/src/vaadin-split-layout.d.ts
@@ -165,13 +165,13 @@ declare class SplitLayout extends ElementMixin(ThemableMixin(HTMLElement)) {
   addEventListener<K extends keyof SplitLayoutEventMap>(
     type: K,
     listener: (this: SplitLayout, ev: SplitLayoutEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof SplitLayoutEventMap>(
     type: K,
     listener: (this: SplitLayout, ev: SplitLayoutEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/tabs/src/vaadin-tabs.d.ts
+++ b/packages/tabs/src/vaadin-tabs.d.ts
@@ -76,13 +76,13 @@ declare class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(HTML
   addEventListener<K extends keyof TabsEventMap>(
     type: K,
     listener: (this: Tabs, ev: TabsEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof TabsEventMap>(
     type: K,
     listener: (this: Tabs, ev: TabsEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -99,13 +99,13 @@ declare class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(Themable
   addEventListener<K extends keyof TextAreaEventMap>(
     type: K,
     listener: (this: TextArea, ev: TextAreaEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof TextAreaEventMap>(
     type: K,
     listener: (this: TextArea, ev: TextAreaEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -119,13 +119,13 @@ declare class TextField extends PatternMixin(InputFieldMixin(ThemableMixin(Eleme
   addEventListener<K extends keyof TextFieldEventMap>(
     type: K,
     listener: (this: TextField, ev: TextFieldEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof TextFieldEventMap>(
     type: K,
     listener: (this: TextField, ev: TextFieldEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -9,10 +9,10 @@ import { PatternMixin } from '@vaadin/field-base/src/pattern-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export interface TimePickerTime {
-  hours: string | number;
-  minutes: string | number;
-  seconds?: string | number;
-  milliseconds?: string | number;
+  hours: number | string;
+  minutes: number | string;
+  seconds?: number | string;
+  milliseconds?: number | string;
 }
 
 export interface TimePickerI18n {
@@ -206,13 +206,13 @@ declare class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(El
   addEventListener<K extends keyof TimePickerEventMap>(
     type: K,
     listener: (this: TimePicker, ev: TimePickerEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof TimePickerEventMap>(
     type: K,
     listener: (this: TimePicker, ev: TimePickerEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -401,13 +401,13 @@ declare class Upload extends ThemableMixin(ElementMixin(HTMLElement)) {
   addEventListener<K extends keyof UploadEventMap>(
     type: K,
     listener: (this: Upload, ev: UploadEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof UploadEventMap>(
     type: K,
     listener: (this: Upload, ev: UploadEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.d.ts
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.d.ts
@@ -8,7 +8,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 /**
  * A mixin for `nav` elements, facilitating navigation and selection of childNodes.
  */
-export declare function ListMixin<T extends Constructor<HTMLElement>>(base: T): T & Constructor<ListMixinClass>;
+export declare function ListMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<ListMixinClass> & T;
 
 export declare class ListMixinClass {
   /**

--- a/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.d.ts
+++ b/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.d.ts
@@ -11,7 +11,7 @@ import type { ListMixinClass } from './vaadin-list-mixin.js';
  */
 export declare function MultiSelectListMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ListMixinClass> & Constructor<ListMixinClass>;
+): Constructor<ListMixinClass> & Constructor<ListMixinClass> & T;
 
 export declare class MultiSelectListMixinClass {
   /**

--- a/packages/vaadin-overlay/src/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay.d.ts
@@ -232,13 +232,13 @@ declare class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(HTML
   addEventListener<K extends keyof OverlayEventMap>(
     type: K,
     listener: (this: OverlayElement, ev: OverlayEventMap[K]) => void,
-    options?: boolean | AddEventListenerOptions,
+    options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof OverlayEventMap>(
     type: K,
     listener: (this: OverlayElement, ev: OverlayEventMap[K]) => void,
-    options?: boolean | EventListenerOptions,
+    options?: EventListenerOptions | boolean,
   ): void;
 }
 

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.d.ts
@@ -12,7 +12,7 @@ import type { ThemePropertyMixinClass } from './vaadin-theme-property-mixin.js';
  */
 export declare function ThemableMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ThemableMixinClass> & Constructor<ThemePropertyMixinClass>;
+): Constructor<ThemableMixinClass> & Constructor<ThemePropertyMixinClass> & T;
 
 export declare class ThemableMixinClass {
   protected static finalize(): void;
@@ -30,7 +30,7 @@ type Theme = {
   themeFor: string;
   styles: CSSResult[];
   moduleId?: string;
-  include?: string | string[];
+  include?: string[] | string;
 };
 
 /**

--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
@@ -7,7 +7,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export declare function ThemePropertyMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): T & Constructor<ThemePropertyMixinClass>;
+): Constructor<ThemePropertyMixinClass> & T;
 
 export declare class ThemePropertyMixinClass {
   /**


### PR DESCRIPTION
## Description

The PR adds the following rules to the project's ESLint config:

- [x] @typescript-eslint/sort-type-union-intersection-members

Part of https://github.com/vaadin/eslint-config-vaadin/issues/16

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
