### PR TITLE
test: update and cleanup validation tests

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -539,13 +539,6 @@ describe('clear button', () => {
     expect(datepicker.value).to.equal('');
   });
 
-  it('should validate on clear', () => {
-    datepicker.required = true;
-    datepicker.value = '1991-20-12';
-    click(clearButton);
-    expect(datepicker.invalid).to.equal(true);
-  });
-
   it('should remove has-value attribute on clear', () => {
     datepicker.value = '2000-02-01';
     click(clearButton);

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -87,49 +87,6 @@ describe('keyboard', () => {
     });
   });
 
-  describe('invalid date', () => {
-    it('should not select date on Enter if input invalid', async () => {
-      await open(datepicker);
-      await sendKeys({ type: 'foo' });
-      await sendKeys({ press: 'Enter' });
-      expect(datepicker.invalid).to.be.true;
-      expect(datepicker.checkValidity()).to.be.false;
-      expect(datepicker.value).to.equal('');
-      expect(input.value).to.equal('foo');
-    });
-
-    it('should validate on blur when not opened', async () => {
-      await sendKeys({ type: 'foo' });
-      await close(datepicker);
-      // Wait for overlay to finish closing
-      await nextRender(datepicker);
-      expect(datepicker.invalid).to.be.true;
-      expect(datepicker.checkValidity()).to.be.false;
-
-      // Clear the invalid input
-      input.select();
-      await sendKeys({ press: 'Backspace' });
-      const spy = sinon.spy(datepicker, 'validate');
-      input.blur();
-      expect(spy.callCount).to.equal(1);
-      expect(datepicker.invalid).to.be.false;
-    });
-
-    it('should validate on clear button', async () => {
-      datepicker.clearButtonVisible = true;
-      await sendKeys({ type: 'foo' });
-      await close(datepicker);
-      // Wait for overlay to finish closing. Without this, clear button click
-      // will trigger "close()" again, which will result in infinite loop.
-      await nextRender(datepicker);
-      const spy = sinon.spy(datepicker, 'validate');
-      datepicker.$.clearButton.click();
-      expect(spy.callCount).to.equal(1);
-      expect(datepicker.invalid).to.be.false;
-      expect(datepicker.checkValidity()).to.be.true;
-    });
-  });
-
   describe('no parseDate', () => {
     beforeEach(() => {
       datepicker.i18n = {

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -76,6 +76,17 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
+    it('should validate on clear button click', () => {
+      datePicker.clearButtonVisible = true;
+      // Set invalid value.
+      setInputValue(datePicker, 'foo');
+      enter(datePicker.inputElement);
+      validateSpy.resetHistory();
+      datePicker.$.clearButton.click();
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(datePicker.invalid).to.be.false;
+    });
+
     it('should validate on value change', () => {
       datePicker.value = '2020-01-01';
       expect(validateSpy.calledOnce).to.be.true;


### PR DESCRIPTION
## Description

Because of historical reasons, there are many tests in `keyboard-input.test.js` suite that cover validation.
This PR is a first part of moving related tests to `validation.test.js` where they should belong to.

## Type of change

- Tests