### PR TITLE
feat: add text, textGenerator and context properties

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -11,6 +11,12 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
  */
 declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   /**
+   * Object with properties passed to `textGenerator`
+   * function to be used for generating tooltip text.
+   */
+  context: Record<string, unknown>;
+
+  /**
    * The id of the element used as a tooltip trigger.
    * The element should be in the DOM by the time when
    * the attribute is set, otherwise a warning is shown.
@@ -23,6 +29,19 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
    * Defaults to an element referenced with `for`.
    */
   target: HTMLElement | undefined;
+
+  /**
+   * String used as a tooltip content.
+   */
+  text: string | null | undefined;
+
+  /**
+   * Function used to generate the tooltip content.
+   * When provided, it overrides the `text` property.
+   * Use the `context` property to provide argument
+   * that can be passed to the generator function.
+   */
+  textGenerator: (context: Record<string, unknown>) => string;
 }
 
 declare global {

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -46,6 +46,46 @@ describe('vaadin-tooltip', () => {
     });
   });
 
+  describe('text', () => {
+    it('should use text property as overlay text content', () => {
+      tooltip.text = 'Foo';
+      expect(overlay.textContent.trim()).to.equal('Foo');
+    });
+
+    it('should clear overlay content when text is set to null', () => {
+      tooltip.text = 'Foo';
+      tooltip.text = null;
+      expect(overlay.textContent.trim()).to.equal('');
+    });
+  });
+
+  describe('textGenerator', () => {
+    it('should use textGenerator property to generate text content', () => {
+      tooltip.textGenerator = () => 'Foo';
+      expect(overlay.textContent.trim()).to.equal('Foo');
+    });
+
+    it('should override text property when textGenerator is set', () => {
+      tooltip.text = 'Foo';
+      tooltip.textGenerator = () => 'Bar';
+      expect(overlay.textContent.trim()).to.equal('Bar');
+    });
+
+    it('should use context property in generator when provided', () => {
+      tooltip.context = { text: 'Foo' };
+      tooltip.textGenerator = (context) => context.text;
+      expect(overlay.textContent.trim()).to.equal('Foo');
+    });
+
+    it('should update text content when context property changes', () => {
+      tooltip.context = { text: 'Foo' };
+      tooltip.textGenerator = (context) => context.text;
+
+      tooltip.context = { text: 'Bar' };
+      expect(overlay.textContent.trim()).to.equal('Bar');
+    });
+  });
+
   describe('target', () => {
     let target;
 

--- a/packages/tooltip/test/typings/tooltip.types.ts
+++ b/packages/tooltip/test/typings/tooltip.types.ts
@@ -13,3 +13,6 @@ assertType<ThemePropertyMixinClass>(tooltip);
 // Properties
 assertType<string | undefined>(tooltip.for);
 assertType<HTMLElement | undefined>(tooltip.target);
+assertType<string | null | undefined>(tooltip.text);
+assertType<Record<string, unknown>>(tooltip.context);
+assertType<(context: Record<string, unknown>) => string>(tooltip.textGenerator);


### PR DESCRIPTION
## Description

Added `text`, `textGenerator` and `context` (name to be decided) properties to `vaadin-tooltip`.

## Type of change

- Feature

## Note

This PR is targeting the `tooltip` feature branch, not `master`.