### PR TITLE
refactor: remove no longer used code

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1248,9 +1248,6 @@ export const ComboBoxMixin = (subclass) =>
       if (this.opened) {
         this._focusedIndex = this.filteredItems.indexOf(e.detail.item);
         this.close();
-      } else if (this.selectedItem !== e.detail.item) {
-        this.selectedItem = e.detail.item;
-        this._detectAndDispatchChange();
       }
     }
 


### PR DESCRIPTION
## Description

Previously, this code was covered by two tests that incorrectly used `selectItem` helper, see #4217.
In fact, the event is always fired on item click, which is only possible when combo-box is opened:

https://github.com/vaadin/web-components/blob/a52a5d29a45ed6ff23a363bd6fb95d78eb7e6165/packages/combo-box/src/vaadin-combo-box-scroller.js#L326-L329

And setting `selectedItem` actually happens when committing value after closing the dropdown:

https://github.com/vaadin/web-components/blob/a52a5d29a45ed6ff23a363bd6fb95d78eb7e6165/packages/combo-box/src/vaadin-combo-box-mixin.js#L887-L890

This behavior is intentional and has been first introduced in https://github.com/vaadin/vaadin-combo-box/pull/785

## Type of change

- Refactor