### PR TITLE
fix: use correct styles to hide input placeholder (#4571) (CP: 23.1)

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -21,6 +21,7 @@ import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constra
 import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -322,6 +323,7 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
 
 interface MultiSelectComboBox
   extends ValidateMixinClass,
+    SlotStylesMixinClass,
     LabelMixinClass,
     KeyboardMixinClass,
     InputMixinClass,

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -14,6 +14,7 @@ import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
+import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -29,10 +30,6 @@ const multiSelectComboBox = css`
   #chips {
     display: flex;
     align-items: center;
-  }
-
-  :host([has-value]) ::slotted(input:placeholder-shown) {
-    color: transparent !important;
   }
 
   ::slotted(input) {
@@ -137,8 +134,11 @@ registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectCo
  * @mixes ThemableMixin
  * @mixes InputControlMixin
  * @mixes ResizeMixin
+ * @mixes SlotStylesMixin
  */
-class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
+class MultiSelectComboBox extends SlotStylesMixin(
+  ResizeMixin(InputControlMixin(ThemableMixin(ElementMixin(PolymerElement)))),
+) {
   static get is() {
     return 'vaadin-multi-select-combo-box';
   }
@@ -458,6 +458,18 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   static get observers() {
     return ['_selectedItemsChanged(selectedItems, selectedItems.*)'];
+  }
+
+  /** @protected */
+  get slotStyles() {
+    const tag = this.localName;
+    return [
+      `
+        ${tag}[has-value] input::placeholder {
+          color: transparent !important;
+        }
+      `,
+    ];
   }
 
   /**

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -10,6 +10,7 @@ import { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constra
 import { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
 import {
@@ -97,5 +98,6 @@ assertType<InputControlMixinClass>(narrowedComboBox);
 assertType<InputMixinClass>(narrowedComboBox);
 assertType<KeyboardMixinClass>(narrowedComboBox);
 assertType<LabelMixinClass>(narrowedComboBox);
+assertType<SlotStylesMixinClass>(narrowedComboBox);
 assertType<ValidateMixinClass>(narrowedComboBox);
 assertType<ThemableMixinClass>(narrowedComboBox);


### PR DESCRIPTION
## Description

Manual cherry-pick of #4571 to `23.1` branch. 
The merge conflict was caused by `import type` used on master in `.ts` and `.d.ts` files.

## Type of change

- Cherry-pick