### PR TITLE
feat: add tabsheet with basic features

### DIFF
--- a/dev/tabsheet.html
+++ b/dev/tabsheet.html
@@ -9,10 +9,37 @@
 
     <script type="module">
       import '@vaadin/tabsheet';
+
+      // Generate content for the panels
+      const lorem = `Odio quis mi. Aliquam massa pede, pharetra quis, tincidunt quis, fringilla at, mauris. Vestibulum a massa.
+        Vestibulum luctus odio ut quam. Maecenas congue convallis diam. Cras urna arcu, vestibulum vitae, blandit ut,
+        laoreet id, risus. Ut condimentum, arcu sit amet placerat blandit, augue nibh pretium nunc, in tempus sem dolor
+        non leo. Etiam fringilla mauris a odio. Nunc lorem diam, interdum eget, lacinia in, scelerisque sit amet, purus.
+        Nam ornare. Donec placerat dui ut orci. Phasellus quis lacus at nisl elementum cursus. Cras bibendum egestas
+        nulla. Phasellus pulvinar ullamcorper odio. Etiam ipsum. Proin tincidunt. Aliquam aliquet.`;
+
+      document.querySelectorAll('[tab]').forEach((panelContent, i, array) => {
+        const dotIndex = lorem.indexOf('.', i * lorem.length / array.length);
+        const content = lorem.substring(dotIndex + 1) + lorem.substring(0, dotIndex + 1);
+        panelContent.textContent = content.repeat(5);
+      });
     </script>
   </head>
 
   <body>
-    Nothing here yet
+    <vaadin-tabsheet>
+      <div slot="prefix">Prefix</div>
+      <div slot="suffix">Suffix</div>
+
+      <vaadin-tabs slot="tabs">
+        <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+        <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+        <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+      </vaadin-tabs>
+
+      <div tab="tab-1"></div>
+      <div tab="tab-2"></div>
+      <div tab="tab-3"></div>
+    </vaadin-tabsheet>
   </body>
 </html>

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.2.0-beta1",
+    "@vaadin/tabs": "23.2.0-beta1",
     "@vaadin/vaadin-lumo-styles": "23.2.0-beta1",
     "@vaadin/vaadin-material-styles": "23.2.0-beta1",
     "@vaadin/vaadin-themable-mixin": "23.2.0-beta1"

--- a/packages/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet.d.ts
@@ -6,6 +6,7 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { DelegateStateMixin } from '@vaadin/field-base/src/delegate-state-mixin.js';
 import type { Tab } from '@vaadin/tabs/src/vaadin-tab.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -59,7 +60,7 @@ export interface TabSheetEventMap extends HTMLElementEventMap, TabSheetCustomEve
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  */
-declare class TabSheet extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) {
+declare class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableMixin(PolymerElement)))) {
   /**
    * The index of the selected tab.
    */

--- a/packages/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet.d.ts
@@ -3,19 +3,93 @@
  * Copyright (c) 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import type { Tab } from '@vaadin/tabs/src/vaadin-tab';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export type TabSheetOrientation = 'horizontal' | 'vertical';
 
+/**
+ * Fired when the `items` property changes.
+ */
+export type TabSheetItemsChangedEvent = CustomEvent<{ value: Tab[] }>;
+
+/**
+ * Fired when the `selected` property changes.
+ */
+export type TabSheetSelectedChangedEvent = CustomEvent<{ value: number }>;
+
+export interface TabSheetCustomEventMap {
+  'items-changed': TabSheetItemsChangedEvent;
+
+  'selected-changed': TabSheetSelectedChangedEvent;
+}
+
+export interface TabSheetEventMap extends HTMLElementEventMap, TabSheetCustomEventMap {}
+
+/**
+ * `<vaadin-tabsheet>` is a Web Component for organizing and grouping content
+ * into scrollable panels. The panels can be switched between by using tabs.
+ *
+ * ```
+ *  <vaadin-tabsheet>
+ *    <div slot="prefix">Prefix</div>
+ *    <div slot="suffix">Suffix</div>
+ *
+ *    <vaadin-tabs slot="tabs">
+ *      <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+ *      <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+ *      <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+ *    </vaadin-tabs>
+ *
+ *    <div tab="tab-1">Panel 1</div>
+ *    <div tab="tab-2">Panel 2</div>
+ *    <div tab="tab-3">Panel 3</div>
+ *  </vaadin-tabsheet>
+ * ```
+ *
+ * ### Styling
+ *
+ * TODO: Styling and theme variants to be implemented separately
+ *
+ * See [Styling Components](hhttps://vaadin.com/docs/latest/components/ds-resources/customization/styling-components) documentation.
+ *
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
+ */
 declare class TabSheet extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) {
+  /**
+   * The index of the selected tab.
+   */
+  selected: number | null | undefined;
+
   /**
    * The tabsheet's orientation. Possible values are `horizontal|vertical`
    */
   orientation: TabSheetOrientation;
+
+  /**
+   * The list of `<vaadin-tab>`s from which a selection can be made.
+   * It is populated from the elements passed inside the slotted
+   * `<vaadin-tabs>`, and updated dynamically when adding or removing items.
+   *
+   * Note: unlike `<vaadin-combo-box>`, this property is read-only.
+   */
+  readonly items: Tab[] | undefined;
+
+  addEventListener<K extends keyof TabSheetEventMap>(
+    type: K,
+    listener: (this: TabSheet, ev: TabSheetEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof TabSheetEventMap>(
+    type: K,
+    listener: (this: TabSheet, ev: TabSheetEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
 }
 
 declare global {

--- a/packages/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet.d.ts
@@ -4,7 +4,19 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-declare class TabSheet extends HTMLElement {}
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export type TabSheetOrientation = 'horizontal' | 'vertical';
+
+declare class TabSheet extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) {
+  /**
+   * The tabsheet's orientation. Possible values are `horizontal|vertical`
+   */
+  orientation: TabSheetOrientation;
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet.d.ts
@@ -6,7 +6,7 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import type { Tab } from '@vaadin/tabs/src/vaadin-tab';
+import type { Tab } from '@vaadin/tabs/src/vaadin-tab.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export type TabSheetOrientation = 'horizontal' | 'vertical';

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -14,7 +14,39 @@ import { Tabs } from '@vaadin/tabs/vaadin-tabs.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * TODO
+ * `<vaadin-tabsheet>` is a Web Component for organizing and grouping content
+ * into scrollable panels. The panels can be switched between by using tabs.
+ *
+ * ```
+ *  <vaadin-tabsheet>
+ *    <div slot="prefix">Prefix</div>
+ *    <div slot="suffix">Suffix</div>
+ *
+ *    <vaadin-tabs slot="tabs">
+ *      <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+ *      <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+ *      <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+ *    </vaadin-tabs>
+ *
+ *    <div tab="tab-1">Panel 1</div>
+ *    <div tab="tab-2">Panel 2</div>
+ *    <div tab="tab-3">Panel 3</div>
+ *  </vaadin-tabsheet>
+ * ```
+ *
+ * ### Styling
+ *
+ * TODO: Styling and theme variants to be implemented separately
+ *
+ * See [Styling Components](hhttps://vaadin.com/docs/latest/components/ds-resources/customization/styling-components) documentation.
+ *
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
+ *
+ * @extends HTMLElement
+ * @mixes ElementMixin
+ * @mixes ThemableMixin
+ * @mixes ControllerMixin
  */
 class TabSheet extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   static get template() {
@@ -49,7 +81,6 @@ class TabSheet extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement
         }
       </style>
 
-      <!-- TODO: part naming (just tabs?) -->
       <div part="tabs-container">
         <slot name="prefix"></slot>
         <slot name="tabs"></slot>
@@ -74,7 +105,6 @@ class TabSheet extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement
        */
       orientation: {
         reflectToAttribute: true,
-        // TODO: Drop default value?
         value: 'horizontal',
         type: String,
         observer: '__orientationChanged',
@@ -120,6 +150,7 @@ class TabSheet extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement
     };
   }
 
+  /** @protected */
   ready() {
     super.ready();
 

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/tabs/vaadin-tab.js';
+import '@vaadin/tabs/src/vaadin-tab.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -109,7 +109,6 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
         reflectToAttribute: true,
         value: 'horizontal',
         type: String,
-        observer: '__orientationChanged',
       },
 
       /**
@@ -160,8 +159,6 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
   /** @protected */
   ready() {
     super.ready();
-
-    this.role = 'tablist';
 
     const tabsItemsChangedListener = () => this._setItems(this.__tabs.items);
 
@@ -245,18 +242,6 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
     panels.forEach((panel) => {
       panel.hidden = panel.getAttribute('tab') !== selectedTabId;
     });
-  }
-
-  /**
-   * An observer which reflects the orientation property to the host as aria-orientation.
-   * @private
-   */
-  __orientationChanged(orientation) {
-    if (orientation) {
-      this.setAttribute('aria-orientation', orientation);
-    } else {
-      this.removeAttribute('aria-orientation');
-    }
   }
 }
 

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -3,7 +3,233 @@
  * Copyright (c) 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/tabs/vaadin-tab.js';
+import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
+import { Tabs } from '@vaadin/tabs/vaadin-tabs.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-class TabSheet extends HTMLElement {}
+/**
+ * TODO
+ */
+class TabSheet extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) {
+  static get template() {
+    return html`
+      <style>
+        :host([hidden]) {
+          display: none !important;
+        }
+
+        :host {
+          display: flex;
+          height: 400px;
+        }
+
+        :host([orientation='horizontal']) {
+          flex-direction: column;
+        }
+
+        [part='tabs-container'] {
+          display: flex;
+          flex-direction: column;
+          align-items: baseline;
+        }
+
+        :host([orientation='horizontal']) [part='tabs-container'] {
+          flex-direction: row;
+        }
+
+        [part='panels'] {
+          overflow: auto;
+          flex: 1;
+        }
+      </style>
+
+      <!-- TODO: part naming (just tabs?) -->
+      <div part="tabs-container">
+        <slot name="prefix"></slot>
+        <slot name="tabs"></slot>
+        <slot name="suffix"></slot>
+      </div>
+
+      <div part="panels">
+        <slot id="panel-slot"></slot>
+      </div>
+    `;
+  }
+
+  static get is() {
+    return 'vaadin-tabsheet';
+  }
+
+  static get properties() {
+    return {
+      /**
+       * The tabsheet's orientation. Possible values are `horizontal|vertical`
+       * @type {!TabSheetOrientation}
+       */
+      orientation: {
+        reflectToAttribute: true,
+        // TODO: Drop default value?
+        value: 'horizontal',
+        type: String,
+        observer: '__orientationChanged',
+      },
+
+      /**
+       * The index of the selected tab.
+       */
+      selected: {
+        value: 0,
+        type: Number,
+        notify: true,
+      },
+
+      /**
+       * The slotted <vaadin-tabs> element.
+       */
+      __tabs: {
+        type: Object,
+      },
+
+      /**
+       * The <vaadin-tab> elements.
+       */
+      __tabItems: {
+        type: Array,
+      },
+
+      /**
+       * The panel elements.
+       */
+      __panels: {
+        type: Array,
+      },
+    };
+  }
+
+  ready() {
+    super.ready();
+
+    this.role = 'tablist';
+
+    const tabsItemsChangedListener = () => {
+      this.__tabItems = this.__tabs.items;
+    };
+
+    const tabsSelectedChangedListener = () => {
+      this.selected = this.__tabs.selected;
+    };
+
+    // Observe the tabs slot for a
+    this.addController(
+      new (class extends SlotController {
+        constructor(host) {
+          super(host, 'tabs');
+        }
+
+        initCustomNode(tabs) {
+          if (!(tabs instanceof Tabs)) {
+            throw Error('The "tabs" slot of a <vaadin-tabsheet> must only contain a <vaadin-tabs> element!');
+          }
+          this.host.__tabs = tabs;
+          tabs.orientation = this.host.orientation;
+          tabs.selected = this.host.selected;
+          tabs.addEventListener('items-changed', tabsItemsChangedListener);
+          tabs.addEventListener('selected-changed', tabsSelectedChangedListener);
+        }
+
+        teardownNode(tabs) {
+          tabs.removeEventListener('items-changed', tabsItemsChangedListener);
+          tabs.removeEventListener('selected-changed', tabsSelectedChangedListener);
+        }
+      })(this),
+    );
+
+    // Observe the panels slot for nodes. Set the assigned element nodes as the __panels array.
+    const panelSlot = this.shadowRoot.querySelector('#panel-slot');
+    this.__panelsObserver = new FlattenedNodesObserver(panelSlot, () => {
+      this.__panels = Array.from(panelSlot.assignedNodes({ flatten: true })).filter(
+        (node) => node.nodeType === Node.ELEMENT_NODE,
+      );
+    });
+  }
+
+  static get observers() {
+    return [
+      '__tabItemsOrPanelsChanged(__tabItems, __panels)',
+      '__selectedTabItemChanged(selected, __tabItems, __panels)',
+      '__propagateTabsProperties(__tabs, orientation, selected)',
+    ];
+  }
+
+  /**
+   * An observer which applies the necessary roles and ARIA attributes
+   * to associate the tab elements with the panels.
+   * @private
+   */
+  __tabItemsOrPanelsChanged(tabItems, panels) {
+    if (!tabItems || !panels) {
+      return;
+    }
+
+    tabItems.forEach((tabItem) => {
+      const panel = panels.find((panel) => panel.getAttribute('tab') === tabItem.id);
+      if (panel) {
+        panel.role = 'tabpanel';
+        panel.id = panel.id || `tabsheet-panel-${generateUniqueId()}`;
+        panel.setAttribute('aria-labelledby', tabItem.id);
+
+        tabItem.setAttribute('aria-controls', panel.id);
+      }
+    });
+  }
+
+  /**
+   * An observer which toggles the visibility of the panels based on the selected tab.
+   * @private
+   */
+  __selectedTabItemChanged(selected, tabItems, panels) {
+    if (!tabItems || !panels || selected === undefined) {
+      return;
+    }
+
+    const selectedTab = tabItems[selected];
+    const selectedTabId = selectedTab ? selectedTab.id : '';
+
+    panels.forEach((panel) => {
+      panel.hidden = panel.getAttribute('tab') !== selectedTabId;
+    });
+  }
+
+  /**
+   * An observer which propagates property value changes to the slotted <vaadin-tabs>.
+   * @private
+   */
+  __propagateTabsProperties(tabs, orientation, selected) {
+    if (tabs) {
+      tabs.orientation = orientation;
+      tabs.selected = selected;
+    }
+  }
+
+  /**
+   * An observer which reflects the orientation property to the host as aria-orientation.
+   * @private
+   */
+  __orientationChanged(orientation) {
+    if (orientation) {
+      this.setAttribute('aria-orientation', orientation);
+    } else {
+      this.removeAttribute('aria-orientation');
+    }
+  }
+}
+
+customElements.define(TabSheet.is, TabSheet);
 
 export { TabSheet };

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -167,30 +167,29 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
     };
 
     // Observe the tabs slot for a <vaadin-tabs> element.
-    this.addController(
-      new (class extends SlotController {
-        constructor(host) {
-          super(host, 'tabs');
-        }
+    this._tabsSlotController = new (class extends SlotController {
+      constructor(host) {
+        super(host, 'tabs');
+      }
 
-        initCustomNode(tabs) {
-          if (!(tabs instanceof Tabs)) {
-            throw Error('The "tabs" slot of a <vaadin-tabsheet> must only contain a <vaadin-tabs> element!');
-          }
-          tabs.addEventListener('items-changed', tabsItemsChangedListener);
-          tabs.addEventListener('selected-changed', tabsSelectedChangedListener);
-          this.host.__tabs = tabs;
-          this.host.stateTarget = tabs;
+      initCustomNode(tabs) {
+        if (!(tabs instanceof Tabs)) {
+          throw Error('The "tabs" slot of a <vaadin-tabsheet> must only contain a <vaadin-tabs> element!');
         }
+        tabs.addEventListener('items-changed', tabsItemsChangedListener);
+        tabs.addEventListener('selected-changed', tabsSelectedChangedListener);
+        this.host.__tabs = tabs;
+        this.host.stateTarget = tabs;
+      }
 
-        teardownNode(tabs) {
-          tabs.removeEventListener('items-changed', tabsItemsChangedListener);
-          tabs.removeEventListener('selected-changed', tabsSelectedChangedListener);
-          this.host._setItems([]);
-          this.host.stateTarget = undefined;
-        }
-      })(this),
-    );
+      teardownNode(tabs) {
+        tabs.removeEventListener('items-changed', tabsItemsChangedListener);
+        tabs.removeEventListener('selected-changed', tabsSelectedChangedListener);
+        this.host._setItems([]);
+        this.host.stateTarget = undefined;
+      }
+    })(this);
+    this.addController(this._tabsSlotController);
 
     // Observe the panels slot for nodes. Set the assigned element nodes as the __panels array.
     const panelSlot = this.shadowRoot.querySelector('#panel-slot');

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -10,7 +10,7 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
-import { Tabs } from '@vaadin/tabs/vaadin-tabs.js';
+import { Tabs } from '@vaadin/tabs/src/vaadin-tabs.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**

--- a/packages/tabsheet/test/dom/__snapshots__/tabsheet.test.snap.js
+++ b/packages/tabsheet/test/dom/__snapshots__/tabsheet.test.snap.js
@@ -1,0 +1,98 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-tabsheet host default"] = 
+`<vaadin-tabsheet
+  aria-orientation="horizontal"
+  orientation="horizontal"
+  role="tablist"
+  selected="0"
+>
+  <div slot="prefix">
+    Prefix
+  </div>
+  <div slot="suffix">
+    Suffix
+  </div>
+  <vaadin-tabs
+    aria-orientation="horizontal"
+    orientation="horizontal"
+    role="tablist"
+    selected="0"
+    slot="tabs"
+  >
+    <vaadin-tab
+      aria-controls="tabsheet-panel-1"
+      aria-selected="true"
+      id="tab-1"
+      orientation="horizontal"
+      role="tab"
+      selected=""
+      tabindex="0"
+    >
+      Tab 1
+    </vaadin-tab>
+    <vaadin-tab
+      aria-controls="tabsheet-panel-2"
+      aria-selected="false"
+      id="tab-2"
+      orientation="horizontal"
+      role="tab"
+      tabindex="-1"
+    >
+      Tab 2
+    </vaadin-tab>
+    <vaadin-tab
+      aria-controls="tabsheet-panel-3"
+      aria-selected="false"
+      id="tab-3"
+      orientation="horizontal"
+      role="tab"
+      tabindex="-1"
+    >
+      Tab 3
+    </vaadin-tab>
+  </vaadin-tabs>
+  <div
+    aria-labelledby="tab-1"
+    id="tabsheet-panel-1"
+    role="tabpanel"
+    tab="tab-1"
+  >
+  </div>
+  <div
+    aria-labelledby="tab-2"
+    hidden=""
+    id="tabsheet-panel-2"
+    role="tabpanel"
+    tab="tab-2"
+  >
+  </div>
+  <div
+    aria-labelledby="tab-3"
+    hidden=""
+    id="tabsheet-panel-3"
+    role="tabpanel"
+    tab="tab-3"
+  >
+  </div>
+</vaadin-tabsheet>
+`;
+/* end snapshot vaadin-tabsheet host default */
+
+snapshots["vaadin-tabsheet shadow default"] = 
+`<div part="tabs-container">
+  <slot name="prefix">
+  </slot>
+  <slot name="tabs">
+  </slot>
+  <slot name="suffix">
+  </slot>
+</div>
+<div part="panels">
+  <slot id="panel-slot">
+  </slot>
+</div>
+`;
+/* end snapshot vaadin-tabsheet shadow default */
+

--- a/packages/tabsheet/test/dom/__snapshots__/tabsheet.test.snap.js
+++ b/packages/tabsheet/test/dom/__snapshots__/tabsheet.test.snap.js
@@ -3,9 +3,7 @@ export const snapshots = {};
 
 snapshots["vaadin-tabsheet host default"] = 
 `<vaadin-tabsheet
-  aria-orientation="horizontal"
   orientation="horizontal"
-  role="tablist"
   selected="0"
 >
   <div slot="prefix">

--- a/packages/tabsheet/test/dom/tabsheet.test.js
+++ b/packages/tabsheet/test/dom/tabsheet.test.js
@@ -1,0 +1,41 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import '../../vaadin-tabsheet.js';
+import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
+
+describe('vaadin-tabsheet', () => {
+  let tabsheet;
+
+  beforeEach(async () => {
+    resetUniqueId();
+    tabsheet = fixtureSync(`
+    <vaadin-tabsheet>
+        <div slot="prefix">Prefix</div>
+        <div slot="suffix">Suffix</div>
+
+        <vaadin-tabs slot="tabs">
+            <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+            <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+            <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+        </vaadin-tabs>
+
+        <div tab="tab-1"></div>
+        <div tab="tab-2"></div>
+        <div tab="tab-3"></div>
+    </vaadin-tabsheet>`);
+
+    await nextFrame();
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(tabsheet).dom.to.equalSnapshot();
+    });
+  });
+
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(tabsheet).shadowDom.to.equalSnapshot();
+    });
+  });
+});

--- a/packages/tabsheet/test/dom/tabsheet.test.js
+++ b/packages/tabsheet/test/dom/tabsheet.test.js
@@ -9,20 +9,21 @@ describe('vaadin-tabsheet', () => {
   beforeEach(async () => {
     resetUniqueId();
     tabsheet = fixtureSync(`
-    <vaadin-tabsheet>
+      <vaadin-tabsheet>
         <div slot="prefix">Prefix</div>
         <div slot="suffix">Suffix</div>
 
         <vaadin-tabs slot="tabs">
-            <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
-            <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
-            <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+          <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+          <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+          <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
         </vaadin-tabs>
 
         <div tab="tab-1"></div>
         <div tab="tab-2"></div>
         <div tab="tab-3"></div>
-    </vaadin-tabsheet>`);
+      </vaadin-tabsheet>
+    `);
 
     await nextFrame();
   });

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -174,5 +174,20 @@ describe('tabsheet', () => {
       const panelId = panel.id;
       expect(tab.getAttribute('aria-controls')).to.equal(panelId);
     });
+
+    it('should not overwrite the id of a dynamically added panel', async () => {
+      // Create a new tab and panel
+      const tab = document.createElement('vaadin-tab');
+      const panel = document.createElement('div');
+      tab.id = 'tab-4';
+      panel.setAttribute('tab', 'tab-4');
+      panel.id = 'custom-id';
+      tabs.appendChild(tab);
+      tabsheet.appendChild(panel);
+
+      await nextFrame();
+
+      expect(panel.id).to.equal('custom-id');
+    });
   });
 });

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -133,6 +133,13 @@ describe('tabsheet', () => {
       tabsheet.selected = 1;
       expect(tabs.selected).to.equal(tabsheet.selected);
     });
+
+    it('should not propagate valued to a detached tabs', async () => {
+      tabs.remove();
+      await nextFrame();
+      tabsheet.selected = 1;
+      expect(tabs.selected).not.to.equal(tabsheet.selected);
+    });
   });
 
   describe('panels', () => {

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -1,3 +1,178 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-tabsheet.js';
 
-describe('tabsheet', () => {});
+describe('tabsheet', () => {
+  let tabsheet, tabs;
+
+  beforeEach(async () => {
+    tabsheet = fixtureSync(`
+        <vaadin-tabsheet>
+            <div slot="prefix">Prefix</div>
+            <div slot="suffix">Suffix</div>
+    
+            <vaadin-tabs slot="tabs">
+                <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+                <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+                <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+            </vaadin-tabs>
+    
+            <div tab="tab-1"></div>
+            <div tab="tab-2"></div>
+            <div tab="tab-3"></div>
+        </vaadin-tabsheet>
+        `);
+    tabs = tabsheet.querySelector('vaadin-tabs');
+
+    await nextFrame();
+  });
+
+  function getPanels() {
+    return [...tabsheet.querySelectorAll(`[tab]`)];
+  }
+
+  describe('custom element definition', () => {
+    let tagName;
+
+    beforeEach(() => {
+      tagName = tabsheet.tagName.toLowerCase();
+    });
+
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
+    });
+
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
+    });
+  });
+
+  describe('items', () => {
+    it('should set items to the array of child tabs', () => {
+      expect(tabsheet.items).to.be.an('array');
+      expect(tabsheet.items.length).to.be.equal(3);
+    });
+
+    it('should update items value when the tabs items change', () => {
+      tabs.removeChild(tabsheet.items[2]);
+      tabs._observer.flush();
+      expect(tabsheet.items.length).to.be.equal(2);
+    });
+
+    it('should not update items value when a detached tabs items change', async () => {
+      tabs.remove();
+      await nextFrame();
+      tabs.removeChild(tabs.items[2]);
+      tabs._observer.flush();
+      expect(tabsheet.items.length).not.to.be.equal(2);
+    });
+
+    it('should empty items value when the tabs is detached', async () => {
+      tabs.remove();
+      await nextFrame();
+      expect(tabsheet.items.length).to.be.equal(0);
+    });
+  });
+
+  describe('selected', () => {
+    it('should select the first tab by default', () => {
+      expect(tabsheet.selected).to.equal(0);
+      expect(tabsheet.items[0].selected).to.be.true;
+    });
+
+    it('should reflect selected property to attribute', () => {
+      expect(tabsheet.hasAttribute('selected')).to.be.true;
+    });
+
+    it('should update selected to new index when other tab is selected', () => {
+      tabs.items[1].click();
+      expect(tabsheet.items[1].selected).to.be.true;
+      expect(tabsheet.selected).to.equal(1);
+    });
+
+    it('should not update selected on selection on a detached tabs', async () => {
+      tabs.remove();
+      await nextFrame();
+      tabs.selected = 1;
+      tabs.items[1].click();
+      expect(tabsheet.selected).not.to.equal(1);
+    });
+
+    it('should close currently selected tab when another one is selected', () => {
+      tabs.items[1].click();
+      expect(tabsheet.items[1].selected).to.be.true;
+      expect(tabsheet.items[0].selected).to.be.false;
+    });
+
+    it('should not change selected state if tab has been removed', () => {
+      const tab = tabsheet.items[1];
+      tabs.removeChild(tab);
+      tabs._observer.flush();
+      tab.selected = true;
+      expect(tabsheet.selected).to.equal(0);
+    });
+
+    it('should dispatch selected-changed event when selected changes', () => {
+      const spy = sinon.spy();
+      tabsheet.addEventListener('selected-changed', spy);
+      tabs.items[1].click();
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('syncing properties', () => {
+    it('should propagate orientation value to tabs', () => {
+      expect(tabs.orientation).to.equal(tabsheet.orientation);
+      tabsheet.orientation = 'vertical';
+      expect(tabs.orientation).to.equal(tabsheet.orientation);
+    });
+
+    it('should propagate selected value to tabs', () => {
+      expect(tabs.selected).to.equal(tabsheet.selected);
+      tabsheet.selected = 1;
+      expect(tabs.selected).to.equal(tabsheet.selected);
+    });
+  });
+
+  describe('panels', () => {
+    it('should only show the first panel by default', () => {
+      expect(getPanels()[0].hidden).to.be.false;
+      expect(getPanels()[1].hidden).to.be.true;
+      expect(getPanels()[2].hidden).to.be.true;
+    });
+
+    it('should show another panel on tab change', () => {
+      tabsheet.selected = 1;
+      expect(getPanels()[0].hidden).to.be.true;
+      expect(getPanels()[1].hidden).to.be.false;
+    });
+
+    it('should not show a panel if no matching panel found', () => {
+      tabsheet.selected = 3;
+      expect(getPanels()[0].hidden).to.be.true;
+      expect(getPanels()[1].hidden).to.be.true;
+      expect(getPanels()[2].hidden).to.be.true;
+    });
+
+    it('should bind dynamically added tab and panel', async () => {
+      // Create a new tab and panel
+      const tab = document.createElement('vaadin-tab');
+      const panel = document.createElement('div');
+      tab.id = 'tab-4';
+      panel.setAttribute('tab', 'tab-4');
+      tabs.appendChild(tab);
+      tabsheet.appendChild(panel);
+
+      await nextFrame();
+
+      expect(panel.role).to.equal('tabpanel');
+      expect(panel.hidden).to.be.true;
+      expect(panel.getAttribute('aria-labelledby')).to.equal(tab.id);
+      expect(panel.id).to.be.ok;
+
+      const panelId = panel.id;
+      expect(tab.getAttribute('aria-controls')).to.equal(panelId);
+    });
+  });
+});

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -8,21 +8,21 @@ describe('tabsheet', () => {
 
   beforeEach(async () => {
     tabsheet = fixtureSync(`
-        <vaadin-tabsheet>
-            <div slot="prefix">Prefix</div>
-            <div slot="suffix">Suffix</div>
-    
-            <vaadin-tabs slot="tabs">
-                <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
-                <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
-                <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
-            </vaadin-tabs>
-    
-            <div tab="tab-1"></div>
-            <div tab="tab-2"></div>
-            <div tab="tab-3"></div>
-        </vaadin-tabsheet>
-        `);
+      <vaadin-tabsheet>
+        <div slot="prefix">Prefix</div>
+        <div slot="suffix">Suffix</div>
+
+        <vaadin-tabs slot="tabs">
+          <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+          <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+          <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+        </vaadin-tabs>
+
+        <div tab="tab-1"></div>
+        <div tab="tab-2"></div>
+        <div tab="tab-3"></div>
+      </vaadin-tabsheet>
+    `);
     tabs = tabsheet.querySelector('vaadin-tabs');
 
     await nextFrame();

--- a/packages/tabsheet/test/typings/tabsheet.types.ts
+++ b/packages/tabsheet/test/typings/tabsheet.types.ts
@@ -1,1 +1,17 @@
 import '../../vaadin-tabsheet.js';
+import type { Tab } from '@vaadin/tabs/src/vaadin-tab.js';
+import type { TabSheetItemsChangedEvent, TabSheetSelectedChangedEvent } from '../../vaadin-tabsheet.js';
+
+const tabsheet = document.createElement('vaadin-tabsheet');
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+tabsheet.addEventListener('items-changed', (event) => {
+  assertType<TabSheetItemsChangedEvent>(event);
+  assertType<Tab[]>(event.detail.value);
+});
+
+tabsheet.addEventListener('selected-changed', (event) => {
+  assertType<TabSheetSelectedChangedEvent>(event);
+  assertType<number>(event.detail.value);
+});

--- a/packages/tabsheet/theme/lumo/vaadin-tabsheet.js
+++ b/packages/tabsheet/theme/lumo/vaadin-tabsheet.js
@@ -1,2 +1,4 @@
+import '@vaadin/tabs/theme/lumo/vaadin-tabs.js';
+import '@vaadin/tabs/theme/lumo/vaadin-tab.js';
 import './vaadin-tabsheet-styles.js';
 import '../../src/vaadin-tabsheet.js';

--- a/packages/tabsheet/theme/material/vaadin-tabsheet.js
+++ b/packages/tabsheet/theme/material/vaadin-tabsheet.js
@@ -1,2 +1,4 @@
+import '@vaadin/tabs/theme/material/vaadin-tabs.js';
+import '@vaadin/tabs/theme/material/vaadin-tab.js';
 import './vaadin-tabsheet-styles.js';
 import '../../src/vaadin-tabsheet.js';


### PR DESCRIPTION
## Description

Added `vaadin-tabsheet` element with basic features.

Excluded from this PR (to be submitted separately):
- Themes, theme variants, visual tests
- Loading state and loading indicator

## Type of change

- Feature

## Note

This PR is targeting the feature branch, not `master`.