### PR TITLE
fix: customize bottom offset for fields with label

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -40,6 +40,10 @@ const requiredField = css`
     padding-top: var(--lumo-space-m);
   }
 
+  :host([has-label]) ::slotted([slot='tooltip']) {
+    --vaadin-tooltip-offset-bottom: calc((var(--lumo-space-m) - var(--lumo-space-xs)) * -1);
+  }
+
   :host([required]) [part='required-indicator']::after {
     content: var(--lumo-required-field-indicator, '•');
     transition: opacity 0.2s;

--- a/packages/vaadin-material-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-material-styles/mixins/input-field-shared.js
@@ -37,6 +37,10 @@ const inputField = css`
     padding-top: 24px;
   }
 
+  :host([has-label]) ::slotted([slot='tooltip']) {
+    --vaadin-tooltip-offset-bottom: -8px;
+  }
+
   [part='input-field'] {
     position: relative;
     top: -0.2px; /* NOTE(platosha): Adjusts for wrong flex baseline in Chrome & Safari */


### PR DESCRIPTION
## Description

Added custom offset overrides for field components to compensate `padding-top` set on the host element.

### Lumo

| Before  | After
|-----------------------|-------------------
| ![Screenshot 2022-09-14 at 11 38 08](https://user-images.githubusercontent.com/10589913/190106095-dd077e6e-946a-4723-8c2a-332c58b64944.png) | ![Screenshot 2022-09-14 at 11 37 53](https://user-images.githubusercontent.com/10589913/190106075-a051eab4-cfad-482c-8973-610a97748758.png)

### Material

| Before  | After
|-----------------------|-------------------
| ![Screenshot 2022-09-14 at 11 29 15](https://user-images.githubusercontent.com/10589913/190106554-002f4ca1-7f16-4996-87c6-f254f58063f2.png) | ![Screenshot 2022-09-14 at 11 29 01](https://user-images.githubusercontent.com/10589913/190106539-94b251d2-fba0-40d5-8c45-ad1122c2959a.png)

## Type of change

- Bugfix