### PR TITLE
fix: improve how list-mixin finds the focused item

### DIFF
--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -11,6 +11,7 @@ const user3 = { id: 'c', name: 'baz', colorIndex: 2 };
 async function waitForIntersectionObserver() {
   await nextFrame();
   await nextFrame();
+  await nextFrame();
 }
 
 describe('user-tags', () => {

--- a/packages/vaadin-list-mixin/test/list-mixin.test.js
+++ b/packages/vaadin-list-mixin/test/list-mixin.test.js
@@ -149,12 +149,19 @@ describe('vaadin-list-mixin', () => {
         </test-list-wrapper-element>
       `);
       list = wrapper.shadowRoot.querySelector('test-list-element');
-    });
-
-    it('should have a list of valid items after the DOM `_observer` has been run', () => {
       // DOM _observer runs asynchronously, we need to flush to access items
       list._observer.flush();
+    });
+
+    it('should have a list of valid items', () => {
       expect(list.items.length).to.be.equal(3);
+    });
+
+    it('should move focus to next element on "arrow-right" keydown', () => {
+      list.orientation = 'horizontal';
+      list._focus(0);
+      arrowRight(list);
+      expect(list.items[1].focused).to.be.true;
     });
   });
 

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.js
@@ -121,7 +121,7 @@ export const ListMixin = (superClass) =>
      * @return {Element}
      */
     get focused() {
-      return this.getRootNode().activeElement;
+      return (this.items || []).find((item) => item.focused);
     }
 
     /**

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.js
@@ -7,6 +7,7 @@ import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nod
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { DirHelper } from '@vaadin/component-base/src/dir-helper.js';
+import { isElementFocused } from '@vaadin/component-base/src/focus-utils.js';
 
 /**
  * A mixin for `nav` elements, facilitating navigation and selection of childNodes.
@@ -121,7 +122,7 @@ export const ListMixin = (superClass) =>
      * @return {Element}
      */
     get focused() {
-      return (this.items || []).find((item) => item.focused);
+      return (this.items || []).find(isElementFocused);
     }
 
     /**


### PR DESCRIPTION
Fixes list-mixin keyboard navigation when the list items are slotted through a wrapping Web Component.

Related to https://github.com/vaadin/platform/issues/3152