### PR TITLE
chore: align license header with other components

### DIFF
--- a/packages/grid-pro/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid-pro/src/lit/column-renderer-directives.d.ts
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive';

--- a/packages/grid-pro/src/lit/column-renderer-directives.js
+++ b/packages/grid-pro/src/lit/column-renderer-directives.js
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { directive } from 'lit/directive.js';
 import { microTask } from '@vaadin/component-base/src/async.js';

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-checkbox.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-checkbox.js
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
 

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import type { GridBodyRenderer, GridDefaultItem, GridItemModel } from '@vaadin/grid/src/vaadin-grid.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import './vaadin-grid-pro-edit-checkbox.js';
 import './vaadin-grid-pro-edit-select.js';

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import '@vaadin/item/src/vaadin-item.js';
 import '@vaadin/list-box/src/vaadin-list-box.js';

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-text-field.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-text-field.js
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.d.ts
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { animationFrame } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';

--- a/packages/grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro.d.ts
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import type { GridCustomEventMap, GridDefaultItem } from '@vaadin/grid/src/vaadin-grid.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';

--- a/packages/grid-pro/src/vaadin-grid-pro.js
+++ b/packages/grid-pro/src/vaadin-grid-pro.js
@@ -1,8 +1,7 @@
 /**
  * @license
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
- * This program is available under Commercial Vaadin Developer License 4.0 (CVDLv4).
- * See <a href="https://vaadin.com/license/cvdl-4.0">the website</a> for the complete license.
+ * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';


### PR DESCRIPTION
## Description

The `grid-pro` package was using a different license header format. Changed it to align with other Pro components.

## Type of change

- Internal change