### PR TITLE
fix: do not throw on content update with undefined columns

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -1038,7 +1038,9 @@ class Grid extends ElementMixin(
       // Header and footer renderers
       this._columnTree.forEach((level) => {
         level.forEach((column) => {
-          column._renderHeaderAndFooter();
+          if (column._renderHeaderAndFooter) {
+            column._renderHeaderAndFooter();
+          }
         });
       });
 

--- a/packages/grid/test/missing-imports.test.js
+++ b/packages/grid/test/missing-imports.test.js
@@ -14,6 +14,14 @@ describe('missing imports', () => {
     `);
   });
 
+  it('should not throw on requestContentUpdate', () => {
+    // Add a column type that is not imported by default
+    grid.appendChild(document.createElement('vaadin-grid-sort-column'));
+    flushGrid(grid);
+
+    expect(() => grid.requestContentUpdate()).to.not.throw();
+  });
+
   [
     'vaadin-grid-column-group',
     'vaadin-grid-filter',


### PR DESCRIPTION
## Description

Fixes an issue with `grid.requestContentUpdate()` throwing an error if some of the grid's column types have not yet been defined.

## Type of change

- Bugfix