### PR TITLE
refactor: small code style tweaks, add missing JSDoc

### DIFF
--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -89,6 +89,7 @@ class InfiniteScroller extends PolymerElement {
       /**
        * The amount of initial scroll top. Needed in order for the
        * user to be able to scroll backwards.
+       * @private
        */
       _initialScroll: {
         value: 500000,
@@ -96,17 +97,22 @@ class InfiniteScroller extends PolymerElement {
 
       /**
        * The index/position mapped at _initialScroll point.
+       * @private
        */
       _initialIndex: {
         value: 0,
       },
 
+      /** @private */
       _buffers: Array,
 
+      /** @private */
       _preventScrollEvent: Boolean,
 
+      /** @private */
       _mayHaveMomentum: Boolean,
 
+      /** @private */
       _initialized: Boolean,
 
       active: {
@@ -116,6 +122,7 @@ class InfiniteScroller extends PolymerElement {
     };
   }
 
+  /** @protected */
   ready() {
     super.ready();
 
@@ -155,6 +162,7 @@ class InfiniteScroller extends PolymerElement {
     }
   }
 
+  /** @private */
   _activated(active) {
     if (active && !this._initialized) {
       this._createPool();
@@ -162,6 +170,7 @@ class InfiniteScroller extends PolymerElement {
     }
   }
 
+  /** @private */
   _finishInit() {
     if (!this._initDone) {
       // Once the first set of items start fading in, stamp the rest
@@ -179,6 +188,7 @@ class InfiniteScroller extends PolymerElement {
     }
   }
 
+  /** @private */
   _translateBuffer(up) {
     const index = up ? 1 : 0;
     this._buffers[index].translateY = this._buffers[index ? 0 : 1].translateY + this._bufferHeight * (index ? -1 : 1);
@@ -187,6 +197,7 @@ class InfiniteScroller extends PolymerElement {
     this._buffers.reverse();
   }
 
+  /** @private */
   _scroll() {
     if (this._scrollDisabled) {
       return;
@@ -283,10 +294,12 @@ class InfiniteScroller extends PolymerElement {
     return this._itemHeightVal;
   }
 
+  /** @private */
   get _bufferHeight() {
     return this.itemHeight * this.bufferSize;
   }
 
+  /** @private */
   _reset() {
     this._scrollDisabled = true;
     this.$.scroller.scrollTop = this._initialScroll;
@@ -306,6 +319,7 @@ class InfiniteScroller extends PolymerElement {
     this._scrollDisabled = false;
   }
 
+  /** @private */
   _createPool() {
     const container = this.getBoundingClientRect();
     this._buffers.forEach((buffer) => {
@@ -339,6 +353,7 @@ class InfiniteScroller extends PolymerElement {
     }, 1);
   }
 
+  /** @private */
   _ensureStampedInstance(itemWrapper) {
     if (itemWrapper.firstElementChild) {
       return;
@@ -354,6 +369,7 @@ class InfiniteScroller extends PolymerElement {
     });
   }
 
+  /** @private */
   _updateClones(viewPortOnly) {
     this._firstIndex = ~~((this._buffers[0].translateY - this._initialScroll) / this.itemHeight) + this._initialIndex;
 
@@ -373,6 +389,7 @@ class InfiniteScroller extends PolymerElement {
     });
   }
 
+  /** @private */
   _isVisible(element, container) {
     const rect = element.getBoundingClientRect();
     return rect.bottom > container.top && rect.top < container.bottom;

--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -119,7 +119,7 @@ class InfiniteScroller extends PolymerElement {
   ready() {
     super.ready();
 
-    this._buffers = Array.prototype.slice.call(this.root.querySelectorAll('.buffer'));
+    this._buffers = [...this.shadowRoot.querySelectorAll('.buffer')];
 
     this.$.fullHeight.style.height = `${this._initialScroll * 2}px`;
 
@@ -128,8 +128,8 @@ class InfiniteScroller extends PolymerElement {
       forwardHostProp(prop, value) {
         if (prop !== 'index') {
           this._buffers.forEach((buffer) => {
-            [].forEach.call(buffer.children, (insertionPoint) => {
-              insertionPoint._itemWrapper.instance[prop] = value;
+            [...buffer.children].forEach((slot) => {
+              slot._itemWrapper.instance[prop] = value;
             });
           });
         }
@@ -166,7 +166,9 @@ class InfiniteScroller extends PolymerElement {
     if (!this._initDone) {
       // Once the first set of items start fading in, stamp the rest
       this._buffers.forEach((buffer) => {
-        [].forEach.call(buffer.children, (insertionPoint) => this._ensureStampedInstance(insertionPoint._itemWrapper));
+        [...buffer.children].forEach((slot) => {
+          this._ensureStampedInstance(slot._itemWrapper);
+        });
       });
 
       if (!this._buffers[0].translateY) {
@@ -315,10 +317,10 @@ class InfiniteScroller extends PolymerElement {
         const contentId = (InfiniteScroller._contentIndex = InfiniteScroller._contentIndex + 1 || 0);
         const slotName = `vaadin-infinite-scroller-item-content-${contentId}`;
 
-        const insertionPoint = document.createElement('slot');
-        insertionPoint.setAttribute('name', slotName);
-        insertionPoint._itemWrapper = itemWrapper;
-        buffer.appendChild(insertionPoint);
+        const slot = document.createElement('slot');
+        slot.setAttribute('name', slotName);
+        slot._itemWrapper = itemWrapper;
+        buffer.appendChild(slot);
 
         itemWrapper.setAttribute('slot', slotName);
         this.appendChild(itemWrapper);
@@ -360,8 +362,8 @@ class InfiniteScroller extends PolymerElement {
       if (!buffer.updated) {
         const firstIndex = this._firstIndex + this.bufferSize * bufferIndex;
 
-        [].forEach.call(buffer.children, (insertionPoint, index) => {
-          const itemWrapper = insertionPoint._itemWrapper;
+        [...buffer.children].forEach((slot, index) => {
+          const itemWrapper = slot._itemWrapper;
           if (!viewPortOnly || this._isVisible(itemWrapper, scrollerRect)) {
             itemWrapper.instance.index = firstIndex + index;
           }

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -310,7 +310,7 @@ describe('basic features', () => {
 
     it('should reflect value in overlay header', () => {
       datepicker.value = '2000-02-01';
-      expect(overlayContent.root.querySelector('[part="label"]').textContent.trim()).to.equal('1.2.2000');
+      expect(overlayContent.shadowRoot.querySelector('[part="label"]').textContent.trim()).to.equal('1.2.2000');
     });
 
     it('should display buttons in correct locale', () => {

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -103,8 +103,8 @@ export function getFirstVisibleItem(scroller, bufferOffset) {
   bufferOffset = bufferOffset || 0;
 
   scroller._buffers.forEach((buffer) => {
-    [].forEach.call(buffer.children, (insertionPoint) => {
-      children.push(insertionPoint._itemWrapper);
+    [...buffer.children].forEach((slot) => {
+      children.push(slot._itemWrapper);
     });
   });
   const scrollerRect = scroller.getBoundingClientRect();

--- a/packages/date-picker/test/overlay.test.js
+++ b/packages/date-picker/test/overlay.test.js
@@ -56,8 +56,8 @@ describe('overlay', () => {
       const yearScroller = overlay.$.yearScroller;
 
       yearScroller._buffers.forEach((buffer) => {
-        Array.from(buffer.children).forEach((insertionPoint) => {
-          const year = insertionPoint._itemWrapper.firstElementChild;
+        [...buffer.children].forEach((slot) => {
+          const year = slot._itemWrapper.firstElementChild;
           const isCurrent = year.textContent.indexOf(new Date().getFullYear()) > -1;
           expect(year.hasAttribute('current')).to.equal(isCurrent);
         });
@@ -69,8 +69,8 @@ describe('overlay', () => {
       overlay.selectedDate = new Date();
 
       yearScroller._buffers.forEach((buffer) => {
-        Array.from(buffer.children).forEach((insertionPoint) => {
-          const year = insertionPoint._itemWrapper.firstElementChild;
+        [...buffer.children].forEach((slot) => {
+          const year = slot._itemWrapper.firstElementChild;
           const isCurrent = year.textContent.indexOf(new Date().getFullYear()) > -1;
           expect(year.hasAttribute('selected')).to.equal(isCurrent);
         });

--- a/packages/date-picker/test/overlay.test.js
+++ b/packages/date-picker/test/overlay.test.js
@@ -152,7 +152,7 @@ describe('overlay', () => {
       it('should reflect value in label', () => {
         overlay.i18n.formatDate = (date) => `${date.month + 1}/${date.day}/${date.year}`;
         overlay.selectedDate = new Date(2000, 1, 1);
-        expect(overlay.root.querySelector('[part="label"]').textContent.trim()).to.equal('2/1/2000');
+        expect(overlay.shadowRoot.querySelector('[part="label"]').textContent.trim()).to.equal('2/1/2000');
       });
 
       it('should not show clear button if not value is set', () => {
@@ -311,7 +311,7 @@ describe('overlay', () => {
       const date = new Date(2000, 1, 1);
       overlay.scrollToDate(date);
       await nextRender();
-      expect(parseInt(overlay.root.querySelector('[part="years-toggle-button"]').textContent)).to.equal(2000);
+      expect(parseInt(overlay.shadowRoot.querySelector('[part="years-toggle-button"]').textContent)).to.equal(2000);
     });
 
     it('should scroll to the given date', async () => {

--- a/packages/date-picker/test/scroller.test.js
+++ b/packages/date-picker/test/scroller.test.js
@@ -112,8 +112,8 @@ describe('vaadin-infinite-scroller', () => {
 
   it('should have an instance stamped to every wrapper', () => {
     scroller._buffers.forEach((buffer) => {
-      Array.from(buffer.children).forEach((insertionPoint) => {
-        expect(insertionPoint._itemWrapper.firstElementChild).to.be.ok;
+      [...buffer.children].forEach((slot) => {
+        expect(slot._itemWrapper.firstElementChild).to.be.ok;
       });
     });
   });

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -171,7 +171,7 @@ registerStyles(
       color: var(--lumo-primary-contrast-color);
     }
 
-    /* TODO magic number (same as used for iron-media-query in vaadin-date-picker-overlay-content) */
+    /* TODO magic number (same as used for media-query in vaadin-date-picker-overlay-content) */
     @media screen and (max-width: 374px) {
       :host {
         background-image: none;


### PR DESCRIPTION
## Description

Some small updates to date-picker and infinite-scroller extracted from #4770:

1. Replaced ES5 leftovers `[].forEach.call` and `Array.prototype.slice.call` with array spread,
2. Replaced legacy Polymer-specific `root` property coming from [Polymer 1](https://polymer-library.polymer-project.org/1.0/docs/devguide/local-dom#dom-api) era with `shadowRoot`,
3. Changed wording to use `slot` instead of `insertionPoint` (which was a [Polymer 1](https://polymer-library.polymer-project.org/1.0/docs/devguide/local-dom#dom-distribution) equivalent),
4. Removed mention of `iron-media-query` from CSS comment (we now use a [different approach](https://github.com/vaadin/web-components/pull/3434)),
5. Added missing JSDoc annotations to all `vaadin-infinite-scroller` properties and methods.

## Type of change

- Refactor