### PR TITLE
fix!: prevent initial validation when radio-group is initialized as invalid

### DIFF
--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -129,6 +129,7 @@ class RadioGroup extends FieldMixin(
       value: {
         type: String,
         notify: true,
+        value: '',
         observer: '__valueChanged',
       },
 
@@ -340,25 +341,28 @@ class RadioGroup extends FieldMixin(
    * @private
    */
   __valueChanged(newValue, oldValue) {
-    if (!oldValue && !newValue) {
+    if (oldValue === undefined && newValue === '') {
       return;
     }
 
-    if (oldValue && !newValue) {
+    if (newValue) {
+      const newSelectedRadioButton = this.__radioButtons.find((radioButton) => {
+        return radioButton.value === newValue;
+      });
+
+      if (newSelectedRadioButton) {
+        this.__selectRadioButton(newSelectedRadioButton);
+        this.toggleAttribute('has-value', true);
+      } else {
+        console.warn(`The radio button with the value "${newValue}" was not found.`);
+      }
+    } else {
       this.__selectRadioButton(null);
       this.removeAttribute('has-value');
-      return;
     }
 
-    const newSelectedRadioButton = this.__radioButtons.find((radioButton) => {
-      return radioButton.value === newValue;
-    });
-
-    if (newSelectedRadioButton) {
-      this.__selectRadioButton(newSelectedRadioButton);
-      this.toggleAttribute('has-value', true);
-    } else {
-      console.warn(`The radio button with the value "${newValue}" was not found.`);
+    if (oldValue !== undefined) {
+      this.validate();
     }
   }
 
@@ -451,8 +455,6 @@ class RadioGroup extends FieldMixin(
     this.__radioButtons.forEach((button) => {
       button.checked = button === radioButton;
     });
-
-    this.validate();
 
     if (this.readonly) {
       this.__updateRadioButtonsDisabledProperty();

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -471,12 +471,12 @@ describe('radio-group', () => {
   });
 
   describe('initial validation', () => {
-    let validateSpy, radio;
+    let validateSpy;
 
     beforeEach(() => {
       group = document.createElement('vaadin-radio-group');
 
-      radio = document.createElement('vaadin-radio-button');
+      const radio = document.createElement('vaadin-radio-button');
       radio.value = '1';
       group.appendChild(radio);
 
@@ -488,13 +488,6 @@ describe('radio-group', () => {
     });
 
     it('should not validate by default', async () => {
-      document.body.appendChild(group);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initially checked radio button', async () => {
-      radio.checked = true;
       document.body.appendChild(group);
       await nextRender();
       expect(validateSpy.called).to.be.false;

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -471,12 +471,12 @@ describe('radio-group', () => {
   });
 
   describe('initial validation', () => {
-    let validateSpy;
+    let validateSpy, radio;
 
     beforeEach(() => {
       group = document.createElement('vaadin-radio-group');
 
-      const radio = document.createElement('vaadin-radio-button');
+      radio = document.createElement('vaadin-radio-button');
       radio.value = '1';
       group.appendChild(radio);
 
@@ -488,6 +488,13 @@ describe('radio-group', () => {
     });
 
     it('should not validate by default', async () => {
+      document.body.appendChild(group);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initially checked radio button', async () => {
+      radio.checked = true;
       document.body.appendChild(group);
       await nextRender();
       expect(validateSpy.called).to.be.false;


### PR DESCRIPTION
## Description

The PR prevents the initial validation that could previously take place when `radio-group` is initially provided with a non-empty value and is initially marked `invalid`.

> **Warning**
> I marked the PR as breaking because it changes the default value of the `value` property to an empty string. 
>
> Without this change, it was not possible to distinguish whether the value has been changed manually via the property.

Part of https://github.com/vaadin/web-components/issues/4150

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
