### PR TITLE
fix: set aria-invalid attribute on the radio-group (#4203) (CP: 23.1)

### DIFF
--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -249,6 +249,23 @@ class RadioGroup extends FieldMixin(
   }
 
   /**
+   * Override an observer from `FieldMixin`.
+   *
+   * @param {boolean} invalid
+   * @protected
+   * @override
+   */
+  _invalidChanged(invalid) {
+    super._invalidChanged(invalid);
+
+    if (invalid) {
+      this.setAttribute('aria-invalid', 'true');
+    } else {
+      this.removeAttribute('aria-invalid');
+    }
+  }
+
+  /**
    * @param {number} index
    * @private
    */

--- a/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
@@ -319,6 +319,7 @@ snapshots["vaadin-radio-group host helper"] =
 
 snapshots["vaadin-radio-group host error"] = 
 `<vaadin-radio-group
+  aria-invalid="true"
   aria-labelledby="error-message-vaadin-radio-group-5"
   has-error-message=""
   invalid=""

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -216,6 +216,19 @@ describe('radio-group', () => {
     });
   });
 
+  describe('aria-invalid attribute', () => {
+    beforeEach(() => {
+      group = fixtureSync(`<vaadin-radio-group></vaadin-radio-group>`);
+    });
+
+    it('should toggle aria-invalid attribute on invalid property change', () => {
+      group.invalid = true;
+      expect(group.getAttribute('aria-invalid')).to.equal('true');
+      group.invalid = false;
+      expect(group.hasAttribute('aria-invalid')).to.be.false;
+    });
+  });
+
   describe('focused state', () => {
     beforeEach(async () => {
       group = fixtureSync(`


### PR DESCRIPTION
## Description

Manual cherry-pick of #4203 to `23.1` branch (there were conflicts in unit tests and snapshot).

## Type of change

- Cherry-pick