### PR TITLE
docs: add ControllerMixin to tab types

### DIFF
--- a/packages/tabs/src/vaadin-tab.d.ts
+++ b/packages/tabs/src/vaadin-tab.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ItemMixin } from '@vaadin/item/src/vaadin-item-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -29,7 +30,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  */
-declare class Tab extends ElementMixin(ThemableMixin(ItemMixin(HTMLElement))) {}
+declare class Tab extends ElementMixin(ThemableMixin(ItemMixin(ControllerMixin(HTMLElement)))) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/tabs/test/typings/tab.types.ts
+++ b/packages/tabs/test/typings/tab.types.ts
@@ -1,0 +1,10 @@
+import '../../vaadin-tab.js';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { ItemMixinClass } from '@vaadin/item/src/vaadin-item-mixin.js';
+
+const tab = document.createElement('vaadin-tab');
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+assertType<ControllerMixinClass>(tab);
+assertType<ItemMixinClass>(tab);


### PR DESCRIPTION
Add the missing `ControllerMixin` to `<vaadin-tab>` types