### PR TITLE
chore: update year in license headers to 2022

### DIFF
--- a/packages/field-base/src/helper-controller.d.ts
+++ b/packages/field-base/src/helper-controller.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2021 Vaadin Ltd.
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';

--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2021 Vaadin Ltd.
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';

--- a/packages/vaadin-charts/src/vaadin-chart-series.d.ts
+++ b/packages/vaadin-charts/src/vaadin-chart-series.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 - 2021 Vaadin Ltd
+ * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import type { ChartSeries } from '@vaadin/charts/src/vaadin-chart-series.js';

--- a/packages/vaadin-charts/src/vaadin-chart-series.js
+++ b/packages/vaadin-charts/src/vaadin-chart-series.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 - 2021 Vaadin Ltd
+ * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { ChartSeries } from '@vaadin/charts/src/vaadin-chart-series.js';

--- a/packages/vaadin-charts/src/vaadin-chart.d.ts
+++ b/packages/vaadin-charts/src/vaadin-chart.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 - 2021 Vaadin Ltd
+ * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import type { Chart } from '@vaadin/charts/src/vaadin-chart.js';

--- a/packages/vaadin-charts/src/vaadin-chart.js
+++ b/packages/vaadin-charts/src/vaadin-chart.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 - 2021 Vaadin Ltd
+ * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import { Chart } from '@vaadin/charts/src/vaadin-chart.js';

--- a/packages/vaadin-charts/theme/lumo/vaadin-chart.js
+++ b/packages/vaadin-charts/theme/lumo/vaadin-chart.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 - 2021 Vaadin Ltd
+ * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import '@vaadin/charts/theme/lumo/vaadin-chart.js';

--- a/packages/vaadin-charts/theme/material/vaadin-chart.js
+++ b/packages/vaadin-charts/theme/material/vaadin-chart.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 - 2021 Vaadin Ltd
+ * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import '@vaadin/charts/theme/material/vaadin-chart.js';

--- a/packages/vaadin-charts/theme/vaadin-chart-base-theme.js
+++ b/packages/vaadin-charts/theme/vaadin-chart-base-theme.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 - 2021 Vaadin Ltd
+ * Copyright (c) 2015 - 2022 Vaadin Ltd.
  * This program is available under Commercial Vaadin Developer License 4.0, available at https://vaadin.com/license/cvdl-4.0.
  */
 import '@vaadin/charts/theme/vaadin-chart-base-theme.js';


### PR DESCRIPTION
## Description

The year was changed in #3247 but there are few files still using `2021`, updated those.

## Type of change

- Internal change