### PR TITLE
fix: ensure variable item height virtualizer scrolls to top

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -349,6 +349,12 @@ export class IronListAdapter {
     }
 
     this.__previousScrollTop = this._scrollTop;
+
+    // If the first visible index is not 0 when scrolled to the top,
+    // add some scroll offset to enable the user to continue scrolling.
+    if (this._scrollTop === 0 && this.firstVisibleIndex !== 0) {
+      this._scrollTop = 1;
+    }
   }
 
   /** @private */

--- a/packages/component-base/test/virtualizer-variable-row-height.test.js
+++ b/packages/component-base/test/virtualizer-variable-row-height.test.js
@@ -1,0 +1,45 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { Virtualizer } from '../src/virtualizer.js';
+
+describe('virtualizer - variable row height', () => {
+  let virtualizer;
+  let scrollTarget;
+
+  beforeEach(() => {
+    scrollTarget = fixtureSync(`
+      <div style="height: 500px; width: 200px;">
+        <div></div>
+      </div>
+    `);
+    const scrollContainer = scrollTarget.firstElementChild;
+
+    virtualizer = new Virtualizer({
+      createElements: (count) => Array.from(Array(count)).map(() => document.createElement('div')),
+      updateElement: (el, index) => {
+        el.style.height = `${30 + index}px`;
+        el.textContent = `Item ${index}`;
+      },
+      scrollTarget,
+      scrollContainer,
+    });
+
+    virtualizer.size = 100;
+  });
+
+  it('should be able to scroll back to the top', async () => {
+    // Scroll down
+    scrollTarget.scrollTop = 1000;
+    await nextFrame();
+
+    //  Try scrolling back to the top until the first visible index is 0
+    let attempts = 100;
+    while (attempts > 0 && virtualizer.firstVisibleIndex !== 0) {
+      attempts -= 1;
+      scrollTarget.scrollTop = 0;
+      await nextFrame();
+    }
+
+    expect(virtualizer.firstVisibleIndex).to.equal(0);
+  });
+});


### PR DESCRIPTION
Fixes #4659 

The root problem is somewhere in the iron-list scrolling logic and the problem can be reproduced with `<iron-list>` alone:

https://user-images.githubusercontent.com/1222264/194555782-d0d76e27-6ea9-430b-9b0a-5d03a713b03b.mp4

Since we don't want to modify the iron-list core, it's better to work around the issue in the adapter instead.