### PR TITLE
chore: update change detection branch to 23.2

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -40,7 +40,7 @@ const hasAllParam = process.argv.includes('--all');
  * Check if lockfile has changed.
  */
 const isLockfileChanged = () => {
-  const log = execSync('git diff --name-only origin/master HEAD').toString();
+  const log = execSync('git diff --name-only origin/23.2 HEAD').toString();
   return log.split('\n').some((line) => line.includes('yarn.lock'));
 };
 
@@ -48,7 +48,7 @@ const isLockfileChanged = () => {
  * Get packages changed since master.
  */
 const getChangedPackages = () => {
-  const output = execSync('./node_modules/.bin/lerna la --since origin/master --json --loglevel silent');
+  const output = execSync('./node_modules/.bin/lerna la --since origin/23.2 --json --loglevel silent');
   return JSON.parse(output.toString()).map((project) => project.name.replace('@vaadin/', ''));
 };
 


### PR DESCRIPTION
## Description

Update the `web-test-runner` change detection script to use `23.2` as a base branch for Vaadin 23.2

## Type of change

- Internal change