### PR TITLE
feat: add default tooltip generator for menu-bar

### DIFF
--- a/dev/menu-bar.html
+++ b/dev/menu-bar.html
@@ -33,9 +33,6 @@
         },
         { text: 'Duplicate', tooltip: 'Create a duplicate' },
       ];
-
-      const tooltip = document.querySelector('[slot="tooltip"]');
-      tooltip.generator = ({ item }) => item.tooltip;
     </script>
   </head>
 

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -20,6 +20,11 @@ export function mouseover(target) {
   fire(target, 'mouseover');
 }
 
+function getTooltipText() {
+  const overlay = document.querySelector('vaadin-tooltip-overlay');
+  return overlay && overlay.textContent;
+}
+
 describe('menu-bar with tooltip', () => {
   let menuBar, tooltip, buttons;
 
@@ -30,13 +35,14 @@ describe('menu-bar with tooltip', () => {
       </vaadin-menu-bar>
     `);
     menuBar.items = [
-      { text: 'Edit' },
+      { text: 'Edit', tooltip: 'Edit tooltip' },
       {
         text: 'Share',
         children: [{ text: 'By email' }],
       },
       {
         text: 'Move',
+        tooltip: 'Move tooltip',
         children: [{ text: 'To folder' }],
       },
     ];
@@ -45,7 +51,6 @@ describe('menu-bar with tooltip', () => {
     buttons = menuBar._buttons;
 
     tooltip = menuBar.querySelector('vaadin-tooltip');
-    tooltip.generator = ({ item }) => item && `${item.text} tooltip`;
   });
 
   it('should set manual on the tooltip to true', () => {
@@ -55,6 +60,16 @@ describe('menu-bar with tooltip', () => {
   it('should show tooltip on menu button mouseover', () => {
     mouseover(buttons[0]);
     expect(tooltip.opened).to.be.true;
+  });
+
+  it('should use the tooltip property of an item as tooltip', () => {
+    mouseover(buttons[0]);
+    expect(getTooltipText()).to.equal('Edit tooltip');
+  });
+
+  it('should not show tooltip for an item which has no tooltip', () => {
+    mouseover(buttons[1]);
+    expect(getTooltipText()).not.to.be.ok;
   });
 
   it('should not show tooltip on another parent menu button mouseover when open', async () => {
@@ -177,6 +192,12 @@ describe('menu-bar with tooltip', () => {
     expect(spyTarget.called).to.be.false;
     expect(spyContent.called).to.be.false;
     expect(spyOpened.called).to.be.false;
+  });
+
+  it('should not override a custom generator', () => {
+    tooltip.generator = () => 'Custom tooltip';
+    mouseover(buttons[0]);
+    expect(getTooltipText()).to.equal('Custom tooltip');
   });
 
   describe('overflow button', () => {

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -21,7 +21,7 @@ export function mouseover(target) {
 }
 
 function getTooltipText() {
-  const overlay = document.querySelector('vaadin-tooltip-overlay');
+  const overlay = document.querySelector('vaadin-tooltip-overlay:not([hidden])');
   return overlay && overlay.textContent;
 }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -107,10 +107,19 @@ export const InteractionsMixin = (superClass) =>
      */
     _showTooltip(button) {
       // Check if there is a slotted vaadin-tooltip element.
-      if (this._tooltipController.node && this._tooltipController.node.isConnected && !this._subMenu.opened) {
-        this._tooltipController.setTarget(button);
-        this._tooltipController.setContext({ item: button.item });
-        this._tooltipController.setOpened(true);
+      const tooltip = this._tooltipController.node;
+      if (tooltip && tooltip.isConnected) {
+        // If the tooltip element doesn't have a generator assigned, use a default one
+        // that reads the `tooltip` property of an item.
+        if (tooltip.generator === undefined) {
+          tooltip.generator = ({ item }) => item && item.tooltip;
+        }
+
+        if (!this._subMenu.opened) {
+          this._tooltipController.setTarget(button);
+          this._tooltipController.setContext({ item: button.item });
+          this._tooltipController.setOpened(true);
+        }
       }
     }
 

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -11,10 +11,31 @@ import { ButtonsMixin } from './vaadin-menu-bar-buttons-mixin.js';
 import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
 
 export interface MenuBarItem {
+  /**
+   * Text to be set as the menu button component's textContent.
+   */
   text?: string;
+  /**
+   * Text to be set as the menu button's tooltip.
+   * Requires a `<vaadin-tooltip slot="tooltip">` element to be added inside the `<vaadin-menu-bar>`.
+   */
+  tooltip?: string;
+  /**
+   * The component to represent the button content.
+   * Either a tagName or an element instance. Defaults to "vaadin-context-menu-item".
+   */
   component?: HTMLElement | string;
+  /**
+   * If true, the button is disabled and cannot be activated.
+   */
   disabled?: boolean;
+  /**
+   * Theme(s) to be set as the theme attribute of the button, overriding any theme set on the menu bar.
+   */
   theme?: string[] | string;
+  /**
+   * Array of submenu items.
+   */
   children?: SubMenuItem[];
 }
 

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -129,6 +129,8 @@ class MenuBar extends ButtonsMixin(
        * @typedef MenuBarItem
        * @type {object}
        * @property {string} text - Text to be set as the menu button component's textContent.
+       * @property {string} tooltip - Text to be set as the menu button's tooltip.
+       * Requires a `<vaadin-tooltip slot="tooltip">` element to be added inside the `<vaadin-menu-bar>`.
        * @property {union: string | object} component - The component to represent the button content.
        * Either a tagName or an element instance. Defaults to "vaadin-context-menu-item".
        * @property {boolean} disabled - If true, the button is disabled and cannot be activated.

--- a/packages/menu-bar/test/typings/menu-bar.types.ts
+++ b/packages/menu-bar/test/typings/menu-bar.types.ts
@@ -16,3 +16,12 @@ menu.addEventListener('item-selected', (event) => {
   assertType<MenuBarItemSelectedEvent>(event);
   assertType<MenuBarItem>(event.detail.value);
 });
+
+const menuItem = menu.items[0];
+
+assertType<string | undefined>(menuItem.tooltip);
+assertType<string | undefined>(menuItem.text);
+assertType<boolean | undefined>(menuItem.disabled);
+assertType<string[] | string | undefined>(menuItem.theme);
+assertType<MenuBarItem[] | undefined>(menuItem.children);
+assertType<HTMLElement | string | undefined>(menuItem.component);


### PR DESCRIPTION
## Description
Apply the following changes (as agreed in the API review):
- add default tooltip generator for menu-bar
  - Makes assigning a generator to the `<vaadin-tooltip>` optional
  - The default tooltip generator reads the `tooltip` property of a `MenuBarItem`.
  - If a custom generator is assigned to the `<vaadin-tooltip>` it will not be overridden by the default generator.

## Type of change

- Feature