### PR TITLE
fix: hide weekdays from assistive technologies

### DIFF
--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -80,7 +80,9 @@ class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
               is="dom-repeat"
               items="[[_getWeekDayNames(i18n.weekdays, i18n.weekdaysShort, showWeekNumbers, i18n.firstDayOfWeek)]]"
             >
-              <th role="columnheader" part="weekday" scope="col" abbr$="[[item.weekDay]]">[[item.weekDayShort]]</th>
+              <th role="columnheader" part="weekday" scope="col" abbr$="[[item.weekDay]]" aria-hidden="true">
+                [[item.weekDayShort]]
+              </th>
             </template>
           </tr>
         </thead>

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -304,7 +304,7 @@ describe('basic features', () => {
     it('should notify i18n mutation to children', () => {
       const monthCalendar = overlayContent.$.monthScroller.querySelector('vaadin-month-calendar');
       const weekdays = monthCalendar.$.monthGrid.querySelectorAll('[part="weekday"]:not(:empty)');
-      const weekdayTitles = Array.prototype.map.call(weekdays, (weekday) => weekday.textContent);
+      const weekdayTitles = Array.prototype.map.call(weekdays, (weekday) => weekday.textContent.trim());
       expect(weekdayTitles).to.eql(['ma', 'ti', 'ke', 'to', 'pe', 'la', 'su']);
     });
 

--- a/packages/date-picker/test/dom/__snapshots__/month-calendar.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/month-calendar.test.snap.js
@@ -64,6 +64,7 @@ snapshots["vaadin-month-calendar shadow default"] =
       </th>
       <th
         abbr="Sunday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -72,6 +73,7 @@ snapshots["vaadin-month-calendar shadow default"] =
       </th>
       <th
         abbr="Monday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -80,6 +82,7 @@ snapshots["vaadin-month-calendar shadow default"] =
       </th>
       <th
         abbr="Tuesday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -88,6 +91,7 @@ snapshots["vaadin-month-calendar shadow default"] =
       </th>
       <th
         abbr="Wednesday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -96,6 +100,7 @@ snapshots["vaadin-month-calendar shadow default"] =
       </th>
       <th
         abbr="Thursday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -104,6 +109,7 @@ snapshots["vaadin-month-calendar shadow default"] =
       </th>
       <th
         abbr="Friday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -112,6 +118,7 @@ snapshots["vaadin-month-calendar shadow default"] =
       </th>
       <th
         abbr="Saturday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -467,6 +474,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
       </th>
       <th
         abbr="Sunday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -475,6 +483,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
       </th>
       <th
         abbr="Monday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -483,6 +492,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
       </th>
       <th
         abbr="Tuesday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -491,6 +501,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
       </th>
       <th
         abbr="Wednesday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -499,6 +510,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
       </th>
       <th
         abbr="Thursday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -507,6 +519,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
       </th>
       <th
         abbr="Friday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -515,6 +528,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
       </th>
       <th
         abbr="Saturday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -907,6 +921,7 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
       </th>
       <th
         abbr="Monday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -915,6 +930,7 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
       </th>
       <th
         abbr="Tuesday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -923,6 +939,7 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
       </th>
       <th
         abbr="Wednesday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -931,6 +948,7 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
       </th>
       <th
         abbr="Thursday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -939,6 +957,7 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
       </th>
       <th
         abbr="Friday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -947,6 +966,7 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
       </th>
       <th
         abbr="Saturday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"
@@ -955,6 +975,7 @@ snapshots["vaadin-month-calendar shadow week numbers"] =
       </th>
       <th
         abbr="Sunday"
+        aria-hidden="true"
         part="weekday"
         role="columnheader"
         scope="col"

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -40,7 +40,7 @@ describe('vaadin-month-calendar', () => {
 
   it('should render days in correct order by default', () => {
     const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
-    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent);
+    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent.trim());
     expect(weekdayTitles).to.eql(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
   });
 
@@ -48,7 +48,7 @@ describe('vaadin-month-calendar', () => {
     monthCalendar.set('i18n.firstDayOfWeek', 1); // Start from Monday.
     await aTimeout();
     const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
-    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent);
+    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent.trim());
     expect(weekdayTitles).to.eql(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
   });
 
@@ -170,7 +170,7 @@ describe('vaadin-month-calendar', () => {
 
     it('should render weekdays in correct locale', () => {
       const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
-      const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent);
+      const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent.trim());
       expect(weekdayTitles).to.eql(['ma', 'ti', 'ke', 'to', 'pe', 'la', 'su']);
     });
 


### PR DESCRIPTION
## Description

This PR adds `aria-hidden` to the cells representing weekdays in order to hide them from assistive technologies as recommended by Tetralogical.

Fixes https://github.com/vaadin/web-components/issues/4313

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
