### PR TITLE
feat: add shouldShow to show tooltip conditionally

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -109,6 +109,14 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   position: TooltipPosition;
 
   /**
+   * Function used to detect whether to show the tooltip based on a condition,
+   * called every time the tooltip is about to be shown on hover and focus.
+   * The function accepts a reference to the target element as a parameter.
+   * The tooltip is only shown when the function invocation returns `true`.
+   */
+  shouldShow: (target: HTMLElement) => boolean;
+
+  /**
    * Reference to the element used as a tooltip trigger.
    * The target must be placed in the same shadow scope.
    * Defaults to an element referenced with `for`.

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -154,6 +154,19 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       },
 
       /**
+       * Function used to detect whether to show the tooltip based on a condition,
+       * called every time the tooltip is about to be shown on hover and focus.
+       * The function accepts a reference to the target element as a parameter.
+       * The tooltip is only shown when the function invocation returns `true`.
+       */
+      shouldShow: {
+        type: Object,
+        value: () => {
+          return (_target) => true;
+        },
+      },
+
+      /**
        * Reference to the element used as a tooltip trigger.
        * The target must be placed in the same shadow scope.
        * Defaults to an element referenced with `for`.
@@ -332,6 +345,10 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       return;
     }
 
+    if (typeof this.shouldShow === 'function' && this.shouldShow(this.target) !== true) {
+      return;
+    }
+
     this.__focusInside = true;
 
     if (!this.__hoverInside || !this._autoOpened) {
@@ -363,6 +380,10 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
   /** @private */
   __onMouseEnter() {
+    if (typeof this.shouldShow === 'function' && this.shouldShow(this.target) !== true) {
+      return;
+    }
+
     this.__hoverInside = true;
 
     if (!this.__focusInside || !this._autoOpened) {

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -331,6 +331,70 @@ describe('vaadin-tooltip', () => {
     });
   });
 
+  describe('shouldShow', () => {
+    let target;
+
+    beforeEach(() => {
+      target = fixtureSync('<input>');
+      tooltip.target = target;
+    });
+
+    it('should not open overlay on mouseenter when shouldShow returns false', () => {
+      tooltip.shouldShow = (target) => !target.readOnly;
+      target.readOnly = true;
+
+      mouseenter(target);
+
+      expect(overlay.opened).to.be.not.ok;
+    });
+
+    it('should not open overlay on keyboard focus when shouldShow returns false', () => {
+      tooltip.shouldShow = (target) => !target.readOnly;
+      target.readOnly = true;
+
+      tabKeyDown(target);
+      target.focus();
+
+      expect(overlay.opened).to.be.not.ok;
+    });
+
+    it('should open overlay on mouseenter when shouldShow returns true', () => {
+      tooltip.shouldShow = (target) => target.readOnly;
+      target.readOnly = true;
+
+      mouseenter(target);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open overlay on keyboard focus when shouldShow returns true', () => {
+      tooltip.shouldShow = (target) => target.readOnly;
+      target.readOnly = true;
+
+      tabKeyDown(target);
+      target.focus();
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open overlay on mouseenter when shouldShow is set to null', () => {
+      tooltip.shouldShow = null;
+
+      mouseenter(target);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not open overlay on keyboard focus when shouldShow is set to null', () => {
+      tooltip.shouldShow = null;
+
+      tabKeyDown(target);
+      target.focus();
+
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
   describe('manual', () => {
     let target;
 

--- a/packages/tooltip/test/typings/tooltip.types.ts
+++ b/packages/tooltip/test/typings/tooltip.types.ts
@@ -20,3 +20,4 @@ assertType<(context: Record<string, unknown>) => string>(tooltip.textGenerator);
 assertType<boolean>(tooltip.manual);
 assertType<boolean>(tooltip.opened);
 assertType<TooltipPosition>(tooltip.position);
+assertType<(target: HTMLElement) => boolean>(tooltip.shouldShow);


### PR DESCRIPTION
## Description

Fixes #4473

Added property to control whether to show the tooltip based on the condition.
Note: this will be also added to `TooltipController` in a separate PR.

## Type of change

- Feature