### PR TITLE
fix: request pages asynchronously when scrolling

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -247,7 +247,7 @@ export class ComboBoxScroller extends PolymerElement {
 
   /** @private */
   __loadingChanged() {
-    setTimeout(() => this.requestContentUpdate());
+    this.requestContentUpdate();
   }
 
   /** @private */
@@ -357,16 +357,26 @@ export class ComboBoxScroller extends PolymerElement {
   /**
    * Dispatches an `index-requested` event for the given index to notify
    * the data provider that it should start loading the page containing the requested index.
+   *
+   * The event is dispatched asynchronously to prevent an immediate page request and therefore
+   * a possible infinite recursion in case the data provider implements page request cancelation logic
+   * by invoking data provider page callbacks with an empty array.
+   * Invoking the data provider page callback with an empty array triggers a synchronous scroller update
+   * and, if the callback corresponds to the currently visible page, then the scroller may synchronously
+   * request that page again which may result in a recurring in the end. That was the case for the Flow counterpart:
+   * https://github.com/vaadin/flow-components/issues/3553#issuecomment-1239344828
    */
   __requestItemByIndex(index) {
-    this.dispatchEvent(
-      new CustomEvent('index-requested', {
-        detail: {
-          index,
-          currentScrollerPos: this._oldScrollerPosition,
-        },
-      }),
-    );
+    requestAnimationFrame(() => {
+      this.dispatchEvent(
+        new CustomEvent('index-requested', {
+          detail: {
+            index,
+            currentScrollerPos: this._oldScrollerPosition,
+          },
+        }),
+      );
+    });
   }
 
   /** @private */

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -361,9 +361,10 @@ export class ComboBoxScroller extends PolymerElement {
    * The event is dispatched asynchronously to prevent an immediate page request and therefore
    * a possible infinite recursion in case the data provider implements page request cancelation logic
    * by invoking data provider page callbacks with an empty array.
-   * Invoking the data provider page callback with an empty array triggers a synchronous scroller update
-   * and, if the callback corresponds to the currently visible page, then the scroller may synchronously
-   * request that page again which may result in a recurring in the end. That was the case for the Flow counterpart:
+   * The infinite recursion may occur otherwise since invoking a data provider page callback with an empty array
+   * triggers a synchronous scroller update and, if the callback corresponds to the currently visible page,
+   * the scroller will synchronously request the page again which may lead to a recurring in the end.
+   * That was the case for the Flow counterpart:
    * https://github.com/vaadin/flow-components/issues/3553#issuecomment-1239344828
    */
   __requestItemByIndex(index) {

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -363,7 +363,7 @@ export class ComboBoxScroller extends PolymerElement {
    * by invoking data provider page callbacks with an empty array.
    * The infinite recursion may occur otherwise since invoking a data provider page callback with an empty array
    * triggers a synchronous scroller update and, if the callback corresponds to the currently visible page,
-   * the scroller will synchronously request the page again which may lead to a recurring in the end.
+   * the scroller will synchronously request the page again which may lead to looping in the end.
    * That was the case for the Flow counterpart:
    * https://github.com/vaadin/flow-components/issues/3553#issuecomment-1239344828
    */

--- a/packages/combo-box/test/dynamic-size.test.js
+++ b/packages/combo-box/test/dynamic-size.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../src/vaadin-combo-box.js';
 import { flushComboBox, getViewportItems, scrollToIndex } from './helpers.js';
 
@@ -31,11 +31,13 @@ describe('dynamic size change', () => {
       comboBox.dataProvider = dataProvider;
     });
 
-    it('should not have item placeholders after size gets reduced', () => {
+    it('should not have item placeholders after size gets reduced', async () => {
       comboBox.opened = true;
       scrollToIndex(comboBox, comboBox.size - 1);
       flushComboBox(comboBox);
+      await nextFrame();
       flushComboBox(comboBox);
+      await nextFrame();
       const items = getViewportItems(comboBox);
       expect(items.length).to.be.above(5);
       items.forEach((item) => {

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -312,6 +312,15 @@ describe('lazy loading', () => {
           expect(dp.calledOnce).to.be.true;
         });
 
+        it('should request pages asynchronously when scrolling', async () => {
+          comboBox.dataProvider = spyDataProvider;
+          spyDataProvider.resetHistory();
+          comboBox._scrollIntoView(50);
+          expect(spyDataProvider.called).to.be.false;
+          await nextFrame();
+          expect(spyDataProvider.calledOnce).to.be.true;
+        });
+
         it('should render all visible items after delayed response', (done) => {
           const items = [...Array(10)].map((_, i) => `item ${i}`);
           comboBox.dataProvider = (params, callback) => {

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -202,19 +202,21 @@ describe('lazy loading', () => {
           expect(params.page).to.equal(0);
         });
 
-        (window.innerHeight > 900 ? it.skip : it)('should request page 1 on scroll', () => {
+        (window.innerHeight > 900 ? it.skip : it)('should request page 1 on scroll', async () => {
           comboBox.dataProvider = spyDataProvider;
           spyDataProvider.resetHistory();
           comboBox._scrollIntoView(75);
+          await nextFrame();
           expect(spyDataProvider.called).to.be.true;
           const pages = spyDataProvider.getCalls().map((call) => call.args[0].page);
           expect(pages).to.contain(1);
         });
 
-        (window.innerHeight > 900 ? it.skip : it)('should request page 2 on scroll', () => {
+        (window.innerHeight > 900 ? it.skip : it)('should request page 2 on scroll', async () => {
           comboBox.dataProvider = spyDataProvider;
           spyDataProvider.resetHistory();
           comboBox._scrollIntoView(125);
+          await nextFrame();
           expect(spyDataProvider.called).to.be.true;
           const pages = spyDataProvider.getCalls().map((call) => call.args[0].page);
           expect(pages).to.contain(2);
@@ -411,23 +413,25 @@ describe('lazy loading', () => {
           expect(spyAsyncDataProvider.calledOnce).to.be.true;
         });
 
-        (window.innerHeight > 900 ? it.skip : it)('should request page 1 on scroll', () => {
+        (window.innerHeight > 900 ? it.skip : it)('should request page 1 on scroll', async () => {
           comboBox.size = SIZE;
           comboBox.dataProvider = spyAsyncDataProvider;
           comboBox.opened = true;
           spyAsyncDataProvider.resetHistory();
           comboBox._scrollIntoView(75);
+          await nextFrame();
           expect(spyAsyncDataProvider.called).to.be.true;
           const pages = spyAsyncDataProvider.getCalls().map((call) => call.args[0].page);
           expect(pages).to.contain(1);
         });
 
-        (window.innerHeight > 900 ? it.skip : it)('should request page 2 on scroll', () => {
+        (window.innerHeight > 900 ? it.skip : it)('should request page 2 on scroll', async () => {
           comboBox.size = SIZE;
           comboBox.dataProvider = spyAsyncDataProvider;
           comboBox.opened = true;
           spyAsyncDataProvider.resetHistory();
           comboBox._scrollIntoView(125);
+          await nextFrame();
           expect(spyAsyncDataProvider.called).to.be.true;
           const pages = spyAsyncDataProvider.getCalls().map((call) => call.args[0].page);
           expect(pages).to.contain(2);
@@ -488,13 +492,13 @@ describe('lazy loading', () => {
           expect(getFocusedItemIndex(comboBox)).to.equal(0);
 
           comboBox._scrollIntoView(50);
+          await nextFrame();
           // Wait for the async data provider to respond
-          await aTimeout(0);
-          // Wait for the __loadingChanged observer
           await aTimeout(0);
           expect(comboBox.selectedItem).to.exist;
 
           comboBox._scrollIntoView(0);
+          await nextFrame();
           expect(getFocusedItemIndex(comboBox)).to.equal(0);
         });
 
@@ -612,7 +616,7 @@ describe('lazy loading', () => {
         expect(comboBox.size).to.equal(SIZE);
       });
 
-      it('should not show the loading on size change while pending the data provider', () => {
+      it('should not show the loading on size change while pending the data provider', async () => {
         const allItems = makeItems(200);
 
         comboBox.size = 200;
@@ -628,8 +632,10 @@ describe('lazy loading', () => {
         comboBox.open();
         expect(comboBox.loading).to.be.false;
         comboBox._scrollIntoView(45);
+        await nextFrame();
         expect(comboBox.loading).to.be.false;
         comboBox._scrollIntoView(150);
+        await nextFrame();
         // Fetching the page = 2 and stucking
         expect(comboBox.loading).to.be.true;
         // Updating the size means we don't need pending requests anymore,
@@ -638,7 +644,7 @@ describe('lazy loading', () => {
         expect(comboBox.loading).to.be.false;
       });
 
-      it('should not show the loading on fast scrolling and size update', () => {
+      it('should not show the loading on fast scrolling and size update', async () => {
         const ITEMS_SIZE = 1000;
         const allItems = makeItems(ITEMS_SIZE);
 
@@ -656,6 +662,7 @@ describe('lazy loading', () => {
         comboBox.open();
         // Scroll fast to a large page
         comboBox._scrollIntoView(400);
+        await nextFrame();
         expect(comboBox.loading).to.be.true;
         // Reduce the size and trigger pending queue cleanup
         comboBox.size = 50;
@@ -806,10 +813,11 @@ describe('lazy loading', () => {
           expect(items[0].item).to.deep.equal(loadedItem);
         });
 
-        it('should render selectedItem as selected when setting it while loading more items', () => {
+        it('should render selectedItem as selected when setting it while loading more items', async () => {
           const alreadyLoadedItem = `item ${comboBox.pageSize - 1}`;
 
           scrollToIndex(comboBox, comboBox.pageSize + 1);
+          await nextFrame();
           expect(comboBox.loading).to.be.true;
 
           comboBox.selectedItem = alreadyLoadedItem;
@@ -853,7 +861,7 @@ describe('lazy loading', () => {
           expect(items[0].item).to.deep.equal(loadedItem);
         });
 
-        it('should render selectedItem as selected when setting it while loading more items', () => {
+        it('should render selectedItem as selected when setting it while loading more items', async () => {
           const alreadyLoadedItem = {
             id: comboBox.pageSize - 1,
             value: `value ${comboBox.pageSize - 1}`,
@@ -861,6 +869,7 @@ describe('lazy loading', () => {
           };
 
           scrollToIndex(comboBox, comboBox.pageSize + 1);
+          await nextFrame();
           expect(comboBox.loading).to.be.true;
 
           comboBox.selectedItem = alreadyLoadedItem;
@@ -1008,10 +1017,11 @@ describe('lazy loading', () => {
           expect(spyDataProvider.called).to.be.false;
         });
 
-        it('should request page 1 on scroll after reopen', () => {
+        it('should request page 1 on scroll after reopen', async () => {
           comboBox.clearCache();
           comboBox.opened = true;
           comboBox._scrollIntoView(75);
+          await nextFrame();
           expect(spyDataProvider.called).to.be.true;
           const pages = spyDataProvider.getCalls().map((call) => call.args[0].page);
           expect(pages).to.contain(1);
@@ -1200,7 +1210,7 @@ describe('lazy loading', () => {
         }
       });
 
-      it('should not show the loading when exact size is suddenly reached in the middle of requested range', () => {
+      it('should not show the loading when exact size is suddenly reached in the middle of requested range', async () => {
         const REAL_SIZE = 294;
         const ESTIMATED_SIZE = 400;
 
@@ -1233,6 +1243,7 @@ describe('lazy loading', () => {
         // Scroll to last page and verify there is no loading indicator and
         // the last page has been fetched and rendered
         comboBox._scrollIntoView(274);
+        await nextFrame();
         expect(comboBox.loading).to.be.false;
         expect(comboBox.filteredItems).to.contain('item 293');
       });


### PR DESCRIPTION
## Description

This PR makes `combo-box-scroller` request a page asynchronously when it encounters an item placeholder while scrolling. This is needed to prevent an immediate page request and therefore a possible infinite recursion in case the data provider implements page request cancelation logic by invoking data provider page callbacks with an empty array. This is exactly the case for the Flow counterpart that clears page callbacks by [invoking them with an empty array](https://github.com/vaadin/flow-components/blob/e39333b546d606aedc12b8c905fa2a3657cd8d45/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js#L69-L70) to prevent too many page requests when scrolling fast. Without the current change, the scroller could immediately re-request the canceled page which led to looping since [the Flow's data provider could in turn try to clear page callbacks again](https://github.com/vaadin/flow-components/blob/e39333b546d606aedc12b8c905fa2a3657cd8d45/vaadin-combo-box-flow-parent/vaadin-combo-box-flow/src/main/resources/META-INF/resources/frontend/comboBoxConnector.js#L145-L148) and so on.

- [x] Implementation
- [x] Unit tests

Fixes https://github.com/vaadin/flow-components/issues/3553

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
