### PR TITLE
fix: update content offset when navbar height changes

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -14,7 +14,7 @@ import { FocusTrapController } from '@vaadin/component-base/src/focus-trap-contr
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * @typedef {import('./vaadin-app-layout.js').AppLayoutI18n} AppLayoutI18n
+ * @typedef {import("./vaadin-app-layout.js").AppLayoutI18n} AppLayoutI18n
  */
 
 /**
@@ -303,7 +303,9 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
       <div part="navbar" id="navbarBottom" bottom hidden>
         <slot name="navbar-bottom"></slot>
       </div>
-      <div hidden><slot id="touchSlot" name="navbar touch-optimized"></slot></div>
+      <div hidden>
+        <slot id="touchSlot" name="navbar touch-optimized"></slot>
+      </div>
     `;
   }
 
@@ -450,6 +452,12 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     });
     this._updateDrawerSize();
     this._updateOverlayMode();
+
+    this._navbarSizeObserver = new ResizeObserver(() => {
+      this._updateOffsetSize();
+    });
+    this._navbarSizeObserver.observe(this.$.navbarTop);
+    this._navbarSizeObserver.observe(this.$.navbarBottom);
 
     window.addEventListener('close-overlay-drawer', this.__closeOverlayDrawerListener);
   }

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -454,6 +454,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     this._updateOverlayMode();
 
     this._navbarSizeObserver = new ResizeObserver(() => {
+      this._blockAnimationUntilAfterNextRender();
       this._updateOffsetSize();
     });
     this._navbarSizeObserver.observe(this.$.navbarTop);

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -14,7 +14,7 @@ import { FocusTrapController } from '@vaadin/component-base/src/focus-trap-contr
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * @typedef {import("./vaadin-app-layout.js").AppLayoutI18n} AppLayoutI18n
+ * @typedef {import('./vaadin-app-layout.js').AppLayoutI18n} AppLayoutI18n
  */
 
 /**

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -303,9 +303,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
       <div part="navbar" id="navbarBottom" bottom hidden>
         <slot name="navbar-bottom"></slot>
       </div>
-      <div hidden>
-        <slot id="touchSlot" name="navbar touch-optimized"></slot>
-      </div>
+      <div hidden><slot id="touchSlot" name="navbar touch-optimized"></slot></div>
     `;
   }
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -83,6 +83,22 @@ describe('vaadin-app-layout', () => {
         await aTimeout(0);
         expect(toggle.offsetHeight).to.be.greaterThan(0);
       });
+
+      it('should update content offset when navbar height changes', async () => {
+        // Add content to navbar and measure original offset
+        const navbarContent = document.createElement('div');
+        navbarContent.style.height = '50px';
+        navbarContent.setAttribute('slot', 'navbar');
+        layout.appendChild(navbarContent);
+        await nextFrame();
+        const initialOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-top'));
+        expect(initialOffset).to.be.greaterThan(0);
+        // Increase navbar content size and measure increase
+        navbarContent.style.height = '100px';
+        await nextFrame();
+        const updatedOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-top'));
+        expect(updatedOffset).to.equal(initialOffset + 50);
+      });
     });
 
     describe('touch-optimized', () => {
@@ -110,6 +126,22 @@ describe('vaadin-app-layout', () => {
         expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.true;
         window.dispatchEvent(new Event('resize'));
         expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.false;
+      });
+
+      it('should update content offset when navbar height changes', async () => {
+        // Add content to navbar and measure original offset
+        const navbarContent = document.createElement('div');
+        navbarContent.style.height = '50px';
+        navbarContent.setAttribute('slot', 'navbar touch-optimized');
+        layout.appendChild(navbarContent);
+        await nextFrame();
+        const initialOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-bottom'));
+        expect(initialOffset).to.be.greaterThan(0);
+        // Increase navbar content size and measure increase
+        navbarContent.style.height = '100px';
+        await nextFrame();
+        const updatedOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-bottom'));
+        expect(updatedOffset).to.equal(initialOffset + 50);
       });
     });
   });


### PR DESCRIPTION
## Description

Adds a resize observer to app layout to recalculate the content offset when the height of the navbar changes.

Fixes https://github.com/vaadin/flow-components/issues/3815

## Type of change

- Bugfix