### PR TITLE
refactor: cleanup duplicate custom CSS properties

### DIFF
--- a/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js
+++ b/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js
@@ -12,14 +12,6 @@ registerStyles(
       --vaadin-avatar-size: var(--lumo-size-m);
     }
 
-    :host([theme~='small']) {
-      --vaadin-avatar-size: var(--lumo-size-s);
-    }
-
-    :host([theme~='xsmall']) {
-      --vaadin-avatar-size: var(--lumo-size-xs);
-    }
-
     :host([theme~='xlarge']) {
       --vaadin-avatar-group-overlap: 12px;
       --vaadin-avatar-group-overlap-border: 3px;


### PR DESCRIPTION
## Description

While reviewing #4106, I noticed that Lumo has duplicate custom CSS properties for `small` and `xsmall` variants:

https://github.com/vaadin/web-components/blob/abd49eb4a8076aca7f48ccd9dc554893a7b8124f/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js#L15-L17

https://github.com/vaadin/web-components/blob/abd49eb4a8076aca7f48ccd9dc554893a7b8124f/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js#L38

https://github.com/vaadin/web-components/blob/abd49eb4a8076aca7f48ccd9dc554893a7b8124f/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js#L19-L21

https://github.com/vaadin/web-components/blob/abd49eb4a8076aca7f48ccd9dc554893a7b8124f/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js#L44

## Type of change

- Refactor