### PR TITLE
refactor: cleanup mask-image support detection

### DIFF
--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -119,15 +119,8 @@ registerStyles(
 
     [part='toolbar'] {
       padding: var(--lumo-space-s);
-      box-shadow: 0 -1px 0 0 var(--lumo-contrast-10pct);
       border-bottom-left-radius: var(--lumo-border-radius-l);
       margin-right: 57px;
-    }
-
-    @supports (mask-image: linear-gradient(#000, #000)) or (-webkit-mask-image: linear-gradient(#000, #000)) {
-      [part='toolbar'] {
-        box-shadow: none;
-      }
     }
 
     /* Today and Cancel buttons */


### PR DESCRIPTION
## Description

Removed usage of `@supports` which was added in https://github.com/vaadin/vaadin-lumo-styles/commit/7e67dcfbdb83cb643ba8354d479bb21b6e8e28aa when we still supported IE11.
This is no longer needed as modern browsers support [`mask-image`](https://caniuse.com/mdn-css_properties_mask-image) used for `[part='months']` and `[part='years']`.

## Type of change

- Refactor