### PR TITLE
fix: keep invalid user input when clearing value

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -549,10 +549,16 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     const parsedObj = (this.__memoValue = this.__parseISO(value));
     const newValue = this.__formatISO(parsedObj) || '';
 
-    if (this.value !== '' && this.value !== null && !parsedObj) {
+    if (value !== '' && value !== null && !parsedObj) {
+      // Value can not be parsed, reset to the old one.
       this.value = oldValue === undefined ? '' : oldValue;
-    } else if (this.value !== newValue) {
+    } else if (value !== newValue) {
+      // Value can be parsed (e.g. 12 -> 12:00), adjust.
       this.value = newValue;
+    } else if (this.__keepInvalidInput) {
+      // User input could not be parsed and was reset
+      // to empty string, do not update input value.
+      delete this.__keepInvalidInput;
     } else {
       this.__updateInputValue(parsedObj);
     }
@@ -576,6 +582,11 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
         this.__updateValue(parsedObj);
       }
     } else {
+      // If user input can not be parsed, keep it.
+      if (value !== '') {
+        this.__keepInvalidInput = true;
+      }
+
       this.value = '';
     }
   }

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -81,20 +81,20 @@ describe('time-picker', () => {
 
     it('should preserve invalid input value while resetting value to empty string', () => {
       timePicker.value = '12:00';
-      setInputValue(comboBox, 'foo');
-      enter(timePicker.inputElement);
+      setInputValue(timePicker, 'foo');
+      enter(inputElement);
       expect(timePicker.value).to.equal('');
-      expect(timePicker.inputElement.value).to.equal('foo');
+      expect(inputElement.value).to.equal('foo');
     });
 
     it('should not restore the previous value in input field if input value is invalid', () => {
       timePicker.value = '12:00';
       timePicker.value = 'foo';
       expect(timePicker.value).to.be.equal('12:00');
-      setInputValue(comboBox, 'bar');
-      enter(timePicker.inputElement);
+      setInputValue(timePicker, 'bar');
+      enter(inputElement);
       expect(timePicker.value).to.be.equal('');
-      expect(comboBox.value).to.be.equal('bar');
+      expect(inputElement.value).to.be.equal('bar');
     });
 
     it('should restore the previous value in input field if input value is empty', () => {

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -79,14 +79,22 @@ describe('time-picker', () => {
       expect(inputElement.value).to.be.equal('12:00');
     });
 
+    it('should preserve invalid input value while resetting value to empty string', () => {
+      timePicker.value = '12:00';
+      setInputValue(comboBox, 'foo');
+      enter(timePicker.inputElement);
+      expect(timePicker.value).to.equal('');
+      expect(timePicker.inputElement.value).to.equal('foo');
+    });
+
     it('should not restore the previous value in input field if input value is invalid', () => {
       timePicker.value = '12:00';
-      timePicker.value = 'invalid';
+      timePicker.value = 'foo';
       expect(timePicker.value).to.be.equal('12:00');
-      setInputValue(comboBox, 'invalid');
+      setInputValue(comboBox, 'bar');
       enter(timePicker.inputElement);
       expect(timePicker.value).to.be.equal('');
-      expect(comboBox.value).to.be.equal('');
+      expect(comboBox.value).to.be.equal('bar');
     });
 
     it('should restore the previous value in input field if input value is empty', () => {

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -121,6 +121,13 @@ describe('validation', () => {
       enter(timePicker.inputElement);
       expect(timePicker.invalid).to.be.true;
     });
+
+    it('should be invalid when trying to change value to an invalid time', () => {
+      timePicker.value = '12:00';
+      setInputValue(timePicker, 'foo');
+      enter(timePicker.inputElement);
+      expect(timePicker.invalid).to.be.true;
+    });
   });
 
   describe('required', () => {


### PR DESCRIPTION
## Description

Currently, the `_valueChanged` observer always tries to update `<input>` value when `value` is set to empty string.
This shouldn't happen when setting `value` to empty string is done as a result of committing invalid user input.

Looks like adding a flag in this case is the only way to reliably distinguish from case when `value` is cleared by the app logic (e.g.  when pressing "Reset" button to clear all the fields in the form) - in that case the  `<input>` value should be still cleared.

Fixes #4246

## Type of change

- Bugfix