### PR TITLE
fix: add and remove styled-mode attribute during chart exports

### DIFF
--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1348,6 +1348,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
               this.tempBodyStyle = document.createElement('style');
               this.tempBodyStyle.textContent = effectiveCss;
               document.body.appendChild(this.tempBodyStyle);
+              document.body.setAttribute('styled-mode', this.options.chart.styledMode.toString());
             }
           }
 
@@ -1356,6 +1357,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
             if (this.tempBodyStyle) {
               document.body.removeChild(this.tempBodyStyle);
               delete this.tempBodyStyle;
+              document.body.removeAttribute('styled-mode');
             }
           }
 

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1348,7 +1348,9 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
               this.tempBodyStyle = document.createElement('style');
               this.tempBodyStyle.textContent = effectiveCss;
               document.body.appendChild(this.tempBodyStyle);
-              document.body.setAttribute('styled-mode', this.options.chart.styledMode.toString());
+              if (this.options.chart.styledMode) {
+                document.body.setAttribute('styled-mode', '');
+              }
             }
           }
 
@@ -1357,7 +1359,9 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
             if (this.tempBodyStyle) {
               document.body.removeChild(this.tempBodyStyle);
               delete this.tempBodyStyle;
-              document.body.removeAttribute('styled-mode');
+              if (this.options.chart.styledMode) {
+                document.body.removeAttribute('styled-mode');
+              }
             }
           }
 

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -145,7 +145,7 @@ describe('vaadin-chart exporting', () => {
     const observer = new MutationObserver((mutations) => {
       styledModeAddedToBody =
         styledModeAddedToBody ||
-        mutations.some((mutation) => mutation.attributeName === attributeName && mutation.oldValue);
+        mutations.some((mutation) => mutation.attributeName === attributeName && mutation.oldValue === '');
     });
 
     observer.observe(targetNode, config);

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -132,6 +132,7 @@ describe('vaadin-chart exporting', () => {
   });
 
   it('should add styled-mode attribute to body before export and delete it afterwards', async () => {
+    chart.options.chart.styledMode = true;
     const attributeName = 'styled-mode';
     expect(document.body.getAttribute(attributeName)).to.be.null;
 
@@ -159,6 +160,38 @@ describe('vaadin-chart exporting', () => {
     expect(fireEventSpy.lastCall.args[1]).to.be.equal('afterExport');
     await nextRender(chart);
     expect(styledModeAddedToBody).to.be.true;
+    expect(document.body.getAttribute(attributeName)).to.be.null;
+  });
+
+  it('styled-mode attribute should not be added to body if styledMode option is set to false', async () => {
+    chart.options.chart.styledMode = false;
+    const attributeName = 'styled-mode';
+    expect(document.body.getAttribute(attributeName)).to.be.null;
+
+    let styledModeAddedToBody = false;
+
+    const targetNode = document.body;
+    const config = { attributes: true, attributeOldValue: true };
+
+    // Track styled-mode attribute addition and removal from the document body
+    const observer = new MutationObserver((mutations) => {
+      styledModeAddedToBody =
+        styledModeAddedToBody ||
+        mutations.some((mutation) => mutation.attributeName === attributeName && mutation.oldValue === '');
+    });
+
+    observer.observe(targetNode, config);
+
+    // Reveal exporting menu items
+    chartContainer.querySelector('button.highcharts-a11y-proxy-button.highcharts-no-tooltip').click();
+
+    // Simulate a PNG export
+    const pngExportButton = chartContainer.querySelectorAll('.highcharts-menu-item')[2];
+    pngExportButton.onclick();
+
+    expect(fireEventSpy.lastCall.args[1]).to.be.equal('afterExport');
+    await nextRender(chart);
+    expect(styledModeAddedToBody).to.be.false;
     expect(document.body.getAttribute(attributeName)).to.be.null;
   });
 

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -134,7 +134,7 @@ describe('vaadin-chart exporting', () => {
   it('should add styled-mode attribute to body before export and delete it afterwards', async () => {
     chart.options.chart.styledMode = true;
     const attributeName = 'styled-mode';
-    expect(document.body.getAttribute(attributeName)).to.be.null;
+    expect(document.body.hasAttribute(attributeName)).to.be.false;
 
     let styledModeAddedToBody = false;
 
@@ -160,13 +160,13 @@ describe('vaadin-chart exporting', () => {
     expect(fireEventSpy.lastCall.args[1]).to.be.equal('afterExport');
     await nextRender(chart);
     expect(styledModeAddedToBody).to.be.true;
-    expect(document.body.getAttribute(attributeName)).to.be.null;
+    expect(document.body.hasAttribute(attributeName)).to.be.false;
   });
 
-  it('styled-mode attribute should not be added to body if styledMode option is set to false', async () => {
+  it('should not add styled-mode attribute to body if styledMode option is set to false', async () => {
     chart.options.chart.styledMode = false;
     const attributeName = 'styled-mode';
-    expect(document.body.getAttribute(attributeName)).to.be.null;
+    expect(document.body.hasAttribute(attributeName)).to.be.false;
 
     let styledModeAddedToBody = false;
 
@@ -192,7 +192,7 @@ describe('vaadin-chart exporting', () => {
     expect(fireEventSpy.lastCall.args[1]).to.be.equal('afterExport');
     await nextRender(chart);
     expect(styledModeAddedToBody).to.be.false;
-    expect(document.body.getAttribute(attributeName)).to.be.null;
+    expect(document.body.hasAttribute(attributeName)).to.be.false;
   });
 
   // TODO add test for print button.

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -131,6 +131,37 @@ describe('vaadin-chart exporting', () => {
     expect(styleRemovedFromBody).to.be.true;
   });
 
+  it('should add styled-mode attribute to body before export and delete it afterwards', async () => {
+    const attributeName = 'styled-mode';
+    expect(document.body.getAttribute(attributeName)).to.be.null;
+
+    let styledModeAddedToBody = false;
+
+    const targetNode = document.body;
+    const config = { attributes: true, attributeOldValue: true };
+
+    // Track styled-mode attribute addition and removal from the document body
+    const observer = new MutationObserver((mutations) => {
+      styledModeAddedToBody =
+        styledModeAddedToBody ||
+        mutations.some((mutation) => mutation.attributeName === attributeName && mutation.oldValue);
+    });
+
+    observer.observe(targetNode, config);
+
+    // Reveal exporting menu items
+    chartContainer.querySelector('button.highcharts-a11y-proxy-button.highcharts-no-tooltip').click();
+
+    // Simulate a PNG export
+    const pngExportButton = chartContainer.querySelectorAll('.highcharts-menu-item')[2];
+    pngExportButton.onclick();
+
+    expect(fireEventSpy.lastCall.args[1]).to.be.equal('afterExport');
+    await nextRender(chart);
+    expect(styledModeAddedToBody).to.be.true;
+    expect(document.body.getAttribute(attributeName)).to.be.null;
+  });
+
   // TODO add test for print button.
   // The original issue https://github.com/highcharts/highcharts/issues/13489 is fixed now.
 });


### PR DESCRIPTION
## Description

The chart export was failing with a mostly black export. Added styled-mode attribute to body before a chart export and removed it afterwards. Added the relevant integration test.

Fixes [#3508](https://github.com/vaadin/flow-components/issues/3508)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.