### PR TITLE
test(text-field): ensure initial validation when the field has constraints and value

### DIFF
--- a/packages/text-field/test/validation.test.js
+++ b/packages/text-field/test/validation.test.js
@@ -16,25 +16,43 @@ describe('validation', () => {
       field.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(field);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      field.value = 'Initial Value';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        field.value = 'Value';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      field.value = 'Initial Value';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate by default', async () => {
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has invalid', async () => {
+        field.invalid = true;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has minlength', async () => {
+        field.minlength = 2;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has maxlength', async () => {
+        field.maxlength = 2;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

This PR adds unit tests that ensure initial validation for `text-field` when it has constraints and value. 

Extracted from https://github.com/vaadin/web-components/pull/4386

Part of https://github.com/vaadin/web-components/issues/4371

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
