### PR TITLE
feat: publish icon assets to npm

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -23,10 +23,10 @@
     "icons": "gulp icons --gulpfile gulpfile.cjs"
   },
   "files": [
+    "assets/**/*",
     "iconset.js",
     "vaadin-icons.js",
-    "vaadin-iconset.js",
-    "assets/**/*"
+    "vaadin-iconset.js"
   ],
   "keywords": [
     "Vaadin",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -25,7 +25,8 @@
   "files": [
     "iconset.js",
     "vaadin-icons.js",
-    "vaadin-iconset.js"
+    "vaadin-iconset.js",
+    "assets/**/*"
   ],
   "keywords": [
     "Vaadin",


### PR DESCRIPTION
## Description

The PR adds a `assets/**/*` glob to `package.json` to get icon assets published to npm along with other source files.

Fixes #1624

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
