### PR TITLE
chore: add component-base dependency used in tests

### DIFF
--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -35,6 +35,7 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
+    "@vaadin/component-base": "23.3.0-alpha3",
     "@vaadin/number-field": "23.3.0-alpha3",
     "@vaadin/vaadin-lumo-styles": "23.3.0-alpha3",
     "@vaadin/vaadin-material-styles": "23.3.0-alpha3"


### PR DESCRIPTION
## Description

Added `@vaadin/component-base` dependency to `integer-field` package, as it's used in snapshot tests:

https://github.com/vaadin/web-components/blob/042668ce33a21ebf5cefd3a630b6095ea3a12a66/packages/integer-field/test/dom/integer-field.test.js#L4

This is aligned with `email-field` package that also imports corresponding dependency only in snapshot tests.

## Type of change

- Internal change

## Note

This was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve this dependency.