### PR TITLE
fix: use correct event to detect overlay closing (#4340) (CP: 23.1)

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -72,7 +72,7 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(PolymerElement)) {
         fullscreen$="[[_fullscreen]]"
         opened="{{opened}}"
         on-vaadin-overlay-open="_onOverlayOpened"
-        on-vaadin-overlay-close="_onOverlayClosed"
+        on-vaadin-overlay-closing="_onOverlayClosed"
         restore-focus-on-close
         restore-focus-node="[[inputElement]]"
         theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -161,7 +161,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
         fullscreen$="[[_fullscreen]]"
         theme$="[[__getOverlayTheme(_theme, _overlayInitialized)]]"
         on-vaadin-overlay-open="_onOverlayOpened"
-        on-vaadin-overlay-close="_onOverlayClosed"
+        on-vaadin-overlay-closing="_onOverlayClosed"
         restore-focus-on-close
         restore-focus-node="[[inputElement]]"
         disable-upgrade

--- a/packages/date-picker/test/form-input.test.js
+++ b/packages/date-picker/test/form-input.test.js
@@ -77,6 +77,13 @@ describe('form input', () => {
       expect(datepicker.inputElement.hasAttribute('invalid')).to.be.true;
     });
 
+    it('should not validate on input click while opened', async () => {
+      await open(datepicker);
+      const spy = sinon.spy(datepicker, 'validate');
+      datepicker.inputElement.click();
+      expect(spy.called).to.be.false;
+    });
+
     it('should re-validate old input after selecting date', async () => {
       // Set invalid value.
       inputValue('foo');


### PR DESCRIPTION
## Description

Manual cherry-pick of #4340 to `23.1` branch. The conflict was caused to the test file renamed on master.

## Type of change

- Cherry-pick