### PR TITLE
feat: add delay and hideDelay to tooltip

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -25,16 +25,14 @@ export type TooltipPosition =
  */
 declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   /**
-   * Sets the default delay to be used by all tooltip instances.
-   * This method should be called before creating any tooltips.
-   * It does not change the default for existing tooltips.
+   * Sets the default delay to be used by all tooltip instances,
+   * except for those that have delay configured using property.
    */
   static setDefaultDelay(delay: number): void;
 
   /**
-   * Sets the default hide delay to be used by all tooltip instances.
-   * This method should be called before creating any tooltips.
-   * It does not change the default for existing tooltips.
+   * Sets the default hide delay to be used by all tooltip instances,
+   * except for those that have hide delay configured using property.
    */
   static setDefaultHideDelay(hideDelay: number): void;
 

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -25,10 +25,31 @@ export type TooltipPosition =
  */
 declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   /**
+   * Sets the default delay to be used by all tooltip instances.
+   * This method should be called before creating any tooltips.
+   * It does not change the default for existing tooltips.
+   */
+  static setDefaultDelay(delay: number): void;
+
+  /**
+   * Sets the default hide delay to be used by all tooltip instances.
+   * This method should be called before creating any tooltips.
+   * It does not change the default for existing tooltips.
+   */
+  static setDefaultHideDelay(hideDelay: number): void;
+
+  /**
    * Object with properties passed to `textGenerator`
    * function to be used for generating tooltip text.
    */
   context: Record<string, unknown>;
+
+  /**
+   * The delay in milliseconds before the tooltip
+   * is opened on hover, when not in manual mode.
+   * On focus, the tooltip is opened immediately.
+   */
+  delay: number;
 
   /**
    * The id of the element used as a tooltip trigger.
@@ -36,6 +57,14 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
    * the attribute is set, otherwise a warning is shown.
    */
   for: string | undefined;
+
+  /**
+   * The delay in milliseconds before the tooltip
+   * is closed on losing hover, when not in manual mode.
+   * On blur, the tooltip is closed immediately.
+   * @attr {number} hide-delay
+   */
+  hideDelay: number;
 
   /**
    * When true, the tooltip is controlled programmatically

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -425,7 +425,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   __warmupTooltip() {
     if (!this._autoOpened) {
       // First tooltip is opened, warm up.
-      if (!warmUpTimeout && !warmedUp) {
+      if (!warmedUp) {
         this.__scheduleWarmUp();
       } else {
         // Warmed up, show another tooltip.

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -78,7 +78,6 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
        */
       delay: {
         type: Number,
-        value: () => defaultDelay,
       },
 
       /**
@@ -99,7 +98,6 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
        */
       hideDelay: {
         type: Number,
-        value: () => defaultHideDelay,
       },
 
       /**
@@ -179,9 +177,8 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /**
-   * Sets the default delay to be used by all tooltip instances.
-   * This method should be called before creating any tooltips.
-   * It does not change the default for existing tooltips.
+   * Sets the default delay to be used by all tooltip instances,
+   * except for those that have delay configured using property.
    *
    * @param {number} delay
    */
@@ -190,9 +187,8 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /**
-   * Sets the default hide delay to be used by all tooltip instances.
-   * This method should be called before creating any tooltips.
-   * It does not change the default for existing tooltips.
+   * Sets the default hide delay to be used by all tooltip instances,
+   * except for those that have hide delay configured using property.
    *
    * @param {number} hideDelay
    */
@@ -365,7 +361,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
    * @protected
    */
   _open(immediate) {
-    if (!immediate && this.delay > 0 && !this.__closeTimeout) {
+    if (!immediate && this.__getDelay() > 0 && !this.__closeTimeout) {
       this.__warmupTooltip();
     } else {
       this.__showTooltip();
@@ -378,7 +374,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
    * @protected
    */
   _close(immediate) {
-    if (!immediate && this.hideDelay > 0) {
+    if (!immediate && this.__getHideDelay() > 0) {
       this.__scheduleClose();
     } else {
       this.__abortClose();
@@ -392,6 +388,16 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       this.__abortCooldown();
       this.__scheduleCooldown();
     }
+  }
+
+  /** @private */
+  __getDelay() {
+    return this.delay != null && this.delay > 0 ? this.delay : defaultDelay;
+  }
+
+  /** @private */
+  __getHideDelay() {
+    return this.hideDelay != null && this.hideDelay > 0 ? this.hideDelay : defaultHideDelay;
   }
 
   /** @private */
@@ -464,7 +470,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       this.__closeTimeout = setTimeout(() => {
         this.__closeTimeout = null;
         this._autoOpened = false;
-      }, this.hideDelay);
+      }, this.__getHideDelay());
     }
   }
 
@@ -474,7 +480,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       instances.delete(this);
       cooldownTimeout = null;
       warmedUp = false;
-    }, this.hideDelay);
+    }, this.__getHideDelay());
   }
 
   /** @private */
@@ -483,7 +489,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       warmUpTimeout = null;
       warmedUp = true;
       this.__showTooltip();
-    }, this.delay);
+    }, this.__getDelay());
   }
 
   /** @private */

--- a/packages/tooltip/test/helpers.js
+++ b/packages/tooltip/test/helpers.js
@@ -1,0 +1,9 @@
+import { fire } from '@vaadin/testing-helpers';
+
+export function mouseenter(target) {
+  fire(target, 'mouseenter');
+}
+
+export function mouseleave(target) {
+  fire(target, 'mouseleave');
+}

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -1,0 +1,280 @@
+import { expect } from '@esm-bundle/chai';
+import { aTimeout, escKeyDown, fixtureSync, focusout, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
+import { Tooltip } from '../vaadin-tooltip.js';
+import { mouseenter, mouseleave } from './helpers.js';
+
+describe('timers', () => {
+  describe('delay', () => {
+    let tooltip, target, overlay;
+
+    beforeEach(() => {
+      tooltip = fixtureSync('<vaadin-tooltip text="tooltip" delay="1"></vaadin-tooltip>');
+      target = fixtureSync('<input>');
+      tooltip.target = target;
+      overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+    });
+
+    afterEach(async () => {
+      await aTimeout(0);
+    });
+
+    it('should open the overlay after a delay on mouseenter', async () => {
+      mouseenter(target);
+      expect(overlay.opened).to.be.not.ok;
+
+      await aTimeout(1);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open the overlay immediately on keyboard focus', () => {
+      tabKeyDown(document.body);
+      target.focus();
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('hideDelay', () => {
+    let tooltip, target, overlay;
+
+    beforeEach(() => {
+      tooltip = fixtureSync('<vaadin-tooltip text="tooltip" hide-delay="1"></vaadin-tooltip>');
+      target = fixtureSync('<input>');
+      tooltip.target = target;
+      overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+    });
+
+    afterEach(async () => {
+      await aTimeout(1);
+    });
+
+    it('should close the overlay after a hide delay on mouseleave', async () => {
+      mouseenter(target);
+      mouseleave(target);
+      expect(overlay.opened).to.be.true;
+
+      await aTimeout(1);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close the overlay immediately on focusout', () => {
+      tabKeyDown(document.body);
+      target.focus();
+
+      focusout(target);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close the overlay immediately on mousedown', () => {
+      tabKeyDown(document.body);
+      target.focus();
+
+      mousedown(target);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close the overlay immediately on Esc keydown', () => {
+      tabKeyDown(document.body);
+      target.focus();
+
+      escKeyDown(target);
+      expect(overlay.opened).to.be.false;
+    });
+  });
+
+  describe('setDefaultDelay', () => {
+    afterEach(() => {
+      Tooltip.setDefaultDelay(0);
+    });
+
+    it('should set default delay for newly created tooltip', () => {
+      Tooltip.setDefaultDelay(10);
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      expect(tooltip.delay).to.equal(10);
+    });
+
+    it('should not change default delay for existing tooltip', () => {
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      Tooltip.setDefaultDelay(10);
+      expect(tooltip.delay).to.equal(0);
+    });
+
+    it('should reset delay when providing a negative number', () => {
+      Tooltip.setDefaultDelay(10);
+      Tooltip.setDefaultDelay(-1);
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      expect(tooltip.delay).to.equal(0);
+    });
+
+    it('should reset delay when providing null instead of number', () => {
+      Tooltip.setDefaultDelay(10);
+      Tooltip.setDefaultDelay(null);
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      expect(tooltip.delay).to.equal(0);
+    });
+
+    it('should reset delay when providing undefined instead of number', () => {
+      Tooltip.setDefaultDelay(10);
+      Tooltip.setDefaultDelay(undefined);
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      expect(tooltip.delay).to.equal(0);
+    });
+  });
+
+  describe('setDefaultHideDelay', () => {
+    afterEach(() => {
+      Tooltip.setDefaultHideDelay(0);
+    });
+
+    it('should set default hide delay for newly created tooltip', () => {
+      Tooltip.setDefaultHideDelay(10);
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      expect(tooltip.hideDelay).to.equal(10);
+    });
+
+    it('should not change default hide delay for existing tooltip', () => {
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      Tooltip.setDefaultHideDelay(10);
+      expect(tooltip.hideDelay).to.equal(0);
+    });
+
+    it('should reset hide delay when providing a negative number', () => {
+      Tooltip.setDefaultHideDelay(10);
+      Tooltip.setDefaultHideDelay(-1);
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      expect(tooltip.hideDelay).to.equal(0);
+    });
+
+    it('should reset hide delay when providing null instead of number', () => {
+      Tooltip.setDefaultHideDelay(10);
+      Tooltip.setDefaultHideDelay(null);
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      expect(tooltip.hideDelay).to.equal(0);
+    });
+
+    it('should reset hide delay when providing undefined instead of number', () => {
+      Tooltip.setDefaultHideDelay(10);
+      Tooltip.setDefaultHideDelay(undefined);
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      expect(tooltip.hideDelay).to.equal(0);
+    });
+  });
+
+  describe('warmup and cooldown', () => {
+    let wrapper, targets, tooltips, overlays;
+
+    beforeEach(() => {
+      wrapper = fixtureSync(`
+        <div>
+          <vaadin-tooltip text="tooltip 1" delay="2" hide-delay="2" for="input-1"></vaadin-tooltip>
+          <vaadin-tooltip text="tooltip 2" delay="2" hide-delay="2" for="input-2"></vaadin-tooltip>
+          <input id="input-1">
+          <input id="input-2">
+        </div>
+      `);
+      tooltips = Array.from(wrapper.querySelectorAll('vaadin-tooltip'));
+      targets = wrapper.querySelectorAll('input');
+      overlays = tooltips.map((el) => el.shadowRoot.querySelector('vaadin-tooltip-overlay'));
+    });
+
+    afterEach(async () => {
+      await aTimeout(2);
+    });
+
+    it('should close first tooltip and open the second one without waiting for delay', async () => {
+      mouseenter(targets[0]);
+      await aTimeout(2);
+
+      mouseleave(targets[0]);
+      mouseenter(targets[1]);
+
+      expect(overlays[0].opened).to.be.false;
+      expect(overlays[1].opened).to.be.true;
+    });
+
+    it('should re-open first tooltip and close the second one without waiting for delay', async () => {
+      mouseenter(targets[0]);
+      await aTimeout(2);
+
+      mouseleave(targets[0]);
+      mouseenter(targets[1]);
+
+      mouseleave(targets[1]);
+      mouseenter(targets[0]);
+
+      expect(overlays[0].opened).to.be.true;
+      expect(overlays[1].opened).to.be.false;
+    });
+
+    it('should warm up again when closing the tooltip and re-opening it after the delay', async () => {
+      mouseenter(targets[0]);
+      await aTimeout(2);
+
+      mouseleave(targets[0]);
+      await aTimeout(2);
+
+      mouseenter(targets[0]);
+      expect(overlays[0].opened).to.be.false;
+
+      await aTimeout(2);
+      expect(overlays[0].opened).to.be.true;
+    });
+
+    it('should not open on mouseleave during the initial warm up delay', async () => {
+      mouseenter(targets[0]);
+      await aTimeout(1);
+
+      mouseleave(targets[0]);
+      await aTimeout(1);
+
+      expect(overlays[0].opened).to.be.false;
+    });
+
+    it('should stop closing on subsequent mouseenter during the hide delay', async () => {
+      mouseenter(targets[0]);
+      await aTimeout(2);
+
+      mouseleave(targets[0]);
+      await aTimeout(1);
+
+      mouseenter(targets[0]);
+      await aTimeout(2);
+      expect(overlays[0].opened).to.be.true;
+    });
+
+    it('should close immediately on Esc key during the hide delay', async () => {
+      mouseenter(targets[0]);
+      await aTimeout(2);
+
+      mouseleave(targets[0]);
+      await aTimeout(1);
+
+      escKeyDown(document.body);
+      expect(overlays[0].opened).to.be.false;
+    });
+
+    it('should keep warmed up state when closing immediately on Esc key', async () => {
+      mouseenter(targets[0]);
+      await aTimeout(2);
+
+      escKeyDown(document.body);
+
+      mouseleave(targets[0]);
+      mouseenter(targets[1]);
+
+      expect(overlays[1].opened).to.be.true;
+    });
+
+    it('should reset warmed up state after the hide delay when closed immediately', async () => {
+      mouseenter(targets[0]);
+      await aTimeout(2);
+
+      escKeyDown(document.body);
+
+      await aTimeout(2);
+      mouseleave(targets[0]);
+      mouseenter(targets[0]);
+
+      expect(overlays[0].opened).to.be.false;
+    });
+  });
+});

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -82,80 +82,163 @@ describe('timers', () => {
   });
 
   describe('setDefaultDelay', () => {
+    let tooltip, target;
+
+    beforeEach(() => {
+      target = fixtureSync('<div>Target</div>');
+    });
+
     afterEach(() => {
       Tooltip.setDefaultDelay(0);
     });
 
-    it('should set default delay for newly created tooltip', () => {
-      Tooltip.setDefaultDelay(10);
-      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      expect(tooltip.delay).to.equal(10);
+    it('should change default delay for newly created tooltip', async () => {
+      Tooltip.setDefaultDelay(2);
+
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      mouseenter(target);
+      await aTimeout(2);
+
+      expect(overlay.opened).to.be.true;
     });
 
-    it('should not change default delay for existing tooltip', () => {
-      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      Tooltip.setDefaultDelay(10);
-      expect(tooltip.delay).to.equal(0);
+    it('should change default delay for existing tooltip', async () => {
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      Tooltip.setDefaultDelay(2);
+
+      mouseenter(target);
+      await aTimeout(2);
+
+      expect(overlay.opened).to.be.true;
     });
 
     it('should reset delay when providing a negative number', () => {
       Tooltip.setDefaultDelay(10);
       Tooltip.setDefaultDelay(-1);
-      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      expect(tooltip.delay).to.equal(0);
+
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      mouseenter(target);
+
+      expect(overlay.opened).to.be.true;
     });
 
     it('should reset delay when providing null instead of number', () => {
       Tooltip.setDefaultDelay(10);
       Tooltip.setDefaultDelay(null);
+
       const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      expect(tooltip.delay).to.equal(0);
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      mouseenter(target);
+
+      expect(overlay.opened).to.be.true;
     });
 
     it('should reset delay when providing undefined instead of number', () => {
       Tooltip.setDefaultDelay(10);
       Tooltip.setDefaultDelay(undefined);
+
       const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      expect(tooltip.delay).to.equal(0);
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      mouseenter(target);
+
+      expect(overlay.opened).to.be.true;
     });
   });
 
   describe('setDefaultHideDelay', () => {
+    let tooltip, target;
+
+    beforeEach(() => {
+      target = fixtureSync('<div>Target</div>');
+    });
+
     afterEach(() => {
       Tooltip.setDefaultHideDelay(0);
     });
 
-    it('should set default hide delay for newly created tooltip', () => {
-      Tooltip.setDefaultHideDelay(10);
-      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      expect(tooltip.hideDelay).to.equal(10);
+    it('should change default hide delay for newly created tooltip', async () => {
+      Tooltip.setDefaultHideDelay(2);
+
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      mouseenter(target);
+
+      mouseleave(target);
+      await aTimeout(2);
+
+      expect(overlay.opened).to.be.false;
     });
 
-    it('should not change default hide delay for existing tooltip', () => {
-      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      Tooltip.setDefaultHideDelay(10);
-      expect(tooltip.hideDelay).to.equal(0);
+    it('should change default hide delay for existing tooltip', async () => {
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      Tooltip.setDefaultHideDelay(2);
+
+      mouseenter(target);
+
+      mouseleave(target);
+      await aTimeout(2);
+
+      expect(overlay.opened).to.be.false;
     });
 
     it('should reset hide delay when providing a negative number', () => {
       Tooltip.setDefaultHideDelay(10);
       Tooltip.setDefaultHideDelay(-1);
-      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      expect(tooltip.hideDelay).to.equal(0);
+
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      mouseenter(target);
+
+      mouseleave(target);
+      expect(overlay.opened).to.be.false;
     });
 
     it('should reset hide delay when providing null instead of number', () => {
       Tooltip.setDefaultHideDelay(10);
       Tooltip.setDefaultHideDelay(null);
-      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      expect(tooltip.hideDelay).to.equal(0);
+
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      mouseenter(target);
+
+      mouseleave(target);
+      expect(overlay.opened).to.be.false;
     });
 
     it('should reset hide delay when providing undefined instead of number', () => {
       Tooltip.setDefaultHideDelay(10);
       Tooltip.setDefaultHideDelay(undefined);
-      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
-      expect(tooltip.hideDelay).to.equal(0);
+
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      mouseenter(target);
+
+      mouseleave(target);
+      expect(overlay.opened).to.be.false;
     });
   });
 

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -1,23 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import {
-  escKeyDown,
-  fire,
-  fixtureSync,
-  focusout,
-  keyboardEventFor,
-  mousedown,
-  tabKeyDown,
-} from '@vaadin/testing-helpers';
+import { escKeyDown, fixtureSync, focusout, keyboardEventFor, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-tooltip.js';
-
-function mouseenter(target) {
-  fire(target, 'mouseenter');
-}
-
-function mouseleave(target) {
-  fire(target, 'mouseleave');
-}
+import { mouseenter, mouseleave } from './helpers.js';
 
 describe('vaadin-tooltip', () => {
   let tooltip, overlay;


### PR DESCRIPTION
## Description

Added `delay` and `hideDelay` properties to `vaadin-tooltip` based on the prototype.

## Type of change

- Feature

## Note

This PR is targeting the `tooltip` feature branch, not `master`.