### PR TITLE
fix: add background for Material overlay content

### DIFF
--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
@@ -10,6 +10,7 @@ registerStyles(
   'vaadin-date-picker-overlay-content',
   css`
     :host {
+      background: var(--material-background-color);
       font-family: var(--material-font-family);
       font-size: var(--material-body-font-size);
       -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
## Description

Fixes #4814

No visual test, as there is [no support](https://github.com/modernweb-dev/web/issues/1072) for `setViewport()` command in webdriver launcher used for visual tests yet.

## Type of change

- Bugfix