### PR TITLE
chore: add missing dependency to integration tests

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -10,6 +10,7 @@
     "@vaadin/accordion": "23.3.0-alpha3",
     "@vaadin/button": "23.3.0-alpha3",
     "@vaadin/checkbox": "23.3.0-alpha3",
+    "@vaadin/checkbox-group": "23.3.0-alpha3",
     "@vaadin/combo-box": "23.3.0-alpha3",
     "@vaadin/custom-field": "23.3.0-alpha3",
     "@vaadin/date-picker": "23.3.0-alpha3",


### PR DESCRIPTION
## Description

Added missing `@vaadin/checkbox-group` dependency to `integration-tests` package, as it's used in tooltip tests.

## Type of change

- Internal change

## Note

This was discovered when trying to use `pnpm` instead of `yarn` as it fails to resolve this dependency.