### PR TITLE
fix: reset styles to handle window resize correctly

### DIFF
--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -182,6 +182,17 @@ export const PositionMixin = (superClass) =>
         return;
       }
 
+      // Cleanup styles to avoid wrong values after window resize
+      // See https://github.com/vaadin/web-components/issues/4604
+      Object.assign(this.style, {
+        top: '',
+        right: '',
+        bottom: '',
+        left: '',
+        justifyContent: '',
+        alignItems: '',
+      });
+
       const targetRect = this.positionTarget.getBoundingClientRect();
 
       // Detect the desired alignment and update the layout accordingly
@@ -282,66 +293,21 @@ export const PositionMixin = (superClass) =>
     }
 
     /**
-     * Returns an adjusted value after resizing the browser window,
-     * to avoid wrong calculations when e.g. previously set `bottom`
-     * CSS property value is larger than the updated viewport height.
-     * See https://github.com/vaadin/web-components/issues/4604
-     */
-    __adjustBottomProperty(cssPropNameToSet, propNames, currentValue) {
-      let adjustedProp;
-
-      if (cssPropNameToSet === propNames.end) {
-        // Adjust horizontally
-        if (propNames.end === PROP_NAMES_VERTICAL.end) {
-          const viewportHeight = Math.min(window.innerHeight, document.documentElement.clientHeight);
-
-          if (currentValue > viewportHeight && this.__oldViewportHeight) {
-            const heightDiff = this.__oldViewportHeight - viewportHeight;
-            adjustedProp = currentValue - heightDiff;
-          }
-
-          this.__oldViewportHeight = viewportHeight;
-        }
-
-        // Adjust vertically
-        if (propNames.end === PROP_NAMES_HORIZONTAL.end) {
-          const viewportWidth = Math.min(window.innerWidth, document.documentElement.clientWidth);
-
-          if (currentValue > viewportWidth && this.__oldViewportWidth) {
-            const widthDiff = this.__oldViewportWidth - viewportWidth;
-            adjustedProp = currentValue - widthDiff;
-          }
-
-          this.__oldViewportWidth = viewportWidth;
-        }
-      }
-
-      return adjustedProp;
-    }
-
-    /**
      * Returns an object with CSS position properties to set,
-     * e.g. { top: "100px", bottom: "" }
+     * e.g. { top: "100px" }
      */
     // eslint-disable-next-line max-params
     __calculatePositionInOneDimension(targetRect, overlayRect, noOverlap, propNames, overlay, shouldAlignStart) {
       const cssPropNameToSet = shouldAlignStart ? propNames.start : propNames.end;
-      const cssPropNameToClear = shouldAlignStart ? propNames.end : propNames.start;
 
       const currentValue = parseFloat(overlay.style[cssPropNameToSet] || getComputedStyle(overlay)[cssPropNameToSet]);
-      const adjustedValue = this.__adjustBottomProperty(cssPropNameToSet, propNames, currentValue);
 
       const diff =
         overlayRect[shouldAlignStart ? propNames.start : propNames.end] -
         targetRect[noOverlap === shouldAlignStart ? propNames.end : propNames.start];
 
-      const valueToSet = adjustedValue
-        ? `${adjustedValue}px`
-        : `${currentValue + diff * (shouldAlignStart ? -1 : 1)}px`;
-
       return {
-        [cssPropNameToSet]: valueToSet,
-        [cssPropNameToClear]: '',
+        [cssPropNameToSet]: `${currentValue + diff * (shouldAlignStart ? -1 : 1)}px`,
       };
     }
   };

--- a/packages/vaadin-overlay/test/position-mixin.test.js
+++ b/packages/vaadin-overlay/test/position-mixin.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { setViewport } from '@web/test-runner-commands';
 import { css } from 'lit';
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
 import { OverlayElement } from '../src/vaadin-overlay.js';
@@ -288,6 +289,28 @@ describe('position mixin', () => {
         expectEdgesAligned(TOP, BOTTOM);
       });
     });
+
+    describe('window resize', () => {
+      let width, height;
+
+      beforeEach(() => {
+        overlay.noVerticalOverlap = true;
+        width = window.innerWidth;
+        height = window.innerHeight;
+      });
+
+      afterEach(async () => {
+        await setViewport({ width, height });
+      });
+
+      it('should adjust vertically on decreasing viewport height', async () => {
+        await setViewport({ width, height: height / 2 });
+
+        updatePosition();
+
+        expectEdgesAligned(BOTTOM, TOP);
+      });
+    });
   });
 
   describe('horizontal align start', () => {
@@ -495,6 +518,28 @@ describe('position mixin', () => {
         target.style.left = `${targetPositionForCentering - 3}px`;
         updatePosition();
         expectEdgesAligned(LEFT, RIGHT);
+      });
+    });
+
+    describe('window resize', () => {
+      let width, height;
+
+      beforeEach(() => {
+        overlay.noHorizontalOverlap = true;
+        width = window.innerWidth;
+        height = window.innerHeight;
+      });
+
+      afterEach(async () => {
+        await setViewport({ width, height });
+      });
+
+      it('should adjust horizontally on decreasing viewport width', async () => {
+        await setViewport({ width: width / 2, height });
+
+        updatePosition();
+
+        expectEdgesAligned(RIGHT, LEFT);
       });
     });
   });


### PR DESCRIPTION
## Description

Fixes #4604

Added logic to adjust bottom coordinate when it's larger when the viewport. E.g. we have `bottom: 1200px` but after resize, the viweport height is `700px` - in this case we just calculate the diff and update the `bottom` property accordingly.

## Type of change

- Bugfix

## Note

Can be tested with the following HTML (use `position="top"` and `margin-top: 200px` for vertical):

```html
<vaadin-button style="margin-left: 200px">
  Edit
  <vaadin-tooltip slot="tooltip" text="Click to edit" manual position="start"></vaadin-tooltip>
</vaadin-button>

<script type="module">
  requestAnimationFrame(() => {
    document.querySelector('vaadin-tooltip').opened = true;
  });
</script>
```

💡 Use "Dock to bottom" / "Dock to right" in DevTools to easily change viewport height / width.