### PR TITLE
fix: assign flattened nodes as list-mixin items

### DIFF
--- a/packages/vaadin-list-mixin/test/list-mixin.test.js
+++ b/packages/vaadin-list-mixin/test/list-mixin.test.js
@@ -93,6 +93,25 @@ customElements.define(
   },
 );
 
+customElements.define(
+  'test-list-wrapper-element',
+  class extends PolymerElement {
+    static get template() {
+      return html`
+        <style>
+          :host {
+            display: block;
+          }
+        </style>
+
+        <test-list-element>
+          <slot></slot>
+        </test-list-element>
+      `;
+    }
+  },
+);
+
 describe('vaadin-list-mixin', () => {
   let list;
 
@@ -116,6 +135,24 @@ describe('vaadin-list-mixin', () => {
     it('`focus` should flush the `_observer` if it is called too soon', () => {
       // Focus flushes the observer in order to be run in 3rd party elements initialization
       list.focus();
+      expect(list.items.length).to.be.equal(3);
+    });
+  });
+
+  describe.only('wrapped list with slotted items', () => {
+    beforeEach(() => {
+      list = fixtureSync(`
+        <test-list-wrapper-element>
+          <test-item-element>Item 0</test-item-element>
+          <test-item-element>Item 1</test-item-element>
+          <test-item-element>Item 2</test-item-element>
+        </test-list-wrapper-element>
+      `).shadowRoot.querySelector('test-list-element');
+    });
+
+    it('should have a list of valid items after the DOM `_observer` has been run', () => {
+      // DOM _observer runs asynchronously, we need to flush to access items
+      list._observer.flush();
       expect(list.items.length).to.be.equal(3);
     });
   });

--- a/packages/vaadin-list-mixin/test/list-mixin.test.js
+++ b/packages/vaadin-list-mixin/test/list-mixin.test.js
@@ -141,13 +141,14 @@ describe('vaadin-list-mixin', () => {
 
   describe('wrapped list with slotted items', () => {
     beforeEach(() => {
-      list = fixtureSync(`
+      const wrapper = fixtureSync(`
         <test-list-wrapper-element>
           <test-item-element>Item 0</test-item-element>
           <test-item-element>Item 1</test-item-element>
           <test-item-element>Item 2</test-item-element>
         </test-list-wrapper-element>
-      `).shadowRoot.querySelector('test-list-element');
+      `);
+      list = wrapper.shadowRoot.querySelector('test-list-element');
     });
 
     it('should have a list of valid items after the DOM `_observer` has been run', () => {

--- a/packages/vaadin-list-mixin/test/list-mixin.test.js
+++ b/packages/vaadin-list-mixin/test/list-mixin.test.js
@@ -139,7 +139,7 @@ describe('vaadin-list-mixin', () => {
     });
   });
 
-  describe.only('wrapped list with slotted items', () => {
+  describe('wrapped list with slotted items', () => {
     beforeEach(() => {
       list = fixtureSync(`
         <test-list-wrapper-element>

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.js
@@ -87,7 +87,7 @@ export const ListMixin = (superClass) =>
       this.addEventListener('click', (e) => this._onClick(e));
 
       this._observer = new FlattenedNodesObserver(this, () => {
-        this._setItems(this._filterItems(Array.from(this.children)));
+        this._setItems(this._filterItems(FlattenedNodesObserver.getFlattenedNodes(this)));
       });
     }
 


### PR DESCRIPTION
Support list items slotted through a wrapping Web Component.

Related to https://github.com/vaadin/platform/issues/3152