### PR TITLE
fix: prevent initial validation for date-picker when no constraints

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -46,7 +46,6 @@ export const DatePickerMixin = (subclass) =>
          */
         value: {
           type: String,
-          observer: '_valueChanged',
           notify: true,
           value: '',
         },
@@ -264,6 +263,11 @@ export const DatePickerMixin = (subclass) =>
          */
         min: {
           type: String,
+<<<<<<< HEAD
+=======
+          value: '',
+          observer: '_minChanged',
+>>>>>>> 9594a5f9f (fix!: prevent initial validation for date-picker)
         },
 
         /**
@@ -277,6 +281,11 @@ export const DatePickerMixin = (subclass) =>
          */
         max: {
           type: String,
+<<<<<<< HEAD
+=======
+          value: '',
+          observer: '_maxChanged',
+>>>>>>> 9594a5f9f (fix!: prevent initial validation for date-picker)
         },
 
         /**
@@ -688,27 +697,40 @@ export const DatePickerMixin = (subclass) =>
       }
     }
 
-    /** @private */
+    /**
+     * Override the value observer from `InputMixin` to implement custom
+     * handling of the `value` property. The date-picker doesn't forward
+     * the value directly to the input like the default implementation of `InputMixin`.
+     * Instead, it parses the value into a date, puts it in `_selectedDate` which
+     * is then displayed in the input with respect to the specified date format.
+     *
+     * @param {string | undefined} value
+     * @param {string | undefined} oldValue
+     * @protected
+     * @override
+     */
     _valueChanged(value, oldValue) {
-      const newDate = this._parseDate(value);
+      if (!value) {
+        this._selectedDate = null;
+        return;
+      }
 
-      // The new value cannot be parsed, revert the old value.
-      if (value && !newDate) {
+      const newDate = this._parseDate(value);
+      if (!newDate) {
+        // The new value cannot be parsed, revert the old value.
         this.value = oldValue;
         return;
       }
 
-      if (value) {
-        // Only update the date instance if the date has actually changed.
-        if (!dateEquals(this._selectedDate, newDate)) {
-          this._selectedDate = newDate;
+      if (!dateEquals(this._selectedDate, newDate)) {
+        // Update the date instance only if the date has actually changed.
+        this._selectedDate = newDate;
+
+        if (oldValue !== undefined) {
+          // Validate only if `value` changes after initialization.
           this.validate();
         }
-      } else {
-        this._selectedDate = null;
       }
-
-      this._toggleHasValue(!!value);
     }
 
     /** @private */

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -263,14 +263,6 @@ export const DatePickerMixin = (subclass) =>
          */
         min: {
           type: String,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-          value: '',
-=======
->>>>>>> bb4fdd640 (revert min / max changes)
-          observer: '_minChanged',
->>>>>>> 9594a5f9f (fix!: prevent initial validation for date-picker)
         },
 
         /**
@@ -284,14 +276,6 @@ export const DatePickerMixin = (subclass) =>
          */
         max: {
           type: String,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-          value: '',
-=======
->>>>>>> bb4fdd640 (revert min / max changes)
-          observer: '_maxChanged',
->>>>>>> 9594a5f9f (fix!: prevent initial validation for date-picker)
         },
 
         /**

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -700,27 +700,29 @@ export const DatePickerMixin = (subclass) =>
      * @override
      */
     _valueChanged(value, oldValue) {
-      if (!value) {
-        this._selectedDate = null;
-        return;
-      }
-
       const newDate = this._parseDate(value);
-      if (!newDate) {
+
+      if (value && !newDate) {
         // The new value cannot be parsed, revert the old value.
         this.value = oldValue;
         return;
       }
 
-      if (!dateEquals(this._selectedDate, newDate)) {
-        // Update the date instance only if the date has actually changed.
-        this._selectedDate = newDate;
+      if (value) {
+        if (!dateEquals(this._selectedDate, newDate)) {
+          // Update the date instance only if the date has actually changed.
+          this._selectedDate = newDate;
 
-        if (oldValue !== undefined) {
-          // Validate only if `value` changes after initialization.
-          this.validate();
+          if (oldValue !== undefined) {
+            // Validate only if `value` changes after initialization.
+            this.validate();
+          }
         }
+      } else {
+        this._selectedDate = null;
       }
+
+      this._toggleHasValue(!!value);
     }
 
     /** @private */

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -264,8 +264,11 @@ export const DatePickerMixin = (subclass) =>
         min: {
           type: String,
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
           value: '',
+=======
+>>>>>>> bb4fdd640 (revert min / max changes)
           observer: '_minChanged',
 >>>>>>> 9594a5f9f (fix!: prevent initial validation for date-picker)
         },
@@ -282,8 +285,11 @@ export const DatePickerMixin = (subclass) =>
         max: {
           type: String,
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
           value: '',
+=======
+>>>>>>> bb4fdd640 (revert min / max changes)
           observer: '_maxChanged',
 >>>>>>> 9594a5f9f (fix!: prevent initial validation for date-picker)
         },

--- a/packages/date-picker/test/form-input.test.js
+++ b/packages/date-picker/test/form-input.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import { DatePicker } from '../vaadin-date-picker.js';
@@ -15,6 +15,48 @@ customElements.define('vaadin-date-picker-2016', DatePicker2016);
 
 describe('form input', () => {
   let datePicker;
+
+  describe('initial', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      datePicker = document.createElement('vaadin-date-picker');
+      validateSpy = sinon.spy(datePicker, 'validate');
+    });
+
+    afterEach(() => {
+      datePicker.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(datePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      datePicker.value = '2020-01-01';
+      document.body.appendChild(datePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and min', async () => {
+      datePicker.min = '2020-01-01';
+      datePicker.value = '2020-01-01';
+      document.body.appendChild(datePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and max', async () => {
+      datePicker.max = '2020-01-01';
+      datePicker.value = '2020-01-01';
+      document.body.appendChild(datePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+  });
 
   describe('basic', () => {
     let validateSpy;
@@ -47,11 +89,21 @@ describe('form input', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
+    it('should not validate on min change when no value is provided', () => {
+      datePicker.min = '2020-01-01';
+      expect(validateSpy.called).to.be.false;
+    });
+
     it('should validate on min change when a value is provided', () => {
       datePicker.value = '2020-01-01';
       validateSpy.resetHistory();
       datePicker.min = '2020-01-01';
       expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should not validate on max change when no value is provided', () => {
+      datePicker.max = '2020-01-01';
+      expect(validateSpy.called).to.be.false;
     });
 
     it('should validate on max change when a value is provided', () => {

--- a/packages/date-picker/test/form-input.test.js
+++ b/packages/date-picker/test/form-input.test.js
@@ -40,22 +40,6 @@ describe('form input', () => {
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
-
-    it('should not validate when the field has an initial value and min', async () => {
-      datePicker.min = '2020-01-01';
-      datePicker.value = '2020-01-01';
-      document.body.appendChild(datePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and max', async () => {
-      datePicker.max = '2020-01-01';
-      datePicker.value = '2020-01-01';
-      document.body.appendChild(datePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
   });
 
   describe('basic', () => {

--- a/packages/date-picker/test/form-input.test.js
+++ b/packages/date-picker/test/form-input.test.js
@@ -40,6 +40,14 @@ describe('form input', () => {
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      datePicker.value = '2020-01-01';
+      datePicker.invalid = true;
+      document.body.appendChild(datePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
   });
 
   describe('basic', () => {


### PR DESCRIPTION
## Description

The PR prevents the initial validation that could previously take place when `date-picker` was initially provided with a non-empty value and no constraints were specified.

Part of https://github.com/vaadin/web-components/issues/4150

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
