### PR TITLE
test: update context-menu tests to use renderer

### DIFF
--- a/packages/context-menu/test/context.test.js
+++ b/packages/context-menu/test/context.test.js
@@ -3,7 +3,6 @@ import { fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -26,11 +25,6 @@ describe('context', () => {
   beforeEach(() => {
     menu = fixtureSync(`
       <vaadin-context-menu>
-        <template>
-          <vaadin-list-box id="menu">
-            <vaadin-item>The menu target: [[target.textContent]]</vaadin-item>
-          </vaadin-list-box>
-        </template>
         <div id="target">
           Foo
           <x-foo></x-foo>
@@ -38,26 +32,29 @@ describe('context', () => {
         <div id="another">Bar</div>
       </vaadin-context-menu>
     `);
+    menu.renderer = (root, _, context) => {
+      root.innerHTML = `
+        <vaadin-list-box id="menu">
+          <vaadin-item>The menu target: ${context.target.textContent}</vaadin-item>
+        </vaadin-list-box>
+      `;
+    };
     foo = document.querySelector('x-foo');
     target = document.querySelector('#target');
     another = document.querySelector('#another');
-  });
-
-  afterEach(() => {
-    menu.close();
   });
 
   it('should use target as default context', () => {
     fire(target, 'vaadin-contextmenu');
 
     expect(menu._context.target).to.eql(target);
-    expect(menu.$.overlay.content.textContent).to.contain(target.textContent);
+    expect(menu.$.overlay.textContent).to.contain(target.textContent);
 
     menu.close();
     fire(another, 'vaadin-contextmenu');
 
     expect(menu._context.target).to.eql(another);
-    expect(menu.$.overlay.content.textContent).to.contain(another.textContent);
+    expect(menu.$.overlay.textContent).to.contain(another.textContent);
   });
 
   it('should use details as context details', () => {

--- a/packages/context-menu/test/integration.test.js
+++ b/packages/context-menu/test/integration.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, click, fixtureSync, isIOS, makeSoloTouchEvent } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -8,11 +7,17 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 class MenuWrapper extends PolymerElement {
   static get template() {
     return html`
-      <vaadin-context-menu id="menu">
-        <template>foo</template>
-      </vaadin-context-menu>
+      <vaadin-context-menu id="menu" renderer="[[_renderer]]"></vaadin-context-menu>
       <button on-click="_showMenu" id="button" style="margin: 20px">Show context menu</button>
     `;
+  }
+
+  constructor() {
+    super();
+
+    this._renderer = (root) => {
+      root.textContent = 'foo';
+    };
   }
 
   _showMenu(e) {

--- a/packages/context-menu/test/overlay.test.js
+++ b/packages/context-menu/test/overlay.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, isIOS, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 
@@ -10,10 +9,12 @@ describe('overlay', () => {
   beforeEach(() => {
     menu = fixtureSync(`
       <vaadin-context-menu>
-        <template>OVERLAY CONTENT</template>
         <div id="target">FOOOO</div>
       </vaadin-context-menu>
     `);
+    menu.renderer = (root) => {
+      root.textContent = 'OVERLAY CONTENT';
+    };
     overlay = menu.$.overlay;
     content = overlay.$.overlay.children[0];
     // Make content have a fixed size

--- a/packages/context-menu/test/properties.test.js
+++ b/packages/context-menu/test/properties.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 
@@ -17,7 +16,6 @@ describe('properties', () => {
     beforeEach(() => {
       menu = fixtureSync(`
         <vaadin-context-menu>
-          <template></template>
           <section>
             <div id="target"></div>
           </section>
@@ -43,11 +41,7 @@ describe('properties', () => {
 
   describe('openOn', () => {
     beforeEach(() => {
-      menu = fixtureSync(`
-        <vaadin-context-menu>
-          <template></template>
-        </vaadin-context-menu>
-      `);
+      menu = fixtureSync('<vaadin-context-menu></vaadin-context-menu>');
     });
 
     it('should open on custom event', () => {
@@ -77,11 +71,7 @@ describe('properties', () => {
 
   describe('opened', () => {
     beforeEach(() => {
-      menu = fixtureSync(`
-        <vaadin-context-menu>
-          <template></template>
-        </vaadin-context-menu>
-      `);
+      menu = fixtureSync('<vaadin-context-menu></vaadin-context-menu>');
     });
 
     it('should be read-only', () => {
@@ -101,11 +91,7 @@ describe('properties', () => {
 
   describe('closeOn', () => {
     beforeEach(() => {
-      menu = fixtureSync(`
-        <vaadin-context-menu>
-          <template></template>
-        </vaadin-context-menu>
-      `);
+      menu = fixtureSync('<vaadin-context-menu></vaadin-context-menu>');
       menu._setOpened(true);
     });
 
@@ -132,9 +118,7 @@ describe('properties', () => {
     beforeEach(() => {
       wrapper = fixtureSync(`
         <div>
-          <vaadin-context-menu>
-            <template></template>
-          </vaadin-context-menu>
+          <vaadin-context-menu></vaadin-context-menu>
           <section>
             <div id="target"></div>
           </section>
@@ -177,11 +161,7 @@ describe('properties', () => {
 
   describe('theme attribute', () => {
     beforeEach(() => {
-      menu = fixtureSync(`
-        <vaadin-context-menu theme="foo">
-          <template></template>
-        </vaadin-context-menu>
-      `);
+      menu = fixtureSync('<vaadin-context-menu theme="foo"></vaadin-context-menu>');
     });
 
     it('should propagate theme attribute to overlay', () => {

--- a/packages/context-menu/test/selection.test.js
+++ b/packages/context-menu/test/selection.test.js
@@ -3,67 +3,64 @@ import { click, enter, fire, fixtureSync, isIOS, nextRender, oneEvent } from '@v
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 
 describe('selection', () => {
-  let menu;
+  let menu, overlay;
 
   beforeEach(() => {
-    menu = fixtureSync(`
-      <vaadin-context-menu>
-        <template>
-          <vaadin-list-box id="menu">
-            <vaadin-item>item1</vaadin-item>
-            <vaadin-item>item2</vaadin-item>
-            <vaadin-item>item3</vaadin-item>
-          </vaadin-list-box>
-        </template>
-      </vaadin-context-menu>
-    `);
+    menu = fixtureSync('<vaadin-context-menu></vaadin-context-menu>');
+    overlay = menu.$.overlay;
+    menu.renderer = (root) => {
+      root.innerHTML = `
+        <vaadin-list-box id="menu">
+          <vaadin-item>item1</vaadin-item>
+          <vaadin-item>item2</vaadin-item>
+          <vaadin-item>item3</vaadin-item>
+        </vaadin-list-box>
+      `;
+    };
   });
 
-  describe('selection', () => {
-    it('should close on item click', async () => {
-      menu._setOpened(true);
-      await oneEvent(menu.$.overlay, 'vaadin-overlay-open');
-      await nextRender(menu.$.overlay);
+  it('should close on item click', async () => {
+    menu._setOpened(true);
+    await oneEvent(overlay, 'vaadin-overlay-open');
+    await nextRender(overlay);
 
-      const listBox = menu.$.overlay.content.querySelector('#menu');
-      click(listBox.items[0]);
-      expect(menu.opened).to.eql(false);
-    });
+    const listBox = overlay.querySelector('#menu');
+    click(listBox.items[0]);
+    expect(menu.opened).to.eql(false);
+  });
 
-    it('should close on keyboard selection', async () => {
-      menu._setOpened(true);
-      await oneEvent(menu.$.overlay, 'vaadin-overlay-open');
-      await nextRender(menu.$.overlay);
+  it('should close on keyboard selection', async () => {
+    menu._setOpened(true);
+    await oneEvent(overlay, 'vaadin-overlay-open');
+    await nextRender(overlay);
 
-      const spy = sinon.spy();
-      menu.addEventListener('opened-changed', spy);
+    const spy = sinon.spy();
+    menu.addEventListener('opened-changed', spy);
 
-      const item = menu.$.overlay.content.querySelector('#menu vaadin-item');
-      enter(item);
-      expect(spy.calledOnce).to.be.true;
-    });
+    const item = overlay.querySelector('#menu vaadin-item');
+    enter(item);
+    expect(spy.calledOnce).to.be.true;
+  });
 
-    it('should focus the child element', async () => {
-      menu._setOpened(true);
-      await oneEvent(menu.$.overlay, 'vaadin-overlay-open');
-      await nextRender(menu.$.overlay);
+  it('should focus the child element', async () => {
+    menu._setOpened(true);
+    await oneEvent(overlay, 'vaadin-overlay-open');
+    await nextRender(overlay);
 
-      const item = menu.$.overlay.content.querySelector('#menu vaadin-item');
-      expect(document.activeElement).to.eql(item);
-    });
+    const item = overlay.querySelector('#menu vaadin-item');
+    expect(document.activeElement).to.eql(item);
+  });
 
-    (isIOS ? it.skip : it)('should focus the child element on `contextmenu` event', async () => {
-      fire(menu, 'contextmenu');
-      await oneEvent(menu.$.overlay, 'vaadin-overlay-open');
-      await nextRender(menu.$.overlay);
+  (isIOS ? it.skip : it)('should focus the child element on `contextmenu` event', async () => {
+    fire(menu, 'contextmenu');
+    await oneEvent(overlay, 'vaadin-overlay-open');
+    await nextRender(overlay);
 
-      const item = menu.$.overlay.content.querySelector('#menu vaadin-item');
-      expect(document.activeElement).to.eql(item);
-    });
+    const item = overlay.querySelector('#menu vaadin-item');
+    expect(document.activeElement).to.eql(item);
   });
 });

--- a/packages/context-menu/test/touch.test.js
+++ b/packages/context-menu/test/touch.test.js
@@ -10,7 +10,6 @@ import {
   touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -19,13 +18,18 @@ import { gestures } from '@vaadin/component-base/src/gestures.js';
 class MenuTouchWrapper extends PolymerElement {
   static get template() {
     return html`
-      <vaadin-context-menu selector="#target" id="menu">
+      <vaadin-context-menu selector="#target" id="menu" renderer="[[_renderer]]">
         <div id="target">Target</div>
-        <template>
-          <div>Menu Content</div>
-        </template>
       </vaadin-context-menu>
     `;
+  }
+
+  constructor() {
+    super();
+
+    this._renderer = (root) => {
+      root.innerHTML = '<div>Menu Content</div>';
+    };
   }
 }
 

--- a/packages/context-menu/test/visual/lumo/context-menu.test.js
+++ b/packages/context-menu/test/visual/lumo/context-menu.test.js
@@ -1,6 +1,5 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../../../theme/lumo/vaadin-context-menu.js';
 import '../../not-animated-styles.js';
 import { openSubMenus } from '../common.js';
@@ -35,16 +34,17 @@ describe('context-menu', () => {
         beforeEach(() => {
           element = fixtureSync(`
             <vaadin-context-menu>
-              <template>
-                <vaadin-list-box>
-                  <vaadin-item>Item 1</vaadin-item>
-                  <vaadin-item>Item 2</vaadin-item>
-                </vaadin-list-box>
-              </template>
-
               <div style="padding: 10px">Target</div>
             </vaadin-context-menu>
           `);
+          element.renderer = (root) => {
+            root.innerHTML = `
+              <vaadin-list-box>
+                <vaadin-item>Item 1</vaadin-item>
+                <vaadin-item>Item 2</vaadin-item>
+              </vaadin-list-box>
+            `;
+          };
         });
 
         it('basic', async () => {

--- a/packages/context-menu/test/visual/material/context-menu.test.js
+++ b/packages/context-menu/test/visual/material/context-menu.test.js
@@ -1,6 +1,5 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../../../theme/material/vaadin-context-menu.js';
 import '../../not-animated-styles.js';
 import { openSubMenus } from '../common.js';
@@ -35,16 +34,17 @@ describe('context-menu', () => {
         beforeEach(() => {
           element = fixtureSync(`
             <vaadin-context-menu>
-              <template>
-                <vaadin-list-box>
-                  <vaadin-item>Item 1</vaadin-item>
-                  <vaadin-item>Item 2</vaadin-item>
-                </vaadin-list-box>
-              </template>
-
               <div style="padding: 10px">Target</div>
             </vaadin-context-menu>
           `);
+          element.renderer = (root) => {
+            root.innerHTML = `
+              <vaadin-list-box>
+                <vaadin-item>Item 1</vaadin-item>
+                <vaadin-item>Item 2</vaadin-item>
+              </vaadin-list-box>
+            `;
+          };
         });
 
         it('basic', async () => {


### PR DESCRIPTION
## Description

Updated unit and visual tests for `vaadin-context-menu` to use `renderer` function instead of `<template>`.

## Type of change

- Tests