### PR TITLE
fix: avoid triggering connected callback from disconnected callback

### DIFF
--- a/packages/component-base/test/dir-mixin.test.js
+++ b/packages/component-base/test/dir-mixin.test.js
@@ -221,6 +221,15 @@ const runTests = (baseClass) => {
       await Promise.resolve();
       expect(element.getAttribute('dir')).to.eql('ltr');
     });
+
+    it('should keep custom direction when disconnecting and reconnecting', async () => {
+      element.setAttribute('dir', 'ltr');
+      setDir('rtl');
+      await Promise.resolve();
+      // Disconnect + reconnect
+      document.body.appendChild(element);
+      expect(element.getAttribute('dir')).to.eql('ltr');
+    });
   });
 };
 


### PR DESCRIPTION
## Description

When moving an element that extends from `DirMixin` in the DOM, the `DirMixin.disconnectedCallback` can trigger the element's `connectedCallback` before the `disconnectedCallback` has finished (currently reproducable in Chrome, FF). That can cause elements to re-run their initialization logic before their cleanup logic is finished. For example in case of the `AppLayout`, this results in the `connectedCallback` adding several event listeners again, after which the remaining logic in `disconnectedCallback` removes them again, leaving the element in a state where the listeners are not registered. See https://github.com/vaadin/web-components/issues/4682#issuecomment-1273226985.

This change removes the `removeAttribute` call from `DirMixin.disconnectedCallback` that causes the premature reconnect, and instead introduces a flag that ensures that the element will subscribe to global dir changes again on reconnect. This also fixes a minor bug where the custom dir of an element was removed on disconnect (see test case).

Fixes: #4682

## Type of change

- Bugfix
