### PR TITLE
chore: add permissions section to GitHub Actions workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Unit tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,10 @@ name: Unit tests
 
 on: pull_request
 
+
+permissions:
+  contents: read
+
 jobs:
   chrome:
     name: Chrome

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,6 @@ name: Unit tests
 
 on: pull_request
 
-
 permissions:
   contents: read
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,6 +2,10 @@ name: Verify
 
 on: pull_request
 
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,7 +2,6 @@ name: Verify
 
 on: pull_request
 
-
 permissions:
   contents: read
 

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -2,7 +2,6 @@ name: Visual tests
 
 on: pull_request
 
-
 permissions:
   contents: read
 

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -2,6 +2,10 @@ name: Visual tests
 
 on: pull_request
 
+
+permissions:
+  contents: read
+
 jobs:
   lumo:
     name: Lumo


### PR DESCRIPTION
## Description

This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.

reference commit in https://github.com/vaadin/flow/pull/14463
