### PR TITLE
test: remove not necessary moduleId definition

### DIFF
--- a/packages/confirm-dialog/test/not-animated-styles.js
+++ b/packages/confirm-dialog/test/not-animated-styles.js
@@ -10,5 +10,4 @@ registerStyles(
       animation: none !important;
     }
   `,
-  { moduleId: 'not-animated-date-picker-overlay' },
 );

--- a/packages/date-picker/test/not-animated-styles.js
+++ b/packages/date-picker/test/not-animated-styles.js
@@ -10,5 +10,4 @@ registerStyles(
       animation: none !important;
     }
   `,
-  { moduleId: 'not-animated-date-picker-overlay' },
 );

--- a/packages/dialog/test/not-animated-styles.js
+++ b/packages/dialog/test/not-animated-styles.js
@@ -10,5 +10,4 @@ registerStyles(
       animation: none !important;
     }
   `,
-  { moduleId: 'not-animated-dialog-overlay' },
 );

--- a/packages/field-highlighter/test/visual/common.js
+++ b/packages/field-highlighter/test/visual/common.js
@@ -30,7 +30,6 @@ registerStyles(
       animation: none !important;
     }
   `,
-  { moduleId: 'not-animated-user-tags-overlay' },
 );
 
 const users = [


### PR DESCRIPTION
## Description

There is an inconsistency across `not-animated-styles.js` files: some of them use `moduleId` while others do not.
Removed this config option for consistency: it does not bring any value, and the styles work without it.

## Type of change

- Tests