### PR TITLE
fix: close overflow avatar overlay on detach

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -298,6 +298,13 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement)
     });
   }
 
+  /** @protected */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    this._opened = false;
+  }
+
   /**
    * @return {!Array<!HTMLElement>}
    * @protected

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -1,5 +1,13 @@
 import { expect } from '@esm-bundle/chai';
-import { enterKeyDown, escKeyDown, fixtureSync, nextRender, spaceKeyDown, tabKeyDown } from '@vaadin/testing-helpers';
+import {
+  enterKeyDown,
+  escKeyDown,
+  fixtureSync,
+  nextRender,
+  oneEvent,
+  spaceKeyDown,
+  tabKeyDown,
+} from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-avatar-group.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
@@ -90,11 +98,9 @@ describe('avatar-group', () => {
       expect(overlay.textContent).to.equal([items[2].name, items[3].abbr, 'anonymous'].join('\n'));
     });
 
-    it('should show overlay on overflow avatar click', () => {
+    it('should show overflow avatar when maxItemsVisible is less than items count', () => {
       const overflow = group.$.overflow;
-      overflow.click();
       expect(overflow.hasAttribute('hidden')).to.be.false;
-      group.$.overlay.close();
     });
 
     it('should show at least two avatars if maxItemsVisible is below 2', async () => {
@@ -186,10 +192,6 @@ describe('avatar-group', () => {
       overflow = group.$.overflow;
     });
 
-    afterEach(() => {
-      overlay.close();
-    });
-
     it('should render avatars to fit width on resize', async () => {
       group.style.width = '110px';
       await onceResized(group);
@@ -273,16 +275,9 @@ describe('avatar-group', () => {
       overflow = group.$.overflow;
     });
 
-    afterEach(() => {
-      overlay.close();
-    });
-
-    it('should open overlay on overflow avatar click', (done) => {
-      overlay.addEventListener('vaadin-overlay-open', () => {
-        expect(overlay.opened).to.be.true;
-        done();
-      });
+    it('should open overlay on overflow avatar click', () => {
       overflow.click();
+      expect(overlay.opened).to.be.true;
     });
 
     it('should open overlay on overflow avatar Enter', () => {
@@ -293,6 +288,13 @@ describe('avatar-group', () => {
     it('should open overlay on overflow avatar Space', () => {
       spaceKeyDown(overflow);
       expect(overlay.opened).to.be.true;
+    });
+
+    it('should close overlay on avatar group detach', async () => {
+      overflow.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      group.remove();
+      expect(overlay.opened).to.be.false;
     });
 
     it('should render list-box with items in the overlay', (done) => {
@@ -531,10 +533,6 @@ describe('avatar-group', () => {
       await nextRender(group);
       overlay = group.$.overlay;
       overflow = group.$.overflow;
-    });
-
-    afterEach(() => {
-      overlay.close();
     });
 
     it('should set aria-expanded="false" on the overflow avatar', () => {

--- a/packages/avatar-group/test/visual/lumo/avatar-group.test.js
+++ b/packages/avatar-group/test/visual/lumo/avatar-group.test.js
@@ -73,7 +73,6 @@ describe('avatar-group', () => {
   it('avatar-size', async () => {
     element.items = [{ name: 'Abc Def' }, { name: 'Ghi Jkl' }, { name: 'Mno Pqr' }, { name: 'Stu Vwx' }];
     element.style.setProperty('--vaadin-avatar-size', '45px');
-    element.$.overflow.click();
     await visualDiff(div, 'avatar-size');
   });
 });

--- a/packages/avatar-group/test/visual/material/avatar-group.test.js
+++ b/packages/avatar-group/test/visual/material/avatar-group.test.js
@@ -73,7 +73,6 @@ describe('avatar-group', () => {
   it('avatar-size', async () => {
     element.items = [{ name: 'Abc Def' }, { name: 'Ghi Jkl' }, { name: 'Mno Pqr' }, { name: 'Stu Vwx' }];
     element.style.setProperty('--vaadin-avatar-size', '45px');
-    element.$.overflow.click();
     await visualDiff(div, 'avatar-size');
   });
 });


### PR DESCRIPTION
## Description

Currently, the `vaadin-avatar-group` does not have a logic to close the overlay on `disconnectedCallback()`.
This causes some problems in tests, like having to call `overlay.close()` manually in `afterEach()`.

Fixed this to align behavior with all the other components that use `vaadin-overlay` extensions internally.

## Type of change

- Bugfix