### PR TITLE
fix: sync the hasInputValue state on input

### DIFF
--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -155,7 +155,11 @@ export const InputMixin = dedupingMixin(
        * @private
        */
       __onInput(event) {
-        this._hasInputValue = event.target.value.length > 0;
+        // In the case a custom web component is passed as `inputElement`,
+        // the actual native input element, on which the event occurred,
+        // can be inside shadow trees.
+        const target = event.composedPath()[0];
+        this._hasInputValue = target.value.length > 0;
         this._onInput(event);
       }
 
@@ -166,9 +170,13 @@ export const InputMixin = dedupingMixin(
        * @protected
        */
       _onInput(event) {
+        // In the case a custom web component is passed as `inputElement`,
+        // the actual native input element, on which the event occurred,
+        // can be inside shadow trees.
+        const target = event.composedPath()[0];
         // Ignore fake input events e.g. used by clear button.
         this.__userInput = event.isTrusted;
-        this.value = event.target.value;
+        this.value = target.value;
         this.__userInput = false;
       }
 

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -68,8 +68,8 @@ export const InputMixin = dedupingMixin(
       constructor() {
         super();
 
-        this._boundOnInput = this._onInput.bind(this);
-        this._boundOnChange = this.__onChange.bind(this);
+        this._boundOnInput = this.__onInput.bind(this);
+        this._boundOnChange = this._onChange.bind(this);
       }
 
       /**
@@ -148,6 +148,18 @@ export const InputMixin = dedupingMixin(
       }
 
       /**
+       * An input event listener used to update `_hasInputValue` property.
+       * Do not override this method.
+       *
+       * @param {Event} event
+       * @private
+       */
+      __onInput(event) {
+        this._hasInputValue = event.target.value.length > 0;
+        this._onInput(event);
+      }
+
+      /**
        * An input event listener used to update the field value.
        *
        * @param {Event} event
@@ -167,18 +179,6 @@ export const InputMixin = dedupingMixin(
        * @protected
        */
       _onChange(_event) {}
-
-      /**
-       * A change event listener used to update `_hasInputValue` property.
-       * Do not override this method.
-       *
-       * @param {Event} event
-       * @private
-       */
-      __onChange(event) {
-        this._hasInputValue = event.target.value.length > 0;
-        this._onChange(event);
-      }
 
       /**
        * Toggle the has-value attribute based on the value property.


### PR DESCRIPTION
## Description

It turns out that `TimePicker` prevents the `change` event on the input element until it loses focus, so it is possible to commit a non-empty value on <kbd>Enter</kbd> but have the `hasInputValue` state not updated. 

This PR makes the `hasInputValue` state update on `input` rather than `change` which ensures `hasInputValue` is synced in the above case as well.

A follow-up to https://github.com/vaadin/web-components/pull/4276

Related to https://github.com/vaadin/flow-components/pull/3515

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
