### PR TITLE
feat: add listeners to open and close tooltip

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -80,12 +80,12 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
     this._uniqueId = `vaadin-tooltip-${generateUniqueId()}`;
 
-    this.__boundOnFocusin = this.__onFocusin.bind(this);
-    this.__boundOnFocusout = this.__onFocusout.bind(this);
-    this.__boundOnMouseDown = this.__onMouseDown.bind(this);
-    this.__boundOnMouseEnter = this.__onMouseEnter.bind(this);
-    this.__boundOnMouseLeave = this.__onMouseLeave.bind(this);
-    this.__boundOnKeydown = this.__onKeyDown.bind(this);
+    this.__onFocusin = this.__onFocusin.bind(this);
+    this.__onFocusout = this.__onFocusout.bind(this);
+    this.__onMouseDown = this.__onMouseDown.bind(this);
+    this.__onMouseEnter = this.__onMouseEnter.bind(this);
+    this.__onMouseLeave = this.__onMouseLeave.bind(this);
+    this.__onKeyDown = this.__onKeyDown.bind(this);
   }
 
   /** @protected */
@@ -100,9 +100,9 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   /** @private */
   __autoOpenedChanged(opened, oldOpened) {
     if (opened) {
-      document.addEventListener('keydown', this.__boundOnKeydown, true);
+      document.addEventListener('keydown', this.__onKeyDown, true);
     } else if (oldOpened) {
-      document.removeEventListener('keydown', this.__boundOnKeydown, true);
+      document.removeEventListener('keydown', this.__onKeyDown, true);
     }
   }
 
@@ -122,21 +122,21 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   /** @private */
   __targetChanged(target, oldTarget) {
     if (oldTarget) {
-      oldTarget.removeEventListener('mouseenter', this.__boundOnMouseEnter);
-      oldTarget.removeEventListener('mouseleave', this.__boundOnMouseLeave);
-      oldTarget.removeEventListener('focusin', this.__boundOnFocusin);
-      oldTarget.removeEventListener('focusout', this.__boundOnFocusout);
-      oldTarget.removeEventListener('mousedown', this.__boundOnMouseDown);
+      oldTarget.removeEventListener('mouseenter', this.__onMouseEnter);
+      oldTarget.removeEventListener('mouseleave', this.__onMouseLeave);
+      oldTarget.removeEventListener('focusin', this.__onFocusin);
+      oldTarget.removeEventListener('focusout', this.__onFocusout);
+      oldTarget.removeEventListener('mousedown', this.__onMouseDown);
 
       removeValueFromAttribute(oldTarget, 'aria-describedby', this._uniqueId);
     }
 
     if (target) {
-      target.addEventListener('mouseenter', this.__boundOnMouseEnter);
-      target.addEventListener('mouseleave', this.__boundOnMouseLeave);
-      target.addEventListener('focusin', this.__boundOnFocusin);
-      target.addEventListener('focusout', this.__boundOnFocusout);
-      target.addEventListener('mousedown', this.__boundOnMouseDown);
+      target.addEventListener('mouseenter', this.__onMouseEnter);
+      target.addEventListener('mouseleave', this.__onMouseLeave);
+      target.addEventListener('focusin', this.__onFocusin);
+      target.addEventListener('focusout', this.__onFocusout);
+      target.addEventListener('mousedown', this.__onMouseDown);
 
       addValueToAttribute(target, 'aria-describedby', this._uniqueId);
     }

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -1,5 +1,13 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import {
+  escKeyDown,
+  fire,
+  fixtureSync,
+  focusout,
+  keyboardEventFor,
+  mousedown,
+  tabKeyDown,
+} from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-tooltip.js';
 
@@ -118,6 +126,114 @@ describe('vaadin-tooltip', () => {
         tooltip.for = 'bar';
         expect(tooltip.target).to.eql(target);
       });
+    });
+  });
+
+  describe('auto open', () => {
+    let target;
+
+    function mouseenter(target) {
+      fire(target, 'mouseenter');
+    }
+
+    function mouseleave(target) {
+      fire(target, 'mouseleave');
+    }
+
+    beforeEach(() => {
+      target = document.createElement('input');
+      document.body.appendChild(target);
+      tooltip.target = target;
+    });
+
+    afterEach(() => {
+      document.body.removeChild(target);
+    });
+
+    it('should open overlay on target keyboard focus', () => {
+      tabKeyDown(target);
+      target.focus();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not open overlay on target mouse focus', () => {
+      mousedown(target);
+      target.focus();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close overlay on target focusout', () => {
+      tabKeyDown(target);
+      target.focus();
+      focusout(target);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should open overlay on target mouseenter', () => {
+      mouseenter(target);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close overlay on target mouseleave', () => {
+      mouseenter(target);
+      mouseleave(target);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close overlay on target mousedown', () => {
+      fire(target, 'mouseenter');
+      mousedown(target);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should re-open overlay on subsequent mouseenter', () => {
+      mouseenter(target);
+      mousedown(target);
+
+      mouseleave(target);
+      mouseenter(target);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close overlay on mouseleave when target has focus', () => {
+      mouseenter(target);
+      tabKeyDown(target);
+      target.focus();
+
+      mouseleave(target);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close overlay on focusout when target has hover', () => {
+      tabKeyDown(target);
+      target.focus();
+      mouseenter(target);
+
+      focusout(target);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close overlay on document Esc keydown', () => {
+      mouseenter(target);
+      escKeyDown(document.body);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should call stopImmediatePropagation for Esc keydown', () => {
+      mouseenter(target);
+      const event = keyboardEventFor('keydown', 27, [], 'Escape');
+      const spy = sinon.spy(event, 'stopImmediatePropagation');
+      target.dispatchEvent(event);
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should not call stopImmediatePropagation when not opened', () => {
+      mouseenter(target);
+      mouseleave(target);
+      const event = keyboardEventFor('keydown', 27, [], 'Escape');
+      const spy = sinon.spy(event, 'stopImmediatePropagation');
+      target.dispatchEvent(event);
+      expect(spy.called).to.be.false;
     });
   });
 });

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -181,7 +181,7 @@ describe('vaadin-tooltip', () => {
     });
 
     it('should close overlay on target mousedown', () => {
-      fire(target, 'mouseenter');
+      mouseenter(target);
       mousedown(target);
       expect(overlay.opened).to.be.false;
     });
@@ -234,6 +234,50 @@ describe('vaadin-tooltip', () => {
       const spy = sinon.spy(event, 'stopImmediatePropagation');
       target.dispatchEvent(event);
       expect(spy.called).to.be.false;
+    });
+
+    it('should not open overlay on mouseenter when target is reset', () => {
+      mouseenter(target);
+      mouseleave(target);
+
+      tooltip.target = null;
+      mouseenter(target);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close overlay on mouseleave when target is reset', () => {
+      mouseenter(target);
+
+      tooltip.target = null;
+      mouseleave(target);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not open overlay on keyboard focus when target is reset', () => {
+      mouseenter(target);
+      mouseleave(target);
+
+      tooltip.target = null;
+      tabKeyDown(target);
+      target.focus();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close overlay on mousedown when target is reset', () => {
+      mouseenter(target);
+
+      tooltip.target = null;
+      mousedown(target);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close overlay on focusout when target is reset', () => {
+      tabKeyDown(target);
+      target.focus();
+
+      tooltip.target = null;
+      focusout(target);
+      expect(overlay.opened).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Description

Added event listeners to open and close tooltip overlay.

## Type of change

- Feature

## Note

This PR is targeting the feature branch, not `master`.