### PR TITLE
chore: add missing dev dependencies used in tests

### DIFF
--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -41,7 +41,9 @@
     "lit": "^2.0.0"
   },
   "devDependencies": {
-    "@vaadin/testing-helpers": "^0.3.2"
+    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/testing-helpers": "^0.3.2",
+    "sinon": "^13.0.2"
   },
   "web-types": [
     "web-types.json",

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -41,6 +41,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/icon": "23.3.0-alpha3",
     "@vaadin/icons": "23.3.0-alpha3",
-    "@vaadin/testing-helpers": "^0.3.2"
+    "@vaadin/testing-helpers": "^0.3.2",
+    "sinon": "^13.0.2"
   }
 }

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -31,5 +31,10 @@
   ],
   "dependencies": {
     "lit": "^2.0.0"
+  },
+  "devDependencies": {
+    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/testing-helpers": "^0.3.2",
+    "sinon": "^13.0.2"
   }
 }


### PR DESCRIPTION
## Description

Added missing dev dependencies used in tests, like `@esm-bundle/chai` and `sinon`.

## Type of change

- Internal change

## Note

This issue was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve these imports.