### PR TITLE
refactor: remove unnecessary checks for virtualizer's presence

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -175,7 +175,7 @@ export class ComboBoxScroller extends PolymerElement {
   }
 
   scrollIntoView(index) {
-    if (!(this.opened && index >= 0)) {
+    if (!this.__virtualizer || !this.opened || index === -1) {
       return;
     }
 
@@ -249,24 +249,16 @@ export class ComboBoxScroller extends PolymerElement {
 
   /** @private */
   __loadingChanged() {
-    if (this.__virtualizer) {
-      setTimeout(() => this.requestContentUpdate());
-    }
+    setTimeout(() => this.requestContentUpdate());
   }
 
   /** @private */
   __selectedItemChanged() {
-    if (this.__virtualizer) {
-      this.requestContentUpdate();
-    }
+    this.requestContentUpdate();
   }
 
   /** @private */
   __focusedIndexChanged(index, oldIndex) {
-    if (!this.__virtualizer) {
-      return;
-    }
-
     if (index !== oldIndex) {
       this.requestContentUpdate();
     }

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -169,13 +169,11 @@ export class ComboBoxScroller extends PolymerElement {
   }
 
   requestContentUpdate() {
-    if (this.__virtualizer) {
-      this.__virtualizer.update();
-    }
+    this.__virtualizer.update();
   }
 
   scrollIntoView(index) {
-    if (!this.__virtualizer || !this.opened || index === -1) {
+    if (!(this.opened && index >= 0)) {
       return;
     }
 


### PR DESCRIPTION
## Description

This PR removes unnecessary checks for the virtualizer's presence from `vaadin-combo-box-scroller` because neither `requestContentUpdate()` nor `scrollIntoView()` can be invoked before a virtualizer instance is created in `ready()`.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
