### PR TITLE
docs: fix custom-field state attributes API docs

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -87,13 +87,15 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  *
  * Attribute           | Description                               | Part name
  * --------------------|-------------------------------------------|------------
- * `disabled`          | Set when the element is disabled          | :host
  * `invalid`           | Set when the element is invalid           | :host
  * `focused`           | Set when the element is focused           | :host
  * `has-label`         | Set when the element has a label          | :host
  * `has-value`         | Set when the element has a value          | :host
  * `has-helper`        | Set when the element has helper text      | :host
  * `has-error-message` | Set when the element has an error message | :host
+ *
+ * You may also manually set `disabled` or `readonly` attribute on this component to make the label
+ * part look visually the same as on a `<vaadin-text-field>` when it is disabled or readonly.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -37,13 +37,15 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * Attribute           | Description                               | Part name
  * --------------------|-------------------------------------------|------------
- * `disabled`          | Set when the element is disabled          | :host
  * `invalid`           | Set when the element is invalid           | :host
  * `focused`           | Set when the element is focused           | :host
  * `has-label`         | Set when the element has a label          | :host
  * `has-value`         | Set when the element has a value          | :host
  * `has-helper`        | Set when the element has helper text      | :host
  * `has-error-message` | Set when the element has an error message | :host
+ *
+ * You may also manually set `disabled` or `readonly` attribute on this component to make the label
+ * part look visually the same as on a `<vaadin-text-field>` when it is disabled or readonly.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Current API documentation is confusing as it makes an impression that the component supports `disabled` property.
This has been changed by mistake in #2795 when updating `vaadin-custom-field` to use new mixins.

Updated JSDoc to be more aligned with the [original docs](https://github.com/vaadin/vaadin-custom-field/blob/3676aef30dc1ac4843c692e1c6450ddb20619631/src/vaadin-custom-field.html#L78-L79) added in https://github.com/vaadin/vaadin-custom-field/pull/68

## Type of change

- Documentation