### PR TITLE
refactor: extract loader mixin from combo-box styles

### DIFF
--- a/packages/combo-box/theme/lumo/vaadin-combo-box-dropdown-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-dropdown-styles.js
@@ -2,6 +2,7 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-overlay/theme/lumo/vaadin-overlay.js';
+import { loader } from '@vaadin/vaadin-lumo-styles/mixins/loader.js';
 import { menuOverlayCore } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
 import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -36,10 +37,7 @@ const comboBoxOverlay = css`
     margin-bottom: var(--lumo-space-xs);
   }
 
-  :host([loading]) [part~='loader'] {
-    box-sizing: border-box;
-    width: var(--lumo-icon-size-s);
-    height: var(--lumo-icon-size-s);
+  [part~='loader'] {
     position: absolute;
     z-index: 1;
     left: var(--lumo-space-s);
@@ -48,38 +46,11 @@ const comboBoxOverlay = css`
     margin-left: auto;
     margin-inline-start: auto;
     margin-inline-end: 0;
-    border: 2px solid transparent;
-    border-color: var(--lumo-primary-color-50pct) var(--lumo-primary-color-50pct) var(--lumo-primary-color)
-      var(--lumo-primary-color);
-    border-radius: calc(0.5 * var(--lumo-icon-size-s));
-    opacity: 0;
-    animation: 1s linear infinite lumo-combo-box-loader-rotate, 0.3s 0.1s lumo-combo-box-loader-fade-in both;
-    pointer-events: none;
-  }
-
-  @keyframes lumo-combo-box-loader-fade-in {
-    0% {
-      opacity: 0;
-    }
-
-    100% {
-      opacity: 1;
-    }
-  }
-
-  @keyframes lumo-combo-box-loader-rotate {
-    0% {
-      transform: rotate(0deg);
-    }
-
-    100% {
-      transform: rotate(360deg);
-    }
   }
 
   /* RTL specific styles */
 
-  :host([loading][dir='rtl']) [part~='loader'] {
+  :host([dir='rtl']) [part~='loader'] {
     left: auto;
     margin-left: 0;
     margin-right: auto;
@@ -88,6 +59,6 @@ const comboBoxOverlay = css`
   }
 `;
 
-registerStyles('vaadin-combo-box-overlay', [overlay, menuOverlayCore, comboBoxOverlay], {
+registerStyles('vaadin-combo-box-overlay', [overlay, menuOverlayCore, comboBoxOverlay, loader], {
   moduleId: 'lumo-combo-box-overlay',
 });

--- a/packages/combo-box/theme/material/vaadin-combo-box-dropdown-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-dropdown-styles.js
@@ -1,5 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-overlay/theme/material/vaadin-overlay.js';
+import { loader } from '@vaadin/vaadin-material-styles/mixins/loader.js';
 import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -21,102 +22,15 @@ const comboBoxOverlay = css`
     padding: 0;
   }
 
-  :host([loading]) [part='loader'] {
-    height: 2px;
+  [part~='loader'] {
     position: absolute;
     z-index: 1;
     top: -2px;
     left: 0;
     right: 0;
-    background: var(--material-background-color)
-      linear-gradient(
-        90deg,
-        transparent 0%,
-        transparent 20%,
-        var(--material-primary-color) 20%,
-        var(--material-primary-color) 40%,
-        transparent 40%,
-        transparent 60%,
-        var(--material-primary-color) 60%,
-        var(--material-primary-color) 80%,
-        transparent 80%,
-        transparent 100%
-      )
-      0 0 / 400% 100% repeat-x;
-    opacity: 0;
-    animation: 3s linear infinite material-combo-box-loader-progress, 0.3s 0.1s both material-combo-box-loader-fade-in;
-  }
-
-  [part='loader']::before {
-    content: '';
-    display: block;
-    height: 100%;
-    opacity: 0.16;
-    background: var(--material-primary-color);
-  }
-
-  @keyframes material-combo-box-loader-fade-in {
-    0% {
-      opacity: 0;
-    }
-
-    100% {
-      opacity: 1;
-    }
-  }
-
-  @keyframes material-combo-box-loader-progress {
-    0% {
-      background-position: 0 0;
-      background-size: 300% 100%;
-    }
-
-    33% {
-      background-position: -100% 0;
-      background-size: 400% 100%;
-    }
-
-    67% {
-      background-position: -200% 0;
-      background-size: 250% 100%;
-    }
-
-    100% {
-      background-position: -300% 0;
-      background-size: 300% 100%;
-    }
-  }
-
-  /* RTL specific styles */
-
-  @keyframes material-combo-box-loader-progress-rtl {
-    0% {
-      background-position: 100% 0;
-      background-size: 300% 100%;
-    }
-
-    33% {
-      background-position: 200% 0;
-      background-size: 400% 100%;
-    }
-
-    67% {
-      background-position: 300% 0;
-      background-size: 250% 100%;
-    }
-
-    100% {
-      background-position: 400% 0;
-      background-size: 300% 100%;
-    }
-  }
-
-  :host([loading][dir='rtl']) [part='loader'] {
-    animation: 3s linear infinite material-combo-box-loader-progress-rtl,
-      0.3s 0.1s both material-combo-box-loader-fade-in;
   }
 `;
 
-registerStyles('vaadin-combo-box-overlay', [menuOverlay, comboBoxOverlay], {
+registerStyles('vaadin-combo-box-overlay', [menuOverlay, comboBoxOverlay, loader], {
   moduleId: 'material-combo-box-overlay',
 });

--- a/packages/vaadin-lumo-styles/mixins/loader.d.ts
+++ b/packages/vaadin-lumo-styles/mixins/loader.d.ts
@@ -1,0 +1,3 @@
+import type { CSSResult } from 'lit';
+
+export const loader: CSSResult;

--- a/packages/vaadin-lumo-styles/mixins/loader.js
+++ b/packages/vaadin-lumo-styles/mixins/loader.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright (c) 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '../color.js';
+import '../sizing.js';
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const loader = css`
+  [part~='loader'] {
+    box-sizing: border-box;
+    width: var(--lumo-icon-size-s);
+    height: var(--lumo-icon-size-s);
+    border: 2px solid transparent;
+    border-color: var(--lumo-primary-color-50pct) var(--lumo-primary-color-50pct) var(--lumo-primary-color)
+      var(--lumo-primary-color);
+    border-radius: calc(0.5 * var(--lumo-icon-size-s));
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  :host(:not([loading])) [part~='loader'] {
+    display: none;
+  }
+
+  :host([loading]) [part~='loader'] {
+    animation: 1s linear infinite lumo-loader-rotate, 0.3s 0.1s lumo-loader-fade-in both;
+  }
+
+  @keyframes lumo-loader-fade-in {
+    0% {
+      opacity: 0;
+    }
+
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes lumo-loader-rotate {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+export { loader };

--- a/packages/vaadin-material-styles/mixins/loader.d.ts
+++ b/packages/vaadin-material-styles/mixins/loader.d.ts
@@ -1,0 +1,3 @@
+import type { CSSResult } from 'lit';
+
+export const loader: CSSResult;

--- a/packages/vaadin-material-styles/mixins/loader.js
+++ b/packages/vaadin-material-styles/mixins/loader.js
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright (c) 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '../color.js';
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const loader = css`
+  [part~='loader'] {
+    height: 2px;
+    background: var(--material-background-color)
+      linear-gradient(
+        90deg,
+        transparent 0%,
+        transparent 20%,
+        var(--material-primary-color) 20%,
+        var(--material-primary-color) 40%,
+        transparent 40%,
+        transparent 60%,
+        var(--material-primary-color) 60%,
+        var(--material-primary-color) 80%,
+        transparent 80%,
+        transparent 100%
+      )
+      0 0 / 400% 100% repeat-x;
+    opacity: 0;
+  }
+
+  :host(:not([loading])) [part~='loader'] {
+    display: none;
+  }
+
+  :host([loading]) [part='loader'] {
+    animation: 3s linear infinite material-loader-progress, 0.3s 0.1s both material-loader-fade-in;
+  }
+
+  [part='loader']::before {
+    content: '';
+    display: block;
+    height: 100%;
+    opacity: 0.16;
+    background: var(--material-primary-color);
+  }
+
+  @keyframes material-loader-fade-in {
+    0% {
+      opacity: 0;
+    }
+
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes material-loader-progress {
+    0% {
+      background-position: 0 0;
+      background-size: 300% 100%;
+    }
+
+    33% {
+      background-position: -100% 0;
+      background-size: 400% 100%;
+    }
+
+    67% {
+      background-position: -200% 0;
+      background-size: 250% 100%;
+    }
+
+    100% {
+      background-position: -300% 0;
+      background-size: 300% 100%;
+    }
+  }
+
+  /* RTL specific styles */
+
+  @keyframes material-loader-progress-rtl {
+    0% {
+      background-position: 100% 0;
+      background-size: 300% 100%;
+    }
+
+    33% {
+      background-position: 200% 0;
+      background-size: 400% 100%;
+    }
+
+    67% {
+      background-position: 300% 0;
+      background-size: 250% 100%;
+    }
+
+    100% {
+      background-position: 400% 0;
+      background-size: 300% 100%;
+    }
+  }
+
+  :host([loading][dir='rtl']) [part='loader'] {
+    animation: 3s linear infinite material-loader-progress-rtl, 0.3s 0.1s both material-loader-fade-in;
+  }
+`;
+
+export { loader };


### PR DESCRIPTION
This PR extracts the loading indicator styles used in `<vaadin-combo-box-overlay>` as separate lumo/material mixins so that they can be [reused](https://github.com/vaadin/web-components/commit/3407e98e79d9f90ce50bfe3c176edb01bf93b703) in `<vaadin-tabsheet>`.

Suggested in https://github.com/vaadin/web-components/pull/4391#discussion_r955000311.