### PR TITLE
fix: add missing Lumo and Material dependencies (#4728) (CP: 23.1)

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -37,6 +37,8 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "~23.1.9",
     "@vaadin/vaadin-license-checker": "^2.1.0",
+    "@vaadin/vaadin-lumo-styles": "~23.1.9",
+    "@vaadin/vaadin-material-styles": "~23.1.9",
     "@vaadin/vaadin-themable-mixin": "~23.1.9",
     "highcharts": "9.2.2"
   },


### PR DESCRIPTION
## Description

Manual cherry-pick of #4728 to `23.1` branch.

## Type of change

- Cherry-pick