### PR TITLE
test: disable animations in time-picker tests

### DIFF
--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { enter, fixtureSync } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
 import '../vaadin-time-picker.js';
 import { setInputValue } from './helpers.js';
 

--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDown, arrowUp, aTimeout, esc, fixtureSync } from '@vaadin/testing-helpers';
+import { arrowDown, arrowUp, esc, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
+import './not-animated-styles.js';
 import '../vaadin-time-picker.js';
 
 describe('keyboard navigation', () => {
@@ -10,13 +11,6 @@ describe('keyboard navigation', () => {
     timePicker = fixtureSync(`<vaadin-time-picker></vaadin-time-picker>`);
     comboBox = timePicker.$.comboBox;
     inputElement = timePicker.inputElement;
-  });
-
-  afterEach(async () => {
-    if (comboBox.opened) {
-      comboBox.opened = false;
-      await aTimeout(50);
-    }
   });
 
   describe('with invalid step', () => {

--- a/packages/time-picker/test/not-animated-styles.js
+++ b/packages/time-picker/test/not-animated-styles.js
@@ -1,0 +1,13 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-time-picker-overlay',
+  css`
+    :host([opening]),
+    :host([closing]),
+    :host([opening]) [part='overlay'],
+    :host([closing]) [part='overlay'] {
+      animation: none !important;
+    }
+  `,
+);

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { arrowDown, arrowUp, enter, esc, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
+import './not-animated-styles.js';
 import '../vaadin-time-picker.js';
 import { outsideClick, setInputValue } from './helpers.js';
 


### PR DESCRIPTION
## Description

Added missing `not-animated-styles.js` import to ensure the time-picker overlay is closed synchronously in tests.

## Type of change

- Tests