### PR TITLE
refactor: remove no longer needed Chrome workaround

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -5,6 +5,7 @@
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
+import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -102,7 +103,7 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
-declare class CustomField extends FieldMixin(FocusMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
+declare class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(ElementMixin(HTMLElement))))) {
   /**
    * Array of available input nodes
    */

--- a/packages/custom-field/test/keyboard.test.js
+++ b/packages/custom-field/test/keyboard.test.js
@@ -1,28 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, isChrome, tabKeyDown } from '@vaadin/testing-helpers';
+import { fixtureSync, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-custom-field.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-
-class XWrapper extends PolymerElement {
-  static get template() {
-    return html`
-      <vaadin-custom-field id="field">
-        <slot name="input-1">
-          <input type="text" />
-        </slot>
-        <slot name="input-2">
-          <input type="text" />
-        </slot>
-        <slot name="input-3">
-          <input type="text" />
-        </slot>
-      </vaadin-custom-field>
-    `;
-  }
-}
-
-customElements.define('x-wrapper', XWrapper);
 
 describe('keyboard navigation', () => {
   let customField;
@@ -83,28 +62,6 @@ describe('keyboard navigation', () => {
         customField.inputs[0].value = 1;
         tabKeyDown(customField.inputs[0], ['shift']);
         expect(customField.value).to.equal('1\t\t\t');
-      });
-    });
-
-    describe('wrapping slots', () => {
-      let wrapper;
-
-      beforeEach(() => {
-        wrapper = fixtureSync(`<x-wrapper></x-wrapper>`);
-        customField = wrapper.$.field;
-      });
-
-      // Skip this test on any platform apart from Chrome
-      (isChrome ? it : it.skip)('should properly set tabindex on Shift Tab for wrapping slots', async () => {
-        for (let i = 2; i > -1; i--) {
-          const input = customField.inputs[i];
-          expect(input.parentElement.hasAttribute('tabindex')).to.be.false;
-          tabKeyDown(input, ['shift']);
-          expect(input.parentElement.getAttribute('tabindex')).to.equal('-1');
-        }
-
-        await aTimeout();
-        expect(customField.inputs.filter((input) => input.hasAttribute('tabindex')).length).to.equal(0);
       });
     });
   });


### PR DESCRIPTION
## Description

The workaround was added in https://github.com/vaadin/vaadin-custom-field/pull/54 to enable using `vaadin-custom-field` in Shadow DOM of the `vaadin-date-time-picker` element. Back then, there was an issue related to <kbd>Shift</kbd> + <kbd>Tab</kbd> (see the `FIXME` comment).

The Chrome bug is now [fixed](https://bugs.chromium.org/p/chromium/issues/detail?id=1014868#c21) so the workaround is no longer needed. The test is also removed, as it tests the workaround.
Also, in Vaadin 22 we changed `vaadin-date-time-picker` to not be based on `vaadin-custom-field` anyways.

## Type of change

- Refactor