### PR TITLE
fix: do not validate when focus is moving inside the field (#4478) (CP: 23.1)

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -413,12 +413,6 @@ class DateTimePicker extends FieldMixin(
   ready() {
     super.ready();
 
-    this.addEventListener('focusout', (e) => {
-      if (e.relatedTarget !== this.__datePicker.$.overlay) {
-        this.validate();
-      }
-    });
-
     this.__datePicker = this._getDirectSlotChild('date-picker');
     this.__timePicker = this._getDirectSlotChild('time-picker');
 
@@ -438,6 +432,20 @@ class DateTimePicker extends FieldMixin(
 
   focus() {
     this.__datePicker.focus();
+  }
+
+  /**
+   * Override method inherited from `FocusMixin` to validate on blur.
+   * @param {boolean} focused
+   * @protected
+   * @override
+   */
+  _setFocused(focused) {
+    super._setFocused(focused);
+
+    if (!focused) {
+      this.validate();
+    }
   }
 
   /**

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';
 
@@ -23,10 +24,13 @@ const fixtures = {
 
 ['default', 'slotted'].forEach((set) => {
   describe(`Validation (${set})`, () => {
-    let dateTimePicker;
+    let dateTimePicker, validateSpy, datePicker, timePicker;
 
     beforeEach(() => {
       dateTimePicker = fixtureSync(fixtures[set]);
+      validateSpy = sinon.spy(dateTimePicker, 'validate');
+      datePicker = dateTimePicker.querySelector('[slot=date-picker]');
+      timePicker = dateTimePicker.querySelector('[slot=time-picker]');
     });
 
     it('should not be required', () => {
@@ -50,6 +54,36 @@ const fixtures = {
       dateTimePicker.value = '2020-02-02T02:02:00';
       expect(dateTimePicker.validate()).to.equal(true);
       expect(dateTimePicker.invalid).to.equal(false);
+    });
+
+    it('should validate on date-picker blur', () => {
+      datePicker.focus();
+      datePicker.blur();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should validate on time-picker blur', () => {
+      timePicker.focus();
+      timePicker.blur();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should not validate when moving focus between pickers', async () => {
+      datePicker.focus();
+      // Move focus to time-picker
+      await sendKeys({ press: 'Tab' });
+      // Move focus to date-picker
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate when moving focus to the date-picker dropdown', async () => {
+      datePicker.focus();
+      await sendKeys({ press: 'ArrowDown' });
+      await sendKeys({ press: 'Tab' });
+      expect(validateSpy.called).to.be.false;
     });
 
     it('should validate min/max times', () => {


### PR DESCRIPTION
## Description

This PR cherry-picks the following fix to `23.1`:

- https://github.com/vaadin/web-components/pull/4478

Fixes https://github.com/vaadin/web-components/issues/4461

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
