### PR TITLE
feat: add focusDelay, change delay to hoverDelay

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -60,7 +60,7 @@ export type TooltipPosition =
  */
 declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   /**
-   * Sets the default hover delay to be used by all tooltip instances,
+   * Sets the default focus delay to be used by all tooltip instances,
    * except for those that have focus delay configured using property.
    */
   static setDefaultFocusDelay(focusDelay: number): void;

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -60,16 +60,22 @@ export type TooltipPosition =
  */
 declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   /**
-   * Sets the default delay to be used by all tooltip instances,
-   * except for those that have delay configured using property.
+   * Sets the default hover delay to be used by all tooltip instances,
+   * except for those that have focus delay configured using property.
    */
-  static setDefaultDelay(delay: number): void;
+  static setDefaultFocusDelay(focusDelay: number): void;
 
   /**
    * Sets the default hide delay to be used by all tooltip instances,
    * except for those that have hide delay configured using property.
    */
   static setDefaultHideDelay(hideDelay: number): void;
+
+  /**
+   * Sets the default hover delay to be used by all tooltip instances,
+   * except for those that have hover delay configured using property.
+   */
+  static setDefaultHoverDelay(delay: number): void;
 
   /**
    * Object with properties passed to `textGenerator`
@@ -79,10 +85,10 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
 
   /**
    * The delay in milliseconds before the tooltip
-   * is opened on hover, when not in manual mode.
-   * On focus, the tooltip is opened immediately.
+   * is opened on focus, when not in manual mode.
+   * @attr {number} focus-delay
    */
-  delay: number;
+  focusDelay: number;
 
   /**
    * The id of the element used as a tooltip trigger.
@@ -98,6 +104,13 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
    * @attr {number} hide-delay
    */
   hideDelay: number;
+
+  /**
+   * The delay in milliseconds before the tooltip
+   * is opened on hover, when not in manual mode.
+   * @attr {number} hover-delay
+   */
+  hoverDelay: number;
 
   /**
    * When true, the tooltip is controlled programmatically

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -13,7 +13,8 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
 
 const DEFAULT_DELAY = 0;
 
-let defaultDelay = DEFAULT_DELAY;
+let defaultFocusDelay = DEFAULT_DELAY;
+let defaultHoverDelay = DEFAULT_DELAY;
 let defaultHideDelay = DEFAULT_DELAY;
 
 const closing = new Set();
@@ -108,10 +109,10 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
       /**
        * The delay in milliseconds before the tooltip
-       * is opened on hover, when not in manual mode.
-       * On focus, the tooltip is opened immediately.
+       * is opened on focus, when not in manual mode.
+       * @attr {number} focus-delay
        */
-      delay: {
+      focusDelay: {
         type: Number,
       },
 
@@ -132,6 +133,15 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
        * @attr {number} hide-delay
        */
       hideDelay: {
+        type: Number,
+      },
+
+      /**
+       * The delay in milliseconds before the tooltip
+       * is opened on hover, when not in manual mode.
+       * @attr {number} hover-delay
+       */
+      hoverDelay: {
         type: Number,
       },
 
@@ -231,13 +241,13 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /**
-   * Sets the default delay to be used by all tooltip instances,
+   * Sets the default hover delay to be used by all tooltip instances,
    * except for those that have delay configured using property.
    *
    * @param {number} delay
    */
-  static setDefaultDelay(delay) {
-    defaultDelay = delay != null && delay >= 0 ? delay : DEFAULT_DELAY;
+  static setDefaultFocusDelay(focusDelay) {
+    defaultFocusDelay = focusDelay != null && focusDelay >= 0 ? focusDelay : DEFAULT_DELAY;
   }
 
   /**
@@ -248,6 +258,16 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
    */
   static setDefaultHideDelay(hideDelay) {
     defaultHideDelay = hideDelay != null && hideDelay >= 0 ? hideDelay : DEFAULT_DELAY;
+  }
+
+  /**
+   * Sets the default hover delay to be used by all tooltip instances,
+   * except for those that have delay configured using property.
+   *
+   * @param {number} delay
+   */
+  static setDefaultHoverDelay(hoverDelay) {
+    defaultHoverDelay = hoverDelay != null && hoverDelay >= 0 ? hoverDelay : DEFAULT_DELAY;
   }
 
   constructor() {
@@ -386,7 +406,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     this.__focusInside = true;
 
     if (!this.__isTargetHidden && (!this.__hoverInside || !this._autoOpened)) {
-      this._open(true);
+      this._open({ focus: true });
     }
   }
 
@@ -399,7 +419,9 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
     this.__focusInside = false;
 
-    if (!this.__hoverInside) {
+    // When both tooltip and its focused target are detached,
+    // avoid closing twice: both on detach and target blur.
+    if (!this.__hoverInside && this._autoOpened) {
       this._close(true);
     }
   }
@@ -431,7 +453,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     this.__hoverInside = true;
 
     if (!this.__isTargetHidden && (!this.__focusInside || !this._autoOpened)) {
-      this._open();
+      this._open({ hover: true });
     }
   }
 
@@ -466,9 +488,13 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
    * @param {boolean} immediate
    * @protected
    */
-  _open(immediate) {
-    if (!immediate && this.__getDelay() > 0 && !this.__closeTimeout) {
-      this.__warmupTooltip();
+  _open(options = { immediate: false }) {
+    const { immediate, hover, focus } = options;
+    const isHover = hover && this.__getHoverDelay() > 0;
+    const isFocus = focus && this.__getFocusDelay() > 0;
+
+    if (!immediate && (isHover || isFocus) && !this.__closeTimeout) {
+      this.__warmupTooltip(isFocus);
     } else {
       this.__showTooltip();
     }
@@ -497,8 +523,13 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /** @private */
-  __getDelay() {
-    return this.delay != null && this.delay > 0 ? this.delay : defaultDelay;
+  __getFocusDelay() {
+    return this.focusDelay != null && this.focusDelay > 0 ? this.focusDelay : defaultFocusDelay;
+  }
+
+  /** @private */
+  __getHoverDelay() {
+    return this.hoverDelay != null && this.hoverDelay > 0 ? this.hoverDelay : defaultHoverDelay;
   }
 
   /** @private */
@@ -528,11 +559,11 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /** @private */
-  __warmupTooltip() {
+  __warmupTooltip(isFocus) {
     if (!this._autoOpened) {
       // First tooltip is opened, warm up.
       if (!warmedUp) {
-        this.__scheduleWarmUp();
+        this.__scheduleWarmUp(isFocus);
       } else {
         // Warmed up, show another tooltip.
         this.__showTooltip();
@@ -586,12 +617,13 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /** @private */
-  __scheduleWarmUp() {
+  __scheduleWarmUp(isFocus) {
+    const delay = isFocus ? this.__getFocusDelay() : this.__getHoverDelay();
     warmUpTimeout = setTimeout(() => {
       warmUpTimeout = null;
       warmedUp = true;
       this.__showTooltip();
-    }, this.__getDelay());
+    }, delay);
   }
 
   /** @private */

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -419,9 +419,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
     this.__focusInside = false;
 
-    // When both tooltip and its focused target are detached,
-    // avoid closing twice: both on detach and target blur.
-    if (!this.__hoverInside && this._autoOpened) {
+    if (!this.__hoverInside) {
       this._close(true);
     }
   }

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -241,8 +241,8 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /**
-   * Sets the default hover delay to be used by all tooltip instances,
-   * except for those that have delay configured using property.
+   * Sets the default focus delay to be used by all tooltip instances,
+   * except for those that have focus delay configured using property.
    *
    * @param {number} delay
    */
@@ -262,7 +262,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
   /**
    * Sets the default hover delay to be used by all tooltip instances,
-   * except for those that have delay configured using property.
+   * except for those that have hover delay configured using property.
    *
    * @param {number} delay
    */

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -3,6 +3,7 @@ import {
   aTimeout,
   escKeyDown,
   fixtureSync,
+  focusin,
   focusout,
   mousedown,
   nextRender,
@@ -13,11 +14,11 @@ import { Tooltip } from '../vaadin-tooltip.js';
 import { mouseenter, mouseleave } from './helpers.js';
 
 describe('timers', () => {
-  describe('delay', () => {
+  describe('hoverDelay', () => {
     let tooltip, target, overlay;
 
     beforeEach(async () => {
-      tooltip = fixtureSync('<vaadin-tooltip text="tooltip" delay="1"></vaadin-tooltip>');
+      tooltip = fixtureSync('<vaadin-tooltip text="tooltip" hover-delay="1"></vaadin-tooltip>');
       target = fixtureSync('<input>');
       tooltip.target = target;
       overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
@@ -40,6 +41,37 @@ describe('timers', () => {
     it('should open the overlay immediately on keyboard focus', () => {
       tabKeyDown(document.body);
       target.focus();
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('focusDelay', () => {
+    let tooltip, target, overlay;
+
+    beforeEach(async () => {
+      tooltip = fixtureSync('<vaadin-tooltip text="tooltip" focus-delay="1"></vaadin-tooltip>');
+      target = fixtureSync('<input>');
+      tooltip.target = target;
+      overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+      await nextRender();
+    });
+
+    afterEach(async () => {
+      // Wait for cooldown timeout.
+      await aTimeout(0);
+    });
+
+    it('should open the overlay after a delay on keyboard focus', async () => {
+      tabKeyDown(document.body);
+      target.focus();
+      expect(overlay.opened).to.be.not.ok;
+
+      await aTimeout(1);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open the overlay immediately on mouseenter', () => {
+      mouseenter(target);
       expect(overlay.opened).to.be.true;
     });
   });
@@ -94,7 +126,7 @@ describe('timers', () => {
     });
   });
 
-  describe('setDefaultDelay', () => {
+  describe('setDefaultHoverDelay', () => {
     let tooltip, target;
 
     beforeEach(() => {
@@ -102,11 +134,11 @@ describe('timers', () => {
     });
 
     afterEach(() => {
-      Tooltip.setDefaultDelay(0);
+      Tooltip.setDefaultHoverDelay(0);
     });
 
     it('should change default delay for newly created tooltip', async () => {
-      Tooltip.setDefaultDelay(2);
+      Tooltip.setDefaultHoverDelay(2);
 
       tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
       tooltip.target = target;
@@ -118,12 +150,12 @@ describe('timers', () => {
       expect(overlay.opened).to.be.true;
     });
 
-    it('should change default delay for existing tooltip', async () => {
+    it('should change default hover delay for existing tooltip', async () => {
       tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
       tooltip.target = target;
       const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
 
-      Tooltip.setDefaultDelay(2);
+      Tooltip.setDefaultHoverDelay(2);
 
       mouseenter(target);
       await aTimeout(2);
@@ -131,9 +163,9 @@ describe('timers', () => {
       expect(overlay.opened).to.be.true;
     });
 
-    it('should reset delay when providing a negative number', () => {
-      Tooltip.setDefaultDelay(10);
-      Tooltip.setDefaultDelay(-1);
+    it('should reset hover delay when providing a negative number', () => {
+      Tooltip.setDefaultHoverDelay(10);
+      Tooltip.setDefaultHoverDelay(-1);
 
       tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
       tooltip.target = target;
@@ -144,9 +176,9 @@ describe('timers', () => {
       expect(overlay.opened).to.be.true;
     });
 
-    it('should reset delay when providing null instead of number', () => {
-      Tooltip.setDefaultDelay(10);
-      Tooltip.setDefaultDelay(null);
+    it('should reset hover delay when providing null instead of number', () => {
+      Tooltip.setDefaultHoverDelay(10);
+      Tooltip.setDefaultHoverDelay(null);
 
       const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
       tooltip.target = target;
@@ -157,15 +189,97 @@ describe('timers', () => {
       expect(overlay.opened).to.be.true;
     });
 
-    it('should reset delay when providing undefined instead of number', () => {
-      Tooltip.setDefaultDelay(10);
-      Tooltip.setDefaultDelay(undefined);
+    it('should reset hover delay when providing undefined instead of number', () => {
+      Tooltip.setDefaultHoverDelay(10);
+      Tooltip.setDefaultHoverDelay(undefined);
 
       const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
       tooltip.target = target;
       const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
 
       mouseenter(target);
+
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('setDefaultFocusDelay', () => {
+    let tooltip, target;
+
+    beforeEach(() => {
+      target = fixtureSync('<div>Target</div>');
+    });
+
+    afterEach(() => {
+      Tooltip.setDefaultFocusDelay(0);
+    });
+
+    it('should change default delay for newly created tooltip', async () => {
+      Tooltip.setDefaultFocusDelay(2);
+
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      tabKeyDown(document.body);
+      focusin(target);
+      await aTimeout(2);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should change default focus delay for existing tooltip', async () => {
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      Tooltip.setDefaultFocusDelay(2);
+
+      tabKeyDown(document.body);
+      focusin(target);
+      await aTimeout(2);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should reset focus delay when providing a negative number', () => {
+      Tooltip.setDefaultFocusDelay(10);
+      Tooltip.setDefaultFocusDelay(-1);
+
+      tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      tabKeyDown(document.body);
+      focusin(target);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should reset focus delay when providing null instead of number', () => {
+      Tooltip.setDefaultFocusDelay(10);
+      Tooltip.setDefaultFocusDelay(null);
+
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      tabKeyDown(document.body);
+      focusin(target);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should reset focus delay when providing undefined instead of number', () => {
+      Tooltip.setDefaultFocusDelay(10);
+      Tooltip.setDefaultFocusDelay(undefined);
+
+      const tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
+      tooltip.target = target;
+      const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+      tabKeyDown(document.body);
+      focusin(target);
 
       expect(overlay.opened).to.be.true;
     });
@@ -261,8 +375,8 @@ describe('timers', () => {
     beforeEach(async () => {
       wrapper = fixtureSync(`
         <div>
-          <vaadin-tooltip text="tooltip 1" delay="2" hide-delay="2" for="input-1"></vaadin-tooltip>
-          <vaadin-tooltip text="tooltip 2" delay="2" hide-delay="2" for="input-2"></vaadin-tooltip>
+          <vaadin-tooltip text="tooltip 1" hover-delay="2" focus-delay="2" hide-delay="2" for="input-1"></vaadin-tooltip>
+          <vaadin-tooltip text="tooltip 2" hover-delay="2" focus-delay="2" hide-delay="2" for="input-2"></vaadin-tooltip>
           <input id="input-1">
           <input id="input-2">
         </div>
@@ -278,7 +392,7 @@ describe('timers', () => {
       await aTimeout(2);
     });
 
-    it('should close first tooltip and open the second one without waiting for delay', async () => {
+    it('should close first tooltip and open the second one without waiting for hover delay', async () => {
       mouseenter(targets[0]);
       await aTimeout(2);
 
@@ -289,7 +403,19 @@ describe('timers', () => {
       expect(overlays[1].opened).to.be.true;
     });
 
-    it('should re-open first tooltip and close the second one without waiting for delay', async () => {
+    it('should close first tooltip and open the second one without waiting for focus delay', async () => {
+      tabKeyDown(document.body);
+      focusin(targets[0]);
+      await aTimeout(2);
+
+      focusout(targets[0], targets[1]);
+      focusin(targets[1], targets[0]);
+
+      expect(overlays[0].opened).to.be.false;
+      expect(overlays[1].opened).to.be.true;
+    });
+
+    it('should re-open first tooltip and close the second one without waiting for hover delay', async () => {
       mouseenter(targets[0]);
       await aTimeout(2);
 
@@ -303,7 +429,22 @@ describe('timers', () => {
       expect(overlays[1].opened).to.be.false;
     });
 
-    it('should warm up again when closing the tooltip and re-opening it after the delay', async () => {
+    it('should re-open first tooltip and close the second one without waiting for focus delay', async () => {
+      tabKeyDown(document.body);
+      focusin(targets[0]);
+      await aTimeout(2);
+
+      focusout(targets[0], targets[1]);
+      focusin(targets[1], targets[0]);
+
+      focusout(targets[1], targets[0]);
+      focusin(targets[0], targets[1]);
+
+      expect(overlays[0].opened).to.be.true;
+      expect(overlays[1].opened).to.be.false;
+    });
+
+    it('should warm up again when closing the tooltip and re-opening it after the hover delay', async () => {
       mouseenter(targets[0]);
       await aTimeout(2);
 
@@ -317,7 +458,22 @@ describe('timers', () => {
       expect(overlays[0].opened).to.be.true;
     });
 
-    it('should not open on mouseleave during the initial warm up delay', async () => {
+    it('should warm up again when closing the tooltip and re-opening it after the focus delay', async () => {
+      tabKeyDown(document.body);
+      focusin(targets[0]);
+      await aTimeout(2);
+
+      focusout(targets[0]);
+      await aTimeout(2);
+
+      focusin(targets[0]);
+      expect(overlays[0].opened).to.be.false;
+
+      await aTimeout(2);
+      expect(overlays[0].opened).to.be.true;
+    });
+
+    it('should not open on mouseleave during the initial warm up hover delay', async () => {
       mouseenter(targets[0]);
       await aTimeout(1);
 
@@ -325,6 +481,17 @@ describe('timers', () => {
       await aTimeout(1);
 
       expect(overlays[0].opened).to.be.not.ok;
+    });
+
+    it('should not open on focusout during the initial warm up focus delay', async () => {
+      tabKeyDown(document.body);
+      focusin(targets[0]);
+      await aTimeout(1);
+
+      focusout(targets[0]);
+      await aTimeout(1);
+
+      expect(overlays[0].opened).to.be.false;
     });
 
     it('should stop closing on subsequent mouseenter during the hide delay', async () => {

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -491,7 +491,7 @@ describe('timers', () => {
       focusout(targets[0]);
       await aTimeout(1);
 
-      expect(overlays[0].opened).to.be.false;
+      expect(overlays[0].opened).to.be.not.ok;
     });
 
     it('should stop closing on subsequent mouseenter during the hide delay', async () => {

--- a/packages/tooltip/test/typings/tooltip.types.ts
+++ b/packages/tooltip/test/typings/tooltip.types.ts
@@ -19,5 +19,8 @@ assertType<Record<string, unknown>>(tooltip.context);
 assertType<(context: Record<string, unknown>) => string>(tooltip.textGenerator);
 assertType<boolean>(tooltip.manual);
 assertType<boolean>(tooltip.opened);
+assertType<number>(tooltip.focusDelay);
+assertType<number>(tooltip.hideDelay);
+assertType<number>(tooltip.hoverDelay);
 assertType<TooltipPosition>(tooltip.position);
 assertType<(target: HTMLElement) => boolean>(tooltip.shouldShow);


### PR DESCRIPTION
## Description

Fixes #4531

1. Added `focusDelay` property to make it possible to show tooltip on keyboard focus after a delay;
2. Renamed `delay` property  to `hoverDelay`, also renamed `setDefaultDelay` method accordingly;
3. Fixed some edge case with target visibility change observer causing timers tests to randomly fail.

## Type of change

- Feature