### PR TITLE
refactor: ensure _selectedDate is null when value is empty

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -287,7 +287,7 @@ export const DatePickerMixin = (subclass) =>
         _minDate: {
           type: Date,
           observer: '__minDateChanged',
-          computed: '__computeMinDate(min)',
+          computed: '__computeMinOrMaxDate(min)',
         },
 
         /**
@@ -298,7 +298,7 @@ export const DatePickerMixin = (subclass) =>
         _maxDate: {
           type: Date,
           observer: '__maxDateChanged',
-          computed: '__computeMaxDate(max)',
+          computed: '__computeMinOrMaxDate(max)',
         },
 
         /** @private */
@@ -1093,13 +1093,8 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /** @private */
-    __computeMinDate(min) {
-      return this._parseDate(min);
-    }
-
-    /** @private */
-    __computeMaxDate(max) {
-      return this._parseDate(max);
+    __computeMinOrMaxDate(dateString) {
+      return this._parseDate(dateString);
     }
 
     /**

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -336,23 +336,23 @@ describe('basic features', () => {
     it('should not accept non-ISO formats', () => {
       datepicker.value = '03/02/01';
       expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.equal('');
+      expect(datepicker._selectedDate).to.be.null;
 
       datepicker.value = '2010/02/03';
       expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.equal('');
+      expect(datepicker._selectedDate).to.be.null;
 
       datepicker.value = '03/02/2010';
       expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.equal('');
+      expect(datepicker._selectedDate).to.be.null;
 
       datepicker.value = '3 Feb 2010';
       expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.equal('');
+      expect(datepicker._selectedDate).to.be.null;
 
       datepicker.value = 'Feb 3, 2010';
       expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.equal('');
+      expect(datepicker._selectedDate).to.be.null;
     });
 
     it('should output ISO format', () => {


### PR DESCRIPTION
## Description

This is a minor refactoring that aims to ensure `_selectedDate` is `null` any time `value` is empty. Previously, `_selectedDate` could become an empty string in certain cirtumstances which is incorrect given its type `Date`.

Along the way, I also refactored the `minDate` and `maxDate` properties to make them computed which allowed throwing away the crappy generic `_handleDateChange` method completely.

Addresses https://github.com/vaadin/web-components/pull/4169#discussion_r918852836

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
