### PR TITLE
refactor!: drop paper-input and iron-input support

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -99,7 +99,7 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(Polyme
   /** @protected */
   connectedCallback() {
     super.connectedCallback();
-    const cssSelector = 'vaadin-text-field,iron-input,paper-input,.paper-input-input,.input';
+    const cssSelector = 'vaadin-text-field,.input';
     this._setInputElement(this.querySelector(cssSelector));
     this._setFocusElement(this.inputElement);
   }


### PR DESCRIPTION
## Description

Updated CSS selector in `vaadin-date-picker-light` to remove support for legacy `iron-input` and `paper-input`.
This is basically the same as #2622 where we removed support for those from `vaadin-combo-box-light`.

https://github.com/vaadin/web-components/blob/33b5873d39acd968f396dc3acd8596bd2c4ae2f7/packages/combo-box/src/vaadin-combo-box-light.js#L128

## Type of change

- Breaking change