### PR TITLE
test: improve validation test coverage

### DIFF
--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -722,26 +722,9 @@ describe('basic', () => {
       comboBox.required = true;
     });
 
-    it('should be invalid when selectedItems is empty', () => {
-      expect(comboBox.validate()).to.be.false;
-      expect(comboBox.invalid).to.be.true;
-    });
-
-    it('should be valid when selectedItems is not empty', () => {
-      comboBox.selectedItems = ['apple'];
-      expect(comboBox.validate()).to.be.true;
-      expect(comboBox.invalid).to.be.false;
-    });
-
     it('should focus on required indicator click', () => {
       comboBox.shadowRoot.querySelector('[part="required-indicator"]').click();
       expect(comboBox.hasAttribute('focused')).to.be.true;
-    });
-
-    it('should not be invalid when empty and readonly', () => {
-      comboBox.readonly = true;
-      expect(comboBox.validate()).to.be.true;
-      expect(comboBox.invalid).to.be.false;
     });
   });
 

--- a/packages/multi-select-combo-box/test/validation.test.js
+++ b/packages/multi-select-combo-box/test/validation.test.js
@@ -1,0 +1,45 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './not-animated-styles.js';
+import '../vaadin-multi-select-combo-box.js';
+
+describe('validation', () => {
+  let comboBox, validateSpy;
+
+  describe('basic', () => {
+    beforeEach(() => {
+      comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
+      comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
+      validateSpy = sinon.spy(comboBox, 'validate');
+    });
+
+    it('should not validate on required change when no items are selected', () => {
+      comboBox.required = true;
+      expect(validateSpy.called).to.be.false;
+      comboBox.required = false;
+      expect(validateSpy.called).to.be.false;
+    });
+  });
+
+  describe('required', () => {
+    beforeEach(() => {
+      comboBox = fixtureSync(`<vaadin-multi-select-combo-box required></vaadin-multi-select-combo-box>`);
+      comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
+    });
+
+    it('should fail validation when selectedItems is empty', () => {
+      expect(comboBox.checkValidity()).to.be.false;
+    });
+
+    it('should pass validation when selectedItems is empty and readonly', () => {
+      comboBox.readonly = true;
+      expect(comboBox.checkValidity()).to.be.true;
+    });
+
+    it('should pass validation when selectedItems is not empty', () => {
+      comboBox.selectedItems = ['apple'];
+      expect(comboBox.checkValidity()).to.be.true;
+    });
+  });
+});

--- a/packages/multi-select-combo-box/test/validation.test.js
+++ b/packages/multi-select-combo-box/test/validation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-multi-select-combo-box.js';
@@ -7,10 +7,43 @@ import '../vaadin-multi-select-combo-box.js';
 describe('validation', () => {
   let comboBox, validateSpy;
 
+  describe('initial', () => {
+    beforeEach(() => {
+      comboBox = document.createElement('vaadin-multi-select-combo-box');
+      comboBox.items = ['apple', 'banana'];
+      validateSpy = sinon.spy(comboBox, 'validate');
+    });
+
+    afterEach(() => {
+      comboBox.remove();
+    });
+
+    it('should not validate by default', async () => {
+      document.body.appendChild(comboBox);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value', async () => {
+      comboBox.selectedItems = ['apple'];
+      document.body.appendChild(comboBox);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when the field has an initial value and invalid', async () => {
+      comboBox.selectedItems = ['apple'];
+      comboBox.invalid = true;
+      document.body.appendChild(comboBox);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+  });
+
   describe('basic', () => {
     beforeEach(() => {
       comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
-      comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
+      comboBox.items = ['apple', 'banana'];
       validateSpy = sinon.spy(comboBox, 'validate');
     });
 
@@ -25,7 +58,7 @@ describe('validation', () => {
   describe('required', () => {
     beforeEach(() => {
       comboBox = fixtureSync(`<vaadin-multi-select-combo-box required></vaadin-multi-select-combo-box>`);
-      comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
+      comboBox.items = ['apple', 'banana'];
     });
 
     it('should fail validation when selectedItems is empty', () => {


### PR DESCRIPTION
## Description

- Extracted validation tests into a separate file `validation.test.js`
- Added tests ensuring no initial validation happens.
- Added a test ensuring no validation happens on required constraint change. It is needed to ensure [#4359](https://github.com/vaadin/web-components/pull/4359) works well for components whose value property has a type other than `string` or value is represented by other property than `value`, e.g. `selectedItems` in `multi-select-combo-box`.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
