### PR TITLE
refactor: remove no longer used event prevention

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -413,11 +413,6 @@ export const ComboBoxMixin = (subclass) =>
       // Prevent blurring the input when clicking inside the overlay
       overlay.addEventListener('mousedown', (e) => e.preventDefault());
 
-      // Preventing the default modal behavior of the overlay on input click
-      overlay.addEventListener('vaadin-overlay-outside-click', (e) => {
-        e.preventDefault();
-      });
-
       // Manual two-way binding for the overlay "opened" property
       overlay.addEventListener('opened-changed', (e) => {
         this._overlayOpened = e.detail.value;


### PR DESCRIPTION
## Description

The combo-box overlay no longer fires `vaadin-overlay-outside-click` event because the `_outsideClickListener` that [fires it](https://github.com/vaadin/web-components/blob/1cf10c0504a9f531914d8611bf6bc1c27a087af8/packages/vaadin-overlay/src/vaadin-overlay.js#L495) was overridden in #2497 based on my suggestion from https://github.com/vaadin/web-components/pull/2497#pullrequestreview-751218241. So this code can be removed.

## Type of change

- Refactor