### PR TITLE
refactor: use KeyboardMixin in vaadin-accordion

### DIFF
--- a/packages/accordion/src/vaadin-accordion.d.ts
+++ b/packages/accordion/src/vaadin-accordion.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { AccordionPanel } from './vaadin-accordion-panel.js';
 
@@ -69,7 +70,7 @@ export type AccordionEventMap = AccordionCustomEventMap & HTMLElementEventMap;
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
-declare class Accordion extends ElementMixin(ThemableMixin(HTMLElement)) {
+declare class Accordion extends KeyboardMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   /**
    * The index of currently opened panel. First panel is opened by
    * default. Only one panel can be opened at the same time.

--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -6,6 +6,7 @@
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { AccordionPanel } from './vaadin-accordion-panel.js';
 
@@ -55,9 +56,10 @@ import { AccordionPanel } from './vaadin-accordion-panel.js';
  *
  * @extends HTMLElement
  * @mixes ElementMixin
+ * @mixes KeyboardMixin
  * @mixes ThemableMixin
  */
-class Accordion extends ThemableMixin(ElementMixin(PolymerElement)) {
+class Accordion extends KeyboardMixin(ThemableMixin(ElementMixin(PolymerElement))) {
   static get template() {
     return html`
       <style>
@@ -142,8 +144,6 @@ class Accordion extends ThemableMixin(ElementMixin(PolymerElement)) {
   ready() {
     super.ready();
 
-    this.addEventListener('keydown', (e) => this._onKeydown(e));
-
     this._observer = new FlattenedNodesObserver(this, (info) => {
       this._setItems(this._filterItems(Array.from(this.children)));
 
@@ -173,10 +173,13 @@ class Accordion extends ThemableMixin(ElementMixin(PolymerElement)) {
   }
 
   /**
+   * Override an event listener from `KeyboardMixin`.
+   *
    * @param {!KeyboardEvent} event
    * @protected
+   * @override
    */
-  _onKeydown(event) {
+  _onKeyDown(event) {
     // Only check keyboard events on details toggle buttons
     const item = event.composedPath()[0];
     if (!this.items.some((el) => el.focusElement === item)) {


### PR DESCRIPTION
## Description

Changed `vaadin-accordion` to use `KeyboardMixin` instead of adding a `keydown` event listener.
This is a preparation step for integration `KeyboardDirectionMixin` that will be added later.

## Type of change

- Refactor