### PR TITLE
chore: remove legacy iconset import from dev page

### DIFF
--- a/dev/dialog.html
+++ b/dev/dialog.html
@@ -11,7 +11,6 @@
       import '@vaadin/dialog';
       import '@vaadin/button';
       import '@vaadin/icon';
-      import '@vaadin/vaadin-lumo-styles/iconset';
     </script>
   </head>
 


### PR DESCRIPTION
## Description

The `dialog.html` dev page uses wrong import that includes legacy iconset and causes a warning in the console.
Actually, there is no need to import icons separately, as they come with Lumo styles through `common.js` file.

## Type of change

- Internal change