### PR TITLE
fix: use correct styles to hide input placeholder

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -21,6 +21,7 @@ import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-co
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
@@ -332,6 +333,7 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
 
 interface MultiSelectComboBox
   extends ValidateMixinClass,
+    SlotStylesMixinClass,
     LabelMixinClass,
     KeyboardMixinClass,
     Omit<InputMixinClass, 'value'>,

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -15,6 +15,7 @@ import { TooltipController } from '@vaadin/component-base/src/tooltip-controller
 import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
+import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -30,10 +31,6 @@ const multiSelectComboBox = css`
   #chips {
     display: flex;
     align-items: center;
-  }
-
-  :host([has-value]) ::slotted(input:placeholder-shown) {
-    color: transparent !important;
   }
 
   ::slotted(input) {
@@ -141,7 +138,9 @@ registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectCo
  * @mixes InputControlMixin
  * @mixes ResizeMixin
  */
-class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
+class MultiSelectComboBox extends SlotStylesMixin(
+  ResizeMixin(InputControlMixin(ThemableMixin(ElementMixin(PolymerElement)))),
+) {
   static get is() {
     return 'vaadin-multi-select-combo-box';
   }
@@ -474,6 +473,18 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   static get observers() {
     return ['_selectedItemsChanged(selectedItems, selectedItems.*)'];
+  }
+
+  /** @protected */
+  get slotStyles() {
+    const tag = this.localName;
+    return [
+      `
+         ${tag}[has-value] input::placeholder {
+           color: transparent !important;
+         }
+       `,
+    ];
   }
 
   /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -480,10 +480,10 @@ class MultiSelectComboBox extends SlotStylesMixin(
     const tag = this.localName;
     return [
       `
-         ${tag}[has-value] input::placeholder {
-           color: transparent !important;
-         }
-       `,
+        ${tag}[has-value] input::placeholder {
+          color: transparent !important;
+        }
+      `,
     ];
   }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -137,6 +137,7 @@ registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectCo
  * @mixes ThemableMixin
  * @mixes InputControlMixin
  * @mixes ResizeMixin
+ * @mixes SlotStylesMixin
  */
 class MultiSelectComboBox extends SlotStylesMixin(
   ResizeMixin(InputControlMixin(ThemableMixin(ElementMixin(PolymerElement)))),

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -10,6 +10,7 @@ import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-co
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
 import type {
@@ -104,5 +105,6 @@ assertType<InputControlMixinClass>(narrowedComboBox);
 assertType<Omit<InputMixinClass, 'value'>>(narrowedComboBox);
 assertType<KeyboardMixinClass>(narrowedComboBox);
 assertType<LabelMixinClass>(narrowedComboBox);
+assertType<SlotStylesMixinClass>(narrowedComboBox);
 assertType<ValidateMixinClass>(narrowedComboBox);
 assertType<ThemableMixinClass>(narrowedComboBox);


### PR DESCRIPTION
## Description

Fixes #4570

Current approach with `::slotted(input:placeholder-shown)` does not work in Safari when using shadow root.

The reason is the fact that the workaround here is always added to the document level:

https://github.com/vaadin/web-components/blob/68d93ffbe63f7d7370123ae23a2febfb175f1de7/packages/input-container/src/vaadin-input-container.js#L126-L128

We should consider using `SlotStylesMixin` instead of keeping that workaround in the `vaadin-input-container.js`.
I will create a separate issue for it because that mixin has to be applied to the actual field components.

This PR is still reasonably small and IMO we can merge it without waiting for the above issue to be fixed.

## Type of change

- Bugfix