### PR TITLE
refactor: use hidden instead of custom attributes

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -48,16 +48,12 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
           flex-grow: 1;
         }
 
-        [part='clear-button']:not([showclear]) {
-          display: none;
+        [hidden] {
+          display: none !important;
         }
 
         [part='years-toggle-button'] {
           display: flex;
-        }
-
-        [part='years-toggle-button'][desktop] {
-          display: none;
         }
 
         :host(:not([years-visible])) [part='years-toggle-button']::before {
@@ -154,10 +150,10 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
       <div part="overlay-header" on-touchend="_preventDefault" desktop$="[[_desktopMode]]" aria-hidden="true">
         <div part="label">[[_formatDisplayed(selectedDate, i18n.formatDate, label)]]</div>
-        <div part="clear-button" showclear$="[[_showClear(selectedDate)]]"></div>
+        <div part="clear-button" hidden$="[[!_showClear(selectedDate)]]"></div>
         <div part="toggle-button"></div>
 
-        <div part="years-toggle-button" desktop$="[[_desktopMode]]" aria-hidden="true">
+        <div part="years-toggle-button" hidden$="[[_desktopMode]]" aria-hidden="true">
           [[_yearAfterXMonths(_visibleMonthIndex)]]
         </div>
       </div>

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -150,7 +150,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
       <div part="overlay-header" on-touchend="_preventDefault" desktop$="[[_desktopMode]]" aria-hidden="true">
         <div part="label">[[_formatDisplayed(selectedDate, i18n.formatDate, label)]]</div>
-        <div part="clear-button" hidden$="[[!_showClear(selectedDate)]]"></div>
+        <div part="clear-button" hidden$="[[!selectedDate]]"></div>
         <div part="toggle-button"></div>
 
         <div part="years-toggle-button" hidden$="[[_desktopMode]]" aria-hidden="true">
@@ -239,6 +239,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
        */
       selectedDate: {
         type: Date,
+        value: null,
       },
 
       /**
@@ -493,10 +494,6 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     }
 
     this.scrollToDate(new Date(), true);
-  }
-
-  _showClear(selectedDate) {
-    return !!selectedDate;
   }
 
   _onYearTap(e) {

--- a/packages/date-picker/test/overlay.test.js
+++ b/packages/date-picker/test/overlay.test.js
@@ -212,7 +212,7 @@ describe('overlay', () => {
             overlay.$.monthScroller.$.scroller.scrollTop -= 1;
             tap(overlay.$.todayButton);
 
-            expect(overlay.selectedDate).to.be.undefined;
+            expect(overlay.selectedDate).to.be.not.ok;
             expect(spy.called).to.be.false;
             done();
           });


### PR DESCRIPTION
## Description

We shouldn't use custom attributes like `desktop` and `showclear` to toggle hidden state. Let's use `hidden` instead.
Note: the "Clear" button in the `fullscreen` overlay is currently on available in Material theme, but not in Lumo.

## Type of change

- Refactor