### PR TITLE
feat: pass context property value to shouldShow

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -78,8 +78,9 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   static setDefaultHoverDelay(delay: number): void;
 
   /**
-   * Object with properties passed to `generator`
-   * function to be used for generating tooltip text.
+   * Object with properties passed to `generator` and
+   * `shouldShow` functions for generating tooltip text
+   * or detecting whether to show the tooltip or not.
    */
   context: Record<string, unknown>;
 
@@ -135,10 +136,11 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
   /**
    * Function used to detect whether to show the tooltip based on a condition,
    * called every time the tooltip is about to be shown on hover and focus.
-   * The function accepts a reference to the target element as a parameter.
+   * The function takes two parameters: `target` and `context`, which contain
+   * values of the corresponding tooltip properties at the time of calling.
    * The tooltip is only shown when the function invocation returns `true`.
    */
-  shouldShow: (target: HTMLElement) => boolean;
+  shouldShow: (target: HTMLElement, context?: Record<string, unknown>) => boolean;
 
   /**
    * Reference to the element used as a tooltip trigger.

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -98,8 +98,9 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
   static get properties() {
     return {
       /**
-       * Object with properties passed to `generator`
-       * function to be used for generating tooltip text.
+       * Object with properties passed to `generator` and
+       * `shouldShow` functions for generating tooltip text
+       * or detecting whether to show the tooltip or not.
        */
       context: {
         type: Object,
@@ -178,13 +179,14 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       /**
        * Function used to detect whether to show the tooltip based on a condition,
        * called every time the tooltip is about to be shown on hover and focus.
-       * The function accepts a reference to the target element as a parameter.
+       * The function takes two parameters: `target` and `context`, which contain
+       * values of the corresponding tooltip properties at the time of calling.
        * The tooltip is only shown when the function invocation returns `true`.
        */
       shouldShow: {
         type: Object,
         value: () => {
-          return (_target) => true;
+          return (_target, _context) => true;
         },
       },
 
@@ -396,7 +398,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       return;
     }
 
-    if (typeof this.shouldShow === 'function' && this.shouldShow(this.target) !== true) {
+    if (!this.__isShouldShow()) {
       return;
     }
 
@@ -444,7 +446,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       return;
     }
 
-    if (typeof this.shouldShow === 'function' && this.shouldShow(this.target) !== true) {
+    if (!this.__isShouldShow()) {
       return;
     }
 
@@ -502,6 +504,15 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     if (!isVisible && this._autoOpened) {
       this._close(true);
     }
+  }
+
+  /** @private */
+  __isShouldShow() {
+    if (typeof this.shouldShow === 'function' && this.shouldShow(this.target, this.context) !== true) {
+      return false;
+    }
+
+    return true;
   }
 
   /**

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -491,6 +491,46 @@ describe('vaadin-tooltip', () => {
       tooltip.target = target;
     });
 
+    it('should pass tooltip target as a first parameter to shouldShow on mouseenter', () => {
+      const spy = sinon.spy();
+      tooltip.shouldShow = spy;
+
+      mouseenter(target);
+      expect(spy.firstCall.args[0]).to.equal(target);
+    });
+
+    it('should pass tooltip context as a second parameter to shouldShow on mouseenter', () => {
+      const context = { foo: 'bar ' };
+      tooltip.context = context;
+
+      const spy = sinon.spy();
+      tooltip.shouldShow = spy;
+      mouseenter(target);
+
+      expect(spy.firstCall.args[1]).to.equal(context);
+    });
+
+    it('should pass tooltip target as a first parameter to shouldShow on keyboard focus', () => {
+      const spy = sinon.spy();
+      tooltip.shouldShow = spy;
+
+      tabKeyDown(target);
+      target.focus();
+      expect(spy.firstCall.args[0]).to.equal(target);
+    });
+
+    it('should pass tooltip context as a second parameter to shouldShow on keyboard focus', () => {
+      const context = { foo: 'bar ' };
+      tooltip.context = context;
+
+      const spy = sinon.spy();
+      tooltip.shouldShow = spy;
+      tabKeyDown(target);
+      target.focus();
+
+      expect(spy.firstCall.args[1]).to.equal(context);
+    });
+
     it('should not open overlay on mouseenter when shouldShow returns false', () => {
       tooltip.shouldShow = (target) => !target.readOnly;
       target.readOnly = true;

--- a/packages/tooltip/test/typings/tooltip.types.ts
+++ b/packages/tooltip/test/typings/tooltip.types.ts
@@ -23,4 +23,4 @@ assertType<number>(tooltip.focusDelay);
 assertType<number>(tooltip.hideDelay);
 assertType<number>(tooltip.hoverDelay);
 assertType<TooltipPosition>(tooltip.position);
-assertType<(target: HTMLElement) => boolean>(tooltip.shouldShow);
+assertType<(target: HTMLElement, context?: Record<string, unknown>) => boolean>(tooltip.shouldShow);


### PR DESCRIPTION
## Description

Implemented the [suggestion](https://github.com/orgs/vaadin/discussions/3196#discussioncomment-3687344) about the `shouldShow` function to accept `context` as an optional second argument.

## Type of change

- Feature