### PR TITLE
refactor: set no-vertical-overlap to tooltip overlay

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -36,6 +36,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
         theme$="[[_theme]]"
         opened="[[_autoOpened]]"
         position-target="[[target]]"
+        no-vertical-overlap
         modeless
       ></vaadin-tooltip-overlay>
     `;

--- a/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
+++ b/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
@@ -5,6 +5,7 @@ snapshots["vaadin-tooltip default"] =
 `<vaadin-tooltip-overlay
   id="vaadin-tooltip-0"
   modeless=""
+  no-vertical-overlap=""
   role="tooltip"
 >
 </vaadin-tooltip-overlay>


### PR DESCRIPTION
## Description

Changed the default appearance of the overlay to not overlap target element.
This will be adjusted later on when adding `position` property.

## Type of change

- Refactor

## Note

This PR is targeting the `tooltip` feature branch, not `master`.