### PR TITLE
test: reorganize and cleanup date-picker tests

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -1,33 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import {
-  aTimeout,
-  click,
-  fixtureSync,
-  keyboardEventFor,
-  makeSoloTouchEvent,
-  oneEvent,
-  tap,
-} from '@vaadin/testing-helpers';
+import { aTimeout, click, fixtureSync, keyboardEventFor, oneEvent, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import * as settings from '@polymer/polymer/lib/utils/settings.js';
-import { close, getFocusedCell, getOverlayContent, idleCallback, open } from './common.js';
-
-settings.setCancelSyntheticClickEvents(false);
-
-function touchTap(target) {
-  const start = makeSoloTouchEvent('touchstart', null, target);
-  const end = makeSoloTouchEvent('touchend', null, target);
-  if (!start.defaultPrevented && !end.defaultPrevented) {
-    target.click();
-    target.focus();
-  }
-}
-
-function isFocused(target) {
-  return target.getRootNode().activeElement === target;
-}
+import { close, getOverlayContent, open, touchTap } from './common.js';
 
 describe('basic features', () => {
   let datepicker, input;
@@ -98,7 +74,7 @@ describe('basic features', () => {
 
   it('should focus the input on touch tap', () => {
     touchTap(input);
-    expect(isFocused(input)).to.be.true;
+    expect(document.activeElement).to.equal(input);
   });
 
   it('should open on input container element click', () => {
@@ -147,77 +123,6 @@ describe('basic features', () => {
 
     datepicker.open();
     expect(datepicker.clientWidth).to.equal(width);
-  });
-
-  describe('fullscreen', () => {
-    beforeEach(() => {
-      datepicker._fullscreen = true;
-    });
-
-    it('should blur when focused', () => {
-      const spy = sinon.spy(input, 'blur');
-      input.dispatchEvent(new CustomEvent('focus'));
-
-      expect(spy.called).to.be.true;
-    });
-
-    it('should blur the input', () => {
-      datepicker.focus();
-      expect(isFocused(input)).to.be.false;
-    });
-
-    it('should not focus the input on touch tap', () => {
-      touchTap(input);
-      expect(isFocused(input)).to.be.false;
-    });
-
-    it('should set focused attribute when focused', async () => {
-      datepicker.focus();
-      await open(datepicker);
-      expect(datepicker.hasAttribute('focused')).to.be.true;
-    });
-
-    it('should close the dropdown on Today button Esc', async () => {
-      await open(datepicker);
-
-      getOverlayContent(datepicker)._todayButton.focus();
-      await sendKeys({ press: 'Escape' });
-
-      expect(datepicker.opened).to.be.false;
-    });
-
-    it('should close the dropdown on Cancel button Esc', async () => {
-      await open(datepicker);
-
-      getOverlayContent(datepicker).focusCancel();
-      await sendKeys({ press: 'Escape' });
-
-      expect(datepicker.opened).to.be.false;
-    });
-
-    it('should remove focused attribute when closed and not focused', async () => {
-      await open(datepicker);
-
-      getOverlayContent(datepicker)._todayButton.focus();
-      await sendKeys({ press: 'Escape' });
-
-      expect(datepicker.hasAttribute('focused')).to.be.false;
-    });
-
-    it('should blur when datepicker is opened', async () => {
-      const spy = sinon.spy(input, 'blur');
-      await open(datepicker);
-      expect(spy.called).to.be.true;
-    });
-
-    it('should focus date element when opened', async () => {
-      await open(datepicker);
-      await idleCallback();
-      const content = getOverlayContent(datepicker);
-      const cell = getFocusedCell(content);
-      expect(cell).to.be.instanceOf(HTMLTableCellElement);
-      expect(cell.hasAttribute('today')).to.be.true;
-    });
   });
 
   describe('value property formats', () => {
@@ -480,20 +385,13 @@ describe('auto open disabled', () => {
 
   it('should focus the input on touch tap', () => {
     touchTap(input);
-    expect(isFocused(input)).to.be.true;
+    expect(document.activeElement).to.equal(input);
   });
 
   it('should not blur the input on open', async () => {
     touchTap(input);
     await open(datepicker);
-    expect(isFocused(input)).to.be.true;
-  });
-
-  it('should blur the input on fullscreen open', async () => {
-    datepicker._fullscreen = true;
-    touchTap(input);
-    await open(datepicker);
-    expect(isFocused(input)).to.be.false;
+    expect(document.activeElement).to.equal(input);
   });
 
   it('should not open on input tap', () => {
@@ -501,13 +399,7 @@ describe('auto open disabled', () => {
     expect(datepicker.opened).not.to.be.true;
   });
 
-  it('should not open on input tap on fullscreen', () => {
-    datepicker._fullscreen = true;
-    tap(input);
-    expect(datepicker.opened).not.to.be.true;
-  });
-
-  it('should open by tapping the calendar icon even if autoOpenDisabled is true', async () => {
+  it('should open on calendar icon tap', async () => {
     tap(toggleButton);
     await oneEvent(datepicker.$.overlay, 'vaadin-overlay-open');
   });
@@ -524,55 +416,34 @@ describe('ios', () => {
 
   it('should focus the input when closed', () => {
     datepicker.focus();
-    expect(isFocused(input)).to.be.true;
+    expect(document.activeElement).to.equal(input);
   });
 
   it('should blur the input when opened', async () => {
     datepicker.focus();
     await open(datepicker);
-    expect(isFocused(input)).to.be.false;
+    expect(document.activeElement).to.not.equal(input);
   });
 
   describe('auto open disabled', () => {
-    let toggleButton;
-
     beforeEach(() => {
       datepicker.autoOpenDisabled = true;
-      toggleButton = datepicker.shadowRoot.querySelector('[part="toggle-button"]');
     });
 
     it('should focus the input on touch tap', () => {
       touchTap(input);
-      expect(isFocused(input)).to.be.true;
+      expect(document.activeElement).to.equal(input);
     });
 
     it('should blur the input on open', async () => {
       touchTap(input);
       await open(datepicker);
-      expect(isFocused(input)).to.be.false;
-    });
-
-    it('should blur the input on fullscreen open', async () => {
-      datepicker._fullscreen = true;
-      touchTap(input);
-      await open(datepicker);
-      expect(isFocused(input)).to.be.false;
+      expect(document.activeElement).to.not.equal(input);
     });
 
     it('should not open on input tap', () => {
       tap(input);
       expect(datepicker.opened).not.to.be.true;
-    });
-
-    it('should not open on input tap on fullscreen', () => {
-      datepicker._fullscreen = true;
-      tap(input);
-      expect(datepicker.opened).not.to.be.true;
-    });
-
-    it('should open by tapping the calendar icon even if autoOpenDisabled is true', async () => {
-      tap(toggleButton);
-      await oneEvent(datepicker.$.overlay, 'vaadin-overlay-open');
     });
   });
 });

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -1,4 +1,4 @@
-import { aTimeout, fire, listenOnce, mousedown, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fire, listenOnce, makeSoloTouchEvent, mousedown, nextRender } from '@vaadin/testing-helpers';
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
@@ -92,6 +92,18 @@ export function outsideClick() {
   document.body.tabIndex = -1;
   // Outside click
   document.body.click();
+}
+
+/**
+ * Emulates a touch on the target resulting in clicking and focusing it.
+ */
+export function touchTap(target) {
+  const start = makeSoloTouchEvent('touchstart', null, target);
+  const end = makeSoloTouchEvent('touchend', null, target);
+  if (!start.defaultPrevented && !end.defaultPrevented) {
+    target.click();
+    target.focus();
+  }
 }
 
 export function monthsEqual(date1, date2) {

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -3,7 +3,7 @@ import { aTimeout, fixtureSync, mousedown, nextRender, oneEvent, touchstart } fr
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import { getFocusedCell, getOverlayContent, isFullscreen, monthsEqual, open, outsideClick } from './common.js';
+import { getFocusedCell, getOverlayContent, monthsEqual, open, outsideClick } from './common.js';
 
 describe('dropdown', () => {
   let datepicker, input, overlay;
@@ -277,29 +277,6 @@ describe('dropdown', () => {
       datepicker.close();
       await sendKeys({ press: 'Tab' });
       expect(input.inputMode).to.equal('');
-    });
-  });
-
-  describe('sizing', () => {
-    beforeEach(() => {
-      const viewport = document.createElement('meta');
-      viewport.setAttribute('name', 'viewport');
-      viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0');
-      document.getElementsByTagName('head')[0].appendChild(viewport);
-      datepicker._fullscreenMediaQuery = 'max-width: 520px';
-    });
-
-    it('should select fullscreen/desktop mode', (done) => {
-      setTimeout(() => {
-        datepicker.open();
-        datepicker.$.overlay.addEventListener('vaadin-overlay-open', () => {
-          const viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-          const fullscreen = viewportWidth < 520;
-
-          expect(isFullscreen(datepicker)).to.equal(fullscreen);
-          done();
-        });
-      });
     });
   });
 });

--- a/packages/date-picker/test/fullscreen.test.js
+++ b/packages/date-picker/test/fullscreen.test.js
@@ -1,0 +1,145 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, tap } from '@vaadin/testing-helpers';
+import { sendKeys, setViewport } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import '../src/vaadin-date-picker.js';
+import { getFocusedCell, getOverlayContent, open, touchTap, waitForOverlayRender } from './common.js';
+
+describe('fullscreen mode', () => {
+  let datepicker, input, overlay, width, height;
+
+  before(() => {
+    width = window.innerWidth;
+    height = window.innerHeight;
+  });
+
+  beforeEach(async () => {
+    await setViewport({ width: 420, height });
+    datepicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+    input = datepicker.inputElement;
+    overlay = datepicker.$.overlay;
+  });
+
+  afterEach(async () => {
+    await setViewport({ width, height });
+  });
+
+  describe('overlay attribute', () => {
+    it('should set fullscreen attribute on the overlay when a viewport is small', async () => {
+      await open(datepicker);
+      expect(overlay.hasAttribute('fullscreen')).to.be.true;
+    });
+
+    it('should remove fullscreen mode from the the overlay after resizing viewport', async () => {
+      await setViewport({ width: 500, height });
+      await open(datepicker);
+      expect(overlay.hasAttribute('fullscreen')).to.be.false;
+    });
+  });
+
+  describe('focus', () => {
+    describe('default', () => {
+      it('should open overlay on input tap', async () => {
+        tap(input);
+        await waitForOverlayRender();
+        expect(datepicker.opened).to.be.true;
+      });
+
+      it('should not focus the input on touch tap', async () => {
+        touchTap(input);
+        await waitForOverlayRender();
+        expect(document.activeElement).to.not.equal(input);
+      });
+
+      it('should blur input element when focusing it', () => {
+        const spy = sinon.spy(input, 'blur');
+        input.focus();
+        expect(spy.called).to.be.true;
+        expect(document.activeElement).to.not.equal(input);
+      });
+
+      it('should blur input element when opening overlay', async () => {
+        const spy = sinon.spy(input, 'blur');
+        await open(datepicker);
+        expect(spy.called).to.be.true;
+      });
+
+      it('should focus date element when opening overlay', async () => {
+        await open(datepicker);
+        const content = getOverlayContent(datepicker);
+        const cell = getFocusedCell(content);
+        expect(cell).to.be.instanceOf(HTMLTableCellElement);
+        expect(cell.hasAttribute('today')).to.be.true;
+      });
+    });
+
+    describe('auto open disabled', () => {
+      beforeEach(() => {
+        datepicker.autoOpenDisabled = true;
+      });
+
+      it('should not open overlay on input tap', () => {
+        tap(input);
+        expect(datepicker.opened).not.to.be.true;
+      });
+
+      it('should focus the input on touch tap', () => {
+        touchTap(input);
+        expect(document.activeElement).to.equal(input);
+      });
+
+      it('should not blur input element when focusing it', () => {
+        const spy = sinon.spy(input, 'blur');
+        input.focus();
+        expect(spy.called).to.be.false;
+        expect(document.activeElement).to.equal(input);
+      });
+
+      it('should blur input element when opening overlay', async () => {
+        const spy = sinon.spy(input, 'blur');
+        await open(datepicker);
+        expect(spy.called).to.be.true;
+      });
+
+      it('should not focus the input when opening overlay', async () => {
+        touchTap(input);
+        await open(datepicker);
+        expect(document.activeElement).to.not.equal(input);
+      });
+    });
+  });
+
+  describe('focused attribute', () => {
+    it('should keep focused attribute after opening overlay', async () => {
+      datepicker.focus();
+      await open(datepicker);
+      expect(datepicker.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should remove focused attribute when closing overlay', async () => {
+      await open(datepicker);
+      await sendKeys({ press: 'Escape' });
+      expect(datepicker.hasAttribute('focused')).to.be.false;
+    });
+  });
+
+  describe('buttons', () => {
+    beforeEach(async () => {
+      await open(datepicker);
+    });
+
+    it('should close the dropdown on Today button Esc', async () => {
+      getOverlayContent(datepicker)._todayButton.focus();
+      await sendKeys({ press: 'Escape' });
+
+      expect(datepicker.opened).to.be.false;
+    });
+
+    it('should close the dropdown on Cancel button Esc', async () => {
+      getOverlayContent(datepicker).focusCancel();
+      await sendKeys({ press: 'Escape' });
+
+      expect(datepicker.opened).to.be.false;
+    });
+  });
+});

--- a/packages/date-picker/test/overlay.test.js
+++ b/packages/date-picker/test/overlay.test.js
@@ -78,57 +78,68 @@ describe('overlay', () => {
     });
 
     describe('taps', () => {
-      beforeEach((done) => {
-        // Wait for ignoreTaps to settle after initial scroll event
-        listenOnce(overlay.$.monthScroller.$.scroller, 'scroll', () => setTimeout(done, 350));
+      let monthScroller, clock;
 
-        overlay.$.monthScroller.$.scroller.scrollTop += 1;
+      beforeEach((done) => {
+        monthScroller = overlay.$.monthScroller;
+        clock = sinon.useFakeTimers({
+          shouldClearNativeTimers: true,
+        });
+
+        // Wait for ignoreTaps to settle after initial scroll event
+        listenOnce(monthScroller.$.scroller, 'scroll', () => {
+          clock.tick(350);
+          done();
+        });
+
+        monthScroller.$.scroller.scrollTop += 1;
+      });
+
+      afterEach(() => {
+        clock.restore();
       });
 
       it('should set ignoreTaps to calendar on scroll', (done) => {
-        listenOnce(overlay.$.monthScroller.$.scroller, 'scroll', () => {
+        listenOnce(monthScroller.$.scroller, 'scroll', () => {
           expect(overlay.$.monthScroller.querySelector('vaadin-month-calendar').ignoreTaps).to.be.true;
           done();
         });
 
-        overlay.$.monthScroller.$.scroller.scrollTop += 1;
+        monthScroller.$.scroller.scrollTop += 1;
       });
 
       it('should not react to year tap after scroll', (done) => {
         const spy = sinon.spy(overlay, '_scrollToPosition');
 
-        listenOnce(overlay.$.monthScroller.$.scroller, 'scroll', () => {
+        listenOnce(monthScroller.$.scroller, 'scroll', () => {
           tap(overlay.$.yearScroller);
           expect(spy.called).to.be.false;
           done();
         });
 
-        overlay.$.monthScroller.$.scroller.scrollTop += 1;
+        monthScroller.$.scroller.scrollTop += 1;
       });
 
       it('should react to year tap after 300ms elapsed after scroll', (done) => {
         const spy = sinon.spy(overlay, '_scrollToPosition');
 
-        listenOnce(overlay.$.monthScroller.$.scroller, 'scroll', () => {
-          setTimeout(() => {
-            tap(overlay.$.yearScroller);
-            expect(spy.called).to.be.true;
-            done();
-          }, 350);
+        listenOnce(monthScroller.$.scroller, 'scroll', () => {
+          clock.tick(350);
+          tap(overlay.$.yearScroller);
+          expect(spy.called).to.be.true;
+          done();
         });
 
-        overlay.$.monthScroller.$.scroller.scrollTop += 1;
+        monthScroller.$.scroller.scrollTop += 1;
       });
 
-      it('should not react if the tap takes more than 300ms', (done) => {
+      it('should not react if the tap takes more than 300ms', () => {
         const spy = sinon.spy(overlay, '_scrollToPosition');
         overlay._onYearScrollTouchStart();
 
-        setTimeout(() => {
-          tap(overlay.$.yearScroller);
-          expect(spy.called).to.be.false;
-          done();
-        }, 350);
+        clock.tick(350);
+        tap(overlay.$.yearScroller);
+        expect(spy.called).to.be.false;
       });
     });
 


### PR DESCRIPTION
## Description

Reorganized `vaadin-date-picker` unit tests for better readability:

1. Moved `fullscreen` tests to separate suite and changed to use `setViewport` command,
2. Updated tests for ignoring overlay taps to use fake timers instead of long `setTimeout`,
3. Removed no longer needed `setCancelSyntheticClickEvents(false)` from one test suite,
4. Simplified focus tests to use `document.activeElement` instead of `isFocused` helper,
4. Removed a duplicate toggle button test from the "auto open disabled" test suite.

## Type of change

- Tests