### PR TITLE
docs: clarify opening tooltip on keyboard focus

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -86,7 +86,7 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
 
   /**
    * The delay in milliseconds before the tooltip
-   * is opened on focus, when not in manual mode.
+   * is opened on keyboard focus, when not in manual mode.
    * @attr {number} focus-delay
    */
   focusDelay: number;

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -111,7 +111,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
       /**
        * The delay in milliseconds before the tooltip
-       * is opened on focus, when not in manual mode.
+       * is opened on keyboard focus, when not in manual mode.
        * @attr {number} focus-delay
        */
       focusDelay: {


### PR DESCRIPTION
## Description

Updated JSDoc for `focusDelay` property to explicitly mention keyboard focus.

## Type of change

- Documentation