### PR TITLE
fix: wait for animation frame before observing target

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -376,7 +376,10 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       target.addEventListener('focusout', this.__onFocusout);
       target.addEventListener('mousedown', this.__onMouseDown);
 
-      this.__targetVisibilityObserver.observe(target);
+      // Wait before observing to avoid Chrome issue.
+      requestAnimationFrame(() => {
+        this.__targetVisibilityObserver.observe(target);
+      });
 
       addValueToAttribute(target, 'aria-describedby', this._uniqueId);
     }

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -6,6 +6,7 @@ import {
   focusout,
   keyboardEventFor,
   mousedown,
+  nextFrame,
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
@@ -422,7 +423,7 @@ describe('vaadin-tooltip', () => {
   describe('inside a scrollable container', () => {
     let container, target;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       container = fixtureSync(`
         <div style="width: 400px; height: 400px; overflow: scroll; border: 1px solid black;">
           <div style="margin: 600px 0; height: 50px; border: solid 1px red;" tabindex="0"></div>
@@ -430,6 +431,7 @@ describe('vaadin-tooltip', () => {
       `);
       target = container.querySelector('div');
       tooltip.target = target;
+      await nextFrame();
     });
 
     describe('target is partially visible', () => {


### PR DESCRIPTION
## Description

Fixes #4629

This was tested manually and it solves the Chrome issue when using Flow counterpart.
I was unable to reproduce the issue in the web component, so proper test is missing.

## Type of change

- Bugfix