### PR TITLE
fix: use correct event to detect overlay closing

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -74,7 +74,7 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(Polyme
         fullscreen$="[[_fullscreen]]"
         opened="{{opened}}"
         on-vaadin-overlay-open="_onOverlayOpened"
-        on-vaadin-overlay-close="_onOverlayClosed"
+        on-vaadin-overlay-closing="_onOverlayClosed"
         restore-focus-on-close
         restore-focus-node="[[inputElement]]"
         theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -162,7 +162,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
         fullscreen$="[[_fullscreen]]"
         theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"
         on-vaadin-overlay-open="_onOverlayOpened"
-        on-vaadin-overlay-close="_onOverlayClosed"
+        on-vaadin-overlay-closing="_onOverlayClosed"
         restore-focus-on-close
         restore-focus-node="[[inputElement]]"
         disable-upgrade

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -76,6 +76,13 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
+    it('should not validate on input click while opened', async () => {
+      await open(datePicker);
+      validateSpy.resetHistory();
+      datePicker.inputElement.click();
+      expect(validateSpy.called).to.be.false;
+    });
+
     it('should validate on clear button click', () => {
       datePicker.clearButtonVisible = true;
       // Set invalid value.


### PR DESCRIPTION
## Description

Fixes #4339

The `vaadin-overlay-closing` event was added in #3144 because the `vaadin-overlay-close` doesn't guarantee the overlay will be closed. This is exactly the case with date-picker which prevents closing on click inside of the `<input>`:

https://github.com/vaadin/web-components/blob/9f4a2acfd8caf464056732be729ffa056fbf3656/packages/date-picker/src/vaadin-date-picker.js#L230-L232

Updated to use the correct event, also added a test for not validating on `<input>` click while opened.

## Type of change

- Bugfix