### PR TITLE
feat: add tooltip support to vaadin-text-area

### DIFF
--- a/dev/text-area.html
+++ b/dev/text-area.html
@@ -9,10 +9,13 @@
 
     <script type="module">
       import '@vaadin/text-area';
+      import '@vaadin/tooltip';
     </script>
   </head>
 
   <body>
-    <vaadin-text-area label="Required" required></vaadin-text-area>
+    <vaadin-text-area label="Feedback" required>
+      <vaadin-tooltip slot="tooltip" text="Help us improve"></vaadin-tooltip>
+    </vaadin-text-area>
   </body>
 </html>

--- a/integration/package.json
+++ b/integration/package.json
@@ -27,6 +27,7 @@
     "@vaadin/radio-group": "23.3.0-alpha0",
     "@vaadin/select": "23.3.0-alpha0",
     "@vaadin/tabs": "23.3.0-alpha0",
+    "@vaadin/text-area": "23.3.0-alpha0",
     "@vaadin/text-field": "23.3.0-alpha0",
     "@vaadin/tooltip": "23.3.0-alpha0",
     "@vaadin/testing-helpers": "^0.3.2",

--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -16,6 +16,7 @@ import { PasswordField } from '@vaadin/password-field';
 import { RadioGroup } from '@vaadin/radio-group';
 import { Select } from '@vaadin/select';
 import { Tab } from '@vaadin/tabs/vaadin-tab.js';
+import { TextArea } from '@vaadin/text-area';
 import { TextField } from '@vaadin/text-field';
 import { TimePicker } from '@vaadin/time-picker';
 import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
@@ -36,6 +37,7 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
   { tagName: RadioGroup.is },
   { tagName: Select.is },
   { tagName: Tab.is },
+  { tagName: TextArea.is },
   { tagName: TextField.is },
   { tagName: TimePicker.is, applyShouldNotShowCondition: (timePicker) => timePicker.click() },
 ].forEach(({ tagName, targetSelector, position, applyShouldNotShowCondition }) => {

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -7,6 +7,7 @@ import '@vaadin/input-container/src/vaadin-input-container.js';
 import { html, PolymerElement } from '@polymer/polymer';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
 import { PatternMixin } from '@vaadin/field-base/src/pattern-mixin.js';
@@ -165,6 +166,8 @@ export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableM
           <slot name="error-message"></slot>
         </div>
       </div>
+
+      <slot name="tooltip"></slot>
     `;
   }
 
@@ -223,6 +226,10 @@ export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableM
       }),
     );
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+
     this.addEventListener('animationend', this._onAnimationEnd);
 
     this._inputField = this.shadowRoot.querySelector('[part=input-field]');

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -128,6 +128,8 @@ snapshots["vaadin-text-area shadow default"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-text-area shadow default */
 
@@ -176,6 +178,8 @@ snapshots["vaadin-text-area shadow disabled"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-text-area shadow disabled */
 
@@ -224,6 +228,8 @@ snapshots["vaadin-text-area shadow readonly"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-text-area shadow readonly */
 
@@ -272,6 +278,8 @@ snapshots["vaadin-text-area shadow invalid"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-text-area shadow invalid */
 
@@ -320,6 +328,8 @@ snapshots["vaadin-text-area shadow theme"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-text-area shadow theme */
 


### PR DESCRIPTION
## Description

Added `vaadin-tooltip` support to `vaadin-text-area` via `tooltip` slot and `TooltipController`.

## Type of change

- Feature