### PR TITLE
fix: add missing field-base package dependency (23.2)

### DIFF
--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -38,6 +38,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/checkbox": "~23.2.2",
     "@vaadin/component-base": "~23.2.2",
+    "@vaadin/field-base": "~23.2.2",
     "@vaadin/vaadin-lumo-styles": "~23.2.2",
     "@vaadin/vaadin-material-styles": "~23.2.2",
     "@vaadin/vaadin-themable-mixin": "~23.2.2"


### PR DESCRIPTION
## Description

Same as #4643 but for `23.2` branch.

## Type of change

- Bugfix
