### PR TITLE
test: extract a setInputValue helper

### DIFF
--- a/packages/time-picker/test/form-input.test.js
+++ b/packages/time-picker/test/form-input.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, focusout, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { TimePicker } from '../src/vaadin-time-picker.js';
+import { setInputValue } from './helpers.js';
 
 class TimePicker20Element extends TimePicker {
   checkValidity() {
@@ -13,11 +14,6 @@ customElements.define('vaadin-time-picker-20', TimePicker20Element);
 
 describe('form input', () => {
   let timePicker, comboBox, inputElement;
-
-  function inputValue(value) {
-    inputElement.value = value;
-    inputElement.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
-  }
 
   describe('initial validation', () => {
     let validateSpy;
@@ -140,10 +136,10 @@ describe('form input', () => {
     it('should not mark empty input as invalid', () => {
       expect(timePicker.validate()).to.equal(true);
 
-      inputValue('22:00');
+      setInputValue(timePicker, '22:00');
       expect(timePicker.validate()).to.equal(true);
 
-      inputValue('');
+      setInputValue(timePicker, '');
       expect(timePicker.validate()).to.equal(true);
     });
 
@@ -164,10 +160,10 @@ describe('form input', () => {
       timePicker.pattern = '^1\\d:.*';
       timePicker.preventInvalidInput = true;
 
-      inputValue('22:00');
+      setInputValue(timePicker, '22:00');
       expect(inputElement.value).to.be.not.ok;
 
-      inputValue('12:34');
+      setInputValue(timePicker, '12:34');
       expect(inputElement.value).to.equal('12:34');
     });
 
@@ -183,20 +179,20 @@ describe('form input', () => {
     });
 
     it('should validate keyboard input (invalid)', () => {
-      inputValue('foo');
+      setInputValue(timePicker, 'foo');
       expect(timePicker.invalid).to.be.equal(false);
       focusout(comboBox);
       expect(timePicker.invalid).to.be.equal(true);
     });
 
     it('should validate keyboard input (valid)', () => {
-      inputValue('12:00');
+      setInputValue(timePicker, '12:00');
       focusout(comboBox);
       expect(timePicker.invalid).to.be.equal(false);
     });
 
     it('should validate keyboard input (disallowed value)', () => {
-      inputValue('99:00');
+      setInputValue(timePicker, '99:00');
       expect(timePicker.invalid).to.be.equal(false);
       focusout(comboBox);
       expect(timePicker.invalid).to.be.equal(true);

--- a/packages/time-picker/test/helpers.js
+++ b/packages/time-picker/test/helpers.js
@@ -1,0 +1,12 @@
+import { fire } from '@vaadin/testing-helpers';
+
+/**
+ * Emulates the user filling in something in the time-picker input.
+ *
+ * @param {Element} timePicker
+ * @param {string} value
+ */
+export function setInputValue(timePicker, value) {
+  timePicker.inputElement.value = value;
+  fire(timePicker.inputElement, 'input');
+}

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -3,14 +3,10 @@ import { arrowDown, arrowUp, enter, esc, fixtureSync, nextFrame } from '@vaadin/
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-time-picker.js';
+import { setInputValue } from './helpers.js';
 
 describe('time-picker', () => {
   let timePicker, comboBox, inputElement;
-
-  function changeInputValue(el, value) {
-    el.value = value;
-    el.dispatchEvent(new CustomEvent('change'));
-  }
 
   beforeEach(() => {
     timePicker = fixtureSync(`<vaadin-time-picker></vaadin-time-picker>`);
@@ -40,7 +36,8 @@ describe('time-picker', () => {
     });
 
     it('should not set value if the format is invalid', () => {
-      changeInputValue(comboBox, 'invalid');
+      setInputValue(comboBox, 'invalid');
+      enter(timePicker.inputElement);
       expect(timePicker.value).to.be.equal('');
       expect(comboBox.value).to.be.equal('invalid');
     });
@@ -52,8 +49,10 @@ describe('time-picker', () => {
     });
 
     it('should change value to empty string when setting invalid value', () => {
-      changeInputValue(comboBox, '09:00');
-      changeInputValue(comboBox, 'invalid');
+      setInputValue(comboBox, '09:00');
+      enter(timePicker.inputElement);
+      setInputValue(comboBox, 'invalid');
+      enter(timePicker.inputElement);
       expect(timePicker.value).to.be.equal('');
     });
 
@@ -84,7 +83,8 @@ describe('time-picker', () => {
       timePicker.value = '12:00';
       timePicker.value = 'invalid';
       expect(timePicker.value).to.be.equal('12:00');
-      changeInputValue(comboBox, 'invalid');
+      setInputValue(comboBox, 'invalid');
+      enter(timePicker.inputElement);
       expect(timePicker.value).to.be.equal('');
       expect(comboBox.value).to.be.equal('');
     });
@@ -93,7 +93,8 @@ describe('time-picker', () => {
       comboBox.value = '12:00';
       comboBox.value = '';
       expect(timePicker.value).to.be.equal('');
-      changeInputValue(comboBox, '');
+      setInputValue(comboBox, '');
+      enter(timePicker.inputElement);
       expect(timePicker.value).to.be.equal('');
       expect(comboBox.value).to.be.equal('');
     });


### PR DESCRIPTION
## Description

This PR introduces a `setInputValue` test helper for emulating the user filling in something in the `time-picker` input and makes unit tests use it instead of custom implementations.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
