### PR TITLE
feat: add internal has-input-value-changed event

### DIFF
--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -50,4 +50,8 @@ export declare class InputMixinClass {
   protected _toggleHasValue(value: boolean): void;
 
   protected _valueChanged(value?: string, oldValue?: string): void;
+
+  private __inputValuePopulatedChanged(): void;
+
+  private __onChange(event: void): void;
 }

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -50,8 +50,4 @@ export declare class InputMixinClass {
   protected _toggleHasValue(value: boolean): void;
 
   protected _valueChanged(value?: string, oldValue?: string): void;
-
-  private __inputValuePopulatedChanged(): void;
-
-  private __onChange(event: void): void;
 }

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -58,7 +58,7 @@ export const InputMixin = dedupingMixin(
            * @private
            */
           __inputValuePopulated: {
-            type: String,
+            type: Boolean,
             value: false,
             observer: '__inputValuePopulatedChanged',
           },
@@ -170,12 +170,12 @@ export const InputMixin = dedupingMixin(
        * A change event listener used to update __inputValuePopulated property.
        * Do not override this method.
        *
-       * @param {Event} _event
+       * @param {Event} event
        * @private
        */
-      __onChange(_event) {
-        this.__inputValuePopulated = _event.target.value.length > 0;
-        this._onChange(_event);
+      __onChange(event) {
+        this.__inputValuePopulated = event.target.value.length > 0;
+        this._onChange(event);
       }
 
       /**

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -55,12 +55,12 @@ export const InputMixin = dedupingMixin(
 
           /**
            * Populated state of the input's value.
-           * @private
+           * @protected
            */
-          __inputValuePopulated: {
+          _hasInputValue: {
             type: Boolean,
             value: false,
-            observer: '__inputValuePopulatedChanged',
+            observer: '_hasInputValueChanged',
           },
         };
       }
@@ -141,7 +141,7 @@ export const InputMixin = dedupingMixin(
        *
        * @private
        */
-      __inputValuePopulatedChanged() {
+      _hasInputValueChanged() {
         this.dispatchEvent(new CustomEvent('input-value-populated-changed'));
       }
 
@@ -174,7 +174,7 @@ export const InputMixin = dedupingMixin(
        * @private
        */
       __onChange(event) {
-        this.__inputValuePopulated = event.target.value.length > 0;
+        this._hasInputValue = event.target.value.length > 0;
         this._onChange(event);
       }
 

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -52,6 +52,16 @@ export const InputMixin = dedupingMixin(
             observer: '_valueChanged',
             notify: true,
           },
+
+          /**
+           * Populated state of the input's value.
+           * @private
+           */
+          __inputValuePopulated: {
+            type: String,
+            value: false,
+            observer: '__inputValuePopulatedChanged',
+          },
         };
       }
 
@@ -59,7 +69,7 @@ export const InputMixin = dedupingMixin(
         super();
 
         this._boundOnInput = this._onInput.bind(this);
-        this._boundOnChange = this._onChange.bind(this);
+        this._boundOnChange = this.__onChange.bind(this);
       }
 
       /**
@@ -127,6 +137,15 @@ export const InputMixin = dedupingMixin(
       }
 
       /**
+       * Observer to notify about the change of private property.
+       *
+       * @private
+       */
+      __inputValuePopulatedChanged() {
+        this.dispatchEvent(new CustomEvent('input-value-populated-changed'));
+      }
+
+      /**
        * An input event listener used to update the field value.
        *
        * @param {Event} event
@@ -146,6 +165,18 @@ export const InputMixin = dedupingMixin(
        * @protected
        */
       _onChange(_event) {}
+
+      /**
+       * A change event listener used to update __inputValuePopulated property.
+       * Do not override this method.
+       *
+       * @param {Event} _event
+       * @private
+       */
+      __onChange(_event) {
+        this.__inputValuePopulated = _event.target.value.length > 0;
+        this._onChange(_event);
+      }
 
       /**
        * Toggle the has-value attribute based on the value property.

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -142,7 +142,7 @@ export const InputMixin = dedupingMixin(
        * @private
        */
       _hasInputValueChanged() {
-        this.dispatchEvent(new CustomEvent('input-value-populated-changed'));
+        this.dispatchEvent(new CustomEvent('has-input-value-changed'));
       }
 
       /**

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -54,7 +54,7 @@ export const InputMixin = dedupingMixin(
           },
 
           /**
-           * Populated state of the input's value.
+           * When true, the input element has a non-empty value entered by the user.
            * @protected
            */
           _hasInputValue: {
@@ -169,7 +169,7 @@ export const InputMixin = dedupingMixin(
       _onChange(_event) {}
 
       /**
-       * A change event listener used to update __inputValuePopulated property.
+       * A change event listener used to update `_hasInputValue` property.
        * Do not override this method.
        *
        * @param {Event} event

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -141,8 +141,10 @@ export const InputMixin = dedupingMixin(
        *
        * @private
        */
-      _hasInputValueChanged() {
-        this.dispatchEvent(new CustomEvent('has-input-value-changed'));
+      _hasInputValueChanged(hasValue, oldHasValue) {
+        if (hasValue || oldHasValue) {
+          this.dispatchEvent(new CustomEvent('has-input-value-changed'));
+        }
       }
 
       /**

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -156,9 +156,9 @@ const runTests = (baseClass) => {
       expect(changeSpy.calledOnce).to.be.true;
     });
 
-    it('should fire input-value-populated-changed event on user value change', async () => {
+    it('should fire has-input-value-changed event on user value change', async () => {
       const spy = sinon.spy();
-      element.addEventListener('input-value-populated-changed', spy);
+      element.addEventListener('has-input-value-changed', spy);
 
       input.value = 'foo';
       input.dispatchEvent(new CustomEvent('change'));

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -110,11 +110,12 @@ const runTests = (baseClass) => {
   });
 
   describe('events', () => {
-    let eventsTag, inputSpy, changeSpy;
+    let eventsTag, inputSpy, changeSpy, hasInputValueSpy;
 
     before(() => {
       inputSpy = sinon.spy();
       changeSpy = sinon.spy();
+      hasInputValueSpy = sinon.spy();
 
       eventsTag = define[baseClass](
         'input-mixin-events',
@@ -134,6 +135,7 @@ const runTests = (baseClass) => {
 
     beforeEach(async () => {
       element = fixtureSync(`<${eventsTag}></${eventsTag}>`);
+      element.addEventListener('has-input-value-changed', hasInputValueSpy);
       await nextRender();
       input = document.createElement('input');
       element.appendChild(input);
@@ -144,6 +146,7 @@ const runTests = (baseClass) => {
     afterEach(() => {
       inputSpy.resetHistory();
       changeSpy.resetHistory();
+      hasInputValueSpy.resetHistory();
     });
 
     it('should call an input event listener', () => {
@@ -157,9 +160,6 @@ const runTests = (baseClass) => {
     });
 
     it('should fire has-input-value-changed event on user value change', async () => {
-      const spy = sinon.spy();
-      element.addEventListener('has-input-value-changed', spy);
-
       input.value = 'foo';
       input.dispatchEvent(new CustomEvent('change'));
       await nextFrame();
@@ -168,7 +168,7 @@ const runTests = (baseClass) => {
       input.dispatchEvent(new CustomEvent('change'));
       await nextFrame();
 
-      expect(spy.calledTwice).to.be.true;
+      expect(hasInputValueSpy.calledTwice).to.be.true;
     });
 
     it('should not call an input event listener when input is unset', async () => {

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -156,6 +156,21 @@ const runTests = (baseClass) => {
       expect(changeSpy.calledOnce).to.be.true;
     });
 
+    it("should notify about populated state of the input's value", async () => {
+      const spy = sinon.spy();
+      element.addEventListener('input-value-populated-changed', spy);
+
+      input.value = 'foo';
+      input.dispatchEvent(new CustomEvent('change'));
+      await nextFrame();
+
+      input.value = '';
+      input.dispatchEvent(new CustomEvent('change'));
+      await nextFrame();
+
+      expect(spy.calledTwice).to.be.true;
+    });
+
     it('should not call an input event listener when input is unset', async () => {
       element.removeChild(input);
       element._setInputElement(undefined);

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -156,7 +156,7 @@ const runTests = (baseClass) => {
       expect(changeSpy.calledOnce).to.be.true;
     });
 
-    it("should notify about populated state of the input's value", async () => {
+    it('should fire input-value-populated-changed event on user value change', async () => {
       const spy = sinon.spy();
       element.addEventListener('input-value-populated-changed', spy);
 

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -111,7 +111,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
           auto-open-disabled="[[autoOpenDisabled]]"
           position-target="[[_inputContainer]]"
           theme$="[[_theme]]"
-          on-change="__onChange"
+          on-change="__onComboBoxChange"
         >
           <vaadin-input-container
             part="input-field"
@@ -581,7 +581,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   }
 
   /** @private */
-  __onChange(event) {
+  __onComboBoxChange(event) {
     event.stopPropagation();
 
     this.validate();


### PR DESCRIPTION
Introduce `__inputValuePopulated` property and `input-value-populated-changed` event which will be used from the Flow counter-part.
Needed for the cases when value is not synced with the flow counter-part because of type differences. For example, in case of date-picker flow counterpart is not notified about inputing arbitrary string `qwerty` therefore it cannot be properly validated.

Event is not documented on purpose as intended for internal use.

Related: https://github.com/vaadin/flow-components/pull/3524.