### PR TITLE
feat: add tooltip support to vaadin-custom-field

### DIFF
--- a/dev/custom-field.html
+++ b/dev/custom-field.html
@@ -24,6 +24,7 @@
         required
       ></vaadin-text-field>
       <vaadin-number-field required></vaadin-number-field>
+      <vaadin-tooltip slot="tooltip" text="Other users will not see this"></vaadin-tooltip>
     </vaadin-custom-field>
 
     <script type="module">
@@ -33,6 +34,7 @@
       import '@vaadin/number-field';
       import '@vaadin/text-field';
       import '@vaadin/select';
+      import '@vaadin/tooltip';
 
       const select = document.querySelector('vaadin-select');
       select.focusElement.setAttribute('aria-label', 'Country code');

--- a/integration/package.json
+++ b/integration/package.json
@@ -11,6 +11,7 @@
     "@vaadin/button": "23.3.0-alpha0",
     "@vaadin/checkbox": "23.3.0-alpha0",
     "@vaadin/combo-box": "23.3.0-alpha0",
+    "@vaadin/custom-field": "23.3.0-alpha0",
     "@vaadin/date-picker": "23.3.0-alpha0",
     "@vaadin/date-time-picker": "23.3.0-alpha0",
     "@vaadin/details": "23.3.0-alpha0",

--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -25,7 +25,11 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
   { tagName: Button.is },
   { tagName: Checkbox.is },
   { tagName: ComboBox.is, applyShouldNotShowCondition: (comboBox) => comboBox.click() },
-  { tagName: CustomField.is },
+  {
+    tagName: CustomField.is,
+    children: '<vaadin-combo-box></vaadin-combo-box>',
+    applyShouldNotShowCondition: (field) => field.inputs[0].click(),
+  },
   { tagName: DatePicker.is, applyShouldNotShowCondition: (datePicker) => datePicker.click() },
   { tagName: DateTimePicker.is, applyShouldNotShowCondition: (element) => element.querySelector('input').click() },
   { tagName: Details.is, targetSelector: '[part="summary"]', position: 'bottom-start' },
@@ -40,13 +44,14 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
   { tagName: Tab.is },
   { tagName: TextField.is },
   { tagName: TimePicker.is, applyShouldNotShowCondition: (timePicker) => timePicker.click() },
-].forEach(({ tagName, targetSelector, position, applyShouldNotShowCondition }) => {
+].forEach(({ tagName, targetSelector, position, applyShouldNotShowCondition, children = '' }) => {
   describe(`${tagName} with a slotted tooltip`, () => {
     let element, tooltip, tooltipOverlay;
 
     beforeEach(() => {
       element = fixtureSync(`
         <${tagName}>
+          ${children}
           <vaadin-tooltip slot="tooltip" text="Tooltip text"></vaadin-tooltip>
         </${tagName}>
       `);

--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -4,6 +4,7 @@ import '@vaadin/tooltip';
 import { Button } from '@vaadin/button';
 import { Checkbox } from '@vaadin/checkbox';
 import { ComboBox } from '@vaadin/combo-box';
+import { CustomField } from '@vaadin/custom-field';
 import { DatePicker } from '@vaadin/date-picker';
 import { DateTimePicker } from '@vaadin/date-time-picker';
 import { Details } from '@vaadin/details';
@@ -24,6 +25,7 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
   { tagName: Button.is },
   { tagName: Checkbox.is },
   { tagName: ComboBox.is, applyShouldNotShowCondition: (comboBox) => comboBox.click() },
+  { tagName: CustomField.is },
   { tagName: DatePicker.is, applyShouldNotShowCondition: (datePicker) => datePicker.click() },
   { tagName: DateTimePicker.is, applyShouldNotShowCondition: (element) => element.querySelector('input').click() },
   { tagName: Details.is, targetSelector: '[part="summary"]', position: 'bottom-start' },

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -228,6 +228,10 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
 
     this._tooltipController = new TooltipController(this);
     this.addController(this._tooltipController);
+    this._tooltipController.setShouldShow((target) => {
+      const inputs = target.inputs || [];
+      return !inputs.some((el) => el.opened);
+    });
   }
 
   /** @protected */

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -8,6 +8,7 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -112,6 +113,8 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
           <slot name="error-message"></slot>
         </div>
       </div>
+
+      <slot name="tooltip"></slot>
     `;
   }
 
@@ -222,6 +225,9 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
     this.__observer = new FlattenedNodesObserver(this.$.slot, () => {
       this.__setInputsFromSlot();
     });
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
   }
 
   /** @protected */

--- a/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
+++ b/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
@@ -135,6 +135,8 @@ snapshots["vaadin-custom-field shadow default"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-custom-field shadow default */
 


### PR DESCRIPTION
## Description

Added `vaadin-tooltip` support to `vaadin-custom-field` via `tooltip` slot and `TooltipController`.

## Type of change

- Feature