### PR TITLE
feat: add tooltip support to message-input

### DIFF
--- a/dev/messages.html
+++ b/dev/messages.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Messages</title>
+    <script type="module" src="./common.js"></script>
+
+    <script type="module">
+      import '@vaadin/message-input';
+      import '@vaadin/message-list';
+      import '@vaadin/tooltip';
+
+      const list = document.querySelector('vaadin-message-list');
+      list.items = [
+        {
+          text: 'Nature does not hurry, yet everything gets accomplished.',
+          time: 'yesterday',
+          userName: 'Matt Mambo',
+          userColorIndex: 1,
+        },
+        {
+          text: 'Using your talent, hobby or profession in a way that makes you contribute with something good to this world is truly the way to go.',
+          time: 'right now',
+          userName: 'Linsey Listy',
+          userColorIndex: 2,
+        },
+      ];
+    </script>
+  </head>
+
+  <body>
+    <vaadin-message-list></vaadin-message-list>
+    <vaadin-message-input>
+      <vaadin-tooltip slot="tooltip" text="Press Enter to send"></vaadin-tooltip>
+    </vaadin-message-input>
+  </body>
+</html>

--- a/integration/package.json
+++ b/integration/package.json
@@ -20,6 +20,7 @@
     "@vaadin/grid-pro": "23.3.0-alpha0",
     "@vaadin/integer-field": "23.3.0-alpha0",
     "@vaadin/number-field": "23.3.0-alpha0",
+    "@vaadin/message-input": "23.3.0-alpha0",
     "@vaadin/multi-select-combo-box": "23.3.0-alpha0",
     "@vaadin/polymer-legacy-adapter": "23.3.0-alpha0",
     "@vaadin/password-field": "23.3.0-alpha0",

--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -9,6 +9,7 @@ import { DateTimePicker } from '@vaadin/date-time-picker';
 import { Details } from '@vaadin/details';
 import { EmailField } from '@vaadin/email-field';
 import { IntegerField } from '@vaadin/integer-field';
+import { MessageInput } from '@vaadin/message-input';
 import { MultiSelectComboBox } from '@vaadin/multi-select-combo-box';
 import { NumberField } from '@vaadin/number-field';
 import { PasswordField } from '@vaadin/password-field';
@@ -28,6 +29,7 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
   { tagName: Details.is, targetSelector: '[part="summary"]', position: 'bottom-start' },
   { tagName: EmailField.is },
   { tagName: IntegerField.is },
+  { tagName: MessageInput.is },
   { tagName: MultiSelectComboBox.is, applyShouldNotShowCondition: (comboBox) => comboBox.click() },
   { tagName: NumberField.is },
   { tagName: PasswordField.is },

--- a/packages/message-input/src/vaadin-message-input.d.ts
+++ b/packages/message-input/src/vaadin-message-input.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -35,7 +36,7 @@ export type MessageInputEventMap = HTMLElementEventMap & MessageInputCustomEvent
  * <vaadin-message-input></vaadin-message-input>
  * ```
  */
-declare class MessageInput extends ThemableMixin(ElementMixin(HTMLElement)) {
+declare class MessageInput extends ThemableMixin(ElementMixin(ControllerMixin(HTMLElement))) {
   /**
    * Current content of the text input field
    */

--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -6,7 +6,9 @@
 import './vaadin-message-input-text-area.js';
 import './vaadin-message-input-button.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
@@ -30,10 +32,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * - `<vaadin-message-input-text-area>` - has the same API as [`<vaadin-text-area>`](#/elements/vaadin-text-area).
  *
  * @extends HTMLElement
+ * @mizes ControllerMixin
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class MessageInput extends ElementMixin(ThemableMixin(PolymerElement)) {
+class MessageInput extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))) {
   static get properties() {
     return {
       /**
@@ -106,11 +109,21 @@ class MessageInput extends ElementMixin(ThemableMixin(PolymerElement)) {
       <vaadin-message-input-button disabled="[[disabled]]" theme="primary contained" on-click="__submit"
         >[[i18n.send]]</vaadin-message-input-button
       >
+
+      <slot name="tooltip"></slot>
     `;
   }
 
   static get is() {
     return 'vaadin-message-input';
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
   }
 
   /**

--- a/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
+++ b/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
@@ -32,6 +32,8 @@ snapshots["vaadin-message-input default"] =
 >
   Send
 </vaadin-message-input-button>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-message-input default */
 
@@ -74,6 +76,8 @@ snapshots["vaadin-message-input disabled"] =
 >
   Send
 </vaadin-message-input-button>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-message-input disabled */
 

--- a/packages/message-input/test/typings/message-input.types.ts
+++ b/packages/message-input/test/typings/message-input.types.ts
@@ -1,9 +1,12 @@
 import '../../vaadin-message-input.js';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { MessageInputSubmitEvent } from '../../vaadin-message-input.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const input = document.createElement('vaadin-message-input');
+
+assertType<ControllerMixinClass>(input);
 
 input.addEventListener('submit', (event) => {
   assertType<MessageInputSubmitEvent>(event);


### PR DESCRIPTION
## Description

Added `vaadin-tooltip` support to `vaadin-message-input` via `tooltip` slot and `TooltipController`.

## Type of change

- Feature