### PR TITLE
feat: add tooltip support to vaadin-button

### DIFF
--- a/dev/button.html
+++ b/dev/button.html
@@ -4,15 +4,19 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Button</title>
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/button';
+      import '@vaadin/tooltip';
     </script>
   </head>
 
   <body>
-    <vaadin-button>Click me</vaadin-button>
+    <vaadin-button>
+      Edit
+      <vaadin-tooltip slot="tooltip" text="Click to edit"></vaadin-tooltip>
+    </vaadin-button>
   </body>
 </html>

--- a/integration/tests/button-tooltip.test.js
+++ b/integration/tests/button-tooltip.test.js
@@ -1,0 +1,22 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '@vaadin/button';
+import '@vaadin/tooltip';
+
+describe('button with tooltip', () => {
+  let button, tooltip;
+
+  beforeEach(() => {
+    button = fixtureSync(`
+      <vaadin-button>
+        Edit
+        <vaadin-tooltip slot="tooltip" text="Click to edit"></vaadin-tooltip>
+      </vaadin-button>
+    `);
+    tooltip = button.querySelector('vaadin-tooltip');
+  });
+
+  it('should set tooltip target as button host element', () => {
+    expect(tooltip.target).to.equal(button);
+  });
+});

--- a/packages/app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle.js
@@ -59,6 +59,7 @@ class DrawerToggle extends Button {
       <slot>
         <div part="icon"></div>
       </slot>
+      <slot name="tooltip"></slot>
     `;
   }
 

--- a/packages/button/src/vaadin-button.d.ts
+++ b/packages/button/src/vaadin-button.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ButtonMixin } from './vaadin-button-mixin.js';
@@ -35,7 +36,7 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  */
-declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(HTMLElement))) {}
+declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -4,7 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ButtonMixin } from './vaadin-button-mixin.js';
 
@@ -38,10 +40,11 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  *
  * @extends HTMLElement
  * @mixes ButtonMixin
+ * @mixes ControllerMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolymerElement))) {
+class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-button';
   }
@@ -105,7 +108,16 @@ class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolymerElement))) {
           <slot name="suffix"></slot>
         </span>
       </div>
+      <slot name="tooltip"></slot>
     `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
   }
 }
 

--- a/packages/button/test/dom/__snapshots__/button.test.snap.js
+++ b/packages/button/test/dom/__snapshots__/button.test.snap.js
@@ -92,6 +92,8 @@ snapshots["vaadin-button shadow default"] =
     </slot>
   </span>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-button shadow default */
 

--- a/packages/crud/src/vaadin-crud-edit.js
+++ b/packages/crud/src/vaadin-crud-edit.js
@@ -26,6 +26,7 @@ class CrudEdit extends Button {
         }
       </style>
       <div part="icon"></div>
+      <slot name="tooltip"></slot>
     `;
   }
 

--- a/packages/password-field/src/vaadin-password-field-button.js
+++ b/packages/password-field/src/vaadin-password-field-button.js
@@ -28,6 +28,7 @@ class PasswordFieldButton extends Button {
           display: none !important;
         }
       </style>
+      <slot name="tooltip"></slot>
     `;
   }
 }


### PR DESCRIPTION
## Description

Added `vaadin-tooltip` support to `vaadin-button` via `tooltip` slot and `TooltipController`.

Note, because of how `SlotController` works, I had to add `tooltip` slot to all components that extend `Button`.
This means that e.g. `vaadin-drawer-toggle` also gets support for the tooltip, which is probably expected.

## Type of change

- Feature