### PR TITLE
fix: do not clear data provider cache when readonly

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -326,6 +326,21 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
 
     return super._shouldLoadPage(page);
   }
+
+  /**
+   * Override method inherited from the combo-box
+   * to not clear the data provider cache when read-only.
+   *
+   * @protected
+   * @override
+   */
+  clearCache() {
+    if (this.readonly) {
+      return;
+    }
+
+    super.clearCache();
+  }
 }
 
 customElements.define(MultiSelectComboBoxInternal.is, MultiSelectComboBoxInternal);

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -660,6 +660,10 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     if (readonly || oldReadonly) {
       this.__updateChips();
     }
+
+    if (this.dataProvider) {
+      this.clearCache();
+    }
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -207,6 +207,31 @@ describe('readonly', () => {
     });
   });
 
+  describe('dataProvider is changed while readonly', () => {
+    const asyncDataProvider1 = getAsyncDataProvider(['item 1', 'item 2']);
+    const asyncDataProvider2 = getAsyncDataProvider(['new item 1', 'new item 2']);
+
+    beforeEach(() => {
+      comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
+      comboBox.dataProvider = asyncDataProvider1;
+      // Load the first page.
+      comboBox.inputElement.click();
+      comboBox.readonly = true;
+      comboBox.dataProvider = asyncDataProvider2;
+    });
+
+    it('should render the new items when readonly is off', async () => {
+      comboBox.readonly = false;
+      comboBox.inputElement.click();
+      // Wait for the async data provider timeout
+      await aTimeout(0);
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items.length).to.equal(2);
+      expect(items[0].textContent).to.equal('new item 1');
+      expect(items[1].textContent).to.equal('new item 2');
+    });
+  });
+
   describe('external filtering', () => {
     beforeEach(() => {
       comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -188,6 +188,25 @@ describe('readonly', () => {
     });
   });
 
+  describe('dataProvider is set after selectedItems', () => {
+    beforeEach(() => {
+      comboBox = fixtureSync(`<vaadin-multi-select-combo-box readonly></vaadin-multi-select-combo-box>`);
+      comboBox.selectedItems = ['apple', 'orange'];
+      comboBox.dataProvider = getAsyncDataProvider(['apple', 'banana', 'lemon', 'orange']);
+      inputElement = comboBox.inputElement;
+    });
+
+    it('should only render selected items in the dropdown when readonly', async () => {
+      inputElement.click();
+      // Wait for the async data provider timeout
+      await aTimeout(0);
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items.length).to.equal(2);
+      expect(items[0].textContent).to.equal('apple');
+      expect(items[1].textContent).to.equal('orange');
+    });
+  });
+
   describe('external filtering', () => {
     beforeEach(() => {
       comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);


### PR DESCRIPTION
## Description

The PR disables clearing the data provider cache when `multi-select-combo-box` is read-only. Generally, all the data provider functionality should be disabled while the field is read-only to preserve `filteredItems` as they contain the selected items that are supposed to be shown in the dropdown in that case.

Fixes https://github.com/vaadin/flow-components/issues/3684

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
