### PR TITLE
fix: force the validation to check for bad user input

### DIFF
--- a/packages/integer-field/test/validation.test.js
+++ b/packages/integer-field/test/validation.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-integer-field.js';
 
@@ -64,6 +65,35 @@ describe('validation', () => {
       expect(validatedSpy.calledOnce).to.be.true;
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
+    });
+  });
+
+  describe('bad input', () => {
+    let input;
+
+    beforeEach(() => {
+      integerField = fixtureSync('<vaadin-integer-field></vaadin-integer-field>');
+      input = integerField.inputElement;
+      input.focus();
+    });
+
+    it('should be valid when committing a valid number', async () => {
+      await sendKeys({ type: '1' });
+      input.blur();
+      expect(integerField.invalid).to.be.false;
+    });
+
+    it('should be invalid when trying to commit a not valid number', async () => {
+      await sendKeys({ type: '1--' });
+      input.blur();
+      expect(integerField.invalid).to.be.true;
+    });
+
+    it('should set an empty value when trying to commit a not valid number', async () => {
+      integerField.value = '1';
+      await sendKeys({ type: '1--' });
+      await sendKeys({ type: 'Enter' });
+      expect(integerField.value).to.equal('');
     });
   });
 });

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -233,6 +233,20 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
   }
 
+  /**
+   * Override a method from `InputConstraintsMixin`
+   * to additionally check for bad user input.
+   *
+   * @override
+   */
+  checkValidity() {
+    if (this.inputElement && this.inputElement.validity.badInput) {
+      return false;
+    }
+
+    return super.checkValidity();
+  }
+
   /** @private */
   _decreaseButtonTouchend(e) {
     // Cancel the following click and focus events

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-number-field.js';
 
@@ -134,6 +135,33 @@ describe('validation', () => {
       expect(validatedSpy.calledOnce).to.be.true;
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
+    });
+  });
+
+  describe('bad input', () => {
+    beforeEach(() => {
+      field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+      input = field.inputElement;
+      input.focus();
+    });
+
+    it('should be valid when committing a valid number', async () => {
+      await sendKeys({ type: '1' });
+      input.blur();
+      expect(field.invalid).to.be.false;
+    });
+
+    it('should be invalid when trying to commit a not valid number', async () => {
+      await sendKeys({ type: '1--' });
+      input.blur();
+      expect(field.invalid).to.be.true;
+    });
+
+    it('should set an empty value when trying to commit a not valid number', async () => {
+      field.value = '1';
+      await sendKeys({ type: '1--' });
+      await sendKeys({ type: 'Enter' });
+      expect(field.value).to.equal('');
     });
   });
 


### PR DESCRIPTION
## Description

The PR overrides `checkValidity` for `number-field` to force it to check for bad user input before anything else. 

Earlier, `number-field` could stay valid after you have entered something bad in the case there were no constraints specified. This behavior was coming from `InputConstraintsMixin` which doesn't check native validity when no constraints. This is generally correct behavior. The exception is `input[type=number]` fields where the native `checkValidity` also checks for bad input.

Fixes #4258

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
