### PR TITLE
test: reorganize validation tests, improve test coverage

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -421,38 +421,6 @@ describe('basic features', () => {
       datepicker.max = '2016-12-31';
     });
 
-    it('should be invalid when value is out of limits', () => {
-      datepicker.value = '2017-01-01';
-      expect(datepicker.invalid).to.be.equal(true);
-    });
-
-    it('should be valid when value is inside the limits', () => {
-      datepicker.value = '2016-07-14';
-      expect(datepicker.invalid).to.be.equal(false);
-    });
-
-    it('should be valid when value is the same as min date', () => {
-      datepicker.value = '2016-01-01';
-      expect(datepicker.invalid).to.be.equal(false);
-    });
-
-    it('should be valid when value is the same as max date', () => {
-      datepicker.value = '2016-12-31';
-      expect(datepicker.invalid).to.be.equal(false);
-    });
-
-    it('should reflect correct invalid value on value-changed eventListener', (done) => {
-      datepicker.value = '2016-01-01'; // Valid
-
-      datepicker.addEventListener('value-changed', () => {
-        expect(datepicker.invalid).to.be.equal(true);
-        done();
-      });
-
-      datepicker.open();
-      getOverlayContent(datepicker)._selectDate(new Date('2017-01-01')); // Invalid
-    });
-
     it('should change invalid state only once', (done) => {
       datepicker.addEventListener('value-changed', () => {
         expect(invalidChangedSpy.calledOnce).to.be.true;
@@ -761,5 +729,18 @@ describe('ios', () => {
       tap(toggleButton);
       await oneEvent(datepicker.$.overlay, 'vaadin-overlay-open');
     });
+  });
+});
+
+describe('required', () => {
+  let datePicker;
+
+  beforeEach(() => {
+    datePicker = fixtureSync(`<vaadin-date-picker required></vaadin-date-picker>`);
+  });
+
+  it('should focus on required indicator click', () => {
+    datePicker.shadowRoot.querySelector('[part="required-indicator"]').click();
+    expect(datePicker.hasAttribute('focused')).to.be.true;
   });
 });

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -1,4 +1,4 @@
-import { listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fire, listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 export function activateScroller(scroller) {
@@ -144,4 +144,15 @@ export async function waitForScrollToFinish(overlayContent) {
   }
 
   await nextRender(overlayContent);
+}
+
+/**
+ * Emulates the user filling in something in the date-picker input.
+ *
+ * @param {Element} comboBox
+ * @param {string} value
+ */
+export function setInputValue(comboBox, value) {
+  comboBox.inputElement.value = value;
+  fire(comboBox.inputElement, 'input');
 }

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -149,10 +149,10 @@ export async function waitForScrollToFinish(overlayContent) {
 /**
  * Emulates the user filling in something in the date-picker input.
  *
- * @param {Element} comboBox
+ * @param {Element} datePicker
  * @param {string} value
  */
-export function setInputValue(comboBox, value) {
-  comboBox.inputElement.value = value;
-  fire(comboBox.inputElement, 'input');
+export function setInputValue(datePicker, value) {
+  datePicker.inputElement.value = value;
+  fire(datePicker.inputElement, 'input');
 }

--- a/packages/date-picker/test/form-input.test.js
+++ b/packages/date-picker/test/form-input.test.js
@@ -69,23 +69,23 @@ describe('form input', () => {
     it('should re-validate old input after selecting date', async () => {
       // Set invalid value.
       setInputValue(datePicker, 'foo');
-      expect(datePicker.validate()).to.equal(false);
+      expect(datePicker.validate()).to.be.false;
       await open(datePicker);
       datePicker.value = '2000-02-01';
       await close(datePicker);
-      expect(datePicker.invalid).to.equal(false);
+      expect(datePicker.invalid).to.be.false;
     });
 
     it('should set proper validity by the time the value-changed event is fired', (done) => {
       // Set invalid value.
       setInputValue(datePicker, 'foo');
-      expect(datePicker.validate()).to.equal(false);
+      expect(datePicker.validate()).to.be.false;
 
       validateSpy.resetHistory();
 
       datePicker.addEventListener('value-changed', () => {
         expect(validateSpy.callCount).to.equal(1);
-        expect(datePicker.invalid).to.equal(false);
+        expect(datePicker.invalid).to.be.false;
         done();
       });
 
@@ -294,13 +294,13 @@ describe('form input', () => {
     it('should validate correctly with custom validator', () => {
       // Try invalid value.
       datePicker.value = '2014-01-01';
-      expect(datePicker.validate()).to.equal(false);
-      expect(datePicker.invalid).to.equal(true);
+      expect(datePicker.validate()).to.be.false;
+      expect(datePicker.invalid).to.be.true;
 
       // Try valid value.
       datePicker.value = '2016-01-01';
-      expect(datePicker.validate()).to.equal(true);
-      expect(datePicker.invalid).to.equal(false);
+      expect(datePicker.validate()).to.be.true;
+      expect(datePicker.invalid).to.be.false;
     });
   });
 });

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -88,13 +88,6 @@ describe('keyboard', () => {
   });
 
   describe('invalid date', () => {
-    it('should validate on close', async () => {
-      await open(datepicker);
-      const spy = sinon.spy(datepicker, 'validate');
-      await close(datepicker);
-      expect(spy.called).to.be.true;
-    });
-
     it('should not select date on Enter if input invalid', async () => {
       await open(datepicker);
       await sendKeys({ type: 'foo' });
@@ -134,23 +127,6 @@ describe('keyboard', () => {
       expect(spy.callCount).to.equal(1);
       expect(datepicker.invalid).to.be.false;
       expect(datepicker.checkValidity()).to.be.true;
-    });
-
-    it('should empty value with invalid input', async () => {
-      datepicker.value = '2000-01-01';
-      input.select();
-      await sendKeys({ type: 'foo' });
-      await close(datepicker);
-      expect(datepicker.value).to.equal('');
-    });
-
-    it('should be invalid with false input', async () => {
-      datepicker.value = '2000-01-01';
-      input.select();
-      await sendKeys({ type: 'foo' });
-      await close(datepicker);
-      expect(datepicker.invalid).to.be.true;
-      expect(datepicker.checkValidity()).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

The PR reorganizes the `date-picker` validation unit tests and improves the test coverage. This is to prepare `date-picker` for future refactoring addressing the initial validation.

Preparation for #4150

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
