### PR TITLE
fix: do not reopen overlay when moving focus within target

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -346,7 +346,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     }
 
     // Do not re-open while focused if closed on Esc or mousedown.
-    if (this.target.contains(event.target) && this.target.contains(event.relatedTarget)) {
+    if (this.target.contains(event.relatedTarget)) {
       return;
     }
 

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -345,8 +345,8 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       return;
     }
 
-    // Do not re-open while focused if closed on Esc.
-    if (this.__focusInside && this.target.contains(event.relatedTarget)) {
+    // Do not re-open while focused if closed on Esc or mousedown.
+    if (this.target.contains(event.target) && this.target.contains(event.relatedTarget)) {
       return;
     }
 

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -339,14 +339,14 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /** @private */
-  __onFocusin() {
+  __onFocusin(event) {
     // Only open on keyboard focus.
     if (!isKeyboardActive()) {
       return;
     }
 
     // Do not re-open while focused if closed on Esc.
-    if (this.__focusInside && this.__escPressed) {
+    if (this.__focusInside && this.target.contains(event.relatedTarget)) {
       return;
     }
 
@@ -369,7 +369,6 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     }
 
     this.__focusInside = false;
-    this.__escPressed = false;
 
     if (!this.__hoverInside) {
       this._close(true);
@@ -380,7 +379,6 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   __onKeyDown(event) {
     if (event.key === 'Escape') {
       event.stopPropagation();
-      this.__escPressed = true;
       this._close(true);
     }
   }

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -345,6 +345,11 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       return;
     }
 
+    // Do not re-open while focused if closed on Esc.
+    if (this.__focusInside && this.__escPressed) {
+      return;
+    }
+
     if (typeof this.shouldShow === 'function' && this.shouldShow(this.target) !== true) {
       return;
     }
@@ -357,8 +362,14 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /** @private */
-  __onFocusout() {
+  __onFocusout(event) {
+    // Do not close when moving focus within a component.
+    if (this.target.contains(event.relatedTarget)) {
+      return;
+    }
+
     this.__focusInside = false;
+    this.__escPressed = false;
 
     if (!this.__hoverInside) {
       this._close(true);
@@ -369,6 +380,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   __onKeyDown(event) {
     if (event.key === 'Escape') {
       event.stopPropagation();
+      this.__escPressed = true;
       this._close(true);
     }
   }

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -1,5 +1,13 @@
 import { expect } from '@esm-bundle/chai';
-import { escKeyDown, fixtureSync, focusout, keyboardEventFor, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
+import {
+  escKeyDown,
+  fixtureSync,
+  focusin,
+  focusout,
+  keyboardEventFor,
+  mousedown,
+  tabKeyDown,
+} from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-tooltip.js';
@@ -183,7 +191,7 @@ describe('vaadin-tooltip', () => {
     let target;
 
     beforeEach(() => {
-      target = fixtureSync('<input>');
+      target = fixtureSync('<div tabindex="0"></div>');
       tooltip.target = target;
     });
 
@@ -336,6 +344,45 @@ describe('vaadin-tooltip', () => {
       mousedown(target);
       mouseenter(target);
       expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close overlay on moving focus within the target element', () => {
+      const input = document.createElement('input');
+      target.appendChild(input);
+
+      tabKeyDown(target);
+      target.focus();
+
+      focusout(target, input);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not re-open overlay on moving focus within the target after Esc', () => {
+      const input = document.createElement('input');
+      target.appendChild(input);
+
+      tabKeyDown(target);
+      target.focus();
+
+      escKeyDown(target);
+
+      focusout(target, input);
+      input.focus();
+
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should re-open overlay on moving focus out of the target after Esc', () => {
+      tabKeyDown(target);
+      target.focus();
+
+      escKeyDown(target);
+
+      focusout(target);
+      focusin(target);
+
+      expect(overlay.opened).to.be.true;
     });
   });
 

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -1,5 +1,13 @@
 import { expect } from '@esm-bundle/chai';
-import { escKeyDown, fixtureSync, focusout, keyboardEventFor, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
+import {
+  escKeyDown,
+  fixtureSync,
+  focusin,
+  focusout,
+  keyboardEventFor,
+  mousedown,
+  tabKeyDown,
+} from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-tooltip.js';
@@ -350,6 +358,22 @@ describe('vaadin-tooltip', () => {
       expect(overlay.opened).to.be.true;
     });
 
+    it('should not re-open overlay on moving focus within the target after mousedown', () => {
+      const input = document.createElement('input');
+      target.appendChild(input);
+
+      tabKeyDown(target);
+      target.focus();
+
+      mousedown(target);
+
+      tabKeyDown(target);
+      focusout(target, input);
+      focusin(input, target);
+
+      expect(overlay.opened).to.be.false;
+    });
+
     it('should not re-open overlay on moving focus within the target after Esc', () => {
       const input = document.createElement('input');
       target.appendChild(input);
@@ -359,8 +383,9 @@ describe('vaadin-tooltip', () => {
 
       escKeyDown(target);
 
+      tabKeyDown(target);
       focusout(target, input);
-      input.focus();
+      focusin(input, target);
 
       expect(overlay.opened).to.be.false;
     });

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -1,13 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import {
-  escKeyDown,
-  fixtureSync,
-  focusin,
-  focusout,
-  keyboardEventFor,
-  mousedown,
-  tabKeyDown,
-} from '@vaadin/testing-helpers';
+import { escKeyDown, fixtureSync, focusout, keyboardEventFor, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-tooltip.js';
@@ -371,18 +363,6 @@ describe('vaadin-tooltip', () => {
       input.focus();
 
       expect(overlay.opened).to.be.false;
-    });
-
-    it('should re-open overlay on moving focus out of the target after Esc', () => {
-      tabKeyDown(target);
-      target.focus();
-
-      escKeyDown(target);
-
-      focusout(target);
-      focusin(target);
-
-      expect(overlay.opened).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #4524

There are actually two fixes in this PR but these are related:

1. Changed to not close tooltip on `focusout` within a field (e.g. `vaadin-password-field` or `vaadin-list-box`),
2. Changed to not re-open tooltip on `focusin` within a field after pressing <kbd>Escape</kbd> to dismiss it.

## Type of change

- Bugfix
