### PR TITLE
test: make sure no initial validation happens for combo-box

### DIFF
--- a/packages/combo-box/test/form-input.test.js
+++ b/packages/combo-box/test/form-input.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, keyboardEventFor } from '@vaadin/testing-helpers';
+import { fixtureSync, keyboardEventFor, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
@@ -71,6 +71,41 @@ describe('form field', () => {
     expect(validatedSpy.calledOnce).to.be.true;
     const event = validatedSpy.firstCall.args[0];
     expect(event.detail.valid).to.be.false;
+  });
+
+  describe('initial validation', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      comboBox = document.createElement('vaadin-combo-box');
+      comboBox.allowCustomValue = true;
+      validateSpy = sinon.spy(comboBox, 'validate');
+    });
+
+    afterEach(() => {
+      comboBox.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(comboBox);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      comboBox.value = 'foo';
+      document.body.appendChild(comboBox);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      comboBox.value = 'foo';
+      comboBox.invalid = true;
+      document.body.appendChild(comboBox);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
   });
 
   describe('enter key behavior', () => {


### PR DESCRIPTION
## Description

This PR adds unit tests verifying that no initial validation happens for `combo-box`.

Part of https://github.com/vaadin/web-components/issues/4150

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
