### PR TITLE
fix: make sure tabs aligns with baseline

### DIFF
--- a/packages/tabs/theme/lumo/vaadin-tabs-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tabs-styles.js
@@ -13,6 +13,13 @@ registerStyles(
       -webkit-tap-highlight-color: transparent;
     }
 
+    /* Needed to align the tabs nicely on the baseline */
+    :host(:not([orientation='vertical']))::before {
+      content: '\\2003';
+      width: 0;
+      display: inline-block;
+    }
+
     :host(:not([orientation='vertical'])) {
       box-shadow: inset 0 -1px 0 0 var(--lumo-contrast-10pct);
       position: relative;

--- a/packages/tabs/theme/material/vaadin-tabs-styles.js
+++ b/packages/tabs/theme/material/vaadin-tabs-styles.js
@@ -14,6 +14,13 @@ registerStyles(
       flex-shrink: 0;
     }
 
+    /* Needed to align the tabs nicely on the baseline */
+    :host(:not([orientation='vertical']))::before {
+      content: '\\2003';
+      width: 0;
+      display: inline-block;
+    }
+
     /* Hide scroll buttons when no needed, and on touch devices */
 
     :host(:not([overflow])) [part='forward-button'],


### PR DESCRIPTION
`<vaadin-tabs>` doesn't seem to align well with the baseline on Firefox. On Chrome and Safari, the component works as expected. This PR fixes the issue

Required by https://github.com/vaadin/platform/issues/3152

With the following snippet:

```html
<div style="display: flex; align-items: baseline; gap: 10px;">
  <div>Sibling</div>

  <vaadin-tabs>
    <vaadin-tab>Foo</vaadin-tab>
    <vaadin-tab>Bar</vaadin-tab>
    <vaadin-tab>Baz</vaadin-tab>
  </vaadin-tabs>
<div>
```

## Lumo
Before:
![before-lumo](https://user-images.githubusercontent.com/1222264/185915794-190d869f-98e7-4044-ae4f-5ffdf0e5bb3d.png)
After:
![after-lumo](https://user-images.githubusercontent.com/1222264/185915996-b4d3c3e6-0124-487e-bf03-79b843bc5408.png)

## Material
Before:
![before-material](https://user-images.githubusercontent.com/1222264/185915820-397aee8b-9afa-4037-9a21-63caebfc70a1.png)
After:
![after-material](https://user-images.githubusercontent.com/1222264/185916090-ac641244-570e-49d3-b2f2-ee39d6f1a0c8.png)

