### PR TITLE
feat: add column API to render buttons in cells

### DIFF
--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -823,10 +823,11 @@ class GridColumn extends ColumnBaseMixin(DirMixin(PolymerElement)) {
       },
 
       /**
-       * When true, sets role="button" and tabindex attribute on the slot element inside a cell,
-       * instead of the cell itself. This is needed to keep focus in sync with VoiceOver cursor
-       * when navigating with Control + Option + arrow keys: focusing the `<td>` element does not
-       * fire a focus event, but focusing an element with role="button" inside a cell fires it.
+       * When true, wraps the cell's slot into an element with role="button", and sets
+       * the tabindex attribute on the button element, instead of the cell itself.
+       * This is needed to keep focus in sync with VoiceOver cursor when navigating
+       * with Control + Option + arrow keys: focusing the `<td>` element does not fire
+       * a focus event, but focusing an element with role="button" inside a cell fires it.
        * @protected
        */
       _focusButtonMode: {

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -823,6 +823,18 @@ class GridColumn extends ColumnBaseMixin(DirMixin(PolymerElement)) {
       },
 
       /**
+       * When true, `tabindex` attribute is set on the element with `role="button"` inside a cell,
+       * rather than cell itself. This is needed to keep focus in sync with VoiceOver cursor when
+       * navigating with Control + Option + arrow keys: focusing the `<td>` element does not fire
+       * `focus` event, but focusing an element with `role="button"` inside a cell fires it.
+       * @protected
+       */
+      _cellButton: {
+        type: Boolean,
+        value: false,
+      },
+
+      /**
        * @type {Array<!HTMLElement>}
        * @protected
        */

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -823,13 +823,14 @@ class GridColumn extends ColumnBaseMixin(DirMixin(PolymerElement)) {
       },
 
       /**
-       * When true, `tabindex` attribute is set on the element with `role="button"` inside a cell,
-       * rather than cell itself. This is needed to keep focus in sync with VoiceOver cursor when
-       * navigating with Control + Option + arrow keys: focusing the `<td>` element does not fire
-       * `focus` event, but focusing an element with `role="button"` inside a cell fires it.
+       * When true, wraps the cell's slot into an element with role="button", and sets
+       * the tabindex attribute on the button element, instead of the cell itself.
+       * This is needed to keep focus in sync with VoiceOver cursor when navigating
+       * with Control + Option + arrow keys: focusing the `<td>` element does not fire
+       * a focus event, but focusing an element with role="button" inside a cell fires it.
        * @protected
        */
-      _cellButton: {
+      _focusButtonMode: {
         type: Boolean,
         value: false,
       },

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -823,11 +823,10 @@ class GridColumn extends ColumnBaseMixin(DirMixin(PolymerElement)) {
       },
 
       /**
-       * When true, wraps the cell's slot into an element with role="button", and sets
-       * the tabindex attribute on the button element, instead of the cell itself.
-       * This is needed to keep focus in sync with VoiceOver cursor when navigating
-       * with Control + Option + arrow keys: focusing the `<td>` element does not fire
-       * a focus event, but focusing an element with role="button" inside a cell fires it.
+       * When true, sets role="button" and tabindex attribute on the slot element inside a cell,
+       * instead of the cell itself. This is needed to keep focus in sync with VoiceOver cursor
+       * when navigating with Control + Option + arrow keys: focusing the `<td>` element does not
+       * fire a focus event, but focusing an element with role="button" inside a cell fires it.
        * @protected
        */
       _focusButtonMode: {

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -109,11 +109,20 @@ export const KeyboardNavigationMixin = (superClass) =>
     }
 
     set __rowFocusMode(value) {
-      ['_itemsFocusable', '_footerFocusable', '_headerFocusable'].forEach((focusable) => {
-        if (value && this.__isCell(this[focusable])) {
-          this[focusable] = this[focusable].parentElement;
-        } else if (!value && this.__isRow(this[focusable])) {
-          this[focusable] = this[focusable].firstElementChild;
+      ['_itemsFocusable', '_footerFocusable', '_headerFocusable'].forEach((prop) => {
+        const focusable = this[prop];
+        if (value) {
+          const parent = focusable && focusable.parentElement;
+          if (this.__isCell(focusable)) {
+            // Cell itself focusable (default)
+            this[prop] = parent;
+          } else if (this.__isCell(parent)) {
+            // Div inside a cell is focusable
+            this[prop] = parent.parentElement;
+          }
+        } else if (!value && this.__isRow(focusable)) {
+          const cell = focusable.firstElementChild;
+          this[prop] = cell._button || cell;
         }
       });
     }
@@ -154,10 +163,21 @@ export const KeyboardNavigationMixin = (superClass) =>
           if (this.__rowFocusMode) {
             // Row focus mode
             this._itemsFocusable = row;
-          } else if (this._itemsFocusable.parentElement) {
+          } else {
             // Cell focus mode
-            const cellIndex = [...this._itemsFocusable.parentElement.children].indexOf(this._itemsFocusable);
-            this._itemsFocusable = row.children[cellIndex];
+            let parent = this._itemsFocusable.parentElement;
+            let cell = this._itemsFocusable;
+
+            if (parent) {
+              // Div inside a cell is focusable
+              if (this.__isCell(parent)) {
+                cell = parent;
+                parent = parent.parentElement;
+              }
+
+              const cellIndex = [...parent.children].indexOf(cell);
+              this._itemsFocusable = this.__getFocusable(row, row.children[cellIndex]);
+            }
           }
         }
       });
@@ -737,11 +757,11 @@ export const KeyboardNavigationMixin = (superClass) =>
       if (section && (cell || row)) {
         this._activeRowGroup = section;
         if (this.$.header === section) {
-          this._headerFocusable = this.__rowFocusMode ? row : cell;
+          this._headerFocusable = this.__getFocusable(row, cell);
         } else if (this.$.items === section) {
-          this._itemsFocusable = this.__rowFocusMode ? row : cell;
+          this._itemsFocusable = this.__getFocusable(row, cell);
         } else if (this.$.footer === section) {
-          this._footerFocusable = this.__rowFocusMode ? row : cell;
+          this._footerFocusable = this.__getFocusable(row, cell);
         }
 
         if (cell) {
@@ -756,6 +776,19 @@ export const KeyboardNavigationMixin = (superClass) =>
       }
 
       this._detectFocusedItemIndex(e);
+    }
+
+    /**
+     * Get the focusable element depending on the current focus mode.
+     * It can be a row, a cell, or a focusable div inside a cell.
+     *
+     * @param {HTMLElement} row
+     * @param {HTMLElement} cell
+     * @return {HTMLElement}
+     * @private
+     */
+    __getFocusable(row, cell) {
+      return this.__rowFocusMode ? row : cell._button || cell;
     }
 
     /**
@@ -847,7 +880,7 @@ export const KeyboardNavigationMixin = (superClass) =>
           const firstVisibleRow = [...this.$[section].children].find((row) => row.offsetHeight);
           const firstVisibleCell = firstVisibleRow ? [...firstVisibleRow.children].find((cell) => !cell.hidden) : null;
           if (firstVisibleRow && firstVisibleCell) {
-            this[`_${section}Focusable`] = this.__rowFocusMode ? firstVisibleRow : firstVisibleCell;
+            this[`_${section}Focusable`] = this.__getFocusable(firstVisibleRow, firstVisibleCell);
           }
         }
       });
@@ -860,7 +893,7 @@ export const KeyboardNavigationMixin = (superClass) =>
         if (firstVisibleCell && firstVisibleRow) {
           // Reset memoized column
           delete this._focusedColumnOrder;
-          this._itemsFocusable = this.__rowFocusMode ? firstVisibleRow : firstVisibleCell;
+          this._itemsFocusable = this.__getFocusable(firstVisibleRow, firstVisibleCell);
         }
       } else {
         this.__updateItemsFocusable();

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -117,12 +117,13 @@ export const KeyboardNavigationMixin = (superClass) =>
             // Cell itself focusable (default)
             this[prop] = parent;
           } else if (this.__isCell(parent)) {
-            // Div inside a cell is focusable
+            // Focus button mode is enabled for the column,
+            // button element inside the cell is focusable.
             this[prop] = parent.parentElement;
           }
         } else if (!value && this.__isRow(focusable)) {
           const cell = focusable.firstElementChild;
-          this[prop] = cell._button || cell;
+          this[prop] = cell._focusButton || cell;
         }
       });
     }
@@ -169,7 +170,8 @@ export const KeyboardNavigationMixin = (superClass) =>
             let cell = this._itemsFocusable;
 
             if (parent) {
-              // Div inside a cell is focusable
+              // Focus button mode is enabled for the column,
+              // button element inside the cell is focusable.
               if (this.__isCell(parent)) {
                 cell = parent;
                 parent = parent.parentElement;
@@ -788,7 +790,7 @@ export const KeyboardNavigationMixin = (superClass) =>
      * @private
      */
     __getFocusable(row, cell) {
-      return this.__rowFocusMode ? row : cell._button || cell;
+      return this.__rowFocusMode ? row : cell._focusButton || cell;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -142,6 +142,17 @@ registerStyles(
       white-space: nowrap;
     }
 
+    [part~='cell'] > [tabindex] {
+      display: flex;
+      align-items: center;
+      outline: none;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
     [part~='details-cell'] {
       position: absolute;
       bottom: 0;

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -293,6 +293,7 @@ export interface GridEventMap<TItem> extends HTMLElementEventMap, GridCustomEven
  * `body-cell` | Body cell in the internal table
  * `footer-cell` | Footer cell in the internal table
  * `details-cell` | Row details cell in the internal table
+ * `focused-cell` | Focused cell in the internal table
  * `resize-handle` | Handle for resizing the columns
  * `reorder-ghost` | Ghost element of the header cell being dragged
  *

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -690,19 +690,23 @@ class Grid extends ElementMixin(
     slot.setAttribute('name', slotName);
 
     if (column && column._focusButtonMode) {
-      slot.setAttribute('role', 'button');
-      slot.setAttribute('tabindex', '-1');
+      const div = document.createElement('div');
+      div.setAttribute('role', 'button');
+      div.setAttribute('tabindex', '-1');
+      cell.appendChild(div);
 
-      // Patch `focus()` to use the slot
-      cell._focusButton = slot;
+      // Patch `focus()` to use the button
+      cell._focusButton = div;
       cell.focus = function () {
         cell._focusButton.focus();
       };
+
+      div.appendChild(slot);
     } else {
       cell.setAttribute('tabindex', '-1');
+      cell.appendChild(slot);
     }
 
-    cell.appendChild(slot);
     cell._content = cellContent;
 
     // With native Shadow DOM, mousedown on slotted element does not focus

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -180,6 +180,7 @@ import { StylingMixin } from './vaadin-grid-styling-mixin.js';
  * `body-cell` | Body cell in the internal table
  * `footer-cell` | Footer cell in the internal table
  * `details-cell` | Row details cell in the internal table
+ * `focused-cell` | Focused cell in the internal table
  * `resize-handle` | Handle for resizing the columns
  * `reorder-ghost` | Ghost element of the header cell being dragged
  *

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -660,7 +660,7 @@ class Grid extends ElementMixin(
   }
 
   /** @private */
-  _createCell(tagName, isCellButton) {
+  _createCell(tagName, column) {
     const contentId = (this._contentIndex = this._contentIndex + 1 || 0);
     const slotName = `vaadin-grid-cell-content-${contentId}`;
 
@@ -689,7 +689,7 @@ class Grid extends ElementMixin(
     const slot = document.createElement('slot');
     slot.setAttribute('name', slotName);
 
-    if (isCellButton) {
+    if (column && column._focusButtonMode) {
       const div = document.createElement('div');
       div.setAttribute('role', 'button');
       div.setAttribute('tabindex', '-1');
@@ -769,7 +769,7 @@ class Grid extends ElementMixin(
           column._cells = column._cells || [];
           cell = column._cells.find((cell) => cell._vacant);
           if (!cell) {
-            cell = this._createCell('td', column._cellButton);
+            cell = this._createCell('td', column);
             column._cells.push(cell);
           }
           cell.setAttribute('part', 'cell body-cell');

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -690,23 +690,19 @@ class Grid extends ElementMixin(
     slot.setAttribute('name', slotName);
 
     if (column && column._focusButtonMode) {
-      const div = document.createElement('div');
-      div.setAttribute('role', 'button');
-      div.setAttribute('tabindex', '-1');
-      cell.appendChild(div);
+      slot.setAttribute('role', 'button');
+      slot.setAttribute('tabindex', '-1');
 
-      // Patch `focus()` to use the button
-      cell._focusButton = div;
+      // Patch `focus()` to use the slot
+      cell._focusButton = slot;
       cell.focus = function () {
         cell._focusButton.focus();
       };
-
-      div.appendChild(slot);
     } else {
       cell.setAttribute('tabindex', '-1');
-      cell.appendChild(slot);
     }
 
+    cell.appendChild(slot);
     cell._content = cellContent;
 
     // With native Shadow DOM, mousedown on slotted element does not focus

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -696,9 +696,9 @@ class Grid extends ElementMixin(
       cell.appendChild(div);
 
       // Patch `focus()` to use the button
-      cell._button = div;
+      cell._focusButton = div;
       cell.focus = function () {
-        cell._button.focus();
+        cell._focusButton.focus();
       };
 
       div.appendChild(slot);

--- a/packages/grid/test/keyboard-navigation-cell-button.test.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.test.js
@@ -39,22 +39,23 @@ describe('keyboard navigation - cell button', () => {
     cell = getRowFirstCell(0);
   });
 
-  it('should set role="button" on the slot element inside the cell', () => {
+  it('should create a focusable div with role="button" inside the cell', () => {
+    expect(cell.firstChild.localName).to.equal('div');
     expect(cell.firstChild.getAttribute('role')).to.equal('button');
   });
 
-  it('should set tabindex on the slot element inside the cell', () => {
+  it('should set tabindex on the focusable div inside the cell', () => {
     expect(cell.hasAttribute('tabindex')).to.be.false;
     expect(cell.firstChild.getAttribute('tabindex')).to.equal('0');
   });
 
-  it('should focus the focusable slot when calling `focus()` on the cell', () => {
+  it('should focus the focusable div when calling `focus()` on the cell', () => {
     const spy = sinon.spy(cell.firstChild, 'focus');
     cell.focus();
     expect(spy.calledOnce).to.be.true;
   });
 
-  it('should update tabindex on the slot when focusing another cell', () => {
+  it('should update tabindex on the div when focusing another cell', () => {
     const cell2 = getRowFirstCell(1);
 
     cell2.focus();
@@ -63,13 +64,13 @@ describe('keyboard navigation - cell button', () => {
     expect(cell2.firstChild.getAttribute('tabindex')).to.equal('0');
   });
 
-  it('should update tabindex on the slot when enabling row focus mode', () => {
+  it('should update tabindex on the div when enabling row focus mode', () => {
     cell.focus();
     arrowLeft(cell.firstChild);
     expect(cell.firstChild.getAttribute('tabindex')).to.equal('-1');
   });
 
-  it('should restore tabindex on the slot when disabling row focus mode', () => {
+  it('should restore tabindex on the div when disabling row focus mode', () => {
     cell.focus();
     arrowLeft(cell.firstChild);
     arrowRight(cell.firstChild);

--- a/packages/grid/test/keyboard-navigation-cell-button.test.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.test.js
@@ -14,7 +14,7 @@ function getRowFirstCell(rowIndex) {
   return getRowCell(rowIndex, 0);
 }
 
-describe('keyboard navigation - cell button', () => {
+describe('keyboard navigation - focus button mode', () => {
   let cell;
 
   beforeEach(async () => {

--- a/packages/grid/test/keyboard-navigation-cell-button.test.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.test.js
@@ -39,23 +39,22 @@ describe('keyboard navigation - cell button', () => {
     cell = getRowFirstCell(0);
   });
 
-  it('should create a focusable div with role="button" inside the cell', () => {
-    expect(cell.firstChild.localName).to.equal('div');
+  it('should set role="button" on the slot element inside the cell', () => {
     expect(cell.firstChild.getAttribute('role')).to.equal('button');
   });
 
-  it('should set tabindex on the focusable div inside the cell', () => {
+  it('should set tabindex on the slot element inside the cell', () => {
     expect(cell.hasAttribute('tabindex')).to.be.false;
     expect(cell.firstChild.getAttribute('tabindex')).to.equal('0');
   });
 
-  it('should focus the focusable div when calling `focus()` on the cell', () => {
+  it('should focus the focusable slot when calling `focus()` on the cell', () => {
     const spy = sinon.spy(cell.firstChild, 'focus');
     cell.focus();
     expect(spy.calledOnce).to.be.true;
   });
 
-  it('should update tabindex on the div when focusing another cell', () => {
+  it('should update tabindex on the slot when focusing another cell', () => {
     const cell2 = getRowFirstCell(1);
 
     cell2.focus();
@@ -64,13 +63,13 @@ describe('keyboard navigation - cell button', () => {
     expect(cell2.firstChild.getAttribute('tabindex')).to.equal('0');
   });
 
-  it('should update tabindex on the div when enabling row focus mode', () => {
+  it('should update tabindex on the slot when enabling row focus mode', () => {
     cell.focus();
     arrowLeft(cell.firstChild);
     expect(cell.firstChild.getAttribute('tabindex')).to.equal('-1');
   });
 
-  it('should restore tabindex on the div when disabling row focus mode', () => {
+  it('should restore tabindex on the slot when disabling row focus mode', () => {
     cell.focus();
     arrowLeft(cell.firstChild);
     arrowRight(cell.firstChild);

--- a/packages/grid/test/keyboard-navigation-cell-button.test.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.test.js
@@ -1,0 +1,75 @@
+import { expect } from '@esm-bundle/chai';
+import { arrowLeft, arrowRight, aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-grid.js';
+import { flushGrid } from './helpers.js';
+
+let grid;
+
+function getRowCell(rowIndex, cellIndex) {
+  return grid.$.items.children[rowIndex].children[cellIndex];
+}
+
+function getRowFirstCell(rowIndex) {
+  return getRowCell(rowIndex, 0);
+}
+
+describe('keyboard navigation - cell button', () => {
+  let cell;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column path="name" _cell-button></vaadin-grid-column>
+        <vaadin-grid-column path="name"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+
+    grid.items = [{ name: 'foo' }, { name: 'bar' }];
+
+    grid._observer.flush();
+    flushGrid(grid);
+
+    await aTimeout(0);
+
+    cell = getRowFirstCell(0);
+  });
+
+  it('should create a focusable div with role="button" inside the cell', () => {
+    expect(cell.firstChild.localName).to.equal('div');
+    expect(cell.firstChild.getAttribute('role')).to.equal('button');
+  });
+
+  it('should set tabindex on the focusable div inside the cell', () => {
+    expect(cell.hasAttribute('tabindex')).to.be.false;
+    expect(cell.firstChild.getAttribute('tabindex')).to.equal('0');
+  });
+
+  it('should focus the focusable div when calling `focus()` on the cell', () => {
+    const spy = sinon.spy(cell.firstChild, 'focus');
+    cell.focus();
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should update tabindex on the div when focusing another cell', () => {
+    const cell2 = getRowFirstCell(1);
+
+    cell2.focus();
+
+    expect(cell.firstChild.getAttribute('tabindex')).to.equal('-1');
+    expect(cell2.firstChild.getAttribute('tabindex')).to.equal('0');
+  });
+
+  it('should update tabindex on the div when enabling row focus mode', () => {
+    cell.focus();
+    arrowLeft(cell.firstChild);
+    expect(cell.firstChild.getAttribute('tabindex')).to.equal('-1');
+  });
+
+  it('should restore tabindex on the div when disabling row focus mode', () => {
+    cell.focus();
+    arrowLeft(cell.firstChild);
+    arrowRight(cell.firstChild);
+    expect(cell.firstChild.getAttribute('tabindex')).to.equal('0');
+  });
+});

--- a/packages/grid/test/keyboard-navigation-cell-button.test.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.test.js
@@ -20,10 +20,14 @@ describe('keyboard navigation - cell button', () => {
   beforeEach(async () => {
     grid = fixtureSync(`
       <vaadin-grid>
-        <vaadin-grid-column path="name" _cell-button></vaadin-grid-column>
         <vaadin-grid-column path="name"></vaadin-grid-column>
       </vaadin-grid>
     `);
+
+    const column = document.createElement('vaadin-grid-column');
+    column.path = 'name';
+    column._focusButtonMode = true;
+    grid.insertBefore(column, grid.firstElementChild);
 
     grid.items = [{ name: 'foo' }, { name: 'bar' }];
 

--- a/packages/grid/test/keyboard-navigation-cell-button.test.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.test.js
@@ -76,4 +76,18 @@ describe('keyboard navigation - cell button', () => {
     arrowRight(cell.firstChild);
     expect(cell.firstChild.getAttribute('tabindex')).to.equal('0');
   });
+
+  it('should set focused-cell part on the div when focusing the cell', () => {
+    cell.focus();
+    expect(cell.firstChild.getAttribute('part')).to.equal('focused-cell');
+  });
+
+  it('should remove focused-cell part from the div when focusing other cell', () => {
+    cell.focus();
+    expect(cell.firstChild.getAttribute('part')).to.equal('focused-cell');
+
+    const cell2 = getRowFirstCell(1);
+    cell2.focus();
+    expect(cell.firstChild.getAttribute('part')).to.be.null;
+  });
 });

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1490,6 +1490,22 @@ describe('keyboard navigation', () => {
     });
   });
 
+  describe('focused-cell part', () => {
+    it('should add focused-cell to cell part when focused', () => {
+      focusFirstHeaderCell();
+
+      expect(getFirstHeaderCell().getAttribute('part')).to.contain('focused-cell');
+    });
+
+    it('should remove focused-cell from cell part when blurred', () => {
+      focusFirstHeaderCell();
+
+      focusable.focus();
+
+      expect(getFirstHeaderCell().getAttribute('part')).to.not.contain('focused-cell');
+    });
+  });
+
   describe('interaction mode', () => {
     beforeEach(async () => {
       grid = fixtureSync(`

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -74,7 +74,8 @@ registerStyles(
     }
 
     :host([navigating]) [part~='row']:focus::before,
-    :host([navigating]) [part~='cell']:focus::before {
+    :host([navigating]) [part~='cell']:focus::before,
+    :host([navigating]) [part~='cell'] > [tabindex]:focus::before {
       content: '';
       position: absolute;
       top: 0;

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -69,13 +69,12 @@ registerStyles(
     }
 
     [part~='row']:focus,
-    [part~='cell']:focus {
+    [part~='focused-cell']:focus {
       outline: none;
     }
 
     :host([navigating]) [part~='row']:focus::before,
-    :host([navigating]) [part~='cell']:focus::before,
-    :host([navigating]) [part~='cell'] > [tabindex]:focus::before {
+    :host([navigating]) [part~='focused-cell']:focus::before {
       content: '';
       position: absolute;
       top: 0;

--- a/packages/grid/theme/material/vaadin-grid-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-styles.js
@@ -131,13 +131,12 @@ registerStyles(
     }
 
     [part~='row']:focus,
-    [part~='cell']:focus {
+    [part~='focused-cell']:focus {
       outline: none;
     }
 
     :host([navigating]) [part~='row']:focus::before,
-    :host([navigating]) [part~='cell']:focus,
-    :host([navigating]) [part~='cell'] > [tabindex]:focus {
+    :host([navigating]) [part~='focused-cell']:focus {
       box-shadow: inset 0 0 0 2px var(--material-primary-color);
     }
 

--- a/packages/grid/theme/material/vaadin-grid-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-styles.js
@@ -136,12 +136,12 @@ registerStyles(
     }
 
     :host([navigating]) [part~='row']:focus::before,
-    :host([navigating]) [part~='cell']:focus {
+    :host([navigating]) [part~='cell']:focus,
+    :host([navigating]) [part~='cell'] > [tabindex]:focus {
       box-shadow: inset 0 0 0 2px var(--material-primary-color);
     }
 
-    :host([navigating]) [part~='row']:focus::before,
-    :host([navigating]) [part~='cell'] > [tabindex]:focus::before {
+    :host([navigating]) [part~='row']:focus::before {
       content: '';
       position: absolute;
       top: 0;

--- a/packages/grid/theme/material/vaadin-grid-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-styles.js
@@ -140,7 +140,8 @@ registerStyles(
       box-shadow: inset 0 0 0 2px var(--material-primary-color);
     }
 
-    :host([navigating]) [part~='row']:focus::before {
+    :host([navigating]) [part~='row']:focus::before,
+    :host([navigating]) [part~='cell'] > [tabindex]:focus::before {
       content: '';
       position: absolute;
       top: 0;


### PR DESCRIPTION
## Description

Pre-requisite for #3820

This PR adds a new internal API for `vaadin-grid-column` element to change how its body cells are rendered.
The idea behind the DOM structure is to align with [ARIA example](https://www.w3.org/WAI/ARIA/apg/example-index/grid/dataGrids.html#htmlsourcecode) for data grid with editable cells.

As discovered in #4114, VoiceOver on MacOS does not trigger `focus` events when navigating between `<td>` elements that have `tabindex` attribute. However, in case if an element inside `<td>` has `tabindex`, it gets focused.

So the outcome of this change is being able to keep keyboard focus in sync with VoiceOver cursor, so that pressing <kbd>Enter</kbd> on the editable cell in `vaadin-grid-pro` would start editing for the correct cell.

### Normal cells

```html
<td role="gridcell">
  <slot name="vaadin-grid-cell-content-12"></slot>
</td>
```

### Cells with button

```html
<td role="gridcell">
  <div role="button" tabindex="-1">
    <slot name="vaadin-grid-cell-content-12"></slot>
  </div>
</td>
```

## Type of change

- Internal feature

## Note

This PR does not contain any changes to `vaadin-grid-pro`, they will be implemented in a separate PR. As an example, we might need to also remove `role` attribute when rendering editor (e.g. `vaadin-text-field`) into the cell content, to avoid confusing screen reader announcement, and then restore `role="button"` on the `div` after editing is stopped. 
