### PR TITLE
test: disable animations in tooltip tests

### DIFF
--- a/packages/avatar/test/visual/lumo/avatar.test.js
+++ b/packages/avatar/test/visual/lumo/avatar.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '@vaadin/tooltip/test/not-animated-styles.js';
 import '../../../theme/lumo/vaadin-avatar.js';
 
 describe('avatar', () => {

--- a/packages/avatar/test/visual/material/avatar.test.js
+++ b/packages/avatar/test/visual/material/avatar.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '@vaadin/tooltip/test/not-animated-styles.js';
 import '../../../theme/material/vaadin-avatar.js';
 
 describe('avatar', () => {

--- a/packages/tooltip/test/not-animated-styles.js
+++ b/packages/tooltip/test/not-animated-styles.js
@@ -10,5 +10,4 @@ registerStyles(
       animation: none !important;
     }
   `,
-  { moduleId: 'not-animated-tooltip-overlay' },
 );

--- a/packages/tooltip/test/not-animated-styles.js
+++ b/packages/tooltip/test/not-animated-styles.js
@@ -1,0 +1,14 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-tooltip-overlay',
+  css`
+    :host([opening]),
+    :host([closing]),
+    :host([opening]) [part='overlay'],
+    :host([closing]) [part='overlay'] {
+      animation: none !important;
+    }
+  `,
+  { moduleId: 'not-animated-tooltip-overlay' },
+);

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, escKeyDown, fixtureSync, focusout, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
 import { Tooltip } from '../vaadin-tooltip.js';
 import { mouseenter, mouseleave } from './helpers.js';
 

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { escKeyDown, fixtureSync, focusout, keyboardEventFor, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
+import './not-animated-styles.js';
 import '../vaadin-tooltip.js';
 import { mouseenter, mouseleave } from './helpers.js';
 

--- a/packages/tooltip/test/visual/lumo/tooltip.test.js
+++ b/packages/tooltip/test/visual/lumo/tooltip.test.js
@@ -1,5 +1,6 @@
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../../not-animated-styles.js';
 import '../../../theme/lumo/vaadin-tooltip.js';
 
 describe('tooltip', () => {

--- a/packages/tooltip/test/visual/material/tooltip.test.js
+++ b/packages/tooltip/test/visual/material/tooltip.test.js
@@ -1,5 +1,6 @@
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../../not-animated-styles.js';
 import '../../../theme/material/vaadin-tooltip.js';
 
 describe('tooltip', () => {


### PR DESCRIPTION
## Description

Added missing `not-animated-styles.js` to make tooltip tests more stable.

## Type of change

- Tests