### PR TITLE
refactor: use relative imports in component-base

### DIFF
--- a/packages/component-base/src/a11y-announcer.js
+++ b/packages/component-base/src/a11y-announcer.js
@@ -3,9 +3,8 @@
  * Copyright (c) 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-
-import { animationFrame } from '@vaadin/component-base/src/async.js';
-import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { animationFrame } from './async.js';
+import { Debouncer } from './debounce.js';
 
 const region = document.createElement('div');
 

--- a/packages/component-base/src/active-mixin.js
+++ b/packages/component-base/src/active-mixin.js
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { addListener } from '@vaadin/component-base/src/gestures.js';
 import { DisabledMixin } from './disabled-mixin.js';
+import { addListener } from './gestures.js';
 import { KeyboardMixin } from './keyboard-mixin.js';
 
 /**

--- a/packages/component-base/test/dir-mixin.test.js
+++ b/packages/component-base/test/dir-mixin.test.js
@@ -3,8 +3,8 @@ import { nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { LitElement } from 'lit';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DirMixin } from '../src/dir-mixin.js';
+import { PolylitMixin } from '../src/polylit-mixin.js';
 
 class DirMixinPolymerElement extends DirMixin(PolymerElement) {
   static get is() {


### PR DESCRIPTION
## Description

Changed some files in `@vaadin/component-base` package to use relative imports.

## Type of change

- Refactor

## Note

This issue was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve these imports.