### PR TITLE
docs: add missing JSDoc annotation for mixin

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -62,6 +62,7 @@ import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
  * @extends HTMLElement
  * @mixes ButtonsMixin
  * @mixes InteractionsMixin
+ * @mixes DisabledMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */


### PR DESCRIPTION
## Description

This is necessary to make `disabled` property appear in the API docs of `vaadin-menu-bar`:

![Screenshot 2022-07-13 at 15 22 42](https://user-images.githubusercontent.com/10589913/178732437-88f5e994-89a2-441e-a36f-e3df240df76a.png)

## Type of change

- Documentation