### PR TITLE
feat: add feature flag to control multiSortPriority

### DIFF
--- a/packages/grid/src/vaadin-grid-multi-sort-priority-append.js
+++ b/packages/grid/src/vaadin-grid-multi-sort-priority-append.js
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+window.Vaadin = window.Vaadin || {};
+window.Vaadin.featureFlags = window.Vaadin.featureFlags || {};
+
+/**
+ * Change the default behavior for `multiSortPriority` property.
+ * Import this file to use "append" instead of "prepend".
+ */
+window.Vaadin.featureFlags.multiSortPriorityAppend = true;

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -4,6 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
+function getDefaultMultiSortPriority() {
+  return window.Vaadin && window.Vaadin.featureFlags && window.Vaadin.featureFlags.multiSortPriorityAppend
+    ? 'append'
+    : 'prepend';
+}
+
 /**
  * @polymerMixin
  */
@@ -37,7 +43,7 @@ export const SortMixin = (superClass) =>
          */
         multiSortPriority: {
           type: String,
-          value: 'prepend',
+          value: getDefaultMultiSortPriority(),
         },
 
         /**

--- a/packages/grid/test/multi-sort-priority.test.js
+++ b/packages/grid/test/multi-sort-priority.test.js
@@ -1,0 +1,31 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../src/vaadin-grid-multi-sort-priority-append.js';
+
+describe('multi-sort priority feature flag', () => {
+  let grid;
+
+  before(async () => {
+    await import('../src/vaadin-grid.js');
+  });
+
+  describe('default', () => {
+    beforeEach(() => {
+      grid = fixtureSync('<vaadin-grid></vaadin-grid>');
+    });
+
+    it('should set multiSortPriority to append by default', () => {
+      expect(grid.multiSortPriority).to.be.equal('append');
+    });
+  });
+
+  describe('prepend', () => {
+    beforeEach(() => {
+      grid = fixtureSync('<vaadin-grid multi-sort-priority="prepend"></vaadin-grid>');
+    });
+
+    it('should allow setting multiSortPriority to prepend', () => {
+      expect(grid.multiSortPriority).to.be.equal('prepend');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4189

This PR adds a new file that can be imported to enable the new behavior by default when using web component / Hilla.
Note: this file won't be used by the Flow counterpart - there will be a separate PR for Flow instead to handle that.

## Type of change

- Feature