### PR TITLE
feat: add setShouldShow to TooltipController

### DIFF
--- a/packages/component-base/src/tooltip-controller.d.ts
+++ b/packages/component-base/src/tooltip-controller.d.ts
@@ -72,6 +72,12 @@ export class TooltipController extends SlotController {
   setPosition(position: TooltipPosition): void;
 
   /**
+   * Set function used to detect whether to show
+   * the tooltip based on a condition.
+   */
+  setShouldShow(shouldShow: (target: HTMLElement) => boolean): void;
+
+  /**
    * Set an HTML element to attach the tooltip to.
    */
   setTarget(target: HTMLElement): void;

--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -41,6 +41,10 @@ export class TooltipController extends SlotController {
     if (this.position !== undefined) {
       tooltipNode.position = this.position;
     }
+
+    if (this.shouldShow !== undefined) {
+      tooltipNode.shouldShow = this.shouldShow;
+    }
   }
 
   /**
@@ -92,6 +96,20 @@ export class TooltipController extends SlotController {
     const tooltipNode = this.node;
     if (tooltipNode) {
       tooltipNode.position = position;
+    }
+  }
+
+  /**
+   * Set function used to detect whether to show
+   * the tooltip based on a condition.
+   * @param {Function} shouldShow
+   */
+  setShouldShow(shouldShow) {
+    this.shouldShow = shouldShow;
+
+    const tooltipNode = this.node;
+    if (tooltipNode) {
+      tooltipNode.shouldShow = shouldShow;
     }
   }
 

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -64,6 +64,12 @@ describe('TooltipController', () => {
       expect(tooltip.opened).to.be.false;
     });
 
+    it('should update tooltip shouldShow using controller shouldShow method', () => {
+      const shouldShow = () => true;
+      controller.setShouldShow(shouldShow);
+      expect(tooltip.shouldShow).to.be.eql(shouldShow);
+    });
+
     it('should update tooltip position using controller setPosition method', () => {
       controller.setPosition('top-start');
       expect(tooltip.position).to.eql('top-start');
@@ -132,6 +138,16 @@ describe('TooltipController', () => {
 
       controller.setOpened(false);
       expect(tooltip.opened).to.be.false;
+    });
+
+    it('should update lazy tooltip shouldShow using controller shouldShow method', async () => {
+      const shouldShow = () => true;
+      controller.setShouldShow(shouldShow);
+
+      host.appendChild(tooltip);
+      await nextFrame();
+
+      expect(tooltip.shouldShow).to.be.eql(shouldShow);
     });
 
     it('should update lazy tooltip position using controller setPosition method', async () => {


### PR DESCRIPTION
## Description

Follow-up to #4476: added `setShouldShow()` method to `TooltipController` for using by component integrations.

## Type of change

- Feature