### PR TITLE
refactor: use KeyboardMixin in vaadin-menu-bar

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.d.ts
@@ -5,10 +5,11 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 
 export declare function InteractionsMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<FocusMixinClass> & Constructor<InteractionsMixinClass> & T;
+): Constructor<FocusMixinClass> & Constructor<InteractionsMixinClass> & Constructor<KeyboardMixinClass> & T;
 
 export declare class InteractionsMixinClass {
   /**

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -189,9 +189,9 @@ export const InteractionsMixin = (superClass) =>
     _onEscape(event) {
       if (event.composedPath().includes(this._expandedButton)) {
         this._close(true);
-      } else {
-        this._hideTooltip();
       }
+
+      this._hideTooltip();
     }
 
     /**

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -5,13 +5,15 @@
  */
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { isKeyboardActive } from '@vaadin/component-base/src/focus-utils.js';
+import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 
 /**
  * @polymerMixin
  * @mixes FocusMixin
+ * @mixes KeyboardMixin
  */
 export const InteractionsMixin = (superClass) =>
-  class InteractionsMixin extends FocusMixin(superClass) {
+  class InteractionsMixin extends KeyboardMixin(FocusMixin(superClass)) {
     static get properties() {
       return {
         /**
@@ -37,7 +39,6 @@ export const InteractionsMixin = (superClass) =>
     ready() {
       super.ready();
 
-      this.addEventListener('keydown', (e) => this._onKeydown(e));
       this.addEventListener('mousedown', () => this._hideTooltip());
       this.addEventListener('mouseleave', () => this._hideTooltip());
 
@@ -144,38 +145,75 @@ export const InteractionsMixin = (superClass) =>
 
     /**
      * @param {!KeyboardEvent} event
-     * @protected
+     * @private
      */
-    _onKeydown(event) {
-      const button = this._getButtonFromEvent(event);
-      if (button) {
-        if (event.key === 'Escape') {
-          this._hideTooltip();
-        }
+    _onArrowDown(event) {
+      // Prevent page scroll.
+      event.preventDefault();
 
-        if (event.keyCode === 40) {
-          // ArrowDown, prevent page scroll
-          event.preventDefault();
-          if (button === this._expandedButton) {
-            // Menu opened previously, focus first item
-            this._focusFirstItem();
-          } else {
-            this.__openSubMenu(button, event);
-          }
-        } else if (event.keyCode === 38) {
-          // ArrowUp, prevent page scroll
-          event.preventDefault();
-          if (button === this._expandedButton) {
-            // Menu opened previously, focus last item
-            this._focusLastItem();
-          } else {
-            this.__openSubMenu(button, event, { focusLast: true });
-          }
-        } else if (event.keyCode === 27 && button === this._expandedButton) {
-          this._close(true);
-        } else {
+      const button = this._getButtonFromEvent(event);
+      if (button === this._expandedButton) {
+        // Menu opened previously, focus first item
+        this._focusFirstItem();
+      } else {
+        this.__openSubMenu(button, event);
+      }
+    }
+
+    /**
+     * @param {!KeyboardEvent} event
+     * @private
+     */
+    _onArrowUp(event) {
+      // Prevent page scroll.
+      event.preventDefault();
+
+      const button = this._getButtonFromEvent(event);
+      if (button === this._expandedButton) {
+        // Menu opened previously, focus last item
+        this._focusLastItem();
+      } else {
+        this.__openSubMenu(button, event, { focusLast: true });
+      }
+    }
+
+    /**
+     * Override an event listener from `KeyboardMixin`:
+     * - to close the sub-menu for expanded button,
+     * - to close a tooltip for collapsed button.
+     *
+     * @param {!KeyboardEvent} event
+     * @protected
+     * @override
+     */
+    _onEscape(event) {
+      if (event.composedPath().includes(this._expandedButton)) {
+        this._close(true);
+      } else {
+        this._hideTooltip();
+      }
+    }
+
+    /**
+     * Override an event listener from `KeyboardMixin`.
+     *
+     * @param {!KeyboardEvent} event
+     * @protected
+     * @override
+     */
+    _onKeyDown(event) {
+      switch (event.key) {
+        case 'ArrowDown':
+          this._onArrowDown(event);
+          break;
+        case 'ArrowUp':
+          this._onArrowUp(event);
+          break;
+        default:
+          super._onKeyDown(event);
+
           this._navigateByKey(event);
-        }
+          break;
       }
     }
 


### PR DESCRIPTION
## Description

Changed `vaadin-menu-bar` to use `KeyboardMixin` instead of adding a `keydown` event listener.
This is a preparation step for integrating `KeyboardDirectionMixin` that will be added later.

## Type of change

- Refactor