### PR TITLE
refactor: do not set overlay content background

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -30,7 +30,6 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
           height: 100%;
           width: 100%;
           outline: none;
-          background: #fff;
         }
 
         [part='overlay-header'] {

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -11,7 +11,6 @@ registerStyles(
   css`
     :host {
       position: relative;
-      background-color: transparent;
       /* Background for the year scroller, placed here as we are using a mask image on the actual years part */
       background-image: linear-gradient(var(--lumo-shade-5pct), var(--lumo-shade-5pct));
       background-size: 57px 100%;

--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
@@ -13,9 +13,6 @@ registerStyles(
       font-size: var(--material-body-font-size);
       -webkit-text-size-adjust: 100%;
       line-height: 1.4;
-
-      /* FIXME(platosha): fix the core styles and remove this override. */
-      background: transparent;
     }
 
     :host([fullscreen]) {


### PR DESCRIPTION
## Description

Using `#fff` in core styles does not bring much value and is problematic when the dark theme is used.
Removed this as it should be theme's responsibility to set the background. Also removed overrides.

## Type of change

- Refactor