### PR TITLE
refactor!: move menu-bar buttons to light DOM

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -9,6 +9,14 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-menu-bar-button',
   css`
+    :host {
+      flex-shrink: 0;
+    }
+
+    :host([slot='overflow']) {
+      margin-inline-end: 0;
+    }
+
     [part='label'] ::slotted(vaadin-context-menu-item) {
       position: relative;
       z-index: 1;

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.d.ts
@@ -4,11 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 
 export declare function ButtonsMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<ButtonsMixinClass> & Constructor<ResizeMixinClass> & T;
+): Constructor<ButtonsMixinClass> & Constructor<ControllerMixinClass> & Constructor<ResizeMixinClass> & T;
 
 export declare class ButtonsMixinClass {
   protected readonly _buttons: HTMLElement[];

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -112,8 +112,12 @@ export const ButtonsMixin = (superClass) =>
 
     /** @private */
     __i18nChanged(i18n, overflow) {
-      if (overflow && i18n && i18n.moreOptions) {
-        overflow.setAttribute('aria-label', i18n.moreOptions);
+      if (overflow && i18n && i18n.moreOptions !== undefined) {
+        if (i18n.moreOptions) {
+          overflow.setAttribute('aria-label', i18n.moreOptions);
+        } else {
+          overflow.removeAttribute('aria-label');
+        }
       }
     }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
-import { isKeyboardActive } from '@vaadin/component-base/src/focus-utils.js';
+import { isElementFocused, isKeyboardActive } from '@vaadin/component-base/src/focus-utils.js';
 import { KeyboardDirectionMixin } from '@vaadin/component-base/src/keyboard-direction-mixin.js';
 
 /**
@@ -55,15 +55,15 @@ export const InteractionsMixin = (superClass) =>
 
     /**
      * Override getter from `KeyboardDirectionMixin`
-     * to look for activeElement in shadow root, or
-     * use the expanded button as a fallback.
+     * to use expanded button for arrow navigation
+     * when the sub-menu is opened and has focus.
      *
      * @return {Element | null}
      * @protected
      * @override
      */
     get focused() {
-      return this.shadowRoot.activeElement || this._expandedButton;
+      return (this._getItems() || []).find(isElementFocused) || this._expandedButton;
     }
 
     /**
@@ -87,11 +87,6 @@ export const InteractionsMixin = (superClass) =>
      */
     _getItems() {
       return this._buttons;
-    }
-
-    /** @private */
-    get __isRTL() {
-      return this.getAttribute('dir') === 'rtl';
     }
 
     /** @protected */
@@ -129,7 +124,7 @@ export const InteractionsMixin = (superClass) =>
 
     /** @protected */
     _hideTooltip(immediate) {
-      const tooltip = this._tooltipController.node;
+      const tooltip = this._tooltipController && this._tooltipController.node;
       if (tooltip) {
         tooltip._stateController.close(immediate);
       }
@@ -192,7 +187,7 @@ export const InteractionsMixin = (superClass) =>
      */
     _setFocused(focused) {
       if (focused) {
-        const target = this.shadowRoot.querySelector('[part$="button"][tabindex="0"]');
+        const target = this.querySelector('[tabindex="0"]');
         if (target) {
           this._buttons.forEach((btn) => {
             this._setTabindex(btn, btn === target);

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -87,8 +86,6 @@ export interface MenuBarEventMap extends HTMLElementEventMap, MenuBarCustomEvent
  * Part name         | Description
  * ------------------|----------------
  * `container`       | The container wrapping menu bar buttons.
- * `menu-bar-button` | The menu bar button.
- * `overflow-button` | The "overflow" button appearing when menu bar width is not enough to fit all the buttons.
  *
  * The following state attributes are available for styling:
  *
@@ -111,9 +108,7 @@ export interface MenuBarEventMap extends HTMLElementEventMap, MenuBarCustomEvent
  *
  * @fires {CustomEvent} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  */
-declare class MenuBar extends ButtonsMixin(
-  DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement))))),
-) {
+declare class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(HTMLElement))))) {
   /**
    * Defines a hierarchical structure, where root level items represent menu bar buttons,
    * and `children` property configures a submenu with items to be opened below

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -6,7 +6,6 @@
 import './vaadin-menu-bar-submenu.js';
 import './vaadin-menu-bar-button.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
@@ -38,8 +37,6 @@ import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
  * Part name         | Description
  * ------------------|----------------
  * `container`       | The container wrapping menu bar buttons.
- * `menu-bar-button` | The menu bar button.
- * `overflow-button` | The "overflow" button appearing when menu bar width is not enough to fit all the buttons.
  *
  * The following state attributes are available for styling:
  *
@@ -63,16 +60,13 @@ import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
  * @fires {CustomEvent<boolean>} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  *
  * @extends HTMLElement
- * @mixes ControllerMixin
  * @mixes ButtonsMixin
  * @mixes InteractionsMixin
  * @mixes DisabledMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class MenuBar extends ButtonsMixin(
-  DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))))),
-) {
+class MenuBar extends ButtonsMixin(DisabledMixin(InteractionsMixin(ElementMixin(ThemableMixin(PolymerElement))))) {
   static get template() {
     return html`
       <style>
@@ -91,27 +85,11 @@ class MenuBar extends ButtonsMixin(
           flex-wrap: nowrap;
           overflow: hidden;
         }
-
-        [part$='button'] {
-          flex-shrink: 0;
-        }
-
-        [part='overflow-button'] {
-          margin-right: 0;
-        }
-
-        .dots::before {
-          display: block;
-          content: '\\00B7\\00B7\\00B7';
-          font-size: inherit;
-          line-height: inherit;
-        }
       </style>
 
       <div part="container">
-        <vaadin-menu-bar-button part="overflow-button" hidden$="[[!_hasOverflow]]" aria-label$="[[i18n.moreOptions]]">
-          <div class="dots"></div>
-        </vaadin-menu-bar-button>
+        <slot></slot>
+        <slot name="overflow"></slot>
       </div>
       <vaadin-menu-bar-submenu is-root=""></vaadin-menu-bar-submenu>
 
@@ -219,7 +197,7 @@ class MenuBar extends ButtonsMixin(
   }
 
   static get observers() {
-    return ['_themeChanged(_theme)'];
+    return ['_themeChanged(_theme, _overflow)'];
   }
 
   /** @protected */
@@ -255,8 +233,8 @@ class MenuBar extends ButtonsMixin(
    * @param {string | null} theme
    * @protected
    */
-  _themeChanged(theme) {
-    if (this.shadowRoot) {
+  _themeChanged(theme, overflow) {
+    if (overflow) {
       this._buttons.forEach((btn) => this._setButtonTheme(btn, theme));
       this.__detectOverflow();
     }

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -453,6 +453,11 @@ describe('overflow button', () => {
     menu.i18n = { ...menu.i18n, moreOptions: moreOptionsSv };
     expect(overflow.getAttribute('aria-label')).to.equal(moreOptionsSv);
   });
+
+  it('should remove the aria-label from the overflow button when empty i18n string is set', () => {
+    menu.i18n = { ...menu.i18n, moreOptions: '' };
+    expect(overflow.hasAttribute('aria-label')).to.be.false;
+  });
 });
 
 describe('has-single-button attribute', () => {

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -8,7 +8,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-menu-bar',
   css`
-    :host([theme='big']) [part$='button'] {
+    :host([theme='big']) ::slotted(vaadin-menu-bar-button) {
       width: 100px;
     }
   `,
@@ -87,7 +87,6 @@ describe('root menu layout', () => {
 
   it('should make the overflow button hidden by default', () => {
     const overflow = buttons[menu.items.length];
-    expect(overflow.getAttribute('part')).to.equal('overflow-button');
     expect(overflow.hasAttribute('hidden')).to.be.true;
   });
 
@@ -558,7 +557,7 @@ describe('responsive behaviour in container', () => {
     assertHidden(buttons[3]);
     expect(buttons[3].disabled).to.be.true;
 
-    container.style.width = '390px';
+    container.style.width = '400px';
     await onceResized(menu);
     assertVisible(buttons[2]);
     expect(buttons[2].disabled).to.not.be.true;

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-button-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-button-styles.js
@@ -54,7 +54,7 @@ const menuBarButton = css`
   }
 
   :host(:nth-last-of-type(2)),
-  :host([part='overflow-button']) {
+  :host([slot='overflow']) {
     border-radius: 0 var(--lumo-border-radius-m) var(--lumo-border-radius-m) 0;
   }
 
@@ -63,18 +63,18 @@ const menuBarButton = css`
     border-radius: var(--lumo-border-radius-m);
   }
 
-  :host([part='overflow-button']) {
+  :host([slot='overflow']) {
     min-width: var(--lumo-button-size);
     padding-left: calc(var(--lumo-button-size) / 4);
     padding-right: calc(var(--lumo-button-size) / 4);
   }
 
-  :host([part='overflow-button']) ::slotted(*) {
+  :host([slot='overflow']) ::slotted(*) {
     font-size: var(--lumo-font-size-xl);
   }
 
-  :host([part='overflow-button']) [part='prefix'],
-  :host([part='overflow-button']) [part='suffix'] {
+  :host([slot='overflow']) [part='prefix'],
+  :host([slot='overflow']) [part='suffix'] {
     margin-left: 0;
     margin-right: 0;
   }
@@ -92,7 +92,7 @@ const menuBarButton = css`
   }
 
   :host([dir='rtl']:nth-last-of-type(2)),
-  :host([dir='rtl'][part='overflow-button']) {
+  :host([dir='rtl'][slot='overflow']) {
     border-radius: var(--lumo-border-radius-m) 0 0 var(--lumo-border-radius-m);
   }
 `;

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
@@ -4,12 +4,12 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-menu-bar',
   css`
-    :host([has-single-button]) [part$='button'] {
+    :host([has-single-button]) ::slotted(vaadin-menu-bar-button) {
       border-radius: var(--lumo-border-radius-m);
     }
 
-    :host([theme~='end-aligned']) [part$='button']:first-child,
-    :host([theme~='end-aligned'][has-single-button]) [part$='button'] {
+    :host([theme~='end-aligned']) ::slotted(vaadin-menu-bar-button:first-child),
+    :host([theme~='end-aligned'][has-single-button]) ::slotted(vaadin-menu-bar-button) {
       margin-inline-start: auto;
     }
   `,

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
@@ -8,7 +8,7 @@ registerStyles(
       border-radius: var(--lumo-border-radius-m);
     }
 
-    :host([theme~='end-aligned']) ::slotted(vaadin-menu-bar-button:first-child),
+    :host([theme~='end-aligned']) ::slotted(vaadin-menu-bar-button:first-of-type),
     :host([theme~='end-aligned'][has-single-button]) ::slotted(vaadin-menu-bar-button) {
       margin-inline-start: auto;
     }

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-button-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-button-styles.js
@@ -54,17 +54,17 @@ const menuBarButton = css`
   }
 
   :host(:nth-last-of-type(2)),
-  :host([part~='overflow-button']) {
+  :host([slot='overflow']) {
     border-radius: 0 4px 4px 0;
   }
 
-  :host([part='overflow-button']) {
+  :host([slot='overflow']) {
     padding-right: 8px;
     padding-left: 8px;
     min-width: 36px;
   }
 
-  :host([part='overflow-button']) ::slotted(*) {
+  :host([slot='overflow']) ::slotted(*) {
     font-size: 24px;
   }
 
@@ -73,7 +73,7 @@ const menuBarButton = css`
   }
 
   :host([theme~='outlined']:not([dir='rtl']):nth-last-of-type(2)),
-  :host([theme~='outlined']:not([dir='rtl'])[part~='overflow-button']) {
+  :host([theme~='outlined']:not([dir='rtl'])[slot='overflow']) {
     margin-right: 0;
   }
 
@@ -88,7 +88,7 @@ const menuBarButton = css`
   }
 
   :host([dir='rtl']:nth-last-of-type(2)),
-  :host([dir='rtl'][part='overflow-button']) {
+  :host([dir='rtl'][slot='overflow']) {
     border-radius: 4px 0 0 4px;
   }
 
@@ -101,7 +101,7 @@ const menuBarButton = css`
   }
 
   :host([theme~='outlined'][dir='rtl']:nth-last-of-type(2)),
-  :host([theme~='outlined'][dir='rtl'][part~='overflow-button']) {
+  :host([theme~='outlined'][dir='rtl'][slot='overflow']) {
     margin-left: 0;
   }
 `;

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-styles.js
@@ -8,12 +8,12 @@ registerStyles(
       padding-bottom: 5px;
     }
 
-    :host([has-single-button]) [part$='button'] {
+    :host([has-single-button]) ::slotted(vaadin-menu-bar-button) {
       border-radius: 4px;
     }
 
-    :host([theme~='end-aligned']) [part$='button']:first-child,
-    :host([theme~='end-aligned'][has-single-button]) [part$='button'] {
+    :host([theme~='end-aligned']) ::slotted(vaadin-menu-bar-button:first-child),
+    :host([theme~='end-aligned'][has-single-button]) ::slotted(vaadin-menu-bar-button) {
       margin-inline-start: auto;
     }
   `,

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-styles.js
@@ -12,7 +12,7 @@ registerStyles(
       border-radius: 4px;
     }
 
-    :host([theme~='end-aligned']) ::slotted(vaadin-menu-bar-button:first-child),
+    :host([theme~='end-aligned']) ::slotted(vaadin-menu-bar-button:first-of-type),
     :host([theme~='end-aligned'][has-single-button]) ::slotted(vaadin-menu-bar-button) {
       margin-inline-start: auto;
     }


### PR DESCRIPTION
## Description

Fixes #4292

Based on the previous prototype: https://github.com/vaadin/web-components/pull/2397/commits/6f44273071412938cad7c713133838ceec2de803

## Type of change

- Breaking change (affects styling)