### PR TITLE
feat: add tooltip support to menu-bar

### DIFF
--- a/dev/menu-bar.html
+++ b/dev/menu-bar.html
@@ -9,6 +9,7 @@
 
     <script type="module">
       import '@vaadin/menu-bar';
+      import '@vaadin/tooltip';
 
       const menuBar = document.querySelector('vaadin-menu-bar');
       menuBar.items = [
@@ -31,10 +32,15 @@
         },
         { text: 'Duplicate' }
       ];
+
+      const tooltip = document.querySelector('[slot="tooltip"]');
+      tooltip.textGenerator = ({item}) => item ? `Tooltip for ${item.text}` : '';
     </script>
   </head>
 
   <body>
-    <vaadin-menu-bar></vaadin-menu-bar>
+    <vaadin-menu-bar>
+      <vaadin-tooltip slot="tooltip"></vaadin-tooltip>
+    </vaadin-menu-bar>
   </body>
 </html>

--- a/integration/package.json
+++ b/integration/package.json
@@ -22,6 +22,7 @@
     "@vaadin/integer-field": "23.3.0-alpha0",
     "@vaadin/number-field": "23.3.0-alpha0",
     "@vaadin/message-input": "23.3.0-alpha0",
+    "@vaadin/menu-bar": "23.3.0-alpha0",
     "@vaadin/multi-select-combo-box": "23.3.0-alpha0",
     "@vaadin/polymer-legacy-adapter": "23.3.0-alpha0",
     "@vaadin/password-field": "23.3.0-alpha0",

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -12,15 +12,15 @@ import {
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/menu-bar/vaadin-menu-bar.js';
-import '@vaadin/tooltip/vaadin-tooltip.js';
+import '@vaadin/menu-bar';
+import '@vaadin/tooltip';
 import { mouseleave } from '@vaadin/tooltip/test/helpers.js';
 
 export function mouseover(target) {
   fire(target, 'mouseover');
 }
 
-describe('tooltip', () => {
+describe('menu-bar with tooltip', () => {
   let menuBar, tooltip, buttons;
 
   beforeEach(async () => {

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -1,0 +1,222 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  arrowDown,
+  arrowRight,
+  escKeyDown,
+  fire,
+  fixtureSync,
+  focusin,
+  focusout,
+  mousedown,
+  nextRender,
+  tabKeyDown,
+} from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '@vaadin/menu-bar/vaadin-menu-bar.js';
+import '@vaadin/tooltip/vaadin-tooltip.js';
+import { mouseleave } from '@vaadin/tooltip/test/helpers.js';
+
+export function mouseover(target) {
+  fire(target, 'mouseover');
+}
+
+describe('tooltip', () => {
+  let menuBar, tooltip, buttons;
+
+  beforeEach(async () => {
+    menuBar = fixtureSync(`
+      <vaadin-menu-bar>
+        <vaadin-tooltip slot="tooltip"></vaadin-tooltip>
+      </vaadin-menu-bar>
+    `);
+    menuBar.items = [
+      { text: 'Edit' },
+      {
+        text: 'Share',
+        children: [{ text: 'By email' }],
+      },
+      {
+        text: 'Move',
+        children: [{ text: 'To folder' }],
+      },
+    ];
+
+    await nextRender();
+    buttons = menuBar._buttons;
+
+    tooltip = menuBar.querySelector('vaadin-tooltip');
+    tooltip.textGenerator = ({ item }) => item && `${item.text} tooltip`;
+  });
+
+  it('should set manual on the tooltip to true', () => {
+    expect(tooltip.manual).to.be.true;
+  });
+
+  it('should show tooltip on menu button mouseover', () => {
+    mouseover(buttons[0]);
+    expect(tooltip.opened).to.be.true;
+  });
+
+  it('should not show tooltip on another parent menu button mouseover when open', async () => {
+    mouseover(buttons[1]);
+    buttons[1].click();
+    await nextRender();
+    mouseover(buttons[2]);
+    await nextRender();
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should hide tooltip on menu bar mouseleave', () => {
+    mouseover(buttons[0]);
+    mouseleave(menuBar);
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should set tooltip target on menu button mouseover', () => {
+    mouseover(buttons[0]);
+    expect(tooltip.target).to.be.equal(buttons[0]);
+  });
+
+  it('should set tooltip context on menu button mouseover', () => {
+    mouseover(buttons[0]);
+    expect(tooltip.context).to.be.instanceOf(Object);
+    expect(tooltip.context.item.text).to.equal('Edit');
+  });
+
+  it('should change tooltip context on another menu button mouseover', () => {
+    mouseover(buttons[0]);
+    mouseover(buttons[1]);
+    expect(tooltip.context.item.text).to.equal('Share');
+  });
+
+  it('should hide tooltip on menu button mousedown', () => {
+    mouseover(buttons[0]);
+    mousedown(buttons[0]);
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should show tooltip on menu button keyboard focus', () => {
+    tabKeyDown(document.body);
+    focusin(buttons[0]);
+    expect(tooltip.opened).to.be.true;
+  });
+
+  it('should not show tooltip on another parent menu button focus when open', async () => {
+    buttons[0].focus();
+    arrowRight(buttons[0]);
+    arrowDown(buttons[1]);
+    arrowRight(buttons[1]);
+    await nextRender();
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should set tooltip target on menu button keyboard focus', () => {
+    tabKeyDown(document.body);
+    focusin(buttons[0]);
+    expect(tooltip.target).to.be.equal(buttons[0]);
+  });
+
+  it('should set tooltip context on menu button keyboard focus', () => {
+    tabKeyDown(document.body);
+    focusin(buttons[0]);
+    expect(tooltip.context).to.be.instanceOf(Object);
+    expect(tooltip.context.item.text).to.equal('Edit');
+  });
+
+  it('should hide tooltip on menu-bar focusout', () => {
+    tabKeyDown(document.body);
+    focusin(buttons[0]);
+    focusout(menuBar);
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should hide tooltip on menuBar menu button content Esc', () => {
+    tabKeyDown(document.body);
+    focusin(buttons[0]);
+    escKeyDown(buttons[0]);
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should set tooltip opened to false when the menuBar is removed', () => {
+    mouseover(buttons[0]);
+
+    menuBar.remove();
+
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should not set tooltip target if there is no tooltip', async () => {
+    const spy = sinon.spy(menuBar._tooltipController, 'setTarget');
+
+    tooltip.remove();
+    await nextRender();
+
+    mouseover(buttons[0]);
+
+    expect(spy.calledOnce).to.be.false;
+  });
+
+  it('should not set tooltip context if there is no tooltip', async () => {
+    const spy = sinon.spy(menuBar._tooltipController, 'setContext');
+
+    tooltip.remove();
+    await nextRender();
+
+    mouseover(buttons[0]);
+
+    expect(spy.calledOnce).to.be.false;
+  });
+
+  it('should not set tooltip opened if there is no tooltip', async () => {
+    const spy = sinon.spy(menuBar._tooltipController, 'setOpened');
+
+    tooltip.remove();
+    await nextRender();
+
+    mouseover(buttons[0]);
+
+    expect(spy.calledOnce).to.be.false;
+  });
+
+  describe('overflow button', () => {
+    beforeEach(async () => {
+      // Reduce the width by the width of the last visible button
+      menuBar.style.display = 'inline-block';
+      menuBar.style.width = `${menuBar.offsetWidth - buttons[2].offsetWidth}px`;
+      await nextRender();
+      await nextRender();
+      // Increase the width by the width of the overflow button
+      menuBar.style.width = `${menuBar.offsetWidth + menuBar._overflow.offsetWidth}px`;
+      await nextRender();
+      await nextRender();
+    });
+
+    it('should not show tooltip on overflow button mouseover', () => {
+      mouseover(buttons[buttons.length - 1]);
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should close tooltip on overflow button mouseover', () => {
+      mouseover(buttons[0]);
+      mouseover(buttons[buttons.length - 1]);
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should close tooltip on overflow button keyboard navigation', () => {
+      buttons[0].focus();
+      arrowRight(buttons[0]);
+      expect(tooltip.opened).to.be.true;
+      arrowRight(buttons[1]);
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should not show tooltip on overflow button keyboard focus', () => {
+      buttons[0].focus();
+      arrowRight(buttons[0]);
+      arrowRight(buttons[1]);
+      tabKeyDown(document.body);
+      focusin(buttons[buttons.length - 1]);
+      expect(tooltip.opened).to.be.false;
+    });
+  });
+});

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -95,6 +95,12 @@ describe('tooltip', () => {
     expect(tooltip.opened).to.be.false;
   });
 
+  it('should not show tooltip on focus without keyboard interaction', async () => {
+    buttons[0].focus();
+    await nextRender();
+    expect(tooltip.opened).to.be.false;
+  });
+
   it('should show tooltip on menu button keyboard focus', () => {
     tabKeyDown(document.body);
     focusin(buttons[0]);
@@ -198,6 +204,24 @@ describe('tooltip', () => {
       arrowRight(buttons[1]);
       tabKeyDown(document.body);
       focusin(buttons[buttons.length - 1]);
+      expect(tooltip.opened).to.be.false;
+    });
+  });
+
+  describe('open on hover', () => {
+    beforeEach(() => {
+      menuBar.openOnHover = true;
+    });
+
+    it('should show tooltip on mouseover for button without children', () => {
+      menuBar.openOnHover = true;
+      mouseover(buttons[0]);
+      expect(tooltip.opened).to.be.true;
+    });
+
+    it('should not show tooltip on mouseover for button with children', () => {
+      menuBar.openOnHover = true;
+      mouseover(buttons[1]);
       expect(tooltip.opened).to.be.false;
     });
   });

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -145,37 +145,19 @@ describe('tooltip', () => {
     expect(tooltip.opened).to.be.false;
   });
 
-  it('should not set tooltip target if there is no tooltip', async () => {
-    const spy = sinon.spy(menuBar._tooltipController, 'setTarget');
+  it('should not set tooltip properties if there is no tooltip', async () => {
+    const spyTarget = sinon.spy(menuBar._tooltipController, 'setTarget');
+    const spyContent = sinon.spy(menuBar._tooltipController, 'setContext');
+    const spyOpened = sinon.spy(menuBar._tooltipController, 'setOpened');
 
     tooltip.remove();
     await nextRender();
 
     mouseover(buttons[0]);
 
-    expect(spy.calledOnce).to.be.false;
-  });
-
-  it('should not set tooltip context if there is no tooltip', async () => {
-    const spy = sinon.spy(menuBar._tooltipController, 'setContext');
-
-    tooltip.remove();
-    await nextRender();
-
-    mouseover(buttons[0]);
-
-    expect(spy.calledOnce).to.be.false;
-  });
-
-  it('should not set tooltip opened if there is no tooltip', async () => {
-    const spy = sinon.spy(menuBar._tooltipController, 'setOpened');
-
-    tooltip.remove();
-    await nextRender();
-
-    mouseover(buttons[0]);
-
-    expect(spy.calledOnce).to.be.false;
+    expect(spyTarget.called).to.be.false;
+    expect(spyContent.called).to.be.false;
+    expect(spyOpened.called).to.be.false;
   });
 
   describe('overflow button', () => {

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
@@ -4,10 +4,11 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin';
 
 export declare function InteractionsMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<InteractionsMixinClass> & T;
+): Constructor<FocusMixinClass> & Constructor<InteractionsMixinClass> & T;
 
 export declare class InteractionsMixinClass {
   /**

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
-import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 
 export declare function InteractionsMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { isKeyboardActive } from '@vaadin/component-base/src/focus-utils';
 

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
-import { isKeyboardActive } from '@vaadin/component-base/src/focus-utils';
+import { isKeyboardActive } from '@vaadin/component-base/src/focus-utils.js';
 
 /**
  * @polymerMixin

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -89,7 +90,9 @@ export interface MenuBarEventMap extends HTMLElementEventMap, MenuBarCustomEvent
  *
  * @fires {CustomEvent} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  */
-declare class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(HTMLElement))))) {
+declare class MenuBar extends ButtonsMixin(
+  DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement))))),
+) {
   /**
    * Defines a hierarchical structure, where root level items represent menu bar buttons,
    * and `children` property configures a submenu with items to be opened below

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -6,8 +6,10 @@
 import './vaadin-menu-bar-submenu.js';
 import './vaadin-menu-bar-button.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ButtonsMixin } from './vaadin-menu-bar-buttons-mixin.js';
 import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
@@ -61,13 +63,16 @@ import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
  * @fires {CustomEvent<boolean>} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  *
  * @extends HTMLElement
+ * @mixes ControllerMixin
  * @mixes ButtonsMixin
  * @mixes InteractionsMixin
  * @mixes DisabledMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(PolymerElement))))) {
+class MenuBar extends ButtonsMixin(
+  DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))))),
+) {
   static get template() {
     return html`
       <style>
@@ -109,6 +114,8 @@ class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(
         </vaadin-menu-bar-button>
       </div>
       <vaadin-menu-bar-submenu is-root=""></vaadin-menu-bar-submenu>
+
+      <slot name="tooltip"></slot>
     `;
   }
 
@@ -211,6 +218,15 @@ class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(
 
   static get observers() {
     return ['_themeChanged(_theme)'];
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this._tooltipController.setManual(true);
+    this.addController(this._tooltipController);
   }
 
   /**

--- a/packages/menu-bar/test/typings/menu-bar.types.ts
+++ b/packages/menu-bar/test/typings/menu-bar.types.ts
@@ -1,4 +1,5 @@
 import '../../vaadin-menu-bar.js';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 import type { MenuBarItem, MenuBarItemSelectedEvent } from '../../vaadin-menu-bar.js';
 
@@ -7,6 +8,7 @@ const menu = document.createElement('vaadin-menu-bar');
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 assertType<ResizeMixinClass>(menu);
+assertType<ControllerMixinClass>(menu);
 
 menu.addEventListener('item-selected', (event) => {
   assertType<MenuBarItemSelectedEvent>(event);

--- a/packages/menu-bar/test/typings/menu-bar.types.ts
+++ b/packages/menu-bar/test/typings/menu-bar.types.ts
@@ -1,5 +1,6 @@
 import '../../vaadin-menu-bar.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 import type { MenuBarItem, MenuBarItemSelectedEvent } from '../../vaadin-menu-bar.js';
 
@@ -9,6 +10,7 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 
 assertType<ResizeMixinClass>(menu);
 assertType<ControllerMixinClass>(menu);
+assertType<FocusMixinClass>(menu);
 
 menu.addEventListener('item-selected', (event) => {
   assertType<MenuBarItemSelectedEvent>(event);


### PR DESCRIPTION
## Description

Added `vaadin-tooltip` support to `vaadin-menu-bar` via `tooltip` slot and `TooltipController`.

## Type of change

- Feature