### PR TITLE
fix: add missing field-base dependency to tabsheet

### DIFF
--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.2.0-beta3",
+    "@vaadin/field-base": "23.2.0-beta3",
     "@vaadin/scroller": "23.2.0-beta3",
     "@vaadin/tabs": "23.2.0-beta3",
     "@vaadin/vaadin-lumo-styles": "23.2.0-beta3",


### PR DESCRIPTION
`@vaadin/field-base/src/delegate-state-mixin.js` is used in `vaadin-tabsheet.js`. Add the missing dependency to `@vaadin/field-base`