### PR TITLE
fix: prevent initial validation for select

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -459,11 +459,10 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
   _valueChanged(value, oldValue) {
     this.toggleAttribute('has-value', Boolean(value));
 
-    // Skip validation for the initial empty string value
-    if (value === '' && oldValue === undefined) {
-      return;
+    // Validate only if `value` changes after initialization.
+    if (oldValue !== undefined) {
+      this.validate();
     }
-    this.validate();
   }
 
   /**

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -11,6 +11,7 @@ import {
   keyboardEventFor,
   keyDownChar,
   nextFrame,
+  nextRender,
   spaceKeyDown,
   tab,
 } from '@vaadin/testing-helpers';
@@ -678,6 +679,40 @@ describe('vaadin-select', () => {
         enterKeyUp(secondOption);
         expect(changeSpy.callCount).to.equal(1);
       });
+    });
+  });
+
+  describe('initial validation', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      select = document.createElement('vaadin-select');
+      validateSpy = sinon.spy(select, 'validate');
+    });
+
+    afterEach(() => {
+      select.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(select);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      select.value = 'value';
+      document.body.appendChild(select);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      select.value = 'value';
+      select.invalid = true;
+      document.body.appendChild(select);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

The PR prevents the initial validation that could previously take place when `select` was initially provided with a non-empty value.

Part of https://github.com/vaadin/web-components/issues/4150

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
