### PR TITLE
fix: do not close overlay with iOS VoiceOver (#4279) (CP: 22.0)

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1090,6 +1090,12 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _onFocusout(event) {
+      // VoiceOver on iOS fires `focusout` event when moving focus to the item in the dropdown.
+      // Do not focus the input in this case, because it would break announcement for the item.
+      if (event.relatedTarget && event.relatedTarget.localName === `${this._tagNamePrefix}-item`) {
+        return;
+      }
+
       // Fixes the problem with `focusout` happening when clicking on the scroll bar on Edge
       if (event.relatedTarget === this.$.dropdown.$.overlay) {
         event.composedPath()[0].focus();

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1092,7 +1092,7 @@ export const ComboBoxMixin = (subclass) =>
     _onFocusout(event) {
       // VoiceOver on iOS fires `focusout` event when moving focus to the item in the dropdown.
       // Do not focus the input in this case, because it would break announcement for the item.
-      if (event.relatedTarget && event.relatedTarget.localName === `${this._tagNamePrefix}-item`) {
+      if (event.relatedTarget && this._getItemElements().includes(event.relatedTarget)) {
         return;
       }
 

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
-import { createEventSpy, setInputValue } from './helpers.js';
+import { createEventSpy, getFirstItem, setInputValue } from './helpers.js';
 
 describe('toggling dropdown', () => {
   let comboBox, overlay, input;
@@ -226,6 +226,15 @@ describe('toggling dropdown', () => {
       focusout(input);
 
       expect(comboBox.opened).to.equal(false);
+    });
+
+    it('should not close the overlay when focus is moved to item', () => {
+      comboBox.open();
+
+      const item = getFirstItem(comboBox);
+      focusout(input, item);
+
+      expect(comboBox.opened).to.be.true;
     });
 
     describe('filtered items are empty', () => {


### PR DESCRIPTION
## Description

Cherry-pick of #4279 to `22.0` branch. Automated cherry-pick failed due to conflict in import in tests.

## Type of change

- Cherry-pick