### PR TITLE
test: rename form-input test suite to validation

### DIFF
--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -12,7 +12,7 @@ class TimePicker20Element extends TimePicker {
 
 customElements.define('vaadin-time-picker-20', TimePicker20Element);
 
-describe('form input', () => {
+describe('validation', () => {
   let timePicker;
 
   describe('initial', () => {


### PR DESCRIPTION
## Description

Same as #4225 but for `vaadin-time-picker`.

## Type of change

- Tests