### PR TITLE
fix: add missing Lumo and Material dependencies

### DIFF
--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -38,6 +38,8 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.2.0-beta1",
+    "@vaadin/vaadin-lumo-styles": "23.2.0-beta1",
+    "@vaadin/vaadin-material-styles": "23.2.0-beta1",
     "@vaadin/vaadin-themable-mixin": "23.2.0-beta1",
     "ol": "6.13.0"
   },


### PR DESCRIPTION
## Description

We missed to add Lumo and Material dependencies to `@vaadin/map` when implementing themes. This PR fixes it.

## Type of change

- Bugfix