### PR TITLE
feat: add KeyboardDirectionMixin to navigate items

### DIFF
--- a/packages/component-base/src/keyboard-direction-mixin.d.ts
+++ b/packages/component-base/src/keyboard-direction-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * Copyright (c) 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';

--- a/packages/component-base/src/keyboard-direction-mixin.d.ts
+++ b/packages/component-base/src/keyboard-direction-mixin.d.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { KeyboardMixinClass } from './keyboard-mixin.js';
+
+/**
+ * A mixin for navigating items with keyboard.
+ */
+export declare function KeyboardDirectionMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<KeyboardDirectionMixinClass> & Constructor<KeyboardMixinClass> & T;
+
+export declare class KeyboardDirectionMixinClass {
+  protected readonly focused: Element | null;
+
+  protected readonly _vertical: boolean;
+
+  /**
+   * Returns index of the next item that satisfies the given condition,
+   * based on the index of the current item and a numeric increment.
+   */
+  protected _getAvailableIndex(
+    items: Element[],
+    index: number,
+    increment: number,
+    condition: (item: Element) => boolean,
+  ): number;
+
+  /**
+   * Focus the item at given index. Override this method to add custom logic.
+   */
+  protected _focus(index: number, navigating: boolean): void;
+
+  /**
+   * Focus the given item. Override this method to add custom logic.
+   */
+  protected _focusItem(item: Element, navigating: boolean): void;
+}

--- a/packages/component-base/src/keyboard-direction-mixin.js
+++ b/packages/component-base/src/keyboard-direction-mixin.js
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright (c) 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { isElementFocused, isElementHidden } from './focus-utils.js';
+import { KeyboardMixin } from './keyboard-mixin.js';
+
+/**
+ * A mixin for navigating items with keyboard.
+ *
+ * @polymerMixin
+ * @mixes KeyboardMixin
+ */
+export const KeyboardDirectionMixin = (superclass) =>
+  class KeyboardDirectionMixinClass extends KeyboardMixin(superclass) {
+    /** @protected */
+    focus() {
+      const items = this._getItems();
+      if (Array.isArray(items)) {
+        const idx = this._getAvailableIndex(items, 0, null, (item) => !isElementHidden(item));
+        if (idx >= 0) {
+          items[idx].focus();
+        }
+      }
+    }
+
+    /**
+     * @return {Element | null}
+     * @protected
+     */
+    get focused() {
+      return (this._getItems() || []).find(isElementFocused);
+    }
+
+    /**
+     * @return {boolean}
+     * @protected
+     */
+    get _vertical() {
+      return true;
+    }
+
+    /**
+     * Get the list of items participating in keyboard navigation.
+     * By default, it treats all the light DOM children as items.
+     * Override this method to provide custom list of elements.
+     *
+     * @return {Element[]}
+     * @protected
+     */
+    _getItems() {
+      return Array.from(this.children);
+    }
+
+    /**
+     * Override an event listener from `KeyboardMixin`.
+     *
+     * @param {!KeyboardEvent} event
+     * @protected
+     * @override
+     */
+    _onKeyDown(event) {
+      super._onKeyDown(event);
+
+      if (event.metaKey || event.ctrlKey) {
+        return;
+      }
+
+      const { key } = event;
+      const items = this._getItems() || [];
+      const currentIdx = items.indexOf(this.focused);
+
+      let idx;
+      let increment;
+
+      const isRTL = !this._vertical && this.getAttribute('dir') === 'rtl';
+      const dirIncrement = isRTL ? -1 : 1;
+
+      if (this.__isPrevKey(key)) {
+        increment = -dirIncrement;
+        idx = currentIdx - dirIncrement;
+      } else if (this.__isNextKey(key)) {
+        increment = dirIncrement;
+        idx = currentIdx + dirIncrement;
+      } else if (key === 'Home') {
+        increment = 1;
+        idx = 0;
+      } else if (key === 'End') {
+        increment = -1;
+        idx = items.length - 1;
+      }
+
+      idx = this._getAvailableIndex(items, idx, increment, (item) => !isElementHidden(item));
+
+      if (idx >= 0) {
+        event.preventDefault();
+        this._focus(idx, true);
+      }
+    }
+
+    /**
+     * @param {string} key
+     * @return {boolean}
+     * @private
+     */
+    __isPrevKey(key) {
+      return this._vertical ? key === 'ArrowUp' : key === 'ArrowLeft';
+    }
+
+    /**
+     * @param {string} key
+     * @return {boolean}
+     * @private
+     */
+    __isNextKey(key) {
+      return this._vertical ? key === 'ArrowDown' : key === 'ArrowRight';
+    }
+
+    /**
+     * Focus the item at given index. Override this method to add custom logic.
+     *
+     * @param {number} index
+     * @param {boolean} navigating
+     * @protected
+     */
+    _focus(index, navigating = false) {
+      const items = this._getItems();
+
+      this._focusItem(items[index], navigating);
+    }
+
+    /**
+     * Focus the given item. Override this method to add custom logic.
+     *
+     * @param {Element} item
+     * @param {boolean} navigating
+     * @protected
+     */
+    _focusItem(item) {
+      if (item) {
+        item.focus();
+
+        // Generally, the items are expected to implement `FocusMixin`
+        // that would set this attribute based on the `keydown` event.
+        // We set it manually to handle programmatic focus() calls.
+        item.setAttribute('focus-ring', '');
+      }
+    }
+
+    /**
+     * Returns index of the next item that satisfies the given condition,
+     * based on the index of the current item and a numeric increment.
+     *
+     * @param {Element[]} items - array of items to iterate over
+     * @param {number} index - index of the current item
+     * @param {number} increment - numeric increment, can be either 1 or -1
+     * @param {Function} condition - function used to check the item
+     * @return {number}
+     * @protected
+     */
+    _getAvailableIndex(items, index, increment, condition) {
+      const totalItems = items.length;
+      let idx = index;
+      for (let i = 0; typeof idx === 'number' && i < totalItems; i += 1, idx += increment || 1) {
+        if (idx < 0) {
+          idx = totalItems - 1;
+        } else if (idx >= totalItems) {
+          idx = 0;
+        }
+
+        const item = items[idx];
+
+        if (!item.hasAttribute('disabled') && this.__isMatchingItem(item, condition)) {
+          return idx;
+        }
+      }
+      return -1;
+    }
+
+    /**
+     * Returns true if the item matches condition.
+     *
+     * @param {Element} item - item to check
+     * @param {Function} condition - function used to check the item
+     * @return {number}
+     * @private
+     */
+    __isMatchingItem(item, condition) {
+      return typeof condition === 'function' ? condition(item) : true;
+    }
+  };

--- a/packages/component-base/test/keyboard-direction-mixin.test.js
+++ b/packages/component-base/test/keyboard-direction-mixin.test.js
@@ -1,0 +1,192 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  arrowDownKeyDown,
+  arrowLeftKeyDown,
+  arrowRightKeyDown,
+  arrowUpKeyDown,
+  endKeyDown,
+  fixtureSync,
+  homeKeyDown,
+} from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { KeyboardDirectionMixin } from '../src/keyboard-direction-mixin.js';
+
+customElements.define(
+  'keyboard-direction-mixin-element',
+  class extends KeyboardDirectionMixin(PolymerElement) {
+    static get template() {
+      return html`
+        <style>
+          ::slotted(.hidden) {
+            display: none;
+          }
+
+          :host(:not([vertical])) {
+            display: flex;
+          }
+        </style>
+        <slot></slot>
+      `;
+    }
+
+    get _vertical() {
+      return this.hasAttribute('vertical');
+    }
+  },
+);
+
+describe('keyboard-direction-mixin', () => {
+  let element, items;
+
+  beforeEach(() => {
+    element = fixtureSync(`
+      <keyboard-direction-mixin-element>
+        <div tabindex="0">Foo</div>
+        <div tabindex="0">Bar</div>
+        <div disabled>Baz</div>
+        <div tabindex="0">Qux</div>
+        <div tabindex="0">Xyz</div>
+        <div tabindex="0">Abc</div>
+      </keyboard-direction-mixin-element>
+    `);
+    items = element.children;
+  });
+
+  describe('focus', () => {
+    it('should focus the first child element', () => {
+      const spy = sinon.spy(items[0], 'focus');
+      element.focus();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should focus the first non-disabled element', () => {
+      items[0].setAttribute('disabled', '');
+      const spy = sinon.spy(items[1], 'focus');
+      element.focus();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should focus the first non-hidden element', () => {
+      items[0].setAttribute('hidden', '');
+      element.focus();
+      expect(element.focused).to.be.equal(items[1]);
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    beforeEach(() => {
+      element.focus();
+    });
+
+    describe('horizontal', () => {
+      describe('LTR', () => {
+        it('should move focus to next element on "arrow-right" keydown in LTR', () => {
+          arrowRightKeyDown(items[0]);
+          expect(element.focused).to.be.equal(items[1]);
+        });
+
+        it('should move focus to prev element on "arrow-right" keydown in LTR', () => {
+          arrowRightKeyDown(items[0]);
+          arrowLeftKeyDown(items[1]);
+          expect(element.focused).to.be.equal(items[0]);
+        });
+      });
+
+      describe('RTL', () => {
+        beforeEach(() => {
+          element.setAttribute('dir', 'rtl');
+        });
+
+        it('should move focus to next element on "arrow-left" keydown in RTL', () => {
+          arrowLeftKeyDown(items[0]);
+          expect(element.focused).to.be.equal(items[1]);
+        });
+
+        it('should move focus to prev element on "arrow-right" keydown in RTL', () => {
+          arrowLeftKeyDown(items[0]);
+          arrowRightKeyDown(items[1]);
+          expect(element.focused).to.be.equal(items[0]);
+        });
+      });
+    });
+
+    describe('vertical', () => {
+      beforeEach(() => {
+        element.setAttribute('vertical', '');
+      });
+
+      it('should move focus to next element on "arrow-down" keydown', () => {
+        arrowDownKeyDown(items[0]);
+        expect(element.focused).to.be.equal(items[1]);
+      });
+
+      it('should move focus to prev element on "arrow-up" keydown', () => {
+        arrowDownKeyDown(items[0]);
+        arrowUpKeyDown(items[1]);
+        expect(element.focused).to.be.equal(items[0]);
+      });
+
+      it('should move focus to first element on "home" keydown', () => {
+        arrowDownKeyDown(items[0]);
+        homeKeyDown(items[1]);
+        expect(element.focused).to.be.equal(items[0]);
+      });
+
+      it('should move focus to last element on "end" keydown', () => {
+        endKeyDown(items[0]);
+        expect(element.focused).to.be.equal(items[5]);
+      });
+
+      it('should focus the first non-disabled element on "home" keydown', () => {
+        items[0].setAttribute('disabled', '');
+        items[3].focus();
+        homeKeyDown(items[3]);
+        expect(element.focused).to.be.equal(items[1]);
+      });
+
+      it('should focus to the last non-disabled element on "end" keydown', () => {
+        items[5].setAttribute('disabled', '');
+        endKeyDown(items[0]);
+        expect(element.focused).to.be.equal(items[4]);
+      });
+
+      it('should set focus-ring on the focused element on keydown', () => {
+        arrowDownKeyDown(items[0]);
+        expect(items[1].hasAttribute('focus-ring')).to.be.true;
+      });
+
+      it('should not move focus on keydown with Ctrl key modifier', () => {
+        const spy = sinon.spy(items[1], 'focus');
+        arrowDownKeyDown(items[0], ['ctrl']);
+        expect(spy.called).to.be.false;
+      });
+
+      it('should not move focus on keydown with Meta key modifier', () => {
+        const spy = sinon.spy(items[1], 'focus');
+        arrowDownKeyDown(items[0], ['meta']);
+        expect(spy.called).to.be.false;
+      });
+    });
+
+    describe('hidden items', () => {
+      it('should skip element hidden using attribute', () => {
+        items[1].setAttribute('hidden', '');
+        arrowRightKeyDown(items[0]);
+        expect(element.focused).to.be.equal(items[3]);
+      });
+
+      it('should skip element hidden with using CSS class', () => {
+        items[1].classList.add('hidden');
+        arrowRightKeyDown(items[0]);
+        expect(element.focused).to.be.equal(items[3]);
+      });
+
+      it('should skip element hidden with using inline style', () => {
+        items[1].style.display = 'none';
+        arrowRightKeyDown(items[0]);
+        expect(element.focused).to.be.equal(items[3]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Added `KeyboardDirectionMixin` that provides some common logic to be used by components:

- `vaadin-list-box` and `vaadin-tabs` (via `ListMixin`)
- `vaadin-accordion`
- `vaadin-menu-bar`
- `vaadin-message-list`

## Type of change

- Internal feature