### PR TITLE
fix: add support for delay properties to menu-bar tooltip

### DIFF
--- a/dev/menu-bar.html
+++ b/dev/menu-bar.html
@@ -38,7 +38,7 @@
 
   <body>
     <vaadin-menu-bar>
-      <vaadin-tooltip slot="tooltip"></vaadin-tooltip>
+      <vaadin-tooltip slot="tooltip" hover-delay="500" hide-delay="500"></vaadin-tooltip>
     </vaadin-menu-bar>
   </body>
 </html>

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import {
   arrowDown,
   arrowRight,
+  aTimeout,
   escKeyDown,
   fire,
   fixtureSync,
@@ -62,6 +63,14 @@ describe('menu-bar with tooltip', () => {
     expect(tooltip.opened).to.be.true;
   });
 
+  it('should use hover delay on menu button mouseover', async () => {
+    tooltip.hoverDelay = 10;
+    mouseover(buttons[0]);
+    expect(tooltip.opened).to.be.false;
+    await aTimeout(10);
+    expect(tooltip.opened).to.be.true;
+  });
+
   it('should use the tooltip property of an item as tooltip', () => {
     mouseover(buttons[0]);
     expect(getTooltipText()).to.equal('Edit tooltip');
@@ -84,6 +93,15 @@ describe('menu-bar with tooltip', () => {
   it('should hide tooltip on menu bar mouseleave', () => {
     mouseover(buttons[0]);
     mouseleave(menuBar);
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should use hide delay on menu button mouseleave', async () => {
+    tooltip.hideDelay = 10;
+    mouseover(buttons[0]);
+    mouseleave(menuBar);
+    expect(tooltip.opened).to.be.true;
+    await aTimeout(10);
     expect(tooltip.opened).to.be.false;
   });
 
@@ -123,6 +141,13 @@ describe('menu-bar with tooltip', () => {
     expect(tooltip.opened).to.be.false;
   });
 
+  it('should not use hide delay on menu button mousedown', () => {
+    tooltip.hideDelay = 10;
+    mouseover(buttons[0]);
+    mousedown(buttons[0]);
+    expect(tooltip.opened).to.be.false;
+  });
+
   it('should not show tooltip on focus without keyboard interaction', async () => {
     buttons[0].focus();
     await nextRender();
@@ -132,6 +157,15 @@ describe('menu-bar with tooltip', () => {
   it('should show tooltip on menu button keyboard focus', () => {
     tabKeyDown(document.body);
     focusin(buttons[0]);
+    expect(tooltip.opened).to.be.true;
+  });
+
+  it('should use focus delay on menu button keyboard focus', async () => {
+    tooltip.focusDelay = 10;
+    tabKeyDown(document.body);
+    focusin(buttons[0]);
+    expect(tooltip.opened).to.be.false;
+    await aTimeout(10);
     expect(tooltip.opened).to.be.true;
   });
 
@@ -165,6 +199,14 @@ describe('menu-bar with tooltip', () => {
   });
 
   it('should hide tooltip on menuBar menu button content Esc', () => {
+    tabKeyDown(document.body);
+    focusin(buttons[0]);
+    escKeyDown(buttons[0]);
+    expect(tooltip.opened).to.be.false;
+  });
+
+  it('should not use hide delay on menu button Esc', () => {
+    tooltip.hideDelay = 10;
     tabKeyDown(document.body);
     focusin(buttons[0]);
     escKeyDown(buttons[0]);

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -97,14 +97,14 @@ export const InteractionsMixin = (superClass) =>
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
-      this._hideTooltip();
+      this._hideTooltip(true);
     }
 
     /**
      * @param {HTMLElement} button
      * @protected
      */
-    _showTooltip(button) {
+    _showTooltip(button, isHover) {
       // Check if there is a slotted vaadin-tooltip element.
       const tooltip = this._tooltipController.node;
       if (tooltip && tooltip.isConnected) {
@@ -117,14 +117,22 @@ export const InteractionsMixin = (superClass) =>
         if (!this._subMenu.opened) {
           this._tooltipController.setTarget(button);
           this._tooltipController.setContext({ item: button.item });
-          this._tooltipController.setOpened(true);
+
+          // Trigger opening using the corresponding delay.
+          tooltip._stateController.open({
+            hover: isHover,
+            focus: !isHover,
+          });
         }
       }
     }
 
     /** @protected */
-    _hideTooltip() {
-      this._tooltipController.setOpened(false);
+    _hideTooltip(immediate) {
+      const tooltip = this._tooltipController.node;
+      if (tooltip) {
+        tooltip._stateController.close(immediate);
+      }
     }
 
     /** @protected */
@@ -246,7 +254,7 @@ export const InteractionsMixin = (superClass) =>
         this._close(true);
       }
 
-      this._hideTooltip();
+      this._hideTooltip(true);
     }
 
     /**
@@ -303,7 +311,7 @@ export const InteractionsMixin = (superClass) =>
         if (button === this._overflow || (this.openOnHover && button.item.children)) {
           this._hideTooltip();
         } else {
-          this._showTooltip(button);
+          this._showTooltip(button, true);
         }
       }
     }
@@ -373,7 +381,7 @@ export const InteractionsMixin = (superClass) =>
             },
           }),
         );
-        this._hideTooltip();
+        this._hideTooltip(true);
 
         this._setExpanded(button, true);
       });


### PR DESCRIPTION
## Description

Same as #4677 but for `vaadin-menu-bar`.

Changed `vaadin-menu-bar` tooltip logic to use the new state controller API added in #4676.
This enables using `focusDelay`, `hoverDelay` and `hideDelay`, as well as global delays.

## Type of change

- Bugfix