### PR TITLE
refactor!: use `h2` element for dialog header title

### DIFF
--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -33,6 +33,10 @@ registerStyles(
       pointer-events: auto;
     }
 
+    ::slotted([slot='title']) {
+      font: inherit !important;
+    }
+
     [part='header-content'] {
       flex: 1;
     }
@@ -260,7 +264,7 @@ export class DialogOverlay extends OverlayElement {
   _headerTitleRenderer() {
     if (this.headerTitle) {
       if (!this.headerTitleElement) {
-        this.headerTitleElement = document.createElement('span');
+        this.headerTitleElement = document.createElement('h2');
         this.headerTitleElement.setAttribute('slot', 'title');
         this.headerTitleElement.classList.add('draggable');
       }

--- a/packages/dialog/test/header-footer.test.js
+++ b/packages/dialog/test/header-footer.test.js
@@ -34,6 +34,14 @@ describe('header/footer feature', () => {
       expect(overlay.textContent).to.include(HEADER_TITLE);
     });
 
+    it('should use `h2` element for rendering header title', () => {
+      dialog.headerTitle = HEADER_TITLE;
+      dialog.opened = true;
+
+      const title = overlay.querySelector('[slot=title]');
+      expect(title.localName).to.equal('h2');
+    });
+
     it('should remove title element if header-title is unset', () => {
       dialog.headerTitle = HEADER_TITLE;
       dialog.opened = true;


### PR DESCRIPTION
## Description

Fixes #3629

This is a behavior altering change: it might end up with user-defined styles for `h2` getting applied to header title.
As mentioned in https://github.com/vaadin/web-components/issues/3629#issuecomment-1128818281, it's still possible to provide a custom header without using `headerTitle`.

In order to ensure that CSS defined on `[part='title']` keeps working, I added the `font: inherit !important` rule.
This is necessary because otherwise, the default global styles from Lumo would override the dialog theme:

https://github.com/vaadin/web-components/blob/f227392d2a6d590ed71052c0ab638ff2b38d17e2/packages/vaadin-lumo-styles/typography.js#L59-L60

https://github.com/vaadin/web-components/blob/f227392d2a6d590ed71052c0ab638ff2b38d17e2/packages/vaadin-lumo-styles/typography.js#L70

Using `!important` here is needed because `::slotted()` always have a lower specificity than any styles from outside.
This is essentially the same case as we have with `<a>` elements wrapped in `<vaadin-tab>` where it's also used:

https://github.com/vaadin/web-components/blob/f227392d2a6d590ed71052c0ab638ff2b38d17e2/packages/tabs/theme/lumo/vaadin-tab-styles.js#L133-L134


## Type of change

- Refactor