### PR TITLE
fix: inject placeholder styles to correct root node

### DIFF
--- a/packages/field-base/src/input-control-mixin.d.ts
+++ b/packages/field-base/src/input-control-mixin.d.ts
@@ -14,6 +14,7 @@ import type { FieldMixinClass } from './field-mixin.js';
 import type { InputConstraintsMixinClass } from './input-constraints-mixin.js';
 import type { InputMixinClass } from './input-mixin.js';
 import type { LabelMixinClass } from './label-mixin.js';
+import type { SlotStylesMixinClass } from './slot-styles-mixin.js';
 import type { ValidateMixinClass } from './validate-mixin.js';
 
 /**
@@ -32,6 +33,7 @@ export declare function InputControlMixin<T extends Constructor<HTMLElement>>(
   Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<LabelMixinClass> &
+  Constructor<SlotStylesMixinClass> &
   Constructor<ValidateMixinClass> &
   T;
 

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -9,6 +9,7 @@ import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { DelegateFocusMixin } from './delegate-focus-mixin.js';
 import { FieldMixin } from './field-mixin.js';
 import { InputConstraintsMixin } from './input-constraints-mixin.js';
+import { SlotStylesMixin } from './slot-styles-mixin.js';
 
 /**
  * A mixin to provide shared logic for the editable form input controls.
@@ -18,10 +19,11 @@ import { InputConstraintsMixin } from './input-constraints-mixin.js';
  * @mixes FieldMixin
  * @mixes InputConstraintsMixin
  * @mixes KeyboardMixin
+ * @mixes SlotStylesMixin
  */
 export const InputControlMixin = (superclass) =>
-  class InputControlMixinClass extends DelegateFocusMixin(
-    InputConstraintsMixin(FieldMixin(KeyboardMixin(superclass))),
+  class InputControlMixinClass extends SlotStylesMixin(
+    DelegateFocusMixin(InputConstraintsMixin(FieldMixin(KeyboardMixin(superclass)))),
   ) {
     static get properties() {
       return {
@@ -116,6 +118,19 @@ export const InputControlMixin = (superclass) =>
     get clearElement() {
       console.warn(`Please implement the 'clearElement' property in <${this.localName}>`);
       return null;
+    }
+
+    /** @protected */
+    get slotStyles() {
+      // Needed for Safari, where ::slotted(...)::placeholder does not work
+      return [
+        `
+          :is(input[slot='input'], textarea[slot='textarea'])::placeholder {
+            font: inherit;
+            color: inherit;
+          }
+        `,
+      ];
     }
 
     /** @protected */

--- a/packages/field-base/src/input-field-mixin.d.ts
+++ b/packages/field-base/src/input-field-mixin.d.ts
@@ -15,6 +15,7 @@ import type { InputConstraintsMixinClass } from './input-constraints-mixin.js';
 import type { InputControlMixinClass } from './input-control-mixin.js';
 import type { InputMixinClass } from './input-mixin.js';
 import type { LabelMixinClass } from './label-mixin.js';
+import type { SlotStylesMixinClass } from './slot-styles-mixin.js';
 import type { ValidateMixinClass } from './validate-mixin.js';
 
 /**
@@ -34,6 +35,7 @@ export declare function InputFieldMixin<T extends Constructor<HTMLElement>>(
   Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<LabelMixinClass> &
+  Constructor<SlotStylesMixinClass> &
   Constructor<ValidateMixinClass> &
   T;
 

--- a/packages/input-container/src/vaadin-input-container.js
+++ b/packages/input-container/src/vaadin-input-container.js
@@ -5,7 +5,6 @@
  */
 import { html, PolymerElement } from '@polymer/polymer';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
@@ -56,7 +55,6 @@ export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
         ::slotted(:is(input, textarea))::placeholder {
           /* Use ::slotted(input:placeholder-shown) in themes to style the placeholder. */
           /* because ::slotted(...)::placeholder does not work in Safari. */
-          /* See the workaround at the end of this file. */
           font: inherit;
           color: inherit;
           /* Override default opacity in Firefox */
@@ -122,15 +120,3 @@ export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
 }
 
 customElements.define(InputContainer.is, InputContainer);
-
-const placeholderStyleWorkaround = css`
-  /* Needed for Safari, where ::slotted(...)::placeholder does not work */
-  :is(input[slot='input'], textarea[slot='textarea'])::placeholder {
-    font: inherit;
-    color: inherit;
-  }
-`;
-
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${placeholderStyleWorkaround.toString()}</style>`;
-document.head.appendChild($tpl.content);

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -15,7 +15,6 @@ import { TooltipController } from '@vaadin/component-base/src/tooltip-controller
 import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -137,11 +136,8 @@ registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectCo
  * @mixes ThemableMixin
  * @mixes InputControlMixin
  * @mixes ResizeMixin
- * @mixes SlotStylesMixin
  */
-class MultiSelectComboBox extends SlotStylesMixin(
-  ResizeMixin(InputControlMixin(ThemableMixin(ElementMixin(PolymerElement)))),
-) {
+class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-multi-select-combo-box';
   }
@@ -480,6 +476,7 @@ class MultiSelectComboBox extends SlotStylesMixin(
   get slotStyles() {
     const tag = this.localName;
     return [
+      ...super.slotStyles,
       `
         ${tag}[has-value] input::placeholder {
           color: transparent !important;

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -5,7 +5,6 @@
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
@@ -69,7 +68,7 @@ export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCus
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
-declare class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
+declare class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   /**
    * Set to true to display value increase/decrease controls.
    * @attr {boolean} has-controls

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -10,7 +10,6 @@ import { TooltipController } from '@vaadin/component-base/src/tooltip-controller
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -51,7 +50,7 @@ registerStyles('vaadin-number-field', inputFieldShared, { moduleId: 'vaadin-numb
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
+export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-number-field';
   }
@@ -190,6 +189,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
   get slotStyles() {
     const tag = this.localName;
     return [
+      ...super.slotStyles,
       `
         ${tag} input[type="number"]::-webkit-outer-spin-button,
         ${tag} input[type="number"]::-webkit-inner-spin-button {

--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 
 /**
@@ -72,7 +71,7 @@ export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFiel
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
-declare class PasswordField extends SlotStylesMixin(TextField) {
+declare class PasswordField extends TextField {
   /**
    * Set to true to hide the eye icon which toggles the password visibility.
    * @attr {boolean} reveal-button-hidden

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -6,7 +6,6 @@
 import './vaadin-password-field-button.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 
 const ownTemplate = html`
@@ -50,9 +49,8 @@ let memoizedTemplate;
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends TextField
- * @mixes SlotStylesMixin
  */
-export class PasswordField extends SlotStylesMixin(TextField) {
+export class PasswordField extends TextField {
   static get is() {
     return 'vaadin-password-field';
   }
@@ -127,6 +125,7 @@ export class PasswordField extends SlotStylesMixin(TextField) {
   get slotStyles() {
     const tag = this.localName;
     return [
+      ...super.slotStyles,
       `
         ${tag} [slot="input"]::-ms-reveal {
           display: none;


### PR DESCRIPTION
## Description

Fixes #4572 

Replaced the workaround added in #2710 with `SlotStylesMixin` to inject placeholder styles correctly.
Using `InputControlMixin` for it is the best place as it's used by all the affected field components:

- `vaadin-combo-box`
- `vaadin-date-picker`
- `vaadin-email-field`
- `vaadin-integer-field`
- `vaadin-multi-select-combo-box`
- `vaadin-number-field`
- `vaadin-password-field`
- `vaadin-text-area`
- `vaadin-text-field`
- `vaadin-time-picker`

Also removed extra mixin application from those component where it was already used previously.

## Type of change

- Bugfix