### PR TITLE
test: ignore a flaky test on Firefox

### DIFF
--- a/packages/grid/test/scrolling-mode.test.js
+++ b/packages/grid/test/scrolling-mode.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, isDesktopSafari, listenOnce, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, isDesktopSafari, isFirefox, listenOnce, nextFrame } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
@@ -98,7 +98,7 @@ describe('scrolling mode', () => {
     // It perhaps has something to do with the specific version of WebKit
     // Playwright uses on CI. It sometimes fails also in Firefox on CI,
     // but not as often as in WebKit.
-    (isDesktopSafari ? it.skip : it)('update on resize', async () => {
+    (isDesktopSafari || isFirefox ? it.skip : it)('update on resize', async () => {
       grid.style.width = '200px';
       await onceResized(grid);
       await nextFrame();


### PR DESCRIPTION
Ignore a flaky test case on Firefox. The test passes fine on Chrome but it randomly keeps failing builds on Firefox for unrelated pull requests. The test is [already ignored on Safari](https://github.com/vaadin/web-components/commit/778e66249c0a1cb9299ad07821aab8aea4c72f9c) for the same reason.