### PR TITLE
fix: enforce dash case for event names in docs

### DIFF
--- a/scripts/prepareDocs.js
+++ b/scripts/prepareDocs.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 const fs = require('fs');
 
+const CAMEL_TO_DASH = /([A-Z])/g;
+
 function generateChangeEventName(property) {
-  return `${property.name}-changed`;
+  return `${property.name.replace(CAMEL_TO_DASH, '-$1').toLowerCase()}-changed`;
 }
 
 function findEvent(element, eventName) {


### PR DESCRIPTION
## Description

This PR fixes a minor regression from #4537 which introduced an issue with incorrect events shown in docs:

![Screenshot 2022-09-13 at 19 03 53](https://user-images.githubusercontent.com/10589913/189951726-364c3e9a-b48e-46b9-97eb-1b29a4591599.png)

## Type of change

- Bugfix