### PR TITLE
test: make sure no initial validation happens for time-picker

### DIFF
--- a/packages/time-picker/test/form-input.test.js
+++ b/packages/time-picker/test/form-input.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, focusout } from '@vaadin/testing-helpers';
+import { fixtureSync, focusout, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { TimePicker } from '../src/vaadin-time-picker.js';
 
@@ -18,6 +18,40 @@ describe('form input', () => {
     inputElement.value = value;
     inputElement.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
   }
+
+  describe('initial validation', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      timePicker = document.createElement('vaadin-time-picker');
+      validateSpy = sinon.spy(timePicker, 'validate');
+    });
+
+    afterEach(() => {
+      timePicker.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(timePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      timePicker.value = '12:00';
+      document.body.appendChild(timePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      timePicker.value = '12:00';
+      timePicker.invalid = true;
+      document.body.appendChild(timePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+  });
 
   describe('default validator', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Description

This PR adds unit tests verifying that no initial validation happens for `time-picker`.

Part of https://github.com/vaadin/web-components/issues/4150

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
