### PR TITLE
fix: do not reset timers when using manual mode

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -389,6 +389,10 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
   /** @private */
   __onFocusin(event) {
+    if (this.manual) {
+      return;
+    }
+
     // Only open on keyboard focus.
     if (!isKeyboardActive()) {
       return;
@@ -412,6 +416,10 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
   /** @private */
   __onFocusout(event) {
+    if (this.manual) {
+      return;
+    }
+
     // Do not close when moving focus within a component.
     if (this.target.contains(event.relatedTarget)) {
       return;
@@ -439,6 +447,10 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
   /** @private */
   __onMouseEnter() {
+    if (this.manual) {
+      return;
+    }
+
     if (typeof this.shouldShow === 'function' && this.shouldShow(this.target) !== true) {
       return;
     }
@@ -457,6 +469,10 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
   /** @private */
   __onMouseLeave() {
+    if (this.manual) {
+      return;
+    }
+
     this.__hoverInside = false;
 
     if (!this.__focusInside) {

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -541,5 +541,82 @@ describe('timers', () => {
 
       expect(overlays[0].opened).to.be.false;
     });
+
+    it('should not keep warmed up state on mouseenter to the manual tooltip target', async () => {
+      tooltips[1].manual = true;
+
+      mouseenter(targets[0]);
+      await aTimeout(2);
+
+      mouseleave(targets[0]);
+      mouseenter(targets[1]);
+      await aTimeout(2);
+
+      expect(overlays[0].opened).to.be.false;
+
+      mouseleave(targets[1]);
+      mouseenter(targets[0]);
+      expect(overlays[0].opened).to.be.false;
+
+      await aTimeout(2);
+      expect(overlays[0].opened).to.be.true;
+    });
+
+    it('should not keep warmed up state on focusout to the manual tooltip target', async () => {
+      tooltips[1].manual = true;
+
+      tabKeyDown(document.body);
+      focusin(targets[0]);
+      await aTimeout(2);
+
+      focusout(targets[0], targets[1]);
+      focusin(targets[1], targets[0]);
+      await aTimeout(2);
+
+      expect(overlays[0].opened).to.be.false;
+
+      focusout(targets[1], targets[0]);
+      focusin(targets[0], targets[1]);
+
+      expect(overlays[0].opened).to.be.false;
+
+      await aTimeout(2);
+      expect(overlays[0].opened).to.be.true;
+    });
+
+    it('should not restart cooldown on mouseleave from the manual tooltip target', async () => {
+      tooltips[1].manual = true;
+
+      mouseenter(targets[0]);
+      await aTimeout(2);
+
+      mouseleave(targets[0]);
+      mouseenter(targets[1]);
+      await aTimeout(1);
+
+      mouseleave(targets[1]);
+      await aTimeout(1);
+
+      mouseenter(targets[0]);
+      expect(overlays[0].opened).to.be.false;
+    });
+
+    it('should not restart cooldown on focusout from the manual tooltip target', async () => {
+      tooltips[1].manual = true;
+
+      tabKeyDown(document.body);
+      focusin(targets[0]);
+      await aTimeout(2);
+
+      focusout(targets[0], targets[1]);
+      focusin(targets[1], targets[0]);
+      await aTimeout(1);
+
+      focusout(targets[1]);
+      await aTimeout(1);
+
+      focusin(targets[0]);
+      expect(overlays[0].opened).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Description

Currently, the tooltip in `manual` mode does not change its `opened` state using mouse / focus event listeners.
However, these listeners still incorrectly affect global "warm up" / "cooldown" timers, which is a bug.

Updated this logic to do nothing when using `manual` mode and added corresponding unit tests.

## Type of change

- Bugfix
