### PR TITLE
fix: restore focus-ring when closing on click

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -5,7 +5,6 @@
  */
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { isElementFocused } from '@vaadin/component-base/src/focus-utils.js';
 import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.js';
@@ -850,14 +849,6 @@ export const DatePickerMixin = (subclass) =>
       if (!this.value) {
         this.validate();
       }
-
-      // Wait for focus to be restored on close by the `vaadin-overlay`.
-      setTimeout(() => {
-        // If the input isn't focused (fullscreen mode), clear focused state.
-        if (!isElementFocused(this._nativeInput)) {
-          this._setFocused(false);
-        }
-      });
     }
 
     /** @private */

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -222,11 +222,6 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
 
   /** @private */
   _onVaadinOverlayClose(e) {
-    if (this._openedWithFocusRing && this.hasAttribute('focused')) {
-      this.setAttribute('focus-ring', '');
-    } else if (!this.hasAttribute('focused')) {
-      this.blur();
-    }
     if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this)) {
       e.preventDefault();
     }

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -173,14 +173,6 @@ describe('basic features', () => {
     expect(monthsEqual(spy.firstCall.args[0], new Date(2000, 1, 1))).to.be.true;
   });
 
-  it('should close on overlay date tap', async () => {
-    await open(datepicker);
-    const spy = sinon.spy(datepicker, 'close');
-    const evt = new CustomEvent('date-tap', { detail: { date: new Date() }, bubbles: true, composed: true });
-    getOverlayContent(datepicker).dispatchEvent(evt);
-    expect(spy.called).to.be.true;
-  });
-
   it('should lead zeros correctly', () => {
     datepicker.value = '+000300-02-01';
     expect(input.value).to.equal('2/1/0300');

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -1,4 +1,4 @@
-import { aTimeout, fire, listenOnce, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fire, listenOnce, mousedown, nextRender } from '@vaadin/testing-helpers';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
@@ -88,6 +88,8 @@ export function idleCallback() {
 export function outsideClick() {
   // Move focus to body
   document.body.tabIndex = 0;
+  // Clear keyboardActive flag
+  mousedown(document.body);
   document.body.focus();
   document.body.tabIndex = -1;
   // Outside click


### PR DESCRIPTION
## Description

Fixes #4154

TL;DR: after `focus-ring` is set after focusing with keyboard, only remove it on blur when the overlay is closed.

### Problem

Currently, the logic for restoring `focus-ring` in the date-picker is broken. The following happens when closing on click:

1. Focus is lost to the `<body>` (in case of outside click) or `<td>` inside of `<vaadin-month-calendar>` (cell click),
2. The `focusout` event is fired on the `<input>` and `_setFocused(false)` removes the `focus-ring` attribute,
3. The [logic](https://github.com/vaadin/web-components/blob/9e022ac3f50fa9a40ab33c0cf0a5fa2a4bc5103b/packages/date-picker/src/vaadin-date-picker.js#L225-L226) trying to set `focus-ring` is called too early, as the focus hasn't been restored to the `<input>` yet,
3. After a timeout, `vaadin-overlay` restores focus, but not `focus-ring` because the `keyboardActive` is `false`.
 
 ### Solution
 
Here is how this behavior will be changed after this PR is merged.

1. On first `focusin` event, calling `_setFocused(true)` sets the flag to indicate if `focus-ring` should be preserved,
2. On `focusout` event, `_setFocused(false)` is no longer called when opened (the focus will be restored anyways),
3. On subsequent `focusin` after restoring focus back to the `<input>`, there is no extra `_setFocused(true)` call.
4. Even though `keyboardActive` is `false` when restoring focus, it's not checked and `focus-ring` is preserved.

## Type of change

- Bugfix