### PR TITLE
refactor: remove unused part styles

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -123,14 +123,12 @@ class DateTimePicker extends FieldMixin(
           --vaadin-field-default-width: 12em;
         }
 
-        [part='date'],
         .slots ::slotted([slot='date-picker']) {
           pointer-events: all;
           min-width: 0;
           flex: 1 1 auto;
         }
 
-        [part='time'],
         .slots ::slotted([slot='time-picker']) {
           pointer-events: all;
           min-width: 0;


### PR DESCRIPTION
## Description

The `date` and `time` parts were removed as part of https://github.com/vaadin/web-components/pull/2782 making  `date-time-picker` use a slotted date-picker and time-picker, but some styles related to those parts have been leftover.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
