### PR TITLE
refactor!: ensure initial validation with constraints and value

### DIFF
--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -49,6 +49,15 @@ export class EmailField extends TextField {
     return 'vaadin-email-field';
   }
 
+  static get properties() {
+    return {
+      pattern: {
+        type: String,
+        value: '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-]{2,}$',
+      },
+    };
+  }
+
   constructor() {
     super();
     this._setType('email');
@@ -61,14 +70,6 @@ export class EmailField extends TextField {
     if (this.inputElement) {
       this.inputElement.autocapitalize = 'off';
     }
-  }
-
-  /** @protected */
-  _createConstraintsObserver() {
-    // NOTE: pattern needs to be set before constraints observer is initialized
-    this.pattern = this.pattern || '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-]{2,}$';
-
-    super._createConstraintsObserver();
   }
 }
 

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -49,18 +49,10 @@ export class EmailField extends TextField {
     return 'vaadin-email-field';
   }
 
-  static get properties() {
-    return {
-      pattern: {
-        type: String,
-        value: '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-]{2,}$',
-      },
-    };
-  }
-
   constructor() {
     super();
     this._setType('email');
+    this.pattern = '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-]{2,}$';
   }
 
   /** @protected */

--- a/packages/email-field/test/email-field.test.js
+++ b/packages/email-field/test/email-field.test.js
@@ -84,25 +84,44 @@ describe('email-field', () => {
       field.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(field);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      field.value = 'foo@example.com';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        field.value = 'foo@example.com';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      field.value = 'foo@example.com';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should validate by default', async () => {
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when using a custom pattern', async () => {
+        field.pattern = '.+@example.com';
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should not validate when pattern is unset', async () => {
+        field.pattern = '';
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when pattern is unset and the field has invalid', async () => {
+        field.pattern = '';
+        field.invalid = true;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

This PR ensures initial validation for `email-field` when it has constraints and value. Unlike other components, in the case of `email-field`, it means that the initial validation will always happen initially when it has value since there is a default pattern constraint. 

In case the user wants to control `invalid` manually, the default pattern can be disabled by providing a custom empty pattern:

```html
<vaadin-email-field value="user@example.com" pattern="" invalid></vaadin-email-field>
```

> **Warning**
> It is a kind of breaking change because manual `invalid` control is no longer possible when the field has a value unless the user disables the default pattern explicitly.

Extracted from https://github.com/vaadin/web-components/pull/4386

Part of https://github.com/vaadin/web-components/issues/4371

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
