### PR TITLE
refactor: move isKeyboardActive to focus utils

### DIFF
--- a/packages/component-base/src/focus-mixin.js
+++ b/packages/component-base/src/focus-mixin.js
@@ -4,28 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
-
-// We consider the keyboard to be active if the window has received a keydown
-// event since the last mousedown event.
-let keyboardActive = false;
-
-// Listen for top-level keydown and mousedown events.
-// Use capture phase so we detect events even if they're handled.
-window.addEventListener(
-  'keydown',
-  () => {
-    keyboardActive = true;
-  },
-  { capture: true },
-);
-
-window.addEventListener(
-  'mousedown',
-  () => {
-    keyboardActive = false;
-  },
-  { capture: true },
-);
+import { isKeyboardActive } from './focus-utils.js';
 
 /**
  * A mixin to handle `focused` and `focus-ring` attributes based on focus.
@@ -40,7 +19,7 @@ export const FocusMixin = dedupingMixin(
        * @return {boolean}
        */
       get _keyboardActive() {
-        return keyboardActive;
+        return isKeyboardActive();
       }
 
       /** @protected */

--- a/packages/component-base/src/focus-utils.d.ts
+++ b/packages/component-base/src/focus-utils.d.ts
@@ -5,6 +5,12 @@
  */
 
 /**
+ * Returns true if the window has received a keydown
+ * event since the last mousedown event.
+ */
+export declare function isKeyboardActive(): boolean;
+
+/**
  * Returns true if the element is hidden, false otherwise.
  *
  * An element is treated as hidden when any of the following conditions are met:

--- a/packages/component-base/src/focus-utils.js
+++ b/packages/component-base/src/focus-utils.js
@@ -4,6 +4,38 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
+// We consider the keyboard to be active if the window has received a keydown
+// event since the last mousedown event.
+let keyboardActive = false;
+
+// Listen for top-level keydown and mousedown events.
+// Use capture phase so we detect events even if they're handled.
+window.addEventListener(
+  'keydown',
+  () => {
+    keyboardActive = true;
+  },
+  { capture: true },
+);
+
+window.addEventListener(
+  'mousedown',
+  () => {
+    keyboardActive = false;
+  },
+  { capture: true },
+);
+
+/**
+ * Returns true if the window has received a keydown
+ * event since the last mousedown event.
+ *
+ * @return {boolean}
+ */
+export function isKeyboardActive() {
+  return keyboardActive;
+}
+
 /**
  * Returns true if the element is hidden directly with `display: none` or `visibility: hidden`,
  * false otherwise.

--- a/packages/component-base/test/focus-utils.test.js
+++ b/packages/component-base/test/focus-utils.test.js
@@ -1,6 +1,12 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
-import { getFocusableElements, isElementFocusable, isElementFocused, isElementHidden } from '../src/focus-utils.js';
+import { fixtureSync, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
+import {
+  getFocusableElements,
+  isElementFocusable,
+  isElementFocused,
+  isElementHidden,
+  isKeyboardActive,
+} from '../src/focus-utils.js';
 
 describe('focus-utils', () => {
   describe('isElementHidden', () => {
@@ -194,6 +200,20 @@ describe('focus-utils', () => {
     it('should return false for a not focused element', () => {
       input.focus();
       expect(isElementFocused(document.body)).to.be.false;
+    });
+  });
+
+  describe('isKeyboardActive', () => {
+    it('should return true when a keydown is fired after mousedown', () => {
+      mousedown(document.body);
+      tabKeyDown(document.body);
+      expect(isKeyboardActive()).to.be.true;
+    });
+
+    it('should return false when a mousedown is fired after keydown', () => {
+      tabKeyDown(document.body);
+      mousedown(document.body);
+      expect(isKeyboardActive()).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

This change is needed for `vaadin-tooltip` which is expected to open on keyboard focus only.
As we are not going to use `FocusMixin` in this component, we need a separate helper for it.

## Type of change

- Refactor