### PR TITLE
docs: update vaadin-tabs JSDoc description

### DIFF
--- a/packages/tabs/src/vaadin-tabs.d.ts
+++ b/packages/tabs/src/vaadin-tabs.d.ts
@@ -29,7 +29,7 @@ export interface TabsCustomEventMap {
 export interface TabsEventMap extends HTMLElementEventMap, TabsCustomEventMap {}
 
 /**
- * `<vaadin-tabs>` is a Web Component for easy switching between different views.
+ * `<vaadin-tabs>` is a Web Component for organizing and grouping content into sections.
  *
  * ```
  *   <vaadin-tabs selected="4">

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -12,7 +12,7 @@ import { ListMixin } from '@vaadin/vaadin-list-mixin/vaadin-list-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * `<vaadin-tabs>` is a Web Component for easy switching between different views.
+ * `<vaadin-tabs>` is a Web Component for organizing and grouping content into sections.
  *
  * ```
  *   <vaadin-tabs selected="4">


### PR DESCRIPTION
## Description

Changed the description to be aligned with the README and [component documentation](https://vaadin.com/docs/latest/components/tabs).
Removed mention of "switching between views" as we don't recommend `vaadin-tabs` for app navigation.

## Type of change

- Documentation