### PR TITLE
chore: fix include globs in coverage config

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -4,11 +4,11 @@ const devServerConfig = require('./web-dev-server.config.js');
 
 const unitTestsConfig = createUnitTestsConfig({
   coverageConfig: {
-    include: ['packages/**/src/*', 'packages/**/*.js'],
+    include: ['packages/**/src/**/*', 'packages/*/*.js'],
     threshold: {
       statements: 95,
-      branches: 90,
-      functions: 92,
+      branches: 95,
+      functions: 95,
       lines: 95,
     },
   },


### PR DESCRIPTION
## Description

Current glob is wrong, as it also includes themes and Quill build in `vendor` folder, whereas in practice we only need `src` files (including subfolders like `src/lit/*.js`) and root entrypoints to be included. Let's fix this to get more reliable numbers. 

This also allows to increase thresholds, mainly due to Quill build excluded from checking coverage.

## Type of change

- Internal change