### PR TITLE
refactor!: ensure initial validation with constraints and value

### DIFF
--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -28,25 +28,43 @@ describe('validation', () => {
       datePicker.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(datePicker);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      datePicker.value = '2020-01-01';
-      document.body.appendChild(datePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        datePicker.value = '2020-01-01';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      datePicker.value = '2020-01-01';
-      datePicker.invalid = true;
-      document.body.appendChild(datePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate without constraints', async () => {
+        document.body.appendChild(datePicker);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without constraints when the field has invalid', async () => {
+        datePicker.invalid = true;
+        document.body.appendChild(datePicker);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has min', async () => {
+        datePicker.min = '2020-01-01';
+        document.body.appendChild(datePicker);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has max', async () => {
+        datePicker.max = '2020-01-01';
+        document.body.appendChild(datePicker);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/packages/integer-field/test/validation.test.js
+++ b/packages/integer-field/test/validation.test.js
@@ -19,25 +19,50 @@ describe('validation', () => {
       integerField.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(integerField);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      integerField.value = '2';
-      document.body.appendChild(integerField);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        integerField.value = '2';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      integerField.value = '2';
-      integerField.invalid = true;
-      document.body.appendChild(integerField);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate without constraints', async () => {
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without constraints when the field has invalid', async () => {
+        integerField.invalid = true;
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has min', async () => {
+        integerField.min = 2;
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has max', async () => {
+        integerField.max = 2;
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has step', async () => {
+        integerField.step = 2;
+        document.body.appendChild(integerField);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -177,25 +177,50 @@ describe('validation', () => {
       field.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(field);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      field.value = '2';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        field.value = '2';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      field.value = '2';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate without constraints', async () => {
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without constraints when the field has invalid', async () => {
+        field.invalid = true;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has min', async () => {
+        field.min = 2;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has max', async () => {
+        field.max = 2;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has step', async () => {
+        field.step = 2;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -27,25 +27,43 @@ describe('validation', () => {
       timePicker.remove();
     });
 
-    it('should not validate by default', async () => {
+    it('should not validate without value', async () => {
       document.body.appendChild(timePicker);
       await nextRender();
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should not validate when the field has an initial value', async () => {
-      timePicker.value = '12:00';
-      document.body.appendChild(timePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
+    describe('with value', () => {
+      beforeEach(() => {
+        timePicker.value = '12:00';
+      });
 
-    it('should not validate when the field has an initial value and invalid', async () => {
-      timePicker.value = '12:00';
-      timePicker.invalid = true;
-      document.body.appendChild(timePicker);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
+      it('should not validate without constraints', async () => {
+        document.body.appendChild(timePicker);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate without constraints when the field has invalid', async () => {
+        timePicker.invalid = true;
+        document.body.appendChild(timePicker);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should validate when the field has min', async () => {
+        timePicker.min = '12:00';
+        document.body.appendChild(timePicker);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
+
+      it('should validate when the field has max', async () => {
+        timePicker.max = '12:00';
+        document.body.appendChild(timePicker);
+        await nextRender();
+        expect(validateSpy.calledOnce).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

This PR ensures initial validation when the field has constraints and value. The following fields are covered in this PR:

- [x] time-picker
- [x] date-picker
- [x] integer-field
- [x] number-field

Extracted from https://github.com/vaadin/web-components/pull/4386

Part of https://github.com/vaadin/web-components/issues/4371

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
