### PR TITLE
fix: do not close on mouseleave to tooltip overlay

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -89,6 +89,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
         no-vertical-overlap$="[[__computeNoVerticalOverlap(position)]]"
         horizontal-align="[[__computeHorizontalAlign(position)]]"
         vertical-align="[[__computeVerticalAlign(position)]]"
+        on-mouseleave="__onOverlayMouseLeave"
         modeless
       ></vaadin-tooltip-overlay>
     `;
@@ -468,7 +469,21 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /** @private */
-  __onMouseLeave() {
+  __onMouseLeave(event) {
+    if (event.relatedTarget !== this._overlayElement) {
+      this.__handleMouseLeave();
+    }
+  }
+
+  /** @private */
+  __onOverlayMouseLeave(event) {
+    if (event.relatedTarget !== this.target) {
+      this.__handleMouseLeave();
+    }
+  }
+
+  /** @private */
+  __handleMouseLeave() {
     if (this.manual) {
       return;
     }

--- a/packages/tooltip/test/helpers.js
+++ b/packages/tooltip/test/helpers.js
@@ -4,8 +4,9 @@ export function mouseenter(target) {
   fire(target, 'mouseenter');
 }
 
-export function mouseleave(target) {
-  fire(target, 'mouseleave');
+export function mouseleave(target, relatedTarget) {
+  const eventProps = relatedTarget ? { relatedTarget } : {};
+  fire(target, 'mouseleave', undefined, eventProps);
 }
 
 export async function waitForIntersectionObserver() {

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -229,6 +229,30 @@ describe('vaadin-tooltip', () => {
       expect(overlay.opened).to.be.false;
     });
 
+    it('should not close overlay on mouseleave from target to overlay', () => {
+      mouseenter(target);
+      mouseleave(target, overlay);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close overlay on mouseleave from overlay to target', () => {
+      mouseenter(target);
+      mouseleave(target, overlay);
+
+      mouseenter(overlay);
+      mouseleave(overlay, target);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close overlay on mouseleave from overlay to outside', () => {
+      mouseenter(target);
+      mouseleave(target, overlay);
+
+      mouseenter(overlay);
+      mouseleave(overlay);
+      expect(overlay.opened).to.be.false;
+    });
+
     it('should close overlay on target mousedown', () => {
       mouseenter(target);
       mousedown(target);


### PR DESCRIPTION
## Description

This PR addresses the issue discovered in https://github.com/vaadin/web-components/pull/4591#discussion_r970533561.

In some conditions, when overlay is open immediately (zero hover delay), the `mouseenter` event is immediately followed by `mouseleave` event because cursor moves to `vaadin-tooltip-overlay` which causes it to close.

Added logic to prevent `mouseleave` to overlay (and then back to target) from closing the tooltip.
This also allows users to e.g. select the text shown in the tooltip and copy it to clipboard.

Finally, this change makes the tooltip satisfy the [WCAG Criterion 1.14.13](https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus):

> If pointer hover can trigger the additional content, then the pointer can be moved over the additional content without the additional content disappearing.
 
## Type of change

- Bugfix