### PR TITLE
chore: remove work in progress note from README

### DIFF
--- a/packages/multi-select-combo-box/README.md
+++ b/packages/multi-select-combo-box/README.md
@@ -1,7 +1,5 @@
 # @vaadin/multi-select-combo-box
 
-> ⚠️ Work in progress, please do not use this component yet.
-
 A web component that wraps `<vaadin-combo-box>` and allows selecting multiple items.
 
 ```html


### PR DESCRIPTION
## Description

Now when `vaadin-multi-select-combo-box` is considered to be ready, let's remove this outdated README note.

## Type of change

- Internal change