### PR TITLE
refactor: add more rules to ESLint config, fix warnings 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,6 +58,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/prefer-function-type": "error",
     "@typescript-eslint/consistent-type-imports": ["error", { "prefer": "type-imports" }],
+    "@typescript-eslint/consistent-type-definitions": ["error", "type"],
     "@typescript-eslint/member-ordering": [
       "error",
       {

--- a/packages/accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/accordion/src/vaadin-accordion-panel.d.ts
@@ -35,6 +35,7 @@ import { Details } from '@vaadin/details/src/vaadin-details.js';
 declare class AccordionPanel extends Details {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-accordion-panel': AccordionPanel;
   }

--- a/packages/accordion/src/vaadin-accordion.d.ts
+++ b/packages/accordion/src/vaadin-accordion.d.ts
@@ -18,11 +18,11 @@ export type AccordionItemsChangedEvent = CustomEvent<{ value: AccordionPanel[] }
  */
 export type AccordionOpenedChangedEvent = CustomEvent<{ value: number | null }>;
 
-export interface AccordionCustomEventMap {
+export type AccordionCustomEventMap = {
   'items-changed': AccordionItemsChangedEvent;
 
   'opened-changed': AccordionOpenedChangedEvent;
-}
+};
 
 export type AccordionEventMap = AccordionCustomEventMap & HTMLElementEventMap;
 
@@ -99,6 +99,7 @@ declare class Accordion extends KeyboardDirectionMixin(ElementMixin(ThemableMixi
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-accordion': Accordion;
   }

--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -7,9 +7,9 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface AppLayoutI18n {
+export type AppLayoutI18n = {
   drawer: string;
-}
+};
 
 /**
  * Fired when the `drawerOpened` property changes.
@@ -26,13 +26,13 @@ export type AppLayoutOverlayChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type AppLayoutPrimarySectionChangedEvent = CustomEvent<{ value: 'drawer' | 'navbar' }>;
 
-export interface AppLayoutCustomEventMap {
+export type AppLayoutCustomEventMap = {
   'drawer-opened-changed': AppLayoutDrawerOpenedChangedEvent;
 
   'overlay-changed': AppLayoutOverlayChangedEvent;
 
   'primary-section-changed': AppLayoutPrimarySectionChangedEvent;
-}
+};
 
 export type AppLayoutEventMap = AppLayoutCustomEventMap & HTMLElementEventMap;
 
@@ -196,6 +196,7 @@ declare class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(HTMLE
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-app-layout': AppLayout;
   }

--- a/packages/app-layout/src/vaadin-drawer-toggle.d.ts
+++ b/packages/app-layout/src/vaadin-drawer-toggle.d.ts
@@ -19,6 +19,7 @@ declare class DrawerToggle extends Button {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-drawer-toggle': DrawerToggle;
   }

--- a/packages/avatar-group/src/vaadin-avatar-group.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group.d.ts
@@ -10,21 +10,21 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 
 export { AvatarI18n };
 
-export interface AvatarGroupI18n extends AvatarI18n {
+export type AvatarGroupI18n = AvatarI18n & {
   activeUsers: {
     one: string;
     many: string;
   };
   joined: string;
   left: string;
-}
+};
 
-export interface AvatarGroupItem {
+export type AvatarGroupItem = {
   name?: string;
   abbr?: string;
   img?: string;
   colorIndex?: number;
-}
+};
 
 /**
  * `<vaadin-avatar-group>` is a Web Component providing avatar group displaying functionality.
@@ -130,6 +130,7 @@ declare class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(HTMLEle
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-avatar-group': AvatarGroup;
   }

--- a/packages/avatar/src/vaadin-avatar.d.ts
+++ b/packages/avatar/src/vaadin-avatar.d.ts
@@ -8,9 +8,9 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface AvatarI18n {
+export type AvatarI18n = {
   anonymous: string;
-}
+};
 
 /**
  * `<vaadin-avatar>` is a Web Component providing avatar displaying functionality.
@@ -88,6 +88,7 @@ declare class Avatar extends FocusMixin(ElementMixin(ThemableMixin(ControllerMix
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-avatar': Avatar;
   }

--- a/packages/board/src/vaadin-board-row.d.ts
+++ b/packages/board/src/vaadin-board-row.d.ts
@@ -53,6 +53,7 @@ declare class BoardRow extends ResizeMixin(ElementMixin(HTMLElement)) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-board-row': BoardRow;
   }

--- a/packages/board/src/vaadin-board.d.ts
+++ b/packages/board/src/vaadin-board.d.ts
@@ -36,6 +36,7 @@ declare class Board extends ElementMixin(HTMLElement) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-board': Board;
   }

--- a/packages/button/src/vaadin-button.d.ts
+++ b/packages/button/src/vaadin-button.d.ts
@@ -39,6 +39,7 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
 declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-button': Button;
   }

--- a/packages/charts/src/vaadin-chart-series.d.ts
+++ b/packages/charts/src/vaadin-chart-series.d.ts
@@ -7,7 +7,7 @@ import type { PointOptionsObject, Series, SeriesOptionsType } from 'highcharts';
 
 export type ChartSeriesMarkers = 'auto' | 'hidden' | 'shown';
 
-export interface ChartSeriesConfig {
+export type ChartSeriesConfig = {
   data?: ChartSeriesValues;
   marker?: { enabled: boolean | null };
   name?: string;
@@ -18,7 +18,7 @@ export interface ChartSeriesConfig {
   yAxis?: string;
   yAxisValueMin?: number;
   yAxisValueMax?: number;
-}
+};
 
 export type ChartSeriesOptions = ChartSeriesConfig & SeriesOptionsType;
 
@@ -169,6 +169,7 @@ declare class ChartSeries extends HTMLElement {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-chart-series': ChartSeries;
   }

--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -183,7 +183,7 @@ export type ChartYaxesExtremesSetEvent = CustomEvent<{
   };
 }>;
 
-export interface ChartCustomEventMap {
+export type ChartCustomEventMap = {
   'chart-add-series': ChartAddSeriesEvent;
 
   'chart-after-export': ChartAfterExportEvent;
@@ -243,7 +243,7 @@ export interface ChartCustomEventMap {
   'xaxes-extremes-set': ChartXaxesExtremesSetEvent;
 
   'yaxes-extremes-set': ChartYaxesExtremesSetEvent;
-}
+};
 
 export type ChartEventMap = ChartCustomEventMap & HTMLElementEventMap;
 
@@ -592,6 +592,7 @@ declare class Chart extends ResizeMixin(ThemableMixin(ElementMixin(HTMLElement))
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-chart': Chart;
   }

--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -24,15 +24,15 @@ export type CheckboxGroupValueChangedEvent = CustomEvent<{ value: string[] }>;
  */
 export type CheckboxGroupValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface CheckboxGroupCustomEventMap {
+export type CheckboxGroupCustomEventMap = {
   'invalid-changed': CheckboxGroupInvalidChangedEvent;
 
   'value-changed': CheckboxGroupValueChangedEvent;
 
   validated: CheckboxGroupValidatedEvent;
-}
+};
 
-export interface CheckboxGroupEventMap extends HTMLElementEventMap, CheckboxGroupCustomEventMap {}
+export type CheckboxGroupEventMap = CheckboxGroupCustomEventMap & HTMLElementEventMap & {};
 
 /**
  * `<vaadin-checkbox-group>` is a web component that allows the user to choose several items from a group of binary choices.
@@ -98,6 +98,7 @@ declare class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementM
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-checkbox-group': CheckboxGroup;
   }

--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -21,13 +21,13 @@ export type CheckboxCheckedChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type CheckboxIndeterminateChangedEvent = CustomEvent<{ value: boolean }>;
 
-export interface CheckboxCustomEventMap {
+export type CheckboxCustomEventMap = {
   'checked-changed': CheckboxCheckedChangedEvent;
 
   'indeterminate-changed': CheckboxIndeterminateChangedEvent;
-}
+};
 
-export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEventMap {}
+export type CheckboxEventMap = CheckboxCustomEventMap & HTMLElementEventMap & {};
 
 /**
  * `<vaadin-checkbox>` is an input field representing a binary choice.
@@ -92,6 +92,7 @@ declare class Checkbox extends LabelMixin(
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-checkbox': Checkbox;
   }

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.d.ts
@@ -7,11 +7,11 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export type ComboBoxDataProviderCallback<TItem> = (items: TItem[], size?: number) => void;
 
-export interface ComboBoxDataProviderParams {
+export type ComboBoxDataProviderParams = {
   page: number;
   pageSize: number;
   filter: string;
-}
+};
 
 export type ComboBoxDataProvider<TItem> = (
   params: ComboBoxDataProviderParams,

--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -60,7 +60,7 @@ export type ComboBoxLightSelectedItemChangedEvent<TItem> = CustomEvent<{ value: 
  */
 export type ComboBoxLightValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface ComboBoxLightEventMap<TItem> extends HTMLElementEventMap {
+export type ComboBoxLightEventMap<TItem> = HTMLElementEventMap & {
   change: ComboBoxLightChangeEvent<TItem>;
 
   'custom-value-set': ComboBoxLightCustomValueSetEvent;
@@ -76,7 +76,7 @@ export interface ComboBoxLightEventMap<TItem> extends HTMLElementEventMap {
   'selected-item-changed': ComboBoxLightSelectedItemChangedEvent<TItem>;
 
   validated: ComboBoxLightValidatedEvent;
-}
+};
 
 /**
  * `<vaadin-combo-box-light>` is a customizable version of the `<vaadin-combo-box>` providing
@@ -145,17 +145,17 @@ declare class ComboBoxLight<TItem = ComboBoxDefaultItem> extends HTMLElement {
   ): void;
 }
 
-interface ComboBoxLight<TItem = ComboBoxDefaultItem>
-  extends ComboBoxDataProviderMixinClass<TItem>,
-    ComboBoxMixinClass<TItem>,
-    KeyboardMixinClass,
-    InputMixinClass,
-    DisabledMixinClass,
-    ThemableMixinClass,
-    ThemePropertyMixinClass,
-    ValidateMixinClass {}
+type ComboBoxLight<TItem = ComboBoxDefaultItem> = ComboBoxDataProviderMixinClass<TItem> &
+  ComboBoxMixinClass<TItem> &
+  DisabledMixinClass &
+  InputMixinClass &
+  KeyboardMixinClass &
+  ThemableMixinClass &
+  ThemePropertyMixinClass &
+  ValidateMixinClass & {};
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-combo-box-light': ComboBoxLight;
   }

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -11,10 +11,10 @@ import type { ComboBox } from './vaadin-combo-box.js';
 
 export type ComboBoxDefaultItem = any;
 
-export interface ComboBoxItemModel<TItem> {
+export type ComboBoxItemModel<TItem> = {
   index: number;
   item: TItem;
-}
+};
 
 export type ComboBoxRenderer<TItem> = (
   root: HTMLElement,

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -71,7 +71,7 @@ export type ComboBoxSelectedItemChangedEvent<TItem> = CustomEvent<{ value: TItem
  */
 export type ComboBoxValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
+export type ComboBoxEventMap<TItem> = HTMLElementEventMap & {
   change: ComboBoxChangeEvent<TItem>;
 
   'custom-value-set': ComboBoxCustomValueSetEvent;
@@ -87,7 +87,7 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
   'selected-item-changed': ComboBoxSelectedItemChangedEvent<TItem>;
 
   validated: ComboBoxValidatedEvent;
-}
+};
 
 /**
  * `<vaadin-combo-box>` is a web component for choosing a value from a filterable list of options
@@ -232,27 +232,27 @@ declare class ComboBox<TItem = ComboBoxDefaultItem> extends HTMLElement {
   ): void;
 }
 
-interface ComboBox<TItem = ComboBoxDefaultItem>
-  extends ComboBoxDataProviderMixinClass<TItem>,
-    ComboBoxMixinClass<TItem>,
-    ValidateMixinClass,
-    PatternMixinClass,
-    LabelMixinClass,
-    KeyboardMixinClass,
-    InputMixinClass,
-    InputControlMixinClass,
-    InputConstraintsMixinClass,
-    FocusMixinClass,
-    FieldMixinClass,
-    DisabledMixinClass,
-    DelegateStateMixinClass,
-    DelegateFocusMixinClass,
-    ThemableMixinClass,
-    ThemePropertyMixinClass,
-    ElementMixinClass,
-    ControllerMixinClass {}
+type ComboBox<TItem = ComboBoxDefaultItem> = ComboBoxDataProviderMixinClass<TItem> &
+  ComboBoxMixinClass<TItem> &
+  ControllerMixinClass &
+  DelegateFocusMixinClass &
+  DelegateStateMixinClass &
+  DisabledMixinClass &
+  ElementMixinClass &
+  FieldMixinClass &
+  FocusMixinClass &
+  InputConstraintsMixinClass &
+  InputControlMixinClass &
+  InputMixinClass &
+  KeyboardMixinClass &
+  LabelMixinClass &
+  PatternMixinClass &
+  ThemableMixinClass &
+  ThemePropertyMixinClass &
+  ValidateMixinClass & {};
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-combo-box': ComboBox;
   }

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -39,9 +39,9 @@ import type {
   ComboBoxLightValueChangedEvent,
 } from '../../vaadin-combo-box-light';
 
-interface TestComboBoxItem {
+type TestComboBoxItem = {
   testProperty: string;
-}
+};
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/combo-box/test/typings/lit.types.ts
+++ b/packages/combo-box/test/typings/lit.types.ts
@@ -4,9 +4,9 @@ import { comboBoxRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-interface TestComboBoxItem {
+type TestComboBoxItem = {
   testProperty: string;
-}
+};
 
 assertType<
   (

--- a/packages/component-base/custom_typings/vaadin.d.ts
+++ b/packages/component-base/custom_typings/vaadin.d.ts
@@ -1,4 +1,4 @@
-interface Vaadin {
+type Vaadin = {
   developmentModeCallback?: {
     'usage-statistics'?(): void;
   };
@@ -6,8 +6,8 @@ interface Vaadin {
   usageStatsChecker?: {
     maybeGatherAndSend(): void;
   };
-}
+};
 
-interface Window {
+type Window = {
   Vaadin: Vaadin;
-}
+};

--- a/packages/component-base/src/async.d.ts
+++ b/packages/component-base/src/async.d.ts
@@ -8,19 +8,19 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-export interface AsyncInterface {
+export type AsyncInterface = {
   run(fn: Function, delay?: number): number;
   cancel(handle: number): void;
-}
+};
 
 /**
  * Not defined in the TypeScript DOM library.
  * See https://developer.mozilla.org/en-US/docs/Web/API/IdleDeadline
  */
-export interface IdleDeadline {
+export type IdleDeadline = {
   didTimeout: boolean;
   timeRemaining(): number;
-}
+};
 
 /**
  * Async interface wrapper around `setTimeout`.

--- a/packages/component-base/src/gestures.d.ts
+++ b/packages/component-base/src/gestures.d.ts
@@ -64,7 +64,7 @@ export { prevent };
  */
 declare function prevent(evName: string): void;
 
-export interface GestureRecognizer {
+export type GestureRecognizer = {
   reset(): void;
   mousedown?(e: MouseEvent): void;
   mousemove?(e: MouseEvent): void;
@@ -73,4 +73,4 @@ export interface GestureRecognizer {
   touchmove?(e: TouchEvent): void;
   touchend?(e: TouchEvent): void;
   click?(e: MouseEvent): void;
-}
+};

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -12,7 +12,7 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
  */
 export type ConfirmDialogOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
-export interface ConfirmDialogCustomEventMap {
+export type ConfirmDialogCustomEventMap = {
   'opened-changed': ConfirmDialogOpenedChangedEvent;
 
   confirm: Event;
@@ -20,7 +20,7 @@ export interface ConfirmDialogCustomEventMap {
   cancel: Event;
 
   reject: Event;
-}
+};
 
 export type ConfirmDialogEventMap = ConfirmDialogCustomEventMap & HTMLElementEventMap;
 
@@ -160,6 +160,7 @@ declare class ConfirmDialog extends SlotMixin(ElementMixin(ThemePropertyMixin(HT
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-confirm-dialog': ConfirmDialog;
   }

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -9,10 +9,10 @@ import { ContextMenuItem, ItemsMixin } from './vaadin-contextmenu-items-mixin.js
 
 export { ContextMenuItem };
 
-export interface ContextMenuRendererContext {
+export type ContextMenuRendererContext = {
   target: HTMLElement;
   detail?: { sourceEvent: Event };
-}
+};
 
 export type ContextMenuRenderer = (
   root: HTMLElement,
@@ -30,7 +30,7 @@ export type ContextMenuOpenedChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type ContextMenuItemSelectedEvent = CustomEvent<{ value: ContextMenuItem }>;
 
-export interface ContextMenuCustomEventMap {
+export type ContextMenuCustomEventMap = {
   'opened-changed': ContextMenuOpenedChangedEvent;
 
   'item-selected': ContextMenuItemSelectedEvent;
@@ -38,9 +38,9 @@ export interface ContextMenuCustomEventMap {
   'close-all-menus': Event;
 
   'items-outside-click': Event;
-}
+};
 
-export interface ContextMenuEventMap extends HTMLElementEventMap, ContextMenuCustomEventMap {}
+export type ContextMenuEventMap = ContextMenuCustomEventMap & HTMLElementEventMap & {};
 
 /**
  * `<vaadin-context-menu>` is a Web Component for creating context menus.
@@ -300,6 +300,7 @@ declare class ContextMenu extends ElementMixin(ThemePropertyMixin(ItemsMixin(HTM
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-context-menu': ContextMenu;
   }

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -7,14 +7,14 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 import { Item } from '@vaadin/item/src/vaadin-item.js';
 import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
 
-export interface ContextMenuItem {
+export type ContextMenuItem = {
   text?: string;
   component?: HTMLElement | string;
   disabled?: boolean;
   checked?: boolean;
   theme?: string[] | string;
   children?: ContextMenuItem[];
-}
+};
 
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
@@ -24,6 +24,7 @@ export interface ContextMenuItem {
 declare class ContextMenuItemElement extends Item {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-context-menu-item': ContextMenuItemElement;
     'vaadin-context-menu-list-box': ContextMenuListBox;

--- a/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
@@ -73,6 +73,7 @@ declare class CookieConsent extends ElementMixin(HTMLElement) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-cookie-consent': CookieConsent;
   }

--- a/packages/crud/src/vaadin-crud-edit-column.d.ts
+++ b/packages/crud/src/vaadin-crud-edit-column.d.ts
@@ -28,6 +28,7 @@ declare class CrudEditColumn extends GridColumn {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-crud-edit-column': CrudEditColumn;
   }

--- a/packages/crud/src/vaadin-crud-edit.d.ts
+++ b/packages/crud/src/vaadin-crud-edit.d.ts
@@ -16,6 +16,7 @@ import { Button } from '@vaadin/button/src/vaadin-button.js';
 declare class CrudEdit extends Button {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-crud-edit': CrudEdit;
   }

--- a/packages/crud/src/vaadin-crud-form.d.ts
+++ b/packages/crud/src/vaadin-crud-form.d.ts
@@ -17,6 +17,7 @@ declare class CrudForm<Item> extends IncludedMixin(FormLayout) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-crud-form': CrudForm<any>;
   }

--- a/packages/crud/src/vaadin-crud-grid.d.ts
+++ b/packages/crud/src/vaadin-crud-grid.d.ts
@@ -30,6 +30,7 @@ declare class CrudGrid extends IncludedMixin(Grid) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-crud-grid': CrudGrid;
   }

--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -21,7 +21,7 @@ export type CrudDataProvider<T> = (params: CrudDataProviderParams, callback: Cru
 
 export type CrudEditorPosition = '' | 'aside' | 'bottom';
 
-export interface CrudI18n {
+export type CrudI18n = {
   newItem: string;
   editItem: string;
   saveItem: string;
@@ -46,7 +46,7 @@ export interface CrudI18n {
       };
     };
   };
-}
+};
 
 /**
  * Fired when the `editorOpened` property changes.
@@ -394,6 +394,7 @@ declare class Crud<Item> extends ControllerMixin(ElementMixin(ThemableMixin(HTML
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-crud': Crud<any>;
   }

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -13,11 +13,11 @@ export type CustomFieldParseValueFn = (value: string) => unknown[];
 
 export type CustomFieldFormatValueFn = (inputValues: unknown[]) => string;
 
-export interface CustomFieldI18n {
+export type CustomFieldI18n = {
   parseValue: CustomFieldParseValueFn;
 
   formatValue: CustomFieldFormatValueFn;
-}
+};
 
 /**
  * Fired when the user commits a value change.
@@ -48,7 +48,7 @@ export type CustomFieldInternalTabEvent = Event & {
   target: CustomField;
 };
 
-export interface CustomFieldCustomEventMap {
+export type CustomFieldCustomEventMap = {
   'invalid-changed': CustomFieldInvalidChangedEvent;
 
   'value-changed': CustomFieldValueChangedEvent;
@@ -56,11 +56,12 @@ export interface CustomFieldCustomEventMap {
   'internal-tab': CustomFieldInternalTabEvent;
 
   validated: CustomFieldValidatedEvent;
-}
+};
 
-export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCustomEventMap {
-  change: CustomFieldChangeEvent;
-}
+export type CustomFieldEventMap = CustomFieldCustomEventMap &
+  HTMLElementEventMap & {
+    change: CustomFieldChangeEvent;
+  };
 
 /**
  * `<vaadin-custom-field>` is a web component for wrapping multiple components as a single field.
@@ -170,6 +171,7 @@ declare class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMi
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-custom-field': CustomField;
   }

--- a/packages/date-picker/src/vaadin-date-picker-light.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-light.d.ts
@@ -35,7 +35,7 @@ export type DatePickerLightValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type DatePickerLightValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface DatePickerLightCustomEventMap {
+export type DatePickerLightCustomEventMap = {
   'opened-changed': DatePickerLightOpenedChangedEvent;
 
   'invalid-changed': DatePickerLightInvalidChangedEvent;
@@ -43,11 +43,12 @@ export interface DatePickerLightCustomEventMap {
   'value-changed': DatePickerLightValueChangedEvent;
 
   validated: DatePickerLightValidatedEvent;
-}
+};
 
-export interface DatePickerLightEventMap extends HTMLElementEventMap, DatePickerLightCustomEventMap {
-  change: DatePickerLightChangeEvent;
-}
+export type DatePickerLightEventMap = DatePickerLightCustomEventMap &
+  HTMLElementEventMap & {
+    change: DatePickerLightChangeEvent;
+  };
 
 /**
  * `<vaadin-date-picker-light>` is a customizable version of the `<vaadin-date-picker>` providing
@@ -110,6 +111,7 @@ declare class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixi
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-date-picker-light': DatePickerLight;
   }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -11,13 +11,13 @@ import type { DelegateFocusMixinClass } from '@vaadin/field-base/src/delegate-fo
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 
-export interface DatePickerDate {
+export type DatePickerDate = {
   day: number;
   month: number;
   year: number;
-}
+};
 
-export interface DatePickerI18n {
+export type DatePickerI18n = {
   monthNames: string[];
   weekdays: string[];
   weekdaysShort: string[];
@@ -29,7 +29,7 @@ export interface DatePickerI18n {
   parseDate(date: string): DatePickerDate | undefined;
   formatDate(date: DatePickerDate): string;
   formatTitle(monthName: string, fullYear: number): string;
-}
+};
 
 export declare function DatePickerMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -36,7 +36,7 @@ export type DatePickerValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type DatePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface DatePickerCustomEventMap {
+export type DatePickerCustomEventMap = {
   'opened-changed': DatePickerOpenedChangedEvent;
 
   'invalid-changed': DatePickerInvalidChangedEvent;
@@ -44,11 +44,12 @@ export interface DatePickerCustomEventMap {
   'value-changed': DatePickerValueChangedEvent;
 
   validated: DatePickerValidatedEvent;
-}
+};
 
-export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCustomEventMap {
-  change: DatePickerChangeEvent;
-}
+export type DatePickerEventMap = DatePickerCustomEventMap &
+  HTMLElementEventMap & {
+    change: DatePickerChangeEvent;
+  };
 
 /**
  * `<vaadin-date-picker>` is an input field that allows to enter a date by typing or by selecting from a calendar overlay.
@@ -157,6 +158,7 @@ declare class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-date-picker': DatePicker;
   }

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -12,7 +12,7 @@ import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import type { TimePickerI18n } from '@vaadin/time-picker/src/vaadin-time-picker.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface DateTimePickerI18n extends DatePickerI18n, TimePickerI18n {}
+export type DateTimePickerI18n = DatePickerI18n & TimePickerI18n & {};
 
 /**
  * Fired when the user commits a value change.
@@ -36,17 +36,18 @@ export type DateTimePickerValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type DateTimePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface DateTimePickerCustomEventMap {
+export type DateTimePickerCustomEventMap = {
   'invalid-changed': DateTimePickerInvalidChangedEvent;
 
   'value-changed': DateTimePickerValueChangedEvent;
 
   validated: DateTimePickerValidatedEvent;
-}
+};
 
-export interface DateTimePickerEventMap extends DateTimePickerCustomEventMap, HTMLElementEventMap {
-  change: DateTimePickerChangeEvent;
-}
+export type DateTimePickerEventMap = DateTimePickerCustomEventMap &
+  HTMLElementEventMap & {
+    change: DateTimePickerChangeEvent;
+  };
 
 /**
  * `<vaadin-date-time-picker>` is a Web Component providing a date time selection field.
@@ -229,6 +230,7 @@ declare class DateTimePicker extends FieldMixin(
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-date-time-picker': DateTimePicker;
   }

--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -13,9 +13,9 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  */
 export type DetailsOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
-export interface DetailsCustomEventMap {
+export type DetailsCustomEventMap = {
   'opened-changed': DetailsOpenedChangedEvent;
-}
+};
 
 export type DetailsEventMap = DetailsCustomEventMap & HTMLElementEventMap;
 
@@ -74,6 +74,7 @@ declare class Details extends ShadowFocusMixin(ElementMixin(ThemableMixin(Contro
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-details': Details;
   }

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -51,11 +51,11 @@ export type DialogOpenedChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type DialogResizeEvent = CustomEvent<DialogResizeDimensions>;
 
-export interface DialogCustomEventMap {
+export type DialogCustomEventMap = {
   'opened-changed': DialogOpenedChangedEvent;
 
   resize: DialogResizeEvent;
-}
+};
 
 export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
 
@@ -219,6 +219,7 @@ declare class Dialog extends ThemePropertyMixin(ElementMixin(DialogDraggableMixi
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-dialog': Dialog;
     'vaadin-dialog-overlay': DialogOverlay;

--- a/packages/email-field/src/vaadin-email-field.d.ts
+++ b/packages/email-field/src/vaadin-email-field.d.ts
@@ -27,17 +27,18 @@ export type EmailFieldValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type EmailFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface EmailFieldCustomEventMap {
+export type EmailFieldCustomEventMap = {
   'invalid-changed': EmailFieldInvalidChangedEvent;
 
   'value-changed': EmailFieldValueChangedEvent;
 
   validated: EmailFieldValidatedEvent;
-}
+};
 
-export interface EmailFieldEventMap extends HTMLElementEventMap, EmailFieldCustomEventMap {
-  change: EmailFieldChangeEvent;
-}
+export type EmailFieldEventMap = EmailFieldCustomEventMap &
+  HTMLElementEventMap & {
+    change: EmailFieldChangeEvent;
+  };
 
 /**
  * `<vaadin-email-field>` is a Web Component for email field control in forms.
@@ -74,6 +75,7 @@ declare class EmailField extends TextField {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-email-field': EmailField;
   }

--- a/packages/field-highlighter/src/vaadin-field-highlighter.d.ts
+++ b/packages/field-highlighter/src/vaadin-field-highlighter.d.ts
@@ -5,12 +5,12 @@
  */
 import type { ReactiveController } from 'lit';
 
-export interface FieldHighlighterUser {
+export type FieldHighlighterUser = {
   id: number;
   name: string;
   colorIndex: number;
   fieldIndex?: number;
-}
+};
 
 /**
  * A field controller for implementing real-time collaboration features: displaying
@@ -69,6 +69,7 @@ declare class FieldHighlighter extends HTMLElement {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-field-highlighter': FieldHighlighter;
   }

--- a/packages/form-layout/src/vaadin-form-item.d.ts
+++ b/packages/form-layout/src/vaadin-form-item.d.ts
@@ -96,6 +96,7 @@ declare class FormItem extends ThemableMixin(HTMLElement) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-form-item': FormItem;
   }

--- a/packages/form-layout/src/vaadin-form-layout.d.ts
+++ b/packages/form-layout/src/vaadin-form-layout.d.ts
@@ -160,6 +160,7 @@ declare class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(HTMLElem
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-form-layout': FormLayout;
   }

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -79,6 +79,7 @@ declare class GridProEditColumn<TItem = GridDefaultItem> extends GridColumn<TIte
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-pro-edit-column': GridProEditColumn<GridDefaultItem>;
   }

--- a/packages/grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro.d.ts
@@ -27,16 +27,15 @@ export type GridProItemPropertyChangedEvent<TItem> = CustomEvent<{
   value: boolean | string;
 }>;
 
-export interface GridProCustomEventMap<TItem> {
+export type GridProCustomEventMap<TItem> = {
   'cell-edit-started': GridProCellEditStartedEvent<TItem>;
 
   'item-property-changed': GridProItemPropertyChangedEvent<TItem>;
-}
+};
 
-export interface GridProEventMap<TItem>
-  extends HTMLElementEventMap,
-    GridProCustomEventMap<TItem>,
-    GridCustomEventMap<TItem> {}
+export type GridProEventMap<TItem> = GridCustomEventMap<TItem> &
+  GridProCustomEventMap<TItem> &
+  HTMLElementEventMap & {};
 
 /**
  * `<vaadin-grid-pro>` is a high quality data grid / data table Web Component with extended functionality.
@@ -84,9 +83,10 @@ declare class GridPro<TItem = GridDefaultItem> extends Grid<TItem> {
   ): void;
 }
 
-interface GridPro extends InlineEditingMixinClass {}
+type GridPro = InlineEditingMixinClass & {};
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-pro': GridPro<GridDefaultItem>;
   }

--- a/packages/grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/grid-pro/test/typings/grid-pro.types.ts
@@ -17,9 +17,9 @@ import type { InlineEditingMixinClass } from '../../src/vaadin-grid-pro-inline-e
 import type { GridPro } from '../../vaadin-grid-pro';
 import type { GridProEditColumn } from '../../vaadin-grid-pro-edit-column';
 
-interface TestGridItem {
+type TestGridItem = {
   testProperty: string;
-}
+};
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/grid-pro/test/typings/lit-renderer-directives.types.ts
+++ b/packages/grid-pro/test/typings/lit-renderer-directives.types.ts
@@ -4,9 +4,9 @@ import { columnEditModeRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-interface TestGridItem {
+type TestGridItem = {
   testProperty: string;
-}
+};
 
 assertType<
   (

--- a/packages/grid/src/vaadin-grid-column-group.d.ts
+++ b/packages/grid/src/vaadin-grid-column-group.d.ts
@@ -48,9 +48,10 @@ declare class GridColumnGroup extends HTMLElement {
   readonly width: string | null | undefined;
 }
 
-interface GridColumnGroup<TItem = GridDefaultItem> extends ColumnBaseMixinClass<TItem> {}
+type GridColumnGroup<TItem = GridDefaultItem> = ColumnBaseMixinClass<TItem> & {};
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-column-group': GridColumnGroup<GridDefaultItem>;
   }

--- a/packages/grid/src/vaadin-grid-column.d.ts
+++ b/packages/grid/src/vaadin-grid-column.d.ts
@@ -140,9 +140,10 @@ declare class GridColumn<TItem = GridDefaultItem> extends HTMLElement {
   autoWidth: boolean;
 }
 
-interface GridColumn<TItem = GridDefaultItem> extends ColumnBaseMixinClass<TItem> {}
+type GridColumn<TItem = GridDefaultItem> = ColumnBaseMixinClass<TItem> & {};
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-column': GridColumn<GridDefaultItem>;
   }

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
@@ -8,15 +8,15 @@ import { GridSorterDirection } from './vaadin-grid-sorter.js';
 
 export { GridSorterDirection };
 
-export interface GridFilterDefinition {
+export type GridFilterDefinition = {
   path: string;
   value: string;
-}
+};
 
-export interface GridSorterDefinition {
+export type GridSorterDefinition = {
   path: string;
   direction: GridSorterDirection;
-}
+};
 
 export type GridDataProviderCallback<TItem> = (items: TItem[], size?: number) => void;
 

--- a/packages/grid/src/vaadin-grid-event-context-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-event-context-mixin.d.ts
@@ -6,7 +6,7 @@
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { GridColumn } from './vaadin-grid-column.js';
 
-export interface GridEventContext<TItem> {
+export type GridEventContext<TItem> = {
   section?: 'body' | 'details' | 'footer' | 'header';
   item?: TItem;
   column?: GridColumn<TItem>;
@@ -15,7 +15,7 @@ export interface GridEventContext<TItem> {
   detailsOpened?: boolean;
   expanded?: boolean;
   level?: number;
-}
+};
 
 export declare function EventContextMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/grid/src/vaadin-grid-filter-column.d.ts
+++ b/packages/grid/src/vaadin-grid-filter-column.d.ts
@@ -32,6 +32,7 @@ declare class GridFilterColumn<TItem = GridDefaultItem> extends GridColumn<TItem
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-filter-column': GridFilterColumn<GridDefaultItem>;
   }

--- a/packages/grid/src/vaadin-grid-filter.d.ts
+++ b/packages/grid/src/vaadin-grid-filter.d.ts
@@ -9,11 +9,11 @@
  */
 export type GridFilterValueChangedEvent = CustomEvent<{ value: string }>;
 
-export interface GridFilterCustomEventMap {
+export type GridFilterCustomEventMap = {
   'value-changed': GridFilterValueChangedEvent;
-}
+};
 
-export interface GridFilterEventMap extends HTMLElementEventMap, GridFilterCustomEventMap {}
+export type GridFilterEventMap = GridFilterCustomEventMap & HTMLElementEventMap & {};
 
 /**
  * `<vaadin-grid-filter>` is a helper element for the `<vaadin-grid>` that provides out-of-the-box UI controls,
@@ -65,6 +65,7 @@ declare class GridFilter extends HTMLElement {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-filter': GridFilter;
   }

--- a/packages/grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column.d.ts
@@ -11,11 +11,11 @@ import { GridColumn } from './vaadin-grid-column.js';
  */
 export type GridSelectionColumnSelectAllChangedEvent = CustomEvent<{ value: boolean }>;
 
-export interface GridSelectionColumnCustomEventMap {
+export type GridSelectionColumnCustomEventMap = {
   'select-all-changed': GridSelectionColumnSelectAllChangedEvent;
-}
+};
 
-export interface GridSelectionColumnEventMap extends HTMLElementEventMap, GridSelectionColumnCustomEventMap {}
+export type GridSelectionColumnEventMap = GridSelectionColumnCustomEventMap & HTMLElementEventMap & {};
 
 /**
  * `<vaadin-grid-selection-column>` is a helper element for the `<vaadin-grid>`
@@ -68,6 +68,7 @@ declare class GridSelectionColumn<TItem = GridDefaultItem> extends GridColumn<TI
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-selection-column': GridSelectionColumn<GridDefaultItem>;
   }

--- a/packages/grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-column.d.ts
@@ -12,11 +12,11 @@ import type { GridSorterDirection } from './vaadin-grid-sorter.js';
  */
 export type GridSortColumnDirectionChangedEvent = CustomEvent<{ value: GridSorterDirection }>;
 
-export interface GridSortColumnCustomEventMap {
+export type GridSortColumnCustomEventMap = {
   'direction-changed': GridSortColumnDirectionChangedEvent;
-}
+};
 
-export interface GridSortColumnEventMap extends HTMLElementEventMap, GridSortColumnCustomEventMap {}
+export type GridSortColumnEventMap = GridSortColumnCustomEventMap & HTMLElementEventMap & {};
 
 /**
  * `<vaadin-grid-sort-column>` is a helper element for the `<vaadin-grid>`
@@ -60,6 +60,7 @@ declare class GridSortColumn<TItem = GridDefaultItem> extends GridColumn<TItem> 
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-sort-column': GridSortColumn<GridDefaultItem>;
   }

--- a/packages/grid/src/vaadin-grid-sorter.d.ts
+++ b/packages/grid/src/vaadin-grid-sorter.d.ts
@@ -13,13 +13,13 @@ export type GridSorterDirection = 'asc' | 'desc' | null;
  */
 export type GridSorterDirectionChangedEvent = CustomEvent<{ value: GridSorterDirection }>;
 
-export interface GridSorterCustomEventMap {
+export type GridSorterCustomEventMap = {
   'sorter-changed': Event;
 
   'direction-changed': GridSorterDirectionChangedEvent;
-}
+};
 
-export interface GridSorterEventMap extends HTMLElementEventMap, GridSorterCustomEventMap {}
+export type GridSorterEventMap = GridSorterCustomEventMap & HTMLElementEventMap & {};
 
 /**
  * `<vaadin-grid-sorter>` is a helper element for the `<vaadin-grid>` that provides out-of-the-box UI controls,
@@ -87,6 +87,7 @@ declare class GridSorter extends ThemableMixin(DirMixin(HTMLElement)) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-sorter': GridSorter;
   }

--- a/packages/grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-column.d.ts
@@ -34,6 +34,7 @@ declare class GridTreeColumn<TItem = GridDefaultItem> extends GridColumn<TItem> 
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-tree-column': GridTreeColumn<GridDefaultItem>;
   }

--- a/packages/grid/src/vaadin-grid-tree-toggle.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-toggle.d.ts
@@ -11,11 +11,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  */
 export type GridTreeToggleExpandedChangedEvent = CustomEvent<{ value: boolean }>;
 
-export interface GridTreeToggleCustomEventMap {
+export type GridTreeToggleCustomEventMap = {
   'expanded-changed': GridTreeToggleExpandedChangedEvent;
-}
+};
 
-export interface GridTreeToggleEventMap extends HTMLElementEventMap, GridTreeToggleCustomEventMap {}
+export type GridTreeToggleEventMap = GridTreeToggleCustomEventMap & HTMLElementEventMap & {};
 
 /**
  * `<vaadin-grid-tree-toggle>` is a helper element for the `<vaadin-grid>`
@@ -96,6 +96,7 @@ declare class GridTreeToggle extends ThemableMixin(DirMixin(HTMLElement)) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid-tree-toggle': GridTreeToggle;
   }

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -52,14 +52,14 @@ export {
 
 export type GridDefaultItem = any;
 
-export interface GridItemModel<TItem> {
+export type GridItemModel<TItem> = {
   index: number;
   item: TItem;
   selected?: boolean;
   expanded?: boolean;
   level?: number;
   detailsOpened?: boolean;
-}
+};
 
 /**
  * Fired when the `activeItem` property changes.
@@ -119,7 +119,7 @@ export type GridLoadingChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type GridSelectedItemsChangedEvent<TItem> = CustomEvent<{ value: TItem[] }>;
 
-export interface GridCustomEventMap<TItem> {
+export type GridCustomEventMap<TItem> = {
   'active-item-changed': GridActiveItemChangedEvent<TItem>;
 
   'cell-activate': GridCellActivateEvent<TItem>;
@@ -141,9 +141,9 @@ export interface GridCustomEventMap<TItem> {
   'loading-changed': GridLoadingChangedEvent;
 
   'selected-items-changed': GridSelectedItemsChangedEvent<TItem>;
-}
+};
 
-export interface GridEventMap<TItem> extends HTMLElementEventMap, GridCustomEventMap<TItem> {}
+export type GridEventMap<TItem> = GridCustomEventMap<TItem> & HTMLElementEventMap & {};
 
 /**
  * `<vaadin-grid>` is a free, high quality data grid / data table Web Component. The content of the
@@ -390,24 +390,24 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
   ): void;
 }
 
-interface Grid<TItem = GridDefaultItem>
-  extends DisabledMixinClass,
-    ElementMixinClass,
-    ThemableMixinClass,
-    ThemePropertyMixinClass,
-    ActiveItemMixinClass<TItem>,
-    ArrayDataProviderMixinClass<TItem>,
-    DataProviderMixinClass<TItem>,
-    RowDetailsMixinClass<TItem>,
-    ScrollMixinClass,
-    SelectionMixinClass<TItem>,
-    SortMixinClass,
-    ColumnReorderingMixinClass,
-    EventContextMixinClass<TItem>,
-    StylingMixinClass<TItem>,
-    DragAndDropMixinClass<TItem> {}
+type Grid<TItem = GridDefaultItem> = ActiveItemMixinClass<TItem> &
+  ArrayDataProviderMixinClass<TItem> &
+  ColumnReorderingMixinClass &
+  DataProviderMixinClass<TItem> &
+  DisabledMixinClass &
+  DragAndDropMixinClass<TItem> &
+  ElementMixinClass &
+  EventContextMixinClass<TItem> &
+  RowDetailsMixinClass<TItem> &
+  ScrollMixinClass &
+  SelectionMixinClass<TItem> &
+  SortMixinClass &
+  StylingMixinClass<TItem> &
+  ThemableMixinClass &
+  ThemePropertyMixinClass & {};
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-grid': Grid<GridDefaultItem>;
   }

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -52,9 +52,9 @@ import type { GridSorter, GridSorterDirectionChangedEvent } from '../../vaadin-g
 import type { GridTreeColumn } from '../../vaadin-grid-tree-column';
 import type { GridTreeToggle, GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
 
-interface TestGridItem {
+type TestGridItem = {
   testProperty: string;
-}
+};
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/grid/test/typings/lit-renderer-directives.types.ts
+++ b/packages/grid/test/typings/lit-renderer-directives.types.ts
@@ -13,9 +13,9 @@ import { columnBodyRenderer, columnFooterRenderer, columnHeaderRenderer, gridRow
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-interface TestGridItem {
+type TestGridItem = {
   testProperty: string;
-}
+};
 
 assertType<
   (

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout.d.ts
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout.d.ts
@@ -29,6 +29,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 declare class HorizontalLayout extends ThemableMixin(ElementMixin(HTMLElement)) {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-horizontal-layout': HorizontalLayout;
   }

--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -72,6 +72,7 @@ declare class Icon extends ThemableMixin(ElementMixin(ControllerMixin(HTMLElemen
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-icon': Icon;
   }

--- a/packages/icon/src/vaadin-iconset.d.ts
+++ b/packages/icon/src/vaadin-iconset.d.ts
@@ -39,6 +39,7 @@ declare class Iconset extends ElementMixin(HTMLElement) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-iconset': Iconset;
   }

--- a/packages/integer-field/src/vaadin-integer-field.d.ts
+++ b/packages/integer-field/src/vaadin-integer-field.d.ts
@@ -27,17 +27,18 @@ export type IntegerFieldValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type IntegerFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface IntegerFieldCustomEventMap {
+export type IntegerFieldCustomEventMap = {
   'invalid-changed': IntegerFieldInvalidChangedEvent;
 
   'value-changed': IntegerFieldValueChangedEvent;
 
   validated: IntegerFieldValidatedEvent;
-}
+};
 
-export interface IntegerFieldEventMap extends HTMLElementEventMap, IntegerFieldCustomEventMap {
-  change: IntegerFieldChangeEvent;
-}
+export type IntegerFieldEventMap = HTMLElementEventMap &
+  IntegerFieldCustomEventMap & {
+    change: IntegerFieldChangeEvent;
+  };
 
 /**
  * `<vaadin-integer-field>` is an input field web component that only accepts entering integer numbers.
@@ -81,6 +82,7 @@ declare class IntegerField extends NumberField {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-integer-field': IntegerField;
   }

--- a/packages/item/src/vaadin-item.d.ts
+++ b/packages/item/src/vaadin-item.d.ts
@@ -53,6 +53,7 @@ declare class Item extends ItemMixin(ThemableMixin(DirMixin(HTMLElement))) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-item': Item;
   }

--- a/packages/list-box/src/vaadin-list-box.d.ts
+++ b/packages/list-box/src/vaadin-list-box.d.ts
@@ -23,15 +23,15 @@ export type ListBoxSelectedChangedEvent = CustomEvent<{ value: number }>;
  */
 export type ListBoxSelectedValuesChangedEvent = CustomEvent<{ value: number[] }>;
 
-export interface ListBoxCustomEventMap {
+export type ListBoxCustomEventMap = {
   'items-changed': ListBoxItemsChangedEvent;
 
   'selected-changed': ListBoxSelectedChangedEvent;
 
   'selected-values-changed': ListBoxSelectedValuesChangedEvent;
-}
+};
 
-export interface ListBoxEventMap extends HTMLElementEventMap, ListBoxCustomEventMap {}
+export type ListBoxEventMap = HTMLElementEventMap & ListBoxCustomEventMap & {};
 
 /**
  * `<vaadin-list-box>` is a Web Component for creating menus.
@@ -76,6 +76,7 @@ declare class ListBox extends MultiSelectListMixin(ThemableMixin(ElementMixin(Co
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-list-box': ListBox;
   }

--- a/packages/login/src/vaadin-login-form.d.ts
+++ b/packages/login/src/vaadin-login-form.d.ts
@@ -13,13 +13,13 @@ export { LoginI18n } from './vaadin-login-mixin.js';
  */
 export type LoginFormLoginEvent = CustomEvent<{ username: string; password: string }>;
 
-export interface LoginFormCustomEventMap {
+export type LoginFormCustomEventMap = {
   'forgot-password': Event;
 
   login: LoginFormLoginEvent;
-}
+};
 
-export interface LoginFormEventMap extends HTMLElementEventMap, LoginFormCustomEventMap {}
+export type LoginFormEventMap = HTMLElementEventMap & LoginFormCustomEventMap & {};
 
 /**
  * `<vaadin-login-form>` is a Web Component providing an easy way to require users
@@ -71,6 +71,7 @@ declare class LoginForm extends ElementMixin(ThemableMixin(LoginMixin(HTMLElemen
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-login-form': LoginForm;
   }

--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -5,7 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
-export interface LoginI18n {
+export type LoginI18n = {
   form: {
     title: string;
     username: string;
@@ -22,7 +22,7 @@ export interface LoginI18n {
     description?: string;
   };
   additionalInformation?: string;
-}
+};
 
 export declare function LoginMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<LoginMixinClass> & T;
 

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -13,13 +13,13 @@ export { LoginI18n } from './vaadin-login-mixin.js';
  */
 export type LoginOverlayLoginEvent = CustomEvent<{ username: string; password: string }>;
 
-export interface LoginOverlayCustomEventMap {
+export type LoginOverlayCustomEventMap = {
   'forgot-password': Event;
 
   login: LoginOverlayLoginEvent;
-}
+};
 
-export interface LoginOverlayEventMap extends HTMLElementEventMap, LoginOverlayCustomEventMap {}
+export type LoginOverlayEventMap = HTMLElementEventMap & LoginOverlayCustomEventMap & {};
 
 /**
  * `<vaadin-login-overlay>` is a wrapper of the `<vaadin-login-form>` which opens a login form in an overlay and
@@ -81,6 +81,7 @@ declare class LoginOverlay extends ElementMixin(ThemableMixin(LoginMixin(HTMLEle
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-login-overlay': LoginOverlay;
   }

--- a/packages/map/src/vaadin-map.d.ts
+++ b/packages/map/src/vaadin-map.d.ts
@@ -57,6 +57,7 @@ declare class Map extends ResizeMixin(FocusMixin(ThemableMixin(ElementMixin(HTML
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-map': Map;
   }

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -10,7 +10,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { ButtonsMixin } from './vaadin-menu-bar-buttons-mixin.js';
 import { InteractionsMixin } from './vaadin-menu-bar-interactions-mixin.js';
 
-export interface MenuBarItem {
+export type MenuBarItem = {
   /**
    * Text to be set as the menu button component's textContent.
    */
@@ -37,31 +37,31 @@ export interface MenuBarItem {
    * Array of submenu items.
    */
   children?: SubMenuItem[];
-}
+};
 
-export interface SubMenuItem {
+export type SubMenuItem = {
   text?: string;
   component?: HTMLElement | string;
   disabled?: boolean;
   theme?: string[] | string;
   checked?: boolean;
   children?: SubMenuItem[];
-}
+};
 
-export interface MenuBarI18n {
+export type MenuBarI18n = {
   moreOptions: string;
-}
+};
 
 /**
  * Fired when a submenu item or menu bar button without children is clicked.
  */
 export type MenuBarItemSelectedEvent = CustomEvent<{ value: MenuBarItem }>;
 
-export interface MenuBarCustomEventMap {
+export type MenuBarCustomEventMap = {
   'item-selected': MenuBarItemSelectedEvent;
-}
+};
 
-export interface MenuBarEventMap extends HTMLElementEventMap, MenuBarCustomEventMap {}
+export type MenuBarEventMap = HTMLElementEventMap & MenuBarCustomEventMap & {};
 
 /**
  * `<vaadin-menu-bar>` is a Web Component providing a set of horizontally stacked buttons offering
@@ -186,6 +186,7 @@ declare class MenuBar extends ButtonsMixin(
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-menu-bar': MenuBar;
   }

--- a/packages/message-input/src/vaadin-message-input-button.d.ts
+++ b/packages/message-input/src/vaadin-message-input-button.d.ts
@@ -14,6 +14,7 @@ import { Button } from '@vaadin/button/src/vaadin-button.js';
 declare class MessageInputButton extends Button {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-message-input-button': MessageInputButton;
   }

--- a/packages/message-input/src/vaadin-message-input-text-area.d.ts
+++ b/packages/message-input/src/vaadin-message-input-text-area.d.ts
@@ -15,6 +15,7 @@ declare class MessageInputTextArea extends TextArea {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-message-input-text-area': MessageInputTextArea;
   }

--- a/packages/message-input/src/vaadin-message-input.d.ts
+++ b/packages/message-input/src/vaadin-message-input.d.ts
@@ -7,10 +7,10 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface MessageInputI18n {
+export type MessageInputI18n = {
   send: string;
   message: string;
-}
+};
 
 /**
  * Fired when a new message is submitted with `<vaadin-message-input>`, either
@@ -18,9 +18,9 @@ export interface MessageInputI18n {
  */
 export type MessageInputSubmitEvent = CustomEvent<{ value: string }>;
 
-export interface MessageInputCustomEventMap {
+export type MessageInputCustomEventMap = {
   submit: MessageInputSubmitEvent;
-}
+};
 
 export type MessageInputEventMap = HTMLElementEventMap & MessageInputCustomEventMap;
 
@@ -80,6 +80,7 @@ declare class MessageInput extends ThemableMixin(ElementMixin(ControllerMixin(HT
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-message-input': MessageInput;
   }

--- a/packages/message-list/src/vaadin-message-avatar.d.ts
+++ b/packages/message-list/src/vaadin-message-avatar.d.ts
@@ -11,6 +11,7 @@ import { Avatar } from '@vaadin/avatar/src/vaadin-avatar.js';
 declare class MessageAvatar extends Avatar {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-message-avatar': MessageAvatar;
   }

--- a/packages/message-list/src/vaadin-message-list.d.ts
+++ b/packages/message-list/src/vaadin-message-list.d.ts
@@ -7,7 +7,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { KeyboardDirectionMixin } from '@vaadin/component-base/src/keyboard-direction-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface MessageListItem {
+export type MessageListItem = {
   text?: string;
   time?: string;
   userName?: string;
@@ -15,7 +15,7 @@ export interface MessageListItem {
   userImg?: string;
   userColorIndex?: number;
   theme?: string;
-}
+};
 
 /**
  * `<vaadin-message-list>` is a Web Component for showing an ordered list of messages. The messages are rendered as <vaadin-message>
@@ -66,6 +66,7 @@ declare class MessageList extends KeyboardDirectionMixin(ThemableMixin(ElementMi
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-message-list': MessageList;
   }

--- a/packages/message-list/src/vaadin-message.d.ts
+++ b/packages/message-list/src/vaadin-message.d.ts
@@ -101,6 +101,7 @@ declare class Message extends FocusMixin(ThemableMixin(ElementMixin(HTMLElement)
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-message': Message;
   }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -32,13 +32,13 @@ export type MultiSelectComboBoxRenderer<TItem> = (
   model: ComboBoxItemModel<TItem>,
 ) => void;
 
-export interface MultiSelectComboBoxI18n {
+export type MultiSelectComboBoxI18n = {
   cleared: string;
   focused: string;
   selected: string;
   deselected: string;
   total: string;
-}
+};
 
 /**
  * Fired when the user commits a value change.
@@ -72,7 +72,7 @@ export type MultiSelectComboBoxSelectedItemsChangedEvent<TItem> = CustomEvent<{ 
  */
 export type MultiSelectComboBoxValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap {
+export type MultiSelectComboBoxEventMap<TItem> = HTMLElementEventMap & {
   change: MultiSelectComboBoxChangeEvent<TItem>;
 
   'custom-value-set': MultiSelectComboBoxCustomValueSetEvent;
@@ -84,7 +84,7 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
   'selected-items-changed': MultiSelectComboBoxSelectedItemsChangedEvent<TItem>;
 
   validated: MultiSelectComboBoxValidatedEvent;
-}
+};
 
 /**
  * `<vaadin-multi-select-combo-box>` is a web component that wraps `<vaadin-combo-box>` and extends
@@ -331,26 +331,26 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
   ): void;
 }
 
-interface MultiSelectComboBox
-  extends ValidateMixinClass,
-    SlotStylesMixinClass,
-    LabelMixinClass,
-    KeyboardMixinClass,
-    Omit<InputMixinClass, 'value'>,
-    InputControlMixinClass,
-    InputConstraintsMixinClass,
-    FocusMixinClass,
-    FieldMixinClass,
-    DisabledMixinClass,
-    DelegateStateMixinClass,
-    DelegateFocusMixinClass,
-    ResizeMixinClass,
-    ThemableMixinClass,
-    ThemePropertyMixinClass,
-    ElementMixinClass,
-    ControllerMixinClass {}
+type MultiSelectComboBox = ControllerMixinClass &
+  DelegateFocusMixinClass &
+  DelegateStateMixinClass &
+  DisabledMixinClass &
+  ElementMixinClass &
+  FieldMixinClass &
+  FocusMixinClass &
+  InputConstraintsMixinClass &
+  InputControlMixinClass &
+  KeyboardMixinClass &
+  LabelMixinClass &
+  Omit<InputMixinClass, 'value'> &
+  ResizeMixinClass &
+  SlotStylesMixinClass &
+  ThemableMixinClass &
+  ThemePropertyMixinClass &
+  ValidateMixinClass & {};
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-multi-select-combo-box': MultiSelectComboBox;
   }

--- a/packages/multi-select-combo-box/test/typings/lit.types.ts
+++ b/packages/multi-select-combo-box/test/typings/lit.types.ts
@@ -4,9 +4,9 @@ import { multiSelectComboBoxRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-interface TestComboBoxItem {
+type TestComboBoxItem = {
   testProperty: string;
-}
+};
 
 assertType<
   (

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -25,9 +25,9 @@ import type {
   MultiSelectComboBoxValidatedEvent,
 } from '../../vaadin-multi-select-combo-box.js';
 
-interface TestComboBoxItem {
+type TestComboBoxItem = {
   testProperty: string;
-}
+};
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 

--- a/packages/notification/src/vaadin-notification.d.ts
+++ b/packages/notification/src/vaadin-notification.d.ts
@@ -26,17 +26,17 @@ export type NotificationRenderer = (root: HTMLElement, notification?: Notificati
  */
 export type NotificationOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
-export interface NotificationCustomEventMap {
+export type NotificationCustomEventMap = {
   'opened-changed': NotificationOpenedChangedEvent;
-}
+};
 
-export interface NotificationEventMap extends HTMLElementEventMap, NotificationCustomEventMap {}
+export type NotificationEventMap = HTMLElementEventMap & NotificationCustomEventMap & {};
 
-export interface ShowOptions {
+export type ShowOptions = {
   duration?: number;
   position?: NotificationPosition;
   theme?: string;
-}
+};
 
 /**
  * An element used internally by `<vaadin-notification>`. Not intended to be used separately.
@@ -182,6 +182,7 @@ declare class Notification extends ThemePropertyMixin(ElementMixin(HTMLElement))
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-notification-container': NotificationContainer;
     'vaadin-notification-card': NotificationCard;

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -29,17 +29,18 @@ export type NumberFieldValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type NumberFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface NumberFieldCustomEventMap {
+export type NumberFieldCustomEventMap = {
   'invalid-changed': NumberFieldInvalidChangedEvent;
 
   'value-changed': NumberFieldValueChangedEvent;
 
   validated: NumberFieldValidatedEvent;
-}
+};
 
-export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCustomEventMap {
-  change: NumberFieldChangeEvent;
-}
+export type NumberFieldEventMap = HTMLElementEventMap &
+  NumberFieldCustomEventMap & {
+    change: NumberFieldChangeEvent;
+  };
 
 /**
  * `<vaadin-number-field>` is an input field web component that only accepts numeric input.
@@ -104,6 +105,7 @@ declare class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(HTM
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-number-field': NumberField;
   }

--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -27,17 +27,18 @@ export type PasswordFieldValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type PasswordFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface PasswordFieldCustomEventMap {
+export type PasswordFieldCustomEventMap = {
   'invalid-changed': PasswordFieldInvalidChangedEvent;
 
   'value-changed': PasswordFieldValueChangedEvent;
 
   validated: PasswordFieldValidatedEvent;
-}
+};
 
-export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFieldCustomEventMap {
-  change: PasswordFieldChangeEvent;
-}
+export type PasswordFieldEventMap = HTMLElementEventMap &
+  PasswordFieldCustomEventMap & {
+    change: PasswordFieldChangeEvent;
+  };
 
 /**
  * `<vaadin-password-field>` is an extension of `<vaadin-text-field>` component for entering passwords.
@@ -111,6 +112,7 @@ declare class PasswordField extends TextField {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-password-field': PasswordField;
   }

--- a/packages/progress-bar/src/vaadin-progress-bar.d.ts
+++ b/packages/progress-bar/src/vaadin-progress-bar.d.ts
@@ -41,6 +41,7 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
 declare class ProgressBar extends ProgressMixin(ThemableMixin(ElementMixin(HTMLElement))) {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-progress-bar': ProgressBar;
   }

--- a/packages/radio-group/src/vaadin-radio-button.d.ts
+++ b/packages/radio-group/src/vaadin-radio-button.d.ts
@@ -16,11 +16,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  */
 export type RadioButtonCheckedChangedEvent = CustomEvent<{ value: boolean }>;
 
-export interface RadioButtonCustomEventMap {
+export type RadioButtonCustomEventMap = {
   'checked-changed': RadioButtonCheckedChangedEvent;
-}
+};
 
-export interface RadioButtonEventMap extends HTMLElementEventMap, RadioButtonCustomEventMap {}
+export type RadioButtonEventMap = HTMLElementEventMap & RadioButtonCustomEventMap & {};
 
 /**
  * `<vaadin-radio-button>` is a web component representing a choice in a radio group.
@@ -79,6 +79,7 @@ declare class RadioButton extends LabelMixin(
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-radio-button': RadioButton;
   }

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -25,15 +25,15 @@ export type RadioGroupValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type RadioGroupValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface RadioGroupCustomEventMap {
+export type RadioGroupCustomEventMap = {
   'invalid-changed': RadioGroupInvalidChangedEvent;
 
   'value-changed': RadioGroupValueChangedEvent;
 
   validated: RadioGroupValidatedEvent;
-}
+};
 
-export interface RadioGroupEventMap extends HTMLElementEventMap, RadioGroupCustomEventMap {}
+export type RadioGroupEventMap = HTMLElementEventMap & RadioGroupCustomEventMap & {};
 
 /**
  * `<vaadin-radio-group>` is a web component that allows the user to choose one item from a group of choices.
@@ -107,6 +107,7 @@ declare class RadioGroup extends FieldMixin(
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-radio-group': RadioGroup;
   }

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
@@ -6,7 +6,7 @@
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface RichTextEditorI18n {
+export type RichTextEditorI18n = {
   undo: string;
   redo: string;
   bold: string;
@@ -32,7 +32,7 @@ export interface RichTextEditorI18n {
   ok: string;
   cancel: string;
   remove: string;
-}
+};
 
 /**
  * Fired when the user commits a value change.
@@ -51,15 +51,16 @@ export type RichTextEditorHtmlValueChangedEvent = CustomEvent<{ value: string }>
  */
 export type RichTextEditorValueChangedEvent = CustomEvent<{ value: string }>;
 
-export interface RichTextEditorCustomEventMap {
+export type RichTextEditorCustomEventMap = {
   'html-value-changed': RichTextEditorHtmlValueChangedEvent;
 
   'value-changed': RichTextEditorValueChangedEvent;
-}
+};
 
-export interface RichTextEditorEventMap extends HTMLElementEventMap, RichTextEditorCustomEventMap {
-  change: RichTextEditorChangeEvent;
-}
+export type RichTextEditorEventMap = HTMLElementEventMap &
+  RichTextEditorCustomEventMap & {
+    change: RichTextEditorChangeEvent;
+  };
 
 /**
  * `<vaadin-rich-text-editor>` is a Web Component for rich text editing.
@@ -192,6 +193,7 @@ declare class RichTextEditor extends ElementMixin(ThemableMixin(HTMLElement)) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-rich-text-editor': RichTextEditor;
   }

--- a/packages/scroller/src/vaadin-scroller.d.ts
+++ b/packages/scroller/src/vaadin-scroller.d.ts
@@ -39,6 +39,7 @@ declare class Scroller extends FocusMixin(ThemableMixin(ElementMixin(ControllerM
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-scroller': Scroller;
   }

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -9,12 +9,12 @@ import { DelegateStateMixin } from '@vaadin/field-base/src/delegate-state-mixin.
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface SelectItem {
+export type SelectItem = {
   label?: string;
   value?: string;
   component?: string;
   disabled?: boolean;
-}
+};
 
 /**
  * Fired when the user commits a value change.
@@ -53,7 +53,7 @@ export type SelectValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type SelectValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface SelectCustomEventMap {
+export type SelectCustomEventMap = {
   'opened-changed': SelectOpenedChangedEvent;
 
   'invalid-changed': SelectInvalidChangedEvent;
@@ -61,11 +61,12 @@ export interface SelectCustomEventMap {
   'value-changed': SelectValueChangedEvent;
 
   validated: SelectValidatedEvent;
-}
+};
 
-export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMap {
-  change: SelectChangeEvent;
-}
+export type SelectEventMap = HTMLElementEventMap &
+  SelectCustomEventMap & {
+    change: SelectChangeEvent;
+  };
 
 /**
  * `<vaadin-select>` is a Web Component for selecting values from a list of items.
@@ -269,6 +270,7 @@ declare class Select extends DelegateFocusMixin(
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-select': Select;
   }

--- a/packages/split-layout/src/vaadin-split-layout.d.ts
+++ b/packages/split-layout/src/vaadin-split-layout.d.ts
@@ -6,11 +6,11 @@
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface SplitLayoutCustomEventMap {
+export type SplitLayoutCustomEventMap = {
   'splitter-dragend': Event;
-}
+};
 
-export interface SplitLayoutEventMap extends HTMLElementEventMap, SplitLayoutCustomEventMap {}
+export type SplitLayoutEventMap = HTMLElementEventMap & SplitLayoutCustomEventMap & {};
 
 /**
  * `<vaadin-split-layout>` is a Web Component implementing a split layout for two
@@ -176,6 +176,7 @@ declare class SplitLayout extends ElementMixin(ThemableMixin(HTMLElement)) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-split-layout': SplitLayout;
   }

--- a/packages/tabs/src/vaadin-tab.d.ts
+++ b/packages/tabs/src/vaadin-tab.d.ts
@@ -33,6 +33,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 declare class Tab extends ElementMixin(ThemableMixin(ItemMixin(ControllerMixin(HTMLElement)))) {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-tab': Tab;
   }

--- a/packages/tabs/src/vaadin-tabs.d.ts
+++ b/packages/tabs/src/vaadin-tabs.d.ts
@@ -20,13 +20,13 @@ export type TabsItemsChangedEvent = CustomEvent<{ value: Element[] }>;
  */
 export type TabsSelectedChangedEvent = CustomEvent<{ value: number }>;
 
-export interface TabsCustomEventMap {
+export type TabsCustomEventMap = {
   'items-changed': TabsItemsChangedEvent;
 
   'selected-changed': TabsSelectedChangedEvent;
-}
+};
 
-export interface TabsEventMap extends HTMLElementEventMap, TabsCustomEventMap {}
+export type TabsEventMap = HTMLElementEventMap & TabsCustomEventMap & {};
 
 /**
  * `<vaadin-tabs>` is a Web Component for organizing and grouping content into sections.
@@ -87,6 +87,7 @@ declare class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(HTML
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-tabs': Tabs;
   }

--- a/packages/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet.d.ts
@@ -20,13 +20,13 @@ export type TabSheetItemsChangedEvent = CustomEvent<{ value: Tab[] }>;
  */
 export type TabSheetSelectedChangedEvent = CustomEvent<{ value: number }>;
 
-export interface TabSheetCustomEventMap {
+export type TabSheetCustomEventMap = {
   'items-changed': TabSheetItemsChangedEvent;
 
   'selected-changed': TabSheetSelectedChangedEvent;
-}
+};
 
-export interface TabSheetEventMap extends HTMLElementEventMap, TabSheetCustomEventMap {}
+export type TabSheetEventMap = HTMLElementEventMap & TabSheetCustomEventMap & {};
 
 /**
  * `<vaadin-tabsheet>` is a Web Component for organizing and grouping content
@@ -99,6 +99,7 @@ declare class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(T
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-tabsheet': TabSheet;
   }

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -31,17 +31,18 @@ export type TextAreaValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type TextAreaValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface TextAreaCustomEventMap {
+export type TextAreaCustomEventMap = {
   'invalid-changed': TextAreaInvalidChangedEvent;
 
   'value-changed': TextAreaValueChangedEvent;
 
   validated: TextAreaValidatedEvent;
-}
+};
 
-export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEventMap {
-  change: TextAreaChangeEvent;
-}
+export type TextAreaEventMap = HTMLElementEventMap &
+  TextAreaCustomEventMap & {
+    change: TextAreaChangeEvent;
+  };
 
 /**
  * `<vaadin-text-area>` is a web component for multi-line text input.
@@ -110,6 +111,7 @@ declare class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(Themable
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-text-area': TextArea;
   }

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -30,17 +30,18 @@ export type TextFieldValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type TextFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface TextFieldCustomEventMap {
+export type TextFieldCustomEventMap = {
   'invalid-changed': TextFieldInvalidChangedEvent;
 
   'value-changed': TextFieldValueChangedEvent;
 
   validated: TextFieldValidatedEvent;
-}
+};
 
-export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomEventMap {
-  change: TextFieldChangeEvent;
-}
+export type TextFieldEventMap = HTMLElementEventMap &
+  TextFieldCustomEventMap & {
+    change: TextFieldChangeEvent;
+  };
 
 /**
  * `<vaadin-text-field>` is a web component that allows the user to input and edit text.
@@ -130,6 +131,7 @@ declare class TextField extends PatternMixin(InputFieldMixin(ThemableMixin(Eleme
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-text-field': TextField;
   }

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -8,17 +8,17 @@ import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js
 import { PatternMixin } from '@vaadin/field-base/src/pattern-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface TimePickerTime {
+export type TimePickerTime = {
   hours: number | string;
   minutes: number | string;
   seconds?: number | string;
   milliseconds?: number | string;
-}
+};
 
-export interface TimePickerI18n {
+export type TimePickerI18n = {
   parseTime(time: string): TimePickerTime | undefined;
   formatTime(time: TimePickerTime | undefined): string;
-}
+};
 
 /**
  * Fired when the user commits a value change.
@@ -47,7 +47,7 @@ export type TimePickerValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type TimePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-export interface TimePickerCustomEventMap {
+export type TimePickerCustomEventMap = {
   'invalid-changed': TimePickerInvalidChangedEvent;
 
   'opened-changed': TimePickerOpenedChangedEvent;
@@ -55,11 +55,12 @@ export interface TimePickerCustomEventMap {
   'value-changed': TimePickerValueChangedEvent;
 
   validated: TimePickerValidatedEvent;
-}
+};
 
-export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCustomEventMap {
-  change: TimePickerChangeEvent;
-}
+export type TimePickerEventMap = HTMLElementEventMap &
+  TimePickerCustomEventMap & {
+    change: TimePickerChangeEvent;
+  };
 
 /**
  * `<vaadin-time-picker>` is a Web Component providing a time-selection field.
@@ -233,6 +234,7 @@ declare class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(El
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-time-picker': TimePicker;
   }

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -164,6 +164,7 @@ declare class Tooltip extends ThemePropertyMixin(ElementMixin(HTMLElement)) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-tooltip': Tooltip;
   }

--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -6,7 +6,7 @@
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface UploadFile extends File {
+export type UploadFile = File & {
   uploadTarget: string;
   elapsed: number;
   elapsedStr: string;
@@ -22,9 +22,9 @@ export interface UploadFile extends File {
   abort?: boolean;
   complete?: boolean;
   uploading?: boolean;
-}
+};
 
-export interface UploadI18n {
+export type UploadI18n = {
   dropFiles: {
     one: string;
     many: string;
@@ -61,7 +61,7 @@ export interface UploadI18n {
   };
   formatSize?(bytes: number): string;
   formatTime?(seconds: number, units: number[]): string;
-}
+};
 
 export type UploadMethod = 'POST' | 'PUT';
 
@@ -139,7 +139,7 @@ export type UploadAbortEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFi
  */
 export type UploadRequestEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile; formData: FormData }>;
 
-export interface UploadCustomEventMap {
+export type UploadCustomEventMap = {
   'file-reject': UploadFileRejectEvent;
 
   'files-changed': UploadFilesChangedEvent;
@@ -163,9 +163,9 @@ export interface UploadCustomEventMap {
   'upload-abort': UploadAbortEvent;
 
   'upload-request': UploadRequestEvent;
-}
+};
 
-export interface UploadEventMap extends HTMLElementEventMap, UploadCustomEventMap {}
+export type UploadEventMap = HTMLElementEventMap & UploadCustomEventMap & {};
 
 /**
  * `<vaadin-upload>` is a Web Component for uploading multiple files with drag and drop support.
@@ -412,6 +412,7 @@ declare class Upload extends ThemableMixin(ElementMixin(HTMLElement)) {
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-upload': Upload;
   }

--- a/packages/vaadin-overlay/src/vaadin-overlay.d.ts
+++ b/packages/vaadin-overlay/src/vaadin-overlay.d.ts
@@ -42,14 +42,14 @@ export type OverlayOutsideClickEvent = CustomEvent<{ sourceEvent: MouseEvent }>;
  */
 export type OverlayEscapePressEvent = CustomEvent<{ sourceEvent: KeyboardEvent }>;
 
-export interface OverlayElementEventMap {
+export type OverlayElementEventMap = {
   'opened-changed': OverlayOpenedChangedEvent;
   'vaadin-overlay-open': OverlayOpenEvent;
   'vaadin-overlay-close': OverlayCloseEvent;
   'vaadin-overlay-closing': OverlayClosingEvent;
   'vaadin-overlay-outside-click': OverlayOutsideClickEvent;
   'vaadin-overlay-escape-press': OverlayEscapePressEvent;
-}
+};
 
 export type OverlayEventMap = HTMLElementEventMap & OverlayElementEventMap;
 
@@ -243,6 +243,7 @@ declare class OverlayElement extends ThemableMixin(DirMixin(ControllerMixin(HTML
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-overlay': OverlayElement;
   }

--- a/packages/vertical-layout/src/vaadin-vertical-layout.d.ts
+++ b/packages/vertical-layout/src/vaadin-vertical-layout.d.ts
@@ -29,6 +29,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 declare class VerticalLayout extends ThemableMixin(ElementMixin(HTMLElement)) {}
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-vertical-layout': VerticalLayout;
   }

--- a/packages/virtual-list/src/vaadin-virtual-list.d.ts
+++ b/packages/virtual-list/src/vaadin-virtual-list.d.ts
@@ -9,10 +9,10 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 
 export type VirtualListDefaultItem = any;
 
-export interface VirtualListItemModel<TItem> {
+export type VirtualListItemModel<TItem> = {
   index: number;
   item: TItem;
-}
+};
 
 export type VirtualListRenderer<TItem> = (
   root: HTMLElement,
@@ -93,6 +93,7 @@ declare class VirtualList<TItem = VirtualListDefaultItem> extends ElementMixin(
 }
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface HTMLElementTagNameMap {
     'vaadin-virtual-list': VirtualList;
   }

--- a/packages/virtual-list/test/typings/lit.types.ts
+++ b/packages/virtual-list/test/typings/lit.types.ts
@@ -4,9 +4,9 @@ import { virtualListRenderer } from '../../lit.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
-interface TestVirtualListItem {
+type TestVirtualListItem = {
   testProperty: string;
-}
+};
 
 assertType<
   (

--- a/packages/virtual-list/test/typings/virtual-list.types.ts
+++ b/packages/virtual-list/test/typings/virtual-list.types.ts
@@ -9,9 +9,9 @@ assertType<VirtualList>(genericVirtualList);
 
 genericVirtualList.items = [1, 2, 3];
 
-interface TestVirtualListItem {
+type TestVirtualListItem = {
   testProperty: string;
-}
+};
 
 const virtualList = genericVirtualList as VirtualList<TestVirtualListItem>;
 


### PR DESCRIPTION
## Description

The PR adds the following rules to the project's ESLint config:

- [x] @typescript-eslint/consistent-type-definitions

Part of https://github.com/vaadin/eslint-config-vaadin/issues/16

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
