### PR TITLE
refactor!: remove no longer used i18n.week string

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -22,7 +22,6 @@ export interface DatePickerI18n {
   weekdays: string[];
   weekdaysShort: string[];
   firstDayOfWeek: number;
-  week: string;
   today: string;
   cancel: string;
   parseDate(date: string): DatePickerDate | undefined;
@@ -119,10 +118,6 @@ export declare class DatePickerMixinClass {
    *   // An integer indicating the first day of the week
    *   // (0 = Sunday, 1 = Monday, etc.).
    *   firstDayOfWeek: 0,
-   *
-   *   // Used in screen reader announcements along with week
-   *   // numbers, if they are displayed.
-   *   week: 'Week',
    *
    *   // Translation of the Today shortcut button text.
    *   today: 'Today',

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -145,10 +145,6 @@ export const DatePickerMixin = (subclass) =>
          *   // (0 = Sunday, 1 = Monday, etc.).
          *   firstDayOfWeek: 0,
          *
-         *   // Used in screen reader announcements along with week
-         *   // numbers, if they are displayed.
-         *   week: 'Week',
-         *
          *   // Translation of the Today shortcut button text.
          *   today: 'Today',
          *
@@ -204,7 +200,6 @@ export const DatePickerMixin = (subclass) =>
               weekdays: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
               weekdaysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
               firstDayOfWeek: 0,
-              week: 'Week',
               today: 'Today',
               cancel: 'Cancel',
               formatDate: (d) => {

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -34,7 +34,6 @@ export function getDefaultI18n() {
     weekdays: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
     weekdaysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
     firstDayOfWeek: 0,
-    week: 'Week',
     today: 'Today',
     cancel: 'Cancel',
     formatDate(d) {

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -162,7 +162,6 @@ describe('vaadin-month-calendar', () => {
         weekdays: 'sunnuntai_maanantai_tiistai_keskiviikko_torstai_perjantai_lauantai'.split('_'),
         weekdaysShort: 'su_ma_ti_ke_to_pe_la'.split('_'),
         firstDayOfWeek: 1,
-        week: 'viikko',
         today: 'Tänään',
         formatTitle: (monthName, fullYear) => `${monthName}-${fullYear}`,
       };


### PR DESCRIPTION
## Description

Follow-up to #4772

Removed `i18n.week` which is no longer used since #3355 where we changed week numbers to be hidden from screen readers, in order to not confuse the user when navigating through the table using the cursor mode.

## Type of change

- Breaking change