### PR TITLE
fix: trap focus in the overlay when fullscreen

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -789,9 +789,14 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     switch (section) {
       case 'calendar':
         if (event.shiftKey) {
-          // Return focus back to the input field.
           event.preventDefault();
-          this.__focusInput();
+
+          if (this.hasAttribute('fullscreen')) {
+            // Trap focus in the overlay
+            this.$.cancelButton.focus();
+          } else {
+            this.__focusInput();
+          }
         }
         break;
       case 'today':
@@ -802,9 +807,14 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
         break;
       case 'cancel':
         if (!event.shiftKey) {
-          // Return focus back to the input field.
           event.preventDefault();
-          this.__focusInput();
+
+          if (this.hasAttribute('fullscreen')) {
+            // Trap focus in the overlay
+            this.focusDateElement();
+          } else {
+            this.__focusInput();
+          }
         }
         break;
       default:
@@ -813,28 +823,12 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
   }
 
   __onTodayButtonKeyDown(event) {
-    if (this.hasAttribute('fullscreen')) {
-      // Do not prevent closing on Esc
-      if (event.key !== 'Escape') {
-        event.stopPropagation();
-      }
-      return;
-    }
-
     if (event.key === 'Tab') {
       this._onTabKeyDown(event, 'today');
     }
   }
 
   __onCancelButtonKeyDown(event) {
-    if (this.hasAttribute('fullscreen')) {
-      // Do not prevent closing on Esc
-      if (event.key !== 'Escape') {
-        event.stopPropagation();
-      }
-      return;
-    }
-
     if (event.key === 'Tab') {
       this._onTabKeyDown(event, 'cancel');
     }

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -324,6 +324,39 @@ describe('keyboard', () => {
         expect(cell.hasAttribute('today')).to.be.true;
       });
     });
+
+    describe('fullscreen', () => {
+      beforeEach(async () => {
+        // Move focus to the calendar
+        await sendKeys({ press: 'Tab' });
+        await nextRender(datepicker);
+
+        datepicker._fullscreen = true;
+      });
+
+      it('should move focus to Cancel button on date cell Shift Tab', async () => {
+        const spy = sinon.spy(overlayContent.$.cancelButton, 'focus');
+
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should move focus to date cell button on Cancel button Tab', async () => {
+        const cell = getFocusedCell(overlayContent);
+        const spy = sinon.spy(cell, 'focus');
+
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+
+        await sendKeys({ press: 'Tab' });
+
+        expect(spy.calledOnce).to.be.true;
+      });
+    });
   });
 
   describe('Escape key', () => {


### PR DESCRIPTION
## Description

Fixes #3918

This PR fixes the a11y issue by making sure that keyboard focus stays in `vaadin-date-picker-overlay` when `fullscreen` mode is used. At the same time, `stopPropagation()` call for `keydown` events is removed as no longer needed.

## Type of change

- Bugfix