### PR TITLE
refactor(date-picker): declare properties `max` and `min` as constraints

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -8,7 +8,7 @@ import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mix
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 
 export interface DatePickerDate {
   day: number;
@@ -37,7 +37,7 @@ export declare function DatePickerMixin<T extends Constructor<HTMLElement>>(
   Constructor<DelegateFocusMixinClass> &
   Constructor<DisabledMixinClass> &
   Constructor<FocusMixinClass> &
-  Constructor<InputMixinClass> &
+  Constructor<InputConstraintsMixinClass> &
   Constructor<KeyboardMixinClass> &
   T;
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -9,6 +9,7 @@ import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js'
 import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-focus-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 
 export interface DatePickerDate {
   day: number;
@@ -38,6 +39,7 @@ export declare function DatePickerMixin<T extends Constructor<HTMLElement>>(
   Constructor<DisabledMixinClass> &
   Constructor<FocusMixinClass> &
   Constructor<InputConstraintsMixinClass> &
+  Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   T;
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -8,7 +8,7 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.js';
-import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
+import { InputConstraintsMixin } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import { VirtualKeyboardController } from '@vaadin/field-base/src/virtual-keyboard-controller.js';
 import { dateAllowed, dateEquals, extractDateParts, getClosestDate } from './vaadin-date-picker-helper.js';
 
@@ -17,7 +17,9 @@ import { dateAllowed, dateEquals, extractDateParts, getClosestDate } from './vaa
  * @param {function(new:HTMLElement)} subclass
  */
 export const DatePickerMixin = (subclass) =>
-  class VaadinDatePickerMixin extends ControllerMixin(DelegateFocusMixin(InputMixin(KeyboardMixin(subclass)))) {
+  class VaadinDatePickerMixin extends ControllerMixin(
+    DelegateFocusMixin(InputConstraintsMixin(KeyboardMixin(subclass))),
+  ) {
     static get properties() {
       return {
         /**
@@ -278,7 +280,6 @@ export const DatePickerMixin = (subclass) =>
          */
         _minDate: {
           type: Date,
-          observer: '__minDateChanged',
           computed: '__computeMinOrMaxDate(min)',
         },
 
@@ -289,7 +290,6 @@ export const DatePickerMixin = (subclass) =>
          */
         _maxDate: {
           type: Date,
-          observer: '__maxDateChanged',
           computed: '__computeMinOrMaxDate(max)',
         },
 
@@ -318,6 +318,10 @@ export const DatePickerMixin = (subclass) =>
         '_selectedDateChanged(_selectedDate, i18n.formatDate)',
         '_focusedDateChanged(_focusedDate, i18n.formatDate)',
       ];
+    }
+
+    static get constraints() {
+      return [...super.constraints, 'min', 'max'];
     }
 
     /**
@@ -756,20 +760,6 @@ export const DatePickerMixin = (subclass) =>
       }
 
       this._toggleHasValue(this._hasValue);
-    }
-
-    /** @private */
-    __minDateChanged() {
-      if (this.value) {
-        this.validate();
-      }
-    }
-
-    /** @private */
-    __maxDateChanged() {
-      if (this.value) {
-        this.validate();
-      }
     }
 
     /** @protected */

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -153,6 +153,6 @@ assertType<FocusMixinClass>(datePickerLight);
 assertType<DisabledMixinClass>(datePickerLight);
 assertType<KeyboardMixinClass>(datePickerLight);
 assertType<DelegateFocusMixinClass>(datePickerLight);
-assertType<InputMixinClass>(datePickerLight);
+assertType<InputConstraintsMixinClass>(datePickerLight);
 assertType<ThemableMixinClass>(datePickerLight);
 assertType<DatePickerMixinClass>(datePickerLight);

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -153,6 +153,7 @@ assertType<FocusMixinClass>(datePickerLight);
 assertType<DisabledMixinClass>(datePickerLight);
 assertType<KeyboardMixinClass>(datePickerLight);
 assertType<DelegateFocusMixinClass>(datePickerLight);
+assertType<InputMixinClass>(datePickerLight);
 assertType<InputConstraintsMixinClass>(datePickerLight);
 assertType<ThemableMixinClass>(datePickerLight);
 assertType<DatePickerMixinClass>(datePickerLight);


### PR DESCRIPTION
## Description

The PR declares the properties `max` and `min` as constraints to let `InputConstraintsMixin` take care of them instead of maintaining custom logic.

Part of https://github.com/vaadin/web-components/issues/4371

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] have performed self-review and corrected misspellings.
