### PR TITLE
refactor: ensure date is rendered before focusing

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -993,7 +993,7 @@ export const DatePickerMixin = (subclass) =>
             if (e.shiftKey) {
               this._overlayContent.focusCancel();
             } else {
-              this._overlayContent.focusDate(this._focusedDate);
+              this._overlayContent.focusDateElement();
             }
           }
           break;

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -13,7 +13,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import * as settings from '@polymer/polymer/lib/utils/settings.js';
-import { close, getFocusedCell, getOverlayContent, monthsEqual, open, waitForScrollToFinish } from './common.js';
+import { close, getOverlayContent, monthsEqual, open } from './common.js';
 
 settings.setCancelSyntheticClickEvents(false);
 
@@ -319,6 +319,8 @@ describe('basic features', () => {
       let spy;
 
       beforeEach(() => {
+        // Do not spy on the DOM element because it can be reused
+        // by infinite scroller. Instead, spy on the native focus.
         spy = sinon.spy(HTMLElement.prototype, 'focus');
       });
 
@@ -328,10 +330,9 @@ describe('basic features', () => {
 
       it('should focus date element when opened', async () => {
         await open(datepicker);
-        const content = getOverlayContent(datepicker);
-        await waitForScrollToFinish(content);
-        const cell = getFocusedCell(content);
-        expect(spy.calledOn(cell)).to.be.true;
+        await nextRender();
+        const cell = spy.lastCall.thisValue;
+        expect(cell.hasAttribute('today')).to.be.true;
       });
     });
   });

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -13,7 +13,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import * as settings from '@polymer/polymer/lib/utils/settings.js';
-import { close, getOverlayContent, monthsEqual, open } from './common.js';
+import { close, getFocusedCell, getOverlayContent, monthsEqual, open, waitForScrollToFinish } from './common.js';
 
 settings.setCancelSyntheticClickEvents(false);
 
@@ -314,6 +314,26 @@ describe('basic features', () => {
       await open(datepicker);
       expect(spy.called).to.be.true;
     });
+
+    describe('focus date', () => {
+      let spy;
+
+      beforeEach(() => {
+        spy = sinon.spy(HTMLElement.prototype, 'focus');
+      });
+
+      afterEach(() => {
+        spy.restore();
+      });
+
+      it('should focus date element when opened', async () => {
+        await open(datepicker);
+        const content = getOverlayContent(datepicker);
+        await waitForScrollToFinish(content);
+        const cell = getFocusedCell(content);
+        expect(spy.calledOn(cell)).to.be.true;
+      });
+    });
   });
 
   describe('value property formats', () => {
@@ -599,7 +619,7 @@ describe('wrapped', () => {
   it('should match the parent width', () => {
     container.querySelector('div').style.width = '120px';
     datepicker.style.width = '100%';
-    expect(datepicker.inputElement.clientWidth).to.equal(120);
+    expect(datepicker.clientWidth).to.equal(120);
   });
 });
 

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -1,4 +1,4 @@
-import { fire, listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fire, listenOnce, nextRender } from '@vaadin/testing-helpers';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 export function activateScroller(scroller) {
@@ -138,9 +138,9 @@ export function getFocusedCell(overlayContent) {
  * @param {HTMLElement} overlayContent
  */
 export async function waitForScrollToFinish(overlayContent) {
-  if (overlayContent._targetPosition) {
+  if (overlayContent._revealPromise) {
     // The overlay content is scrolling.
-    await oneEvent(overlayContent, 'scroll-animation-finished');
+    await overlayContent._revealPromise;
   }
 
   await nextRender(overlayContent);

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -249,62 +249,76 @@ describe('keyboard', () => {
       expect(spy.called).to.be.true;
     });
 
-    it('should focus date scrolled out of the view on input Tab', async () => {
-      // Move focus to the calendar
-      await sendKeys({ press: 'Tab' });
-      await nextRender(datepicker);
-
-      const cell = getFocusedCell(overlayContent);
-
-      // Scroll to date outside viewport
-      overlayContent.revealDate(new Date(2000, 0, 1));
-      await waitForScrollToFinish(overlayContent);
-
-      // Move focus to the input
-      await sendKeys({ down: 'Shift' });
-      await sendKeys({ press: 'Tab' });
-      await sendKeys({ up: 'Shift' });
-
-      const spy = sinon.spy(cell, 'focus');
-
-      // Move focus back to the date
-      await sendKeys({ press: 'Tab' });
-      await waitForScrollToFinish(overlayContent);
-
-      expect(spy.calledOnce).to.be.true;
-    });
-
-    it('should focus date scrolled out of the view on Today button Shift Tab', async () => {
-      // Move focus to the calendar
-      await sendKeys({ press: 'Tab' });
-      await nextRender(datepicker);
-
-      const cell = getFocusedCell(overlayContent);
-
-      // Scroll to date outside viewport
-      overlayContent.revealDate(new Date(2000, 0, 1));
-      await waitForScrollToFinish(overlayContent);
-
-      // Move focus to the Today button
-      await sendKeys({ press: 'Tab' });
-
-      const spy = sinon.spy(cell, 'focus');
-
-      // Move focus back to the date
-      await sendKeys({ down: 'Shift' });
-      await sendKeys({ press: 'Tab' });
-      await sendKeys({ up: 'Shift' });
-
-      await waitForScrollToFinish(overlayContent);
-
-      expect(spy.calledOnce).to.be.true;
-    });
-
     it('should clear selection on close', async () => {
       input.select();
 
       await close(datepicker);
       expect(input.selectionStart).to.equal(input.selectionEnd);
+    });
+
+    describe('focus date not in the viewport', () => {
+      let spy;
+
+      afterEach(() => {
+        spy.restore();
+      });
+
+      it('should focus date scrolled out of the view on input Tab', async () => {
+        // Move focus to the calendar
+        await sendKeys({ press: 'Tab' });
+        await nextRender(datepicker);
+
+        // Scroll to date outside viewport
+        overlayContent.revealDate(new Date(2000, 0, 1));
+        await waitForScrollToFinish(overlayContent);
+
+        // Move focus to the input
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+
+        // Do not spy on the DOM element because it can be reused
+        // by infinite scroller. Instead, spy on the native focus.
+        spy = sinon.spy(HTMLElement.prototype, 'focus');
+
+        // Move focus back to the date
+        await sendKeys({ press: 'Tab' });
+        await waitForScrollToFinish(overlayContent);
+
+        expect(spy.calledOnce).to.be.true;
+
+        const cell = spy.firstCall.thisValue;
+        expect(cell.hasAttribute('today')).to.be.true;
+      });
+
+      it('should focus date scrolled out of the view on Today button Shift Tab', async () => {
+        // Move focus to the calendar
+        await sendKeys({ press: 'Tab' });
+        await nextRender(datepicker);
+
+        // Scroll to date outside viewport
+        overlayContent.revealDate(new Date(2000, 0, 1));
+        await waitForScrollToFinish(overlayContent);
+
+        // Move focus to the Today button
+        await sendKeys({ press: 'Tab' });
+
+        // Do not spy on the DOM element because it can be reused
+        // by infinite scroller. Instead, spy on the native focus.
+        spy = sinon.spy(HTMLElement.prototype, 'focus');
+
+        // Move focus back to the date
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+
+        await waitForScrollToFinish(overlayContent);
+
+        expect(spy.calledOnce).to.be.true;
+
+        const cell = spy.firstCall.thisValue;
+        expect(cell.hasAttribute('today')).to.be.true;
+      });
     });
   });
 

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -269,7 +269,9 @@ describe('keyboard', () => {
         await nextRender(datepicker);
 
         // Scroll to date outside viewport
-        overlayContent.revealDate(new Date(2000, 0, 1));
+        const date = new Date();
+        date.setFullYear(date.getFullYear() - 1);
+        overlayContent.revealDate(date);
         await waitForScrollToFinish(overlayContent);
 
         // Move focus to the input
@@ -297,7 +299,9 @@ describe('keyboard', () => {
         await nextRender(datepicker);
 
         // Scroll to date outside viewport
-        overlayContent.revealDate(new Date(2000, 0, 1));
+        const date = new Date();
+        date.setFullYear(date.getFullYear() - 1);
+        overlayContent.revealDate(date);
         await waitForScrollToFinish(overlayContent);
 
         // Move focus to the Today button

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -249,6 +249,57 @@ describe('keyboard', () => {
       expect(spy.called).to.be.true;
     });
 
+    it('should focus date scrolled out of the view on input Tab', async () => {
+      // Move focus to the calendar
+      await sendKeys({ press: 'Tab' });
+      await nextRender(datepicker);
+
+      const cell = getFocusedCell(overlayContent);
+
+      // Scroll to date outside viewport
+      overlayContent.revealDate(new Date(2000, 0, 1));
+      await waitForScrollToFinish(overlayContent);
+
+      // Move focus to the input
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+
+      const spy = sinon.spy(cell, 'focus');
+
+      // Move focus back to the date
+      await sendKeys({ press: 'Tab' });
+      await waitForScrollToFinish(overlayContent);
+
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should focus date scrolled out of the view on Today button Shift Tab', async () => {
+      // Move focus to the calendar
+      await sendKeys({ press: 'Tab' });
+      await nextRender(datepicker);
+
+      const cell = getFocusedCell(overlayContent);
+
+      // Scroll to date outside viewport
+      overlayContent.revealDate(new Date(2000, 0, 1));
+      await waitForScrollToFinish(overlayContent);
+
+      // Move focus to the Today button
+      await sendKeys({ press: 'Tab' });
+
+      const spy = sinon.spy(cell, 'focus');
+
+      // Move focus back to the date
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+
+      await waitForScrollToFinish(overlayContent);
+
+      expect(spy.calledOnce).to.be.true;
+    });
+
     it('should clear selection on close', async () => {
       input.select();
 

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -134,7 +134,6 @@ import { getDefaultI18n, getFocusedCell, getOverlayContent, open, waitForScrollT
       overlay.initialPosition = initialDate;
       await nextRender(overlay);
       await overlay.focusDate(initialDate);
-      await waitForScrollToFinish(overlay);
     });
 
     it('should focus one week forward with arrow down', async () => {

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -525,5 +525,17 @@ import { getDefaultI18n, getFocusedCell, getOverlayContent, open, waitForScrollT
       date.setDate(31);
       expect(overlay.focusedDate).to.eql(date);
     });
+
+    it('should only reveal date once when navigating days', async () => {
+      const spy = sinon.spy(overlay, 'revealDate');
+      await sendKeys({ press: 'ArrowDown' });
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should reveal date when focusing date element', async () => {
+      const spy = sinon.spy(overlay, 'revealDate');
+      await overlay.focusDateElement();
+      expect(spy.calledOnce).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
## Description

This PR aims to address two problems related to focusing the date element and make it more reliable.

### Fullscreen mode

When clicking `vaadin-date-picker` in `fullscreen` mode, it opens and attempts to focus the date immediately.
This logic currently uses a promise that resolves after `requestAnimationFrame()`:

https://github.com/vaadin/web-components/blob/8e74163e2d7a47d43500015297bb81cb14403b18/packages/date-picker/src/vaadin-date-picker-overlay-content.js#L864-L866

However, this is not reliable because in some cases `vaadin-infinite-list` does not create `vaadin-month-calendar` elements by the time when `__tryFocusDate()` is called,  so `focusableDateElement` returns `undefined`.

In this case, trying to focus date element silently fails, so we end up with the following behavior:

https://user-images.githubusercontent.com/10589913/182655663-81701c25-3f38-4e8a-9610-e43c9a36777b.mp4

As you can see on the recording, the date element is not focused (for focused date, the blinking animation is stopped). Also when pressing <kbd>Tab</kbd>, focus moves to `<input>` which means that previously it was on the `<body>` element.

### Deskop mode

When using desktop mode, there is another issue related to `focusDateElement()` method when pressing <kbd>Shift</kbd> + <kbd>Tab</kbd> on the "Today" button. If the date was scrolled out of the viewport, the following happens:

https://user-images.githubusercontent.com/10589913/182654547-5007347d-8181-40f7-9e6f-e499c5261749.mp4

In this case, the problem is that date element with `tabindex="0"` is not in the viewport, so focus jumps back to the `input` element because we don't call `event.preventDefault()` and rely on the native focus to reach out the date element.

This is fixed by changing the event listener for "Today" button to call `focusDateElement()` instead of `revealDate()`.
At the same time, in `focusDateElement()` we now ensure the date is scrolled into view before trying to focus it.

Same issue also happens when pressing <kbd>Tab</kbd> on the `input` element when the date that can be focused is out of the viewport. This is also fixed by using `focusDateElement()` and then moving focus programmatically.

## Type of change

- Refactor