### PR TITLE
fix: do not remove custom `label-position="top"` attribute

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -531,8 +531,12 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
 
         if (child.localName === 'vaadin-form-item') {
           if (this._labelsOnTop) {
-            child.setAttribute('label-position', 'top');
-          } else {
+            if (child.getAttribute('label-position') !== 'top') {
+              child.__useLayoutLabelPosition = true;
+              child.setAttribute('label-position', 'top');
+            }
+          } else if (child.__useLayoutLabelPosition) {
+            delete child.__useLayoutLabelPosition;
             child.removeAttribute('label-position');
           }
         }

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -332,6 +332,31 @@ describe('form layout', () => {
       expect(layout.children[2].getAttribute('label-position')).to.equal('top');
     });
 
+    describe('custom label-position', () => {
+      beforeEach(async () => {
+        const item = document.createElement('vaadin-form-item');
+        item.setAttribute('label-position', 'top');
+        layout.insertBefore(item, layout.lastElementChild);
+        await nextRender();
+      });
+
+      it('should not remove custom label-position attribute on added form-item elements', () => {
+        expect(layout.children[3].getAttribute('label-position')).to.equal('top');
+      });
+
+      it('should not remove custom label-position attribute after updating responsive steps', () => {
+        layout.responsiveSteps = [{ columns: 1, labelsPosition: 'top' }];
+
+        expect(layout.children[2].getAttribute('label-position')).to.equal('top');
+        expect(layout.children[3].getAttribute('label-position')).to.equal('top');
+
+        layout.responsiveSteps = [{ columns: 1 }];
+
+        expect(layout.children[2].getAttribute('label-position')).to.be.null;
+        expect(layout.children[3].getAttribute('label-position')).to.equal('top');
+      });
+    });
+
     describe('responsive', () => {
       beforeEach(() => {
         document.body.style.minWidth = '0';


### PR DESCRIPTION
## Description

Added flag to distinguish `vaadin-form-item` elements managed by layout from those that have custom `label-position`.

Note: the flag is set on individual item elements which should make it possible to also keep the label position when adding to another layout (which is the case when using Vaadin Designer, although I don't remember if it supports `label-position`).

Fixes #1195

## Type of change

- Bugfix