### PR TITLE
Fix: increase contrast between spinner halves

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/loader.js
+++ b/packages/vaadin-lumo-styles/mixins/loader.js
@@ -13,7 +13,7 @@ const loader = css`
     width: var(--lumo-icon-size-s);
     height: var(--lumo-icon-size-s);
     border: 2px solid transparent;
-    border-color: var(--lumo-primary-color-50pct) var(--lumo-primary-color-50pct) var(--lumo-primary-color)
+    border-color: var(--lumo-primary-color-10pct) var(--lumo-primary-color-10pct) var(--lumo-primary-color)
       var(--lumo-primary-color);
     border-radius: calc(0.5 * var(--lumo-icon-size-s));
     opacity: 0;


### PR DESCRIPTION
After the color changes in 23, the contrast between the primary and primary-50pct colors is barely noticeable in the spinner.

Use primary-10pct for the other half instead.

<img width="398" alt="Screenshot 2022-08-29 at 13 38 35" src="https://user-images.githubusercontent.com/66382/187183089-58e03a46-0267-4e94-a32a-f484036c9e90.png">
