### PR TITLE
refactor: remove no longer used pseudo-element

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -56,10 +56,6 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
           display: flex;
         }
 
-        :host(:not([years-visible])) [part='years-toggle-button']::before {
-          transform: rotate(180deg);
-        }
-
         #scrollers {
           display: flex;
           height: 100%;

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -181,10 +181,6 @@ registerStyles(
       color: var(--lumo-primary-contrast-color);
     }
 
-    [part='years-toggle-button']::before {
-      content: none;
-    }
-
     /* TODO magic number (same as used for iron-media-query in vaadin-date-picker-overlay-content) */
     @media screen and (max-width: 374px) {
       :host {

--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
@@ -87,11 +87,6 @@ registerStyles(
       color: var(--material-secondary-text-color);
     }
 
-    [part='years-toggle-button']::before {
-      content: '';
-      display: none;
-    }
-
     [part='years-toggle-button']::after {
       content: var(--material-icons-play);
       display: inline-block;


### PR DESCRIPTION
## Description

The `[part='year-toggle-button']::before` pseudo-element was removed in https://github.com/vaadin/vaadin-date-picker/pull/628.
Removed leftover styles that are unused since then, as the pseudo-element does not exist. 

## Type of change

- Refactor