### PR TITLE
fix: set aria-invalid attribute on the radio-group

### DIFF
--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -250,6 +250,23 @@ class RadioGroup extends FieldMixin(
   }
 
   /**
+   * Override an observer from `FieldMixin`.
+   *
+   * @param {boolean} invalid
+   * @protected
+   * @override
+   */
+  _invalidChanged(invalid) {
+    super._invalidChanged(invalid);
+
+    if (invalid) {
+      this.setAttribute('aria-invalid', 'true');
+    } else {
+      this.removeAttribute('aria-invalid');
+    }
+  }
+
+  /**
    * @param {number} index
    * @private
    */

--- a/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
@@ -319,6 +319,7 @@ snapshots["vaadin-radio-group host helper"] =
 
 snapshots["vaadin-radio-group host error"] = 
 `<vaadin-radio-group
+  aria-invalid="true"
   aria-labelledby="error-message-vaadin-radio-group-2"
   has-error-message=""
   invalid=""

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -169,6 +169,19 @@ describe('radio-group', () => {
     });
   });
 
+  describe('aria-invalid attribute', () => {
+    beforeEach(() => {
+      group = fixtureSync(`<vaadin-radio-group></vaadin-radio-group>`);
+    });
+
+    it('should toggle aria-invalid attribute on invalid property change', () => {
+      group.invalid = true;
+      expect(group.getAttribute('aria-invalid')).to.equal('true');
+      group.invalid = false;
+      expect(group.hasAttribute('aria-invalid')).to.be.false;
+    });
+  });
+
   describe('focused state', () => {
     beforeEach(async () => {
       group = fixtureSync(`


### PR DESCRIPTION
## Description

Fixes #4199

## Screen readers

### VoiceOver

![Screenshot 2022-07-14 at 16 59 14](https://user-images.githubusercontent.com/10589913/179000469-647c0d88-e89a-4429-bcec-1f10e1c8e070.png)

### NVDA

![Screenshot 2022-07-14 at 16 59 58](https://user-images.githubusercontent.com/10589913/179000513-5db3c0cb-e1ef-4934-ab9f-96ed983c4dd2.png)

## Type of change

- Bugfix