### PR TITLE
fix: hide tooltip on disabled button mouseover

### DIFF
--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -72,6 +72,19 @@ describe('menu-bar with tooltip', () => {
     expect(tooltip.opened).to.be.false;
   });
 
+  it('should hide tooltip on menu bar container mouseover', () => {
+    mouseover(buttons[0]);
+    mouseover(menuBar._container);
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should show tooltip again on menu bar button mouseover', () => {
+    mouseover(buttons[0]);
+    mouseover(menuBar._container);
+    mouseover(buttons[1]);
+    expect(tooltip.opened).to.be.true;
+  });
+
   it('should set tooltip target on menu button mouseover', () => {
     mouseover(buttons[0]);
     expect(tooltip.target).to.be.equal(buttons[0]);

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -305,7 +305,10 @@ export const InteractionsMixin = (superClass) =>
      */
     _onMouseOver(e) {
       const button = this._getButtonFromEvent(e);
-      if (button && button !== this._expandedButton) {
+      if (!button) {
+        // Hide tooltip on mouseover to disabled button
+        this._hideTooltip();
+      } else if (button !== this._expandedButton) {
         const isOpened = this._subMenu.opened;
         if (button.item.children && (this.openOnHover || isOpened)) {
           this.__openSubMenu(button, false);


### PR DESCRIPTION
## Description

Fixes #4599

Added logic to hide tooltip in case when `event.composedPath()` does not contain a menu-bar button.
This can happen especially for `disabled` buttons because they have `pointer-events: none`.

## Type of change

- Bugfix
