### PR TITLE
fix: use feature detection for iOS dnd polyfilling

### DIFF
--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -137,8 +137,10 @@ export const DragAndDropMixin = (superClass) =>
         const rowRect = row.getBoundingClientRect();
 
         if (usesDnDPolyfill) {
+          // The polyfill drag image is automatically centered so there is no need to adjust the position
           e.dataTransfer.setDragImage(row);
         } else {
+          // The native drag image needs to be shifted manually to compensate for the touch position offset
           e.dataTransfer.setDragImage(row, e.clientX - rowRect.left, e.clientY - rowRect.top);
         }
 

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -17,6 +17,9 @@ const DropLocation = {
   EMPTY: 'empty',
 };
 
+// Detects if the browser doesn't support HTML5 Drag & Drop API (and falls back to the @vaadin/vaadin-mobile-drag-drop polyfill)
+const usesDnDPolyfill = !('draggable' in document.createElement('div'));
+
 /**
  * @polymerMixin
  */
@@ -133,7 +136,7 @@ export const DragAndDropMixin = (superClass) =>
 
         const rowRect = row.getBoundingClientRect();
 
-        if (this._ios) {
+        if (usesDnDPolyfill) {
           e.dataTransfer.setDragImage(row);
         } else {
           e.dataTransfer.setDragImage(row, e.clientX - rowRect.left, e.clientY - rowRect.top);

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -339,15 +339,8 @@ describe('drag and drop', () => {
       });
 
       it('should generate drag image with offset', () => {
-        grid._ios = false;
         const event = fireDragStart();
         expect(event.dataTransfer.setDragImage.getCall(0).args.length).to.equal(3);
-      });
-
-      it('should generate drag image without offset', () => {
-        grid._ios = true;
-        const event = fireDragStart();
-        expect(event.dataTransfer.setDragImage.getCall(0).args.length).to.equal(1);
       });
     });
 

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -174,7 +174,7 @@ registerStyles(
       background: var(--lumo-primary-color-50pct);
     }
 
-    #scroller:not([ios]) [part~='row'][dragstart]:not([dragstart=''])::after {
+    #scroller [part~='row'][dragstart]:not([dragstart=''])::after {
       display: block;
       position: absolute;
       left: var(--_grid-drag-start-x);

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -170,10 +170,6 @@ registerStyles(
       border-radius: var(--lumo-border-radius-s) 0 0 var(--lumo-border-radius-s);
     }
 
-    [ios] [part~='row'][dragstart] [part~='cell'] {
-      background: var(--lumo-primary-color-50pct);
-    }
-
     #scroller [part~='row'][dragstart]:not([dragstart=''])::after {
       display: block;
       position: absolute;

--- a/packages/grid/theme/material/vaadin-grid-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-styles.js
@@ -225,7 +225,7 @@ registerStyles(
       background: var(--material-primary-color);
     }
 
-    #scroller:not([ios]) [part~='row'][dragstart]:not([dragstart=''])::after {
+    #scroller [part~='row'][dragstart]:not([dragstart=''])::after {
       display: block;
       position: absolute;
       left: var(--_grid-drag-start-x);
@@ -262,7 +262,7 @@ registerStyles(
       border-left: 1px solid var(--material-divider-color);
     }
 
-    :host([dir='rtl']) #scroller:not([ios]) [part~='row'][dragstart]:not([dragstart=''])::after {
+    :host([dir='rtl']) #scroller [part~='row'][dragstart]:not([dragstart=''])::after {
       left: auto;
       right: var(--_grid-drag-start-x);
     }

--- a/packages/grid/theme/material/vaadin-grid-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-styles.js
@@ -221,10 +221,6 @@ registerStyles(
       box-shadow: none !important;
     }
 
-    [ios] [part~='row'][dragstart] [part~='cell'] {
-      background: var(--material-primary-color);
-    }
-
     #scroller [part~='row'][dragstart]:not([dragstart=''])::after {
       display: block;
       position: absolute;


### PR DESCRIPTION
The current vaadin-grid-drag-and-drop-mixin [uses `this._ios`](https://github.com/vaadin/web-components/blob/5ea19bd6d763a3281b8899ae90ec3c80e09fa7b4/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js#L136) to determine whether the [`@vaadin/vaadin-mobile-drag-drop`](https://www.npmjs.com/package/@vaadin/vaadin-mobile-drag-drop) polyfill is in use or not. This effectively means that row drag and drop doesn't currently work (because of [this bug](https://github.com/vaadin/web-components/issues/1603)) with the latest iOS 16 which [supports DnD natively](https://caniuse.com/mdn-html_global_attributes_draggable).

This PR updates the mixin to use feature detection instead

Fixes https://github.com/vaadin/web-components/issues/1603