### PR TITLE
refactor: cleanup duplicate cell content style

### DIFF
--- a/packages/crud/theme/lumo/vaadin-crud-styles.js
+++ b/packages/crud/theme/lumo/vaadin-crud-styles.js
@@ -117,10 +117,6 @@ registerStyles(
       :host([dir='rtl']:not([theme~='no-border'])[editor-position='aside']) [part='editor']:not([hidden]) {
         border-right: 0;
       }
-
-      vaadin-grid-cell-content {
-        text-overflow: ellipsis;
-      }
     `,
   ],
   { moduleId: 'lumo-crud' },


### PR DESCRIPTION
## Description

This CSS is no longer needed: it was added to `vaadin-crud` in https://github.com/vaadin/vaadin-crud/pull/59 but then corresponding code has been moved to `vaadin-grid` itself as part of https://github.com/vaadin/vaadin-grid/pull/1446. Let's remove it from `vaadin-crud` theme.

## Type of change

- Refactor