### PR TITLE
fix: prevent initial validation when checkbox-group is initialized as invalid

### DIFF
--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -303,15 +303,14 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
 
   /**
    * @param {string | null | undefined} value
+   * @param {string | null | undefined} oldValue
    * @private
    */
-  __valueChanged(value) {
+  __valueChanged(value, oldValue) {
     // Setting initial value to empty array, skip validation
-    if (value.length === 0 && this.__oldValue === undefined) {
+    if (value.length === 0 && oldValue === undefined) {
       return;
     }
-
-    this.__oldValue = value;
 
     this.toggleAttribute('has-value', value.length > 0);
 
@@ -319,7 +318,9 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
       checkbox.checked = value.includes(checkbox.value);
     });
 
-    this.validate();
+    if (oldValue !== undefined) {
+      this.validate();
+    }
   }
 
   /**

--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-checkbox-group.js';
@@ -459,6 +459,40 @@ describe('vaadin-checkbox-group', () => {
       expect(aria).to.include(helper.id);
       expect(aria).to.include(error.id);
       expect(aria).to.include(label.id);
+    });
+  });
+
+  describe('initial validation', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      group = document.createElement('vaadin-checkbox-group');
+      validateSpy = sinon.spy(group, 'validate');
+    });
+
+    afterEach(() => {
+      group.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      group.value = ['en'];
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      group.value = ['en'];
+      group.invalid = true;
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

The PR prevents the initial validation that could previously take place when `checkbox-group` is initially provided with a non-empty value and is initially marked `invalid`.

Part of https://github.com/vaadin/web-components/issues/4150

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
