### PR TITLE
refactor: cleanup no longer needed styles

### DIFF
--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -395,13 +395,3 @@ registerStyles(
   `,
   { moduleId: 'lumo-grid' },
 );
-
-registerStyles(
-  'vaadin-checkbox',
-  css`
-    :host(.vaadin-grid-select-all-checkbox) {
-      font-size: var(--lumo-font-size-m);
-    }
-  `,
-  { moduleId: 'vaadin-grid-select-all-checkbox-lumo' },
-);


### PR DESCRIPTION
## Description

Related to #4241

The font-size CSS property has been added to the `vaadin-checkbox` Lumo styles in #2746:

https://github.com/vaadin/web-components/blob/4fb709e15e78a2e1d12c7f38e5a28bfa7f028442/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js#L14

So we can now remove these styles from grid to avoid warning when importing grid after the checkbox.

## Type of change

- Refactor