### PR TITLE
chore: fix components dev dependencies used in tests

### DIFF
--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/checkbox": "23.3.0-alpha3",
+    "@vaadin/checkbox-group": "23.3.0-alpha3",
     "@vaadin/combo-box": "23.3.0-alpha3",
     "@vaadin/date-picker": "23.3.0-alpha3",
     "@vaadin/date-time-picker": "23.3.0-alpha3",

--- a/packages/field-highlighter/test/field-highlighter.test.js
+++ b/packages/field-highlighter/test/field-highlighter.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/vaadin-text-field/vaadin-text-field.js';
+import '@vaadin/text-field';
 import { FieldHighlighter } from '../src/vaadin-field-highlighter.js';
 
 async function waitForIntersectionObserver() {


### PR DESCRIPTION
## Description

- Added missing `@vaadin/checkbox-group` dependency imported in `field-components.test.js`
- Fixed import of `vaadin-text-field` to use non-prefixed version in `field-highlighter.test.js`

## Type of change

- Internal change

## Note

This issue was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve these imports.