### PR TITLE
chore: add missing icon dev dependency used in tests

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/icon": "23.3.0-alpha3",
     "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^13.0.2"
   },


### PR DESCRIPTION
## Description

Added missing `@vaadin/icon` dev dependency imported in `vaadin-button` visual tests.

## Type of change

- Internal change

## Note

This was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve imports for icon.