### PR TITLE
fix: prevent initial validation when the field is initialized as invalid

### DIFF
--- a/packages/email-field/test/email-field.test.js
+++ b/packages/email-field/test/email-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-email-field.js';
 
@@ -93,6 +93,40 @@ describe('email-field', () => {
 
     it('should not remove "invalid" state when ready', () => {
       expect(field.invalid).to.be.true;
+    });
+  });
+
+  describe('initial validation', () => {
+    let field, validateSpy;
+
+    beforeEach(() => {
+      field = document.createElement('vaadin-email-field');
+      validateSpy = sinon.spy(field, 'validate');
+    });
+
+    afterEach(() => {
+      field.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(field);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      field.value = 'foo@example.com';
+      document.body.appendChild(field);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      field.value = 'foo@example.com';
+      field.invalid = true;
+      document.body.appendChild(field);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
     });
   });
 

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -112,14 +112,20 @@ export const InputFieldMixin = (superclass) =>
     }
 
     /**
-     * Override a method from `InputMixin` to validate the field
+     * Override an observer from `InputMixin` to validate the field
      * when a new value is set programmatically.
-     * @param {string} value
+     *
+     * @param {string | undefined} newValue
+     * @param {string | undefined} oldValue
      * @protected
      * @override
      */
-    _forwardInputValue(value) {
-      super._forwardInputValue(value);
+    _valueChanged(newValue, oldValue) {
+      super._valueChanged(newValue, oldValue);
+
+      if (oldValue === undefined) {
+        return;
+      }
 
       if (this.invalid) {
         this.validate();

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -64,6 +64,34 @@ describe('input-field-mixin', () => {
     it('should propagate autocapitalize property to the input', () => {
       element.autocapitalize = 'none';
       expect(input.getAttribute('autocapitalize')).to.equal('none');
+    });
+  });
+
+  describe('initial validation', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      element = document.createElement('input-field-mixin-element');
+      validateSpy = sinon.spy(element, 'validate');
+    });
+
+    afterEach(() => {
+      element.remove();
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      element.value = 'Initial Value';
+      document.body.appendChild(element);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      element.value = 'Initial Value';
+      element.invalid = true;
+      document.body.appendChild(element);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
     });
   });
 

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
+import { fixtureSync, keyDownOn, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-integer-field.js';
 
@@ -221,6 +221,40 @@ describe('integer-field', () => {
         expect(integerField.step).to.be.null;
         expect(console.warn.called).to.be.false;
       });
+    });
+  });
+
+  describe('initial validation', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      integerField = document.createElement('vaadin-integer-field');
+      validateSpy = sinon.spy(integerField, 'validate');
+    });
+
+    afterEach(() => {
+      integerField.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(integerField);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      integerField.value = 2;
+      document.body.appendChild(integerField);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      integerField.value = 2;
+      integerField.invalid = true;
+      document.body.appendChild(integerField);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
     });
   });
 

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -243,14 +243,14 @@ describe('integer-field', () => {
     });
 
     it('should not validate when the field has an initial value', async () => {
-      integerField.value = 2;
+      integerField.value = '2';
       document.body.appendChild(integerField);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
     it('should not validate when the field has an initial value and invalid', async () => {
-      integerField.value = 2;
+      integerField.value = '2';
       integerField.invalid = true;
       document.body.appendChild(integerField);
       await nextRender();

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-number-field.js';
 
@@ -134,6 +134,40 @@ describe('validation', () => {
       expect(validatedSpy.calledOnce).to.be.true;
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
+    });
+  });
+
+  describe('initial', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      field = document.createElement('vaadin-number-field');
+      validateSpy = sinon.spy(field, 'validate');
+    });
+
+    afterEach(() => {
+      field.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(field);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      field.value = 2;
+      document.body.appendChild(field);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      field.value = 2;
+      field.invalid = true;
+      document.body.appendChild(field);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
     });
   });
 

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -156,14 +156,14 @@ describe('validation', () => {
     });
 
     it('should not validate when the field has an initial value', async () => {
-      field.value = 2;
+      field.value = '2';
       document.body.appendChild(field);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
     it('should not validate when the field has an initial value and invalid', async () => {
-      field.value = 2;
+      field.value = '2';
       field.invalid = true;
       document.body.appendChild(field);
       await nextRender();

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, focusout, makeSoloTouchEvent, mousedown } from '@vaadin/testing-helpers';
+import { fixtureSync, focusout, makeSoloTouchEvent, mousedown, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-password-field.js';
@@ -177,6 +177,40 @@ describe('password-field', () => {
     it('should remove aria-hidden attribute when revealButtonHidden set to false', () => {
       passwordField.revealButtonHidden = false;
       expect(revealButton.hasAttribute('aria-hidden')).to.be.false;
+    });
+  });
+
+  describe('initial validation', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      passwordField = document.createElement('vaadin-password-field');
+      validateSpy = sinon.spy(passwordField, 'validate');
+    });
+
+    afterEach(() => {
+      passwordField.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(passwordField);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      passwordField.value = 'Initial Value';
+      document.body.appendChild(passwordField);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      passwordField.value = 'Initial Value';
+      passwordField.invalid = true;
+      document.body.appendChild(passwordField);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
     });
   });
 

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-text-area.js';
 
@@ -113,6 +113,40 @@ describe('text-area', () => {
       it('should update has-value attribute when boolean value is set', () => {
         textArea.value = false;
         expect(textArea.hasAttribute('has-value')).to.be.true;
+      });
+    });
+
+    describe('initial validation', () => {
+      let validateSpy;
+
+      beforeEach(() => {
+        textArea = document.createElement('vaadin-text-area');
+        validateSpy = sinon.spy(textArea, 'validate');
+      });
+
+      afterEach(() => {
+        textArea.remove();
+      });
+
+      it('should not validate by default', async () => {
+        document.body.appendChild(textArea);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value', async () => {
+        textArea.value = 'Initial Value';
+        document.body.appendChild(textArea);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value and invalid', async () => {
+        textArea.value = 'Initial Value';
+        textArea.invalid = true;
+        document.body.appendChild(textArea);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
       });
     });
 

--- a/packages/text-field/test/text-field.test.js
+++ b/packages/text-field/test/text-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-text-field.js';
 
@@ -164,6 +164,40 @@ describe('text-field', () => {
         input.dispatchEvent(new CustomEvent('focus', { bubbles: false }));
         await aTimeout(1);
         expect(input.selectionEnd - input.selectionStart).to.equal(3);
+      });
+    });
+
+    describe('initial validation', () => {
+      let validateSpy;
+
+      beforeEach(() => {
+        textField = document.createElement('vaadin-text-field');
+        validateSpy = sinon.spy(textField, 'validate');
+      });
+
+      afterEach(() => {
+        textField.remove();
+      });
+
+      it('should not validate by default', async () => {
+        document.body.appendChild(textField);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value', async () => {
+        textField.value = 'Initial Value';
+        document.body.appendChild(textField);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value and invalid', async () => {
+        textField.value = 'Initial Value';
+        textField.invalid = true;
+        document.body.appendChild(textField);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
       });
     });
 


### PR DESCRIPTION
## Description

The PR prevents the initial validation that could previously take place when the field is initially provided with a non-empty value and is initially marked `invalid`: 

```js
const textField = document.createElement('vaadin-text-field');
textField.value = 'Initial Value';
textField.invalid = true;
document.appendChild(textField);
```

The initial validation is problematic because it fires a `validated` event that may result in an `invalid` state reset on the Flow side, see https://github.com/vaadin/flow-components/pull/3429#issuecomment-1177365424 for a more detailed case.

Part of https://github.com/vaadin/web-components/issues/4150

## Covered components

 This PR only fixes the issue for the components that extend `InputFieldMixin`:

- [x] text-field
- [x] email-field
- [x] password-field
- [x] text-area
- [x] number-field
- [x] integer-field

Other components will be covered in the next PRs.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
