### PR TITLE
test: move validation tests to correct file

### DIFF
--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -627,20 +627,6 @@ describe('keyboard', () => {
       expect(datepicker.value).to.equal('2000-01-01');
     });
 
-    it('should not be invalid on blur if valid date is entered', async () => {
-      await sendKeys({ type: '1/1/2000' });
-      await sendKeys({ press: 'Tab' });
-      expect(datepicker.invalid).not.to.be.true;
-    });
-
-    it('should validate on blur only once', async () => {
-      await sendKeys({ type: 'foo' });
-      const spy = sinon.spy(datepicker, 'validate');
-      await sendKeys({ press: 'Tab' });
-      expect(spy.callCount).to.equal(1);
-      expect(datepicker.invalid).to.be.true;
-    });
-
     it('should revert input value on Esc when overlay not initialized', async () => {
       await sendKeys({ type: '1/1/2000' });
       await sendKeys({ press: 'Escape' });
@@ -677,13 +663,6 @@ describe('keyboard', () => {
       await sendKeys({ type: '1/1/2000' });
       await sendKeys({ press: 'Enter' });
       expect(datepicker.value).to.equal('2000-01-01');
-    });
-
-    it('should be invalid on enter with false input', async () => {
-      await sendKeys({ type: 'foo' });
-      await sendKeys({ press: 'Enter' });
-      expect(datepicker.value).to.equal('');
-      expect(datepicker.invalid).to.be.true;
     });
   });
 

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -206,6 +206,7 @@ describe('validation', () => {
   describe('input value', () => {
     beforeEach(() => {
       datePicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+      datePicker.inputElement.focus();
     });
 
     it('should be valid when committing a valid date', () => {
@@ -226,6 +227,20 @@ describe('validation', () => {
       enter(datePicker.inputElement);
       expect(datePicker.value).to.equal('');
       expect(datePicker.inputElement.value).to.equal('foo');
+    });
+
+    it('should be valid on blur after entering a valid date', () => {
+      datePicker.autoOpenDisabled = true;
+      setInputValue(datePicker, '1/1/2022');
+      datePicker.inputElement.blur();
+      expect(datePicker.invalid).to.be.false;
+    });
+
+    it('should be invalid on blur after entering an invalid date', () => {
+      datePicker.autoOpenDisabled = true;
+      setInputValue(datePicker, 'foo');
+      datePicker.inputElement.blur();
+      expect(datePicker.invalid).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Description

Moved a few validation-related tests from `keyboard-input.test.js` to `validation.test.js` file.

## Type of change

- Tests