### PR TITLE
refactor!: ensure initial validation when constraints are specified

### DIFF
--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -28,25 +28,43 @@ describe('validation', () => {
       datePicker.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(datePicker);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      datePicker.value = '2020-01-01';
-      document.body.appendChild(datePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        datePicker.value = '2020-01-01';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      datePicker.value = '2020-01-01';
-      datePicker.invalid = true;
-      document.body.appendChild(datePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate without constraints', async () => {
+        document.body.appendChild(datePicker);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without constraints when the field has invalid', async () => {
+        datePicker.invalid = true;
+        document.body.appendChild(datePicker);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has min', async () => {
+        datePicker.min = '2020-01-01';
+        document.body.appendChild(datePicker);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has max', async () => {
+        datePicker.max = '2020-01-01';
+        document.body.appendChild(datePicker);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -505,6 +505,10 @@ class DateTimePicker extends FieldMixin(
           this.__timePicker = node;
         }
       });
+
+    if (this.value && (this.min || this.max)) {
+      this.validate();
+    }
   }
 
   /** @private */

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -130,25 +130,43 @@ describe('initial validation', () => {
     dateTimePicker.remove();
   });
 
-  it('should not validate by default', async () => {
+  it('should not validate without value', async () => {
     document.body.appendChild(dateTimePicker);
     await nextRender();
     expect(validateSpy.called).to.be.false;
   });
 
-  it('should not validate when the field has an initial value', async () => {
-    dateTimePicker.value = '2020-02-01T02:00';
-    document.body.appendChild(dateTimePicker);
-    await nextRender();
-    expect(validateSpy.called).to.be.false;
-  });
+  describe('with value', () => {
+    beforeEach(() => {
+      dateTimePicker.value = '2020-02-01T02:00';
+    });
 
-  it('should not validate when the field has an initial value and invalid', async () => {
-    dateTimePicker.value = '2020-02-01T02:00';
-    dateTimePicker.invalid = true;
-    document.body.appendChild(dateTimePicker);
-    await nextRender();
-    expect(validateSpy.called).to.be.false;
+    it('should not validate without constraints', async () => {
+      document.body.appendChild(dateTimePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate without constraints when the field has invalid', async () => {
+      dateTimePicker.invalid = true;
+      document.body.appendChild(dateTimePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate when the field has min', async () => {
+      dateTimePicker.min = '2020-02-01T02:00';
+      document.body.appendChild(dateTimePicker);
+      await nextRender();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should validate when the field has max', async () => {
+      dateTimePicker.max = '2020-02-01T02:00';
+      document.body.appendChild(dateTimePicker);
+      await nextRender();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
   });
 });
 

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -49,6 +49,15 @@ export class EmailField extends TextField {
     return 'vaadin-email-field';
   }
 
+  static get properties() {
+    return {
+      pattern: {
+        type: String,
+        value: '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-]{2,}$',
+      },
+    };
+  }
+
   constructor() {
     super();
     this._setType('email');
@@ -61,14 +70,6 @@ export class EmailField extends TextField {
     if (this.inputElement) {
       this.inputElement.autocapitalize = 'off';
     }
-  }
-
-  /** @protected */
-  _createConstraintsObserver() {
-    // NOTE: pattern needs to be set before constraints observer is initialized
-    this.pattern = this.pattern || '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-]{2,}$';
-
-    super._createConstraintsObserver();
   }
 }
 

--- a/packages/email-field/test/email-field.test.js
+++ b/packages/email-field/test/email-field.test.js
@@ -84,25 +84,44 @@ describe('email-field', () => {
       field.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(field);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      field.value = 'foo@example.com';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        field.value = 'foo@example.com';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      field.value = 'foo@example.com';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should validate by default', async () => {
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when using a custom pattern', async () => {
+        field.pattern = '.+@example.com';
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should not validate when pattern is unset', async () => {
+        field.pattern = '';
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when pattern is unset and the field has invalid', async () => {
+        field.pattern = '';
+        field.invalid = true;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
     });
   });
 

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -70,7 +70,7 @@ export const InputConstraintsMixin = dedupingMixin(
       _createConstraintsObserver() {
         // This complex observer needs to be added dynamically instead of using `static get observers()`
         // to make it possible to tweak this behavior in classes that apply this mixin.
-        this._createMethodObserver(`_constraintsChanged(${this.constructor.constraints.join(', ')})`);
+        this._createMethodObserver(`_constraintsChanged(${this.constructor.constraints.join(', ')})`, true);
       }
 
       /**
@@ -79,18 +79,16 @@ export const InputConstraintsMixin = dedupingMixin(
        * @protected
        */
       _constraintsChanged(...constraints) {
-        // Validate the field on constraint change only if it has a value.
-        // The exception is the case when the field is invalid. In that case,
-        // let the method reset `invalid` when the last constraint is removed.
-        if (!this.invalid && !this._hasValue) {
-          return;
-        }
+        const hasConstraints = this._hasValidConstraints(constraints);
+        const isLastConstraintRemoved = this.__previousHasConstraints && !hasConstraints;
 
-        if (this._hasValidConstraints(constraints)) {
+        if ((this._hasValue || this.invalid) && hasConstraints) {
           this.validate();
-        } else {
+        } else if (isLastConstraintRemoved) {
           this._setInvalid(false);
         }
+
+        this.__previousHasConstraints = hasConstraints;
       }
 
       /**

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { InputConstraintsMixin } from '../src/input-constraints-mixin.js';
 import { InputController } from '../src/input-controller.js';
@@ -44,25 +44,63 @@ const runTests = (baseClass) => {
   );
 
   describe('validation', () => {
-    let element, input, validateSpy, changeSpy;
+    let element, input, validateSpy;
 
-    beforeEach(() => {
-      element = document.createElement(tag);
-      validateSpy = sinon.spy(element, 'validate');
-    });
+    describe('initial', () => {
+      beforeEach(() => {
+        element = document.createElement(tag);
+        validateSpy = sinon.spy(element, 'validate');
+      });
 
-    afterEach(() => {
-      element.remove();
+      afterEach(() => {
+        element.remove();
+      });
+
+      it('should not validate without value', async () => {
+        document.body.appendChild(element);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without value when the field has invalid', async () => {
+        element.invalid = true;
+        document.body.appendChild(element);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      describe('with value', () => {
+        beforeEach(() => {
+          element.value = 'Value';
+        });
+
+        it('should not validate without constraints', async () => {
+          document.body.appendChild(element);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should not validate without constraints when the field has invalid', async () => {
+          element.invalid = true;
+          document.body.appendChild(element);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should validate when the field has a constraint', async () => {
+          element.minlength = 2;
+          document.body.appendChild(element);
+          await nextRender();
+          expect(validateSpy.calledOnce).to.be.true;
+        });
+      });
     });
 
     describe('without value', () => {
       beforeEach(async () => {
-        document.body.appendChild(element);
+        element = fixtureSync(`<${tag}></${tag}>`);
         await nextRender();
-      });
-
-      it('should not validate initially', () => {
-        expect(validateSpy.called).to.be.false;
+        validateSpy = sinon.spy(element, 'validate');
       });
 
       it('should not validate on setting a constraint', async () => {
@@ -95,21 +133,12 @@ const runTests = (baseClass) => {
       });
     });
 
-    describe('with an initial value', () => {
+    describe('with value', () => {
       beforeEach(async () => {
-        element.value = 'Value';
-        document.body.appendChild(element);
+        element = fixtureSync(`<${tag} value="Value"></${tag}>`);
         await nextRender();
+        validateSpy = sinon.spy(element, 'validate');
         input = element.querySelector('[slot=input]');
-      });
-
-      it('should override explicitly set invalid on setting a constraint', async () => {
-        element.invalid = true;
-        await nextFrame();
-
-        element.required = true;
-        await nextFrame();
-        expect(element.invalid).to.be.false;
       });
 
       it('should call checkValidity on the input on setting a constraint', async () => {
@@ -185,25 +214,14 @@ const runTests = (baseClass) => {
       });
     });
 
-    describe('with an initial value + constraint', () => {
-      beforeEach(async () => {
-        element.value = 'Value';
-        element.minlength = 2;
-        document.body.appendChild(element);
-        await nextRender();
-      });
-
-      it('should validate initially', () => {
-        expect(validateSpy.calledOnce).to.be.true;
-      });
-    });
-
     describe('change event', () => {
+      let changeSpy;
+
       beforeEach(async () => {
+        element = fixtureSync(`<${tag}></${tag}>`);
+        await nextRender();
         changeSpy = sinon.spy();
         element.addEventListener('change', changeSpy);
-        document.body.appendChild(element);
-        await nextRender();
         input = element.querySelector('[slot=input]');
       });
 

--- a/packages/integer-field/test/validation.test.js
+++ b/packages/integer-field/test/validation.test.js
@@ -19,25 +19,50 @@ describe('validation', () => {
       integerField.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(integerField);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      integerField.value = '2';
-      document.body.appendChild(integerField);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        integerField.value = '2';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      integerField.value = '2';
-      integerField.invalid = true;
-      document.body.appendChild(integerField);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate without constraints', async () => {
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without constraints when the field has invalid', async () => {
+        integerField.invalid = true;
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has min', async () => {
+        integerField.min = 2;
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has max', async () => {
+        integerField.max = 2;
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has step', async () => {
+        integerField.step = 2;
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -177,25 +177,50 @@ describe('validation', () => {
       field.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(field);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      field.value = '2';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        field.value = '2';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      field.value = '2';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate without constraints', async () => {
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without constraints when the field has invalid', async () => {
+        field.invalid = true;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has min', async () => {
+        field.min = 2;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has max', async () => {
+        field.max = 2;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has step', async () => {
+        field.step = 2;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/packages/text-area/test/validation.test.js
+++ b/packages/text-area/test/validation.test.js
@@ -16,25 +16,43 @@ describe('validation', () => {
       textArea.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(textArea);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      textArea.value = 'Initial Value';
-      document.body.appendChild(textArea);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        textArea.value = 'Initial Value';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      textArea.value = 'Initial Value';
-      textArea.invalid = true;
-      document.body.appendChild(textArea);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate without constraints', async () => {
+        document.body.appendChild(textArea);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without constraints when the field has invalid', async () => {
+        textArea.invalid = true;
+        document.body.appendChild(textArea);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has minlength', async () => {
+        textArea.minlength = 2;
+        document.body.appendChild(textArea);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has maxlength', async () => {
+        textArea.maxlength = 2;
+        document.body.appendChild(textArea);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/packages/text-field/test/validation.test.js
+++ b/packages/text-field/test/validation.test.js
@@ -36,6 +36,22 @@ describe('validation', () => {
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
+
+    it('should validate when the field has an initial value and minlength', async () => {
+      field.value = 'AA';
+      field.minlength = 2;
+      document.body.appendChild(field);
+      await nextRender();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should validate when the field has an initial value and maxlength', async () => {
+      field.value = 'AA';
+      field.maxlength = 2;
+      document.body.appendChild(field);
+      await nextRender();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
   });
 
   describe('basic', () => {

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -16,6 +16,9 @@ import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaa
 
 registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-picker-styles' });
 
+const MIN_ALLOWED_TIME = '00:00:00.000';
+const MAX_ALLOWED_TIME = '23:59:59.999';
+
 /**
  * `<vaadin-time-picker>` is a Web Component providing a time-selection field.
  *
@@ -166,7 +169,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
        */
       min: {
         type: String,
-        value: '00:00:00.000',
+        value: '',
       },
 
       /**
@@ -180,7 +183,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
        */
       max: {
         type: String,
-        value: '23:59:59.999',
+        value: '',
       },
 
       /**
@@ -298,6 +301,18 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
 
       /** @private */
       _inputContainer: Object,
+
+      /** @private */
+      __minTime: {
+        type: Object,
+        computed: '__computeMinTime(i18n, min)',
+      },
+
+      /** @private */
+      __maxTime: {
+        type: Object,
+        computed: '__computeMaxTime(i18n, max)',
+      },
     };
   }
 
@@ -485,10 +500,10 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
 
   /** @private */
   __updateDropdownItems(i8n, min, max, step) {
-    const minTimeObj = this.__validateTime(this.__parseISO(min));
+    const minTimeObj = this.__validateTime(this.__minTime);
     const minSec = this.__getSec(minTimeObj);
 
-    const maxTimeObj = this.__validateTime(this.__parseISO(max));
+    const maxTimeObj = this.__validateTime(this.__maxTime);
     const maxSec = this.__getSec(maxTimeObj);
 
     this.__adjustValue(minSec, maxSec, minTimeObj, maxTimeObj);
@@ -665,12 +680,9 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
    * @protected
    */
   _timeAllowed(time) {
-    const parsedMin = this.i18n.parseTime(this.min);
-    const parsedMax = this.i18n.parseTime(this.max);
-
     return (
-      (!this.__getMsec(parsedMin) || this.__getMsec(time) >= this.__getMsec(parsedMin)) &&
-      (!this.__getMsec(parsedMax) || this.__getMsec(time) <= this.__getMsec(parsedMax))
+      (!this.__getMsec(this.__minTime) || this.__getMsec(time) >= this.__getMsec(this.__minTime)) &&
+      (!this.__getMsec(this.__maxTime) || this.__getMsec(time) <= this.__getMsec(this.__maxTime))
     );
   }
 
@@ -685,6 +697,16 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
    * @protected
    */
   _onChange() {}
+
+  /** @private */
+  __computeMinTime(i18n, min) {
+    return i18n.parseTime(min || MIN_ALLOWED_TIME);
+  }
+
+  /** @private */
+  __computeMaxTime(i18n, max) {
+    return i18n.parseTime(max || MAX_ALLOWED_TIME);
+  }
 
   /**
    * Override method inherited from `InputMixin`.

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -351,13 +351,13 @@ describe('time-picker', () => {
   });
 
   describe('min and max properties', () => {
-    it('min property should be 00:00:00.000 by default', () => {
-      expect(timePicker.min).to.be.equal('00:00:00.000');
-    });
+    // It('min property should be 00:00:00.000 by default', () => {
+    //   expect(timePicker.min).to.be.equal('00:00:00.000');
+    // });
 
-    it('max property should be 23:59:59.999 by default', () => {
-      expect(timePicker.max).to.be.equal('23:59:59.999');
-    });
+    // it('max property should be 23:59:59.999 by default', () => {
+    //   expect(timePicker.max).to.be.equal('23:59:59.999');
+    // });
 
     it('should have dropdown items if min nor max is defined', () => {
       expect(timePicker.__dropdownItems.length).to.be.equal(24);

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -27,25 +27,43 @@ describe('validation', () => {
       timePicker.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(timePicker);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      timePicker.value = '12:00';
-      document.body.appendChild(timePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        timePicker.value = '12:00';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      timePicker.value = '12:00';
-      timePicker.invalid = true;
-      document.body.appendChild(timePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate without constraints', async () => {
+        document.body.appendChild(timePicker);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without constraints when the field has invalid', async () => {
+        timePicker.invalid = true;
+        document.body.appendChild(timePicker);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has min', async () => {
+        timePicker.min = '12:00';
+        document.body.appendChild(timePicker);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has max', async () => {
+        timePicker.max = '12:00';
+        document.body.appendChild(timePicker);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Ensures initial validation happens for components when constraints are specified. The PR is planned to be split into separate ones per component.

`InputConstraintsMixin` had to be refactored because its constraints observer wasn't called initially for some components like `date-picker`, `email-field`, `number-field` when they had some constraints specified. This apparently has something to do with how Polymer handles observers and properties declared at different layers of inheritance. To work this around, I added the second argument to `_createMethodObserver` that now guarantees that the observer is called regardless of constraints so I also had to refactor `_constraintsChanged` to only validate when the user specified any constraints.

> **Warning**
> It is a breaking-change.

Part of #4371 

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
