### PR TITLE
fix: adjust end property value on viewport resize

### DIFF
--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -291,6 +291,44 @@ export const PositionMixin = (superClass) =>
     }
 
     /**
+     * Returns an adjusted value after resizing the browser window,
+     * to avoid wrong calculations when e.g. previously set `bottom`
+     * CSS property value is larger than the updated viewport height.
+     * See https://github.com/vaadin/web-components/issues/4604
+     */
+    __adjustBottomProperty(cssPropNameToSet, propNames, currentValue) {
+      let adjustedProp;
+
+      if (cssPropNameToSet === propNames.end) {
+        // Adjust horizontally
+        if (propNames.end === PROP_NAMES_VERTICAL.end) {
+          const viewportHeight = Math.min(window.innerHeight, document.documentElement.clientHeight);
+
+          if (currentValue > viewportHeight && this.__oldViewportHeight) {
+            const heightDiff = this.__oldViewportHeight - viewportHeight;
+            adjustedProp = currentValue - heightDiff;
+          }
+
+          this.__oldViewportHeight = viewportHeight;
+        }
+
+        // Adjust vertically
+        if (propNames.end === PROP_NAMES_HORIZONTAL.end) {
+          const viewportWidth = Math.min(window.innerWidth, document.documentElement.clientWidth);
+
+          if (currentValue > viewportWidth && this.__oldViewportWidth) {
+            const widthDiff = this.__oldViewportWidth - viewportWidth;
+            adjustedProp = currentValue - widthDiff;
+          }
+
+          this.__oldViewportWidth = viewportWidth;
+        }
+      }
+
+      return adjustedProp;
+    }
+
+    /**
      * Returns an object with CSS position properties to set,
      * e.g. { top: "100px" }
      */
@@ -300,13 +338,18 @@ export const PositionMixin = (superClass) =>
       const cssPropNameToClear = shouldAlignStart ? propNames.end : propNames.start;
 
       const currentValue = parseFloat(overlay.style[cssPropNameToSet] || getComputedStyle(overlay)[cssPropNameToSet]);
+      const adjustedValue = this.__adjustBottomProperty(cssPropNameToSet, propNames, currentValue);
 
       const diff =
         overlayRect[shouldAlignStart ? propNames.start : propNames.end] -
         targetRect[noOverlap === shouldAlignStart ? propNames.end : propNames.start];
 
+      const valueToSet = adjustedValue
+        ? `${adjustedValue}px`
+        : `${currentValue + diff * (shouldAlignStart ? -1 : 1)}px`;
+
       return {
-        [cssPropNameToSet]: `${currentValue + diff * (shouldAlignStart ? -1 : 1)}px`,
+        [cssPropNameToSet]: valueToSet,
         [cssPropNameToClear]: '',
       };
     }

--- a/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/vaadin-overlay/src/vaadin-overlay-position-mixin.js
@@ -191,17 +191,6 @@ export const PositionMixin = (superClass) =>
         return;
       }
 
-      // Cleanup styles to avoid wrong values after window resize
-      // See https://github.com/vaadin/web-components/issues/4604
-      Object.assign(this.style, {
-        top: '',
-        right: '',
-        bottom: '',
-        left: '',
-        justifyContent: '',
-        alignItems: '',
-      });
-
       const targetRect = this.positionTarget.getBoundingClientRect();
 
       // Detect the desired alignment and update the layout accordingly
@@ -308,6 +297,7 @@ export const PositionMixin = (superClass) =>
     // eslint-disable-next-line max-params
     __calculatePositionInOneDimension(targetRect, overlayRect, noOverlap, propNames, overlay, shouldAlignStart) {
       const cssPropNameToSet = shouldAlignStart ? propNames.start : propNames.end;
+      const cssPropNameToClear = shouldAlignStart ? propNames.end : propNames.start;
 
       const currentValue = parseFloat(overlay.style[cssPropNameToSet] || getComputedStyle(overlay)[cssPropNameToSet]);
 
@@ -317,6 +307,7 @@ export const PositionMixin = (superClass) =>
 
       return {
         [cssPropNameToSet]: `${currentValue + diff * (shouldAlignStart ? -1 : 1)}px`,
+        [cssPropNameToClear]: '',
       };
     }
   };

--- a/packages/vaadin-overlay/test/position-mixin.test.js
+++ b/packages/vaadin-overlay/test/position-mixin.test.js
@@ -96,6 +96,21 @@ describe('position mixin', () => {
     expectEdgesAligned(LEFT, LEFT);
   });
 
+  it('should not lose scroll position on overlay position update', () => {
+    // Move the target to the center of the viewport
+    target.style.top = '50vh';
+    // Increase the height of the child to make the overlay scrollable
+    overlay.querySelector('#overlay-child').style.height = '100vh';
+
+    // Scroll the overlay
+    overlay.$.overlay.scrollTop = 100;
+
+    updatePosition();
+
+    // Expect the overlay to be scrolled to the same position
+    expect(overlay.$.overlay.scrollTop).to.equal(100);
+  });
+
   describe('vertical align top', () => {
     beforeEach(() => {
       overlay.verticalAlign = TOP;


### PR DESCRIPTION
Revert overlay positioning back to https://github.com/vaadin/web-components/pull/4607/commits/e8f5f043c66ff9c228e3d8c3b363d3d773ada1e7

Fixes #4690 