### PR TITLE
fix: do not mark select as invalid when readonly

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -702,7 +702,7 @@ class Select extends DelegateFocusMixin(FieldMixin(ElementMixin(ThemableMixin(Po
    * @return {boolean}
    */
   checkValidity() {
-    return !this.required || !!this.value;
+    return !this.required || this.readonly || !!this.value;
   }
 
   /**

--- a/packages/select/test/validation.test.js
+++ b/packages/select/test/validation.test.js
@@ -44,6 +44,16 @@ describe('validation', () => {
       expect(select.invalid).to.be.true;
     });
 
+    it('should pass the validation when the field is required and readonly', () => {
+      select.required = true;
+      select.readonly = true;
+
+      select.validate();
+
+      expect(select.checkValidity()).to.be.true;
+      expect(select.invalid).to.be.false;
+    });
+
     it('should validate when closing the overlay', () => {
       const spy = sinon.spy(select, 'validate');
       select.opened = true;


### PR DESCRIPTION
## Description

Fixes #4180

Extracted this from #4198 to keep Git history cleaner.

## Type of change

- Bugfix