### PR TITLE
fix: add support for setting custom role attribute

### DIFF
--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -236,7 +236,11 @@ class Avatar extends FocusMixin(ElementMixin(ThemableMixin(ControllerMixin(Polym
 
     this.__updateVisibility();
 
-    this.setAttribute('role', 'button');
+    // By default, if the user hasn't provided a custom role,
+    // the role attribute is set to "button".
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'button');
+    }
 
     if (!this.hasAttribute('tabindex')) {
       this.setAttribute('tabindex', '0');

--- a/packages/avatar/test/avatar.test.js
+++ b/packages/avatar/test/avatar.test.js
@@ -342,5 +342,10 @@ describe('vaadin-avatar', () => {
       const abbrElement = avatar.shadowRoot.querySelector('#avatar-abbr');
       expect(abbrElement.getAttribute('aria-hidden')).to.equal('true');
     });
+
+    it('should not override custom role set on the avatar', () => {
+      const custom = fixtureSync('<vaadin-avatar role="image"></vaadin-avatar>');
+      expect(custom.getAttribute('role')).to.equal('image');
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #4782

Updated `vaadin-avatar` to use the same logic for `role` attribute as in `vaadin-button`.

## Type of change

- Bugfix