### PR TITLE
fix: make sure virtualizer clears item placeholder height

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -155,6 +155,10 @@ export class IronListAdapter {
       // Assign a temporary placeholder sizing to elements that would otherwise end up having
       // no height.
       el.style.paddingTop = `${this.__placeholderHeight}px`;
+
+      // Manually schedule the resize handler to make sure the placeholder gets removed
+      // in case the resize observer doesn't trigger.
+      setTimeout(() => this._resizeHandler());
     } else {
       // Add element height to the queue
       this.__elementHeightQueue.push(elementHeight);
@@ -277,7 +281,7 @@ export class IronListAdapter {
     physicalItems.forEach((el) => {
       el.style.position = 'absolute';
       fragment.appendChild(el);
-      this.__resizeObserver.observe(el, { box: 'border-box' });
+      this.__resizeObserver.observe(el);
     });
     this.elementsContainer.appendChild(fragment);
     return physicalItems;

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -277,7 +277,7 @@ export class IronListAdapter {
     physicalItems.forEach((el) => {
       el.style.position = 'absolute';
       fragment.appendChild(el);
-      this.__resizeObserver.observe(el);
+      this.__resizeObserver.observe(el, { box: 'border-box' });
     });
     this.elementsContainer.appendChild(fragment);
     return physicalItems;

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -156,9 +156,9 @@ export class IronListAdapter {
       // no height.
       el.style.paddingTop = `${this.__placeholderHeight}px`;
 
-      // Manually schedule the resize handler to make sure the placeholder gets removed
-      // in case the resize observer doesn't trigger.
-      setTimeout(() => this._resizeHandler());
+      // Manually schedule the resize handler to make sure the placeholder padding is
+      // cleared in case the resize observer never triggers.
+      requestAnimationFrame(() => this._resizeHandler());
     } else {
       // Add element height to the queue
       this.__elementHeightQueue.push(elementHeight);

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -67,4 +67,27 @@ describe('virtualizer - item height', () => {
     expect(item.offsetHeight).to.be.above(EVEN_ITEM_HEIGHT);
     expect(item.offsetHeight).to.be.below(ODD_ITEM_HEIGHT);
   });
+
+  it('should clear the temporary placeholder padding from the item', async () => {
+    // Wait for the content to update (and resize observer to fire)
+    await aTimeout(200);
+
+    // Cache the height of the first item
+    const firstItem = elementsContainer.querySelector(`#item-0`);
+    const firstItemHeight = firstItem.offsetHeight;
+
+    // Update the first item. Due to how the test updateElement function is implemented,
+    // the item height will first be set to 0, which causes the virtualizer to
+    // temporarily add padding to the element.
+    virtualizer.update(0, 0);
+
+    // Manually restore the item's height
+    firstItem.style.height = `${firstItemHeight}px`;
+
+    // Give some time for the resize observer to fire
+    await aTimeout(100);
+
+    // The padding should have been be cleared and the item should have its original height.
+    expect(firstItem.offsetHeight).to.equal(firstItemHeight);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow-components/issues/3900

The issue was caused by the following sequence:
1. The first time the list renders, everything looks good
2. When the items get refreshed, [virtual-list requests an update from virtualizer
](https://github.com/vaadin/web-components/blob/3d4723a4d2d1f9094fdedcdcd789b9479d8fd5fd/packages/virtual-list/src/vaadin-virtual-list.js#L169)
3. Virtualizer [runs](https://github.com/vaadin/web-components/blob/3d4723a4d2d1f9094fdedcdcd789b9479d8fd5fd/packages/component-base/src/virtualizer-iron-list-adapter.js#L147) the given `updateElement` callback function
4. This causes the `<flow-component-renderer>` to replace its content and the item becomes temporarily empty / to have zero height
5. The `__updateElement` function notices the item height is 0 and it [adds placeholder padding to it](https://github.com/vaadin/web-components/blob/3d4723a4d2d1f9094fdedcdcd789b9479d8fd5fd/packages/component-base/src/virtualizer-iron-list-adapter.js#L157). It expects the temporary padding to get cleared once the item regains size, which would cause the resize observer to fire
6. Before the virtualizer's resize observer ever gets to react to the size change, the flow-component-renderer is populated with new content, which makes the item's height again match the original value.
7. Since the item's content-box height is the same as it was initially, from the resize observer's point of view, item resize never took place, so it doesn't fire
8. The placeholder padding remains on the item!

Fix attempt 1:
~To fix this issue, let's make the virtualizer's resize observer use `box: 'border-box'` so that a change in the item's padding will also make the observer invoke.~

EDIT: Looks like this approach breaks some other tests. Will need to find a better one.

Fix attempt 2:
To fix this issue, let's make the virtualizer manually schedule a resize handler call after it applies the placeholder padding to make sure it gets cleared in this scenario.