### PR TITLE
fix!: remove no longer supported i18n properties

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -16,8 +16,6 @@ export interface TimePickerTime {
 }
 
 export interface TimePickerI18n {
-  clear: string;
-  selector: string;
   parseTime(time: string): TimePickerTime | undefined;
   formatTime(time: TimePickerTime | undefined): string;
 }


### PR DESCRIPTION
## Description

The usage of `i18n.clear` and `i18n.selector` has been removed in #2541 which is included to Vaadin 22. 
But we forgot to remove corresponding properties from the `TimePickerI18n` type.

This change is so small that we can hopefully ship it within a minor version (23.3).

## Type of change

- Behavior altering fix