### PR TITLE
feat: add opened property, open() and close() methods

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -116,6 +116,7 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -93,6 +93,12 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  * ----------------|----------------
  * `toggle-button` | The toggle button
  *
+ * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
+ *
+ * Attribute | Description
+ * ----------|------------------------------------------
+ * `opened`  | Set when the time-picker dropdown is open
+ *
  * ### Internal components
  *
  * In addition to `<vaadin-time-picker>` itself, the following internal

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -35,6 +35,11 @@ export type TimePickerChangeEvent = Event & {
 export type TimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `opened` property changes.
+ */
+export type TimePickerOpenedChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type TimePickerValueChangedEvent = CustomEvent<{ value: string }>;
@@ -46,6 +51,8 @@ export type TimePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface TimePickerCustomEventMap {
   'invalid-changed': TimePickerInvalidChangedEvent;
+
+  'opened-changed': TimePickerOpenedChangedEvent;
 
   'value-changed': TimePickerValueChangedEvent;
 
@@ -116,6 +123,11 @@ declare class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(El
    * - `hh:mm:ss.fff`
    */
   value: string;
+
+  /**
+   * True if the dropdown is open, false otherwise.
+   */
+  opened: boolean;
 
   /**
    * Minimum time allowed.
@@ -191,6 +203,16 @@ declare class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(El
    * to ensure the component works properly.
    */
   i18n: TimePickerI18n;
+
+  /**
+   * Opens the dropdown list.
+   */
+  open(): void;
+
+  /**
+   * Closes the dropdown list.
+   */
+  close(): void;
 
   /**
    * Returns true if `value` is valid, and sets the `invalid` flag appropriately.

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -67,6 +67,7 @@ registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
@@ -109,6 +110,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
           id="comboBox"
           filtered-items="[[__dropdownItems]]"
           value="{{_comboBoxValue}}"
+          opened="{{opened}}"
           disabled="[[disabled]]"
           readonly="[[readonly]]"
           clear-button-visible="[[clearButtonVisible]]"
@@ -158,6 +160,16 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
         type: String,
         notify: true,
         value: '',
+      },
+
+      /**
+       * True if the dropdown is open, false otherwise.
+       */
+      opened: {
+        type: Boolean,
+        notify: true,
+        value: false,
+        reflectToAttribute: true,
       },
 
       /**
@@ -339,7 +351,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     this._inputContainer = this.shadowRoot.querySelector('[part~="input-field"]');
 
     this._tooltipController = new TooltipController(this);
-    this._tooltipController.setShouldShow((timePicker) => !timePicker.$.comboBox.opened);
+    this._tooltipController.setShouldShow((timePicker) => !timePicker.opened);
     this.addController(this._tooltipController);
   }
 
@@ -354,6 +366,22 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     if (input) {
       this.$.comboBox._setInputElement(input);
     }
+  }
+
+  /**
+   * Opens the dropdown list.
+   */
+  open() {
+    if (!this.disabled && !this.readonly) {
+      this.opened = true;
+    }
+  }
+
+  /**
+   * Closes the dropdown list.
+   */
+  close() {
+    this.opened = false;
   }
 
   /**

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -50,6 +50,12 @@ registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-
  * ----------------|----------------
  * `toggle-button` | The toggle button
  *
+ * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
+ *
+ * Attribute | Description
+ * ----------|------------------------------------------
+ * `opened`  | Set when the time-picker dropdown is open
+ *
  * ### Internal components
  *
  * In addition to `<vaadin-time-picker>` itself, the following internal

--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -92,19 +92,32 @@ describe('combo-box', () => {
     timePicker.autoOpenDisabled = true;
     expect(comboBox.autoOpenDisabled).to.be.true;
   });
+
+  it('should propagate opened property to combo-box', () => {
+    timePicker.opened = true;
+    expect(comboBox.opened).to.be.true;
+    timePicker.opened = false;
+    expect(comboBox.opened).to.be.false;
+  });
+
+  it('should sync opened property from combo-box', () => {
+    comboBox.opened = true;
+    expect(timePicker.opened).to.be.true;
+    comboBox.opened = false;
+    expect(timePicker.opened).to.be.false;
+  });
 });
 
 describe('autoOpenDisabled', () => {
-  let timePicker, comboBox, inputElement;
+  let timePicker, inputElement;
 
   beforeEach(() => {
     timePicker = fixtureSync(`<vaadin-time-picker auto-open-disabled value="05:00"></vaadin-time-picker>`);
-    comboBox = timePicker.$.comboBox;
     inputElement = timePicker.inputElement;
   });
 
   it('should focus the correct item when opened', () => {
-    comboBox.open();
+    timePicker.open();
 
     const items = document.querySelectorAll('vaadin-time-picker-item');
     expect(items[5].hasAttribute('focused')).to.be.true;

--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -157,7 +157,7 @@ describe('keyboard navigation', () => {
       timePicker.step = 1800;
       timePicker.value = '02:00';
       inputElement.focus();
-      comboBox.opened = true;
+      timePicker.open();
     });
 
     it('should not change the value on arrow up', () => {

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -173,6 +173,41 @@ describe('time-picker', () => {
     });
   });
 
+  describe('toggle overlay', () => {
+    let overlay;
+
+    beforeEach(() => {
+      overlay = comboBox.shadowRoot.querySelector('vaadin-time-picker-overlay');
+    });
+
+    it('should open overlay using open() call', () => {
+      timePicker.open();
+      expect(timePicker.opened).to.be.true;
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close overlay using close() call', () => {
+      timePicker.open();
+      timePicker.close();
+      expect(timePicker.opened).to.be.false;
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not open overlay when disabled', () => {
+      timePicker.disabled = true;
+      timePicker.open();
+      expect(timePicker.opened).to.be.false;
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not open overlay when readonly', () => {
+      comboBox.readonly = true;
+      comboBox.open();
+      expect(comboBox.opened).to.be.false;
+      expect(overlay.opened).to.be.false;
+    });
+  });
+
   describe('properties and attributes', () => {
     it('should propagate required property to input', () => {
       timePicker.required = true;
@@ -307,7 +342,7 @@ describe('time-picker', () => {
 
     it('should not fire change on programmatic value change after manual one', () => {
       timePicker.value = '00:00';
-      comboBox.opened = true;
+      timePicker.open();
       inputElement.value = '';
       arrowDown(inputElement);
       enter(inputElement);
@@ -320,13 +355,13 @@ describe('time-picker', () => {
 
     it('should not fire change if the value was not changed', () => {
       timePicker.value = '01:00';
-      comboBox.opened = true;
+      timePicker.open();
       enter(inputElement);
       expect(spy.called).to.be.false;
     });
 
     it('should not fire change on revert', () => {
-      comboBox.opened = true;
+      timePicker.open();
       timePicker.value = '01:00';
       esc(inputElement);
       esc(inputElement);
@@ -335,7 +370,7 @@ describe('time-picker', () => {
 
     it('should fire just one change event', async () => {
       timePicker.focus();
-      comboBox.opened = true;
+      timePicker.open();
       await sendKeys({ type: '0' });
       enter(inputElement);
       inputElement.blur();

--- a/packages/time-picker/test/typings/time-picker.types.ts
+++ b/packages/time-picker/test/typings/time-picker.types.ts
@@ -8,6 +8,7 @@ import type {
   TimePicker,
   TimePickerChangeEvent,
   TimePickerInvalidChangedEvent,
+  TimePickerOpenedChangedEvent,
   TimePickerValidatedEvent,
   TimePickerValueChangedEvent,
 } from '../../vaadin-time-picker.js';
@@ -31,6 +32,11 @@ timePicker.addEventListener('change', (event) => {
 
 timePicker.addEventListener('invalid-changed', (event) => {
   assertType<TimePickerInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+timePicker.addEventListener('opened-changed', (event) => {
+  assertType<TimePickerOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 


### PR DESCRIPTION
## Description

Fixes #954

Added missing `opened` property, `open()` and `close()` methods and updated tests to use them.
See https://github.com/vaadin/web-components/issues/954#issuecomment-1211854844 for the rationale behind adding these APIs to the component.

One more reason is adding `vaadin-tooltip` to `vaadin-date-time-picker` where we want to only show the tooltip when both date-picker and time-picker elements have `opened` set to `false` without touching their shadow DOM.

## Type of change

- Feature