### PR TITLE
fix: prevent mousedown event for toggle button

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -164,7 +164,7 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
         >
           <slot name="prefix" slot="prefix"></slot>
           <slot name="value"></slot>
-          <div part="toggle-button" slot="suffix" aria-hidden="true"></div>
+          <div part="toggle-button" slot="suffix" aria-hidden="true" on-mousedown="_onToggleMouseDown"></div>
         </vaadin-input-container>
 
         <div part="helper-text">
@@ -496,6 +496,13 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
     event.preventDefault();
 
     this.opened = !this.readonly;
+  }
+
+  /** @private */
+  _onToggleMouseDown(event) {
+    // Prevent mousedown event to avoid blur and preserve focused state
+    // while opening, and to restore focus-ring attribute on closing.
+    event.preventDefault();
   }
 
   /**

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -307,6 +307,13 @@ describe('vaadin-select', () => {
         expect(event.defaultPrevented).to.be.true;
       });
 
+      it('should prevent default for the toggle button mousedown', () => {
+        const e = new CustomEvent('mousedown', { bubbles: true });
+        const spy = sinon.spy(e, 'preventDefault');
+        select.shadowRoot.querySelector('[part=toggle-button]').dispatchEvent(e);
+        expect(spy.calledOnce).to.be.true;
+      });
+
       it('should open the overlay on ArrowUp', () => {
         arrowUp(valueButton);
         expect(select.opened).to.be.true;


### PR DESCRIPTION
## Description

We have some logic to call `event.preventDefault()` on `mousedown` in combo-box and date-picker components:

https://github.com/vaadin/web-components/blob/2b0859f55b105278acf722dc25f8f5a5a52bbcc8/packages/date-picker/src/vaadin-date-picker.js#L212-L213

https://github.com/vaadin/web-components/blob/2b0859f55b105278acf722dc25f8f5a5a52bbcc8/packages/combo-box/src/vaadin-combo-box-mixin.js#L826-L827

Adding it to `vaadin-select` to align behavior and restore `focus-ring` if opened with toggle button while keyboard focused.

Fixes #4147

## Type of change

- Bugfix