### PR TITLE
fix: do not close overlay with iOS VoiceOver

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1252,6 +1252,12 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _onFocusout(event) {
+      // VoiceOver on iOS fires `focusout` event when moving focus to the item in the dropdown.
+      // Do not focus the input in this case, because it would break announcement for the item.
+      if (event.relatedTarget && event.relatedTarget.localName === `${this._tagNamePrefix}-item`) {
+        return;
+      }
+
       // Fixes the problem with `focusout` happening when clicking on the scroll bar on Edge
       if (event.relatedTarget === this.$.overlay) {
         event.composedPath()[0].focus();

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
-import { outsideClick, setInputValue } from './helpers.js';
+import { getFirstItem, outsideClick, setInputValue } from './helpers.js';
 
 describe('toggling dropdown', () => {
   let comboBox, overlay, input;
@@ -239,6 +239,15 @@ describe('toggling dropdown', () => {
       focusout(input);
 
       expect(comboBox.opened).to.be.false;
+    });
+
+    it('should not close the overlay when focus is moved to item', () => {
+      comboBox.open();
+
+      const item = getFirstItem(comboBox);
+      focusout(input, item);
+
+      expect(comboBox.opened).to.be.true;
     });
 
     it('should restore focus to the field on outside click', async () => {


### PR DESCRIPTION
## Description

Fixes #3363

Tested this using VoiceOver on iOS. With this fix, the focus moves to item, so it can be selected by using double tap.
Check out the screen recording with sound turned on to hear VoiceOver announcements:

https://user-images.githubusercontent.com/10589913/182129731-69a05f12-2ae1-4201-9dc6-8149aea9a4d2.mp4

## Type of change

- Bugfix