### PR TITLE
chore: add imported packages to direct dependencies

### DIFF
--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -36,9 +36,11 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/button": "23.3.0-alpha3",
+    "@vaadin/component-base": "23.3.0-alpha3",
     "@vaadin/text-field": "23.3.0-alpha3",
     "@vaadin/vaadin-lumo-styles": "23.3.0-alpha3",
-    "@vaadin/vaadin-material-styles": "23.3.0-alpha3"
+    "@vaadin/vaadin-material-styles": "23.3.0-alpha3",
+    "@vaadin/vaadin-themable-mixin": "23.3.0-alpha3"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",


### PR DESCRIPTION
## Description

Currently, `@vaadin/password-field` package imports some transitive dependencies coming from `@vaadin/text-field`.
This PR adds `@vaadin/component-base` and `@vaadin/vaadin-themable-mixin` as direct dependencies.

## Type of change

- Internal change

## Note

This issue was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve these imports.