### PR TITLE
refactor!: set an empty string as default value for min and max

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -14,6 +14,9 @@ import { PatternMixin } from '@vaadin/field-base/src/pattern-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
+const MIN_ALLOWED_TIME = '00:00:00.000';
+const MAX_ALLOWED_TIME = '23:59:59.999';
+
 registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-picker-styles' });
 
 /**
@@ -166,7 +169,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
        */
       min: {
         type: String,
-        value: '00:00:00.000',
+        value: '',
       },
 
       /**
@@ -180,7 +183,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
        */
       max: {
         type: String,
-        value: '23:59:59.999',
+        value: '',
       },
 
       /**
@@ -485,10 +488,10 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
 
   /** @private */
   __updateDropdownItems(i8n, min, max, step) {
-    const minTimeObj = this.__validateTime(this.__parseISO(min));
+    const minTimeObj = this.__validateTime(this.__parseISO(min || MIN_ALLOWED_TIME));
     const minSec = this.__getSec(minTimeObj);
 
-    const maxTimeObj = this.__validateTime(this.__parseISO(max));
+    const maxTimeObj = this.__validateTime(this.__parseISO(max || MAX_ALLOWED_TIME));
     const maxSec = this.__getSec(maxTimeObj);
 
     this.__adjustValue(minSec, maxSec, minTimeObj, maxTimeObj);
@@ -665,8 +668,8 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
    * @protected
    */
   _timeAllowed(time) {
-    const parsedMin = this.i18n.parseTime(this.min);
-    const parsedMax = this.i18n.parseTime(this.max);
+    const parsedMin = this.i18n.parseTime(this.min || MIN_ALLOWED_TIME);
+    const parsedMax = this.i18n.parseTime(this.max || MAX_ALLOWED_TIME);
 
     return (
       (!this.__getMsec(parsedMin) || this.__getMsec(time) >= this.__getMsec(parsedMin)) &&

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -351,12 +351,12 @@ describe('time-picker', () => {
   });
 
   describe('min and max properties', () => {
-    it('min property should be 00:00:00.000 by default', () => {
-      expect(timePicker.min).to.be.equal('00:00:00.000');
+    it('min property should be empty by default', () => {
+      expect(timePicker.min).to.be.equal('');
     });
 
-    it('max property should be 23:59:59.999 by default', () => {
-      expect(timePicker.max).to.be.equal('23:59:59.999');
+    it('max property should be empty by default', () => {
+      expect(timePicker.max).to.be.equal('');
     });
 
     it('should have dropdown items if min nor max is defined', () => {


### PR DESCRIPTION
## Description

This PR sets the default value for the `time-picker` properties `min` and `max` to an empty string. This is needed to prevent `InputConstraintsMixin` from treating these properties as active constraints by default once we declare them in `static get constraints` which will be done in the next PR. 

And, in general, it is not convenient for the user when `min` and `max` have a non-empty default value because then neither `null` nor an empty string can be used to reset them.

> **Warning**
> A minor breaking change

Extracted from https://github.com/vaadin/web-components/pull/4386

Part of https://github.com/vaadin/web-components/issues/4371

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
