### PR TITLE
docs: add missing attribute JSDoc annotations

### DIFF
--- a/packages/message-list/src/vaadin-message.d.ts
+++ b/packages/message-list/src/vaadin-message.d.ts
@@ -56,6 +56,7 @@ declare class Message extends FocusMixin(ThemableMixin(ElementMixin(HTMLElement)
    * It will be placed in the name part to indicate who has sent the message.
    * It is also used as a tooltip for the avatar.
    * Example: `message.userName = "Jessica Jacobs";`
+   * @attr {string} user-name
    */
   userName: string | null | undefined;
 
@@ -64,6 +65,7 @@ declare class Message extends FocusMixin(ThemableMixin(ElementMixin(HTMLElement)
    * The abbreviation will be passed on to avatar of the message.
    * If the user does not have an avatar picture set with `userImg`, `userAbbr` will be shown in the avatar.
    * Example: `message.userAbbr = "JJ";`
+   * @attr {string} user-abbr
    */
   userAbbr: string | null | undefined;
 
@@ -71,6 +73,7 @@ declare class Message extends FocusMixin(ThemableMixin(ElementMixin(HTMLElement)
    * An URL for a user image.
    * The image will be used in the avatar component to show who has sent the message.
    * Example: `message.userImg = "/static/img/avatar.jpg";`
+   * @attr {string} user-img
    */
   userImg: string | null | undefined;
 
@@ -92,6 +95,7 @@ declare class Message extends FocusMixin(ThemableMixin(ElementMixin(HTMLElement)
    * ```js
    * message.userColorIndex = 1;
    * ```
+   * @attr {number} user-color-index
    */
   userColorIndex: number | null | undefined;
 }

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -67,6 +67,7 @@ class Message extends FocusMixin(ElementMixin(ThemableMixin(PolymerElement))) {
        * It will be placed in the name part to indicate who has sent the message.
        * It is also used as a tooltip for the avatar.
        * Example: `message.userName = "Jessica Jacobs";`
+       * @attr {string} user-name
        */
       userName: {
         type: String,
@@ -77,6 +78,7 @@ class Message extends FocusMixin(ElementMixin(ThemableMixin(PolymerElement))) {
        * The abbreviation will be passed on to avatar of the message.
        * If the user does not have an avatar picture set with `userImg`, `userAbbr` will be shown in the avatar.
        * Example: `message.userAbbr = "JJ";`
+       * @attr {string} user-abbr
        */
       userAbbr: {
         type: String,
@@ -86,6 +88,7 @@ class Message extends FocusMixin(ElementMixin(ThemableMixin(PolymerElement))) {
        * An URL for a user image.
        * The image will be used in the avatar component to show who has sent the message.
        * Example: `message.userImg = "/static/img/avatar.jpg";`
+       * @attr {string} user-img
        */
       userImg: {
         type: String,
@@ -109,6 +112,7 @@ class Message extends FocusMixin(ElementMixin(ThemableMixin(PolymerElement))) {
        * ```js
        * message.userColorIndex = 1;
        * ```
+       * @attr {number} user-color-index
        */
       userColorIndex: {
         type: Number,


### PR DESCRIPTION
## Description

Same as #4440 but for `vaadin-message` camel-case properties.

## Type of change

- Documentation