### PR TITLE
refactor!: ensure initial validation with constraints and value

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -505,6 +505,10 @@ class DateTimePicker extends FieldMixin(
           this.__timePicker = node;
         }
       });
+
+    if (this.value && (this.min || this.max)) {
+      this.validate();
+    }
   }
 
   /** @private */

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -155,25 +155,43 @@ describe('initial validation', () => {
     dateTimePicker.remove();
   });
 
-  it('should not validate by default', async () => {
+  it('should not validate without value', async () => {
     document.body.appendChild(dateTimePicker);
     await nextRender();
     expect(validateSpy.called).to.be.false;
   });
 
-  it('should not validate when the field has an initial value', async () => {
-    dateTimePicker.value = '2020-02-01T02:00';
-    document.body.appendChild(dateTimePicker);
-    await nextRender();
-    expect(validateSpy.called).to.be.false;
-  });
+  describe('with value', () => {
+    beforeEach(() => {
+      dateTimePicker.value = '2020-02-01T02:00';
+    });
 
-  it('should not validate when the field has an initial value and invalid', async () => {
-    dateTimePicker.value = '2020-02-01T02:00';
-    dateTimePicker.invalid = true;
-    document.body.appendChild(dateTimePicker);
-    await nextRender();
-    expect(validateSpy.called).to.be.false;
+    it('should not validate without constraints', async () => {
+      document.body.appendChild(dateTimePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate without constraints when the field has invalid', async () => {
+      dateTimePicker.invalid = true;
+      document.body.appendChild(dateTimePicker);
+      await nextRender();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate when the field has min', async () => {
+      dateTimePicker.min = '2020-02-01T02:00';
+      document.body.appendChild(dateTimePicker);
+      await nextRender();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should validate when the field has max', async () => {
+      dateTimePicker.max = '2020-02-01T02:00';
+      document.body.appendChild(dateTimePicker);
+      await nextRender();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
   });
 });
 


### PR DESCRIPTION
## Description

This PR ensures initial validation when `date-time-picker` has constraints and value.

**Question:** Should it go as a breaking change? It is kind of a breaking change because previously the user could control `invalid` manually even with constraints which becomes no longer possible.

Extracted from https://github.com/vaadin/web-components/pull/4386

Part of https://github.com/vaadin/web-components/issues/4371

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
