### PR TITLE
refactor: remove no longer needed flag, add tests

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -641,16 +641,12 @@ export const ComboBoxMixin = (subclass) =>
       if (e.key === 'Tab') {
         this.$.overlay.restoreFocusOnClose = false;
       } else if (e.key === 'ArrowDown') {
-        this._closeOnBlurIsPrevented = true;
         this._onArrowDown();
-        this._closeOnBlurIsPrevented = false;
 
         // Prevent caret from moving
         e.preventDefault();
       } else if (e.key === 'ArrowUp') {
-        this._closeOnBlurIsPrevented = true;
         this._onArrowUp();
-        this._closeOnBlurIsPrevented = false;
 
         // Prevent caret from moving
         e.preventDefault();

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -613,8 +613,6 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _onClick(e) {
-      this._closeOnBlurIsPrevented = true;
-
       const path = e.composedPath();
 
       if (this._isClearButton(e)) {
@@ -624,8 +622,6 @@ export const ComboBoxMixin = (subclass) =>
       } else {
         this._onHostClick(e);
       }
-
-      this._closeOnBlurIsPrevented = false;
     }
 
     /**

--- a/packages/combo-box/test/combo-box-light.test.js
+++ b/packages/combo-box/test/combo-box-light.test.js
@@ -241,6 +241,34 @@ describe('custom buttons', () => {
       toggleButton.dispatchEvent(e);
       expect(spy.calledOnce).to.be.true;
     });
+
+    it('should open overlay on toggle button Arrow Down', async () => {
+      comboBox.inputElement.focus();
+
+      // Focus the custom clear button
+      await sendKeys({ press: 'Tab' });
+
+      // Focus the custom toggle button
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'ArrowDown' });
+
+      expect(comboBox.opened).to.be.true;
+    });
+
+    it('should open overlay on toggle button Arrow Up', async () => {
+      comboBox.inputElement.focus();
+
+      // Focus the custom clear button
+      await sendKeys({ press: 'Tab' });
+
+      // Focus the custom toggle button
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'ArrowUp' });
+
+      expect(comboBox.opened).to.be.true;
+    });
   });
 
   describe('clear-button', () => {


### PR DESCRIPTION
## Description

Originally, the [`keydown` listener](https://github.com/vaadin/vaadin-combo-box/blob/f81a39866e69ea096e5a15f9550fa37d9591f35e/vaadin-combo-box.html#L325-L341) did not set `_closeOnBlurIsPrevented` flag on <kbd>Arrow Down</kbd> or <kbd>Arrow Up</kbd>. This logic was introduced when adding custom input support and `vaadin-combo-box-light` - see https://github.com/vaadin/vaadin-combo-box/pull/254

The reason for it was the fact that pressing <kbd>Arrow Down</kbd> or <kbd>Arrow Up</kbd> on custom toggle button was firing `blur` event when using `<paper-input>` element, as mentioned [here](https://github.com/vaadin/vaadin-combo-box/blob/7aeeef0f38057f895a5718a72209297caaee3a77/vaadin-dropdown-behavior.html#L93-L99). See the recording from 1.x version to see what happened in this case:

https://user-images.githubusercontent.com/10589913/178044730-1b608d53-f197-43fc-bcdc-a8e7a98efe2d.mp4

We no longer support `<paper-input>` so it makes sense to remove this obsolete workaround.
I also added tests for `vaadin-combo-box-light` with custom toggle button to ensure it works.

UPD: also removed setting this flag in `_onClick` listener. It's actually no longer needed after `blur` listener on the input element was replaced with `focusout` listener on the host as part of https://github.com/vaadin/vaadin-combo-box/pull/520.

## Type of change

- Refactor