### PR TITLE
test: make sure no initial validation happens for date-time-picker

### DIFF
--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';
 
@@ -115,6 +115,40 @@ const fixtures = {
         expect(dateTimePicker.invalid).to.be.true;
       });
     });
+  });
+});
+
+describe('initial validation', () => {
+  let validateSpy, dateTimePicker;
+
+  beforeEach(() => {
+    dateTimePicker = document.createElement('vaadin-date-time-picker');
+    validateSpy = sinon.spy(dateTimePicker, 'validate');
+  });
+
+  afterEach(() => {
+    dateTimePicker.remove();
+  });
+
+  it('should not validate by default', async () => {
+    document.body.appendChild(dateTimePicker);
+    await nextRender();
+    expect(validateSpy.called).to.be.false;
+  });
+
+  it('should not validate when the field has an initial value', async () => {
+    dateTimePicker.value = '2020-02-01T02:00';
+    document.body.appendChild(dateTimePicker);
+    await nextRender();
+    expect(validateSpy.called).to.be.false;
+  });
+
+  it('should not validate when the field has an initial value and invalid', async () => {
+    dateTimePicker.value = '2020-02-01T02:00';
+    dateTimePicker.invalid = true;
+    document.body.appendChild(dateTimePicker);
+    await nextRender();
+    expect(validateSpy.called).to.be.false;
   });
 });
 


### PR DESCRIPTION
## Description

This PR adds unit tests verifying that no initial validation happens for `date-time-picker`.

Part of https://github.com/vaadin/web-components/issues/4150

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
