### PR TITLE
fix: clear selection on clear button touchend

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -198,7 +198,13 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
             ></vaadin-multi-select-combo-box-chip>
             <div id="chips" part="chips" slot="prefix"></div>
             <slot name="input"></slot>
-            <div id="clearButton" part="clear-button" slot="suffix" aria-hidden="true"></div>
+            <div
+              id="clearButton"
+              part="clear-button"
+              slot="suffix"
+              on-touchend="_onClearButtonTouchend"
+              aria-hidden="true"
+            ></div>
             <div id="toggleButton" class="toggle-button" part="toggle-button" slot="suffix" aria-hidden="true"></div>
           </vaadin-multi-select-combo-box-container>
         </vaadin-multi-select-combo-box-internal>
@@ -894,6 +900,14 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     }
 
     this._overflowItems = items;
+  }
+
+  /** @private */
+  _onClearButtonTouchend(event) {
+    // Cancel the following click and focus events
+    event.preventDefault();
+
+    this.clear();
   }
 
   /**

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -218,6 +218,19 @@ describe('basic', () => {
       await sendKeys({ press: 'Escape' });
       expect(comboBox.selectedItems).to.deep.equal(['apple', 'orange']);
     });
+
+    it('should prevent default for touchend event on clear button', () => {
+      comboBox.selectedItems = ['apple', 'orange'];
+      const event = new CustomEvent('touchend', { cancelable: true });
+      clearButton.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should clear selected items on clear button touchend', () => {
+      comboBox.selectedItems = ['apple', 'orange'];
+      clearButton.dispatchEvent(new CustomEvent('touchend', { cancelable: true }));
+      expect(comboBox.selectedItems).to.deep.equal([]);
+    });
   });
 
   describe('chips', () => {


### PR DESCRIPTION
## Description

Fixes #4129
Depends on #4140

Created a separate event listener for clear button `touchend` event to call `clear()` on the host element.
The internal combo-box also has a `touchend` listener, but it only clears `<input>` value.

We might simplify this logic in the future as part of #4130 by moving the listener to `InputControlMixin`.

## Type of change

- Bugfix