### PR TITLE
fix: only show tooltip when target is fully visible

### DIFF
--- a/packages/tooltip/test/helpers.js
+++ b/packages/tooltip/test/helpers.js
@@ -1,4 +1,4 @@
-import { fire } from '@vaadin/testing-helpers';
+import { fire, nextFrame } from '@vaadin/testing-helpers';
 
 export function mouseenter(target) {
   fire(target, 'mouseenter');
@@ -6,4 +6,10 @@ export function mouseenter(target) {
 
 export function mouseleave(target) {
   fire(target, 'mouseleave');
+}
+
+export async function waitForIntersectionObserver() {
+  await nextFrame();
+  await nextFrame();
+  await nextFrame();
 }


### PR DESCRIPTION
## Description

Fixes #4502

Based on the implementation from #3590. Here is an example of the new behavior:

https://user-images.githubusercontent.com/10589913/188890662-60a6a030-6668-4b02-858e-be064239c050.mp4

Can be tested using the following HTML:

```html
<div style="width: 300px; height: 300px; overflow: scroll; border: 1px solid black;">
  <div style="margin: 600px 0; height: 50px; border: solid 1px red;" tabindex="0" id="test"></div>
</div>

<vaadin-tooltip text="Click to save changes" for="test"></vaadin-tooltip>
```

## Type of change

- Bugfix