### PR TITLE
refactor: make generating unique controller ID opt-in

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -129,7 +129,7 @@
     "grouped-accessor-pairs": ["error", "getBeforeSet"],
     "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
     "max-classes-per-file": ["error", 3],
-    "max-params": ["error", 4],
+    "max-params": ["error", 5],
     "no-bitwise": "off",
     "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-else-return": "error",

--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -27,6 +27,7 @@ export class SlotController extends EventTarget implements ReactiveController {
     slotName: string,
     slotFactory?: () => HTMLElement,
     slotInitializer?: (host: HTMLElement, node: HTMLElement) => void,
+    useUniqueId?: boolean,
   );
 
   hostConnected(): void;

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -23,14 +23,18 @@ export class SlotController extends EventTarget {
     return `${prefix}-${host.localName}-${generateUniqueId()}`;
   }
 
-  constructor(host, slotName, slotFactory, slotInitializer) {
+  constructor(host, slotName, slotFactory, slotInitializer, useUniqueId) {
     super();
 
     this.host = host;
     this.slotName = slotName;
     this.slotFactory = slotFactory;
     this.slotInitializer = slotInitializer;
-    this.defaultId = SlotController.generateId(slotName, host);
+
+    // Only generate the default ID if requested by the controller.
+    if (useUniqueId) {
+      this.defaultId = SlotController.generateId(slotName, host);
+    }
   }
 
   hostConnected() {

--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -19,6 +19,7 @@ export class ErrorController extends SlotController {
 
         this.__updateHasError();
       },
+      true,
     );
   }
 

--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -11,7 +11,7 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 export class HelperController extends SlotController {
   constructor(host) {
     // Do not provide slot factory, as only create helper lazily.
-    super(host, 'helper');
+    super(host, 'helper', null, null, true);
   }
 
   get helperId() {

--- a/packages/field-base/src/input-controller.js
+++ b/packages/field-base/src/input-controller.js
@@ -29,6 +29,7 @@ export class InputController extends SlotController {
           callback(node);
         }
       },
+      true,
     );
   }
 }

--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -23,6 +23,7 @@ export class LabelController extends SlotController {
 
         this.__observeLabel(node);
       },
+      true,
     );
   }
 

--- a/packages/field-base/src/text-area-controller.js
+++ b/packages/field-base/src/text-area-controller.js
@@ -31,6 +31,7 @@ export class TextAreaController extends SlotController {
           callback(node);
         }
       },
+      true,
     );
   }
 }


### PR DESCRIPTION
## Description

Currently, creating an instance of `SlotController` always generates a unique ID in the constructor.
In practice, this ID is only used by controllers responsible for handling `label`, `helper-text` etc.

Now when we have other controllers e.g. `TooltipController`, this creates problems with snapshots.
Even though the generated ID is actually unused, it still gets reserved, thus increasing the counter.

Updated `SlotController` to add an extra constructor argument to explicitly make this opt-in.

## Type of change

- Refactor