### PR TITLE
refactor: cleanup checkValidity typings override

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -154,11 +154,6 @@ declare class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMi
    */
   value: string | null | undefined;
 
-  /**
-   * Returns true if the current inputs values satisfy all constraints (if any).
-   */
-  checkValidity(): boolean;
-
   addEventListener<K extends keyof CustomFieldEventMap>(
     type: K,
     listener: (this: CustomField, ev: CustomFieldEventMap[K]) => void,


### PR DESCRIPTION
## Description

Same as #4488 but for `vaadin-custom-field` which extends `FieldMixin` and `ValidateMixin`.

## Type of change

- Refactor