### PR TITLE
test: improve date focus tests to reduce flakiness

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -13,7 +13,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import * as settings from '@polymer/polymer/lib/utils/settings.js';
-import { close, getFocusedCell, getOverlayContent, monthsEqual, open } from './common.js';
+import { close, getFocusedCell, getOverlayContent, idleCallback, monthsEqual, open } from './common.js';
 
 settings.setCancelSyntheticClickEvents(false);
 
@@ -318,6 +318,7 @@ describe('basic features', () => {
     it('should focus date element when opened', async () => {
       await open(datepicker);
       await nextRender();
+      await idleCallback();
       const content = getOverlayContent(datepicker);
       const cell = getFocusedCell(content);
       expect(cell).to.be.instanceOf(HTMLTableCellElement);

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -316,7 +316,7 @@ describe('basic features', () => {
     });
 
     describe('focus date', () => {
-      function onceFocused() {
+      function onceFocused(callback) {
         return new Promise((resolve) => {
           // Do not spy on the DOM element because it can be reused
           // by infinite scroller. Instead, spy on the native focus.
@@ -324,12 +324,15 @@ describe('basic features', () => {
             stub.restore();
             resolve(stub.firstCall.thisValue);
           });
+
+          callback();
         });
       }
 
       it('should focus date element when opened', async () => {
-        await open(datepicker);
-        const cell = await onceFocused();
+        const cell = await onceFocused(() => {
+          datepicker.open();
+        });
         expect(cell).to.be.instanceOf(HTMLTableCellElement);
         expect(cell.hasAttribute('today')).to.be.true;
       });

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -330,6 +330,7 @@ describe('basic features', () => {
       it('should focus date element when opened', async () => {
         await open(datepicker);
         const cell = await onceFocused();
+        expect(cell).to.be.instanceOf(HTMLTableCellElement);
         expect(cell.hasAttribute('today')).to.be.true;
       });
     });

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -13,7 +13,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import * as settings from '@polymer/polymer/lib/utils/settings.js';
-import { close, getOverlayContent, monthsEqual, open } from './common.js';
+import { close, getFocusedCell, getOverlayContent, monthsEqual, open } from './common.js';
 
 settings.setCancelSyntheticClickEvents(false);
 
@@ -315,27 +315,13 @@ describe('basic features', () => {
       expect(spy.called).to.be.true;
     });
 
-    describe('focus date', () => {
-      function onceFocused(callback) {
-        return new Promise((resolve) => {
-          // Do not spy on the DOM element because it can be reused
-          // by infinite scroller. Instead, spy on the native focus.
-          const stub = sinon.stub(HTMLTableCellElement.prototype, 'focus').callsFake(() => {
-            stub.restore();
-            resolve(stub.firstCall.thisValue);
-          });
-
-          callback();
-        });
-      }
-
-      it('should focus date element when opened', async () => {
-        const cell = await onceFocused(() => {
-          datepicker.open();
-        });
-        expect(cell).to.be.instanceOf(HTMLTableCellElement);
-        expect(cell.hasAttribute('today')).to.be.true;
-      });
+    it('should focus date element when opened', async () => {
+      await open(datepicker);
+      await nextRender();
+      const content = getOverlayContent(datepicker);
+      const cell = getFocusedCell(content);
+      expect(cell).to.be.instanceOf(HTMLTableCellElement);
+      expect(cell.hasAttribute('today')).to.be.true;
     });
   });
 

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -320,7 +320,7 @@ describe('basic features', () => {
         return new Promise((resolve) => {
           // Do not spy on the DOM element because it can be reused
           // by infinite scroller. Instead, spy on the native focus.
-          const stub = sinon.stub(HTMLElement.prototype, 'focus').callsFake(() => {
+          const stub = sinon.stub(HTMLTableCellElement.prototype, 'focus').callsFake(() => {
             stub.restore();
             resolve(stub.firstCall.thisValue);
           });

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -5,7 +5,6 @@ import {
   fixtureSync,
   keyboardEventFor,
   makeSoloTouchEvent,
-  nextRender,
   oneEvent,
   tap,
 } from '@vaadin/testing-helpers';
@@ -275,13 +274,11 @@ describe('basic features', () => {
     it('should set focused attribute when focused', async () => {
       datepicker.focus();
       await open(datepicker);
-      await nextRender();
       expect(datepicker.hasAttribute('focused')).to.be.true;
     });
 
     it('should close the dropdown on Today button Esc', async () => {
       await open(datepicker);
-      await nextRender();
 
       getOverlayContent(datepicker).$.todayButton.focus();
       await sendKeys({ press: 'Escape' });
@@ -291,7 +288,6 @@ describe('basic features', () => {
 
     it('should close the dropdown on Cancel button Esc', async () => {
       await open(datepicker);
-      await nextRender();
 
       getOverlayContent(datepicker).$.cancelButton.focus();
       await sendKeys({ press: 'Escape' });
@@ -301,7 +297,6 @@ describe('basic features', () => {
 
     it('should remove focused attribute when closed and not focused', async () => {
       await open(datepicker);
-      await nextRender();
 
       getOverlayContent(datepicker).$.todayButton.focus();
       await sendKeys({ press: 'Escape' });
@@ -317,7 +312,6 @@ describe('basic features', () => {
 
     it('should focus date element when opened', async () => {
       await open(datepicker);
-      await nextRender();
       await idleCallback();
       const content = getOverlayContent(datepicker);
       const cell = getFocusedCell(content);

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -316,22 +316,20 @@ describe('basic features', () => {
     });
 
     describe('focus date', () => {
-      let spy;
-
-      beforeEach(() => {
-        // Do not spy on the DOM element because it can be reused
-        // by infinite scroller. Instead, spy on the native focus.
-        spy = sinon.spy(HTMLElement.prototype, 'focus');
-      });
-
-      afterEach(() => {
-        spy.restore();
-      });
+      function onceFocused() {
+        return new Promise((resolve) => {
+          // Do not spy on the DOM element because it can be reused
+          // by infinite scroller. Instead, spy on the native focus.
+          const stub = sinon.stub(HTMLElement.prototype, 'focus').callsFake(() => {
+            stub.restore();
+            resolve(stub.firstCall.thisValue);
+          });
+        });
+      }
 
       it('should focus date element when opened', async () => {
         await open(datepicker);
-        await nextRender();
-        const cell = spy.lastCall.thisValue;
+        const cell = await onceFocused();
         expect(cell.hasAttribute('today')).to.be.true;
       });
     });

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -1,4 +1,4 @@
-import { fire, listenOnce, nextRender } from '@vaadin/testing-helpers';
+import { fire, listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 export function activateScroller(scroller) {
@@ -138,9 +138,9 @@ export function getFocusedCell(overlayContent) {
  * @param {HTMLElement} overlayContent
  */
 export async function waitForScrollToFinish(overlayContent) {
-  if (overlayContent._revealPromise) {
+  if (overlayContent._targetPosition) {
     // The overlay content is scrolling.
-    await overlayContent._revealPromise;
+    await oneEvent(overlayContent, 'scroll-animation-finished');
   }
 
   await nextRender(overlayContent);

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -1,4 +1,4 @@
-import { fire, listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fire, listenOnce, nextRender } from '@vaadin/testing-helpers';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 export function activateScroller(scroller) {
@@ -58,6 +58,12 @@ export function close(datepicker) {
   return new Promise((resolve) => {
     listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', resolve);
     datepicker.close();
+  });
+}
+
+export function idleCallback() {
+  return new Promise((resolve) => {
+    window.requestIdleCallback ? window.requestIdleCallback(resolve) : setTimeout(resolve, 16);
   });
 }
 
@@ -138,9 +144,9 @@ export function getFocusedCell(overlayContent) {
  * @param {HTMLElement} overlayContent
  */
 export async function waitForScrollToFinish(overlayContent) {
-  if (overlayContent._targetPosition) {
+  if (overlayContent._revealPromise) {
     // The overlay content is scrolling.
-    await oneEvent(overlayContent, 'scroll-animation-finished');
+    await overlayContent._revealPromise;
   }
 
   await nextRender(overlayContent);

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -1,4 +1,5 @@
-import { fire, listenOnce, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fire, listenOnce, nextRender } from '@vaadin/testing-helpers';
+import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 export function activateScroller(scroller) {
@@ -49,9 +50,23 @@ export function getDefaultI18n() {
 
 export function open(datepicker) {
   return new Promise((resolve) => {
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', resolve);
+    listenOnce(datepicker.$.overlay, 'vaadin-overlay-open', async () => {
+      // Wait until infinite scrollers are rendered
+      await waitForOverlayRender();
+
+      resolve();
+    });
     datepicker.open();
   });
+}
+
+export async function waitForOverlayRender() {
+  // Wait until infinite scrollers are rendered
+  await aTimeout(1);
+  await nextRender();
+
+  // Force dom-repeat to render table elements
+  flush();
 }
 
 export function close(datepicker) {

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -546,7 +546,6 @@ describe('keyboard', () => {
     it('should fire change on selecting date with Enter', async () => {
       // Open the overlay
       await open(datepicker);
-      await nextRender(datepicker);
 
       // Move focus to the calendar
       await sendKeys({ press: 'ArrowDown' });
@@ -559,7 +558,6 @@ describe('keyboard', () => {
     it('should fire change on selecting date with Space', async () => {
       // Open the overlay
       await open(datepicker);
-      await nextRender(datepicker);
 
       // Move focus to the calendar
       await sendKeys({ press: 'ArrowDown' });

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -271,8 +271,8 @@ describe('keyboard', () => {
         // Scroll to date outside viewport
         const date = new Date();
         date.setFullYear(date.getFullYear() - 1);
-        overlayContent.revealDate(date);
-        await waitForScrollToFinish(overlayContent);
+        overlayContent.revealDate(date, false);
+        await nextRender();
 
         // Move focus to the input
         await sendKeys({ down: 'Shift' });
@@ -301,8 +301,8 @@ describe('keyboard', () => {
         // Scroll to date outside viewport
         const date = new Date();
         date.setFullYear(date.getFullYear() - 1);
-        overlayContent.revealDate(date);
-        await waitForScrollToFinish(overlayContent);
+        overlayContent.revealDate(date, false);
+        await nextRender();
 
         // Move focus to the Today button
         await sendKeys({ press: 'Tab' });

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -288,6 +288,7 @@ describe('keyboard', () => {
         await sendKeys({ press: 'Tab' });
 
         const cell = await onceFocused();
+        expect(cell).to.be.instanceOf(HTMLTableCellElement);
         expect(cell.hasAttribute('today')).to.be.true;
       });
 
@@ -311,6 +312,7 @@ describe('keyboard', () => {
         await sendKeys({ up: 'Shift' });
 
         const cell = await onceFocused();
+        expect(cell).to.be.instanceOf(HTMLTableCellElement);
         expect(cell.hasAttribute('today')).to.be.true;
       });
     });

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -257,7 +257,7 @@ describe('keyboard', () => {
     });
 
     describe('focus date not in the viewport', () => {
-      function onceFocused() {
+      function onceFocused(callback) {
         return new Promise((resolve) => {
           // Do not spy on the DOM element because it can be reused
           // by infinite scroller. Instead, spy on the native focus.
@@ -265,6 +265,8 @@ describe('keyboard', () => {
             stub.restore();
             resolve(stub.firstCall.thisValue);
           });
+
+          callback();
         });
       }
 
@@ -285,9 +287,10 @@ describe('keyboard', () => {
         await sendKeys({ up: 'Shift' });
 
         // Move focus back to the date
-        await sendKeys({ press: 'Tab' });
+        const cell = await onceFocused(() => {
+          sendKeys({ press: 'Tab' });
+        });
 
-        const cell = await onceFocused();
         expect(cell).to.be.instanceOf(HTMLTableCellElement);
         expect(cell.hasAttribute('today')).to.be.true;
       });
@@ -307,11 +310,12 @@ describe('keyboard', () => {
         await sendKeys({ press: 'Tab' });
 
         // Move focus back to the date
-        await sendKeys({ down: 'Shift' });
-        await sendKeys({ press: 'Tab' });
-        await sendKeys({ up: 'Shift' });
+        const cell = await onceFocused(async () => {
+          await sendKeys({ down: 'Shift' });
+          await sendKeys({ press: 'Tab' });
+          await sendKeys({ up: 'Shift' });
+        });
 
-        const cell = await onceFocused();
         expect(cell).to.be.instanceOf(HTMLTableCellElement);
         expect(cell.hasAttribute('today')).to.be.true;
       });

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -4,7 +4,6 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { close, getFocusedCell, getOverlayContent, idleCallback, open, waitForScrollToFinish } from './common.js';
 
 describe('keyboard', () => {
@@ -76,7 +75,6 @@ describe('keyboard', () => {
     it('should reflect focused date to input', async () => {
       datepicker.value = '2000-01-01';
       await open(datepicker);
-      await nextRender(datepicker);
 
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
@@ -172,13 +170,7 @@ describe('keyboard', () => {
       // Open the overlay
       await open(datepicker);
       overlayContent = getOverlayContent(datepicker);
-
-      // Wait until infinite scrollers are rendered
-      await aTimeout(1);
-      await nextRender();
-
-      // Force dom-repeat to render table elements
-      flush();
+      await idleCallback();
     });
 
     it('should keep focused attribute when the focus moves to the overlay', async () => {
@@ -340,12 +332,6 @@ describe('keyboard', () => {
       beforeEach(async () => {
         // Open the overlay
         await open(datepicker);
-        // Wait until infinite scrollers are rendered
-        await aTimeout(1);
-        await nextRender();
-
-        // Force dom-repeat to render table elements
-        flush();
       });
 
       it('should close the overlay when input is focused', async () => {
@@ -417,7 +403,6 @@ describe('keyboard', () => {
       beforeEach(async () => {
         datepicker.value = '2000-01-01';
         await open(datepicker);
-        await nextRender(datepicker);
         input.select();
       });
 

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -261,7 +261,7 @@ describe('keyboard', () => {
         return new Promise((resolve) => {
           // Do not spy on the DOM element because it can be reused
           // by infinite scroller. Instead, spy on the native focus.
-          const stub = sinon.stub(HTMLElement.prototype, 'focus').callsFake(() => {
+          const stub = sinon.stub(HTMLTableCellElement.prototype, 'focus').callsFake(() => {
             stub.restore();
             resolve(stub.firstCall.thisValue);
           });

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -257,10 +257,15 @@ describe('keyboard', () => {
 
     describe('focus date not in the viewport', () => {
       beforeEach(async () => {
+        // Disable scrolling animation
+        const stub = sinon.stub(overlayContent, 'revealDate').callsFake((date) => {
+          stub.wrappedMethod.call(overlayContent, date, false);
+        });
+
         // Scroll to date outside viewport
         const date = new Date();
         date.setFullYear(date.getFullYear() - 1);
-        overlayContent.revealDate(date, false);
+        overlayContent.revealDate(date);
         await idleCallback();
       });
 
@@ -285,7 +290,6 @@ describe('keyboard', () => {
         await sendKeys({ up: 'Shift' });
 
         await waitForScrollToFinish(overlayContent);
-        await nextRender();
 
         const cell = getFocusedCell(overlayContent);
         expect(cell).to.be.instanceOf(HTMLTableCellElement);

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -575,7 +575,7 @@ describe('keyboard', () => {
 
     it('should fire change on selecting date with Enter', async () => {
       // Open the overlay
-      await sendKeys({ press: 'ArrowDown' });
+      await open(datepicker);
       await nextRender(datepicker);
 
       // Move focus to the calendar
@@ -588,7 +588,7 @@ describe('keyboard', () => {
 
     it('should fire change on selecting date with Space', async () => {
       // Open the overlay
-      await sendKeys({ press: 'ArrowDown' });
+      await open(datepicker);
       await nextRender(datepicker);
 
       // Move focus to the calendar

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -132,6 +132,7 @@ import {
 
     beforeEach(async () => {
       overlay = document.createElement('vaadin-date-picker-overlay-content');
+      overlay.scrollDuration = 0;
       overlay.style.position = 'absolute';
       overlay.style.top = '0';
       overlay.style.width = '400px';

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -131,13 +131,13 @@ import {
     let overlay;
 
     beforeEach(async () => {
-      overlay = document.createElement('vaadin-date-picker-overlay-content');
-      overlay.scrollDuration = 0;
-      overlay.style.position = 'absolute';
-      overlay.style.top = '0';
-      overlay.style.width = '400px';
+      overlay = fixtureSync(`
+        <vaadin-date-picker-overlay-content
+          style="position: absolute; top: 0; width: 400px"
+          scroll-duration="0"
+        ></vaadin-date-picker-overlay-content>
+      `);
       overlay.i18n = getDefaultI18n();
-      document.body.appendChild(overlay);
 
       // Set initialPosition to activate scrollers
       const initialDate = new Date(2000, 0, 1);
@@ -153,10 +153,6 @@ import {
       await overlay.focusDate(initialDate);
 
       await idleCallback();
-    });
-
-    afterEach(() => {
-      document.body.removeChild(overlay);
     });
 
     it('should focus one week forward with arrow down', async () => {

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -5,7 +5,14 @@ import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker.js';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
-import { getDefaultI18n, getFocusedCell, getOverlayContent, open, waitForScrollToFinish } from './common.js';
+import {
+  getDefaultI18n,
+  getFocusedCell,
+  getOverlayContent,
+  idleCallback,
+  open,
+  waitForScrollToFinish,
+} from './common.js';
 
 (isIOS ? describe.skip : describe)('keyboard navigation', () => {
   describe('date-picker', () => {
@@ -143,6 +150,8 @@ import { getDefaultI18n, getFocusedCell, getOverlayContent, open, waitForScrollT
       flush();
 
       await overlay.focusDate(initialDate);
+
+      await idleCallback();
     });
 
     afterEach(() => {

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -4,13 +4,13 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker.js';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import {
   getDefaultI18n,
   getFocusedCell,
   getOverlayContent,
   idleCallback,
   open,
+  waitForOverlayRender,
   waitForScrollToFinish,
 } from './common.js';
 
@@ -29,7 +29,6 @@ import {
       it('should be focused on today if no value / initial position is set', async () => {
         const today = new Date();
         await open(datepicker);
-        await nextRender(datepicker);
 
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
@@ -43,7 +42,7 @@ import {
 
         input.click();
         await oneEvent(datepicker.$.overlay, 'vaadin-overlay-open');
-        await nextRender(datepicker);
+        await waitForOverlayRender();
 
         // Reset overlay focused date
         input.click();
@@ -65,7 +64,6 @@ import {
 
       it('should be focused on selected value when overlay is opened', async () => {
         await open(datepicker);
-        await nextRender(datepicker);
 
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
@@ -76,7 +74,6 @@ import {
 
       it('should not lose focused date after deselecting', async () => {
         await open(datepicker);
-        await nextRender(datepicker);
 
         const content = getOverlayContent(datepicker);
         const focused = content.focusedDate;
@@ -101,7 +98,6 @@ import {
 
       it('should be focused on initial position when opened', async () => {
         await open(datepicker);
-        await nextRender(datepicker);
 
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
@@ -113,7 +109,7 @@ import {
       it('should be focused on initial position when focused date is empty', async () => {
         input.click();
         await oneEvent(datepicker.$.overlay, 'vaadin-overlay-open');
-        await nextRender(datepicker);
+        await waitForOverlayRender();
 
         // Reset overlay focused date
         input.click();
@@ -143,15 +139,8 @@ import {
       const initialDate = new Date(2000, 0, 1);
       overlay.initialPosition = initialDate;
 
-      // Wait until infinite scrollers are rendered
-      await aTimeout(1);
-      await nextRender();
-
-      // Force dom-repeat to render table elements
-      flush();
-
+      await waitForOverlayRender();
       await overlay.focusDate(initialDate);
-
       await idleCallback();
     });
 


### PR DESCRIPTION
## Description

Follow-up to #4296. 

It looks like some newly added tests are flaky, most likely due to animated scroll to date.
Changed `revealDate()` calls to scroll immediately, this should make it more stable.

Also, some other tests were failing on `master` so I made other tweaks to setup.

## Type of change

- Tests