### PR TITLE
refactor: validate input field on programmatic blur

### DIFF
--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -85,15 +85,17 @@ export const InputFieldMixin = (superclass) =>
     }
 
     /**
-     * Override an event listener from `DelegateFocusMixin`.
-     * @param {FocusEvent} event
+     * Override an event listener from `FocusMixin`.
+     * @param {boolean} focused
      * @protected
      * @override
      */
-    _onBlur(event) {
-      super._onBlur(event);
+    _setFocused(focused) {
+      super._setFocused(focused);
 
-      this.validate();
+      if (!focused) {
+        this.validate();
+      }
     }
 
     /**

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -103,7 +103,14 @@ describe('input-field-mixin', () => {
 
     it('should validate on input blur', () => {
       const spy = sinon.spy(element, 'validate');
-      input.dispatchEvent(new Event('blur'));
+      input.focus();
+      input.blur();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should validate on programmatic blur', () => {
+      const spy = sinon.spy(element, 'validate');
+      element.blur();
       expect(spy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
## Description

Fixes #1395

Updated `InputFieldMixin` to align with other components (e.g. `vaadin-combo-box`, `vaadin-select`, `vaadin-time-picker`).
 
## Type of change

- Refactor