### PR TITLE
fix: align `checkValidity()` behavior with text-field

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -387,6 +387,20 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
   }
 
   /**
+   * Override an observer from `FieldMixin`.
+   *
+   * @protected
+   * @override
+   */
+  _requiredChanged(required) {
+    super._requiredChanged(required);
+
+    if (required === false) {
+      this._setInvalid(false);
+    }
+  }
+
+  /**
    * @param {SelectRenderer | undefined | null} renderer
    * @param {SelectOverlay | undefined} overlay
    * @private

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -702,7 +702,12 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
    * @return {boolean}
    */
   checkValidity() {
-    return !this.required || !!this.value;
+    // Readonly select should not be marked as invalid when required
+    if (this.required && !this.readonly) {
+      return !!this.value;
+    }
+
+    return !this.invalid;
   }
 
   /**

--- a/packages/select/test/validation.test.js
+++ b/packages/select/test/validation.test.js
@@ -44,6 +44,25 @@ describe('validation', () => {
       expect(select.invalid).to.be.true;
     });
 
+    it('should pass the validation when the field is required and readonly', () => {
+      select.required = true;
+      select.readonly = true;
+
+      select.validate();
+
+      expect(select.checkValidity()).to.be.true;
+      expect(select.invalid).to.be.false;
+    });
+
+    it('should not pass the validation when invalid is set and required is not set', () => {
+      select.invalid = true;
+
+      select.validate();
+
+      expect(select.checkValidity()).to.be.false;
+      expect(select.invalid).to.be.true;
+    });
+
     it('should validate when closing the overlay', () => {
       const spy = sinon.spy(select, 'validate');
       select.opened = true;

--- a/packages/select/test/validation.test.js
+++ b/packages/select/test/validation.test.js
@@ -63,6 +63,15 @@ describe('validation', () => {
       expect(select.invalid).to.be.true;
     });
 
+    it('should update invalid state when required property is removed', () => {
+      select.required = true;
+      select.validate();
+      expect(select.invalid).to.be.true;
+
+      select.required = false;
+      expect(select.invalid).to.be.false;
+    });
+
     it('should validate when closing the overlay', () => {
       const spy = sinon.spy(select, 'validate');
       select.opened = true;


### PR DESCRIPTION
## Description

1. Updated to not mark `vaadin-select` as invalid when `readonly` is set
2. Updated to reset `invalid` property when `required` is set to `false`
3. Updated to not reset `invalid` property when `required` is not set

Fixes #4180

## Type of change

- Bugfix / refactor