### PR TITLE
refactor: add _hasValue getter to InputMixin

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1045,7 +1045,7 @@ export const ComboBoxMixin = (subclass) =>
             this.value = '';
           }
 
-          this._toggleHasValue(this.value !== '');
+          this._toggleHasValue(this._hasValue);
           this._inputElementValue = this.value;
         }
       } else {
@@ -1089,7 +1089,7 @@ export const ComboBoxMixin = (subclass) =>
           this._inputElementValue = value;
         }
 
-        this._toggleHasValue(this.value !== '');
+        this._toggleHasValue(this._hasValue);
       } else {
         this.selectedItem = null;
       }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -755,7 +755,7 @@ export const DatePickerMixin = (subclass) =>
         this._selectedDate = null;
       }
 
-      this._toggleHasValue(!!value);
+      this._toggleHasValue(this._hasValue);
     }
 
     /** @private */

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -24,6 +24,12 @@ export declare class InputMixinClass {
   readonly inputElement: HTMLElement;
 
   /**
+   * Indicates whether the value is different from the default one.
+   * Override if the `value` property has a type other than `string`.
+   */
+  _hasValue: boolean;
+
+  /**
    * The value of the field.
    */
   value: string;

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -24,12 +24,6 @@ export declare class InputMixinClass {
   readonly inputElement: HTMLElement;
 
   /**
-   * Indicates whether the value is different from the default one.
-   * Override if the `value` property has a type other than `string`.
-   */
-  protected readonly _hasValue: boolean;
-
-  /**
    * The value of the field.
    */
   value: string;
@@ -38,6 +32,12 @@ export declare class InputMixinClass {
    * Clear the value of the field.
    */
   clear(): void;
+
+  /**
+   * Indicates whether the value is different from the default one.
+   * Override if the `value` property has a type other than `string`.
+   */
+  protected readonly _hasValue: boolean;
 
   protected _addInputListeners(input: HTMLElement): void;
 

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -27,7 +27,7 @@ export declare class InputMixinClass {
    * Indicates whether the value is different from the default one.
    * Override if the `value` property has a type other than `string`.
    */
-  _hasValue: boolean;
+  readonly _hasValue: boolean;
 
   /**
    * The value of the field.

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -29,15 +29,15 @@ export declare class InputMixinClass {
   value: string;
 
   /**
-   * Clear the value of the field.
-   */
-  clear(): void;
-
-  /**
    * Indicates whether the value is different from the default one.
    * Override if the `value` property has a type other than `string`.
    */
   protected readonly _hasValue: boolean;
+
+  /**
+   * Clear the value of the field.
+   */
+  clear(): void;
 
   protected _addInputListeners(input: HTMLElement): void;
 

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -47,7 +47,7 @@ export declare class InputMixinClass {
 
   protected _setInputElement(input: HTMLElement): void;
 
-  protected _toggleHasValue(value: boolean): void;
+  protected _toggleHasValue(hasValue: boolean): void;
 
   protected _valueChanged(value?: string, oldValue?: string): void;
 }

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -27,7 +27,7 @@ export declare class InputMixinClass {
    * Indicates whether the value is different from the default one.
    * Override if the `value` property has a type other than `string`.
    */
-  readonly _hasValue: boolean;
+  protected readonly _hasValue: boolean;
 
   /**
    * The value of the field.

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -190,6 +190,7 @@ export const InputMixin = dedupingMixin(
 
       /**
        * Toggle the has-value attribute based on the value property.
+       *
        * @param {boolean} hasValue
        * @protected
        */
@@ -204,7 +205,7 @@ export const InputMixin = dedupingMixin(
        * @protected
        */
       _valueChanged(newVal, oldVal) {
-        this._toggleHasValue(newVal !== '' && newVal != null);
+        this._toggleHasValue(this._hasValue);
 
         // Setting initial value to empty string, do nothing.
         if (newVal === '' && oldVal === undefined) {
@@ -218,6 +219,16 @@ export const InputMixin = dedupingMixin(
 
         // Setting a value programmatically, sync it to input element.
         this._forwardInputValue(newVal);
+      }
+
+      /**
+       * Indicates whether the value is different from the default one.
+       * Override if the `value` property has a type other than `string`.
+       *
+       * @protected
+       */
+      get _hasValue() {
+        return this.value != null && this.value !== '';
       }
     },
 );

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -449,12 +449,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
         computed: '__computeEffectiveFilteredItems(items, filteredItems, selectedItems, readonly)',
       },
 
-      /** @protected */
-      _hasValue: {
-        type: Boolean,
-        value: false,
-      },
-
       /** @private */
       _overflowItems: {
         type: Array,
@@ -592,16 +586,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /**
-   * Override method inherited from `InputMixin`
-   * to keep attribute after clearing the input.
-   * @protected
-   * @override
-   */
-  _toggleHasValue() {
-    super._toggleHasValue(this._hasValue);
-  }
-
-  /**
    * Implement callback from `ResizeMixin` to update chips.
    * @protected
    * @override
@@ -687,9 +671,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   /** @private */
   _selectedItemsChanged(selectedItems) {
-    this._hasValue = Boolean(selectedItems && selectedItems.length);
-
-    this._toggleHasValue();
+    this._toggleHasValue(this._hasValue);
 
     // Use placeholder for announcing items
     if (this._hasValue) {
@@ -1122,6 +1104,17 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   /** @private */
   __computeEffectiveFilteredItems(items, filteredItems, selectedItems, readonly) {
     return !items && readonly ? selectedItems : filteredItems;
+  }
+
+  /**
+   * Override a method from `InputMixin` to
+   * compute the presence of value based on `selectedItems`.
+   *
+   * @protected
+   * @override
+   */
+  get _hasValue() {
+    return this.selectedItems && this.selectedItems.length > 0;
   }
 }
 

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -563,7 +563,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       this.__updateInputValue(parsedObj);
     }
 
-    this._toggleHasValue(!!this.value);
+    this._toggleHasValue(this._hasValue);
   }
 
   /** @private */


### PR DESCRIPTION
## Description

This PR adds a `_hasValue` getter to `InputMixin` that indicates whether the value is different from the default one. 
This getter is supposed to be overridden in components whose `value` property has a type other than `string`. 

This getter is needed for https://github.com/vaadin/web-components/pull/4359 to make `InputConstraintsMixin` correctly determine if the value is empty in order to prevent `multi-select-combo-box` from being validated on `required` change because it relies on `selectedItems` when computing the presence of value rather than `value`.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
