### PR TITLE
test: remove redundant unit tests

### DIFF
--- a/packages/email-field/test/email-field.test.js
+++ b/packages/email-field/test/email-field.test.js
@@ -72,30 +72,6 @@ describe('email-field', () => {
     });
   });
 
-  describe('invalid', () => {
-    let field;
-
-    beforeEach(() => {
-      field = fixtureSync('<vaadin-email-field invalid></vaadin-email-field>');
-    });
-
-    it('should not remove "invalid" state when ready', () => {
-      expect(field.invalid).to.be.true;
-    });
-  });
-
-  describe('invalid with value', () => {
-    let field;
-
-    beforeEach(() => {
-      field = fixtureSync('<vaadin-email-field invalid value="foo@example.com"></vaadin-email-field>');
-    });
-
-    it('should not remove "invalid" state when ready', () => {
-      expect(field.invalid).to.be.true;
-    });
-  });
-
   describe('initial validation', () => {
     let field, validateSpy;
 


### PR DESCRIPTION
## Description

The PR removes some `email-field` unit tests ensuring the initial `invalid` is not overridden. These tests are redundant because there is already an `initial validation` test suite that determines when the initial validation should happen and when not, which in practice also ensures that `invalid` will not be overridden.

Part of #4371 

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
