### PR TITLE
fix: do not override position set with attribute

### DIFF
--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -39,7 +39,7 @@ export class TooltipController extends SlotController {
     }
 
     if (this.position !== undefined) {
-      tooltipNode.position = this.position;
+      this.__updatePosition(tooltipNode, this.position);
     }
 
     if (this.shouldShow !== undefined) {
@@ -93,10 +93,7 @@ export class TooltipController extends SlotController {
   setPosition(position) {
     this.position = position;
 
-    const tooltipNode = this.node;
-    if (tooltipNode) {
-      tooltipNode.position = position;
-    }
+    this.__updatePosition(this.node, position);
   }
 
   /**
@@ -123,6 +120,13 @@ export class TooltipController extends SlotController {
     const tooltipNode = this.node;
     if (tooltipNode) {
       tooltipNode.target = target;
+    }
+  }
+
+  /** @private */
+  __updatePosition(node, position) {
+    if (node && !node.hasAttribute('position')) {
+      node.position = position;
     }
   }
 }

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -74,6 +74,12 @@ describe('TooltipController', () => {
       controller.setPosition('top-start');
       expect(tooltip.position).to.eql('top-start');
     });
+
+    it('should not override position attribute using controller setPosition method', () => {
+      tooltip.setAttribute('position', 'end');
+      controller.setPosition('top-start');
+      expect(tooltip.position).to.not.eql('top-start');
+    });
   });
 
   describe('slotted tooltip', () => {


### PR DESCRIPTION
## Description

As discussed, we would like to set default position for input field components to `top` instead of `bottom`.
However, using `setPosition()` in the `TooltipController` for this would override position set with attribute:

```html
<vaadin-text-field>
  <vaadin-tooltip slot="tooltip" text="Other users will see this" position="end"></vaadin-tooltip>
</vaadin-text-field>
```

Changed the `setPosition()` logic to explicitly check for the attribute presence to avoid such cases.

## Type of change

- Bugfix