### PR TITLE
feat: add manual and opened tooltip properties

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -24,6 +24,18 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   for: string | undefined;
 
   /**
+   * When true, the tooltip is controlled programmatically
+   * instead of reacting to focus and mouse events.
+   */
+  manual: boolean;
+
+  /**
+   * When true, the tooltip is opened programmatically.
+   * Only works if `manual` is set to `true`.
+   */
+  opened: boolean;
+
+  /**
    * Reference to the element used as a tooltip trigger.
    * The target must be placed in the same shadow scope.
    * Defaults to an element referenced with `for`.

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -35,7 +35,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
         role="tooltip"
         renderer="[[_renderer]]"
         theme$="[[_theme]]"
-        opened="[[_autoOpened]]"
+        opened="[[__computeOpened(manual, opened, _autoOpened)]]"
         position-target="[[target]]"
         modeless
       ></vaadin-tooltip-overlay>
@@ -63,6 +63,24 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       for: {
         type: String,
         observer: '__forChanged',
+      },
+
+      /**
+       * When true, the tooltip is controlled programmatically
+       * instead of reacting to focus and mouse events.
+       */
+      manual: {
+        type: Boolean,
+        value: false,
+      },
+
+      /**
+       * When true, the tooltip is opened programmatically.
+       * Only works if `manual` is set to `true`.
+       */
+      opened: {
+        type: Boolean,
+        value: false,
       },
 
       /**
@@ -140,6 +158,11 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     if (this._autoOpened) {
       this._autoOpened = false;
     }
+  }
+
+  /** @private */
+  __computeOpened(manual, opened, autoOpened) {
+    return manual ? opened : autoOpened;
   }
 
   /** @private */

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -181,13 +181,8 @@ describe('vaadin-tooltip', () => {
     let target;
 
     beforeEach(() => {
-      target = document.createElement('input');
-      document.body.appendChild(target);
+      target = fixtureSync('<input>');
       tooltip.target = target;
-    });
-
-    afterEach(() => {
-      document.body.removeChild(target);
     });
 
     it('should open overlay on target keyboard focus', () => {
@@ -325,15 +320,9 @@ describe('vaadin-tooltip', () => {
     let target;
 
     beforeEach(() => {
-      target = document.createElement('input');
-      document.body.appendChild(target);
+      target = fixtureSync('<input>');
       tooltip.target = target;
-
       tooltip.manual = true;
-    });
-
-    afterEach(() => {
-      document.body.removeChild(target);
     });
 
     it('should not open overlay on target keyboard focus', () => {

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -11,6 +11,14 @@ import {
 import sinon from 'sinon';
 import '../vaadin-tooltip.js';
 
+function mouseenter(target) {
+  fire(target, 'mouseenter');
+}
+
+function mouseleave(target) {
+  fire(target, 'mouseleave');
+}
+
 describe('vaadin-tooltip', () => {
   let tooltip, overlay;
 
@@ -172,14 +180,6 @@ describe('vaadin-tooltip', () => {
   describe('auto open', () => {
     let target;
 
-    function mouseenter(target) {
-      fire(target, 'mouseenter');
-    }
-
-    function mouseleave(target) {
-      fire(target, 'mouseleave');
-    }
-
     beforeEach(() => {
       target = document.createElement('input');
       document.body.appendChild(target);
@@ -318,6 +318,59 @@ describe('vaadin-tooltip', () => {
       tooltip.target = null;
       focusout(target);
       expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('manual', () => {
+    let target;
+
+    beforeEach(() => {
+      target = document.createElement('input');
+      document.body.appendChild(target);
+      tooltip.target = target;
+
+      tooltip.manual = true;
+    });
+
+    afterEach(() => {
+      document.body.removeChild(target);
+    });
+
+    it('should not open overlay on target keyboard focus', () => {
+      tabKeyDown(target);
+      target.focus();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not open overlay on target mouseenter', () => {
+      mouseenter(target);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should open overlay when opened is set to true', () => {
+      tooltip.opened = true;
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close overlay on target focusout', () => {
+      tooltip.opened = true;
+      target.focus();
+      focusout(target);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close overlay on target mouseleave', () => {
+      tooltip.opened = true;
+      mouseenter(target);
+      mouseleave(target);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close overlay when opened is set to false', () => {
+      tooltip.opened = true;
+
+      tooltip.opened = false;
+      expect(overlay.opened).to.be.false;
     });
   });
 });

--- a/packages/tooltip/test/typings/tooltip.types.ts
+++ b/packages/tooltip/test/typings/tooltip.types.ts
@@ -16,3 +16,5 @@ assertType<HTMLElement | undefined>(tooltip.target);
 assertType<string | null | undefined>(tooltip.text);
 assertType<Record<string, unknown>>(tooltip.context);
 assertType<(context: Record<string, unknown>) => string>(tooltip.textGenerator);
+assertType<boolean>(tooltip.manual);
+assertType<boolean>(tooltip.opened);


### PR DESCRIPTION
## Description

Added `manual` and `opened` properties to `vaadin-tooltip` based on the prototype.

## Type of change

- Feature

## Note

This PR is targeting the `tooltip` feature branch, not `master`.