### PR TITLE
fix: add missing Lumo and Material dependencies

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -37,6 +37,8 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "23.3.0-alpha3",
+    "@vaadin/vaadin-lumo-styles": "23.3.0-alpha3",
+    "@vaadin/vaadin-material-styles": "23.3.0-alpha3",
     "@vaadin/vaadin-themable-mixin": "23.3.0-alpha3",
     "highcharts": "9.2.2"
   },


### PR DESCRIPTION
## Description

We missed to add Lumo and Material dependencies to `@vaadin/charts` when implementing themes. This PR fixes it.

## Type of change

- Bugfix

## Note

This issue was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve these imports.