### PR TITLE
fix: add missing field-base package dependency

### DIFF
--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -38,6 +38,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/checkbox": "23.3.0-alpha2",
     "@vaadin/component-base": "23.3.0-alpha2",
+    "@vaadin/field-base": "23.3.0-alpha2",
     "@vaadin/vaadin-lumo-styles": "23.3.0-alpha2",
     "@vaadin/vaadin-material-styles": "23.3.0-alpha2",
     "@vaadin/vaadin-themable-mixin": "23.3.0-alpha2"


### PR DESCRIPTION
## Description

There is a problem when using `@vaadin/checkbox-group` because of using import from transitive dependency:

```
Error: [vite]: Rollup failed to resolve import "@vaadin/field-base/src/field-mixin.js" from "node_modules/@vaadin/checkbox-group/src/vaadin-checkbox-group.js".
```

The `@vaadin/field-base` is actually installed through `@vaadin/checkbox` but Vite fails to resolve it somehow.

## Type of change

- Bugfix
