### PR TITLE
refactor: use KeyboardDirectionMixin in message-list

### DIFF
--- a/packages/message-list/src/vaadin-message-list.d.ts
+++ b/packages/message-list/src/vaadin-message-list.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { KeyboardDirectionMixin } from '@vaadin/component-base/src/keyboard-direction-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export interface MessageListItem {
@@ -43,7 +44,7 @@ export interface MessageListItem {
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  */
-declare class MessageList extends ThemableMixin(ElementMixin(HTMLElement)) {
+declare class MessageList extends KeyboardDirectionMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   /**
    * An array of objects which will be rendered as messages.
    * The message objects can have the following properties:

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -7,6 +7,7 @@ import '@polymer/polymer/lib/elements/dom-repeat.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { KeyboardDirectionMixin } from '@vaadin/component-base/src/keyboard-direction-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { Message } from './vaadin-message.js';
 
@@ -40,8 +41,9 @@ import { Message } from './vaadin-message.js';
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin
+ * @mixes KeyboardDirectionMixin
  */
-class MessageList extends ElementMixin(ThemableMixin(PolymerElement)) {
+class MessageList extends KeyboardDirectionMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-message-list';
   }
@@ -108,9 +110,18 @@ class MessageList extends ElementMixin(ThemableMixin(PolymerElement)) {
     // Make screen readers announce new messages
     this.setAttribute('aria-relevant', 'additions');
     this.setAttribute('role', 'log');
+  }
 
-    // Keyboard navi
-    this.addEventListener('keydown', (e) => this._onKeydown(e));
+  /**
+   * Override method inherited from `KeyboardDirectionMixin`
+   * to use the list of message elements as items.
+   *
+   * @return {Element[]}
+   * @protected
+   * @override
+   */
+  _getItems() {
+    return this._messages;
   }
 
   /** @protected */
@@ -138,54 +149,6 @@ class MessageList extends ElementMixin(ThemableMixin(PolymerElement)) {
     if (this.items.length > 0) {
       this.scrollTop = this.scrollHeight - this.clientHeight;
     }
-  }
-
-  /**
-   * @param {!KeyboardEvent} event
-   * @protected
-   */
-  _onKeydown(event) {
-    if (event.metaKey || event.ctrlKey) {
-      return;
-    }
-
-    // Get index of the item that was focused when event happened
-    const target = event.composedPath()[0];
-    let currentIndex = this._messages.indexOf(target);
-
-    switch (event.key) {
-      case 'ArrowUp':
-        currentIndex -= 1;
-        break;
-      case 'ArrowDown':
-        currentIndex += 1;
-        break;
-      case 'Home':
-        currentIndex = 0;
-        break;
-      case 'End':
-        currentIndex = this._messages.length - 1;
-        break;
-      default:
-        return; // Nothing to do
-    }
-    if (currentIndex < 0) {
-      currentIndex = this._messages.length - 1;
-    }
-    if (currentIndex > this._messages.length - 1) {
-      currentIndex = 0;
-    }
-    this._focus(currentIndex);
-    event.preventDefault();
-  }
-
-  /**
-   * @param {number} idx
-   * @protected
-   */
-  _focus(idx) {
-    const target = this._messages[idx];
-    target.focus();
   }
 
   /** @private */

--- a/packages/message-list/test/message-list.test.js
+++ b/packages/message-list/test/message-list.test.js
@@ -308,6 +308,7 @@ describe('message-list', () => {
     });
 
     it('should set tabindex on the next message on "arrow-down" keydown', () => {
+      messageElements[0].focus();
       arrowDown(messageElements[0]);
       messageElements.forEach((msg, idx) => {
         expect(msg.tabIndex).to.equal(idx === 1 ? 0 : -1);
@@ -315,36 +316,42 @@ describe('message-list', () => {
     });
 
     it('should move focus to the next message on "arrow-down" keydown', () => {
+      messageElements[0].focus();
       arrowDown(messageElements[0]);
       expect(messageElements[0].hasAttribute('focused')).to.be.false;
       expect(messageElements[1].hasAttribute('focused')).to.be.true;
     });
 
     it('should focus first message on last message "arrow-down" keydown', () => {
+      messageElements[3].focus();
       arrowDown(messageElements[3]);
       expect(messageElements[3].hasAttribute('focused')).to.be.false;
       expect(messageElements[0].hasAttribute('focused')).to.be.true;
     });
 
     it('should move focus to the previous message on "arrow-up" keydown', () => {
+      messageElements[1].focus();
       arrowUp(messageElements[1]);
       expect(messageElements[1].hasAttribute('focused')).to.be.false;
       expect(messageElements[0].hasAttribute('focused')).to.be.true;
     });
 
     it('should focus last message on first message "arrow-down" keydown', () => {
+      messageElements[0].focus();
       arrowUp(messageElements[0]);
       expect(messageElements[0].hasAttribute('focused')).to.be.false;
       expect(messageElements[3].hasAttribute('focused')).to.be.true;
     });
 
     it('should move focus to the first message on "home" keydown', () => {
+      messageElements[2].focus();
       home(messageElements[2]);
       expect(messageElements[2].hasAttribute('focused')).to.be.false;
       expect(messageElements[0].hasAttribute('focused')).to.be.true;
     });
 
-    it('should move focus to the last panel on "end" keydown', () => {
+    it('should move focus to the last message on "end" keydown', () => {
+      messageElements[1].focus();
       end(messageElements[1]);
       expect(messageElements[1].hasAttribute('focused')).to.be.false;
       expect(messageElements[3].hasAttribute('focused')).to.be.true;
@@ -352,11 +359,13 @@ describe('message-list', () => {
 
     it('should set focus-ring attribute when moving focus using keyboard', () => {
       expect(messageElements[1].hasAttribute('focus-ring')).to.be.false;
+      messageElements[0].focus();
       arrowDown(messageElements[0]);
       expect(messageElements[1].hasAttribute('focus-ring')).to.be.true;
     });
 
     it('should ignore keydown events when Ctrl modifier key is pressed', () => {
+      messageElements[1].focus();
       arrowDown(messageElements[1]);
       arrowDown(messageElements[2], ['ctrl']);
       expect(messageElements[3].hasAttribute('focused')).to.be.false;
@@ -364,6 +373,7 @@ describe('message-list', () => {
     });
 
     it('should not change focus when unrelated key is pressed', () => {
+      messageElements[0].focus();
       arrowDown(messageElements[0]);
       arrowRight(messageElements[1]);
       expect(messageElements[1].hasAttribute('focused')).to.be.true;


### PR DESCRIPTION
## Description

Updated `vaadin-message-list` to use the newly added `KeyboardDirectionMixin` instead of the custom logic.

## Type of change

- Refactor