### PR TITLE
test: rename form-input test suite to validation

### DIFF
--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -13,7 +13,7 @@ class DatePicker2016 extends DatePicker {
 
 customElements.define('vaadin-date-picker-2016', DatePicker2016);
 
-describe('form input', () => {
+describe('validation', () => {
   let datePicker;
 
   describe('initial', () => {


### PR DESCRIPTION
## Description

The name `form-input.test.js` is caused by the fact that originally, validation logic was introduced as part of `<iron-form>` support, see https://github.com/vaadin/vaadin-date-picker/pull/69. Let's align it with other components that use `describe('validation'`.

## Type of change

- Tests