### PR TITLE
fix: focus the input on change event in Safari

### DIFF
--- a/packages/checkbox/test/checkbox.test.js
+++ b/packages/checkbox/test/checkbox.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, mousedown, mouseup, nextFrame } from '@vaadin/testing-helpers';
-import { sendKeys, sendMouse } from '@web/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-checkbox.js';
 
@@ -138,6 +138,10 @@ describe('checkbox', () => {
     });
 
     describe('focus', () => {
+      afterEach(() => {
+        resetMouse();
+      });
+
       it('should focus on input click if not focused', async () => {
         const rect = input.getBoundingClientRect();
         const middleX = Math.floor(rect.x + rect.width / 2);

--- a/packages/checkbox/test/checkbox.test.js
+++ b/packages/checkbox/test/checkbox.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, mousedown, mouseup, nextFrame } from '@vaadin/testing-helpers';
-import { sendKeys } from '@web/test-runner-commands';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-checkbox.js';
 
@@ -135,6 +135,16 @@ describe('checkbox', () => {
       await nextFrame();
 
       expect(checkbox.hasAttribute('has-label')).to.be.false;
+    });
+
+    describe('focus', () => {
+      it('should focus on input click if not focused', async () => {
+        const rect = input.getBoundingClientRect();
+        const middleX = Math.floor(rect.x + rect.width / 2);
+        const middleY = Math.floor(rect.y + rect.height / 2);
+        await sendMouse({ type: 'click', position: [middleX, middleY] });
+        expect(checkbox.hasAttribute('focused')).to.be.true;
+      });
     });
 
     describe('active attribute', () => {

--- a/packages/checkbox/test/checkbox.test.js
+++ b/packages/checkbox/test/checkbox.test.js
@@ -138,8 +138,8 @@ describe('checkbox', () => {
     });
 
     describe('focus', () => {
-      afterEach(() => {
-        resetMouse();
+      afterEach(async () => {
+        await resetMouse();
       });
 
       it('should focus on input click if not focused', async () => {

--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -5,6 +5,7 @@
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
+import { isElementFocused } from '@vaadin/component-base/src/focus-utils.js';
 import { DelegateStateMixin } from './delegate-state-mixin.js';
 import { InputMixin } from './input-mixin.js';
 
@@ -44,7 +45,15 @@ export const CheckedMixin = dedupingMixin(
        * @override
        */
       _onChange(event) {
-        this._toggleChecked(event.target.checked);
+        const input = event.target;
+
+        this._toggleChecked(input.checked);
+
+        // Clicking the checkbox or radio-button in Safari
+        // does not make it focused, so we do it manually.
+        if (!isElementFocused(input)) {
+          input.focus();
+        }
       }
 
       /** @protected */

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
+import { sendMouse } from '@web/test-runner-commands';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { CheckedMixin } from '../src/checked-mixin.js';
@@ -105,6 +106,21 @@ describe('checked-mixin', () => {
         element.checked = false;
         expect(input.checked).to.be.false;
       });
+    });
+  });
+
+  describe('focus', () => {
+    beforeEach(() => {
+      element = fixtureSync(`<checked-mixin-element checked></checked-mixin-element>`);
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should focus on input click if not focused', async () => {
+      const rect = input.getBoundingClientRect();
+      const middleX = Math.floor(rect.x + rect.width / 2);
+      const middleY = Math.floor(rect.y + rect.height / 2);
+      await sendMouse({ type: 'click', position: [middleX, middleY] });
+      expect(document.activeElement).to.eql(input);
     });
   });
 });

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -115,8 +115,8 @@ describe('checked-mixin', () => {
       input = element.querySelector('[slot=input]');
     });
 
-    afterEach(() => {
-      resetMouse();
+    afterEach(async () => {
+      await resetMouse();
     });
 
     it('should focus on input click if not focused', async () => {

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
-import { sendMouse } from '@web/test-runner-commands';
+import { resetMouse, sendMouse } from '@web/test-runner-commands';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { CheckedMixin } from '../src/checked-mixin.js';
@@ -113,6 +113,10 @@ describe('checked-mixin', () => {
     beforeEach(() => {
       element = fixtureSync(`<checked-mixin-element checked></checked-mixin-element>`);
       input = element.querySelector('[slot=input]');
+    });
+
+    afterEach(() => {
+      resetMouse();
     });
 
     it('should focus on input click if not focused', async () => {

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, mousedown, mouseup, nextFrame } from '@vaadin/testing-helpers';
-import { sendKeys } from '@web/test-runner-commands';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-radio-button.js';
 
@@ -94,6 +94,14 @@ describe('radio-button', () => {
       radio.disabled = true;
       radio.click();
       expect(spy.called).to.be.false;
+    });
+
+    it('should focus on input click if not focused', async () => {
+      const rect = input.getBoundingClientRect();
+      const middleX = Math.floor(rect.x + rect.width / 2);
+      const middleY = Math.floor(rect.y + rect.height / 2);
+      await sendMouse({ type: 'click', position: [middleX, middleY] });
+      expect(radio.hasAttribute('focused')).to.be.true;
     });
   });
 

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -50,8 +50,8 @@ describe('radio-button', () => {
       label = radio.querySelector('[slot=label]');
     });
 
-    afterEach(() => {
-      resetMouse();
+    afterEach(async () => {
+      await resetMouse();
     });
 
     it('should set input checked to false by default', () => {

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, mousedown, mouseup, nextFrame } from '@vaadin/testing-helpers';
-import { sendKeys, sendMouse } from '@web/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-radio-button.js';
 
@@ -48,6 +48,10 @@ describe('radio-button', () => {
       radio = fixtureSync('<vaadin-radio-button></vaadin-radio-button>');
       input = radio.querySelector('[slot=input]');
       label = radio.querySelector('[slot=label]');
+    });
+
+    afterEach(() => {
+      resetMouse();
     });
 
     it('should set input checked to false by default', () => {


### PR DESCRIPTION
## Description

Note: new tests might pass in CI without the change, as in GitHub Actions we test in Playwright on Linux, not MacOS.
Locally they pass though, and I'd like to avoid checking for `isSafari` instead of checking the focused element.

Fixes #4165

## Type of change

- Bugfix