### PR TITLE
chore: add missing Lit dev dependency for tests

### DIFF
--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -52,6 +52,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/polymer-legacy-adapter": "23.3.0-alpha3",
     "@vaadin/testing-helpers": "^0.3.2",
+    "lit": "^2.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -51,6 +51,7 @@
     "@vaadin/polymer-legacy-adapter": "23.3.0-alpha3",
     "@vaadin/testing-helpers": "^0.3.2",
     "@vaadin/text-area": "23.3.0-alpha3",
+    "lit": "^2.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.3.2",
+    "lit": "^2.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [


### PR DESCRIPTION
## Description

Added `lit` dev dependency which was missing from some packages that use it for renderer directives tests.

## Type of change

- Internal change

## Note

This issue was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve these imports.