### PR TITLE
fix: add missing Lumo and Material dependencies (CP: 23.1)

### DIFF
--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -38,6 +38,8 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "^23.1.5",
     "@vaadin/vaadin-license-checker": "^2.1.0",
+    "@vaadin/vaadin-lumo-styles": "^23.1.5",
+    "@vaadin/vaadin-material-styles": "^23.1.5",
     "@vaadin/vaadin-themable-mixin": "^23.1.5",
     "ol": "6.13.0"
   },


### PR DESCRIPTION
## Description

Manual cherry-pick of #4355 to `23.1` branch.

## Type of change

- Cherry-pick