### PR TITLE
fix: check data provider in selection column before using it

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column.js
+++ b/packages/grid/src/vaadin-grid-selection-column.js
@@ -259,7 +259,7 @@ class GridSelectionColumn extends GridColumn {
   /** @private */
   __onSelectedItemsChanged() {
     this._selectAllChangeLock = true;
-    if (Array.isArray(this._grid.items)) {
+    if (Array.isArray(this._grid.items) && this._grid.dataProvider) {
       this.__withFilteredItemsArray((items) => {
         if (!this._grid.selectedItems.length) {
           this.selectAll = false;

--- a/packages/grid/test/selection-column-lazy-import.test.js
+++ b/packages/grid/test/selection-column-lazy-import.test.js
@@ -1,0 +1,13 @@
+import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+
+it('should not throw when grid with items imported lazily after selection column', async () => {
+  fixtureSync(`
+    <vaadin-grid items="[]">
+      <vaadin-grid-selection-column></vaadin-grid-selection-column>
+    </vaadin-grid>
+  `);
+
+  // The order of imports matters in this test
+  await import('../vaadin-grid-selection-column.js');
+  await import('../vaadin-grid.js');
+});


### PR DESCRIPTION
If `vaadin-grid-selection-column` is defined before `vaadin-grid` and the grid has an `items` array, the "selected-items-changed" event listener in `vaadin-grid-selection-column` throws an error.

The error happens because the initial "selected-items-changed" event gets dispatched before a `dataProvider` has been generated for the `items` array, while the `<vaadin-grid>` is being upgraded.