### PR TITLE
test: reorganize and cleanup validation tests

### DIFF
--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -538,6 +538,59 @@ describe('vaadin-select', () => {
       });
     });
 
+    describe('change event', () => {
+      let menu, changeSpy;
+
+      beforeEach(async () => {
+        menu = select._menuElement;
+        await nextFrame();
+        changeSpy = sinon.spy();
+        select.addEventListener('change', changeSpy);
+      });
+
+      it('should not fire `change` event when programmatically opened and selected changed', () => {
+        select.opened = true;
+        menu.selected = 1;
+        select.opened = false;
+        expect(changeSpy.called).to.be.false;
+      });
+
+      it('should not fire `change` event when programmatically opened and value changed', () => {
+        select.opened = true;
+        select.value = 'Option 1';
+        expect(changeSpy.called).to.be.false;
+      });
+
+      it('should not fire `change` event when committing a value programmatically', () => {
+        menu.selected = 1;
+        select.value = 'Option 1';
+        expect(changeSpy.called).to.be.false;
+      });
+
+      it('should fire `change` event when value changes when alphanumeric keys are pressed', () => {
+        keyDownChar(valueButton, 'o');
+        keyDownChar(valueButton, 'p');
+        keyDownChar(valueButton, 't');
+        expect(changeSpy.callCount).to.equal(1);
+      });
+
+      it('should fire `change` event when value changes by user clicking the item', () => {
+        select.opened = true;
+        menu.firstElementChild.click();
+        expect(changeSpy.callCount).to.equal(1);
+      });
+
+      it('should fire `change` event when value changes by user selecting item with keyboard', () => {
+        select.opened = true;
+        arrowUp(menu);
+
+        const secondOption = menu.querySelector('[value="v2"]');
+        enterKeyDown(secondOption);
+        enterKeyUp(secondOption);
+        expect(changeSpy.callCount).to.equal(1);
+      });
+    });
+
     describe('validation', () => {
       it('should pass the validation when the field is valid', () => {
         select.validate();
@@ -600,74 +653,6 @@ describe('vaadin-select', () => {
         expect(validatedSpy.calledOnce).to.be.true;
         const event = validatedSpy.firstCall.args[0];
         expect(event.detail.valid).to.be.false;
-      });
-    });
-
-    describe('initial validation', () => {
-      let spy;
-
-      beforeEach(async () => {
-        select.required = true;
-        spy = sinon.spy();
-        select.validate = spy;
-        await nextFrame();
-      });
-
-      it('should not validate the initial empty value', () => {
-        expect(spy.called).to.be.false;
-      });
-    });
-
-    describe('change event', () => {
-      let menu, changeSpy;
-
-      beforeEach(async () => {
-        menu = select._menuElement;
-        await nextFrame();
-        changeSpy = sinon.spy();
-        select.addEventListener('change', changeSpy);
-      });
-
-      it('should not fire `change` event when programmatically opened and selected changed', () => {
-        select.opened = true;
-        menu.selected = 1;
-        select.opened = false;
-        expect(changeSpy.called).to.be.false;
-      });
-
-      it('should not fire `change` event when programmatically opened and value changed', () => {
-        select.opened = true;
-        select.value = 'Option 1';
-        expect(changeSpy.called).to.be.false;
-      });
-
-      it('should not fire `change` event when committing a value programmatically', () => {
-        menu.selected = 1;
-        select.value = 'Option 1';
-        expect(changeSpy.called).to.be.false;
-      });
-
-      it('should fire `change` event when value changes when alphanumeric keys are pressed', () => {
-        keyDownChar(valueButton, 'o');
-        keyDownChar(valueButton, 'p');
-        keyDownChar(valueButton, 't');
-        expect(changeSpy.callCount).to.equal(1);
-      });
-
-      it('should fire `change` event when value changes by user clicking the item', () => {
-        select.opened = true;
-        menu.firstElementChild.click();
-        expect(changeSpy.callCount).to.equal(1);
-      });
-
-      it('should fire `change` event when value changes by user selecting item with keyboard', () => {
-        select.opened = true;
-        arrowUp(menu);
-
-        const secondOption = menu.querySelector('[value="v2"]');
-        enterKeyDown(secondOption);
-        enterKeyUp(secondOption);
-        expect(changeSpy.callCount).to.equal(1);
       });
     });
   });

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -11,7 +11,6 @@ import {
   keyboardEventFor,
   keyDownChar,
   nextFrame,
-  nextRender,
   spaceKeyDown,
   tab,
 } from '@vaadin/testing-helpers';
@@ -589,105 +588,6 @@ describe('vaadin-select', () => {
         enterKeyUp(secondOption);
         expect(changeSpy.callCount).to.equal(1);
       });
-    });
-
-    describe('validation', () => {
-      it('should pass the validation when the field is valid', () => {
-        select.validate();
-        expect(select.checkValidity()).to.be.true;
-        expect(select.invalid).to.be.false;
-      });
-
-      it('should not pass the validation when the field is required and has no value', () => {
-        expect(select.invalid).to.be.false;
-        select.setAttribute('required', '');
-
-        enterKeyDown(valueButton);
-        escKeyDown(valueButton);
-        expect(select.checkValidity()).to.be.false;
-        expect(select.invalid).to.be.true;
-      });
-
-      it('should validate when closing the overlay', () => {
-        const spy = sinon.spy();
-        select.validate = spy;
-        select.opened = true;
-
-        select.opened = false;
-        expect(spy.called).to.be.true;
-      });
-
-      it('should validate when blurring', () => {
-        const spy = sinon.spy();
-        select.validate = spy;
-        select.blur();
-
-        expect(spy.called).to.be.true;
-      });
-
-      it('should validate when setting value', () => {
-        const spy = sinon.spy();
-        select.validate = spy;
-        select.value = 'v2';
-        expect(spy.callCount).to.be.equal(1);
-        select.value = '';
-        expect(spy.callCount).to.be.equal(2);
-      });
-
-      it('should fire a validated event on validation success', () => {
-        const validatedSpy = sinon.spy();
-        select.addEventListener('validated', validatedSpy);
-        select.validate();
-
-        expect(validatedSpy.calledOnce).to.be.true;
-        const event = validatedSpy.firstCall.args[0];
-        expect(event.detail.valid).to.be.true;
-      });
-
-      it('should fire a validated event on validation failure', () => {
-        const validatedSpy = sinon.spy();
-        select.addEventListener('validated', validatedSpy);
-        select.required = true;
-        select.validate();
-
-        expect(validatedSpy.calledOnce).to.be.true;
-        const event = validatedSpy.firstCall.args[0];
-        expect(event.detail.valid).to.be.false;
-      });
-    });
-  });
-
-  describe('initial validation', () => {
-    let validateSpy;
-
-    beforeEach(() => {
-      select = document.createElement('vaadin-select');
-      validateSpy = sinon.spy(select, 'validate');
-    });
-
-    afterEach(() => {
-      select.remove();
-    });
-
-    it('should not validate by default', async () => {
-      document.body.appendChild(select);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value', async () => {
-      select.value = 'value';
-      document.body.appendChild(select);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and invalid', async () => {
-      select.value = 'value';
-      select.invalid = true;
-      document.body.appendChild(select);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
     });
   });
 

--- a/packages/select/test/validation.test.js
+++ b/packages/select/test/validation.test.js
@@ -1,0 +1,126 @@
+import { expect } from '@esm-bundle/chai';
+import { enterKeyDown, escKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '@vaadin/item/vaadin-item.js';
+import '@vaadin/list-box/vaadin-list-box.js';
+import './not-animated-styles.js';
+import '../vaadin-select.js';
+import { html, render } from 'lit';
+
+describe('validation', () => {
+  let select, valueButton;
+
+  describe('basic', () => {
+    beforeEach(async () => {
+      select = fixtureSync('<vaadin-select></vaadin-select>');
+      select.renderer = (root) => {
+        render(
+          html`
+            <vaadin-list-box>
+              <vaadin-item value="v1" label="o2">Option 2</vaadin-item>
+              <vaadin-item value="v2" label="o2">Option 2</vaadin-item>
+              <vaadin-item value="">Option 3</vaadin-item>
+            </vaadin-list-box>
+          `,
+          root,
+        );
+      };
+      valueButton = select._valueButton;
+      await nextRender();
+    });
+
+    it('should pass the validation when the field is valid', () => {
+      select.validate();
+      expect(select.checkValidity()).to.be.true;
+      expect(select.invalid).to.be.false;
+    });
+
+    it('should not pass the validation when the field is required and has no value', () => {
+      select.required = true;
+
+      enterKeyDown(valueButton);
+      escKeyDown(valueButton);
+      expect(select.checkValidity()).to.be.false;
+      expect(select.invalid).to.be.true;
+    });
+
+    it('should validate when closing the overlay', () => {
+      const spy = sinon.spy(select, 'validate');
+      select.opened = true;
+
+      select.opened = false;
+      expect(spy.called).to.be.true;
+    });
+
+    it('should validate on programmatic blur', () => {
+      const spy = sinon.spy(select, 'validate');
+      select.blur();
+
+      expect(spy.called).to.be.true;
+    });
+
+    it('should validate when setting value property', () => {
+      const spy = sinon.spy(select, 'validate');
+      select.value = 'v2';
+      expect(spy.callCount).to.be.equal(1);
+
+      select.value = '';
+      expect(spy.callCount).to.be.equal(2);
+    });
+
+    it('should fire a validated event on validation success', () => {
+      const validatedSpy = sinon.spy();
+      select.addEventListener('validated', validatedSpy);
+      select.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.true;
+    });
+
+    it('should fire a validated event on validation failure', () => {
+      const validatedSpy = sinon.spy();
+      select.addEventListener('validated', validatedSpy);
+      select.required = true;
+      select.validate();
+
+      expect(validatedSpy.calledOnce).to.be.true;
+      const event = validatedSpy.firstCall.args[0];
+      expect(event.detail.valid).to.be.false;
+    });
+  });
+
+  describe('initial', () => {
+    let validateSpy;
+
+    beforeEach(() => {
+      select = document.createElement('vaadin-select');
+      validateSpy = sinon.spy(select, 'validate');
+    });
+
+    afterEach(() => {
+      select.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(select);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      select.value = 'value';
+      document.body.appendChild(select);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      select.value = 'value';
+      select.invalid = true;
+      document.body.appendChild(select);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Description

1. Moved the validation test suites into separate file to align with other component packages, e.g. `number-field`
2. Removed old test for initial validation added in https://github.com/vaadin/vaadin-select/pull/66 - it is no longer needed as it's now covered by new tests added in #4174

## Type of change

- Tests