### PR TITLE
docs: add missing theme property type

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -8,6 +8,7 @@ import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mix
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
 import type { ComboBoxDefaultItem, ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
 export {
@@ -151,6 +152,7 @@ interface ComboBoxLight<TItem = ComboBoxDefaultItem>
     InputMixinClass,
     DisabledMixinClass,
     ThemableMixinClass,
+    ThemePropertyMixinClass,
     ValidateMixinClass {}
 
 declare global {

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -18,6 +18,7 @@ import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
 import type { ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
 import type { ComboBoxDefaultItem } from './vaadin-combo-box-mixin.js';
@@ -247,6 +248,7 @@ interface ComboBox<TItem = ComboBoxDefaultItem>
     DelegateStateMixinClass,
     DelegateFocusMixinClass,
     ThemableMixinClass,
+    ThemePropertyMixinClass,
     ElementMixinClass,
     ControllerMixinClass {}
 

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -126,6 +126,7 @@ assertType<string>(narrowedComboBox.value);
 assertType<boolean>(narrowedComboBox.required);
 assertType<string>(narrowedComboBox.name);
 assertType<string>(narrowedComboBox.allowedCharPattern);
+assertType<string | null | undefined>(narrowedComboBox.theme);
 
 // ComboBox mixins
 assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBox);
@@ -203,6 +204,7 @@ assertType<boolean>(narrowedComboBoxLight.invalid);
 assertType<boolean>(narrowedComboBoxLight.disabled);
 assertType<boolean>(narrowedComboBoxLight.readonly);
 assertType<string>(narrowedComboBoxLight.value);
+assertType<string | null | undefined>(narrowedComboBoxLight.theme);
 
 // ComboBoxLight mixins
 assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -6,6 +6,7 @@
 import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { ActiveItemMixinClass } from './vaadin-grid-active-item-mixin.js';
 import type { ArrayDataProviderMixinClass } from './vaadin-grid-array-data-provider-mixin.js';
 import type { GridColumn } from './vaadin-grid-column.js';
@@ -393,6 +394,7 @@ interface Grid<TItem = GridDefaultItem>
   extends DisabledMixinClass,
     ElementMixinClass,
     ThemableMixinClass,
+    ThemePropertyMixinClass,
     ActiveItemMixinClass<TItem>,
     ArrayDataProviderMixinClass<TItem>,
     DataProviderMixinClass<TItem>,

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -185,6 +185,8 @@ assertType<boolean>(narrowedGrid.allRowsVisible);
 assertType<() => void>(narrowedGrid.recalculateColumnWidths);
 assertType<() => void>(narrowedGrid.requestContentUpdate);
 
+assertType<string | null | undefined>(narrowedGrid.theme);
+
 /* GridColumn */
 const genericColumn = document.createElement('vaadin-grid-column');
 assertType<GridColumn>(genericColumn);

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -23,6 +23,7 @@ import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
 export type MultiSelectComboBoxRenderer<TItem> = (
   root: HTMLElement,
@@ -343,6 +344,7 @@ interface MultiSelectComboBox
     DelegateFocusMixinClass,
     ResizeMixinClass,
     ThemableMixinClass,
+    ThemePropertyMixinClass,
     ElementMixinClass,
     ControllerMixinClass {}
 

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -89,6 +89,7 @@ assertType<string | null | undefined>(narrowedComboBox.helperText);
 assertType<boolean>(narrowedComboBox.readonly);
 assertType<string | null | undefined>(narrowedComboBox.label);
 assertType<boolean>(narrowedComboBox.required);
+assertType<string | null | undefined>(narrowedComboBox.theme);
 
 // Mixins
 assertType<ControllerMixinClass>(narrowedComboBox);


### PR DESCRIPTION
The `theme` property is missing type definition in the following components:
- `<vaadin-grid>`
- `<vaadin-combo-box>`
- `<vaadin-combo-box-light>`
- `<vaadin-multi-select-combo-box>`

This PR fixes the issue by adding the missing `ThemePropertyMixinClass` to the element type