### PR TITLE
test: move Enter key tests to keyboard suite

### DIFF
--- a/packages/combo-box/test/form-input.test.js
+++ b/packages/combo-box/test/form-input.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, keyboardEventFor, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
@@ -105,26 +105,6 @@ describe('form field', () => {
       document.body.appendChild(comboBox);
       await nextRender();
       expect(validateSpy.called).to.be.false;
-    });
-  });
-
-  describe('enter key behavior', () => {
-    let keydownEvent;
-
-    beforeEach(() => {
-      // Fake a keydown event to mimic form submit.
-      keydownEvent = keyboardEventFor('keydown', 13, [], 'Enter');
-    });
-
-    it('should prevent default on open combobox', () => {
-      comboBox.open();
-      comboBox.dispatchEvent(keydownEvent);
-      expect(keydownEvent.defaultPrevented).to.be.true;
-    });
-
-    it('should not prevent default on closed combobox', () => {
-      comboBox.dispatchEvent(keydownEvent);
-      expect(keydownEvent.defaultPrevented).to.be.false;
     });
   });
 });

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -622,4 +622,24 @@ describe('keyboard', () => {
       expect(keyDownSpy.called).to.be.true;
     });
   });
+
+  describe('enter key behavior', () => {
+    let keydownEvent;
+
+    beforeEach(() => {
+      // Fake a keydown event to mimic form submit.
+      keydownEvent = keyboardEventFor('keydown', 13, [], 'Enter');
+    });
+
+    it('should prevent default on open combobox', () => {
+      comboBox.open();
+      comboBox.dispatchEvent(keydownEvent);
+      expect(keydownEvent.defaultPrevented).to.be.true;
+    });
+
+    it('should not prevent default on closed combobox', () => {
+      comboBox.dispatchEvent(keydownEvent);
+      expect(keydownEvent.defaultPrevented).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## Description

Moved two tests for <kbd>Enter</kbd> key from `form-input.test.js` to `keyboard.test.js` as that file is a better place.
Once this PR and #4229 are merged, we can then remove the test suite to `validation.test.js` as in #4225

## Type of change

- Tests