### PR TITLE
test: update helper to click actual dropdown items

### DIFF
--- a/packages/combo-box/test/helpers.js
+++ b/packages/combo-box/test/helpers.js
@@ -75,10 +75,7 @@ export const flushComboBox = (comboBox) => {
  * Emulates selecting an item at the given index.
  */
 export const selectItem = (comboBox, index) => {
-  // Simulates clicking on the overlay items, but it more reliable in tests.
-  fire(comboBox._scroller, 'selection-changed', {
-    item: comboBox.items[index],
-  });
+  getAllItems(comboBox)[index].click();
 };
 
 /**

--- a/packages/combo-box/test/object-values.test.js
+++ b/packages/combo-box/test/object-values.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
@@ -9,7 +9,7 @@ describe('object values', () => {
   let comboBox, input;
 
   describe('label and value paths', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
       input = comboBox.inputElement;
 
@@ -27,6 +27,7 @@ describe('object values', () => {
       ];
 
       comboBox.open();
+      await nextRender();
     });
 
     it('it should change combo-box value when value path changes', () => {
@@ -41,8 +42,7 @@ describe('object values', () => {
       expect(input.value).to.eql('foo');
     });
 
-    it('should use the default label property in overlay items', async () => {
-      await aTimeout(1);
+    it('should use the default label property in overlay items', () => {
       expect(getFirstItem(comboBox).textContent).to.contain('foo');
     });
 
@@ -158,6 +158,8 @@ describe('object values', () => {
       selectItem(comboBox, 2);
       expect(input.value).to.eql('zero');
       expect(comboBox.value).to.eql(0);
+
+      comboBox.open();
 
       selectItem(comboBox, 5);
       expect(input.value).to.eql('zero as a string');

--- a/packages/combo-box/test/selecting-items.test.js
+++ b/packages/combo-box/test/selecting-items.test.js
@@ -3,7 +3,7 @@ import { aTimeout, fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
-import { getAllItems, getFirstItem, onceScrolled, scrollToIndex, selectItem, setInputValue } from './helpers.js';
+import { getAllItems, getFirstItem, onceScrolled, scrollToIndex, setInputValue } from './helpers.js';
 
 describe('selecting items', () => {
   let comboBox;
@@ -83,14 +83,15 @@ describe('selecting items', () => {
   it('should close the dropdown when reselecting the current value', () => {
     comboBox.value = 'foo';
     comboBox.open();
-    selectItem(comboBox, 0);
+    getFirstItem(comboBox).click();
     expect(comboBox.opened).to.be.false;
   });
 
   it('should not fire an event when reselecting the current value', () => {
     comboBox.value = 'foo';
+    comboBox.open();
     valueChangedSpy.resetHistory();
-    selectItem(comboBox, 0);
+    getFirstItem(comboBox).click();
     expect(valueChangedSpy.callCount).to.equal(0);
   });
 


### PR DESCRIPTION
## Description

The helper that simulates clicks claims it makes tests more reliable. However, in many other tests we actually click items without issues. Furthermore, there were at least two tests where `selectItem()` was called without opening combo-box 🙈 


## Type of change

- Test