### PR TITLE
test: update date-picker unit tests to use helpers

### DIFF
--- a/integration/tests/dialog-date-picker.test.js
+++ b/integration/tests/dialog-date-picker.test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import './not-animated-styles.js';
 import '@vaadin/date-picker';
 import '@vaadin/dialog';
-import { getOverlayContent, open, waitForScrollToFinish } from '@vaadin/date-picker/test/common.js';
+import { open, waitForScrollToFinish } from '@vaadin/date-picker/test/common.js';
 
 describe('date-picker in dialog', () => {
   let dialog, datepicker;
@@ -27,10 +27,13 @@ describe('date-picker in dialog', () => {
   });
 
   describe('modal', () => {
+    let overlayContent;
+
     beforeEach(async () => {
       datepicker.inputElement.focus();
       await open(datepicker);
       await nextRender();
+      overlayContent = datepicker._overlayContent;
     });
 
     it('should focus the Today button on second Tab when inside a dialog', async () => {
@@ -38,12 +41,12 @@ describe('date-picker in dialog', () => {
       await sendKeys({ press: 'Tab' });
 
       await nextRender();
-      await waitForScrollToFinish(getOverlayContent(datepicker));
+      await waitForScrollToFinish(overlayContent);
 
       // Focus the Today button
       await sendKeys({ press: 'Tab' });
 
-      expect(getOverlayContent(datepicker)._todayButton.hasAttribute('focused')).to.be.true;
+      expect(overlayContent._todayButton.hasAttribute('focused')).to.be.true;
     });
 
     it('should focus the Cancel button on Shift + Tab when inside a dialog', async () => {
@@ -52,7 +55,7 @@ describe('date-picker in dialog', () => {
       await sendKeys({ press: 'Tab' });
       await sendKeys({ up: 'Shift' });
 
-      expect(getOverlayContent(datepicker)._cancelButton.hasAttribute('focused')).to.be.true;
+      expect(overlayContent._cancelButton.hasAttribute('focused')).to.be.true;
     });
 
     it('should focus the input on calendar date Shift Tab when inside a dialog', async () => {
@@ -60,7 +63,7 @@ describe('date-picker in dialog', () => {
       await sendKeys({ press: 'Tab' });
 
       await nextRender();
-      await waitForScrollToFinish(getOverlayContent(datepicker));
+      await waitForScrollToFinish(overlayContent);
 
       const spy = sinon.spy(datepicker.inputElement, 'focus');
 

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -187,17 +187,19 @@ describe('basic features', () => {
     let overlayContent;
 
     beforeEach(async () => {
-      datepicker.set('i18n.weekdays', 'sunnuntai_maanantai_tiistai_keskiviikko_torstai_perjantai_lauantai'.split('_'));
-      datepicker.set('i18n.weekdaysShort', 'su_ma_ti_ke_to_pe_la'.split('_'));
-      datepicker.set('i18n.firstDayOfWeek', 1);
-      datepicker.set('i18n.formatDate', (d) => {
-        if (d) {
-          return [d.day, d.month + 1, d.year].join('.');
-        }
-      });
-      datepicker.set('i18n.clear', 'Tyhjennä');
-      datepicker.set('i18n.today', 'Tänään');
-      datepicker.set('i18n.cancel', 'Peruuta');
+      datepicker.i18n = {
+        ...datepicker.i18n,
+        weekdays: ['sunnuntai', 'maanantai', 'tiistai', 'keskiviikko', 'torstai', 'perjantai', 'lauantai'],
+        weekdaysShort: ['su', 'ma', 'ti', 'ke', 'to', 'pe', 'la'],
+        firstDayOfWeek: 1,
+        today: 'Tänään',
+        cancel: 'Peruuta',
+        formatDate: (d) => {
+          if (d) {
+            return [d.day, d.month + 1, d.year].join('.');
+          }
+        },
+      };
 
       await open(datepicker);
       overlayContent = getOverlayContent(datepicker);

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -3,7 +3,7 @@ import { click, fixtureSync, keyboardEventFor, oneEvent, tap } from '@vaadin/tes
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import { close, getOverlayContent, open, touchTap, waitForOverlayRender } from './common.js';
+import { close, open, touchTap, waitForOverlayRender } from './common.js';
 
 describe('basic features', () => {
   let datepicker, input;
@@ -202,7 +202,7 @@ describe('basic features', () => {
       };
 
       await open(datepicker);
-      overlayContent = getOverlayContent(datepicker);
+      overlayContent = datepicker._overlayContent;
     });
 
     it('should notify i18n mutation to children', () => {

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -119,14 +119,6 @@ export function getFirstVisibleItem(scroller, bufferOffset) {
   });
 }
 
-export function getOverlayContent(datepicker) {
-  // Ensure overlay content is rendered
-  if (!datepicker._overlayContent) {
-    datepicker.$.overlay.requestContentUpdate();
-  }
-  return datepicker._overlayContent;
-}
-
 export function getFocusedMonth(overlayContent) {
   const months = Array.from(overlayContent.querySelectorAll('vaadin-month-calendar'));
   return months.find((month) => {

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -119,10 +119,6 @@ export function getFirstVisibleItem(scroller, bufferOffset) {
   });
 }
 
-export function isFullscreen(datepicker) {
-  return datepicker.$.overlay.getAttribute('fullscreen') !== null;
-}
-
 export function getOverlayContent(datepicker) {
   // Ensure overlay content is rendered
   if (!datepicker._overlayContent) {

--- a/packages/date-picker/test/custom-input.test.js
+++ b/packages/date-picker/test/custom-input.test.js
@@ -3,10 +3,10 @@ import { fire, fixtureSync, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker-light.js';
-import { getOverlayContent, open, waitForScrollToFinish } from './common.js';
+import { getOverlayContent, open, setInputValue, waitForScrollToFinish } from './common.js';
 
 describe('custom input', () => {
-  let datepicker, input, overlay;
+  let datepicker, overlay;
 
   beforeEach(() => {
     datepicker = fixtureSync(`
@@ -15,7 +15,6 @@ describe('custom input', () => {
       </vaadin-date-picker-light>
     `);
     overlay = datepicker.$.overlay;
-    input = datepicker.inputElement;
   });
 
   it('should open calendar on tap', () => {
@@ -24,23 +23,21 @@ describe('custom input', () => {
   });
 
   it('should open calendar on input', () => {
-    input.value = '1';
-    fire(input, 'input');
+    setInputValue(datepicker, '1');
     expect(overlay.opened).to.be.true;
   });
 
   it('should not open calendar on input when autoOpenDisabled is true', () => {
     datepicker.autoOpenDisabled = true;
-    input.value = '1';
-    fire(input, 'input');
+    setInputValue(datepicker, '1');
     expect(overlay.opened).not.to.be.true;
   });
 
   it('should close on overlay date tap', async () => {
     await open(datepicker);
     const spy = sinon.spy(datepicker, 'close');
-    const evt = new CustomEvent('date-tap', { detail: { date: new Date() }, bubbles: true, composed: true });
-    getOverlayContent(datepicker).dispatchEvent(evt);
+    const overlayContent = getOverlayContent(datepicker);
+    fire(overlayContent, 'date-tap', { date: new Date() });
     expect(spy.called).to.be.true;
   });
 

--- a/packages/date-picker/test/custom-input.test.js
+++ b/packages/date-picker/test/custom-input.test.js
@@ -3,7 +3,7 @@ import { fire, fixtureSync, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker-light.js';
-import { getOverlayContent, open, setInputValue, waitForScrollToFinish } from './common.js';
+import { open, setInputValue, waitForScrollToFinish } from './common.js';
 
 describe('custom input', () => {
   let datepicker, overlay;
@@ -36,16 +36,14 @@ describe('custom input', () => {
   it('should close on overlay date tap', async () => {
     await open(datepicker);
     const spy = sinon.spy(datepicker, 'close');
-    const overlayContent = getOverlayContent(datepicker);
-    fire(overlayContent, 'date-tap', { date: new Date() });
+    fire(datepicker._overlayContent, 'date-tap', { date: new Date() });
     expect(spy.called).to.be.true;
   });
 
   it('should show week numbers', async () => {
     datepicker.showWeekNumbers = true;
     await open(datepicker);
-    const overlayContent = getOverlayContent(datepicker);
-    expect(overlayContent.showWeekNumbers).to.be.true;
+    expect(datepicker._overlayContent.showWeekNumbers).to.be.true;
   });
 
   describe('theme attribute', () => {
@@ -59,8 +57,7 @@ describe('custom input', () => {
 
     it('should propagate theme attribute to overlay content', async () => {
       await open(datepicker);
-      const overlayContent = getOverlayContent(datepicker);
-      expect(overlayContent.getAttribute('theme')).to.equal('foo');
+      expect(datepicker._overlayContent.getAttribute('theme')).to.equal('foo');
     });
 
     describe('in content', () => {
@@ -69,7 +66,7 @@ describe('custom input', () => {
       });
 
       it('should propagate theme attribute to month calendar', async () => {
-        const overlayContent = getOverlayContent(datepicker);
+        const overlayContent = datepicker._overlayContent;
         await waitForScrollToFinish(overlayContent);
         const monthCalendar = overlayContent.querySelector('vaadin-month-calendar');
         expect(monthCalendar.getAttribute('theme')).to.equal('foo');

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -3,7 +3,7 @@ import { aTimeout, fire, fixtureSync, mousedown, nextRender, oneEvent, touchstar
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import { getFocusedCell, getOverlayContent, monthsEqual, open, outsideClick, waitForOverlayRender } from './common.js';
+import { getFocusedCell, monthsEqual, open, outsideClick, waitForOverlayRender } from './common.js';
 
 describe('dropdown', () => {
   let datepicker, input, overlay;
@@ -57,8 +57,7 @@ describe('dropdown', () => {
   describe('scroll to date', () => {
     it('should scroll to today by default', async () => {
       datepicker.open();
-      const overlayContent = getOverlayContent(datepicker);
-      const spy = sinon.spy(overlayContent, 'scrollToDate');
+      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -70,8 +69,7 @@ describe('dropdown', () => {
       datepicker.initialPosition = '2016-01-01';
 
       datepicker.open();
-      const overlayContent = getOverlayContent(datepicker);
-      const spy = sinon.spy(overlayContent, 'scrollToDate');
+      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -83,8 +81,7 @@ describe('dropdown', () => {
       datepicker.value = '2000-02-01';
 
       datepicker.open();
-      const overlayContent = getOverlayContent(datepicker);
-      const spy = sinon.spy(overlayContent, 'scrollToDate');
+      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -94,7 +91,7 @@ describe('dropdown', () => {
 
     it('should remember the initial position on reopen', async () => {
       await open(datepicker);
-      const overlayContent = getOverlayContent(datepicker);
+      const overlayContent = datepicker._overlayContent;
       const initialPosition = overlayContent.initialPosition;
 
       datepicker.close();
@@ -106,11 +103,10 @@ describe('dropdown', () => {
 
     it('should scroll to date on reopen', async () => {
       datepicker.open();
-      const overlayContent = getOverlayContent(datepicker);
 
       // We must scroll to initial position on reopen because
       // scrollTop can be reset while the dropdown is closed.
-      const spy = sinon.spy(overlayContent, 'scrollToDate');
+      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
       expect(spy.called).to.be.true;
@@ -127,8 +123,7 @@ describe('dropdown', () => {
       datepicker.min = '2100-01-01';
 
       datepicker.open();
-      const overlayContent = getOverlayContent(datepicker);
-      const spy = sinon.spy(overlayContent, 'scrollToDate');
+      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -140,8 +135,7 @@ describe('dropdown', () => {
       datepicker.max = '2000-01-01';
 
       datepicker.open();
-      const overlayContent = getOverlayContent(datepicker);
-      const spy = sinon.spy(overlayContent, 'scrollToDate');
+      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -156,8 +150,7 @@ describe('dropdown', () => {
       datepicker.initialPosition = '2015-01-01';
 
       datepicker.open();
-      const overlayContent = getOverlayContent(datepicker);
-      const spy = sinon.spy(overlayContent, 'scrollToDate');
+      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -212,8 +205,7 @@ describe('dropdown', () => {
 
   describe('date tap', () => {
     function dateTap() {
-      const content = getOverlayContent(datepicker);
-      const date = getFocusedCell(content);
+      const date = getFocusedCell(datepicker._overlayContent);
       mousedown(date);
       date.focus();
       date.click();

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, mousedown, nextRender, oneEvent, touchstart } from '@vaadin/testing-helpers';
+import { aTimeout, fire, fixtureSync, mousedown, nextRender, oneEvent, touchstart } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
@@ -49,10 +49,8 @@ describe('dropdown', () => {
     });
 
     it('should prevent default for the toggle button mousedown', () => {
-      const e = new CustomEvent('mousedown', { bubbles: true });
-      const spy = sinon.spy(e, 'preventDefault');
-      toggleButton.dispatchEvent(e);
-      expect(spy.calledOnce).to.be.true;
+      const event = fire(toggleButton, 'mousedown');
+      expect(event.defaultPrevented).to.be.true;
     });
   });
 

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -313,39 +313,6 @@ describe('keyboard', () => {
         expect(cell.hasAttribute('today')).to.be.true;
       });
     });
-
-    describe('fullscreen', () => {
-      beforeEach(async () => {
-        // Move focus to the calendar
-        await sendKeys({ press: 'Tab' });
-        await nextRender(datepicker);
-
-        datepicker._fullscreen = true;
-      });
-
-      it('should move focus to Cancel button on date cell Shift Tab', async () => {
-        const spy = sinon.spy(overlayContent._cancelButton, 'focus');
-
-        await sendKeys({ down: 'Shift' });
-        await sendKeys({ press: 'Tab' });
-        await sendKeys({ up: 'Shift' });
-
-        expect(spy.calledOnce).to.be.true;
-      });
-
-      it('should move focus to date cell button on Cancel button Tab', async () => {
-        const cell = getFocusedCell(overlayContent);
-        const spy = sinon.spy(cell, 'focus');
-
-        await sendKeys({ down: 'Shift' });
-        await sendKeys({ press: 'Tab' });
-        await sendKeys({ up: 'Shift' });
-
-        await sendKeys({ press: 'Tab' });
-
-        expect(spy.calledOnce).to.be.true;
-      });
-    });
   });
 
   describe('Escape key', () => {

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -4,22 +4,14 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker.js';
-import {
-  close,
-  getFocusedCell,
-  getOverlayContent,
-  idleCallback,
-  open,
-  waitForOverlayRender,
-  waitForScrollToFinish,
-} from './common.js';
+import { close, getFocusedCell, idleCallback, open, waitForOverlayRender, waitForScrollToFinish } from './common.js';
 
 describe('keyboard', () => {
   let datepicker;
   let input;
 
   function focusedDate() {
-    return getOverlayContent(datepicker).focusedDate;
+    return datepicker._overlayContent.focusedDate;
   }
 
   beforeEach(() => {
@@ -61,8 +53,9 @@ describe('keyboard', () => {
       expect(datepicker.value).to.equal('2001-01-01');
     });
 
-    it('should update focused date on value change', () => {
+    it('should update focused date on value change', async () => {
       datepicker.value = '2000-01-01';
+      await open(datepicker);
       expect(focusedDate().getMonth()).to.equal(0);
       expect(focusedDate().getDate()).to.equal(1);
       expect(focusedDate().getFullYear()).to.equal(2000);
@@ -71,7 +64,7 @@ describe('keyboard', () => {
     // FIXME: flaky test often failing locally due to scroll animation
     it.skip('should display focused date while overlay focused', async () => {
       await sendKeys({ type: '1/2/2000' });
-      const content = getOverlayContent(datepicker);
+      const content = datepicker._overlayContent;
       await waitForScrollToFinish(content);
 
       // Move focus to the calendar
@@ -185,7 +178,7 @@ describe('keyboard', () => {
     beforeEach(async () => {
       // Open the overlay
       await open(datepicker);
-      overlayContent = getOverlayContent(datepicker);
+      overlayContent = datepicker._overlayContent;
       await idleCallback();
     });
 

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, isIOS, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
@@ -7,14 +7,13 @@ import '../vaadin-date-picker.js';
 import {
   getDefaultI18n,
   getFocusedCell,
-  getOverlayContent,
   idleCallback,
   open,
   waitForOverlayRender,
   waitForScrollToFinish,
 } from './common.js';
 
-(isIOS ? describe.skip : describe)('keyboard navigation', () => {
+describe('keyboard navigation', () => {
   describe('date-picker', () => {
     let datepicker;
     let input;
@@ -33,7 +32,7 @@ import {
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(getOverlayContent(datepicker));
+        const cell = getFocusedCell(datepicker._overlayContent);
         expect(cell.date).to.eql(new Date(today.getFullYear(), today.getMonth(), today.getDate()));
       });
 
@@ -49,7 +48,7 @@ import {
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(getOverlayContent(datepicker));
+        const cell = getFocusedCell(datepicker._overlayContent);
         expect(cell.date).to.eql(new Date(today.getFullYear(), today.getMonth(), today.getDate()));
       });
     });
@@ -67,14 +66,14 @@ import {
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(getOverlayContent(datepicker));
+        const cell = getFocusedCell(datepicker._overlayContent);
         expect(cell.date).to.eql(new Date(2001, 0, 1));
       });
 
       it('should not lose focused date after deselecting', async () => {
         await open(datepicker);
 
-        const content = getOverlayContent(datepicker);
+        const content = datepicker._overlayContent;
         const focused = content.focusedDate;
 
         // Move focus to the calendar
@@ -101,7 +100,7 @@ import {
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(getOverlayContent(datepicker));
+        const cell = getFocusedCell(datepicker._overlayContent);
         expect(cell.date).to.eql(new Date(2001, 0, 1));
       });
 
@@ -115,7 +114,7 @@ import {
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(getOverlayContent(datepicker));
+        const cell = getFocusedCell(datepicker._overlayContent);
         expect(cell.date).to.eql(new Date(2001, 0, 1));
       });
     });

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextRender, tap } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, makeSoloTouchEvent, nextRender, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-month-calendar.js';
 import { getDefaultI18n } from './common.js';
@@ -7,12 +7,16 @@ import { getDefaultI18n } from './common.js';
 describe('vaadin-month-calendar', () => {
   let monthCalendar, valueChangedSpy;
 
+  function getDateCells(calendar) {
+    return [...calendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)')];
+  }
+
+  function getWeekDayCells(calendar) {
+    return [...calendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)')];
+  }
+
   beforeEach(async () => {
-    monthCalendar = fixtureSync(`
-      <vaadin-month-calendar
-        style="position: absolute; top: 0"
-      ></vaadin-month-calendar>
-    `);
+    monthCalendar = fixtureSync('<vaadin-month-calendar></vaadin-month-calendar>');
     monthCalendar.i18n = getDefaultI18n();
     monthCalendar.month = new Date(2016, 1, 1);
     valueChangedSpy = sinon.spy();
@@ -27,7 +31,7 @@ describe('vaadin-month-calendar', () => {
     return (done) => {
       monthCalendar.month = new Date(2016, monthNumber, 1);
       setTimeout(() => {
-        const numberOfDays = monthCalendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)').length;
+        const numberOfDays = getDateCells(monthCalendar).length;
         expect(numberOfDays).to.equal(expectedDays[monthNumber]);
         done();
       });
@@ -40,29 +44,29 @@ describe('vaadin-month-calendar', () => {
   }
 
   it('should render days in correct order by default', () => {
-    const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
-    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent.trim());
+    const weekdays = getWeekDayCells(monthCalendar);
+    const weekdayTitles = weekdays.map((weekday) => weekday.textContent.trim());
     expect(weekdayTitles).to.eql(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
   });
 
   it('should render days in correct order by first day of week', async () => {
     monthCalendar.i18n = { ...monthCalendar.i18n, firstDayOfWeek: 1 }; // Start from Monday.
     await nextRender();
-    const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
-    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent.trim());
+    const weekdays = getWeekDayCells(monthCalendar);
+    const weekdayTitles = weekdays.map((weekday) => weekday.textContent.trim());
     expect(weekdayTitles).to.eql(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
   });
 
   it('should re-render after changing the month', async () => {
     monthCalendar.month = new Date(2000, 0, 1); // Feb 2016 -> Jan 2000
     await nextRender();
-    const days = monthCalendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)').length;
+    const days = getDateCells(monthCalendar).length;
     expect(days).to.equal(31);
     expect(monthCalendar.shadowRoot.querySelector('[part="month-header"]').textContent).to.equal('January 2000');
   });
 
   it('should fire value change on tap', () => {
-    const dateElements = monthCalendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)');
+    const dateElements = getDateCells(monthCalendar);
     tap(dateElements[10]);
     expect(valueChangedSpy.calledOnce).to.be.true;
   });
@@ -70,7 +74,7 @@ describe('vaadin-month-calendar', () => {
   it('should fire date-tap on tap', () => {
     const tapSpy = sinon.spy();
     monthCalendar.addEventListener('date-tap', tapSpy);
-    const dateElements = monthCalendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)');
+    const dateElements = getDateCells(monthCalendar);
     tap(dateElements[10]);
     expect(tapSpy.calledOnce).to.be.true;
     tap(dateElements[10]);
@@ -84,7 +88,7 @@ describe('vaadin-month-calendar', () => {
   });
 
   it('should update value on tap', () => {
-    const dateElements = monthCalendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)');
+    const dateElements = getDateCells(monthCalendar);
     for (let i = 0; i < dateElements.length; i++) {
       if (dateElements[i].date.getDate() === 10) {
         // Tenth of February.
@@ -99,7 +103,7 @@ describe('vaadin-month-calendar', () => {
   it('should not react if the tap takes more than 300ms', async () => {
     const tapSpy = sinon.spy();
     monthCalendar.addEventListener('date-tap', tapSpy);
-    const dateElement = monthCalendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)')[10];
+    const dateElement = getDateCells(monthCalendar)[10];
     monthCalendar._onMonthGridTouchStart();
     await aTimeout(350);
     tap(dateElement);
@@ -110,24 +114,15 @@ describe('vaadin-month-calendar', () => {
     const tapSpy = sinon.spy();
     monthCalendar.addEventListener('date-tap', tapSpy);
     monthCalendar.ignoreTaps = true;
-    const dateElement = monthCalendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)')[10];
+    const dateElement = getDateCells(monthCalendar)[10];
     tap(dateElement);
     expect(tapSpy.called).to.be.false;
   });
 
   it('should prevent default on touchend', () => {
-    const preventDefaultSpy = sinon.spy();
-    const touchendEvent = new CustomEvent('touchend', {
-      bubbles: true,
-      cancelable: true,
-    });
-    touchendEvent.changedTouches = [{}];
-    touchendEvent.preventDefault = preventDefaultSpy;
-
-    // Dispatch a fake touchend event from a date element.
-    const dateElement = monthCalendar.shadowRoot.querySelector('[part="date"]:not(:empty)');
-    dateElement.dispatchEvent(touchendEvent);
-    expect(preventDefaultSpy.called).to.be.true;
+    const dateElement = getDateCells(monthCalendar)[0];
+    const event = makeSoloTouchEvent('touchend', null, dateElement);
+    expect(event.defaultPrevented).to.be.true;
   });
 
   it('should work with sub 100 years', async () => {
@@ -135,14 +130,14 @@ describe('vaadin-month-calendar', () => {
     month.setFullYear(99);
     monthCalendar.month = month;
     await nextRender();
-    const date = monthCalendar.shadowRoot.querySelector('[part="date"]:not(:empty)').date;
+    const date = getDateCells(monthCalendar)[0].date;
     expect(date.getFullYear()).to.equal(month.getFullYear());
   });
 
   it('should not update value on disabled date tap', async () => {
     monthCalendar.maxDate = new Date('2016-02-09');
     await nextRender();
-    const dateElements = monthCalendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)');
+    const dateElements = getDateCells(monthCalendar);
     for (let i = 0; i < dateElements.length; i++) {
       if (dateElements[i].date.getDate() === 10) {
         // Tenth of February.
@@ -159,8 +154,8 @@ describe('vaadin-month-calendar', () => {
           'tammikuu_helmikuu_maaliskuu_huhtikuu_toukokuu_kesäkuu_heinäkuu_elokuu_syyskuu_lokakuu_marraskuu_joulukuu'.split(
             '_',
           ),
-        weekdays: 'sunnuntai_maanantai_tiistai_keskiviikko_torstai_perjantai_lauantai'.split('_'),
-        weekdaysShort: 'su_ma_ti_ke_to_pe_la'.split('_'),
+        weekdays: ['sunnuntai', 'maanantai', 'tiistai', 'keskiviikko', 'torstai', 'perjantai', 'lauantai'],
+        weekdaysShort: ['su', 'ma', 'ti', 'ke', 'to', 'pe', 'la'],
         firstDayOfWeek: 1,
         today: 'Tänään',
         formatTitle: (monthName, fullYear) => `${monthName}-${fullYear}`,
@@ -169,26 +164,24 @@ describe('vaadin-month-calendar', () => {
     });
 
     it('should render weekdays in correct locale', () => {
-      const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
-      const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent.trim());
+      const weekdays = getWeekDayCells(monthCalendar);
+      const weekdayTitles = weekdays.map((weekday) => weekday.textContent.trim());
       expect(weekdayTitles).to.eql(['ma', 'ti', 'ke', 'to', 'pe', 'la', 'su']);
     });
 
     it('should label dates in correct locale', () => {
-      const dates = monthCalendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)');
-      Array.from(dates)
-        .slice(0, 7)
-        .forEach((date, index) => {
-          const label = date.getAttribute('aria-label');
-          const day = ['maanantai', 'tiistai', 'keskiviikko', 'torstai', 'perjantai', 'lauantai', 'sunnuntai'][index];
-          expect(label).to.equal(`${index + 1} helmikuu 2016, ${day}`);
-        });
+      const dates = getDateCells(monthCalendar);
+      dates.slice(0, 7).forEach((date, index) => {
+        const label = date.getAttribute('aria-label');
+        const day = ['maanantai', 'tiistai', 'keskiviikko', 'torstai', 'perjantai', 'lauantai', 'sunnuntai'][index];
+        expect(label).to.equal(`${index + 1} helmikuu 2016, ${day}`);
+      });
     });
 
     it('should label today in correct locale', async () => {
       monthCalendar.month = new Date();
       await nextRender();
-      const today = monthCalendar.shadowRoot.querySelector('[part="date"]:not(:empty)[today]');
+      const today = getDateCells(monthCalendar).find((date) => date.hasAttribute('today'));
       expect(today.getAttribute('aria-label').split(', ').pop()).to.equal('Tänään');
     });
 

--- a/packages/date-picker/test/theme-propagation.test.js
+++ b/packages/date-picker/test/theme-propagation.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-date-picker.js';
-import { getOverlayContent, open, waitForScrollToFinish } from './common.js';
+import { open, waitForScrollToFinish } from './common.js';
 
 describe('theme attribute', () => {
   let datepicker;
@@ -22,8 +22,7 @@ describe('theme attribute', () => {
 
   it('should propagate theme attribute to overlay content', async () => {
     await open(datepicker);
-    const overlayContent = getOverlayContent(datepicker);
-    expect(overlayContent.getAttribute('theme')).to.equal('foo');
+    expect(datepicker._overlayContent.getAttribute('theme')).to.equal('foo');
   });
 
   describe('in content', () => {
@@ -32,7 +31,7 @@ describe('theme attribute', () => {
     });
 
     it('should propagate theme attribute to month calendar', async () => {
-      const overlayContent = getOverlayContent(datepicker);
+      const overlayContent = datepicker._overlayContent;
       await waitForScrollToFinish(overlayContent);
       const monthCalendar = overlayContent.querySelector('vaadin-month-calendar');
       expect(monthCalendar.getAttribute('theme')).to.equal('foo');

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -3,7 +3,7 @@ import { enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import { DatePicker } from '../vaadin-date-picker.js';
-import { close, getOverlayContent, open, setInputValue } from './common.js';
+import { close, open, setInputValue } from './common.js';
 
 class DatePicker2016 extends DatePicker {
   checkValidity() {
@@ -197,7 +197,7 @@ describe('validation', () => {
       const invalidChangedSpy = sinon.spy();
       datePicker.addEventListener('invalid-changed', invalidChangedSpy);
       datePicker.open();
-      getOverlayContent(datePicker)._selectDate(new Date('2017-01-01')); // Invalid
+      datePicker._overlayContent._selectDate(new Date('2017-01-01')); // Invalid
     });
 
     it('should reflect correct invalid value on value-changed eventListener', (done) => {
@@ -211,7 +211,7 @@ describe('validation', () => {
       });
 
       datePicker.open();
-      getOverlayContent(datePicker)._selectDate(new Date('2017-01-01')); // Invalid
+      datePicker._overlayContent._selectDate(new Date('2017-01-01')); // Invalid
     });
 
     it('should fire a validated event on validation success', () => {


### PR DESCRIPTION
## Description

- Updated date-picker tests to use helpers for better readability.
- Fixed usage of Polymer specific `this.set()` API in `i18n` tests.

## Type of change

- Tests