### PR TITLE
refactor: replace `.filter()` usage with `.find()` and `.some()`

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -105,7 +105,7 @@ export const ItemsMixin = (superClass) =>
       // Overlay's outside click listener doesn't work with modeless
       // overlays (submenus) so we need additional logic for it
       this.__itemsOutsideClickListener = (e) => {
-        if (!e.composedPath().filter((el) => el.localName === 'vaadin-context-menu-overlay')[0]) {
+        if (!e.composedPath().some((el) => el.localName === 'vaadin-context-menu-overlay')) {
           this.dispatchEvent(new CustomEvent('items-outside-click'));
         }
       };
@@ -335,7 +335,7 @@ export const ItemsMixin = (superClass) =>
         });
         const openSubMenu = (
           e,
-          itemElement = e.composedPath().filter((e) => e.localName === 'vaadin-context-menu-item')[0],
+          itemElement = e.composedPath().find((e) => e.localName === 'vaadin-context-menu-item'),
         ) => {
           // Delay enabling the mouseover listener to avoid it from triggering on parent menu open
           if (!this.__openListenerActive) {

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -1171,7 +1171,7 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
   /** @private */
   __new(event) {
     // This allows listening to parent element and fire only when clicking on default or custom new-button.
-    if (event.composedPath().filter((e) => e.nodeType === 1 && e.hasAttribute('new-button'))[0]) {
+    if (event.composedPath().some((e) => e.nodeType === 1 && e.hasAttribute('new-button'))) {
       this.__confirmBeforeChangingEditedItem(null, true);
     }
   }

--- a/packages/field-highlighter/src/fields/vaadin-checkbox-group-observer.js
+++ b/packages/field-highlighter/src/fields/vaadin-checkbox-group-observer.js
@@ -12,6 +12,6 @@ export class CheckboxGroupObserver extends FieldObserver {
 
   getFocusTarget(event) {
     const fields = this.getFields();
-    return Array.from(event.composedPath()).filter((node) => fields.includes(node))[0];
+    return Array.from(event.composedPath()).find((node) => fields.includes(node));
   }
 }

--- a/packages/field-highlighter/src/fields/vaadin-list-box-observer.js
+++ b/packages/field-highlighter/src/fields/vaadin-list-box-observer.js
@@ -12,6 +12,6 @@ export class ListBoxObserver extends FieldObserver {
 
   getFocusTarget(event) {
     const fields = this.getFields();
-    return Array.from(event.composedPath()).filter((node) => fields.includes(node))[0];
+    return Array.from(event.composedPath()).find((node) => fields.includes(node));
   }
 }

--- a/packages/field-highlighter/src/fields/vaadin-radio-group-observer.js
+++ b/packages/field-highlighter/src/fields/vaadin-radio-group-observer.js
@@ -12,6 +12,6 @@ export class RadioGroupObserver extends FieldObserver {
 
   getFocusTarget(event) {
     const fields = this.getFields();
-    return Array.from(event.composedPath()).filter((node) => fields.includes(node))[0];
+    return Array.from(event.composedPath()).find((node) => fields.includes(node));
   }
 }

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -221,7 +221,7 @@ export class UserTags extends PolymerElement {
   }
 
   getTagForUser(user) {
-    return Array.from(this.wrapper.children).filter((tag) => tag.uid === user.id)[0];
+    return Array.from(this.wrapper.children).find((tag) => tag.uid === user.id);
   }
 
   getChangedTags(addedUsers, removedUsers) {

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -226,7 +226,7 @@ export const InlineEditingMixin = (superClass) =>
 
     /** @private */
     _getRowByIndex(index) {
-      return Array.from(this.$.items.children).filter((el) => el.index === index)[0];
+      return Array.from(this.$.items.children).find((el) => el.index === index);
     }
 
     /** @private */
@@ -456,7 +456,7 @@ export const InlineEditingMixin = (superClass) =>
       this._stopEdit();
 
       if (nextRow && nextCol) {
-        const nextCell = Array.from(nextRow.children).filter((cell) => cell._column === nextCol)[0];
+        const nextCell = Array.from(nextRow.children).find((cell) => cell._column === nextCol);
         e.preventDefault();
 
         // Prevent vaadin-grid handler from being called

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -52,7 +52,7 @@ export const ColumnResizingMixin = (superClass) =>
 
         const eventX = e.detail.x;
         const columnRowCells = Array.from(this.$.header.querySelectorAll('[part~="row"]:last-child [part~="cell"]'));
-        const targetCell = columnRowCells.filter((cell) => cell._column === column)[0];
+        const targetCell = columnRowCells.find((cell) => cell._column === column);
         // Resize the target column
         if (targetCell.offsetWidth) {
           const style = getComputedStyle(targetCell._content);

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -196,7 +196,7 @@ export const DragAndDropMixin = (superClass) =>
           return;
         }
 
-        let row = e.composedPath().filter((node) => node.localName === 'tr')[0];
+        let row = e.composedPath().find((node) => node.localName === 'tr');
 
         if (!this._effectiveSize || this.dropMode === DropMode.ON_GRID) {
           // The grid is empty or "on-grid" drop mode was used, always default to "empty"

--- a/packages/grid/src/vaadin-grid-event-context-mixin.js
+++ b/packages/grid/src/vaadin-grid-event-context-mixin.js
@@ -42,9 +42,9 @@ export const EventContextMixin = (superClass) =>
         return context;
       }
 
-      context.section = ['body', 'header', 'footer', 'details'].filter(
+      context.section = ['body', 'header', 'footer', 'details'].find(
         (section) => cell.getAttribute('part').indexOf(section) > -1,
-      )[0];
+      );
 
       if (cell._column) {
         context.column = cell._column;

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -746,7 +746,7 @@ class Grid extends ElementMixin(
         if (section === 'body') {
           // Body
           column._cells = column._cells || [];
-          cell = column._cells.filter((cell) => cell._vacant)[0];
+          cell = column._cells.find((cell) => cell._vacant);
           if (!cell) {
             cell = this._createCell('td');
             column._cells.push(cell);
@@ -757,7 +757,7 @@ class Grid extends ElementMixin(
           if (index === cols.length - 1 && this.rowDetailsRenderer) {
             // Add details cell as last cell to body rows
             this._detailsCells = this._detailsCells || [];
-            const detailsCell = this._detailsCells.filter((cell) => cell._vacant)[0] || this._createCell('td');
+            const detailsCell = this._detailsCells.find((cell) => cell._vacant) || this._createCell('td');
             if (this._detailsCells.indexOf(detailsCell) === -1) {
               this._detailsCells.push(detailsCell);
             }
@@ -783,7 +783,7 @@ class Grid extends ElementMixin(
             column[`_${section}Cell`] = cell;
           } else {
             column._emptyCells = column._emptyCells || [];
-            cell = column._emptyCells.filter((cell) => cell._vacant)[0] || this._createCell(tagName);
+            cell = column._emptyCells.find((cell) => cell._vacant) || this._createCell(tagName);
             cell._column = column;
             row.appendChild(cell);
             if (column._emptyCells.indexOf(cell) === -1) {

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -13,9 +13,9 @@ describe('drag and drop', () => {
   ];
 
   const getDraggable = (grid, rowIndex = 0) => {
-    const row = Array.from(grid.$.items.children).filter((row) => row.index === rowIndex)[0];
+    const row = Array.from(grid.$.items.children).find((row) => row.index === rowIndex);
     const cellContent = row.querySelector('slot').assignedNodes()[0];
-    return [row, cellContent].filter((node) => node.getAttribute('draggable') === 'true')[0];
+    return [row, cellContent].find((node) => node.getAttribute('draggable') === 'true');
   };
 
   const fireDragStart = (draggable = getDraggable(grid)) => {
@@ -296,7 +296,7 @@ describe('drag and drop', () => {
         fireDragStart();
         fireDrop();
         const event = dropSpy.getCall(0).args[0];
-        const textData = event.detail.dragData.filter((d) => d.type === 'text')[0].data;
+        const textData = event.detail.dragData.find((d) => d.type === 'text').data;
         expect(textData).to.eql('foo\tbar\nbaz\tqux');
       });
 
@@ -309,7 +309,7 @@ describe('drag and drop', () => {
         fireDragStart();
         fireDrop();
         const event = dropSpy.getCall(0).args[0];
-        const textData = event.detail.dragData.filter((d) => d.type === 'text')[0].data;
+        const textData = event.detail.dragData.find((d) => d.type === 'text').data;
         expect(textData).to.eql('foo\tbar');
       });
 
@@ -320,7 +320,7 @@ describe('drag and drop', () => {
         fireDragStart();
         fireDrop();
         const event = dropSpy.getCall(0).args[0];
-        const textData = event.detail.dragData.filter((d) => d.type === 'text')[0].data;
+        const textData = event.detail.dragData.find((d) => d.type === 'text').data;
         expect(textData).to.eql('bar\tfoo\nqux\tbaz');
         grid._swapColumnOrders(columns[0], columns[1]);
       });
@@ -333,7 +333,7 @@ describe('drag and drop', () => {
         fireDragStart();
         fireDrop();
         const event = dropSpy.getCall(0).args[0];
-        const dragData = event.detail.dragData.filter((d) => d.type === 'text/plain')[0];
+        const dragData = event.detail.dragData.find((d) => d.type === 'text/plain');
         expect(dragData.data).to.eql('bar,qux');
         expect(dragData.type).to.eql('text/plain');
       });

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -89,11 +89,11 @@ describe('scroll to index', () => {
         grid.scrollToIndex(index);
         flushGrid(grid);
         grid.scrollTop += 1; // Scroll a little to validate the test
-        let row = Array.from(grid.$.items.children).filter((r) => r.index === index)[0];
+        let row = Array.from(grid.$.items.children).find((r) => r.index === index);
         const rowTop = row.getBoundingClientRect().top;
 
         grid.size -= ~~(grid.size / 4);
-        row = Array.from(grid.$.items.children).filter((r) => r.index === index)[0];
+        row = Array.from(grid.$.items.children).find((r) => r.index === index);
         expect(row.getBoundingClientRect().top).to.be.closeTo(rowTop, 0.5);
       });
     });

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -112,7 +112,7 @@ export const InteractionsMixin = (superClass) =>
 
     /** @private */
     _getButtonFromEvent(e) {
-      return Array.from(e.composedPath()).filter((el) => el.localName === 'vaadin-menu-bar-button')[0];
+      return Array.from(e.composedPath()).find((el) => el.localName === 'vaadin-menu-bar-button');
     }
 
     /** @private */
@@ -344,7 +344,7 @@ export const InteractionsMixin = (superClass) =>
 
     /** @private */
     __onContextMenuKeydown(e) {
-      const item = Array.from(e.composedPath()).filter((el) => el._item)[0];
+      const item = Array.from(e.composedPath()).find((el) => el._item);
       if (item) {
         const list = item.parentNode;
         if (e.keyCode === 38 && item === list.items[0]) {

--- a/packages/vaadin-list-mixin/test/list-mixin.test.js
+++ b/packages/vaadin-list-mixin/test/list-mixin.test.js
@@ -792,7 +792,7 @@ describe('vaadin-list-mixin', () => {
       expect(getComputedStyle(list.items[0]).getPropertyValue('display')).to.equal('block');
       arrowDown(list);
       expect(getComputedStyle(list.items[1]).getPropertyValue('display')).to.equal('none');
-      expect(list.items.filter((item) => item.textContent === 'Bax')[0].focused).to.be.true;
+      expect(list.items.find((item) => item.textContent === 'Bax').focused).to.be.true;
     });
 
     it('should move focus to next not hidden element on "arrow-up"', () => {
@@ -800,7 +800,7 @@ describe('vaadin-list-mixin', () => {
       expect(getComputedStyle(list.items[0]).getPropertyValue('display')).to.equal('block');
       arrowUp(list);
       expect(getComputedStyle(list.items[list.items.length - 1]).getPropertyValue('display')).to.equal('none');
-      expect(list.items.filter((item) => item.textContent === 'Bin')[0].focused).to.be.true;
+      expect(list.items.find((item) => item.textContent === 'Bin').focused).to.be.true;
     });
 
     it('should not set tabIndex=0 to hidden items, but the next one in the loop', () => {
@@ -811,13 +811,13 @@ describe('vaadin-list-mixin', () => {
     it('should skip hidden items to key search', () => {
       keyDownChar(list, 'b');
       keyDownChar(list, 'b');
-      expect(list.items.filter((item) => item.textContent === 'Bin')[0].focused).to.be.true;
+      expect(list.items.find((item) => item.textContent === 'Bin').focused).to.be.true;
     });
 
     it('should skip hidden items to focus loop', () => {
       arrowDown(list);
       arrowDown(list);
-      expect(list.items.filter((item) => item.textContent === 'Fox')[0].focused).to.be.true;
+      expect(list.items.find((item) => item.textContent === 'Fox').focused).to.be.true;
     });
   });
 

--- a/packages/vaadin-overlay/src/vaadin-overlay.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay.js
@@ -404,7 +404,7 @@ class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(PolymerEleme
    * @protected
    */
   _setTemplateFromNodes(nodes) {
-    this.template = nodes.filter((node) => node.localName && node.localName === 'template')[0] || this.template;
+    this.template = nodes.find((node) => node.localName && node.localName === 'template') || this.template;
   }
 
   /**

--- a/packages/vaadin-overlay/test/legacy.test.js
+++ b/packages/vaadin-overlay/test/legacy.test.js
@@ -96,7 +96,7 @@ describe('overlay legacy', () => {
 
       const backdropCall = HTMLElement.prototype.addEventListener
         .getCalls()
-        .filter((call) => call.calledOn(overlay.$.backdrop))[0];
+        .find((call) => call.calledOn(overlay.$.backdrop));
       expect(backdropCall).to.not.be.undefined;
       expect(backdropCall.calledWith('click')).to.be.true;
 


### PR DESCRIPTION
Since we no longer support IE11, we can replace `array.filter(...)[0]` pattern with `.find()` (and `.some()`) which is more performant and easier to read.