### PR TITLE
refactor: remove not needed stopPropagation

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -469,7 +469,10 @@ export const DatePickerMixin = (subclass) =>
         this._close();
       });
 
-      this._overlayContent.addEventListener('close', this._close.bind(this));
+      this._overlayContent.addEventListener('close', () => {
+        this._close();
+      });
+
       this._overlayContent.addEventListener('focus-input', this._focusAndSelect.bind(this));
 
       // User confirmed selected date by clicking the calendar.
@@ -478,7 +481,7 @@ export const DatePickerMixin = (subclass) =>
 
         this._selectDate(e.detail.date);
 
-        this._close(e);
+        this._close();
       });
 
       // User confirmed selected date by pressing Enter or Today.
@@ -590,10 +593,7 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /** @private */
-    _close(e) {
-      if (e) {
-        e.stopPropagation();
-      }
+    _close() {
       this._focus();
       this.close();
     }


### PR DESCRIPTION
## Description

Using `stopPropagation()` for `close` and `date-tap` events was added in https://github.com/vaadin/vaadin-date-picker/commit/872df2ce04865e2f0a2f7c95f7e2782bdb9dfc05. Back in the day, `vaadin-date-picker` was using `iron-dropdown` internally, which wasn't teleported to `body`, so these events could bubble.

Now when we have `vaadin-date-picker-overlay-content` teleported, I don't see a problem in bubbling, as these events will not fire on the `vaadin-date-picker` element. Also, we already have `date-selected` event not using `stopPropagation()`.

## Type of change

- Refactor