### PR TITLE
fix: add missing hidden styles to message-input

### DIFF
--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -98,6 +98,10 @@ class MessageInput extends ElementMixin(ThemableMixin(ControllerMixin(PolymerEle
           overflow: hidden;
           flex-shrink: 0;
         }
+
+        :host([hidden]) {
+          display: none !important;
+        }
       </style>
       <vaadin-message-input-text-area
         disabled="[[disabled]]"

--- a/packages/message-input/test/message-input.test.js
+++ b/packages/message-input/test/message-input.test.js
@@ -28,6 +28,13 @@ describe('message-input', () => {
     });
   });
 
+  describe('hidden', () => {
+    it('should have display: none when hidden', () => {
+      messageInput.setAttribute('hidden', '');
+      expect(getComputedStyle(messageInput).display).to.equal('none');
+    });
+  });
+
   describe('submit functionality', () => {
     it('should fire a submit event on button click', () => {
       const spy = sinon.spy();


### PR DESCRIPTION
## Description

Added missing styles for `hidden` attribute to `vaadin-message-input`.

## Type of change

- Bugfix