### PR TITLE
refactor: cleanup obsolete tap event logic

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -331,7 +331,6 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
     this.setAttribute('role', 'dialog');
 
-    addListener(this, 'tap', this._stopPropagation);
     addListener(this.$.scrollers, 'track', this._track.bind(this));
     addListener(this.shadowRoot.querySelector('[part="clear-button"]'), 'tap', this._clear.bind(this));
     addListener(this.shadowRoot.querySelector('[part="today-button"]'), 'tap', this._onTodayTap.bind(this));
@@ -976,10 +975,6 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     todayMidnight.setMonth(today.getMonth());
     todayMidnight.setDate(today.getDate());
     return this._dateAllowed(todayMidnight, min, max);
-  }
-
-  _stopPropagation(e) {
-    e.stopPropagation();
   }
 }
 

--- a/packages/date-picker/test/overlay.test.js
+++ b/packages/date-picker/test/overlay.test.js
@@ -33,14 +33,6 @@ describe('overlay', () => {
       afterNextRender(overlay.$.monthScroller, () => waitUntilScrolledTo(overlay, overlay.initialPosition, done));
     });
 
-    it('should stop tap events from bubbling outside the overlay', () => {
-      const tapSpy = sinon.spy();
-      document.addEventListener('tap', tapSpy);
-      overlay.$.monthScroller.dispatchEvent(new CustomEvent('tap', { bubbles: true }));
-      document.removeEventListener('tap', tapSpy);
-      expect(tapSpy.called).to.be.false;
-    });
-
     it('should return correct month', () => {
       overlay._originDate = new Date(2016, 2, 31);
       expect(overlay._dateAfterXMonths(11).getMonth()).to.equal(1);


### PR DESCRIPTION
## Description

Using `stopPropagation()` was added in https://github.com/vaadin/vaadin-date-picker/pull/278 to prevent re-opening date-picker on selecting date (https://github.com/vaadin/vaadin-date-picker/issues/250). Back in the day, the component was using `iron-dropdown` which was not teleported under `<body>`, so its events like `tap` could bubble from there to `vaadin-date-picker` host element, causing this issue.

Removed this logic as the underlying issue no longer happens after switching to use `vaadin-overlay`.

## Type of change

- Refactor