### PR TITLE
docs: add missing attribute JSDoc annotation

### DIFF
--- a/packages/avatar/src/vaadin-avatar.d.ts
+++ b/packages/avatar/src/vaadin-avatar.d.ts
@@ -57,6 +57,7 @@ declare class Avatar extends FocusMixin(ElementMixin(ThemableMixin(HTMLElement))
 
   /**
    * Color index used for avatar background.
+   * @attr {number} color-index
    */
   colorIndex: number | null | undefined;
 

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -158,6 +158,7 @@ class Avatar extends FocusMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
       /**
        * Color index used for avatar background.
+       * @attr {number} color-index
        */
       colorIndex: {
         type: Number,


### PR DESCRIPTION
## Description

Added `@attr` annotation needed for VSCode Lit plugin autocomplete to use correct attribute name.
Currently, it suggests `colorIndex`, while correct suggestions are `.colorIndex` and `color-index`.
 
![Screenshot 2022-09-02 at 11 55 00](https://user-images.githubusercontent.com/10589913/188103351-35fa4c59-ea76-426d-ba62-5b1656008543.png)

## Type of change

- Documentation