### PR TITLE
docs: fix i18n property JSDoc formatting

### DIFF
--- a/packages/avatar/src/vaadin-avatar.d.ts
+++ b/packages/avatar/src/vaadin-avatar.d.ts
@@ -66,10 +66,13 @@ declare class Avatar extends FocusMixin(ElementMixin(ThemableMixin(HTMLElement))
    * _i18n_ object or just the property you want to modify.
    *
    * The object has the following JSON structure and default values:
-   *           {
-   *             // Translation of the anonymous user avatar title.
-   *             anonymous: 'anonymous'
-   *           }
+   *
+   * ```
+   * {
+   *   // Translation of the anonymous user avatar title.
+   *   anonymous: 'anonymous'
+   * }
+   * ```
    */
   i18n: AvatarI18n;
 }

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -170,13 +170,17 @@ class Avatar extends FocusMixin(ElementMixin(ThemableMixin(PolymerElement))) {
        * _i18n_ object or just the property you want to modify.
        *
        * The object has the following JSON structure and default values:
-          {
-            // Translation of the anonymous user avatar title.
-            anonymous: 'anonymous'
-          }
-      * @type {!AvatarI18n}
-      * @default {English/US}
-      */
+       *
+       * ```
+       * {
+       *   // Translation of the anonymous user avatar title.
+       *   anonymous: 'anonymous'
+       * }
+       * ```
+       *
+       * @type {!AvatarI18n}
+       * @default {English/US}
+       */
       i18n: {
         type: Object,
         value: () => {

--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -67,24 +67,26 @@ export declare class LoginMixinClass {
    * and `header` sections, `header` can be added to override `title` and `description` properties
    * in `vaadin-login-overlay`):
    *
-   *         {
-   *           header: {
-   *             title: 'App name',
-   *             description: 'Inspiring application description'
-   *           },
-   *           form: {
-   *             title: 'Log in',
-   *             username: 'Username',
-   *             password: 'Password',
-   *             submit: 'Log in',
-   *             forgotPassword: 'Forgot password'
-   *           },
-   *           errorMessage: {
-   *             title: 'Incorrect username or password',
-   *             message: 'Check that you have entered the correct username and password and try again.'
-   *           },
-   *           additionalInformation: 'In case you need to provide some additional info for the user.'
-   *         }
+   * ```
+   * {
+   *   header: {
+   *     title: 'App name',
+   *     description: 'Inspiring application description'
+   *   },
+   *   form: {
+   *     title: 'Log in',
+   *     username: 'Username',
+   *     password: 'Password',
+   *     submit: 'Log in',
+   *     forgotPassword: 'Forgot password'
+   *   },
+   *   errorMessage: {
+   *     title: 'Incorrect username or password',
+   *     message: 'Check that you have entered the correct username and password and try again.'
+   *   },
+   *   additionalInformation: 'In case you need to provide some additional info for the user.'
+   * }
+   * ```
    */
   i18n: LoginI18n;
 

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -81,35 +81,38 @@ export const LoginMixin = (superClass) =>
         },
 
         /**
-       * The object used to localize this component.
-       * For changing the default localization, change the entire
-       * _i18n_ object or just the property you want to modify.
-       *
-       * The object has the following JSON structure (by default it doesn't include `additionalInformation`
-       * and `header` sections, `header` can be added to override `title` and `description` properties
-       * in `vaadin-login-overlay`):
-
-        {
-          header: {
-            title: 'App name',
-            description: 'Inspiring application description'
-          },
-          form: {
-            title: 'Log in',
-            username: 'Username',
-            password: 'Password',
-            submit: 'Log in',
-            forgotPassword: 'Forgot password'
-          },
-          errorMessage: {
-            title: 'Incorrect username or password',
-            message: 'Check that you have entered the correct username and password and try again.'
-          },
-          additionalInformation: 'In case you need to provide some additional info for the user.'
-        }
-       * @type {!LoginI18n}
-       * @default {English/US}
-       */
+         * The object used to localize this component.
+         * For changing the default localization, change the entire
+         * _i18n_ object or just the property you want to modify.
+         *
+         * The object has the following JSON structure (by default it doesn't include `additionalInformation`
+         * and `header` sections, `header` can be added to override `title` and `description` properties
+         * in `vaadin-login-overlay`):
+         *
+         * ```
+         * {
+         *   header: {
+         *     title: 'App name',
+         *     description: 'Inspiring application description'
+         *   },
+         *   form: {
+         *     title: 'Log in',
+         *     username: 'Username',
+         *     password: 'Password',
+         *     submit: 'Log in',
+         *     forgotPassword: 'Forgot password'
+         *   },
+         *   errorMessage: {
+         *     title: 'Incorrect username or password',
+         *     message: 'Check that you have entered the correct username and password and try again.'
+         *   },
+         *   additionalInformation: 'In case you need to provide some additional info for the user.'
+         * }
+         * ```
+         *
+         * @type {!LoginI18n}
+         * @default {English/US}
+         */
         i18n: {
           type: Object,
           value() {


### PR DESCRIPTION
## Description

Aligned the JSDoc comments for `avatar` and `login` with other components e.g. `upload`.
This makes the code snippets representing object structure looks better in API docs.

## Example

### Before

![Screenshot 2022-07-15 at 14 27 35](https://user-images.githubusercontent.com/10589913/179215083-33b91da9-f02e-4b14-847f-749db30be3b2.png)

### After

![Screenshot 2022-07-15 at 14 27 19](https://user-images.githubusercontent.com/10589913/179215067-c3338266-c65a-4c2d-9baf-7e5215de040b.png)

## Type of change

- Documentation