### PR TITLE
fix: focus entered date on open with auto-open disabled

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -1097,7 +1097,7 @@ export const DatePickerMixin = (subclass) =>
 
     /** @private */
     _userInputValueChanged() {
-      if (this.opened && this._inputValue) {
+      if (this._inputValue) {
         const parsedDate = this._getParsedDate();
 
         if (this._isValidDate(parsedDate)) {

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -598,6 +598,15 @@ describe('keyboard', () => {
       expect(datepicker.opened).not.to.be.true;
     });
 
+    it('should focus parsed date when opening overlay', async () => {
+      await sendKeys({ type: '1/20/2000' });
+      await open(datepicker);
+      await waitForOverlayRender();
+
+      expect(focusedDate().getMonth()).to.equal(0);
+      expect(focusedDate().getDate()).to.equal(20);
+    });
+
     it('should set datepicker value on blur', async () => {
       await sendKeys({ type: '1/1/2000' });
       await sendKeys({ press: 'Tab' });


### PR DESCRIPTION
## Description

Update `_focusedDate` property on date picker also when the overlay is not opened, so that the entered date can be focused when opening the overlay.

Fixes https://github.com/vaadin/flow-components/issues/3826

## Type of change

- Bugfix
