### PR TITLE
fix: set ARIA attributes on the native input

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -7,6 +7,7 @@ import './vaadin-combo-box-item.js';
 import './vaadin-combo-box-overlay.js';
 import './vaadin-combo-box-scroller.js';
 import { dashToCamelCase } from '@polymer/polymer/lib/utils/case-map.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ValidateMixin } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -120,9 +121,10 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
   ready() {
     super.ready();
 
-    // Wait until the slotted elements are rendered
-    requestAnimationFrame(() => {
-      this._toggleElement = this.querySelector('.toggle-button');
+    this._toggleElement = this.querySelector('.toggle-button');
+
+    // Wait until the slotted input DOM is ready
+    afterNextRender(this, () => {
       this._setInputElement(this.querySelector('vaadin-text-field,.input'));
       this._revertInputValue();
     });

--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -119,14 +119,13 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
   /** @protected */
   ready() {
     super.ready();
-    this._toggleElement = this.querySelector('.toggle-button');
-  }
 
-  /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-    this._setInputElement(this.querySelector('vaadin-text-field,.input'));
-    this._revertInputValue();
+    // Wait until the slotted elements are rendered
+    requestAnimationFrame(() => {
+      this._toggleElement = this.querySelector('.toggle-button');
+      this._setInputElement(this.querySelector('vaadin-text-field,.input'));
+      this._revertInputValue();
+    });
   }
 
   /**
@@ -146,6 +145,38 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
    */
   get _propertyForValue() {
     return dashToCamelCase(this.attrForValue);
+  }
+
+  /**
+   * @protected
+   * @override
+   * @return {HTMLInputElement | undefined}
+   */
+  get _nativeInput() {
+    const input = this.inputElement;
+
+    if (input) {
+      // Support `<input class="input">`
+      if (input instanceof HTMLInputElement) {
+        return input;
+      }
+
+      // Support `<input>` in light DOM (e.g. `vaadin-text-field`)
+      const slottedInput = input.querySelector('input');
+      if (slottedInput) {
+        return slottedInput;
+      }
+
+      if (input.shadowRoot) {
+        // Support `<input>` in Shadow DOM (e.g. `mwc-textfield`)
+        const shadowInput = input.shadowRoot.querySelector('input');
+        if (shadowInput) {
+          return shadowInput;
+        }
+      }
+    }
+
+    return undefined;
   }
 
   /** @protected */

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -281,13 +281,25 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /**
+     * Get a reference to the native `<input>` element.
+     * Override to provide a custom input.
+     * @protected
+     * @return {HTMLInputElement | undefined}
+     */
+    get _nativeInput() {
+      return this.inputElement;
+    }
+
+    /**
      * Override method inherited from `InputMixin`
      * to customize the input element.
      * @protected
      * @override
      */
-    _inputElementChanged(input) {
-      super._inputElementChanged(input);
+    _inputElementChanged(inputElement) {
+      super._inputElementChanged(inputElement);
+
+      const input = this._nativeInput;
 
       if (input) {
         input.autocomplete = 'off';
@@ -507,7 +519,7 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _updateActiveDescendant(index) {
-      const input = this.inputElement;
+      const input = this._nativeInput;
       if (!input) {
         return;
       }
@@ -543,7 +555,7 @@ export const ComboBoxMixin = (subclass) =>
         }
       }
 
-      const input = this.inputElement;
+      const input = this._nativeInput;
       if (input) {
         input.setAttribute('aria-expanded', !!opened);
 

--- a/packages/combo-box/test/combo-box-light.test.js
+++ b/packages/combo-box/test/combo-box-light.test.js
@@ -1,6 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import {
+  arrowDownKeyDown,
   click,
+  escKeyDown,
   fire,
   fixtureSync,
   isDesktopSafari,
@@ -8,6 +10,7 @@ import {
   mousedown,
   mouseup,
   nextFrame,
+  nextRender,
   touchend,
   touchstart,
 } from '@vaadin/testing-helpers';
@@ -48,12 +51,13 @@ customElements.define('my-input', MyInput);
 describe('vaadin-combo-box-light', () => {
   let comboBox, overlay, inputElement;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     comboBox = fixtureSync(`
       <vaadin-combo-box-light>
         <vaadin-text-field></vaadin-text-field>
       </vaadin-combo-box-light>
     `);
+    await nextRender();
     comboBox.items = ['foo', 'bar', 'baz'];
     overlay = comboBox.$.overlay;
     inputElement = comboBox.querySelector('vaadin-text-field');
@@ -165,12 +169,13 @@ describe('vaadin-combo-box-light', () => {
 describe('attr-for-value', () => {
   let comboBox, customInput, inputElement;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     comboBox = fixtureSync(`
       <vaadin-combo-box-light attr-for-value="custom-value">
         <my-input class="input"></my-input>
       </vaadin-combo-box-light>
     `);
+    await nextRender();
     comboBox.items = ['foo', 'bar', 'baz'];
     customInput = comboBox.querySelector('.input');
     inputElement = customInput.$.input;
@@ -205,10 +210,64 @@ describe('attr-for-value', () => {
   });
 });
 
+describe('ARIA', () => {
+  let comboBox, input;
+
+  describe('input in light DOM', () => {
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box-light>
+          <vaadin-text-field></vaadin-text-field>
+        </vaadin-combo-box-light>
+      `);
+      await nextRender();
+      comboBox.items = ['foo', 'bar', 'baz'];
+      input = comboBox.querySelector('input');
+    });
+
+    it('should set correct attributes on the input in light DOM', () => {
+      expect(input.getAttribute('role')).to.equal('combobox');
+      expect(input.getAttribute('aria-autocomplete')).to.equal('list');
+    });
+
+    it('should toggle aria-expanded attribute on the input in light DOM', () => {
+      arrowDownKeyDown(input);
+      expect(input.getAttribute('aria-expanded')).to.equal('true');
+      escKeyDown(input);
+      expect(input.getAttribute('aria-expanded')).to.equal('false');
+    });
+  });
+
+  describe('input in Shadow DOM', () => {
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box-light attr-for-value="custom-value">
+          <my-input class="input"></my-input>
+        </vaadin-combo-box-light>
+      `);
+      await nextRender();
+      comboBox.items = ['foo', 'bar', 'baz'];
+      input = comboBox.inputElement.shadowRoot.querySelector('input');
+    });
+
+    it('should set correct attributes on the input in shadow DOM', () => {
+      expect(input.getAttribute('role')).to.equal('combobox');
+      expect(input.getAttribute('aria-autocomplete')).to.equal('list');
+    });
+
+    it('should toggle aria-expanded attribute on the input in shadow DOM', () => {
+      arrowDownKeyDown(input);
+      expect(input.getAttribute('aria-expanded')).to.equal('true');
+      escKeyDown(input);
+      expect(input.getAttribute('aria-expanded')).to.equal('false');
+    });
+  });
+});
+
 describe('custom buttons', () => {
   let comboBox;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     comboBox = fixtureSync(`
       <vaadin-combo-box-light>
         <vaadin-text-field>
@@ -217,6 +276,7 @@ describe('custom buttons', () => {
         </vaadin-text-field>
       </vaadin-combo-box-light>
     `);
+    await nextRender();
     comboBox.items = ['foo', 'bar', 'baz'];
   });
 
@@ -406,7 +466,7 @@ describe('theme attribute', () => {
 describe('nested template', () => {
   let comboBox;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     comboBox = fixtureSync(`
       <vaadin-combo-box-light>
         <vaadin-text-field>
@@ -420,6 +480,7 @@ describe('nested template', () => {
         </vaadin-text-field>
       </vaadin-combo-box-light>
     `);
+    await nextRender();
     comboBox.items = ['bar', 'baz', 'qux'];
   });
 

--- a/packages/combo-box/test/item-template.test.js
+++ b/packages/combo-box/test/item-template.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDownKeyDown, fixtureSync } from '@vaadin/testing-helpers';
+import { arrowDownKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
@@ -12,9 +12,10 @@ describe('item template', () => {
 
   ['combo-box', 'combo-box-light'].forEach((name) => {
     describe(name, () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         wrapper = fixtureSync(`<mock-${name}-template-wrapper></mock-${name}-template-wrapper>`);
         comboBox = wrapper.$.comboBox;
+        await nextRender();
         comboBox.items = ['foo', 'bar'];
         comboBox.open();
         firstItem = getFirstItem(comboBox);

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDownKeyDown, aTimeout, enterKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { arrowDownKeyDown, aTimeout, enterKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
 import './not-animated-styles.js';
@@ -1279,12 +1279,13 @@ describe('lazy loading', () => {
   });
 
   describe('combo-box-light', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       comboBox = fixtureSync(`
         <vaadin-combo-box-light>
           <vaadin-text-field></vaadin-text-field>
         </vaadin-combo-box-light>
       `);
+      await nextRender();
     });
 
     isComboBoxLight = true;


### PR DESCRIPTION
## Description

Fixes #4050

In Vaadin 14, we only had ARIA attributes set on the `input` when using `<vaadin-combo-box>`, see [this code](https://github.com/vaadin/vaadin-combo-box/blob/0e6848c31aae7bb406252240496ef51a5889316b/src/vaadin-combo-box.html#L390).
After changing to use new mixin structure in Vaadin 22, all the ARIA logic was moved to `ComboBoxMixin`.

This PR restores `_nativeInput` getter and overrides it in `<vaadin-combo-box-light>` to detect native `<input>`.
In order to make it work, we need to postpone checking `inputElement` using `afterNextRender()` call.
Otherwise, the slotted `<input>` in case of using `<vaadin-text-field>` would not yet be created.

Note, this is a behavior altering fix as requires users who rely on synchronous presence of `inputElement` to update their tests, similarly to how I updated `combo-box-light.test.js` in this PR to use `await nextRender()`.

## Type of change

- Bugfix