### PR TITLE
docs: deprecate legacy @vaadin/vaadin- packages

### DIFF
--- a/packages/vaadin-accordion/src/vaadin-accordion.js
+++ b/packages/vaadin-accordion/src/vaadin-accordion.js
@@ -11,3 +11,5 @@ import { Accordion } from '@vaadin/accordion/src/vaadin-accordion.js';
 export const AccordionElement = Accordion;
 
 export * from '@vaadin/accordion/src/vaadin-accordion.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-accordion" is deprecated. Use "@vaadin/accordion" instead.');

--- a/packages/vaadin-app-layout/src/vaadin-app-layout.js
+++ b/packages/vaadin-app-layout/src/vaadin-app-layout.js
@@ -11,3 +11,7 @@ import { AppLayout } from '@vaadin/app-layout/src/vaadin-app-layout.js';
 export const AppLayoutElement = AppLayout;
 
 export * from '@vaadin/app-layout/src/vaadin-app-layout.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-app-layout" is deprecated. Use "@vaadin/app-layout" instead.',
+);

--- a/packages/vaadin-avatar/src/vaadin-avatar-group.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar-group.js
@@ -11,3 +11,5 @@ import { AvatarGroup } from '@vaadin/avatar-group/src/vaadin-avatar-group.js';
 export const AvatarGroupElement = AvatarGroup;
 
 export * from '@vaadin/avatar-group/src/vaadin-avatar-group.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-avatar" is deprecated. Use "@vaadin/avatar-group" instead.');

--- a/packages/vaadin-avatar/src/vaadin-avatar.js
+++ b/packages/vaadin-avatar/src/vaadin-avatar.js
@@ -11,3 +11,5 @@ import { Avatar } from '@vaadin/avatar/src/vaadin-avatar.js';
 export const AvatarElement = Avatar;
 
 export * from '@vaadin/avatar/src/vaadin-avatar.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-avatar" is deprecated. Use "@vaadin/avatar" instead.');

--- a/packages/vaadin-board/src/vaadin-board.js
+++ b/packages/vaadin-board/src/vaadin-board.js
@@ -11,3 +11,5 @@ import { Board } from '@vaadin/board/src/vaadin-board.js';
 export const BoardElement = Board;
 
 export * from '@vaadin/board/src/vaadin-board.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-board" is deprecated. Use "@vaadin/board" instead.');

--- a/packages/vaadin-button/src/vaadin-button.js
+++ b/packages/vaadin-button/src/vaadin-button.js
@@ -11,3 +11,5 @@ import { Button } from '@vaadin/button/src/vaadin-button.js';
 export const ButtonElement = Button;
 
 export * from '@vaadin/button/src/vaadin-button.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-button" is deprecated. Use "@vaadin/button" instead.');

--- a/packages/vaadin-charts/src/vaadin-chart.js
+++ b/packages/vaadin-charts/src/vaadin-chart.js
@@ -11,3 +11,5 @@ import { Chart } from '@vaadin/charts/src/vaadin-chart.js';
 export const ChartElement = Chart;
 
 export * from '@vaadin/charts/src/vaadin-chart.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-charts" is deprecated. Use "@vaadin/charts" instead.');

--- a/packages/vaadin-checkbox/src/vaadin-checkbox-group.js
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox-group.js
@@ -11,3 +11,7 @@ import { CheckboxGroup } from '@vaadin/checkbox-group/src/vaadin-checkbox-group.
 export const CheckboxGroupElement = CheckboxGroup;
 
 export * from '@vaadin/checkbox-group/src/vaadin-checkbox-group.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-checkbox" is deprecated. Use "@vaadin/checkbox-group" instead.',
+);

--- a/packages/vaadin-checkbox/src/vaadin-checkbox.js
+++ b/packages/vaadin-checkbox/src/vaadin-checkbox.js
@@ -11,3 +11,5 @@ import { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
 export const CheckboxElement = Checkbox;
 
 export * from '@vaadin/checkbox/src/vaadin-checkbox.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-checkbox" is deprecated. Use "@vaadin/checkbox" instead.');

--- a/packages/vaadin-combo-box/src/vaadin-combo-box.js
+++ b/packages/vaadin-combo-box/src/vaadin-combo-box.js
@@ -11,3 +11,5 @@ import { ComboBox } from '@vaadin/combo-box/src/vaadin-combo-box.js';
 export const ComboBoxElement = ComboBox;
 
 export * from '@vaadin/combo-box/src/vaadin-combo-box.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-combo-box" is deprecated. Use "@vaadin/combo-box" instead.');

--- a/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js
@@ -11,3 +11,7 @@ import { ConfirmDialog } from '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.
 export const ConfirmDialogElement = ConfirmDialog;
 
 export * from '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-confirm-dialog" is deprecated. Use "@vaadin/confirm-dialog" instead.',
+);

--- a/packages/vaadin-context-menu/src/vaadin-context-menu.js
+++ b/packages/vaadin-context-menu/src/vaadin-context-menu.js
@@ -11,3 +11,7 @@ import { ContextMenu } from '@vaadin/context-menu/src/vaadin-context-menu.js';
 export const ContextMenuElement = ContextMenu;
 
 export * from '@vaadin/context-menu/src/vaadin-context-menu.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-context-menu" is deprecated. Use "@vaadin/context-menu" instead.',
+);

--- a/packages/vaadin-cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/vaadin-cookie-consent/src/vaadin-cookie-consent.js
@@ -11,3 +11,7 @@ import { CookieConsent } from '@vaadin/cookie-consent/src/vaadin-cookie-consent.
 export const CookieConsentElement = CookieConsent;
 
 export * from '@vaadin/cookie-consent/src/vaadin-cookie-consent.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-cookie-consent" is deprecated. Use "@vaadin/cookie-consent" instead.',
+);

--- a/packages/vaadin-crud/src/vaadin-crud.js
+++ b/packages/vaadin-crud/src/vaadin-crud.js
@@ -11,3 +11,5 @@ import { Crud } from '@vaadin/crud/src/vaadin-crud.js';
 export const CrudElement = Crud;
 
 export * from '@vaadin/crud/src/vaadin-crud.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-crud" is deprecated. Use "@vaadin/crud" instead.');

--- a/packages/vaadin-custom-field/src/vaadin-custom-field.js
+++ b/packages/vaadin-custom-field/src/vaadin-custom-field.js
@@ -11,3 +11,7 @@ import { CustomField } from '@vaadin/custom-field/src/vaadin-custom-field.js';
 export const CustomFieldElement = CustomField;
 
 export * from '@vaadin/custom-field/src/vaadin-custom-field.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-custom-field" is deprecated. Use "@vaadin/custom-field" instead.',
+);

--- a/packages/vaadin-date-picker/src/vaadin-date-picker.js
+++ b/packages/vaadin-date-picker/src/vaadin-date-picker.js
@@ -11,3 +11,7 @@ import { DatePicker } from '@vaadin/date-picker/src/vaadin-date-picker.js';
 export const DatePickerElement = DatePicker;
 
 export * from '@vaadin/date-picker/src/vaadin-date-picker.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-date-picker" is deprecated. Use "@vaadin/date-picker" instead.',
+);

--- a/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/vaadin-date-time-picker/src/vaadin-date-time-picker.js
@@ -11,3 +11,7 @@ import { DateTimePicker } from '@vaadin/date-time-picker/src/vaadin-date-time-pi
 export const DateTimePickerElement = DateTimePicker;
 
 export * from '@vaadin/date-time-picker/src/vaadin-date-time-picker.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-date-time-picker" is deprecated. Use "@vaadin/date-time-picker" instead.',
+);

--- a/packages/vaadin-details/src/vaadin-details.js
+++ b/packages/vaadin-details/src/vaadin-details.js
@@ -11,3 +11,5 @@ import { Details } from '@vaadin/details/src/vaadin-details.js';
 export const DetailsElement = Details;
 
 export * from '@vaadin/details/src/vaadin-details.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-details" is deprecated. Use "@vaadin/details" instead.');

--- a/packages/vaadin-dialog/src/vaadin-dialog.js
+++ b/packages/vaadin-dialog/src/vaadin-dialog.js
@@ -11,3 +11,5 @@ import { Dialog } from '@vaadin/dialog/src/vaadin-dialog.js';
 export const DialogElement = Dialog;
 
 export * from '@vaadin/dialog/src/vaadin-dialog.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-dialog" is deprecated. Use "@vaadin/dialog" instead.');

--- a/packages/vaadin-form-layout/src/vaadin-form-layout.js
+++ b/packages/vaadin-form-layout/src/vaadin-form-layout.js
@@ -11,3 +11,7 @@ import { FormLayout } from '@vaadin/form-layout/src/vaadin-form-layout.js';
 export const FormLayoutElement = FormLayout;
 
 export * from '@vaadin/form-layout/src/vaadin-form-layout.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-form-layout" is deprecated. Use "@vaadin/form-layout" instead.',
+);

--- a/packages/vaadin-grid-pro/src/vaadin-grid-pro.js
+++ b/packages/vaadin-grid-pro/src/vaadin-grid-pro.js
@@ -12,3 +12,5 @@ import { GridPro } from '@vaadin/grid-pro/src/vaadin-grid-pro.js';
 export const GridProElement = GridPro;
 
 export * from '@vaadin/grid-pro/src/vaadin-grid-pro.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-grid-pro" is deprecated. Use "@vaadin/grid-pro" instead.');

--- a/packages/vaadin-grid/src/vaadin-grid.js
+++ b/packages/vaadin-grid/src/vaadin-grid.js
@@ -11,3 +11,5 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 export const GridElement = Grid;
 
 export * from '@vaadin/grid/src/vaadin-grid.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-grid" is deprecated. Use "@vaadin/grid" instead.');

--- a/packages/vaadin-icon/src/vaadin-icon.js
+++ b/packages/vaadin-icon/src/vaadin-icon.js
@@ -11,3 +11,5 @@ import { Icon } from '@vaadin/icon/src/vaadin-icon.js';
 export const IconElement = Icon;
 
 export * from '@vaadin/icon/src/vaadin-icon.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-icon" is deprecated. Use "@vaadin/icon" instead.');

--- a/packages/vaadin-icons/vaadin-icons.js
+++ b/packages/vaadin-icons/vaadin-icons.js
@@ -4,3 +4,5 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/icons/vaadin-icons.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-icons" is deprecated. Use "@vaadin/icons" instead.');

--- a/packages/vaadin-item/src/vaadin-item.js
+++ b/packages/vaadin-item/src/vaadin-item.js
@@ -11,3 +11,5 @@ import { Item } from '@vaadin/item/src/vaadin-item.js';
 export const ItemElement = Item;
 
 export * from '@vaadin/item/src/vaadin-item.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-item" is deprecated. Use "@vaadin/item" instead.');

--- a/packages/vaadin-list-box/src/vaadin-list-box.js
+++ b/packages/vaadin-list-box/src/vaadin-list-box.js
@@ -11,3 +11,5 @@ import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
 export const ListBoxElement = ListBox;
 
 export * from '@vaadin/list-box/src/vaadin-list-box.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-list-box" is deprecated. Use "@vaadin/list-box" instead.');

--- a/packages/vaadin-login/src/vaadin-login-overlay.js
+++ b/packages/vaadin-login/src/vaadin-login-overlay.js
@@ -11,3 +11,5 @@ import { LoginOverlay } from '@vaadin/login/src/vaadin-login-overlay.js';
 export const LoginOverlayElement = LoginOverlay;
 
 export * from '@vaadin/login/src/vaadin-login-overlay.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-login" is deprecated. Use "@vaadin/login" instead.');

--- a/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
+++ b/packages/vaadin-menu-bar/src/vaadin-menu-bar.js
@@ -11,3 +11,5 @@ import { MenuBar } from '@vaadin/menu-bar/src/vaadin-menu-bar.js';
 export const MenuBarElement = MenuBar;
 
 export * from '@vaadin/menu-bar/src/vaadin-menu-bar.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-menu-bar" is deprecated. Use "@vaadin/menu-bar" instead.');

--- a/packages/vaadin-messages/src/vaadin-message-input.js
+++ b/packages/vaadin-messages/src/vaadin-message-input.js
@@ -11,3 +11,7 @@ import { MessageInput } from '@vaadin/message-input/src/vaadin-message-input.js'
 export const MessageInputElement = MessageInput;
 
 export * from '@vaadin/message-input/src/vaadin-message-input.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-messages" is deprecated. Use "@vaadin/message-input" instead.',
+);

--- a/packages/vaadin-messages/src/vaadin-message-list.js
+++ b/packages/vaadin-messages/src/vaadin-message-list.js
@@ -11,3 +11,7 @@ import { MessageList } from '@vaadin/message-list/src/vaadin-message-list.js';
 export const MessageListElement = MessageList;
 
 export * from '@vaadin/message-list/src/vaadin-message-list.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-messages" is deprecated. Use "@vaadin/message-list" instead.',
+);

--- a/packages/vaadin-messages/src/vaadin-message.js
+++ b/packages/vaadin-messages/src/vaadin-message.js
@@ -11,3 +11,7 @@ import { Message } from '@vaadin/message-list/src/vaadin-message.js';
 export const MessageElement = Message;
 
 export * from '@vaadin/message-list/src/vaadin-message.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-messages" is deprecated. Use "@vaadin/message-list" instead.',
+);

--- a/packages/vaadin-notification/src/vaadin-notification.js
+++ b/packages/vaadin-notification/src/vaadin-notification.js
@@ -11,3 +11,7 @@ import { Notification } from '@vaadin/notification/src/vaadin-notification.js';
 export const NotificationElement = Notification;
 
 export * from '@vaadin/notification/src/vaadin-notification.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-notification" is deprecated. Use "@vaadin/notification" instead.',
+);

--- a/packages/vaadin-ordered-layout/src/vaadin-horizontal-layout.js
+++ b/packages/vaadin-ordered-layout/src/vaadin-horizontal-layout.js
@@ -11,3 +11,7 @@ import { HorizontalLayout } from '@vaadin/horizontal-layout/src/vaadin-horizonta
 export const HorizontalLayoutElement = HorizontalLayout;
 
 export * from '@vaadin/horizontal-layout/src/vaadin-horizontal-layout.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-ordered-layout" is deprecated. Use "@vaadin/horizontal-layout" instead.',
+);

--- a/packages/vaadin-ordered-layout/src/vaadin-scroller.js
+++ b/packages/vaadin-ordered-layout/src/vaadin-scroller.js
@@ -11,3 +11,7 @@ import { Scroller } from '@vaadin/scroller/src/vaadin-scroller.js';
 export const ScrollerElement = Scroller;
 
 export * from '@vaadin/scroller/src/vaadin-scroller.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-ordered-layout" is deprecated. Use "@vaadin/scroller" instead.',
+);

--- a/packages/vaadin-ordered-layout/src/vaadin-vertical-layout.js
+++ b/packages/vaadin-ordered-layout/src/vaadin-vertical-layout.js
@@ -11,3 +11,7 @@ import { VerticalLayout } from '@vaadin/vertical-layout/src/vaadin-vertical-layo
 export const VerticalLayoutElement = VerticalLayout;
 
 export * from '@vaadin/vertical-layout/src/vaadin-vertical-layout.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-ordered-layout" is deprecated. Use "@vaadin/vertical-layout" instead.',
+);

--- a/packages/vaadin-progress-bar/src/vaadin-progress-bar.js
+++ b/packages/vaadin-progress-bar/src/vaadin-progress-bar.js
@@ -11,3 +11,7 @@ import { ProgressBar } from '@vaadin/progress-bar/src/vaadin-progress-bar.js';
 export const ProgressBarElement = ProgressBar;
 
 export * from '@vaadin/progress-bar/src/vaadin-progress-bar.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-progress-bar" is deprecated. Use "@vaadin/progress-bar" instead.',
+);

--- a/packages/vaadin-radio-button/src/vaadin-radio-group.js
+++ b/packages/vaadin-radio-button/src/vaadin-radio-group.js
@@ -11,3 +11,7 @@ import { RadioGroup } from '@vaadin/radio-group/src/vaadin-radio-group.js';
 export const RadioGroupElement = RadioGroup;
 
 export * from '@vaadin/radio-group/src/vaadin-radio-group.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-radio-button" is deprecated. Use "@vaadin/radio-group" instead.',
+);

--- a/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js
@@ -11,3 +11,7 @@ import { RichTextEditor } from '@vaadin/rich-text-editor/src/vaadin-rich-text-ed
 export const RichTextEditorElement = RichTextEditor;
 
 export * from '@vaadin/rich-text-editor/src/vaadin-rich-text-editor.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-rich-text-editor" is deprecated. Use "@vaadin/rich-text-editor" instead.',
+);

--- a/packages/vaadin-select/src/vaadin-select.js
+++ b/packages/vaadin-select/src/vaadin-select.js
@@ -11,3 +11,5 @@ import { Select } from '@vaadin/select/src/vaadin-select.js';
 export const SelectElement = Select;
 
 export * from '@vaadin/select/src/vaadin-select.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-select" is deprecated. Use "@vaadin/select" instead.');

--- a/packages/vaadin-split-layout/src/vaadin-split-layout.js
+++ b/packages/vaadin-split-layout/src/vaadin-split-layout.js
@@ -11,3 +11,7 @@ import { SplitLayout } from '@vaadin/split-layout/src/vaadin-split-layout.js';
 export const SplitLayoutElement = SplitLayout;
 
 export * from '@vaadin/split-layout/src/vaadin-split-layout.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-split-layout" is deprecated. Use "@vaadin/split-layout" instead.',
+);

--- a/packages/vaadin-tabs/src/vaadin-tabs.js
+++ b/packages/vaadin-tabs/src/vaadin-tabs.js
@@ -11,3 +11,5 @@ import { Tabs } from '@vaadin/tabs/src/vaadin-tabs.js';
 export const TabsElement = Tabs;
 
 export * from '@vaadin/tabs/src/vaadin-tabs.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-tabs" is deprecated. Use "@vaadin/tabs" instead.');

--- a/packages/vaadin-template-renderer/vaadin-template-renderer.js
+++ b/packages/vaadin-template-renderer/vaadin-template-renderer.js
@@ -1,1 +1,5 @@
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-template-renderer" is deprecated. Use "@vaadin/polymer-legacy-adapter" instead.',
+);

--- a/packages/vaadin-text-field/src/vaadin-email-field.js
+++ b/packages/vaadin-text-field/src/vaadin-email-field.js
@@ -11,3 +11,7 @@ import { EmailField } from '@vaadin/email-field/src/vaadin-email-field.js';
 export const EmailFieldElement = EmailField;
 
 export * from '@vaadin/email-field/src/vaadin-email-field.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-text-field" is deprecated. Use "@vaadin/email-field" instead.',
+);

--- a/packages/vaadin-text-field/src/vaadin-integer-field.js
+++ b/packages/vaadin-text-field/src/vaadin-integer-field.js
@@ -11,3 +11,7 @@ import { IntegerField } from '@vaadin/integer-field/src/vaadin-integer-field.js'
 export const IntegerFieldElement = IntegerField;
 
 export * from '@vaadin/integer-field/src/vaadin-integer-field.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-text-field" is deprecated. Use "@vaadin/integer-field" instead.',
+);

--- a/packages/vaadin-text-field/src/vaadin-number-field.js
+++ b/packages/vaadin-text-field/src/vaadin-number-field.js
@@ -11,3 +11,7 @@ import { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
 export const NumberFieldElement = NumberField;
 
 export * from '@vaadin/number-field/src/vaadin-number-field.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-text-field" is deprecated. Use "@vaadin/number-field" instead.',
+);

--- a/packages/vaadin-text-field/src/vaadin-password-field.js
+++ b/packages/vaadin-text-field/src/vaadin-password-field.js
@@ -11,3 +11,7 @@ import { PasswordField } from '@vaadin/password-field/src/vaadin-password-field.
 export const PasswordFieldElement = PasswordField;
 
 export * from '@vaadin/password-field/src/vaadin-password-field.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-text-field" is deprecated. Use "@vaadin/password-field" instead.',
+);

--- a/packages/vaadin-text-field/src/vaadin-text-area.js
+++ b/packages/vaadin-text-field/src/vaadin-text-area.js
@@ -11,3 +11,5 @@ import { TextArea } from '@vaadin/text-area/src/vaadin-text-area.js';
 export const TextAreaElement = TextArea;
 
 export * from '@vaadin/text-area/src/vaadin-text-area.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-text-field" is deprecated. Use "@vaadin/text-area" instead.');

--- a/packages/vaadin-text-field/src/vaadin-text-field.js
+++ b/packages/vaadin-text-field/src/vaadin-text-field.js
@@ -11,3 +11,7 @@ import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 export const TextFieldElement = TextField;
 
 export * from '@vaadin/text-field/src/vaadin-text-field.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-text-field" is deprecated. Use "@vaadin/text-field" instead.',
+);

--- a/packages/vaadin-time-picker/src/vaadin-time-picker.js
+++ b/packages/vaadin-time-picker/src/vaadin-time-picker.js
@@ -11,3 +11,7 @@ export * from '@vaadin/time-picker/src/vaadin-time-picker.js';
  * @deprecated Import `TimePicker` from `@vaadin/time-picker` instead.
  */
 export const TimePickerElement = TimePicker;
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-time-picker" is deprecated. Use "@vaadin/time-picker" instead.',
+);

--- a/packages/vaadin-upload/src/vaadin-upload.js
+++ b/packages/vaadin-upload/src/vaadin-upload.js
@@ -11,3 +11,5 @@ import { Upload } from '@vaadin/upload/src/vaadin-upload.js';
 export const UploadElement = Upload;
 
 export * from '@vaadin/upload/src/vaadin-upload.js';
+
+console.warn('WARNING: Since Vaadin 23.2, "@vaadin/vaadin-upload" is deprecated. Use "@vaadin/upload" instead.');

--- a/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
+++ b/packages/vaadin-virtual-list/src/vaadin-virtual-list.js
@@ -11,3 +11,7 @@ import { VirtualList } from '@vaadin/virtual-list/src/vaadin-virtual-list.js';
 export const VirtualListElement = VirtualList;
 
 export * from '@vaadin/virtual-list/src/vaadin-virtual-list.js';
+
+console.warn(
+  'WARNING: Since Vaadin 23.2, "@vaadin/vaadin-virtual-list" is deprecated. Use "@vaadin/virtual-list" instead.',
+);


### PR DESCRIPTION
## Description

Let's deprecate `@vaadin/vaadin-` packages so that we can remove them in the next major (Vaadin 24).

These files are no longer imported by Flow counterparts (although they still install them via `@NpmPackage`).
So there shouldn't be any warning shown for Flow users, only for those who import them manually.

Fixes #3008

## Type of change

- Deprecation