### PR TITLE
refactor!: validate on constraint change when value is present

### DIFF
--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -80,8 +80,8 @@ export const InputConstraintsMixin = dedupingMixin(
        */
       _constraintsChanged(...constraints) {
         // Prevent marking field as invalid when setting required state
-        // or any other constraint before a user has entered the value.
-        if (!this.invalid) {
+        // or any other constraints before the user has entered the value.
+        if (!this.invalid && this.value === '') {
           return;
         }
 

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -82,7 +82,7 @@ export const InputConstraintsMixin = dedupingMixin(
         // Validate the field on constraint change only if it has a value.
         // The exception is the case when the field is invalid. In that case,
         // let the method reset `invalid` when the last constraint is removed.
-        if (!this.invalid && !this._hasValue) {
+        if (!this.invalid && this.value === '') {
           return;
         }
 

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -79,9 +79,10 @@ export const InputConstraintsMixin = dedupingMixin(
        * @protected
        */
       _constraintsChanged(...constraints) {
-        // Prevent marking field as invalid when setting required state
-        // or any other constraints before the user has entered the value.
-        if (!this.invalid && this.value === '') {
+        // Validate the field on constraint change only if it has a value.
+        // The exception is the case when the field is invalid. In that case,
+        // let the method reset `invalid` when the last constraint is removed.
+        if (!this.invalid && !this._hasValue) {
           return;
         }
 

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -82,7 +82,7 @@ export const InputConstraintsMixin = dedupingMixin(
         // Validate the field on constraint change only if it has a value.
         // The exception is the case when the field is invalid. In that case,
         // let the method reset `invalid` when the last constraint is removed.
-        if (!this.invalid && this.value === '') {
+        if (!this.invalid && !this._hasValue) {
           return;
         }
 


### PR DESCRIPTION
## Description

This PR modifies `InputConstraintsMixin` to run validation on constraint change not only when the component is invalid but also when `value` is present.

> **Warning**
> Behavior altering change

Depends on 
- https://github.com/vaadin/web-components/pull/4363
- https://github.com/vaadin/web-components/pull/4362

Part of #4196

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
