### PR TITLE
test: reorganize validation tests, improve test coverage

### DIFF
--- a/packages/time-picker/test/form-input.test.js
+++ b/packages/time-picker/test/form-input.test.js
@@ -121,14 +121,6 @@ describe('form input', () => {
       enter(timePicker.inputElement);
       expect(timePicker.invalid).to.be.true;
     });
-
-    it('should set an empty value when trying to commit an invalid time', () => {
-      timePicker.value = '12:00';
-      setInputValue(timePicker, 'foo');
-      enter(timePicker.inputElement);
-      expect(timePicker.value).to.equal('');
-      expect(timePicker.inputElement.value).to.equal('foo');
-    });
   });
 
   describe('required', () => {


### PR DESCRIPTION
## Description

The PR reorganizes `time-picker` validation unit tests and improves test coverage, similar to how it was done for `date-picker` in #4163.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
