### PR TITLE
feat: add TooltipController allowing to set target

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-controller.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-controller.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+/**
+ * A controller that manages the slotted tooltip element.
+ */
+export class TooltipController extends SlotController {
+  /**
+   * An HTML element to attach the tooltip to.
+   */
+  target: HTMLElement;
+
+  /**
+   * Set an HTML element to attach the tooltip to.
+   */
+  setTarget(target: HTMLElement): void;
+}

--- a/packages/tooltip/src/vaadin-tooltip-controller.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-controller.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * Copyright (c) 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';

--- a/packages/tooltip/src/vaadin-tooltip-controller.js
+++ b/packages/tooltip/src/vaadin-tooltip-controller.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+/**
+ * A controller that manages the slotted tooltip element.
+ */
+export class TooltipController extends SlotController {
+  constructor(host) {
+    // Do not provide slot factory to create tooltip lazily.
+    super(host, 'tooltip');
+
+    this.setTarget(host);
+
+    host.addEventListener('tooltip-target-changed', (e) => {
+      this.setTarget(e.detail.target);
+    });
+  }
+
+  /**
+   * Override to initialize the newly added custom tooltip.
+   *
+   * @param {Node} tooltipNode
+   * @protected
+   * @override
+   */
+  initCustomNode(tooltipNode) {
+    tooltipNode.target = this.target;
+  }
+
+  /**
+   * Set an HTML element to attach the tooltip to.
+   * @param {HTMLElement} target
+   */
+  setTarget(target) {
+    this.target = target;
+
+    const tooltipNode = this.node;
+    if (tooltipNode) {
+      tooltipNode.target = target;
+    }
+  }
+}

--- a/packages/tooltip/src/vaadin-tooltip-controller.js
+++ b/packages/tooltip/src/vaadin-tooltip-controller.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * Copyright (c) 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';

--- a/packages/tooltip/test/tooltip-controller.test.js
+++ b/packages/tooltip/test/tooltip-controller.test.js
@@ -1,0 +1,43 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../vaadin-tooltip.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { TooltipController } from '../src/vaadin-tooltip-controller.js';
+
+customElements.define(
+  'tooltip-host',
+  class extends ControllerMixin(PolymerElement) {
+    static get template() {
+      return html`
+        <slot></slot>
+        <slot name="tooltip"></slot>
+      `;
+    }
+  },
+);
+
+describe('TooltipController', () => {
+  let host, tooltip;
+
+  beforeEach(() => {
+    host = fixtureSync(`
+      <tooltip-host>
+        <div>Target</div>
+        <vaadin-tooltip slot="tooltip"></vaadin-tooltip>
+      </tooltip-host>
+    `);
+    tooltip = host.querySelector('vaadin-tooltip');
+    host.addController(new TooltipController(host));
+  });
+
+  it('should set tooltip target to the host itself by default', () => {
+    expect(tooltip.target).to.eql(host);
+  });
+
+  it('should update tooltip target on tooltip-target-changed event', () => {
+    const target = host.querySelector('div');
+    host.dispatchEvent(new CustomEvent('tooltip-target-changed', { detail: { target } }));
+    expect(tooltip.target).to.eql(target);
+  });
+});


### PR DESCRIPTION
## Description

Added `TooltipController` to manage the slotted tooltip. For now, only `target` is supported.
There will be a separate PR adding `text` property and `textGenerator` function.

## Type of change

- Feature

## Note

This PR is targeting the feature branch, not `master`.