### PR TITLE
fix: add fallback icon to show for slotted whitespace text

### DIFF
--- a/packages/app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle.js
@@ -56,10 +56,11 @@ class DrawerToggle extends Button {
           top: 12px;
         }
       </style>
-      <slot>
+      <slot name="icon">
         <div part="icon"></div>
       </slot>
       <slot name="tooltip"></slot>
+      <slot></slot>
     `;
   }
 

--- a/packages/app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle.js
@@ -3,8 +3,10 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { Button } from '@vaadin/button/src/vaadin-button.js';
+import { isEmptyTextNode } from '@vaadin/component-base/src/dom-utils.js';
 
 /**
  * The Drawer Toggle component controls the drawer in App Layout component.
@@ -56,11 +58,11 @@ class DrawerToggle extends Button {
           top: 12px;
         }
       </style>
-      <slot name="icon">
+      <slot id="slot">
         <div part="icon"></div>
       </slot>
+      <div part="icon" hidden$="[[!_showFallbackIcon]]"></div>
       <slot name="tooltip"></slot>
-      <slot></slot>
     `;
   }
 
@@ -75,6 +77,12 @@ class DrawerToggle extends Button {
         value: 'Toggle navigation panel',
         reflectToAttribute: true,
       },
+
+      /** @private */
+      _showFallbackIcon: {
+        type: Boolean,
+        value: false,
+      },
     };
   }
 
@@ -84,6 +92,23 @@ class DrawerToggle extends Button {
     this.addEventListener('click', () => {
       this.dispatchEvent(new CustomEvent('drawer-toggle-click', { bubbles: true, composed: true }));
     });
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._observer = new FlattenedNodesObserver(this, () => {
+      this._toggleFallbackIcon();
+    });
+  }
+
+  /** @private */
+  _toggleFallbackIcon() {
+    const nodes = this.$.slot.assignedNodes();
+
+    // Show fallback icon if there are 1-2 empty text nodes assigned to the default slot.
+    this._showFallbackIcon = nodes.length > 0 && nodes.every((node) => isEmptyTextNode(node));
   }
 }
 

--- a/packages/app-layout/test/dom/__snapshots__/drawer-toggle.test.snap.js
+++ b/packages/app-layout/test/dom/__snapshots__/drawer-toggle.test.snap.js
@@ -2,13 +2,16 @@
 export const snapshots = {};
 
 snapshots["vaadin-app-layout default"] = 
-`<slot name="icon">
+`<slot id="slot">
   <div part="icon">
   </div>
 </slot>
+<div
+  hidden=""
+  part="icon"
+>
+</div>
 <slot name="tooltip">
-</slot>
-<slot>
 </slot>
 `;
 /* end snapshot vaadin-app-layout default */

--- a/packages/app-layout/test/dom/__snapshots__/drawer-toggle.test.snap.js
+++ b/packages/app-layout/test/dom/__snapshots__/drawer-toggle.test.snap.js
@@ -1,0 +1,15 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-app-layout default"] = 
+`<slot name="icon">
+  <div part="icon">
+  </div>
+</slot>
+<slot name="tooltip">
+</slot>
+<slot>
+</slot>
+`;
+/* end snapshot vaadin-app-layout default */
+

--- a/packages/app-layout/test/dom/drawer-toggle.test.js
+++ b/packages/app-layout/test/dom/drawer-toggle.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-drawer-toggle.js';
+
+describe('vaadin-app-layout', () => {
+  let toggle;
+
+  beforeEach(() => {
+    toggle = fixtureSync('<vaadin-drawer-toggle></vaadin-drawer-toggle>');
+  });
+
+  it('default', async () => {
+    await expect(toggle).shadowDom.to.equalSnapshot();
+  });
+});

--- a/packages/app-layout/test/drawer-toggle.test.js
+++ b/packages/app-layout/test/drawer-toggle.test.js
@@ -87,4 +87,57 @@ describe('drawer-toggle', () => {
       expect(toggle.getAttribute('aria-label')).to.equal('Label');
     });
   });
+
+  describe('fallback icon', () => {
+    let icon;
+
+    beforeEach(() => {
+      icon = toggle.shadowRoot.querySelectorAll('[part="icon"]')[1];
+    });
+
+    it('should not show fallback icon by default', () => {
+      expect(icon.hasAttribute('hidden')).to.be.true;
+    });
+
+    it('should show fallback icon when adding non-empty element', () => {
+      const div = document.createElement('div');
+      toggle.appendChild(div);
+      toggle._observer.flush();
+      expect(icon.hasAttribute('hidden')).to.be.true;
+    });
+
+    it('should show fallback icon when adding whitespace text node', () => {
+      const text = document.createTextNode(' ');
+      toggle.appendChild(text);
+      toggle._observer.flush();
+      expect(icon.hasAttribute('hidden')).to.be.false;
+    });
+
+    it('should show fallback icon when adding element to non-default slot', () => {
+      // Emulate adding element in HTML wrapped with whitespace text nodes
+      toggle.innerHTML = ' <vaadin-tooltip slot="tooltip"></vaadin-tooltip> ';
+      toggle._observer.flush();
+      expect(icon.hasAttribute('hidden')).to.be.false;
+    });
+
+    it('should hide fallback icon when removing whitespace text node', () => {
+      const text = document.createTextNode(' ');
+      toggle.appendChild(text);
+      toggle._observer.flush();
+
+      toggle.removeChild(text);
+      toggle._observer.flush();
+      expect(icon.hasAttribute('hidden')).to.be.true;
+    });
+
+    it('should hide fallback icon when clearing all slotted content', () => {
+      // Emulate adding element in HTML wrapped with whitespace text nodes
+      toggle.innerHTML = ' <vaadin-tooltip slot="tooltip"></vaadin-tooltip> ';
+      toggle._observer.flush();
+
+      toggle.innerHTML = '';
+      toggle._observer.flush();
+      expect(icon.hasAttribute('hidden')).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes #4623

This change is needed to fix the problem that happens when adding slotted content to `vaadin-drawer-toggle`.
This can happen as a side effect of using `slot="tooltip"` adding by https://github.com/vaadin/web-components/pull/4448 (whitespace nodes are added).

## Type of change

- Bugfix