### PR TITLE
fix: do not allow any interaction when disabled

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -124,13 +124,11 @@ class DateTimePicker extends FieldMixin(
         }
 
         .slots ::slotted([slot='date-picker']) {
-          pointer-events: all;
           min-width: 0;
           flex: 1 1 auto;
         }
 
         .slots ::slotted([slot='time-picker']) {
-          pointer-events: all;
           min-width: 0;
           flex: 1 1.65 auto;
         }


### PR DESCRIPTION
## Description

`date-time-picker` sets `pointer-events: all` on its child pickers which results in them reacting to hover when disabled. In the [original PR](https://github.com/vaadin/vaadin-date-time-picker/pull/29), there is not any mention of why `pointer-events` was necessary, nor did I come up with any use case for it, so I believe they can be removed.

Fixes https://github.com/vaadin/web-components/issues/4344

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
