### PR TITLE
feat: propagate tabsheet theme to the slotted tabs

### DIFF
--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -157,7 +157,7 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
 
   /** @override */
   static get delegateProps() {
-    return ['selected'];
+    return ['selected', 'theme'];
   }
 
   /** @protected */

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -157,7 +157,12 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
 
   /** @override */
   static get delegateProps() {
-    return ['selected', 'theme'];
+    return ['selected'];
+  }
+
+  /** @override */
+  static get delegateAttrs() {
+    return ['theme'];
   }
 
   /** @protected */

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -303,11 +303,8 @@ describe('tabsheet', () => {
       tabsheet.setAttribute('theme', 'foo');
       tabs.remove();
 
-      const newTabs = tabsheet.appendChild(
-        Object.assign(document.createElement('vaadin-tabs'), {
-          slot: 'tabs',
-        }),
-      );
+      const newTabs = fixtureSync(`<vaadin-tabs slot="tabs"></vaadin-tabs>`);
+      tabsheet.appendChild(newTabs);
       await nextFrame();
       expect(newTabs.getAttribute('theme')).to.equal('foo');
     });

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -286,4 +286,28 @@ describe('tabsheet', () => {
       expect(tabsheet.getAttribute('overflow')).to.equal('top');
     });
   });
+
+  describe('theme propagation', () => {
+    it('should set the theme attribute to the slotted tabs', () => {
+      tabsheet.setAttribute('theme', 'foo');
+      expect(tabs.getAttribute('theme')).to.equal('foo');
+    });
+
+    it('should remove the theme attribute to the slotted tabs', () => {
+      tabsheet.setAttribute('theme', 'foo');
+      tabsheet.removeAttribute('theme');
+      expect(tabs.hasAttribute('theme')).to.be.false;
+    });
+
+    it('set the theme attribute to newly added tabs', async () => {
+      tabsheet.setAttribute('theme', 'foo');
+      tabs.remove();
+
+      const newTabs = document.createElement('vaadin-tabs');
+      newTabs.setAttribute('slot', 'tabs');
+      tabsheet.appendChild(newTabs);
+      await nextFrame();
+      expect(newTabs.getAttribute('theme')).to.equal('foo');
+    });
+  });
 });

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -299,13 +299,15 @@ describe('tabsheet', () => {
       expect(tabs.hasAttribute('theme')).to.be.false;
     });
 
-    it('set the theme attribute to newly added tabs', async () => {
+    it('should set the theme attribute to newly added tabs', async () => {
       tabsheet.setAttribute('theme', 'foo');
       tabs.remove();
 
-      const newTabs = document.createElement('vaadin-tabs');
-      newTabs.setAttribute('slot', 'tabs');
-      tabsheet.appendChild(newTabs);
+      const newTabs = tabsheet.appendChild(
+        Object.assign(document.createElement('vaadin-tabs'), {
+          slot: 'tabs',
+        }),
+      );
       await nextFrame();
       expect(newTabs.getAttribute('theme')).to.equal('foo');
     });


### PR DESCRIPTION
## Description

Automatically propagate the `theme` of `<vaadin-tabsheet>` to the slotted `<vaadin-tabs>`

## Type of change

- Feature

## Note

This PR is targeting the `feat/tabsheet` feature branch, not `master`.