### PR TITLE
test: use the sendKeys API instead of inputText helpers

### DIFF
--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -6,8 +6,6 @@ import {
   enterKeyDown,
   escKeyDown,
   fixtureSync,
-  focusout,
-  inputText,
   keyboardEventFor,
   nextFrame,
 } from '@vaadin/testing-helpers';
@@ -536,6 +534,7 @@ describe('keyboard', () => {
   describe('auto open disabled', () => {
     beforeEach(() => {
       comboBox.autoOpenDisabled = true;
+      input.focus();
     });
 
     it('should open the overlay with arrow down', () => {
@@ -548,53 +547,53 @@ describe('keyboard', () => {
       expect(comboBox.opened).to.equal(true);
     });
 
-    it('should apply input value on focusout if input valid', () => {
-      inputText(input, 'FOO');
-      focusout(comboBox);
+    it('should apply input value on focusout if input valid', async () => {
+      await sendKeys({ type: 'FOO' });
+      input.blur();
       expect(input.value).to.equal('foo');
       expect(comboBox.value).to.equal('foo');
     });
 
-    it('should apply input value on enter if input valid', () => {
-      inputText(input, 'FOO');
-      enterKeyDown(input);
+    it('should apply input value on enter if input valid', async () => {
+      await sendKeys({ type: 'FOO' });
+      await sendKeys({ press: 'Enter' });
       expect(input.value).to.equal('foo');
       expect(comboBox.value).to.equal('foo');
     });
 
-    it('should not apply input value on enter if input invalid', () => {
-      inputText(input, 'quux');
-      enterKeyDown(input);
+    it('should not apply input value on enter if input invalid', async () => {
+      await sendKeys({ type: 'quux' });
+      await sendKeys({ press: 'Enter' });
       expect(input.value).to.equal('quux');
       expect(comboBox.value).to.equal('');
     });
 
-    it('should revert input value on focusout if input invalid', () => {
-      inputText(input, 'quux');
-      focusout(comboBox);
+    it('should revert input value on focusout if input invalid', async () => {
+      await sendKeys({ type: 'quux' });
+      input.blur();
       expect(input.value).to.equal('');
       expect(comboBox.value).to.equal('');
     });
 
-    it('should revert input value on esc if input valid', () => {
-      inputText(input, 'foo');
-      escKeyDown(input);
+    it('should revert input value on esc if input valid', async () => {
+      await sendKeys({ type: 'foo' });
+      await sendKeys({ press: 'Escape' });
       expect(input.value).to.equal('');
       expect(comboBox.value).to.equal('');
     });
 
-    it('should revert input value on esc if input invalid', () => {
-      inputText(input, 'quux');
-      escKeyDown(input);
+    it('should revert input value on esc if input invalid', async () => {
+      await sendKeys({ type: 'quux' });
+      await sendKeys({ press: 'Escape' });
       expect(input.value).to.equal('');
       expect(comboBox.value).to.equal('');
     });
 
-    it('should revert changed input value on esc if clear button is visible', () => {
+    it('should revert changed input value on esc if clear button is visible', async () => {
       comboBox.value = 'bar';
       comboBox.clearButtonVisible = true;
-      inputText(input, 'foo');
-      escKeyDown(input);
+      await sendKeys({ type: 'foo' });
+      await sendKeys({ press: 'Escape' });
       expect(input.value).to.equal('bar');
       expect(comboBox.value).to.equal('bar');
     });
@@ -614,8 +613,8 @@ describe('keyboard', () => {
       expect(comboBox.value).to.equal('bar');
     });
 
-    it('should not propagate when input value is not empty', () => {
-      inputText(input, 'foo');
+    it('should not propagate when input value is not empty', async () => {
+      await sendKeys({ type: 'foo' });
 
       const event = keyboardEventFor('keydown', 27, [], 'Escape');
       const keyDownSpy = sinon.spy(event, 'stopPropagation');

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -5,11 +5,10 @@ import {
   aTimeout,
   enterKeyDown,
   escKeyDown,
-  fire,
   fixtureSync,
   focusout,
+  inputText,
   keyboardEventFor,
-  keyDownOn,
   nextFrame,
 } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
@@ -22,19 +21,6 @@ describe('keyboard', () => {
 
   function getFocusedIndex() {
     return comboBox._focusedIndex;
-  }
-
-  function inputChar(char) {
-    const target = input;
-    target.value += char;
-    keyDownOn(target, char.charCodeAt(0));
-    fire(target, 'input');
-  }
-
-  function inputText(text) {
-    for (let i = 0; i < text.length; i++) {
-      inputChar(text[i]);
-    }
   }
 
   beforeEach(() => {
@@ -563,42 +549,42 @@ describe('keyboard', () => {
     });
 
     it('should apply input value on focusout if input valid', () => {
-      inputText('FOO');
+      inputText(input, 'FOO');
       focusout(comboBox);
       expect(input.value).to.equal('foo');
       expect(comboBox.value).to.equal('foo');
     });
 
     it('should apply input value on enter if input valid', () => {
-      inputText('FOO');
+      inputText(input, 'FOO');
       enterKeyDown(input);
       expect(input.value).to.equal('foo');
       expect(comboBox.value).to.equal('foo');
     });
 
     it('should not apply input value on enter if input invalid', () => {
-      inputText('quux');
+      inputText(input, 'quux');
       enterKeyDown(input);
       expect(input.value).to.equal('quux');
       expect(comboBox.value).to.equal('');
     });
 
     it('should revert input value on focusout if input invalid', () => {
-      inputText('quux');
+      inputText(input, 'quux');
       focusout(comboBox);
       expect(input.value).to.equal('');
       expect(comboBox.value).to.equal('');
     });
 
     it('should revert input value on esc if input valid', () => {
-      inputText('foo');
+      inputText(input, 'foo');
       escKeyDown(input);
       expect(input.value).to.equal('');
       expect(comboBox.value).to.equal('');
     });
 
     it('should revert input value on esc if input invalid', () => {
-      inputText('quux');
+      inputText(input, 'quux');
       escKeyDown(input);
       expect(input.value).to.equal('');
       expect(comboBox.value).to.equal('');
@@ -607,7 +593,7 @@ describe('keyboard', () => {
     it('should revert changed input value on esc if clear button is visible', () => {
       comboBox.value = 'bar';
       comboBox.clearButtonVisible = true;
-      inputText('foo');
+      inputText(input, 'foo');
       escKeyDown(input);
       expect(input.value).to.equal('bar');
       expect(comboBox.value).to.equal('bar');
@@ -629,7 +615,7 @@ describe('keyboard', () => {
     });
 
     it('should not propagate when input value is not empty', () => {
-      inputText('foo');
+      inputText(input, 'foo');
 
       const event = keyboardEventFor('keydown', 27, [], 'Escape');
       const keyDownSpy = sinon.spy(event, 'stopPropagation');

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, inputText, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { InputController } from '../src/input-controller.js';
 import { PatternMixin } from '../src/pattern-mixin.js';
@@ -73,6 +74,7 @@ const runTests = (baseClass) => {
       sinon.stub(console, 'warn');
       element.preventInvalidInput = true;
       element.value = '1';
+      element.inputElement.focus();
       await nextFrame();
     });
 
@@ -87,7 +89,7 @@ const runTests = (baseClass) => {
     it('should prevent invalid pattern', async () => {
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText(input, 'f');
+      await sendKeys({ type: 'f' });
       await nextFrame();
       expect(element.value).to.equal('1');
     });
@@ -95,7 +97,7 @@ const runTests = (baseClass) => {
     it('should temporarily set input-prevented attribute on invalid input', async () => {
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText(input, 'f');
+      await sendKeys({ type: 'f' });
       await nextFrame();
       expect(element.hasAttribute('input-prevented')).to.be.true;
     });
@@ -103,7 +105,7 @@ const runTests = (baseClass) => {
     it('should not set input-prevented attribute on valid input', async () => {
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText(input, '1');
+      await sendKeys({ type: '1' });
       await nextFrame();
       expect(element.hasAttribute('input-prevented')).to.be.false;
     });
@@ -112,7 +114,7 @@ const runTests = (baseClass) => {
       element.pattern = '[0-9]*';
       await nextFrame();
       const clock = sinon.useFakeTimers();
-      inputText(input, 'f');
+      await sendKeys({ type: 'f' });
       clock.tick(200);
       expect(element.hasAttribute('input-prevented')).to.be.false;
       clock.restore();
@@ -122,7 +124,7 @@ const runTests = (baseClass) => {
       element.value = '';
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText(input, 'f');
+      await sendKeys({ type: 'f' });
       await nextFrame();
       expect(input.value).to.equal('');
     });
@@ -132,7 +134,7 @@ const runTests = (baseClass) => {
       element.addEventListener('value-changed', spy);
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText(input, 'f');
+      await sendKeys({ type: 'f' });
       await nextFrame();
       expect(spy.called).to.be.false;
     });
@@ -140,15 +142,15 @@ const runTests = (baseClass) => {
     it('should not prevent valid pattern', async () => {
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText(input, '2');
+      await sendKeys({ type: '2' });
       await nextFrame();
-      expect(input.value).to.equal('2');
+      expect(input.value).to.equal('12');
     });
 
     it('should not prevent too short value', async () => {
       input.minlength = 1;
       await nextFrame();
-      inputText(input, '');
+      await sendKeys({ press: 'Backspace' });
       await nextFrame();
       expect(input.value).to.equal('');
     });
@@ -156,7 +158,7 @@ const runTests = (baseClass) => {
     it('should not prevent empty value for required field', async () => {
       element.required = true;
       await nextFrame();
-      inputText(input, '');
+      await sendKeys({ press: 'Backspace' });
       await nextFrame();
       expect(input.value).to.equal('');
     });

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, inputText, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { InputController } from '../src/input-controller.js';
 import { PatternMixin } from '../src/pattern-mixin.js';
@@ -79,11 +79,6 @@ const runTests = (baseClass) => {
     afterEach(() => {
       console.warn.restore();
     });
-
-    function inputText(value) {
-      input.value = value;
-      input.dispatchEvent(new CustomEvent('input'));
-    }
 
     it('should warn about using preventInvalidInput', () => {
       expect(console.warn.calledOnce).to.be.true;

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -87,7 +87,7 @@ const runTests = (baseClass) => {
     it('should prevent invalid pattern', async () => {
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText('f');
+      inputText(input, 'f');
       await nextFrame();
       expect(element.value).to.equal('1');
     });
@@ -95,7 +95,7 @@ const runTests = (baseClass) => {
     it('should temporarily set input-prevented attribute on invalid input', async () => {
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText('f');
+      inputText(input, 'f');
       await nextFrame();
       expect(element.hasAttribute('input-prevented')).to.be.true;
     });
@@ -103,7 +103,7 @@ const runTests = (baseClass) => {
     it('should not set input-prevented attribute on valid input', async () => {
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText('1');
+      inputText(input, '1');
       await nextFrame();
       expect(element.hasAttribute('input-prevented')).to.be.false;
     });
@@ -112,7 +112,7 @@ const runTests = (baseClass) => {
       element.pattern = '[0-9]*';
       await nextFrame();
       const clock = sinon.useFakeTimers();
-      inputText('f');
+      inputText(input, 'f');
       clock.tick(200);
       expect(element.hasAttribute('input-prevented')).to.be.false;
       clock.restore();
@@ -122,7 +122,7 @@ const runTests = (baseClass) => {
       element.value = '';
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText('f');
+      inputText(input, 'f');
       await nextFrame();
       expect(input.value).to.equal('');
     });
@@ -132,7 +132,7 @@ const runTests = (baseClass) => {
       element.addEventListener('value-changed', spy);
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText('f');
+      inputText(input, 'f');
       await nextFrame();
       expect(spy.called).to.be.false;
     });
@@ -140,7 +140,7 @@ const runTests = (baseClass) => {
     it('should not prevent valid pattern', async () => {
       element.pattern = '[0-9]*';
       await nextFrame();
-      inputText('2');
+      inputText(input, '2');
       await nextFrame();
       expect(input.value).to.equal('2');
     });
@@ -148,7 +148,7 @@ const runTests = (baseClass) => {
     it('should not prevent too short value', async () => {
       input.minlength = 1;
       await nextFrame();
-      inputText('');
+      inputText(input, '');
       await nextFrame();
       expect(input.value).to.equal('');
     });
@@ -156,7 +156,7 @@ const runTests = (baseClass) => {
     it('should not prevent empty value for required field', async () => {
       element.required = true;
       await nextFrame();
-      inputText('');
+      inputText(input, '');
       await nextFrame();
       expect(input.value).to.equal('');
     });

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -226,13 +226,13 @@ describe('text-area', () => {
 
     it('should prevent non matching input', () => {
       textArea.pattern = '[0-9]*';
-      inputText('f');
+      inputText(textArea, 'f');
       expect(textArea.inputElement.value).to.equal('1');
     });
 
     it('should not prevent input when pattern is invalid', () => {
       textArea.pattern = '[0-9])))]*';
-      inputText('f');
+      inputText(textArea, 'f');
       expect(textArea.inputElement.value).to.equal('f');
     });
   });

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, inputText, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-text-area.js';
 
@@ -222,18 +223,19 @@ describe('text-area', () => {
     beforeEach(() => {
       textArea.preventInvalidInput = true;
       textArea.value = '1';
+      textArea.inputElement.focus();
     });
 
-    it('should prevent non matching input', () => {
+    it('should prevent non matching input', async () => {
       textArea.pattern = '[0-9]*';
-      inputText(textArea, 'f');
+      await sendKeys({ type: 'f' });
       expect(textArea.inputElement.value).to.equal('1');
     });
 
-    it('should not prevent input when pattern is invalid', () => {
+    it('should not prevent input when pattern is invalid', async () => {
       textArea.pattern = '[0-9])))]*';
-      inputText(textArea, 'f');
-      expect(textArea.inputElement.value).to.equal('f');
+      await sendKeys({ type: 'f' });
+      expect(textArea.inputElement.value).to.equal('1f');
     });
   });
 

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, inputText, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-text-area.js';
 
@@ -223,11 +223,6 @@ describe('text-area', () => {
       textArea.preventInvalidInput = true;
       textArea.value = '1';
     });
-
-    function inputText(value) {
-      textArea.inputElement.value = value;
-      textArea.inputElement.dispatchEvent(new CustomEvent('input'));
-    }
 
     it('should prevent non matching input', () => {
       textArea.pattern = '[0-9]*';

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -222,20 +222,19 @@ describe('text-area', () => {
   describe('prevent invalid input', () => {
     beforeEach(() => {
       textArea.preventInvalidInput = true;
-      textArea.value = '1';
       textArea.inputElement.focus();
     });
 
     it('should prevent non matching input', async () => {
       textArea.pattern = '[0-9]*';
       await sendKeys({ type: 'f' });
-      expect(textArea.inputElement.value).to.equal('1');
+      expect(textArea.inputElement.value).to.equal('');
     });
 
     it('should not prevent input when pattern is invalid', async () => {
       textArea.pattern = '[0-9])))]*';
       await sendKeys({ type: 'f' });
-      expect(textArea.inputElement.value).to.equal('1f');
+      expect(textArea.inputElement.value).to.equal('f');
     });
   });
 


### PR DESCRIPTION
## Description

This PR replaces `inputText` helpers with the `sendKeys` API.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
