### PR TITLE
fix: inject placeholder styles to correct root node (#4577) (CP: 22.0)

### DIFF
--- a/packages/field-base/src/input-control-mixin.d.ts
+++ b/packages/field-base/src/input-control-mixin.d.ts
@@ -14,6 +14,7 @@ import { FieldMixinClass } from './field-mixin.js';
 import { InputConstraintsMixinClass } from './input-constraints-mixin.js';
 import { InputMixinClass } from './input-mixin.js';
 import { LabelMixinClass } from './label-mixin.js';
+import { SlotStylesMixinClass } from './slot-styles-mixin.js';
 import { ValidateMixinClass } from './validate-mixin.js';
 
 /**
@@ -33,6 +34,7 @@ export declare function InputControlMixin<T extends Constructor<HTMLElement>>(
   Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<LabelMixinClass> &
+  Constructor<SlotStylesMixinClass> &
   Constructor<ValidateMixinClass>;
 
 export declare class InputControlMixinClass {

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -7,6 +7,7 @@ import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { DelegateFocusMixin } from './delegate-focus-mixin.js';
 import { FieldMixin } from './field-mixin.js';
 import { InputConstraintsMixin } from './input-constraints-mixin.js';
+import { SlotStylesMixin } from './slot-styles-mixin.js';
 
 /**
  * A mixin to provide shared logic for the editable form input controls.
@@ -16,10 +17,11 @@ import { InputConstraintsMixin } from './input-constraints-mixin.js';
  * @mixes FieldMixin
  * @mixes InputConstraintsMixin
  * @mixes KeyboardMixin
+ * @mixes SlotStylesMixin
  */
 export const InputControlMixin = (superclass) =>
-  class InputControlMixinClass extends DelegateFocusMixin(
-    InputConstraintsMixin(FieldMixin(KeyboardMixin(superclass))),
+  class InputControlMixinClass extends SlotStylesMixin(
+    DelegateFocusMixin(InputConstraintsMixin(FieldMixin(KeyboardMixin(superclass)))),
   ) {
     static get properties() {
       return {
@@ -89,6 +91,19 @@ export const InputControlMixin = (superclass) =>
     get clearElement() {
       console.warn(`Please implement the 'clearElement' property in <${this.localName}>`);
       return null;
+    }
+
+    /** @protected */
+    get slotStyles() {
+      // Needed for Safari, where ::slotted(...)::placeholder does not work
+      return [
+        `
+          :is(input[slot='input'], textarea[slot='textarea'])::placeholder {
+            font: inherit;
+            color: inherit;
+          }
+        `,
+      ];
     }
 
     /** @protected */

--- a/packages/field-base/src/input-field-mixin.d.ts
+++ b/packages/field-base/src/input-field-mixin.d.ts
@@ -15,6 +15,7 @@ import { InputConstraintsMixinClass } from './input-constraints-mixin.js';
 import { InputControlMixinClass } from './input-control-mixin.js';
 import { InputMixinClass } from './input-mixin.js';
 import { LabelMixinClass } from './label-mixin.js';
+import { SlotStylesMixinClass } from './slot-styles-mixin.js';
 import { ValidateMixinClass } from './validate-mixin.js';
 
 /**
@@ -35,6 +36,7 @@ export declare function InputFieldMixin<T extends Constructor<HTMLElement>>(
   Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<LabelMixinClass> &
+  Constructor<SlotStylesMixinClass> &
   Constructor<ValidateMixinClass>;
 
 export declare class InputFieldMixinClass {

--- a/packages/input-container/src/vaadin-input-container.js
+++ b/packages/input-container/src/vaadin-input-container.js
@@ -5,7 +5,6 @@
  */
 import { html, PolymerElement } from '@polymer/polymer';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
@@ -56,7 +55,6 @@ export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
         ::slotted(:is(input, textarea))::placeholder {
           /* Use ::slotted(input:placeholder-shown) in themes to style the placeholder. */
           /* because ::slotted(...)::placeholder does not work in Safari. */
-          /* See the workaround at the end of this file. */
           font: inherit;
           color: inherit;
           /* Override default opacity in Firefox */
@@ -122,15 +120,3 @@ export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
 }
 
 customElements.define(InputContainer.is, InputContainer);
-
-const placeholderStyleWorkaround = css`
-  /* Needed for Safari, where ::slotted(...)::placeholder does not work */
-  :is(input[slot='input'], textarea[slot='textarea'])::placeholder {
-    font: inherit;
-    color: inherit;
-  }
-`;
-
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${placeholderStyleWorkaround.toString()}</style>`;
-document.head.appendChild($tpl.content);

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -5,7 +5,6 @@
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
@@ -52,7 +51,7 @@ export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCus
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
+declare class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   /**
    * Set to true to display value increase/decrease controls.
    * @attr {boolean} has-controls

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -9,7 +9,6 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -49,7 +48,7 @@ registerStyles('vaadin-number-field', inputFieldShared, { moduleId: 'vaadin-numb
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(ElementMixin(PolymerElement)))) {
+export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-number-field';
   }
@@ -182,6 +181,7 @@ export class NumberField extends InputFieldMixin(SlotStylesMixin(ThemableMixin(E
   get slotStyles() {
     const tag = this.localName;
     return [
+      ...super.slotStyles,
       `
         ${tag} input[type="number"]::-webkit-outer-spin-button,
         ${tag} input[type="number"]::-webkit-inner-spin-button {

--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 
 /**
@@ -56,7 +55,7 @@ export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFiel
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class PasswordField extends SlotStylesMixin(SlotMixin(TextField)) {
+declare class PasswordField extends SlotMixin(TextField) {
   /**
    * Set to true to hide the eye icon which toggles the password visibility.
    * @attr {boolean} reveal-button-hidden

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -5,7 +5,6 @@
  */
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';
-import { SlotStylesMixin } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 
 const ownTemplate = html`
@@ -48,9 +47,8 @@ let memoizedTemplate;
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
  * @extends TextField
- * @mixes SlotStylesMixin
  */
-export class PasswordField extends SlotStylesMixin(SlotMixin(TextField)) {
+export class PasswordField extends SlotMixin(TextField) {
   static get is() {
     return 'vaadin-password-field';
   }
@@ -138,6 +136,7 @@ export class PasswordField extends SlotStylesMixin(SlotMixin(TextField)) {
   get slotStyles() {
     const tag = this.localName;
     return [
+      ...super.slotStyles,
       `
         ${tag} [slot="input"]::-ms-reveal {
           display: none;


### PR DESCRIPTION
## Description

Manual cherry-pick of #4577 to `22.0` branch with some tweaks (e.g. removed `multi-select-combo-box`).

## Type of change

- Cherry-pick