### PR TITLE
fix: clear selection when using `clear()` method

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -304,6 +304,11 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
   clearCache(): void;
 
   /**
+   * Clears the selected items.
+   */
+  clear(): void;
+
+  /**
    * Requests an update for the content of items.
    * While performing the update, it invokes the renderer (passed in the `renderer` property) once an item.
    *

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -511,7 +511,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /**
-   * Clear the selected items.
+   * Clears the selected items.
    */
   clear() {
     this.__updateSelection([]);

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -511,6 +511,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /**
+   * Clear the selected items.
+   */
+  clear() {
+    this.__updateSelection([]);
+
+    announce(this.i18n.cleared);
+  }
+
+  /**
    * Clears the cached pages and reloads data from data provider when needed.
    */
   clearCache() {
@@ -895,9 +904,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   _onClearButtonClick(event) {
     event.stopPropagation();
 
-    this.__updateSelection([]);
-
-    announce(this.i18n.cleared);
+    this.clear();
   }
 
   /**

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -170,6 +170,17 @@ describe('accessibility', () => {
       expect(region.textContent).to.equal('Selection cleared');
     });
 
+    it('should announce when using clear() method', () => {
+      comboBox.selectedItems = [apple, banana, lemon];
+      comboBox.clearButtonVisible = true;
+
+      comboBox.clear();
+
+      clock.tick(150);
+
+      expect(region.textContent).to.equal('Selection cleared');
+    });
+
     it('should announce when focusing a chip with keyboard', async () => {
       comboBox.selectedItems = [apple];
 

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -104,6 +104,12 @@ describe('selecting items', () => {
       await sendKeys({ down: 'Tab' });
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
+
+    it('should un-select item when using clear() method', () => {
+      comboBox.selectedItems = ['orange'];
+      comboBox.clear();
+      expect(comboBox.selectedItems).to.deep.equal([]);
+    });
   });
 
   describe('dataProvider', () => {


### PR DESCRIPTION
## Description

The `clear()` method in `vaadin-multi-select-combo-box` is inherited from `InputControlMixin` and not overridden.
Its current behavior is quite confusing: when the MSC has items selected, calling `clear()` does nothing.

Let's update the logic and override this method to make it work same as in regular `vaadin-combo-box`.

## Type of change

- Bugfix