### PR TITLE
feat: add setPosition API to TooltipController

### DIFF
--- a/packages/component-base/src/tooltip-controller.d.ts
+++ b/packages/component-base/src/tooltip-controller.d.ts
@@ -5,6 +5,20 @@
  */
 import { SlotController } from './slot-controller.js';
 
+type TooltipPosition =
+  | 'bottom-end'
+  | 'bottom-start'
+  | 'bottom'
+  | 'end-bottom'
+  | 'end-top'
+  | 'end'
+  | 'start-bottom'
+  | 'start-top'
+  | 'start'
+  | 'top-end'
+  | 'top-start'
+  | 'top';
+
 /**
  * A controller that manages the slotted tooltip element.
  */
@@ -28,6 +42,11 @@ export class TooltipController extends SlotController {
   opened: boolean;
 
   /**
+   * Position of the tooltip with respect to its target.
+   */
+  position: TooltipPosition;
+
+  /**
    * An HTML element to attach the tooltip to.
    */
   target: HTMLElement;
@@ -46,6 +65,11 @@ export class TooltipController extends SlotController {
    * Toggle opened state on the slotted tooltip.
    */
   setOpened(opened: boolean): void;
+
+  /**
+   * Set position on the slotted tooltip.
+   */
+  setPosition(position: TooltipPosition): void;
 
   /**
    * Set an HTML element to attach the tooltip to.

--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -67,6 +67,19 @@ export class TooltipController extends SlotController {
   }
 
   /**
+   * Set position on the slotted tooltip.
+   * @param {string} position
+   */
+  setPosition(position) {
+    this.position = position;
+
+    const tooltipNode = this.node;
+    if (tooltipNode) {
+      tooltipNode.position = position;
+    }
+  }
+
+  /**
    * Set an HTML element to attach the tooltip to.
    * @param {HTMLElement} target
    */

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -63,7 +63,7 @@ describe('TooltipController', () => {
     expect(tooltip.opened).to.be.false;
   });
 
-  it('should update position target using controller setPosition method', () => {
+  it('should update tooltip position using controller setPosition method', () => {
     controller.setPosition('top-start');
     expect(tooltip.position).to.eql('top-start');
   });

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -62,4 +62,9 @@ describe('TooltipController', () => {
     controller.setOpened(false);
     expect(tooltip.opened).to.be.false;
   });
+
+  it('should update position target using controller setPosition method', () => {
+    controller.setPosition('top-start');
+    expect(tooltip.position).to.eql('top-start');
+  });
 });


### PR DESCRIPTION
## Description

In some components we might want to customize the tooltip position to use non-default value.
Example: in `vaadin-details`, it makes sense to use `bottom-start` for better appearance:

![Screenshot 2022-09-01 at 11 42 15](https://user-images.githubusercontent.com/10589913/187871679-5948bcd6-8589-4de0-baa1-3e1ef62fb05b.png)

## Type of change

- Feature

## Note

This PR is targeting the `tooltip` feature branch, not `master`.