### PR TITLE
fix: do not throw when setting manual and opened

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -64,6 +64,17 @@ class TooltipOverlay extends PositionMixin(OverlayElement) {
     };
   }
 
+  /** @protected */
+  ready() {
+    super.ready();
+
+    // When setting `manual` and `opened` attributes, the overlay is already moved to body
+    // by the time when `ready()` callback of the `vaadin-tooltip` is executed by Polymer,
+    // so querySelector() would return null. So we use this workaround to set properties.
+    this.owner = this.__dataHost;
+    this.owner._overlayElement = this;
+  }
+
   requestContentUpdate() {
     super.requestContentUpdate();
 

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -293,14 +293,6 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /** @protected */
-  ready() {
-    super.ready();
-
-    this._overlayElement = this.shadowRoot.querySelector('vaadin-tooltip-overlay');
-    this._overlayElement.owner = this;
-  }
-
-  /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
 

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -594,3 +594,20 @@ describe('vaadin-tooltip', () => {
     });
   });
 });
+
+describe('manual opened', () => {
+  let tooltip, overlay;
+
+  beforeEach(() => {
+    tooltip = fixtureSync('<vaadin-tooltip text="Test" manual opened></vaadin-tooltip>');
+    overlay = tooltip._overlayElement;
+  });
+
+  afterEach(() => {
+    tooltip.opened = false;
+  });
+
+  it('should set owner on the overlay element', () => {
+    expect(overlay.owner).to.equal(tooltip);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #4609

Added a workaround to ensure `_overlayElement` and `owner` properties on tooltip and overlay are set correctly.
This bug happens because of `ready()` callbacks running in reverse order (child before parent) in Polymer.

## Type of change

- Bugfix