### PR TITLE
fix: add support for delay properties to grid tooltip

### DIFF
--- a/dev/grid.html
+++ b/dev/grid.html
@@ -43,7 +43,7 @@
       <vaadin-grid-column path="name" width="200px" flex-shrink="0"></vaadin-grid-column>
       <vaadin-grid-column path="name" width="200px" flex-shrink="0"></vaadin-grid-column>
 
-      <vaadin-tooltip slot="tooltip"></vaadin-tooltip>
+      <vaadin-tooltip slot="tooltip" hover-delay="500" hide-delay="500"></vaadin-tooltip>
     </vaadin-grid>
   </body>
 </html>

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -587,7 +587,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       }
 
       if (key === 'Escape') {
-        this._hideTooltip();
+        this._hideTooltip(true);
       }
     }
 

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -400,7 +400,7 @@ class Grid extends ElementMixin(
   disconnectedCallback() {
     super.disconnectedCallback();
     this.isAttached = false;
-    this._hideTooltip();
+    this._hideTooltip(true);
   }
 
   /** @private */
@@ -683,7 +683,7 @@ class Grid extends ElementMixin(
       });
 
       cell.addEventListener('mousedown', () => {
-        this._hideTooltip();
+        this._hideTooltip(true);
       });
     }
 
@@ -1016,16 +1016,25 @@ class Grid extends ElementMixin(
    */
   _showTooltip(event) {
     // Check if there is a slotted vaadin-tooltip element.
-    if (this._tooltipController.node && this._tooltipController.node.isConnected) {
+    const tooltip = this._tooltipController.node;
+    if (tooltip && tooltip.isConnected) {
       this._tooltipController.setTarget(event.target);
       this._tooltipController.setContext(this.getEventContext(event));
-      this._tooltipController.setOpened(true);
+
+      // Trigger opening using the corresponding delay.
+      tooltip._stateController.open({
+        focus: event.type === 'focusin',
+        hover: event.type === 'mouseenter',
+      });
     }
   }
 
   /** @protected */
-  _hideTooltip() {
-    this._tooltipController.setOpened(false);
+  _hideTooltip(immediate) {
+    const tooltip = this._tooltipController.node;
+    if (tooltip) {
+      tooltip._stateController.close(immediate);
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Changed `vaadin-grid` tooltip logic to use the new state controller API added in #4676.
This enables using `focusDelay`, `hoverDelay` and `hideDelay`, as well as global delays.

## Type of change

- Bugfix