### PR TITLE
refactor: use scroller for tabsheet content

### DIFF
--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.2.0-beta3",
+    "@vaadin/scroller": "23.2.0-beta3",
     "@vaadin/tabs": "23.2.0-beta3",
     "@vaadin/vaadin-lumo-styles": "23.2.0-beta3",
     "@vaadin/vaadin-material-styles": "23.2.0-beta3",

--- a/packages/tabsheet/src/vaadin-tabsheet-scroller.js
+++ b/packages/tabsheet/src/vaadin-tabsheet-scroller.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Scroller } from '@vaadin/scroller/src/vaadin-scroller.js';
+
+/**
+ * An element used internally by `<vaadin-tabsheet>`. Not intended to be used separately.
+ *
+ * @extends Scroller
+ * @private
+ */
+class TabsheetScroller extends Scroller {
+  static get is() {
+    return 'vaadin-tabsheet-scroller';
+  }
+}
+
+customElements.define(TabsheetScroller.is, TabsheetScroller);

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/tabs/src/vaadin-tab.js';
+import './vaadin-tabsheet-scroller.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
@@ -90,7 +91,6 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
 
         [part='content'] {
           position: relative;
-          overflow: auto;
           flex: 1;
           box-sizing: border-box;
         }
@@ -102,10 +102,10 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
         <slot name="suffix"></slot>
       </div>
 
-      <div part="content">
+      <vaadin-tabsheet-scroller part="content">
         <div part="loader"></div>
         <slot id="panel-slot"></slot>
-      </div>
+      </vaadin-tabsheet-scroller>
     `;
   }
 

--- a/packages/tabsheet/test/dom/__snapshots__/tabsheet.test.snap.js
+++ b/packages/tabsheet/test/dom/__snapshots__/tabsheet.test.snap.js
@@ -84,12 +84,15 @@ snapshots["vaadin-tabsheet shadow default"] =
   <slot name="suffix">
   </slot>
 </div>
-<div part="content">
+<vaadin-tabsheet-scroller
+  part="content"
+  tabindex="0"
+>
   <div part="loader">
   </div>
   <slot id="panel-slot">
   </slot>
-</div>
+</vaadin-tabsheet-scroller>
 `;
 /* end snapshot vaadin-tabsheet shadow default */
 

--- a/packages/tabsheet/theme/lumo/vaadin-tabsheet.js
+++ b/packages/tabsheet/theme/lumo/vaadin-tabsheet.js
@@ -1,4 +1,5 @@
 import '@vaadin/tabs/theme/lumo/vaadin-tabs.js';
 import '@vaadin/tabs/theme/lumo/vaadin-tab.js';
+import '@vaadin/scroller/theme/lumo/vaadin-scroller.js';
 import './vaadin-tabsheet-styles.js';
 import '../../src/vaadin-tabsheet.js';

--- a/packages/tabsheet/theme/material/vaadin-tabsheet.js
+++ b/packages/tabsheet/theme/material/vaadin-tabsheet.js
@@ -1,4 +1,5 @@
 import '@vaadin/tabs/theme/material/vaadin-tabs.js';
 import '@vaadin/tabs/theme/material/vaadin-tab.js';
+import '@vaadin/scroller/theme/material/vaadin-scroller.js';
 import './vaadin-tabsheet-styles.js';
 import '../../src/vaadin-tabsheet.js';


### PR DESCRIPTION
## Description

The scrollable content area of `<vaadin-tabsheet>` should be keyboard focusable. This PR changes the content element to be a `<vaadin-scroller>` extension.

## Type of change

- Refactor

## Note

This PR is targeting the `feat/tabsheet` feature branch, not `master`.