### PR TITLE
refactor: do not return index from __requestItemByIndex

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -294,7 +294,7 @@ export class ComboBoxScroller extends PolymerElement {
 
     el.setProperties({
       item,
-      index: this.__requestItemByIndex(item, index),
+      index,
       label: this.getItemLabel(item),
       selected: this.__isItemSelected(item, this.selectedItem, this.itemIdPath),
       renderer: this.renderer,
@@ -310,6 +310,10 @@ export class ComboBoxScroller extends PolymerElement {
       el.setAttribute('theme', this.theme);
     } else {
       el.removeAttribute('theme');
+    }
+
+    if (item instanceof ComboBoxPlaceholder) {
+      this.__requestItemByIndex(index);
     }
   }
 
@@ -351,19 +355,18 @@ export class ComboBoxScroller extends PolymerElement {
   }
 
   /**
-   * If dataProvider is used, dispatch a request for the item’s index if
-   * the item is a placeholder object.
-   *
-   * @return {number}
+   * Dispatches an `index-requested` event for the given index to notify
+   * the data provider that it should start loading the page containing the requested index.
    */
-  __requestItemByIndex(item, index) {
-    if (item instanceof ComboBoxPlaceholder && index !== undefined) {
-      this.dispatchEvent(
-        new CustomEvent('index-requested', { detail: { index, currentScrollerPos: this._oldScrollerPosition } }),
-      );
-    }
-
-    return index;
+  __requestItemByIndex(index) {
+    this.dispatchEvent(
+      new CustomEvent('index-requested', {
+        detail: {
+          index,
+          currentScrollerPos: this._oldScrollerPosition,
+        },
+      }),
+    );
   }
 
   /** @private */


### PR DESCRIPTION
## Description

There is no sense in returning `index` from `__requestItemByIndex` given that `index` is passed in arguments which means the caller has a reference to it.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
