### PR TITLE
docs: add tooltip component API docs

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -22,6 +22,30 @@ export type TooltipPosition =
 
 /**
  * `<vaadin-tooltip>` is a Web Component for creating tooltips.
+ *
+ * ```html
+ * <button id="confirm">Confirm</button>
+ * <vaadin-tooltip text="Click to save changes" for="confirm"></vaadin-tooltip>
+ * ```
+ *
+ * ### Styling
+ *
+ * `<vaadin-tooltip>` uses `<vaadin-tooltip-overlay>` internal
+ * themable component as the actual visible overlay.
+ *
+ * See [`<vaadin-overlay>`](#/elements/vaadin-overlay) documentation
+ * for `<vaadin-tooltip-overlay>` parts.
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute        | Description
+ * -----------------|----------------------------------------
+ * `position`       | Reflects the `position` property value.
+ *
+ * Note: the `theme` attribute value set on `<vaadin-tooltip>` is
+ * propagated to the internal `<vaadin-tooltip-overlay>` component.
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  */
 declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   /**

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -25,6 +25,30 @@ let cooldownTimeout = null;
 /**
  * `<vaadin-tooltip>` is a Web Component for creating tooltips.
  *
+ * ```html
+ * <button id="confirm">Confirm</button>
+ * <vaadin-tooltip text="Click to save changes" for="confirm"></vaadin-tooltip>
+ * ```
+ *
+ * ### Styling
+ *
+ * `<vaadin-tooltip>` uses `<vaadin-tooltip-overlay>` internal
+ * themable component as the actual visible overlay.
+ *
+ * See [`<vaadin-overlay>`](#/elements/vaadin-overlay) documentation
+ * for `<vaadin-tooltip-overlay>` parts.
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute        | Description
+ * -----------------|----------------------------------------
+ * `position`       | Reflects the `position` property value.
+ *
+ * Note: the `theme` attribute value set on `<vaadin-tooltip>` is
+ * propagated to the internal `<vaadin-tooltip-overlay>` component.
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
+ *
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemePropertyMixin


### PR DESCRIPTION
## Description

Added missing API documentation for `vaadin-tooltip` web component.

## Type of change

- Docs

## Note

This PR is targeting the `tooltip` feature branch, not `master`.