### PR TITLE
fix: add missing field-base dependency

### DIFF
--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
+    "@vaadin/field-base": "~23.1.8",
     "@vaadin/component-base": "~23.1.8",
     "@vaadin/vaadin-lumo-styles": "~23.1.8",
     "@vaadin/vaadin-material-styles": "~23.1.8",

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -34,8 +34,8 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@vaadin/field-base": "~23.1.8",
     "@vaadin/component-base": "~23.1.8",
+    "@vaadin/field-base": "~23.1.8",
     "@vaadin/vaadin-lumo-styles": "~23.1.8",
     "@vaadin/vaadin-material-styles": "~23.1.8",
     "@vaadin/vaadin-themable-mixin": "~23.1.8"


### PR DESCRIPTION
## Description

Added a missing `field-base` dependency to `form-layout`.

https://github.com/vaadin/web-components/blob/2aa5a81aeb07cfbc7f3f2fcc3a8302fc6e398864/packages/form-layout/src/vaadin-form-item.js#L7

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
