### PR TITLE
fix: set ARIA attributes on the native input (#4295) (CP: 23.1)

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -239,13 +239,25 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /**
+     * Get a reference to the native `<input>` element.
+     * Override to provide a custom input.
+     * @protected
+     * @return {HTMLInputElement | undefined}
+     */
+    get _nativeInput() {
+      return this.inputElement;
+    }
+
+    /**
      * Override method inherited from `InputMixin`
      * to customize the input element.
      * @protected
      * @override
      */
-    _inputElementChanged(input) {
-      super._inputElementChanged(input);
+    _inputElementChanged(inputElement) {
+      super._inputElementChanged(inputElement);
+
+      const input = this._nativeInput;
 
       if (input) {
         input.autocomplete = 'off';
@@ -346,7 +358,7 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _updateActiveDescendant(index) {
-      const input = this.inputElement;
+      const input = this._nativeInput;
       if (!input) {
         return;
       }
@@ -382,7 +394,7 @@ export const ComboBoxMixin = (subclass) =>
         }
       }
 
-      const input = this.inputElement;
+      const input = this._nativeInput;
       if (input) {
         input.setAttribute('aria-expanded', !!opened);
 

--- a/packages/combo-box/test/combo-box-light.test.js
+++ b/packages/combo-box/test/combo-box-light.test.js
@@ -1,12 +1,15 @@
 import { expect } from '@esm-bundle/chai';
 import {
+  arrowDownKeyDown,
   click,
+  escKeyDown,
   fixtureSync,
   isDesktopSafari,
   isIOS,
   mousedown,
   mouseup,
   nextFrame,
+  nextRender,
   touchend,
   touchstart,
 } from '@vaadin/testing-helpers';
@@ -47,12 +50,13 @@ customElements.define('my-input', MyInput);
 describe('vaadin-combo-box-light', () => {
   let comboBox, overlay, inputElement;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     comboBox = fixtureSync(`
       <vaadin-combo-box-light>
         <vaadin-text-field></vaadin-text-field>
       </vaadin-combo-box-light>
     `);
+    await nextRender();
     comboBox.items = ['foo', 'bar', 'baz'];
     overlay = comboBox.$.dropdown.$.overlay;
     inputElement = comboBox.querySelector('vaadin-text-field');
@@ -166,12 +170,13 @@ describe('vaadin-combo-box-light', () => {
 describe('attr-for-value', () => {
   let comboBox, customInput, inputElement;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     comboBox = fixtureSync(`
       <vaadin-combo-box-light attr-for-value="custom-value">
         <my-input class="input"></my-input>
       </vaadin-combo-box-light>
     `);
+    await nextRender();
     comboBox.items = ['foo', 'bar', 'baz'];
     customInput = comboBox.querySelector('.input');
     inputElement = customInput.$.input;
@@ -206,10 +211,64 @@ describe('attr-for-value', () => {
   });
 });
 
+describe('ARIA', () => {
+  let comboBox, input;
+
+  describe('input in light DOM', () => {
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box-light>
+          <vaadin-text-field></vaadin-text-field>
+        </vaadin-combo-box-light>
+      `);
+      await nextRender();
+      comboBox.items = ['foo', 'bar', 'baz'];
+      input = comboBox.querySelector('input');
+    });
+
+    it('should set correct attributes on the input in light DOM', () => {
+      expect(input.getAttribute('role')).to.equal('combobox');
+      expect(input.getAttribute('aria-autocomplete')).to.equal('list');
+    });
+
+    it('should toggle aria-expanded attribute on the input in light DOM', () => {
+      arrowDownKeyDown(input);
+      expect(input.getAttribute('aria-expanded')).to.equal('true');
+      escKeyDown(input);
+      expect(input.getAttribute('aria-expanded')).to.equal('false');
+    });
+  });
+
+  describe('input in Shadow DOM', () => {
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box-light attr-for-value="custom-value">
+          <my-input class="input"></my-input>
+        </vaadin-combo-box-light>
+      `);
+      await nextRender();
+      comboBox.items = ['foo', 'bar', 'baz'];
+      input = comboBox.inputElement.shadowRoot.querySelector('input');
+    });
+
+    it('should set correct attributes on the input in shadow DOM', () => {
+      expect(input.getAttribute('role')).to.equal('combobox');
+      expect(input.getAttribute('aria-autocomplete')).to.equal('list');
+    });
+
+    it('should toggle aria-expanded attribute on the input in shadow DOM', () => {
+      arrowDownKeyDown(input);
+      expect(input.getAttribute('aria-expanded')).to.equal('true');
+      escKeyDown(input);
+      expect(input.getAttribute('aria-expanded')).to.equal('false');
+    });
+  });
+});
+
 describe('custom buttons', () => {
   let comboBox;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     comboBox = fixtureSync(`
       <vaadin-combo-box-light>
         <vaadin-text-field>
@@ -218,6 +277,7 @@ describe('custom buttons', () => {
         </vaadin-text-field>
       </vaadin-combo-box-light>
     `);
+    await nextRender();
     comboBox.items = ['foo', 'bar', 'baz'];
   });
 
@@ -379,7 +439,7 @@ describe('theme attribute', () => {
 describe('nested template', () => {
   let comboBox;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     comboBox = fixtureSync(`
       <vaadin-combo-box-light>
         <vaadin-text-field>
@@ -393,6 +453,7 @@ describe('nested template', () => {
         </vaadin-text-field>
       </vaadin-combo-box-light>
     `);
+    await nextRender();
     comboBox.items = ['bar', 'baz', 'qux'];
   });
 

--- a/packages/combo-box/test/item-template.test.js
+++ b/packages/combo-box/test/item-template.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDownKeyDown, fixtureSync } from '@vaadin/testing-helpers';
+import { arrowDownKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
@@ -12,9 +12,10 @@ describe('item template', () => {
 
   ['combo-box', 'combo-box-light'].forEach((name) => {
     describe(name, () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         wrapper = fixtureSync(`<mock-${name}-template-wrapper></mock-${name}-template-wrapper>`);
         comboBox = wrapper.$.comboBox;
+        await nextRender();
         comboBox.items = ['foo', 'bar'];
         comboBox.open();
         firstItem = getFirstItem(comboBox);

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, enterKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, enterKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
 import './not-animated-styles.js';
@@ -1209,12 +1209,13 @@ describe('lazy loading', () => {
   });
 
   describe('combo-box-light', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       comboBox = fixtureSync(`
         <vaadin-combo-box-light>
           <vaadin-text-field></vaadin-text-field>
         </vaadin-combo-box-light>
       `);
+      await nextRender();
     });
 
     isComboBoxLight = true;


### PR DESCRIPTION
## Description

Manual cherry-pick of #4295 to `23.1` branch. The automated cherry-pick failed due to conflict in imports in tests.

## Type of change

- Cherry-pick