### PR TITLE
feat: add position property to tooltip

### DIFF
--- a/dev/tooltip.html
+++ b/dev/tooltip.html
@@ -11,6 +11,43 @@
     </script>
   </head>
   <body>
+    <style>
+      #wrapper {
+        width: 350px;
+        height: 350px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin: 1rem;
+      }
+
+      #target {
+        width: 150px;
+        height: 150px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        border: solid 1px #e2e2e2;
+      }
+    </style>
+
+    <div id="wrapper">
+      <div id="target">Save</div>
+    </div>
+
+    <vaadin-tooltip text="BS" position="bottom-start" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="B" position="bottom" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="BE" position="bottom-end" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="ST" position="start-top" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="S" position="start" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="SB" position="start-bottom" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="TS" position="top-start" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="T" position="top" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="TE" position="top-end" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="ET" position="end-top" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="E" position="end" for="target"></vaadin-tooltip>
+    <vaadin-tooltip text="EB" position="end-bottom" for="target"></vaadin-tooltip>
+
     <button id="button">Confirm</button>
     <vaadin-tooltip text="Click to save changes" for="button"></vaadin-tooltip>
   </body>

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -56,7 +56,7 @@ class TooltipOverlay extends PositionMixin(OverlayElement) {
       const offset = targetRect.width / 2 - overlayRect.width / 2;
 
       if (this.style.left) {
-        const left = parseFloat(this.style.left) + offset;
+        const left = overlayRect.left + offset;
         if (left > 0) {
           this.style.left = `${left}px`;
         }

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -27,6 +27,58 @@ class TooltipOverlay extends PositionMixin(OverlayElement) {
 
     return memoizedTemplate;
   }
+
+  static get properties() {
+    return {
+      position: {
+        type: String,
+        reflectToAttribute: true,
+      },
+    };
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  _updatePosition() {
+    super._updatePosition();
+
+    if (!this.positionTarget) {
+      return;
+    }
+
+    // Center the tooltip overlay horizontally
+    if (this.position === 'bottom' || this.position === 'top') {
+      const targetRect = this.positionTarget.getBoundingClientRect();
+      const overlayRect = this.$.overlay.getBoundingClientRect();
+
+      const offset = targetRect.width / 2 - overlayRect.width / 2;
+
+      if (this.style.left) {
+        const left = parseFloat(this.style.left) + offset;
+        if (left > 0) {
+          this.style.left = `${left}px`;
+        }
+      }
+
+      if (this.style.right) {
+        const right = parseFloat(this.style.right) + offset;
+        if (right > 0) {
+          this.style.right = `${right}px`;
+        }
+      }
+    }
+
+    // Center the tooltip overlay vertically
+    if (this.position === 'start' || this.position === 'end') {
+      const targetRect = this.positionTarget.getBoundingClientRect();
+      const overlayRect = this.$.overlay.getBoundingClientRect();
+
+      const offset = targetRect.height / 2 - overlayRect.height / 2;
+      this.style.top = `${parseFloat(this.style.top) + offset}px`;
+    }
+  }
 }
 
 customElements.define(TooltipOverlay.is, TooltipOverlay);

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -76,7 +76,7 @@ class TooltipOverlay extends PositionMixin(OverlayElement) {
       const overlayRect = this.$.overlay.getBoundingClientRect();
 
       const offset = targetRect.height / 2 - overlayRect.height / 2;
-      this.style.top = `${parseFloat(this.style.top) + offset}px`;
+      this.style.top = `${overlayRect.top + offset}px`;
     }
   }
 }

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -6,6 +6,20 @@
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
+export type TooltipPosition =
+  | 'bottom-end'
+  | 'bottom-start'
+  | 'bottom'
+  | 'end-bottom'
+  | 'end-top'
+  | 'end'
+  | 'start-bottom'
+  | 'start-top'
+  | 'start'
+  | 'top-end'
+  | 'top-start'
+  | 'top';
+
 /**
  * `<vaadin-tooltip>` is a Web Component for creating tooltips.
  */
@@ -34,6 +48,14 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
    * Only works if `manual` is set to `true`.
    */
   opened: boolean;
+
+  /**
+   * Position of the tooltip with respect to its target.
+   * Supported values: `top-start`, `top`, `top-end`,
+   * `bottom-start`, `bottom`, `bottom-end`, `start-top`,
+   * `start`, `start-bottom`, `end-top`, `end`, `end-bottom`.
+   */
+  position: TooltipPosition;
 
   /**
    * Reference to the element used as a tooltip trigger.

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -37,7 +37,11 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
         theme$="[[_theme]]"
         opened="[[__computeOpened(manual, opened, _autoOpened)]]"
         position-target="[[target]]"
-        no-vertical-overlap
+        position="[[position]]"
+        no-horizontal-overlap$="[[__computeNoHorizontalOverlap(position)]]"
+        no-vertical-overlap$="[[__computeNoVerticalOverlap(position)]]"
+        horizontal-align="[[__computeHorizontalAlign(position)]]"
+        vertical-align="[[__computeVerticalAlign(position)]]"
         modeless
       ></vaadin-tooltip-overlay>
     `;
@@ -82,6 +86,17 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       opened: {
         type: Boolean,
         value: false,
+      },
+
+      /**
+       * Position of the tooltip with respect to its target.
+       * Supported values: `top-start`, `top`, `top-end`,
+       * `bottom-start`, `bottom`, `bottom-end`, `start-top`,
+       * `start`, `start-bottom`, `end-top`, `end`, `end-bottom`.
+       */
+      position: {
+        type: String,
+        value: 'bottom',
       },
 
       /**
@@ -159,6 +174,26 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     if (this._autoOpened) {
       this._autoOpened = false;
     }
+  }
+
+  /** @private */
+  __computeHorizontalAlign(position) {
+    return ['top-end', 'bottom-end', 'start-top', 'start', 'start-bottom'].includes(position) ? 'end' : 'start';
+  }
+
+  /** @private */
+  __computeNoHorizontalOverlap(position) {
+    return ['start-top', 'start', 'start-bottom', 'end-top', 'end', 'end-bottom'].includes(position);
+  }
+
+  /** @private */
+  __computeNoVerticalOverlap(position) {
+    return ['top-start', 'top-end', 'top', 'bottom-start', 'bottom', 'bottom-end'].includes(position);
+  }
+
+  /** @private */
+  __computeVerticalAlign(position) {
+    return ['top-start', 'top-end', 'top', 'start-bottom', 'end-bottom'].includes(position) ? 'bottom' : 'top';
   }
 
   /** @private */

--- a/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
+++ b/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
@@ -6,9 +6,154 @@ snapshots["vaadin-tooltip default"] =
   id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
+  position="bottom"
   role="tooltip"
 >
 </vaadin-tooltip-overlay>
 `;
 /* end snapshot vaadin-tooltip default */
+
+snapshots["vaadin-tooltip top-start"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-vertical-overlap=""
+  position="top-start"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip top-start */
+
+snapshots["vaadin-tooltip top"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-vertical-overlap=""
+  position="top"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip top */
+
+snapshots["vaadin-tooltip top-end"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-vertical-overlap=""
+  position="top-end"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip top-end */
+
+snapshots["vaadin-tooltip bottom-start"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-vertical-overlap=""
+  position="bottom-start"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip bottom-start */
+
+snapshots["vaadin-tooltip bottom"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-vertical-overlap=""
+  position="bottom"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip bottom */
+
+snapshots["vaadin-tooltip bottom-end"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-vertical-overlap=""
+  position="bottom-end"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip bottom-end */
+
+snapshots["vaadin-tooltip start-top"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-horizontal-overlap=""
+  position="start-top"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip start-top */
+
+snapshots["vaadin-tooltip start"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-horizontal-overlap=""
+  position="start"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip start */
+
+snapshots["vaadin-tooltip start-bottom"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-horizontal-overlap=""
+  position="start-bottom"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip start-bottom */
+
+snapshots["vaadin-tooltip end-top"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-horizontal-overlap=""
+  position="end-top"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip end-top */
+
+snapshots["vaadin-tooltip end"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-horizontal-overlap=""
+  position="end"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip end */
+
+snapshots["vaadin-tooltip end-bottom"] = 
+`<vaadin-tooltip-overlay
+  id="vaadin-tooltip-0"
+  modeless=""
+  no-horizontal-overlap=""
+  position="end-bottom"
+  role="tooltip"
+>
+</vaadin-tooltip-overlay>
+`;
+/* end snapshot vaadin-tooltip end-bottom */
 

--- a/packages/tooltip/test/dom/tooltip.test.js
+++ b/packages/tooltip/test/dom/tooltip.test.js
@@ -14,4 +14,64 @@ describe('vaadin-tooltip', () => {
   it('default', async () => {
     await expect(tooltip).shadowDom.to.equalSnapshot();
   });
+
+  it('top-start', async () => {
+    tooltip.position = 'top-start';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('top', async () => {
+    tooltip.position = 'top';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('top-end', async () => {
+    tooltip.position = 'top-end';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('bottom-start', async () => {
+    tooltip.position = 'bottom-start';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('bottom', async () => {
+    tooltip.position = 'bottom';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('bottom-end', async () => {
+    tooltip.position = 'bottom-end';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('start-top', async () => {
+    tooltip.position = 'start-top';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('start', async () => {
+    tooltip.position = 'start';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('start-bottom', async () => {
+    tooltip.position = 'start-bottom';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('end-top', async () => {
+    tooltip.position = 'end-top';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('end', async () => {
+    tooltip.position = 'end';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
+
+  it('end-bottom', async () => {
+    tooltip.position = 'end-bottom';
+    await expect(tooltip).shadowDom.to.equalSnapshot();
+  });
 });

--- a/packages/tooltip/test/dom/tooltip.test.js
+++ b/packages/tooltip/test/dom/tooltip.test.js
@@ -15,63 +15,23 @@ describe('vaadin-tooltip', () => {
     await expect(tooltip).shadowDom.to.equalSnapshot();
   });
 
-  it('top-start', async () => {
-    tooltip.position = 'top-start';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('top', async () => {
-    tooltip.position = 'top';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('top-end', async () => {
-    tooltip.position = 'top-end';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('bottom-start', async () => {
-    tooltip.position = 'bottom-start';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('bottom', async () => {
-    tooltip.position = 'bottom';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('bottom-end', async () => {
-    tooltip.position = 'bottom-end';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('start-top', async () => {
-    tooltip.position = 'start-top';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('start', async () => {
-    tooltip.position = 'start';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('start-bottom', async () => {
-    tooltip.position = 'start-bottom';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('end-top', async () => {
-    tooltip.position = 'end-top';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('end', async () => {
-    tooltip.position = 'end';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
-  });
-
-  it('end-bottom', async () => {
-    tooltip.position = 'end-bottom';
-    await expect(tooltip).shadowDom.to.equalSnapshot();
+  [
+    'top-start',
+    'top',
+    'top-end',
+    'bottom-start',
+    'bottom',
+    'bottom-end',
+    'start-top',
+    'start',
+    'start-bottom',
+    'end-top',
+    'end',
+    'end-bottom',
+  ].forEach((position) => {
+    it(position, async () => {
+      tooltip.position = position;
+      await expect(tooltip).shadowDom.to.equalSnapshot();
+    });
   });
 });

--- a/packages/tooltip/test/tooltip-position.test.js
+++ b/packages/tooltip/test/tooltip-position.test.js
@@ -1,0 +1,376 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import '../vaadin-tooltip.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-tooltip-overlay',
+  css`
+    [part='overlay'] {
+      width: 50px;
+      border: 1px solid blue;
+    }
+  `,
+);
+
+describe('position', () => {
+  let tooltip, target, overlay;
+
+  beforeEach(() => {
+    tooltip = fixtureSync('<vaadin-tooltip text="tooltip"></vaadin-tooltip>');
+    target = fixtureSync(`
+      <div style="display: flex; width: 100px; height: 100px; margin: 100px; outline: 1px solid red;"></div>
+    `);
+    tooltip.target = target;
+    overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+  });
+
+  async function openAndMeasure() {
+    fire(target, 'mouseenter');
+    await oneEvent(overlay, 'vaadin-overlay-open');
+    const overlayRect = overlay.$.overlay.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    return { overlayRect, targetRect };
+  }
+
+  // Overlay above the target (position="top-*")
+  function assertPlacedAbove(overlayRect, targetRect) {
+    expect(overlayRect.bottom).to.be.equal(targetRect.top);
+  }
+
+  // Overlay below the target (position="bottom-*")
+  function assertPlacedBelow(overlayRect, targetRect) {
+    expect(overlayRect.top).to.be.equal(targetRect.bottom);
+  }
+
+  // Overlay before the target (position="start-*")
+  function assertPlacedBefore(overlayRect, targetRect, dir) {
+    const x1 = dir === 'rtl' ? 'left' : 'right';
+    const x2 = dir === 'rtl' ? 'right' : 'left';
+    expect(overlayRect[x1]).to.be.equal(targetRect[x2]);
+  }
+
+  // Overlay after the target (position="end-*")
+  function assertPlacedAfter(overlayRect, targetRect, dir) {
+    const x1 = dir === 'rtl' ? 'right' : 'left';
+    const x2 = dir === 'rtl' ? 'left' : 'right';
+    expect(overlayRect[x1]).to.be.equal(targetRect[x2]);
+  }
+
+  function assertStartAligned(overlayRect, targetRect, dir) {
+    const x = dir === 'rtl' ? 'right' : 'left';
+    expect(overlayRect[x]).to.be.equal(targetRect[x]);
+  }
+
+  function assertEndAligned(overlayRect, targetRect, dir) {
+    const x = dir === 'rtl' ? 'left' : 'right';
+    expect(overlayRect[x]).to.be.equal(targetRect[x]);
+  }
+
+  function assertTopAligned(overlayRect, targetRect) {
+    expect(overlayRect.top).to.be.equal(targetRect.top);
+  }
+
+  function assertBottomAligned(overlayRect, targetRect) {
+    expect(overlayRect.bottom).to.be.equal(targetRect.bottom);
+  }
+
+  function assertCenteredHorizontally(overlayRect, targetRect, dir) {
+    const coord = dir === 'rtl' ? 'right' : 'left';
+    const offset = dir === 'rtl' ? -overlayRect.width / 2 : overlayRect.width / 2;
+    expect(overlayRect[coord]).to.be.equal(targetRect[coord] + offset);
+  }
+
+  function assertCenteredVertically(overlayRect, targetRect) {
+    const offset = targetRect.height / 2 - overlayRect.height / 2;
+    expect(overlayRect.top).to.be.equal(targetRect.top + offset);
+  }
+
+  describe('top-start', () => {
+    beforeEach(() => {
+      tooltip.position = 'top-start';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`top-start ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target top start with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedAbove(overlayRect, targetRect);
+          assertStartAligned(overlayRect, targetRect, dir);
+        });
+      });
+    });
+  });
+
+  describe('top', () => {
+    beforeEach(() => {
+      tooltip.position = 'top';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`top ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target top with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedAbove(overlayRect, targetRect);
+          assertCenteredHorizontally(overlayRect, targetRect, dir);
+        });
+      });
+    });
+  });
+
+  describe('top-end', () => {
+    beforeEach(() => {
+      tooltip.position = 'top-end';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`top-end ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target top with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedAbove(overlayRect, targetRect);
+          assertEndAligned(overlayRect, targetRect, dir);
+        });
+      });
+    });
+  });
+
+  describe('bottom-start', () => {
+    beforeEach(() => {
+      tooltip.position = 'bottom-start';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`bottom-start ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target bottom start with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedBelow(overlayRect, targetRect);
+          assertStartAligned(overlayRect, targetRect, dir);
+        });
+      });
+    });
+  });
+
+  describe('bottom', () => {
+    beforeEach(() => {
+      tooltip.position = 'bottom';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`bottom ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target bottom with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedBelow(overlayRect, targetRect);
+          assertCenteredHorizontally(overlayRect, targetRect, dir);
+        });
+      });
+    });
+  });
+
+  describe('bottom-end', () => {
+    beforeEach(() => {
+      tooltip.position = 'bottom-end';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`bottom-end ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target bottom end with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedBelow(overlayRect, targetRect);
+          assertEndAligned(overlayRect, targetRect, dir);
+        });
+      });
+    });
+  });
+
+  describe('start-top', () => {
+    beforeEach(() => {
+      tooltip.position = 'start-top';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`start-top ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target start top with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedBefore(overlayRect, targetRect, dir);
+          assertTopAligned(overlayRect, targetRect);
+        });
+      });
+    });
+  });
+
+  describe('start', () => {
+    beforeEach(() => {
+      tooltip.position = 'start';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`start ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target start with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedBefore(overlayRect, targetRect, dir);
+          assertCenteredVertically(overlayRect, targetRect);
+        });
+      });
+    });
+  });
+
+  describe('start-bottom', () => {
+    beforeEach(() => {
+      tooltip.position = 'start-bottom';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`start-top ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target start bottom with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedBefore(overlayRect, targetRect, dir);
+          assertBottomAligned(overlayRect, targetRect);
+        });
+      });
+    });
+  });
+
+  describe('end-top', () => {
+    beforeEach(() => {
+      tooltip.position = 'end-top';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`end-top ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target end top with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedAfter(overlayRect, targetRect, dir);
+          assertTopAligned(overlayRect, targetRect);
+        });
+      });
+    });
+  });
+
+  describe('end', () => {
+    beforeEach(() => {
+      tooltip.position = 'end';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`end ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target end with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedAfter(overlayRect, targetRect, dir);
+          assertCenteredVertically(overlayRect, targetRect);
+        });
+      });
+    });
+  });
+
+  describe('end-bottom', () => {
+    beforeEach(() => {
+      tooltip.position = 'end-bottom';
+    });
+
+    ['ltr', 'rtl'].forEach((dir) => {
+      describe(`end-bottom ${dir}`, () => {
+        before(() => {
+          document.documentElement.setAttribute('dir', dir);
+        });
+
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
+
+        it(`should position overlay against target end-bottom with ${dir}`, async () => {
+          const { overlayRect, targetRect } = await openAndMeasure();
+          assertPlacedAfter(overlayRect, targetRect, dir);
+          assertBottomAligned(overlayRect, targetRect);
+        });
+      });
+    });
+  });
+});

--- a/packages/tooltip/test/tooltip-position.test.js
+++ b/packages/tooltip/test/tooltip-position.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import '../vaadin-tooltip.js';
+import '../src/vaadin-tooltip.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
@@ -18,9 +18,7 @@ describe('position', () => {
 
   beforeEach(() => {
     tooltip = fixtureSync('<vaadin-tooltip text="tooltip"></vaadin-tooltip>');
-    target = fixtureSync(`
-      <div style="display: flex; width: 100px; height: 100px; margin: 100px; outline: 1px solid red;"></div>
-    `);
+    target = fixtureSync('<div style="width: 100px; height: 100px; margin: 100px; outline: 1px solid red;"></div>');
     tooltip.target = target;
     overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
   });

--- a/packages/tooltip/test/typings/tooltip.types.ts
+++ b/packages/tooltip/test/typings/tooltip.types.ts
@@ -1,6 +1,7 @@
 import '../../vaadin-tooltip.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import type { TooltipPosition } from '../../vaadin-tooltip.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -18,3 +19,4 @@ assertType<Record<string, unknown>>(tooltip.context);
 assertType<(context: Record<string, unknown>) => string>(tooltip.textGenerator);
 assertType<boolean>(tooltip.manual);
 assertType<boolean>(tooltip.opened);
+assertType<TooltipPosition>(tooltip.position);


### PR DESCRIPTION
## Description

Added `position` property and corresponding unit tests, also updated snapshot tests to use `position`.
Visual tests will be added in a separate PR on top of this one, together with Lumo and Material themes.

Here is the overview of all the 12 supported `position` property values:

![Screenshot 2022-08-24 at 14 21 04](https://user-images.githubusercontent.com/10589913/186406080-f9bb9057-5237-4c4f-8258-ba3a018965d3.png)

## Type of change

- Feature

## Note

- The PR targets `tooltip` feature branch, not `master` branch.