### PR TITLE
chore: fix dev dependency version after rebasing

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/icon": "23.3.0-alpha3",
+    "@vaadin/icon": "24.0.0-alpha0",
     "@vaadin/testing-helpers": "^0.3.2",
     "sinon": "^13.0.2"
   },


### PR DESCRIPTION
## Description

Missed to update this version while rebasing `24.0` branch. This PR fixes that. 

## Type of change

- Internal change