### PR TITLE
refactor: cleanup validation methods typings

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -189,13 +189,4 @@ export declare class DatePickerMixinClass {
    * Closes the dropdown.
    */
   close(): void;
-
-  /**
-   * Returns true if the current input value satisfies all constraints (if any)
-   *
-   * Override the `checkValidity` method for custom validations.
-   *
-   * @returns True if the value is valid
-   */
-  checkValidity(): boolean;
 }

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -192,17 +192,6 @@ declare class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(El
    */
   i18n: TimePickerI18n;
 
-  /**
-   * Returns true if `value` is valid, and sets the `invalid` flag appropriately.
-   */
-  validate(): boolean;
-
-  /**
-   * Returns true if the current input value satisfies all constraints (if any).
-   * You can override this method for custom validations.
-   */
-  checkValidity(): boolean;
-
   addEventListener<K extends keyof TimePickerEventMap>(
     type: K,
     listener: (this: TimePicker, ev: TimePickerEventMap[K]) => void,

--- a/packages/time-picker/test/typings/time-picker.types.ts
+++ b/packages/time-picker/test/typings/time-picker.types.ts
@@ -3,6 +3,7 @@ import type { ControllerMixinClass } from '@vaadin/component-base/src/controller
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type {
   TimePicker,
@@ -21,6 +22,7 @@ assertType<ControllerMixinClass>(timePicker);
 assertType<ElementMixinClass>(timePicker);
 assertType<InputControlMixinClass>(timePicker);
 assertType<PatternMixinClass>(timePicker);
+assertType<ValidateMixinClass>(timePicker);
 assertType<ThemableMixinClass>(timePicker);
 
 // Events


### PR DESCRIPTION
## Description

There is no need to re-declare `validate()` and `checkValidity()` methods as they are declared in `ValidateMixin`.

## Type of change

- Refactor