### PR TITLE
feat: add more properties to TooltipController

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-controller.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-controller.d.ts
@@ -10,9 +10,42 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  */
 export class TooltipController extends SlotController {
   /**
+   * Object with properties passed to `textGenerator`
+   * function to be used for generating tooltip text.
+   */
+  context: Record<string, unknown>;
+
+  /**
+   * When true, the tooltip is controlled programmatically
+   * instead of reacting to focus and mouse events.
+   */
+  manual: boolean;
+
+  /**
+   * When true, the tooltip is opened programmatically.
+   * Only works if `manual` is set to `true`.
+   */
+  opened: boolean;
+
+  /**
    * An HTML element to attach the tooltip to.
    */
   target: HTMLElement;
+
+  /**
+   * Set a context object to be used by text generator.
+   */
+  setContext(context: Record<string, unknown>): void;
+
+  /**
+   * Toggle manual state on the slotted tooltip.
+   */
+  setManual(manual: boolean): void;
+
+  /**
+   * Toggle opened state on the slotted tooltip.
+   */
+  setOpened(opened: boolean): void;
 
   /**
    * Set an HTML element to attach the tooltip to.

--- a/packages/tooltip/src/vaadin-tooltip-controller.js
+++ b/packages/tooltip/src/vaadin-tooltip-controller.js
@@ -18,6 +18,14 @@ export class TooltipController extends SlotController {
     host.addEventListener('tooltip-target-changed', (e) => {
       this.setTarget(e.detail.target);
     });
+
+    host.addEventListener('tooltip-context-changed', (e) => {
+      this.setContext(e.detail.context);
+    });
+
+    host.addEventListener('tooltip-opened-changed', (e) => {
+      this.setOpened(e.detail.opened);
+    });
   }
 
   /**
@@ -29,6 +37,45 @@ export class TooltipController extends SlotController {
    */
   initCustomNode(tooltipNode) {
     tooltipNode.target = this.target;
+  }
+
+  /**
+   * Set a context object to be used by text generator.
+   * @param {object} context
+   */
+  setContext(context) {
+    this.context = context;
+
+    const tooltipNode = this.node;
+    if (tooltipNode) {
+      tooltipNode.context = context;
+    }
+  }
+
+  /**
+   * Toggle manual state on the slotted tooltip.
+   * @param {boolean} manual
+   */
+  setManual(manual) {
+    this.manual = manual;
+
+    const tooltipNode = this.node;
+    if (tooltipNode) {
+      tooltipNode.manual = manual;
+    }
+  }
+
+  /**
+   * Toggle opened state on the slotted tooltip.
+   * @param {boolean} opened
+   */
+  setOpened(opened) {
+    this.opened = opened;
+
+    const tooltipNode = this.node;
+    if (tooltipNode) {
+      tooltipNode.opened = opened;
+    }
   }
 
   /**

--- a/packages/tooltip/test/tooltip-controller.test.js
+++ b/packages/tooltip/test/tooltip-controller.test.js
@@ -18,7 +18,7 @@ customElements.define(
 );
 
 describe('TooltipController', () => {
-  let host, tooltip;
+  let host, tooltip, controller;
 
   beforeEach(() => {
     host = fixtureSync(`
@@ -28,7 +28,8 @@ describe('TooltipController', () => {
       </tooltip-host>
     `);
     tooltip = host.querySelector('vaadin-tooltip');
-    host.addController(new TooltipController(host));
+    controller = new TooltipController(host);
+    host.addController(controller);
   });
 
   it('should set tooltip target to the host itself by default', () => {
@@ -39,5 +40,47 @@ describe('TooltipController', () => {
     const target = host.querySelector('div');
     host.dispatchEvent(new CustomEvent('tooltip-target-changed', { detail: { target } }));
     expect(tooltip.target).to.eql(target);
+  });
+
+  it('should update tooltip target using controller setTarget method', () => {
+    const target = host.querySelector('div');
+    controller.setTarget(target);
+    expect(tooltip.target).to.eql(target);
+  });
+
+  it('should update tooltip context on tooltip-context-changed event', () => {
+    const context = { foo: 'bar' };
+    host.dispatchEvent(new CustomEvent('tooltip-context-changed', { detail: { context } }));
+    expect(tooltip.context).to.eql(context);
+  });
+
+  it('should update tooltip context using controller setContext method', () => {
+    const context = { foo: 'bar' };
+    controller.setContext(context);
+    expect(tooltip.context).to.eql(context);
+  });
+
+  it('should update tooltip manual using controller setManual method', () => {
+    controller.setManual(true);
+    expect(tooltip.manual).to.be.true;
+
+    controller.setManual(false);
+    expect(tooltip.manual).to.be.false;
+  });
+
+  it('should update tooltip opened on tooltip-opened-changed event', () => {
+    host.dispatchEvent(new CustomEvent('tooltip-opened-changed', { detail: { opened: true } }));
+    expect(tooltip.opened).to.be.true;
+
+    host.dispatchEvent(new CustomEvent('tooltip-opened-changed', { detail: { opened: false } }));
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should update tooltip opened using controller setOpened method', () => {
+    controller.setOpened(true);
+    expect(tooltip.opened).to.be.true;
+
+    controller.setOpened(false);
+    expect(tooltip.opened).to.be.false;
   });
 });


### PR DESCRIPTION
## Description

Added `context`, `manual` and `opened` properties to `TooltipController` with methods to set them.
Also added two events to update `context` and `opened` for using by `vaadin-grid` integration.

## Type of change

- Feature

## Note

This PR is targeting the `tooltip` feature branch, not `master`.