### PR TITLE
test: add test for removing slotted helper

### DIFF
--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -423,6 +423,12 @@ const runTests = (baseClass) => {
         await nextFrame();
         expect(helper.textContent).to.not.equal('3 digits');
       });
+
+      it('should remove has-helper attribute when slotted helper is removed', async () => {
+        element.removeChild(helper);
+        await nextFrame();
+        expect(element.hasAttribute('has-helper')).to.be.false;
+      });
     });
 
     describe('slotted with property', () => {
@@ -751,11 +757,11 @@ const runTests = (baseClass) => {
   describe('slotted label', () => {
     beforeEach(async () => {
       element = fixtureSync(`
-          <${tag}>
-            <label slot="label">Label</label>
-            <input slot="input">
-          </${tag}>
-        `);
+        <${tag}>
+          <label slot="label">Label</label>
+          <input slot="input">
+        </${tag}>
+      `);
       await nextRender();
       input = element.querySelector('[slot=input]');
       label = element.querySelector('[slot=label]');


### PR DESCRIPTION
## Description

As mentioned in https://github.com/vaadin/web-components/pull/4205#issuecomment-1184595152, some of the removed radio-group unit tests were still needed. 
So I checked the `FieldMixin` tests and at least the test case for removing slotted helper was missing.

I'm not sure if we should restore `radio-group` tests as the actual fix in the #2759 where they were introduced was to rename conflicting `_observer` which is also used in other components e.g. `vaadin-checkbox-group` 🤔 

## Type of change

- Tests