### PR TITLE
refactor: remove obsolete overlay positioning logic from menu bar

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -46,7 +46,6 @@ export const InteractionsMixin = (superClass) =>
 
       const overlay = this._subMenu.$.overlay;
       overlay.addEventListener('keydown', this.__boundOnContextMenuKeydown);
-      overlay.addEventListener('vaadin-overlay-open', this.__alignOverlayPosition.bind(this));
 
       const container = this._container;
       container.addEventListener('click', this.__onButtonClick.bind(this));
@@ -248,30 +247,6 @@ export const InteractionsMixin = (superClass) =>
     /** @private */
     get _subMenu() {
       return this.shadowRoot.querySelector('vaadin-menu-bar-submenu');
-    }
-
-    /** @private */
-    __alignOverlayPosition(e) {
-      /* c8 ignore next */
-      if (!this._expandedButton) {
-        // When `openOnHover` is true, quickly moving cursor can close submenu,
-        // so by the time when event listener gets executed button is null.
-        // See https://github.com/vaadin/vaadin-menu-bar/issues/85
-        return;
-      }
-      const overlay = e.target;
-      const { width, height, left } = this._expandedButton.getBoundingClientRect();
-      if (overlay.hasAttribute('bottom-aligned')) {
-        overlay.style.bottom = `${parseInt(getComputedStyle(overlay).bottom) + height}px`;
-      }
-      const endAligned = overlay.hasAttribute('end-aligned');
-      if (endAligned) {
-        if (this.__isRTL) {
-          overlay.style.left = `${left}px`;
-        } else {
-          overlay.style.right = `${parseInt(getComputedStyle(overlay).right) - width}px`;
-        }
-      }
     }
 
     /** @private */


### PR DESCRIPTION
## Description

Removes obsolete end-aligned / bottom-aligned positioning logic from menu bar. Since the refactoring to use position mixin this method seems unnecessary and actually creates an unintended offset from the position target that is later cleaned up by a delayed repositioning of the position mixin:

https://user-images.githubusercontent.com/357820/192282199-ddaf0765-5705-45d5-b6f3-f26ccad6a286.mov

Similar behavior when using bottom-aligned:

![Bildschirmfoto 2022-09-26 um 14 50 57](https://user-images.githubusercontent.com/357820/192282161-0de8f67d-df20-4c06-bf42-acc5321f90ea.png)

