### PR TITLE
refactor: use modern startsWith(), endsWith()

### DIFF
--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1221,7 +1221,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
       // eslint-disable-next-line no-prototype-builtins
       if (jsonConfiguration.hasOwnProperty(attr)) {
         const targetProperty = jsonConfiguration[attr];
-        if (attr.indexOf('_fn_') === 0 && (typeof targetProperty === 'string' || targetProperty instanceof String)) {
+        if (attr.startsWith('_fn_') && (typeof targetProperty === 'string' || targetProperty instanceof String)) {
           try {
             // eslint-disable-next-line no-eval
             jsonConfiguration[attr.substr(4)] = eval(`(${targetProperty})`);
@@ -1766,7 +1766,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
       let style = '';
       if (this.hasAttribute('style')) {
         style = this.getAttribute('style');
-        if (style.charAt(style.length - 1) !== ';') {
+        if (!style.endsWith(';')) {
           style += ';';
         }
       }

--- a/packages/component-base/src/gestures.js
+++ b/packages/component-base/src/gestures.js
@@ -277,7 +277,7 @@ function _handleNative(ev) {
   }
   if (!ev[HANDLED_OBJ]) {
     ev[HANDLED_OBJ] = {};
-    if (type.slice(0, 5) === 'touch') {
+    if (type.startsWith('touch')) {
       const t = ev.changedTouches[0];
       if (type === 'touchstart') {
         // Only handle the first finger

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -89,9 +89,9 @@ function matchesThemeFor(themeFor, tagName) {
  */
 function getIncludePriority(moduleName = '') {
   let includePriority = 0;
-  if (moduleName.indexOf('lumo-') === 0 || moduleName.indexOf('material-') === 0) {
+  if (moduleName.startsWith('lumo-') || moduleName.startsWith('material-')) {
     includePriority = 1;
-  } else if (moduleName.indexOf('vaadin-') === 0) {
+  } else if (moduleName.startsWith('vaadin-')) {
     includePriority = 2;
   }
   return includePriority;


### PR DESCRIPTION
## Description

This PR simplifies some JS conditions by using `startsWith()`, `endsWith()`.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
