### PR TITLE
refactor: rename tooltip.textGenerator to generator

### DIFF
--- a/dev/grid.html
+++ b/dev/grid.html
@@ -31,7 +31,7 @@
       };
 
       const tooltip = document.querySelector('[slot="tooltip"]');
-      tooltip.textGenerator = ({column, item}) => {
+      tooltip.generator = ({column, item}) => {
         return column && column.path && item ? `Tooltip ${column.path} ${item.name}` : '';
       };
     </script>

--- a/dev/menu-bar.html
+++ b/dev/menu-bar.html
@@ -35,7 +35,7 @@
       ];
 
       const tooltip = document.querySelector('[slot="tooltip"]');
-      tooltip.textGenerator = ({ item }) => item.tooltip;
+      tooltip.generator = ({ item }) => item.tooltip;
     </script>
   </head>
 

--- a/integration/tests/grid-tooltip.test.js
+++ b/integration/tests/grid-tooltip.test.js
@@ -38,7 +38,7 @@ describe('tooltip', () => {
     flushGrid(grid);
 
     tooltip = grid.querySelector('vaadin-tooltip');
-    tooltip.textGenerator = ({ column, item }) => {
+    tooltip.generator = ({ column, item }) => {
       return column && column.path && item ? `${column.path}: ${item[column.path]}` : '';
     };
   });

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -45,7 +45,7 @@ describe('menu-bar with tooltip', () => {
     buttons = menuBar._buttons;
 
     tooltip = menuBar.querySelector('vaadin-tooltip');
-    tooltip.textGenerator = ({ item }) => item && `${item.text} tooltip`;
+    tooltip.generator = ({ item }) => item && `${item.text} tooltip`;
   });
 
   it('should set manual on the tooltip to true', () => {

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -132,7 +132,7 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement)
           on-keydown="_onOverflowKeyDown"
           aria-haspopup="listbox"
         >
-          <vaadin-tooltip slot="tooltip" text-generator="[[__overflowTextGenerator]]"></vaadin-tooltip>
+          <vaadin-tooltip slot="tooltip" generator="[[__overflowTextGenerator]]"></vaadin-tooltip>
         </vaadin-avatar>
       </div>
       <vaadin-avatar-group-overlay

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -82,7 +82,7 @@ describe('avatar-group', () => {
       expect(overflow.abbr).to.equal('+3');
     });
 
-    it('should set text generator on the overflow avatar tooltip', () => {
+    it('should set generator on the overflow avatar tooltip', () => {
       const overflow = group.$.overflow;
       const items = group.items;
       const tooltip = overflow.querySelector('vaadin-tooltip');

--- a/packages/component-base/src/tooltip-controller.d.ts
+++ b/packages/component-base/src/tooltip-controller.d.ts
@@ -24,7 +24,7 @@ type TooltipPosition =
  */
 export class TooltipController extends SlotController {
   /**
-   * Object with properties passed to `textGenerator`
+   * Object with properties passed to `generator`
    * function to be used for generating tooltip text.
    */
   context: Record<string, unknown>;
@@ -52,7 +52,7 @@ export class TooltipController extends SlotController {
   target: HTMLElement;
 
   /**
-   * Set a context object to be used by text generator.
+   * Set a context object to be used by generator.
    */
   setContext(context: Record<string, unknown>): void;
 

--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -48,7 +48,7 @@ export class TooltipController extends SlotController {
   }
 
   /**
-   * Set a context object to be used by text generator.
+   * Set a context object to be used by generator.
    * @param {object} context
    */
   setContext(context) {

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -78,7 +78,7 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   static setDefaultHoverDelay(delay: number): void;
 
   /**
-   * Object with properties passed to `textGenerator`
+   * Object with properties passed to `generator`
    * function to be used for generating tooltip text.
    */
   context: Record<string, unknown>;
@@ -158,7 +158,7 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
    * Use the `context` property to provide argument
    * that can be passed to the generator function.
    */
-  textGenerator: (context: Record<string, unknown>) => string;
+  generator: (context: Record<string, unknown>) => string;
 }
 
 declare global {

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -98,7 +98,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   static get properties() {
     return {
       /**
-       * Object with properties passed to `textGenerator`
+       * Object with properties passed to `generator`
        * function to be used for generating tooltip text.
        */
       context: {
@@ -212,7 +212,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
        * Use the `context` property to provide argument
        * that can be passed to the generator function.
        */
-      textGenerator: {
+      generator: {
         type: Object,
       },
 
@@ -238,7 +238,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   static get observers() {
-    return ['__textGeneratorChanged(_overlayElement, textGenerator, context)'];
+    return ['__generatorChanged(_overlayElement, generator, context)'];
   }
 
   /**
@@ -328,7 +328,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
   /** @private */
   __tooltipRenderer(root) {
-    root.textContent = typeof this.textGenerator === 'function' ? this.textGenerator(this.context) : this.text;
+    root.textContent = typeof this.generator === 'function' ? this.generator(this.context) : this.text;
   }
 
   /** @private */
@@ -655,13 +655,13 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   }
 
   /** @private */
-  __textGeneratorChanged(overlayElement, textGenerator, context) {
+  __generatorChanged(overlayElement, generator, context) {
     if (overlayElement) {
-      if (textGenerator !== this.__oldTextGenerator || context !== this.__oldContext) {
+      if (generator !== this.__oldTextGenerator || context !== this.__oldContext) {
         overlayElement.requestContentUpdate();
       }
 
-      this.__oldTextGenerator = textGenerator;
+      this.__oldTextGenerator = generator;
       this.__oldContext = context;
     }
   }

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -73,37 +73,37 @@ describe('vaadin-tooltip', () => {
     });
   });
 
-  describe('textGenerator', () => {
-    it('should use textGenerator property to generate text content', () => {
-      tooltip.textGenerator = () => 'Foo';
+  describe('generator', () => {
+    it('should use generator property to generate text content', () => {
+      tooltip.generator = () => 'Foo';
       expect(overlay.textContent.trim()).to.equal('Foo');
     });
 
-    it('should override text property when textGenerator is set', () => {
+    it('should override text property when generator is set', () => {
       tooltip.text = 'Foo';
-      tooltip.textGenerator = () => 'Bar';
+      tooltip.generator = () => 'Bar';
       expect(overlay.textContent.trim()).to.equal('Bar');
     });
 
     it('should use context property in generator when provided', () => {
       tooltip.context = { text: 'Foo' };
-      tooltip.textGenerator = (context) => context.text;
+      tooltip.generator = (context) => context.text;
       expect(overlay.textContent.trim()).to.equal('Foo');
     });
 
     it('should update text content when context property changes', () => {
       tooltip.context = { text: 'Foo' };
-      tooltip.textGenerator = (context) => context.text;
+      tooltip.generator = (context) => context.text;
 
       tooltip.context = { text: 'Bar' };
       expect(overlay.textContent.trim()).to.equal('Bar');
     });
 
     it('should set hidden on the overlay when generator clears text', () => {
-      tooltip.textGenerator = () => 'Bar';
+      tooltip.generator = () => 'Bar';
       expect(overlay.hasAttribute('hidden')).to.be.false;
 
-      tooltip.textGenerator = () => '';
+      tooltip.generator = () => '';
       expect(overlay.hasAttribute('hidden')).to.be.true;
     });
   });

--- a/packages/tooltip/test/typings/tooltip.types.ts
+++ b/packages/tooltip/test/typings/tooltip.types.ts
@@ -16,7 +16,7 @@ assertType<string | undefined>(tooltip.for);
 assertType<HTMLElement | undefined>(tooltip.target);
 assertType<string | null | undefined>(tooltip.text);
 assertType<Record<string, unknown>>(tooltip.context);
-assertType<(context: Record<string, unknown>) => string>(tooltip.textGenerator);
+assertType<(context: Record<string, unknown>) => string>(tooltip.generator);
 assertType<boolean>(tooltip.manual);
 assertType<boolean>(tooltip.opened);
 assertType<number>(tooltip.focusDelay);


### PR DESCRIPTION
Apply the following changes (as agreed in API review):
- Rename `tooltip.textGenerator` to `tooltip.generator`