### PR TITLE
feat: add helper function to detect empty text node

### DIFF
--- a/packages/component-base/src/dom-utils.d.ts
+++ b/packages/component-base/src/dom-utils.d.ts
@@ -23,3 +23,8 @@ export function addValueToAttribute(element: HTMLElement, attr: string, value: s
  * If the value is the last one, the whole attribute is removed.
  */
 export function removeValueFromAttribute(element: HTMLElement, attr: string, value: string): void;
+
+/**
+ * Returns true if the given node is an empty text node, false otherwise.
+ */
+export function isEmptyTextNode(node: Node): boolean;

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -90,3 +90,13 @@ export function removeValueFromAttribute(element, attr, value) {
   }
   element.setAttribute(attr, serializeAttributeValue(values));
 }
+
+/**
+ * Returns true if the given node is an empty text node, false otherwise.
+ *
+ * @param {Node} node
+ * @return {boolean}
+ */
+export function isEmptyTextNode(node) {
+  return node.nodeType === Node.TEXT_NODE && node.textContent.trim() === '';
+}

--- a/packages/component-base/test/dom-utils.test.js
+++ b/packages/component-base/test/dom-utils.test.js
@@ -1,6 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 import { defineCE, fixtureSync } from '@vaadin/testing-helpers';
-import { addValueToAttribute, getAncestorRootNodes, removeValueFromAttribute } from '../src/dom-utils.js';
+import {
+  addValueToAttribute,
+  getAncestorRootNodes,
+  isEmptyTextNode,
+  removeValueFromAttribute,
+} from '../src/dom-utils.js';
 
 describe('dom-utils', () => {
   describe('getAncestorRootNodes', () => {
@@ -73,6 +78,28 @@ describe('dom-utils', () => {
 
       removeValueFromAttribute(element, 'aria-labelledby', 'label-id');
       expect(element.hasAttribute('aria-labelledby')).to.be.false;
+    });
+  });
+
+  describe('isEmptyTextNode', () => {
+    let node;
+
+    beforeEach(() => {
+      node = document.createTextNode('');
+    });
+
+    it('should return true when node has empty text content', () => {
+      expect(isEmptyTextNode(node)).to.be.true;
+    });
+
+    it('should return true when node has whitespace text content', () => {
+      node.textContent = '  ';
+      expect(isEmptyTextNode(node)).to.be.true;
+    });
+
+    it('should return false when node has non-empty text content', () => {
+      node.textContent = '0';
+      expect(isEmptyTextNode(node)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

Added `isEmptyTextNode` helper to check if the node is an empty text (with whitespace `textContent`).
This can be useful for implementing logic such as suggested in https://github.com/vaadin/web-components/pull/4624#discussion_r976103095.

## Type of change

- Internal feature