### PR TITLE
fix: do not throw when setting opened attribute

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -438,9 +438,7 @@ export const ComboBoxMixin = (subclass) =>
       };
 
       // Ensure the scroller is rendered
-      if (!this.opened) {
-        overlay.requestContentUpdate();
-      }
+      overlay.requestContentUpdate();
 
       const scroller = overlay.querySelector(scrollerTag);
 

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -521,6 +521,10 @@ describe('value set before attach', () => {
 
 describe('pre-opened', () => {
   it('should not throw error when adding a pre-opened combo-box', () => {
+    expect(() => fixtureSync(`<vaadin-combo-box opened></vaadin-combo-box>`)).to.not.throw(Error);
+  });
+
+  it('should not throw error when adding a pre-opened combo-box with items', () => {
     expect(() => fixtureSync(`<vaadin-combo-box opened items="[0]"></vaadin-combo-box>`)).to.not.throw(Error);
   });
 


### PR DESCRIPTION
## Description

This code was updated in #3944 with the assumption that setting `opened` should trigger sync observer for overlay and render the scroller. However, this is not the case when `opened` is set without items. Restored old logic and added the test.

## Type of change

- Bugfix