### PR TITLE
test: move grid focus-trap test to integration

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -7,6 +7,7 @@
   "author": "Vaadin Ltd",
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/button": "23.3.0-alpha0",
     "@vaadin/accordion": "23.3.0-alpha0",
     "@vaadin/combo-box": "23.3.0-alpha0",
     "@vaadin/details": "23.3.0-alpha0",
@@ -18,6 +19,7 @@
     "@vaadin/tooltip": "23.3.0-alpha0",
     "@vaadin/testing-helpers": "^0.3.2",
     "@vaadin/time-picker": "23.3.0-alpha0",
+    "@vaadin/vaadin-overlay": "23.3.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "23.3.0-alpha0",
     "sinon": "^13.0.2"
   }

--- a/integration/tests/grid-overlay-focus-trap.test.js
+++ b/integration/tests/grid-overlay-focus-trap.test.js
@@ -2,9 +2,9 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '@vaadin/button';
+import '@vaadin/grid';
 import '@vaadin/vaadin-overlay';
-import '../vaadin-grid.js';
-import { flushGrid } from './helpers.js';
+import { flushGrid } from '@vaadin/grid/test/helpers.js';
 
 describe('overlay focus-trap', () => {
   let overlay, grid, button;


### PR DESCRIPTION
## Description

Moved the test added in https://github.com/vaadin/web-components/pull/3480 for `vaadin-grid` inside of the `vaadin-overlay` to integration tests.

## Type of change

- Tests