### PR TITLE
refactor: move TooltipController to component-base

### DIFF
--- a/packages/component-base/src/tooltip-controller.d.ts
+++ b/packages/component-base/src/tooltip-controller.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { SlotController } from './slot-controller.js';
 
 /**
  * A controller that manages the slotted tooltip element.

--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { SlotController } from './slot-controller.js';
 
 /**
  * A controller that manages the slotted tooltip element.

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -1,9 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-tooltip.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { TooltipController } from '../src/vaadin-tooltip-controller.js';
+import { ControllerMixin } from '../src/controller-mixin.js';
+import { TooltipController } from '../src/tooltip-controller.js';
 
 customElements.define(
   'tooltip-host',


### PR DESCRIPTION
## Description

Moved the `TooltipController` from the original `tooltip` package to `component-base` package.
This is needed to avoid having dependency on `tooltip` in all components that support it.

Note: while controller unit tests use `vaadin-tooltip`, they do not rely on its internal logic.
So IMO it's ok to not import the tooltip in controller tests, to avoid circular dependency.

## Type of change

- Refactor

## Note

This PR is targeting the `tooltip` feature branch, not `master`.