### PR TITLE
feat: add tooltip support to icon

### DIFF
--- a/dev/icon.html
+++ b/dev/icon.html
@@ -10,10 +10,13 @@
     <script type="module">
       import '@vaadin/icon';
       import '@vaadin/icons/vaadin-iconset.js';
+      import '@vaadin/tooltip';
     </script>
   </head>
 
   <body>
-    <vaadin-icon icon="vaadin:phone"></vaadin-icon>
+    <vaadin-icon icon="vaadin:phone">
+      <vaadin-tooltip slot="tooltip" text="Icon tooltip text"></vaadin-tooltip>
+    </vaadin-icon>
   </body>
 </html>

--- a/integration/package.json
+++ b/integration/package.json
@@ -19,6 +19,7 @@
     "@vaadin/email-field": "23.3.0-alpha0",
     "@vaadin/grid": "23.3.0-alpha0",
     "@vaadin/grid-pro": "23.3.0-alpha0",
+    "@vaadin/icon": "23.3.0-alpha0",
     "@vaadin/integer-field": "23.3.0-alpha0",
     "@vaadin/number-field": "23.3.0-alpha0",
     "@vaadin/message-input": "23.3.0-alpha0",

--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -10,6 +10,7 @@ import { DatePicker } from '@vaadin/date-picker';
 import { DateTimePicker } from '@vaadin/date-time-picker';
 import { Details } from '@vaadin/details';
 import { EmailField } from '@vaadin/email-field';
+import { Icon } from '@vaadin/icon';
 import { IntegerField } from '@vaadin/integer-field';
 import { MessageInput } from '@vaadin/message-input';
 import { MultiSelectComboBox } from '@vaadin/multi-select-combo-box';
@@ -37,6 +38,7 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
   { tagName: DateTimePicker.is, applyShouldNotShowCondition: (element) => element.querySelector('input').click() },
   { tagName: Details.is, targetSelector: '[part="summary"]', position: 'bottom-start' },
   { tagName: EmailField.is },
+  { tagName: Icon.is },
   { tagName: IntegerField.is },
   { tagName: MessageInput.is },
   { tagName: MultiSelectComboBox.is, applyShouldNotShowCondition: (comboBox) => comboBox.click() },

--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { IconSvgLiteral } from './vaadin-icon-svg.js';
@@ -46,7 +47,7 @@ import type { IconSvgLiteral } from './vaadin-icon-svg.js';
  * }
  * ```
  */
-declare class Icon extends ThemableMixin(ElementMixin(HTMLElement)) {
+declare class Icon extends ThemableMixin(ElementMixin(ControllerMixin(HTMLElement))) {
   /**
    * The name of the icon to use. The name should be of the form:
    * `iconset_name:icon_name`. When using `vaadin-icons` it is possible

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -4,7 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ensureSvgLiteral, renderSvg } from './vaadin-icon-svg.js';
 import { Iconset } from './vaadin-iconset.js';
@@ -51,10 +53,11 @@ const DEFAULT_ICONSET = 'vaadin';
  * ```
  *
  * @extends HTMLElement
+ * @mixes ControllerMixin
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class Icon extends ThemableMixin(ElementMixin(PolymerElement)) {
+class Icon extends ThemableMixin(ElementMixin(ControllerMixin(PolymerElement))) {
   static get template() {
     return html`
       <style>
@@ -87,6 +90,8 @@ class Icon extends ThemableMixin(ElementMixin(PolymerElement)) {
         preserveAspectRatio="xMidYMid meet"
         aria-hidden="true"
       ></svg>
+
+      <slot name="tooltip"></slot>
     `;
   }
 
@@ -147,6 +152,9 @@ class Icon extends ThemableMixin(ElementMixin(PolymerElement)) {
   ready() {
     super.ready();
     this.__svgElement = this.shadowRoot.querySelector('svg');
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
   }
 
   /** @private */

--- a/packages/icon/test/typings/icon.types.ts
+++ b/packages/icon/test/typings/icon.types.ts
@@ -1,8 +1,10 @@
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin';
 import type { Icon, IconSvgLiteral } from '../../vaadin-icon';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const icon = document.createElement('vaadin-icon');
 assertType<Icon>(icon);
+assertType<ControllerMixinClass>(icon);
 
 assertType<IconSvgLiteral | null>(icon.svg);


### PR DESCRIPTION
## Description

Added `vaadin-tooltip` support to `vaadin-icon` via `tooltip` slot and `TooltipController`.

## Type of change

- Feature