### PR TITLE
fix: handle toggling visibility when recalculating column widths

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -605,6 +605,11 @@ class Grid extends ElementMixin(
     // Flush to make sure DOM is up-to-date when measuring the column widths
     this.__virtualizer.flush();
 
+    // Flush to account for any changes to the visibility of the columns
+    if (this._debouncerHiddenChanged) {
+      this._debouncerHiddenChanged.flush();
+    }
+
     cols.forEach((col) => {
       col.width = `${this.__getDistributedWidth(col)}px`;
     });

--- a/packages/grid/test/column-auto-width.test.js
+++ b/packages/grid/test/column-auto-width.test.js
@@ -120,8 +120,6 @@ describe('column auto-width', () => {
 
     await nextFrame();
 
-    spy.resetHistory();
-    expect(grid._recalculateColumnWidths.called).to.be.false;
 
     columns[1].hidden = false;
     grid.recalculateColumnWidths();

--- a/packages/grid/test/column-auto-width.test.js
+++ b/packages/grid/test/column-auto-width.test.js
@@ -119,8 +119,6 @@ describe('column auto-width', () => {
     columns[1].hidden = true;
 
     await nextFrame();
-
-
     columns[1].hidden = false;
     grid.recalculateColumnWidths();
 

--- a/packages/grid/test/column-auto-width.test.js
+++ b/packages/grid/test/column-auto-width.test.js
@@ -114,6 +114,22 @@ describe('column auto-width', () => {
     expectColumnWidthsToBeOk(columns);
   });
 
+  it('should have correct column widths once an invisible column is made visible', async () => {
+    grid.items = testItems;
+    columns[1].hidden = true;
+
+    await nextFrame();
+
+    spy.resetHistory();
+    expect(grid._recalculateColumnWidths.called).to.be.false;
+
+    columns[1].hidden = false;
+    grid.recalculateColumnWidths();
+
+    await recalculateWidths();
+    expectColumnWidthsToBeOk(columns);
+  });
+
   it('should have correct column widths when using renderers', async () => {
     columns[0].renderer = function (root, column, model) {
       root.textContent = model.index;


### PR DESCRIPTION
## Description
When called after toggling visibility, `recalculateColumnWidths` calculates the new widths before the visibility changes are applied and the columns are rendered again. 

In order to make sure that the changes in visibility are applied before the width calculations, `debouncerHiddenChanged` is flushed when `recalculateColumnWidths` is called.

Fixes https://github.com/vaadin/flow-components/issues/2848

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.