### PR TITLE
refactor(time-picker): declare properties max and min as constraints

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -305,6 +305,10 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     return ['__updateDropdownItems(i18n.*, min, max, step)'];
   }
 
+  static get constraints() {
+    return [...super.constraints, 'min', 'max'];
+  }
+
   /**
    * Used by `InputControlMixin` as a reference to the clear button element.
    * @protected

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -83,6 +83,30 @@ describe('validation', () => {
       expect(timePicker.inputElement.hasAttribute('invalid')).to.be.true;
     });
 
+    it('should not validate on min change without value', () => {
+      timePicker.min = '12:00';
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on min change with value', () => {
+      timePicker.value = '12:00';
+      validateSpy.resetHistory();
+      timePicker.min = '12:00';
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should not validate on max change without value', () => {
+      timePicker.max = '12:00';
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on max change with value', () => {
+      timePicker.value = '12:00';
+      validateSpy.resetHistory();
+      timePicker.max = '12:00';
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
     it('should fire a validated event on validation success', () => {
       const validatedSpy = sinon.spy();
       timePicker.addEventListener('validated', validatedSpy);


### PR DESCRIPTION
## Description

The PR declares the properties `max` and `min` as constraints to activate `InputConstraintsMixin`'s logic for them.

Part of #4371 

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
