### PR TITLE
refactor!: remove `value` from API docs and typings

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -328,7 +328,7 @@ interface MultiSelectComboBox
   extends ValidateMixinClass,
     LabelMixinClass,
     KeyboardMixinClass,
-    InputMixinClass,
+    Omit<InputMixinClass, 'value'>,
     InputControlMixinClass,
     InputConstraintsMixinClass,
     FocusMixinClass,

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -427,6 +427,11 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       filteredItems: Array,
 
       /** @private */
+      value: {
+        type: String,
+      },
+
+      /** @private */
       __effectiveItems: {
         type: Array,
         computed: '__computeEffectiveItems(items, selectedItems, readonly)',

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -100,7 +100,7 @@ assertType<FieldMixinClass>(narrowedComboBox);
 assertType<FocusMixinClass>(narrowedComboBox);
 assertType<InputConstraintsMixinClass>(narrowedComboBox);
 assertType<InputControlMixinClass>(narrowedComboBox);
-assertType<InputMixinClass>(narrowedComboBox);
+assertType<Omit<InputMixinClass, 'value'>>(narrowedComboBox);
 assertType<KeyboardMixinClass>(narrowedComboBox);
 assertType<LabelMixinClass>(narrowedComboBox);
 assertType<ValidateMixinClass>(narrowedComboBox);


### PR DESCRIPTION
## Description

The `value` property in `vaadin-multi-select-combo-box` is inherited from `InputControlMixin` that wraps `InputMixin`.
Currently, it's listed in the [API docs](https://cdn.vaadin.com/vaadin-web-components/23.2.0-alpha3/index.html#/elements/vaadin-multi-select-combo-box) and shown in TS code completion, which might be confusing.

Let's consider removing `value` from public API of the component to make it possible to drop it in the next major.

## Type of change

- Refactor