### PR TITLE
fix: check if input is focused instead of using attribute

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -186,7 +186,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
         filteredItems.splice(params.page * params.pageSize, items.length, ...items);
         this.filteredItems = filteredItems;
 
-        if (!this.opened && !this.hasAttribute('focused')) {
+        if (!this.opened && !this._isInputFocused()) {
           this._commitValue();
         }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -732,7 +732,7 @@ export const ComboBoxMixin = (subclass) =>
       // and there's no need to modify the selection range if the input isn't focused anyway.
       // This affects Safari. When the overlay is open, and then hitting tab, browser should focus
       // the next focusable element instead of the combo-box itself.
-      if (this._isInputFocused()) {
+      if (this._isInputFocused() && this.inputElement.setSelectionRange) {
         this.inputElement.setSelectionRange(start, end);
       }
     }

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -6,6 +6,7 @@
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
+import { isElementFocused } from '@vaadin/component-base/src/focus-utils.js';
 import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
@@ -511,6 +512,11 @@ export const ComboBoxMixin = (subclass) =>
       this._updateActiveDescendant(index);
     }
 
+    /** @protected */
+    _isInputFocused() {
+      return this.inputElement && isElementFocused(this.inputElement);
+    }
+
     /** @private */
     _updateActiveDescendant(index) {
       const input = this.inputElement;
@@ -537,14 +543,14 @@ export const ComboBoxMixin = (subclass) =>
         this._openedWithFocusRing = this.hasAttribute('focus-ring');
         // For touch devices, we don't want to popup virtual keyboard
         // unless input element is explicitly focused by the user.
-        if (!this.hasAttribute('focused') && !isTouch) {
+        if (!this._isInputFocused() && !isTouch) {
           this.focus();
         }
 
         this.$.overlay.restoreFocusOnClose = true;
       } else {
         this._onClosed();
-        if (this._openedWithFocusRing && this.hasAttribute('focused')) {
+        if (this._openedWithFocusRing && this._isInputFocused()) {
           this.setAttribute('focus-ring', '');
         }
       }
@@ -726,8 +732,7 @@ export const ComboBoxMixin = (subclass) =>
       // and there's no need to modify the selection range if the input isn't focused anyway.
       // This affects Safari. When the overlay is open, and then hitting tab, browser should focus
       // the next focusable element instead of the combo-box itself.
-      // Checking the focused property here is enough instead of checking the activeElement.
-      if (this.hasAttribute('focused')) {
+      if (this._isInputFocused()) {
         this.inputElement.setSelectionRange(start, end);
       }
     }
@@ -837,7 +842,7 @@ export const ComboBoxMixin = (subclass) =>
         toggleElement.addEventListener('mousedown', (e) => e.preventDefault());
         // Unfocus previously focused element if focus is not inside combo box (on touch devices)
         toggleElement.addEventListener('click', () => {
-          if (isTouch && !this.hasAttribute('focused')) {
+          if (isTouch && !this._isInputFocused()) {
             document.activeElement.blur();
           }
         });

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -589,11 +589,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       this._focusedChipIndex = -1;
       this.validate();
     }
-
-    // Propagate focused attribute to internal combo box
-    if (this.$ && this.$.comboBox) {
-      this.$.comboBox.toggleAttribute('focused', focused);
-    }
   }
 
   /**

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -149,14 +149,6 @@ describe('basic', () => {
         combo.clearCache();
       }).to.not.throw(Error);
     });
-
-    it('should propagate focused attribute to combo-box', () => {
-      expect(internal.hasAttribute('focused')).to.be.false;
-      comboBox.focus();
-      expect(internal.hasAttribute('focused')).to.be.true;
-      comboBox.blur();
-      expect(internal.hasAttribute('focused')).to.be.false;
-    });
   });
 
   describe('pageSize', () => {

--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -162,6 +162,7 @@ describe('keyboard navigation', () => {
     beforeEach(() => {
       timePicker.step = 1800;
       timePicker.value = '02:00';
+      inputElement.focus();
       comboBox.opened = true;
     });
 
@@ -173,6 +174,18 @@ describe('keyboard navigation', () => {
     it('should not change the value on arrow down', () => {
       arrowDown(inputElement);
       expect(timePicker.value).to.be.equal('02:00');
+    });
+
+    it('should select the input field on arrow up', () => {
+      arrowUp(inputElement);
+      expect(inputElement.selectionStart).to.eql(0);
+      expect(inputElement.selectionEnd).to.eql(5);
+    });
+
+    it('should select the input field on arrow down', () => {
+      arrowDown(inputElement);
+      expect(inputElement.selectionStart).to.eql(0);
+      expect(inputElement.selectionEnd).to.eql(5);
     });
 
     it('should not call __onArrowPressWithStep on arrow down/up', () => {


### PR DESCRIPTION
## Description

Fixes #4151

Checking for `activeElement` is necessary in order to avoid relying on `focused` attribute here:

https://github.com/vaadin/web-components/blob/1e3728b378deb126c1f680276509d8b361f55552/packages/combo-box/src/vaadin-combo-box-mixin.js#L839-L842

Unfortunately, we don't currently have a setup to run tests that rely on touch devices, so no test 😕 

This also reverts #3971 as no longer necessary, as `ComboBoxDataProviderMixin` is also updated.

## Type of change

- Bugfix