### PR TITLE
refactor: do not show tooltip on iOS and Android

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -671,15 +671,21 @@ class Grid extends ElementMixin(
     cell.id = slotName.replace('-content-', '-');
     cell.setAttribute('tabindex', '-1');
     cell.setAttribute('role', tagName === 'td' ? 'gridcell' : 'columnheader');
-    cell.addEventListener('mouseenter', (event) => {
-      this._showTooltip(event);
-    });
-    cell.addEventListener('mouseleave', () => {
-      this._hideTooltip();
-    });
-    cell.addEventListener('mousedown', () => {
-      this._hideTooltip();
-    });
+
+    // For now we only support tooltip on desktop
+    if (!isAndroid && !isIOS) {
+      cell.addEventListener('mouseenter', (event) => {
+        this._showTooltip(event);
+      });
+
+      cell.addEventListener('mouseleave', () => {
+        this._hideTooltip();
+      });
+
+      cell.addEventListener('mousedown', () => {
+        this._hideTooltip();
+      });
+    }
 
     const slot = document.createElement('slot');
     slot.setAttribute('name', slotName);


### PR DESCRIPTION
## Description

Fixes #4579

Looks like with `pointerenter` and `pointerdown` events there is no flash, most likely because of different timing:

https://user-images.githubusercontent.com/10589913/189892745-ed959052-b806-4399-8f89-dcad11269f35.mp4

## Type of change

- Refactor