### PR TITLE
docs: add missing attribute JSDoc annotation

### DIFF
--- a/packages/scroller/src/vaadin-scroller.d.ts
+++ b/packages/scroller/src/vaadin-scroller.d.ts
@@ -28,6 +28,7 @@ declare class Scroller extends FocusMixin(ThemableMixin(ElementMixin(ControllerM
   /**
    * This property indicates the scroll direction. Supported values are `vertical`, `horizontal`, `none`.
    * When `scrollDirection` is undefined scrollbars will be shown in both directions.
+   * @attr {string} scroll-direction
    */
   scrollDirection: 'horizontal' | 'none' | 'vertical' | undefined;
 

--- a/packages/scroller/src/vaadin-scroller.js
+++ b/packages/scroller/src/vaadin-scroller.js
@@ -71,6 +71,7 @@ class Scroller extends FocusMixin(ElementMixin(ControllerMixin(ThemableMixin(Pol
       /**
        * This property indicates the scroll direction. Supported values are `vertical`, `horizontal`, `none`.
        * When `scrollDirection` is undefined scrollbars will be shown in both directions.
+       * @attr {string} scroll-direction
        */
       scrollDirection: {
         type: String,


### PR DESCRIPTION
## Description

Same as #4440 but for `vaadin-scroller` camel-case property `scrollDirection`.

## Type of change

- Documentation