### PR TITLE
test: move context-menu template tests to ITs

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -12,6 +12,7 @@
     "@vaadin/checkbox": "24.0.0-alpha0",
     "@vaadin/checkbox-group": "24.0.0-alpha0",
     "@vaadin/combo-box": "24.0.0-alpha0",
+    "@vaadin/context-menu": "24.0.0-alpha0",
     "@vaadin/custom-field": "24.0.0-alpha0",
     "@vaadin/date-picker": "24.0.0-alpha0",
     "@vaadin/date-time-picker": "24.0.0-alpha0",

--- a/integration/tests/context-menu-template.test.js
+++ b/integration/tests/context-menu-template.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
 import '@vaadin/context-menu';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import './not-animated-styles.js';
 
 describe('template', () => {
   let menu, target;

--- a/integration/tests/context-menu-template.test.js
+++ b/integration/tests/context-menu-template.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
+import '@vaadin/context-menu';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 
 describe('template', () => {
   let menu, target;

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -50,7 +50,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/polymer-legacy-adapter": "24.0.0-alpha0",
     "@vaadin/testing-helpers": "^0.3.2",
     "lit": "^2.0.0",
     "sinon": "^13.0.2"


### PR DESCRIPTION
## Description

Moved the context-menu `<template>` tests to the `integration-tests` package.

## Type of change

- Tests