### PR TITLE
feat: add tooltip support to number-field based fields

### DIFF
--- a/dev/integer-field.html
+++ b/dev/integer-field.html
@@ -9,10 +9,13 @@
 
     <script type="module">
       import '@vaadin/integer-field';
+      import '@vaadin/tooltip';
     </script>
   </head>
 
   <body>
-    <vaadin-integer-field label="Quantity"></vaadin-integer-field>
+    <vaadin-integer-field label="Quantity" value="5" has-controls>
+      <vaadin-tooltip slot="tooltip" text="Integer field tooltip text"></vaadin-tooltip>
+    </vaadin-integer-field>
   </body>
 </html>

--- a/dev/number-field.html
+++ b/dev/number-field.html
@@ -9,10 +9,13 @@
 
     <script type="module">
       import '@vaadin/number-field';
+      import '@vaadin/tooltip';
     </script>
   </head>
 
   <body>
-    <vaadin-number-field label="Required" required></vaadin-number-field>
+    <vaadin-number-field value="2.1" step="0.1" label="Size (kg)" has-controls>
+      <vaadin-tooltip slot="tooltip" text="Number field tooltip text"></vaadin-tooltip>
+    </vaadin-number-field>
   </body>
 </html>

--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -6,6 +6,8 @@ import { Checkbox } from '@vaadin/checkbox';
 import { ComboBox } from '@vaadin/combo-box';
 import { Details } from '@vaadin/details';
 import { EmailField } from '@vaadin/email-field';
+import { IntegerField } from '@vaadin/integer-field';
+import { NumberField } from '@vaadin/number-field';
 import { PasswordField } from '@vaadin/password-field';
 import { Select } from '@vaadin/select';
 import { Tab } from '@vaadin/tabs/vaadin-tab.js';
@@ -19,6 +21,8 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
   { tagName: ComboBox.is, applyShouldNotShowCondition: (comboBox) => comboBox.click() },
   { tagName: Details.is, targetSelector: '[part="summary"]', position: 'bottom-start' },
   { tagName: EmailField.is },
+  { tagName: IntegerField.is },
+  { tagName: NumberField.is },
   { tagName: PasswordField.is },
   { tagName: Select.is },
   { tagName: Tab.is },

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -148,6 +148,8 @@ snapshots["vaadin-integer-field shadow default"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-integer-field shadow default */
 
@@ -204,6 +206,8 @@ snapshots["vaadin-integer-field shadow controls"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-integer-field shadow controls */
 
@@ -265,6 +269,8 @@ snapshots["vaadin-integer-field shadow disabled"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-integer-field shadow disabled */
 
@@ -326,6 +332,8 @@ snapshots["vaadin-integer-field shadow readonly"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-integer-field shadow readonly */
 
@@ -387,6 +395,8 @@ snapshots["vaadin-integer-field shadow invalid"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-integer-field shadow invalid */
 
@@ -448,6 +458,8 @@ snapshots["vaadin-integer-field shadow theme"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-integer-field shadow theme */
 

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -6,6 +6,7 @@
 import '@vaadin/input-container/src/vaadin-input-container.js';
 import { html, PolymerElement } from '@polymer/polymer';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
@@ -127,6 +128,8 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
           <slot name="error-message"></slot>
         </div>
       </div>
+
+      <slot name="tooltip"></slot>
     `;
   }
 
@@ -231,6 +234,9 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
     );
 
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
   }
 
   /**

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -148,6 +148,8 @@ snapshots["vaadin-number-field shadow default"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-number-field shadow default */
 
@@ -204,6 +206,8 @@ snapshots["vaadin-number-field shadow controls"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-number-field shadow controls */
 
@@ -265,6 +269,8 @@ snapshots["vaadin-number-field shadow disabled"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-number-field shadow disabled */
 
@@ -326,6 +332,8 @@ snapshots["vaadin-number-field shadow readonly"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-number-field shadow readonly */
 
@@ -387,6 +395,8 @@ snapshots["vaadin-number-field shadow invalid"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-number-field shadow invalid */
 
@@ -448,6 +458,8 @@ snapshots["vaadin-number-field shadow theme"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-number-field shadow theme */
 


### PR DESCRIPTION
## Description

Added `vaadin-tooltip` support to `vaadin-number-field` and fields that extend it (`vaadin-integer-field`) via `tooltip` slot and `TooltipController`.

## Type of change

- Feature