### PR TITLE
fix: add missing Lumo and Material dependencies (#4728) (CP: 23.2)

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -38,6 +38,8 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "~23.2.4",
+    "@vaadin/vaadin-lumo-styles": "~23.2.4",
+    "@vaadin/vaadin-material-styles": "~23.2.4",
     "@vaadin/vaadin-themable-mixin": "~23.2.4",
     "highcharts": "9.2.2"
   },


### PR DESCRIPTION
## Description

Manual cherry-pick of #4728 to `23.2` branch.

## Type of change

- Cherry-pick