### PR TITLE
refactor: do not set hidden attribute on the overlay

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -82,7 +82,6 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
 
       <vaadin-combo-box-overlay
         id="overlay"
-        hidden$="[[_isOverlayHidden(filteredItems, loading)]]"
         opened="[[_overlayOpened]]"
         loading$="[[loading]]"
         theme$="[[_theme]]"

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -202,7 +202,6 @@ class ComboBox extends ComboBoxDataProviderMixin(
 
       <vaadin-combo-box-overlay
         id="overlay"
-        hidden$="[[_isOverlayHidden(filteredItems, loading)]]"
         opened="[[_overlayOpened]]"
         loading$="[[loading]]"
         theme$="[[_theme]]"

--- a/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
+++ b/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
@@ -439,7 +439,6 @@ snapshots["vaadin-combo-box shadow default"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
-  hidden=""
   id="overlay"
   no-vertical-overlap=""
 >
@@ -500,7 +499,6 @@ snapshots["vaadin-combo-box shadow disabled"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
-  hidden=""
   id="overlay"
   no-vertical-overlap=""
 >
@@ -561,7 +559,6 @@ snapshots["vaadin-combo-box shadow readonly"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
-  hidden=""
   id="overlay"
   no-vertical-overlap=""
 >
@@ -622,7 +619,6 @@ snapshots["vaadin-combo-box shadow invalid"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
-  hidden=""
   id="overlay"
   no-vertical-overlap=""
 >
@@ -683,7 +679,6 @@ snapshots["vaadin-combo-box shadow theme"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
-  hidden=""
   id="overlay"
   no-vertical-overlap=""
   theme="align-right"

--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -258,10 +258,11 @@ describe('internal filtering', () => {
       expect(comboBox.filteredItems).to.be.null;
     });
 
-    it('should hide overlay when filtered items length is 0', () => {
+    it('should close overlay when filtered items length is 0', () => {
       setInputValue(comboBox, 'THIS IS NOT FOUND');
 
-      expect(comboBox.opened && overlay.hasAttribute('hidden')).to.be.true;
+      expect(comboBox.opened).to.be.true;
+      expect(overlay.opened).to.be.false;
     });
 
     it('should reset the filter on value change', () => {

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -127,22 +127,31 @@ describe('toggling dropdown', () => {
       expect(comboBox.opened).to.be.true;
     });
 
-    it('should be hidden with null items', () => {
+    it('should not open overlay when setting items to null', () => {
       comboBox.items = null;
 
       comboBox.open();
 
       expect(comboBox.opened).to.be.true;
-      expect(overlay.hasAttribute('hidden')).to.be.true;
+      expect(overlay.opened).to.be.false;
     });
 
-    it('should be hidden with no items', () => {
+    it('should not open overlay when setting empty items array', () => {
       comboBox.items = [];
 
       comboBox.open();
 
       expect(comboBox.opened).to.be.true;
-      expect(overlay.hasAttribute('hidden')).to.be.true;
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not open overlay when setting empty filteredItems array', () => {
+      comboBox.filteredItems = [];
+
+      comboBox.open();
+
+      expect(comboBox.opened).to.be.true;
+      expect(overlay.opened).to.be.false;
     });
 
     (isIOS ? describe : describe.skip)('after opening', () => {
@@ -319,24 +328,6 @@ describe('toggling dropdown', () => {
 
     it('dropdown should not be shown when read-only', () => {
       click(input);
-      expect(comboBox.opened).to.be.false;
-    });
-  });
-
-  describe('empty list', () => {
-    it('vaadin-combo-box-overlay should not be attached when filteredItems is empty', () => {
-      comboBox.open();
-      expect(comboBox.opened).to.be.true;
-      expect(document.querySelector('vaadin-combo-box-overlay')).to.be.ok;
-      comboBox.close();
-      expect(comboBox.opened).to.be.false;
-      expect(document.querySelector('vaadin-combo-box-overlay')).not.to.be.ok;
-
-      comboBox.filteredItems = [];
-      comboBox.open();
-      expect(comboBox.opened).to.be.true;
-      expect(document.querySelector('vaadin-combo-box-overlay')).not.to.be.ok;
-      comboBox.close();
       expect(comboBox.opened).to.be.false;
     });
   });

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -25,6 +25,7 @@ describe('toggling dropdown', () => {
       expect(comboBox.opened).to.be.false;
       tap(comboBox.querySelector('[slot="label"]'));
       expect(comboBox.opened).to.be.true;
+      expect(overlay.opened).to.be.true;
     });
 
     it('should not open synchronously by clicking label when autoOpenDisabled is true', () => {
@@ -32,6 +33,7 @@ describe('toggling dropdown', () => {
       expect(comboBox.opened).to.be.false;
       tap(comboBox.querySelector('[slot="label"]'));
       expect(comboBox.opened).to.be.false;
+      expect(overlay.opened).to.be.false;
     });
 
     it('should restore attribute focus-ring if it was initially set before opening and combo-box is focused', () => {
@@ -45,6 +47,7 @@ describe('toggling dropdown', () => {
       expect(comboBox.opened).to.be.false;
       tap(input);
       expect(comboBox.opened).to.be.true;
+      expect(overlay.opened).to.be.true;
     });
 
     it('should not open synchronously by clicking input when autoOpenDisabled is true', () => {
@@ -52,12 +55,14 @@ describe('toggling dropdown', () => {
       expect(comboBox.opened).to.be.false;
       tap(input);
       expect(comboBox.opened).to.be.false;
+      expect(overlay.opened).to.be.false;
     });
 
     it('should open by clicking icon', () => {
       clickToggleIcon();
 
       expect(comboBox.opened).to.be.true;
+      expect(overlay.opened).to.be.true;
     });
 
     it('should open by clicking icon when autoOpenDisabled is true and input is invalid', () => {
@@ -103,6 +108,7 @@ describe('toggling dropdown', () => {
       comboBox.open();
 
       expect(comboBox.opened).to.be.true;
+      expect(overlay.opened).to.be.true;
     });
 
     it('should set body `pointer-events: none` on open and restore initial value on close', () => {
@@ -232,7 +238,7 @@ describe('toggling dropdown', () => {
 
       focusout(input);
 
-      expect(comboBox.opened).to.equal(false);
+      expect(comboBox.opened).to.be.false;
     });
 
     it('should restore focus to the field on outside click', async () => {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -38,7 +38,6 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
 
       <vaadin-multi-select-combo-box-overlay
         id="overlay"
-        hidden$="[[_isOverlayHidden(filteredItems, loading)]]"
         opened="[[_overlayOpened]]"
         loading$="[[loading]]"
         theme$="[[_theme]]"

--- a/packages/time-picker/src/vaadin-time-picker-combo-box.js
+++ b/packages/time-picker/src/vaadin-time-picker-combo-box.js
@@ -35,7 +35,6 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
 
       <vaadin-time-picker-overlay
         id="overlay"
-        hidden$="[[_isOverlayHidden(filteredItems, loading)]]"
         opened="[[_overlayOpened]]"
         loading$="[[loading]]"
         theme$="[[_theme]]"


### PR DESCRIPTION
## Description

The logic for setting `hidden` attribute on the overlay comes from an old implementation: https://github.com/vaadin/vaadin-combo-box/pull/569. Later when we discovered an issue caused by it in the time-picker https://github.com/vaadin/vaadin-time-picker/issues/58, we changed to set `opened` to `false` - see https://github.com/vaadin/vaadin-combo-box/pull/684 and https://github.com/vaadin/vaadin-combo-box/pull/964. But the old logic was not removed.

In fact, there is no need to set `hidden` as removing `opened` is enough to hide the overlay:

https://github.com/vaadin/web-components/blob/9cd686c08ad9b2d53bfbc561e251720bb0bf7344/packages/vaadin-overlay/src/vaadin-overlay.js#L145-L148

Finally, as you can see here, the logic to set `hidden` and `opened` has some duplicated checks:

https://github.com/vaadin/web-components/blob/9cd686c08ad9b2d53bfbc561e251720bb0bf7344/packages/combo-box/src/vaadin-combo-box-mixin.js#L477

https://github.com/vaadin/web-components/blob/9cd686c08ad9b2d53bfbc561e251720bb0bf7344/packages/combo-box/src/vaadin-combo-box-mixin.js#L484

That said, we can safely remove `hidden` from the overlay, and rely on its `opened` state instead.

## Type of change

- Refactor