### PR TITLE
fix: do not throw error with incorrect value attribute

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -550,7 +550,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     const newValue = this.__formatISO(parsedObj) || '';
 
     if (this.value !== '' && this.value !== null && !parsedObj) {
-      this.value = oldValue;
+      this.value = oldValue === undefined ? '' : oldValue;
     } else if (this.value !== newValue) {
       this.value = newValue;
     } else {

--- a/packages/time-picker/test/form-input.test.js
+++ b/packages/time-picker/test/form-input.test.js
@@ -241,4 +241,10 @@ describe('form input', () => {
       expect(timePicker.invalid).to.equal(false);
     });
   });
+
+  describe('incorrect value', () => {
+    it('should not throw error when setting incorrect value using attribute', () => {
+      expect(() => fixtureSync(`<vaadin-time-picker value="1500"></vaadin-time-picker>`)).to.not.throw(Error);
+    });
+  });
 });


### PR DESCRIPTION
## Description

When using `value` attribute, the `_valueChanged` observer gets called with `value` containing the attribute value and `oldValue` containing `undefined`. As the value can't be parsed, it's reset to `oldValue`, which is `undefined`.

Fixed by setting empty string instead of the old value in this case, to avoid infinite loop.

## Type of change

- Bugfix