### PR TITLE
docs: add missing attribute JSDoc annotation

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group.d.ts
@@ -95,6 +95,7 @@ declare class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(HTMLEle
    * The maximum number of avatars to display. By default, all the avatars are displayed.
    * When _maxItemsVisible_ is set, the overflowing avatars are grouped into one avatar with
    * a dropdown. Setting 0 or 1 has no effect so there are always at least two avatars visible.
+   * @attr {number} max-items-visible
    */
   maxItemsVisible: number | null | undefined;
 

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -201,6 +201,7 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement)
        * The maximum number of avatars to display. By default, all the avatars are displayed.
        * When _maxItemsVisible_ is set, the overflowing avatars are grouped into one avatar with
        * a dropdown. Setting 0 or 1 has no effect so there are always at least two avatars visible.
+       * @attr {number} max-items-visible
        */
       maxItemsVisible: {
         type: Number,


### PR DESCRIPTION
## Description

Same as #4440 but for `maxItemsVisible` property in `vaadin-avatar-group`.

## Type of change

- Documentation