### PR TITLE
docs: add disabled attribute to styling API

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -68,6 +68,12 @@ export interface MenuBarEventMap extends HTMLElementEventMap, MenuBarCustomEvent
  * `menu-bar-button` | The menu bar button.
  * `overflow-button` | The "overflow" button appearing when menu bar width is not enough to fit all the buttons.
  *
+ * The following state attributes are available for styling:
+ *
+ * Attribute           | Description
+ * --------------------|----------------------------------
+ * `disabled`          | Set when the menu bar is disabled
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -39,6 +39,12 @@ import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
  * `menu-bar-button` | The menu bar button.
  * `overflow-button` | The "overflow" button appearing when menu bar width is not enough to fit all the buttons.
  *
+ * The following state attributes are available for styling:
+ *
+ * Attribute           | Description
+ * --------------------|----------------------------------
+ * `disabled`          | Set when the menu bar is disabled
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
  * ### Internal components


### PR DESCRIPTION
## Description

When adding `disabled` property, we missed to list corresponding state attribute in the API docs. This PR fixes that.

## Type of change

- Documentation