### PR TITLE
feat: add custom CSS properties to define offset

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -68,6 +68,17 @@ class TooltipOverlay extends PositionMixin(OverlayElement) {
     super.requestContentUpdate();
 
     this.toggleAttribute('hidden', this.textContent.trim() === '');
+
+    // Copy custom properties from the tooltip
+    if (this.positionTarget && this.owner) {
+      const style = getComputedStyle(this.owner);
+      ['top', 'bottom', 'start', 'end'].forEach((prop) => {
+        this.style.setProperty(
+          `--vaadin-tooltip-offset-${prop}`,
+          style.getPropertyValue(`--vaadin-tooltip-offset-${prop}`),
+        );
+      });
+    }
   }
 
   /**
@@ -110,17 +121,6 @@ class TooltipOverlay extends PositionMixin(OverlayElement) {
 
       const offset = targetRect.height / 2 - overlayRect.height / 2;
       this.style.top = `${overlayRect.top + offset}px`;
-    }
-
-    // Copy custom properties from the tooltip
-    if (this.owner) {
-      const style = getComputedStyle(this.owner);
-      ['top', 'bottom', 'start', 'end'].forEach((prop) => {
-        this.style.setProperty(
-          `--vaadin-tooltip-offset-${prop}`,
-          style.getPropertyValue(`--vaadin-tooltip-offset-${prop}`),
-        );
-      });
     }
   }
 }

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -5,6 +5,33 @@
  */
 import { OverlayElement } from '@vaadin/vaadin-overlay/src/vaadin-overlay.js';
 import { PositionMixin } from '@vaadin/vaadin-overlay/src/vaadin-overlay-position-mixin.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-tooltip-overlay',
+  css`
+    :host([position^='top'][top-aligned]) [part='overlay'],
+    :host([position^='bottom'][top-aligned]) [part='overlay'] {
+      margin-top: var(--vaadin-tooltip-offset-top, 0);
+    }
+
+    :host([position^='top'][bottom-aligned]) [part='overlay'],
+    :host([position^='bottom'][bottom-aligned]) [part='overlay'] {
+      margin-bottom: var(--vaadin-tooltip-offset-bottom, 0);
+    }
+
+    :host([position^='start'][start-aligned]) [part='overlay'],
+    :host([position^='end'][start-aligned]) [part='overlay'] {
+      margin-inline-start: var(--vaadin-tooltip-offset-start, 0);
+    }
+
+    :host([position^='start'][end-aligned]) [part='overlay'],
+    :host([position^='end'][end-aligned]) [part='overlay'] {
+      margin-inline-end: var(--vaadin-tooltip-offset-end, 0);
+    }
+  `,
+  { moduleId: 'vaadin-tooltip-overlay-styles' },
+);
 
 let memoizedTemplate;
 
@@ -83,6 +110,17 @@ class TooltipOverlay extends PositionMixin(OverlayElement) {
 
       const offset = targetRect.height / 2 - overlayRect.height / 2;
       this.style.top = `${overlayRect.top + offset}px`;
+    }
+
+    // Copy custom properties from the tooltip
+    if (this.owner) {
+      const style = getComputedStyle(this.owner);
+      ['top', 'bottom', 'start', 'end'].forEach((prop) => {
+        this.style.setProperty(
+          `--vaadin-tooltip-offset-${prop}`,
+          style.getPropertyValue(`--vaadin-tooltip-offset-${prop}`),
+        );
+      });
     }
   }
 }

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -45,6 +45,17 @@ export type TooltipPosition =
  * Note: the `theme` attribute value set on `<vaadin-tooltip>` is
  * propagated to the internal `<vaadin-tooltip-overlay>` component.
  *
+ * ### Custom CSS Properties
+ *
+ * The following custom CSS properties are available on the `<vaadin-tooltip>` element:
+ *
+ * Custom CSS property              | Description
+ * ---------------------------------|-------------
+ * `--vaadin-tooltip-offset-top`    | Used as an offset when the tooltip is aligned vertically below the target
+ * `--vaadin-tooltip-offset-bottom` | Used as an offset when the tooltip is aligned vertically above the target
+ * `--vaadin-tooltip-offset-start`  | Used as an offset when the tooltip is aligned horizontally after the target
+ * `--vaadin-tooltip-offset-end`    | Used as an offset when the tooltip is aligned horizontally before the target
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  */
 declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -47,6 +47,17 @@ let cooldownTimeout = null;
  * Note: the `theme` attribute value set on `<vaadin-tooltip>` is
  * propagated to the internal `<vaadin-tooltip-overlay>` component.
  *
+ * ### Custom CSS Properties
+ *
+ * The following custom CSS properties are available on the `<vaadin-tooltip>` element:
+ *
+ * Custom CSS property              | Description
+ * ---------------------------------|-------------
+ * `--vaadin-tooltip-offset-top`    | Used as an offset when the tooltip is aligned vertically below the target
+ * `--vaadin-tooltip-offset-bottom` | Used as an offset when the tooltip is aligned vertically above the target
+ * `--vaadin-tooltip-offset-start`  | Used as an offset when the tooltip is aligned horizontally after the target
+ * `--vaadin-tooltip-offset-end`    | Used as an offset when the tooltip is aligned horizontally before the target
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *
  * @extends HTMLElement
@@ -265,6 +276,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     super.ready();
 
     this._overlayElement = this.shadowRoot.querySelector('vaadin-tooltip-overlay');
+    this._overlayElement.owner = this;
   }
 
   /** @protected */

--- a/packages/tooltip/test/tooltip-offset.test.js
+++ b/packages/tooltip/test/tooltip-offset.test.js
@@ -1,0 +1,115 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import '../src/vaadin-tooltip.js';
+
+describe('offset', () => {
+  let tooltip, target, overlay;
+
+  beforeEach(() => {
+    tooltip = fixtureSync('<vaadin-tooltip text="tooltip"></vaadin-tooltip>');
+    target = fixtureSync('<div style="width: 100px; height: 100px; margin: 100px; outline: 1px solid red;"></div>');
+    tooltip.target = target;
+    overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+  });
+
+  async function open() {
+    fire(target, 'mouseenter');
+    await oneEvent(overlay, 'vaadin-overlay-open');
+  }
+
+  ['top-start', 'top', 'top-end'].forEach((position) => {
+    describe(`${position} offset`, () => {
+      beforeEach(() => {
+        tooltip.position = position;
+        tooltip.style.setProperty('--vaadin-tooltip-offset-bottom', '10px');
+        tooltip.style.setProperty('--vaadin-tooltip-offset-top', '10px');
+      });
+
+      it(`should use "--vaadin-tooltip-offset-bottom" for ${position} position by default (above target)`, async () => {
+        await open();
+        expect(getComputedStyle(overlay.$.overlay).marginBottom).to.equal('10px');
+        expect(getComputedStyle(overlay.$.overlay).marginTop).to.equal('0px');
+      });
+
+      it(`should use "--vaadin-tooltip-offset-top" for ${position} position when flipped (below target)`, async () => {
+        target.style.marginTop = 0;
+        await open();
+        expect(getComputedStyle(overlay.$.overlay).marginTop).to.equal('10px');
+        expect(getComputedStyle(overlay.$.overlay).marginBottom).to.equal('0px');
+      });
+    });
+  });
+
+  ['bottom-start', 'bottom', 'bottom-end'].forEach((position) => {
+    describe(`${position} offset`, () => {
+      beforeEach(() => {
+        tooltip.position = position;
+        tooltip.style.setProperty('--vaadin-tooltip-offset-bottom', '10px');
+        tooltip.style.setProperty('--vaadin-tooltip-offset-top', '10px');
+      });
+
+      it(`should use "--vaadin-tooltip-offset-top" for ${position} position by default (below target)`, async () => {
+        await open();
+        expect(getComputedStyle(overlay.$.overlay).marginTop).to.equal('10px');
+        expect(getComputedStyle(overlay.$.overlay).marginBottom).to.equal('0px');
+      });
+
+      it(`should use "--vaadin-tooltip-offset-bottom" for ${position} position when flipped (above target)`, async () => {
+        target.style.position = 'absolute';
+        target.style.bottom = 0;
+        target.style.marginBottom = 0;
+        await open();
+        expect(getComputedStyle(overlay.$.overlay).marginBottom).to.equal('10px');
+        expect(getComputedStyle(overlay.$.overlay).marginTop).to.equal('0px');
+      });
+    });
+  });
+
+  ['start-top', 'start', 'start-bottom'].forEach((position) => {
+    describe(`${position} offset`, () => {
+      beforeEach(() => {
+        tooltip.position = position;
+        tooltip.style.setProperty('--vaadin-tooltip-offset-end', '10px');
+        tooltip.style.setProperty('--vaadin-tooltip-offset-start', '10px');
+      });
+
+      it(`should use "--vaadin-tooltip-offset-end" for ${position} position by default (before target)`, async () => {
+        await open();
+        expect(getComputedStyle(overlay.$.overlay).marginInlineEnd).to.equal('10px');
+        expect(getComputedStyle(overlay.$.overlay).marginInlineStart).to.equal('0px');
+      });
+
+      it(`should use "--vaadin-tooltip-offset-start" for ${position} position when flipped (after target)`, async () => {
+        target.style.marginInlineStart = 0;
+        await open();
+        expect(getComputedStyle(overlay.$.overlay).marginInlineStart).to.equal('10px');
+        expect(getComputedStyle(overlay.$.overlay).marginInlineEnd).to.equal('0px');
+      });
+    });
+  });
+
+  ['end-top', 'end', 'end-bottom'].forEach((position) => {
+    describe(`${position} offset`, () => {
+      beforeEach(() => {
+        tooltip.position = position;
+        tooltip.style.setProperty('--vaadin-tooltip-offset-start', '10px');
+        tooltip.style.setProperty('--vaadin-tooltip-offset-end', '10px');
+      });
+
+      it(`should use "--vaadin-tooltip-offset-start" for ${position} position by default (after target)`, async () => {
+        await open();
+        expect(getComputedStyle(overlay.$.overlay).marginInlineStart).to.equal('10px');
+        expect(getComputedStyle(overlay.$.overlay).marginInlineEnd).to.equal('0px');
+      });
+
+      it(`should use "--vaadin-tooltip-offset-end" for ${position} position when flipped (before target)`, async () => {
+        target.style.position = 'absolute';
+        target.style.right = 0;
+        target.style.marginInlineEnd = 0;
+        await open();
+        expect(getComputedStyle(overlay.$.overlay).marginInlineEnd).to.equal('10px');
+        expect(getComputedStyle(overlay.$.overlay).marginInlineStart).to.equal('0px');
+      });
+    });
+  });
+});

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -38,6 +38,10 @@ describe('vaadin-tooltip', () => {
   });
 
   describe('overlay', () => {
+    it('should set owner property on the overlay', () => {
+      expect(overlay.owner).to.be.equal(tooltip);
+    });
+
     it('should not have tabindex on the overlay part', () => {
       expect(overlay.$.overlay.hasAttribute('tabindex')).to.be.false;
     });

--- a/packages/tooltip/theme/lumo/vaadin-tooltip-styles.js
+++ b/packages/tooltip/theme/lumo/vaadin-tooltip-styles.js
@@ -4,20 +4,17 @@ import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const tooltipOverlay = css`
+  :host {
+    --vaadin-tooltip-offset-top: var(--lumo-space-xs);
+    --vaadin-tooltip-offset-bottom: var(--lumo-space-xs);
+    --vaadin-tooltip-offset-start: var(--lumo-space-xs);
+    --vaadin-tooltip-offset-end: var(--lumo-space-xs);
+  }
+
   [part='overlay'] {
     background-color: var(--lumo-contrast);
     color: var(--lumo-primary-contrast-color);
     font-size: var(--lumo-font-size-xs);
-  }
-
-  :host([position^='top']) [part='overlay'],
-  :host([position^='bottom']) [part='overlay'] {
-    margin: var(--lumo-space-xs) 0;
-  }
-
-  :host([position^='start']) [part='overlay'],
-  :host([position^='end']) [part='overlay'] {
-    margin: 0 var(--lumo-space-xs);
   }
 
   [part='content'] {

--- a/packages/tooltip/theme/material/vaadin-tooltip-styles.js
+++ b/packages/tooltip/theme/material/vaadin-tooltip-styles.js
@@ -2,20 +2,17 @@ import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const tooltipOverlay = css`
+  :host {
+    --vaadin-tooltip-offset-top: 0.25rem;
+    --vaadin-tooltip-offset-bottom: 0.25rem;
+    --vaadin-tooltip-offset-start: 0.25rem;
+    --vaadin-tooltip-offset-end: 0.25rem;
+  }
+
   [part='overlay'] {
     background-color: rgba(97, 97, 97, 0.92);
     color: #fff;
     font-size: 0.6875rem;
-  }
-
-  :host([position^='top']) [part='overlay'],
-  :host([position^='bottom']) [part='overlay'] {
-    margin: 0.25rem 0;
-  }
-
-  :host([position^='start']) [part='overlay'],
-  :host([position^='end']) [part='overlay'] {
-    margin: 0 0.25rem;
   }
 
   [part='content'] {


### PR DESCRIPTION
## Description

Fixes #4530

Added custom CSS properties to control offset for different tooltip positions and updated themes to use them.
This should make it possible for e.g. `vaadin-text-field` with a label to tweak the slotted tooltip offset.

The next step would be to also add corresponding styles, probably to "mixins" folders in Lumo / Material packages.

## Type of change

- Feature