### PR TITLE
refactor!: make checkValidity() not take disabled state into account

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -697,6 +697,15 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
   }
 
   /**
+   * Returns true if the current value satisfies all constraints (if any)
+   *
+   * @return {boolean}
+   */
+  checkValidity() {
+    return !this.required || !!this.value;
+  }
+
+  /**
    * Renders items when they are provided by the `items` property and clears the content otherwise.
    * @param {!HTMLElement} root
    * @param {!Select} _select

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -697,15 +697,6 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
   }
 
   /**
-   * Returns true if the current value satisfies all constraints (if any)
-   *
-   * @return {boolean}
-   */
-  checkValidity() {
-    return this.disabled || !this.required || !!this.value;
-  }
-
-  /**
    * Renders items when they are provided by the `items` property and clears the content otherwise.
    * @param {!HTMLElement} root
    * @param {!Select} _select

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -555,16 +555,6 @@ describe('vaadin-select', () => {
         expect(select.invalid).to.be.true;
       });
 
-      it('should pass the validation when the field is required and has no value but disabled', () => {
-        expect(select.invalid).to.be.false;
-        select.setAttribute('required', '');
-        select.setAttribute('disabled', '');
-
-        select.validate();
-        expect(select.checkValidity()).to.be.true;
-        expect(select.invalid).to.be.false;
-      });
-
       it('should validate when closing the overlay', () => {
         const spy = sinon.spy();
         select.validate = spy;


### PR DESCRIPTION
## Description

Taking the `disabled` state into account in `checkValidity()` appears to be pointless because `select` cannot be focused when disabled, so no user interaction should trigger validation. Moreover, no other components rely on `disabled` in their `checkValidity()` methods.

It only makes sense to consider `select` always valid when it is read-only but that will be addressed separately in #4180.

> **Warning**
> The change seems to be minor but I anyway marked it as breaking because `checkValidity()` is a public API. 

Related to https://github.com/vaadin/web-components/issues/4180

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
