### PR TITLE
fix: focus entered date on open with auto-open disabled (#4828) (CP: 22)

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -976,7 +976,7 @@ export const DatePickerMixin = (subclass) =>
 
     /** @private */
     _userInputValueChanged() {
-      if (this.opened && this._inputValue) {
+      if (this._inputValue) {
         const parsedDate = this._getParsedDate();
 
         if (this._isValidDate(parsedDate)) {

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -619,6 +619,14 @@ import { close, getOverlayContent, open } from './common.js';
       expect(datepicker.opened).not.to.be.true;
     });
 
+    it('should focus parsed date when opening overlay', () => {
+      inputText('1/20/2000');
+      datepicker.open();
+
+      expect(focusedDate().getMonth()).to.equal(0);
+      expect(focusedDate().getDate()).to.equal(20);
+    });
+
     it('should set datepicker value on blur', () => {
       inputText('1/1/2000');
       target.dispatchEvent(new Event('blur'));


### PR DESCRIPTION
Cherry-pick of #4828  

(cherry picked from commit 6e04c8dbfdaf839275441cd6374b399aa0dcf5b9)
