### PR TITLE
chore: fix copy-paste leftovers in README

### DIFF
--- a/packages/confirm-dialog/README.md
+++ b/packages/confirm-dialog/README.md
@@ -63,4 +63,4 @@ Read the [contributing guide](https://vaadin.com/docs/latest/guide/contributing/
 Commercial Vaadin Developer License 4.0 (CVDLv4). For license terms, see LICENSE.
 
 Vaadin collects usage statistics at development time to improve this product.
-For confirm-dialog and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.
+For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.

--- a/packages/cookie-consent/README.md
+++ b/packages/cookie-consent/README.md
@@ -38,4 +38,4 @@ Read the [contributing guide](https://vaadin.com/docs/latest/guide/contributing/
 Commercial Vaadin Developer License 4.0 (CVDLv4). For license terms, see LICENSE.
 
 Vaadin collects usage statistics at development time to improve this product.
-For crud and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.
+For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.

--- a/packages/crud/README.md
+++ b/packages/crud/README.md
@@ -61,4 +61,4 @@ Read the [contributing guide](https://vaadin.com/docs/latest/guide/contributing/
 Commercial Vaadin Developer License 4.0 (CVDLv4). For license terms, see LICENSE.
 
 Vaadin collects usage statistics at development time to improve this product.
-For crud and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.
+For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.

--- a/packages/grid-pro/README.md
+++ b/packages/grid-pro/README.md
@@ -76,4 +76,4 @@ Read the [contributing guide](https://vaadin.com/docs/latest/guide/contributing/
 Commercial Vaadin Developer License 4.0 (CVDLv4). For license terms, see LICENSE.
 
 Vaadin collects usage statistics at development time to improve this product.
-For grid-pro and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.
+For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.


### PR DESCRIPTION
## Description

Some Pro components packages have been created based on `vaadin-details` and then updated to replace all of the occurrences of `details` which ended up with some weird-looking copy-paste leftovers 🤦‍♂️ 

## Type of change

- Internal change