### PR TITLE
docs: add missing attribute JSDoc annotation

### DIFF
--- a/packages/field-base/src/input-control-mixin.d.ts
+++ b/packages/field-base/src/input-control-mixin.d.ts
@@ -46,6 +46,7 @@ export declare class InputControlMixinClass {
    *
    * For example, to allow entering only numbers and minus signs, use:
    * `allowedCharPattern = "[\\d-]"`
+   * @attr {string} allowed-char-pattern
    */
   allowedCharPattern: string;
 

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -35,6 +35,7 @@ export const InputControlMixin = (superclass) =>
          *
          * For example, to allow entering only numbers and minus signs, use:
          * `allowedCharPattern = "[\\d-]"`
+         * @attr {string} allowed-char-pattern
          */
         allowedCharPattern: {
           type: String,


### PR DESCRIPTION
## Description

Added missing `@attr` annotation to enable correct attribute in VSCode Lit plugin autocomplete popup.

## Type of change

- Documentation