### PR TITLE
refactor: cleanup overlay content default styles

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -129,19 +129,6 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
           z-index: 2;
           flex-shrink: 0;
         }
-
-        [part~='overlay-header']:not([desktop]) {
-          padding-bottom: 40px;
-        }
-
-        [part~='years-toggle-button'] {
-          position: absolute;
-          top: auto;
-          right: 8px;
-          bottom: 0;
-          z-index: 1;
-          padding: 8px;
-        }
       </style>
 
       <div part="overlay-header" on-touchend="_preventDefault" desktop$="[[_desktopMode]]" aria-hidden="true">

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -162,8 +162,6 @@ registerStyles(
     /* Very narrow screen (year scroller initially hidden) */
 
     [part='years-toggle-button'] {
-      position: relative;
-      right: auto;
       display: flex;
       align-items: center;
       height: var(--lumo-size-s);

--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
@@ -36,11 +36,6 @@ registerStyles(
       box-shadow: var(--material-shadow-elevation-4dp);
     }
 
-    /* FIXME(platosha): fix the core styles and remove this override. */
-    [part='overlay-header']:not([desktop]) {
-      padding-bottom: 8px;
-    }
-
     [part='label'] {
       padding: 0 8px;
       flex: auto;
@@ -54,11 +49,6 @@ registerStyles(
       width: 24px;
       height: 24px;
       text-align: center;
-    }
-
-    [part='clear-button'],
-    [part='toggle-button'],
-    [part='years-toggle-button'] {
       padding: 8px;
       color: var(--material-secondary-text-color);
     }
@@ -78,7 +68,6 @@ registerStyles(
     }
 
     [part='years-toggle-button'] {
-      position: static;
       padding: 4px 8px;
       font-size: var(--material-body-font-size);
       font-weight: 500;


### PR DESCRIPTION
## Description

Removed some styles that are leftovers from `vaadin-date-picker` 2.0 version - see [example](https://cdn.vaadin.com/vaadin-date-picker/2.0.6/demo/#date-picker-basic-demos):

Overlay header (uses `padding-bottom: 40px`):

![Screenshot 2022-08-26 at 16 02 39](https://user-images.githubusercontent.com/10589913/186911158-3e1962fa-60cb-43ad-bfd7-87c4afb45283.png)

Year toggle button (uses `position: absolute`):

![Screenshot 2022-08-26 at 16 01 40](https://user-images.githubusercontent.com/10589913/186911140-2ba343f5-ba0d-4966-aa07-4edfbcd4d89e.png)

These styles are not used in Lumo and Material and require overrides. So I think we can just remove them.

## Type of change

- Refactor