### PR TITLE
fix: use global keyup listener to remove active

### DIFF
--- a/packages/component-base/src/active-mixin.js
+++ b/packages/component-base/src/active-mixin.js
@@ -82,15 +82,15 @@ export const ActiveMixin = (superclass) =>
 
         // Element can become hidden before the `keyup` event, e.g. on button click.
         // Use document listener to ensure `active` attribute is removed correctly.
-        const keyUpListener = (e) => {
-          if (this._activeKeys.includes(e.key)) {
-            this._setActive(false);
-          }
-
-          document.removeEventListener('keyup', keyUpListener);
-        };
-
-        document.addEventListener('keyup', keyUpListener);
+        document.addEventListener(
+          'keyup',
+          (e) => {
+            if (this._activeKeys.includes(e.key)) {
+              this._setActive(false);
+            }
+          },
+          { once: true },
+        );
       }
     }
 

--- a/packages/component-base/src/active-mixin.js
+++ b/packages/component-base/src/active-mixin.js
@@ -79,21 +79,18 @@ export const ActiveMixin = (superclass) =>
 
       if (this._shouldSetActive(event) && this._activeKeys.includes(event.key)) {
         this._setActive(true);
-      }
-    }
 
-    /**
-     * Removes the `active` attribute from the element if the activation key is released.
-     *
-     * @param {KeyboardEvent} event
-     * @protected
-     * @override
-     */
-    _onKeyUp(event) {
-      super._onKeyUp(event);
+        // Element can become hidden before the `keyup` event, e.g. on button click.
+        // Use document listener to ensure `active` attribute is removed correctly.
+        const keyUpListener = (e) => {
+          if (this._activeKeys.includes(e.key)) {
+            this._setActive(false);
+          }
 
-      if (this._activeKeys.includes(event.key)) {
-        this._setActive(false);
+          document.removeEventListener('keyup', keyUpListener);
+        };
+
+        document.addEventListener('keyup', keyUpListener);
       }
     }
 

--- a/packages/component-base/test/active-mixin.test.js
+++ b/packages/component-base/test/active-mixin.test.js
@@ -83,6 +83,15 @@ describe('active-mixin', () => {
       expect(element.hasAttribute('active')).to.be.false;
     });
 
+    it('should remove active attribute when element gets hidden on keydown', async () => {
+      element.addEventListener('keydown', () => {
+        element.setAttribute('hidden', '');
+      });
+      await sendKeys({ down: 'Space' });
+      await sendKeys({ up: 'Space' });
+      expect(element.hasAttribute('active')).to.be.false;
+    });
+
     describe('custom activation keys', () => {
       beforeEach(() => {
         Object.defineProperty(element, '_activeKeys', {


### PR DESCRIPTION
## Description

Using `keyup` listener on the element where the `keydown` was fired is not reliable, because the `keyup` event will not fire on the element that gets hidden by setting `hidden` attribute. Instead, it will fire on the `<body>` element.

Fixes https://github.com/vaadin/flow-components/issues/3552

## Type of change

- Bugfix