### PR TITLE
chore: do not reflect selected as tabsheet attribute

### DIFF
--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -176,7 +176,6 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
       selected: {
         value: 0,
         type: Number,
-        reflectToAttribute: true,
         notify: true,
       },
 

--- a/packages/tabsheet/test/dom/__snapshots__/tabsheet.test.snap.js
+++ b/packages/tabsheet/test/dom/__snapshots__/tabsheet.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["vaadin-tabsheet host default"] = 
-`<vaadin-tabsheet selected="0">
+`<vaadin-tabsheet>
   <div slot="prefix">
     Prefix
   </div>

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -81,10 +81,6 @@ describe('tabsheet', () => {
       expect(tabsheet.items[0].selected).to.be.true;
     });
 
-    it('should reflect selected property to attribute', () => {
-      expect(tabsheet.hasAttribute('selected')).to.be.true;
-    });
-
     it('should update selected to new index when other tab is selected', () => {
       tabs.items[1].click();
       expect(tabsheet.items[1].selected).to.be.true;


### PR DESCRIPTION
There's no need to reflect `selected` as an attribute of `<vaadin-tabsheet>`.