### PR TITLE
refactor!: remove no longer used i18n.calendar string

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -23,7 +23,6 @@ export interface DatePickerI18n {
   weekdaysShort: string[];
   firstDayOfWeek: number;
   week: string;
-  calendar: string;
   today: string;
   cancel: string;
   parseDate(date: string): DatePickerDate | undefined;
@@ -124,9 +123,6 @@ export declare class DatePickerMixinClass {
    *   // Used in screen reader announcements along with week
    *   // numbers, if they are displayed.
    *   week: 'Week',
-   *
-   *   // Translation of the Calendar icon button title.
-   *   calendar: 'Calendar',
    *
    *   // Translation of the Today shortcut button text.
    *   today: 'Today',

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -149,9 +149,6 @@ export const DatePickerMixin = (subclass) =>
          *   // numbers, if they are displayed.
          *   week: 'Week',
          *
-         *   // Translation of the Calendar icon button title.
-         *   calendar: 'Calendar',
-         *
          *   // Translation of the Today shortcut button text.
          *   today: 'Today',
          *
@@ -208,7 +205,6 @@ export const DatePickerMixin = (subclass) =>
               weekdaysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
               firstDayOfWeek: 0,
               week: 'Week',
-              calendar: 'Calendar',
               today: 'Today',
               cancel: 'Cancel',
               formatDate: (d) => {

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -35,7 +35,6 @@ export function getDefaultI18n() {
     weekdaysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     firstDayOfWeek: 0,
     week: 'Week',
-    calendar: 'Calendar',
     today: 'Today',
     cancel: 'Cancel',
     formatDate(d) {


### PR DESCRIPTION
## Description

Removed `i18n.calendar` which is no longer used since re-implementing keyboard navigation in https://github.com/vaadin/web-components/pull/3372.
Corresponding Flow counterpart API is already deprecated in https://github.com/vaadin/flow-components/pull/2689

## Type of change

- Breaking change