### PR TITLE
docs: add missing JSDoc annotation for mixin (#4193) (#4194)

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -56,6 +56,7 @@ import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
  * @extends HTMLElement
  * @mixes ButtonsMixin
  * @mixes InteractionsMixin
+ * @mixes DisabledMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */


### PR DESCRIPTION
## Description

Cherry-pick to `23.0` branch.

## Type of change

- Cherry-pick