### PR TITLE
fix: add the missing default value for `value`

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -435,6 +435,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       /** @private */
       value: {
         type: String,
+        value: '',
       },
 
       /** @private */


### PR DESCRIPTION
## Description

Polymer works in a way that overriding a property doesn't preserve its default value, so the default value has to be replicated for every override.

This PR adds the missing default value for the `value` property of `multi-select-combo-box` which should fix the visual test failures in https://github.com/vaadin/web-components/pull/4359.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
