### PR TITLE
fix: add missing field-base package dependency (23.1)

### DIFF
--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -36,6 +36,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/checkbox": "~23.1.8",
     "@vaadin/component-base": "~23.1.8",
+    "@vaadin/field-base": "~23.1.8",
     "@vaadin/vaadin-lumo-styles": "~23.1.8",
     "@vaadin/vaadin-material-styles": "~23.1.8",
     "@vaadin/vaadin-themable-mixin": "~23.1.8"


### PR DESCRIPTION
## Description

Same as #4643 but for `23.1` branch.

## Type of change

- Bugfix
