### PR TITLE
fix: do not validate when focus is moving inside the field

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -414,12 +414,6 @@ class DateTimePicker extends FieldMixin(
   ready() {
     super.ready();
 
-    this.addEventListener('focusout', (e) => {
-      if (e.relatedTarget !== this.__datePicker.$.overlay) {
-        this.validate();
-      }
-    });
-
     this.__datePicker = this._getDirectSlotChild('date-picker');
     this.__timePicker = this._getDirectSlotChild('time-picker');
 
@@ -434,6 +428,20 @@ class DateTimePicker extends FieldMixin(
 
   focus() {
     this.__datePicker.focus();
+  }
+
+  /**
+   * Override method inherited from `FocusMixin` to validate on blur.
+   * @param {boolean} focused
+   * @protected
+   * @override
+   */
+  _setFocused(focused) {
+    super._setFocused(focused);
+
+    if (!focused) {
+      this.validate();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

This PR prevents `date-time-picker` from being validated when focus is moving inside it, for example, between child pickers.  The field should be only validated when focus moves away.

Fixes #4461

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
