### PR TITLE
fix: consider any custom element a non-empty helper

### DIFF
--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -82,7 +82,11 @@ export class HelperController extends SlotController {
       return false;
     }
 
-    return helperNode.children.length > 0 || this.__isNotEmpty(helperNode.textContent);
+    return (
+      helperNode.children.length > 0 ||
+      (helperNode.nodeType === Node.ELEMENT_NODE && customElements.get(helperNode.localName)) ||
+      this.__isNotEmpty(helperNode.textContent)
+    );
   }
 
   /**

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -462,6 +462,22 @@ const runTests = (baseClass) => {
       });
     });
 
+    describe('slotted custom element', () => {
+      beforeEach(async () => {
+        const helperTag = define[baseClass]('custom-helper', '<div>Helper</div>', (Base) => Base);
+        element = fixtureSync(`
+          <${tag}>
+            <${helperTag} slot="helper"></${helperTag}>
+          </${tag}>
+        `);
+        await nextRender();
+      });
+
+      it('should set has-helper attribute when helper is a custom element', () => {
+        expect(element.hasAttribute('has-helper')).to.be.true;
+      });
+    });
+
     describe('lazy', () => {
       describe('DOM manipulations', () => {
         let defaultHelper;


### PR DESCRIPTION
## Description

Fixes #4757

Updated `HelperController` to check if a helper node is a valid custom element and if so, consider it a non-empty.
This is a better option than checking for a shadow root presence, because it might not be attached at this point.

## Type of change

- Bugfix