### PR TITLE
fix: do not open a closed tooltip on mouse-enter while hovering

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -384,6 +384,11 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       return;
     }
 
+    if (this.__hoverInside) {
+      // Already hovering inside the element, do nothing.
+      return;
+    }
+
     this.__hoverInside = true;
 
     if (!this.__focusInside || !this._autoOpened) {

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -329,6 +329,13 @@ describe('vaadin-tooltip', () => {
       focusout(target);
       expect(overlay.opened).to.be.true;
     });
+
+    it('should not open a closed overlay on mouseenter if already hovering on target', () => {
+      mouseenter(target);
+      mousedown(target);
+      mouseenter(target);
+      expect(overlay.opened).to.be.false;
+    });
   });
 
   describe('shouldShow', () => {


### PR DESCRIPTION
## Description

Relates to https://github.com/vaadin/web-components/pull/4492#pullrequestreview-1096459113

A new `mouseenter` event may occur on an element even if `mouseleave` hasn't taken place since the last `mouseenter`. The component is already tracking the hover state internally. Use it to determine if a `mouseenter` should be ignored.

## Type of change

- Bugfix