### PR TITLE
feat: add tooltip support to vaadin-checkbox-group

### DIFF
--- a/dev/checkbox-group.html
+++ b/dev/checkbox-group.html
@@ -9,6 +9,7 @@
 
     <script type="module">
       import '@vaadin/checkbox-group';
+      import '@vaadin/tooltip';
     </script>
   </head>
 
@@ -17,6 +18,7 @@
       <vaadin-checkbox value="en" label="English"></vaadin-checkbox>
       <vaadin-checkbox value="fr" label="Français"></vaadin-checkbox>
       <vaadin-checkbox value="de" label="Deutsch"></vaadin-checkbox>
+      <vaadin-tooltip slot="tooltip" text="If not selected, English is used"></vaadin-tooltip>
     </vaadin-checkbox-group>
 
     <br />

--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -3,6 +3,7 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/tooltip';
 import { Button } from '@vaadin/button';
 import { Checkbox } from '@vaadin/checkbox';
+import { CheckboxGroup } from '@vaadin/checkbox-group';
 import { ComboBox } from '@vaadin/combo-box';
 import { CustomField } from '@vaadin/custom-field';
 import { DatePicker } from '@vaadin/date-picker';
@@ -25,6 +26,7 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
 [
   { tagName: Button.is },
   { tagName: Checkbox.is },
+  { tagName: CheckboxGroup.is },
   { tagName: ComboBox.is, applyShouldNotShowCondition: (comboBox) => comboBox.click() },
   {
     tagName: CustomField.is,

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -9,6 +9,7 @@ import { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -111,6 +112,8 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
           <slot name="error-message"></slot>
         </div>
       </div>
+
+      <slot name="tooltip"></slot>
     `;
   }
 
@@ -159,6 +162,9 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
 
       this.__warnOfCheckboxesWithoutValue(addedCheckboxes);
     });
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
   }
 
   /**

--- a/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
+++ b/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
@@ -151,6 +151,8 @@ snapshots["vaadin-checkbox-group shadow default"] =
     </slot>
   </div>
 </div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-checkbox-group shadow default */
 


### PR DESCRIPTION
## Description

Added `vaadin-tooltip` support to `vaadin-checkbox-group` via `tooltip` slot and `TooltipController`.

## Type of change

- Feature