### PR TITLE
test: fix focusable content test on MacOS WebKit

### DIFF
--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -150,7 +150,7 @@ describe('keyboard', () => {
         };
         document.body.appendChild(focusable);
 
-        // Workaround Firefox sendKeys bug
+        // Workaround Playwright sendKeys bug
         focusable.focus();
         input.focus();
         arrowDownKeyDown(input);

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -134,32 +134,31 @@ describe('keyboard', () => {
     });
 
     describe('focusable items content', () => {
-      let button;
+      let focusable;
 
       beforeEach(() => {
-        button = document.createElement('button');
-        button.textContent = 'Button';
+        focusable = document.createElement('input');
       });
 
       afterEach(() => {
-        button.remove();
+        focusable.remove();
       });
 
       it('should tab to the next focusable when items have focusable content', async () => {
         comboBox.renderer = (root) => {
           root.innerHTML = '<input>';
         };
-        document.body.appendChild(button);
+        document.body.appendChild(focusable);
 
         // Workaround Firefox sendKeys bug
-        button.focus();
+        focusable.focus();
         input.focus();
         arrowDownKeyDown(input);
 
         await aTimeout(0);
 
         await sendKeys({ press: 'Tab' });
-        expect(document.activeElement).to.equal(button);
+        expect(document.activeElement).to.equal(focusable);
       });
     });
   });


### PR DESCRIPTION
## Description

When using Playwright on MacOS to test in WebKit, the `<button>` element can't get focus when pressing <kbd>Tab</kbd> because the corresponding flag in settings is not set https://github.com/microsoft/playwright/issues/2114#issuecomment-625467787. Updated the test to use `<input>` instead.

## Type of change

- Tests