### PR TITLE
refactor: remove obsolete iOS touch workaround

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -102,13 +102,6 @@ export const DatePickerMixin = (subclass) =>
         },
 
         /**
-         * An array of ancestor elements whose -webkit-overflow-scrolling is forced from value
-         * 'touch' to value 'auto' in order to prevent them from clipping the dropdown. iOS only.
-         * @private
-         */
-        _touchPrevented: Array,
-
-        /**
          * The object used to localize this component.
          * To change the default localization, replace the entire
          * `i18n` object with a custom one.
@@ -310,12 +303,6 @@ export const DatePickerMixin = (subclass) =>
         _ios: {
           type: Boolean,
           value: isIOS,
-        },
-
-        /** @private */
-        _webkitOverflowScroll: {
-          type: Boolean,
-          value: document.createElement('div').style.webkitOverflowScrolling === '',
         },
 
         /** @private */
@@ -762,10 +749,6 @@ export const DatePickerMixin = (subclass) =>
 
       window.addEventListener('scroll', this._boundOnScroll, true);
 
-      if (this._webkitOverflowScroll) {
-        this._touchPrevented = this._preventWebkitOverflowScrollingTouch(this.parentElement);
-      }
-
       if (this._focusOverlayOnOpen) {
         this._overlayContent.focusDateElement();
         this._focusOverlayOnOpen = false;
@@ -777,25 +760,6 @@ export const DatePickerMixin = (subclass) =>
         this.focusElement.blur();
         this._overlayContent.focusDateElement();
       }
-    }
-
-    // A hack needed for iOS to prevent dropdown from being clipped in an
-    // ancestor container with -webkit-overflow-scrolling: touch;
-    /** @private */
-    _preventWebkitOverflowScrollingTouch(element) {
-      const result = [];
-      while (element) {
-        if (window.getComputedStyle(element).webkitOverflowScrolling === 'touch') {
-          const oldInlineValue = element.style.webkitOverflowScrolling;
-          element.style.webkitOverflowScrolling = 'auto';
-          result.push({
-            element,
-            oldInlineValue,
-          });
-        }
-        element = element.parentElement;
-      }
-      return result;
     }
 
     /** @private */
@@ -823,13 +787,6 @@ export const DatePickerMixin = (subclass) =>
     /** @protected */
     _onOverlayClosed() {
       window.removeEventListener('scroll', this._boundOnScroll, true);
-
-      if (this._touchPrevented) {
-        this._touchPrevented.forEach((prevented) => {
-          prevented.element.style.webkitOverflowScrolling = prevented.oldInlineValue;
-        });
-        this._touchPrevented = [];
-      }
 
       // No need to select date on close if it was confirmed by the user.
       if (this.__userConfirmedDate) {

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, click, down, fixtureSync, isIOS, touchstart } from '@vaadin/testing-helpers';
+import { aTimeout, click, down, fixtureSync, touchstart } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '../src/vaadin-date-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -22,22 +22,6 @@ describe('dropdown', () => {
     datepicker.open();
     datepicker.parentElement.removeChild(datepicker);
     expect(datepicker.$.overlay.parentElement).to.not.be.ok;
-  });
-
-  (isIOS ? it : it.skip)('should handle webkit-overflow-scrolling', (done) => {
-    document.body.style.webkitOverflowScrolling = 'touch';
-
-    datepicker.open();
-
-    datepicker.$.overlay.addEventListener('vaadin-overlay-open', () => {
-      expect(window.getComputedStyle(document.body).webkitOverflowScrolling).to.equal('auto');
-      datepicker.close();
-    });
-
-    datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
-      expect(window.getComputedStyle(document.body).webkitOverflowScrolling).to.equal('touch');
-      done();
-    });
   });
 
   it('should restore focus to the field on outside click', async () => {


### PR DESCRIPTION
## Description

This logic was added in https://github.com/vaadin/vaadin-date-picker/pull/77 as a fix for https://github.com/vaadin/vaadin-date-picker/issues/66. Back in the day, the `vaadin-date-picker` was using `iron-dropdown`, which was not teleported under document body.

Now when we use `vaadin-overlay`, the original clipping issue is no longer applicable. Also, starting from Safari 13, the prefixed [`-webkit-overflow-scrolling`](https://caniuse.com/mdn-css_properties_-webkit-overflow-scrolling) property is no longer supported - see [release notes](https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes). Let's remove this code.

## Type of change

- Refactor