### PR TITLE
fix!: remove unsupported i18n.clear property

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -24,7 +24,6 @@ export interface DatePickerI18n {
   firstDayOfWeek: number;
   week: string;
   calendar: string;
-  clear: string;
   today: string;
   cancel: string;
   parseDate(date: string): DatePickerDate | undefined;

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -36,7 +36,6 @@ export function getDefaultI18n() {
     firstDayOfWeek: 0,
     week: 'Week',
     calendar: 'Calendar',
-    clear: 'Clear',
     today: 'Today',
     cancel: 'Cancel',
     formatDate(d) {


### PR DESCRIPTION
## Description

The usage of `i18n.clear` has been removed in #2532 which is included to Vaadin 22. 
But we forgot to remove corresponding property from the `DatePickerI18n` type.

This change is so small that we can hopefully ship it within a minor version (23.3).

## Type of change

- Behavior altering fix