### PR TITLE
refactor!: validate on constraint change when field has value

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -924,6 +924,10 @@ class DateTimePicker extends FieldMixin(
       this.__datePicker.min = this.__formatDateISO(this.__minDateTime, this.__defaultDateMinMaxValue);
     }
     this.__updateTimePickerMinMax();
+
+    if (this.__datePicker && this.__timePicker && this.value) {
+      this.validate();
+    }
   }
 
   /** @private */
@@ -933,6 +937,10 @@ class DateTimePicker extends FieldMixin(
       this.__datePicker.max = this.__formatDateISO(this.__maxDateTime, this.__defaultDateMinMaxValue);
     }
     this.__updateTimePickerMinMax();
+
+    if (this.__datePicker && this.__timePicker && this.value) {
+      this.validate();
+    }
   }
 
   /** @private */

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -23,10 +23,11 @@ const fixtures = {
 
 ['default', 'slotted'].forEach((set) => {
   describe(`Validation (${set})`, () => {
-    let dateTimePicker;
+    let dateTimePicker, validateSpy;
 
     beforeEach(() => {
       dateTimePicker = fixtureSync(fixtures[set]);
+      validateSpy = sinon.spy(dateTimePicker, 'validate');
     });
 
     it('should not be required', () => {
@@ -50,6 +51,30 @@ const fixtures = {
       dateTimePicker.value = '2020-02-02T02:02:00';
       expect(dateTimePicker.validate()).to.equal(true);
       expect(dateTimePicker.invalid).to.equal(false);
+    });
+
+    it('should not validate on min change without value', () => {
+      dateTimePicker.min = '2020-02-02T02:00';
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on min change with value', () => {
+      dateTimePicker.value = '2020-02-02T02:00';
+      validateSpy.resetHistory();
+      dateTimePicker.min = '2020-02-02T02:00';
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should not validate on max change without value', () => {
+      dateTimePicker.max = '2020-02-02T02:00';
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on max change with value', () => {
+      dateTimePicker.value = '2020-02-02T02:00';
+      validateSpy.resetHistory();
+      dateTimePicker.max = '2020-02-02T02:00';
+      expect(validateSpy.calledOnce).to.be.true;
     });
 
     it('should validate min/max times', () => {


### PR DESCRIPTION
## Description

The PR ensures `date-time-picker` is validated on constraint change when it has a value. Since `InputConstraintsMixin` only supports constraints for a single target element, it cannot be used for `date-time-picker`, so I had to come up with a custom implementation.

Part of #4371 

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
