### PR TITLE
refactor: use relative import in menu-overlay mixin

### DIFF
--- a/packages/vaadin-material-styles/mixins/menu-overlay.js
+++ b/packages/vaadin-material-styles/mixins/menu-overlay.js
@@ -4,9 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '../color.js';
-import './overlay.js';
-import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { overlay } from './overlay.js';
 
 const menuOverlay = overlay;
 


### PR DESCRIPTION
## Description

Changed one file in `@vaadin/vaadin-material-styles` package to use relative import.

## Type of change

- Refactor

## Note

This was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve this import.