### PR TITLE
chore: fix Pro components types license headers

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';

--- a/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 

--- a/packages/crud/src/vaadin-crud-edit-column.d.ts
+++ b/packages/crud/src/vaadin-crud-edit-column.d.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 

--- a/packages/crud/src/vaadin-crud-edit.d.ts
+++ b/packages/crud/src/vaadin-crud-edit.d.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { Button } from '@vaadin/button/src/vaadin-button.js';
 

--- a/packages/crud/src/vaadin-crud-form.d.ts
+++ b/packages/crud/src/vaadin-crud-form.d.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { FormLayout } from '@vaadin/form-layout/src/vaadin-form-layout.js';
 import { IncludedMixin } from './vaadin-crud-include-mixin.js';

--- a/packages/crud/src/vaadin-crud-grid.d.ts
+++ b/packages/crud/src/vaadin-crud-grid.d.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { IncludedMixin } from './vaadin-crud-include-mixin.js';

--- a/packages/crud/src/vaadin-crud-include-mixin.d.ts
+++ b/packages/crud/src/vaadin-crud-include-mixin.d.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 

--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';


### PR DESCRIPTION
## Description

Some Pro components had their `d.ts` files created using a copy-paste from free components, and therefore used the wrong license header mentioning Apache 2.0 instead of CVDL 4.0 license. Updated these to use correct license.

## Type of change

- Internal change