### PR TITLE
test: move some unit tests to field-base

### DIFF
--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -30,6 +30,19 @@ const runTests = (baseClass) => {
       await nextFrame();
       expect(element.hasAttribute('invalid')).to.be.true;
     });
+
+    it('should fire invalid-changed event on invalid property change', async () => {
+      const spy = sinon.spy();
+      element.addEventListener('invalid-changed', spy);
+      element.invalid = true;
+      await nextFrame();
+      expect(spy.calledOnce).to.be.true;
+
+      spy.resetHistory();
+      element.invalid = false;
+      await nextFrame();
+      expect(spy.calledOnce).to.be.true;
+    });
   });
 
   describe('checkValidity', () => {

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -532,21 +532,6 @@ describe('radio-group', () => {
       expect(group.invalid).to.be.true;
     });
 
-    it('should dispatch invalid-changed event when invalid changes', async () => {
-      const spy = sinon.spy();
-      group.addEventListener('invalid-changed', spy);
-      group.required = true;
-
-      // Focus on the first radio button.
-      await sendKeys({ press: 'Tab' });
-      // Move focus out of the group.
-      await sendKeys({ down: 'Shift' });
-      await sendKeys({ press: 'Tab' });
-      await sendKeys({ up: 'Shift' });
-
-      expect(spy.calledOnce).to.be.true;
-    });
-
     it('should fire a validated event on validation success', () => {
       const validatedSpy = sinon.spy();
       group.addEventListener('validated', validatedSpy);


### PR DESCRIPTION
## Description

Moved some `radio-group` unit tests to `validate-mixin.test.js` as those tests are actually testing `ValidateMixin`.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
