### PR TITLE
test: fix date-time-picker test to wait for open

### DIFF
--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -3,6 +3,7 @@ import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';
+import { waitForOverlayRender } from '@vaadin/date-picker/test/common.js';
 
 class DateTimePicker2020Element extends customElements.get('vaadin-date-time-picker') {
   checkValidity() {
@@ -86,6 +87,7 @@ const fixtures = {
     it('should not validate when moving focus to the date-picker dropdown', async () => {
       datePicker.focus();
       await sendKeys({ press: 'ArrowDown' });
+      await waitForOverlayRender();
       await sendKeys({ press: 'Tab' });
       expect(validateSpy.called).to.be.false;
     });


### PR DESCRIPTION
## Description

Added a helper to wait for overlay opening, in order to avoid random test failures:

```
packages/date-time-picker/test/validation.test.js:

 🚧 Browser logs:
      An error was thrown in a Promise outside a test. Did you forget to await a function or assertion?
      TypeError: this.shadowRoot is null
        at get focusableDateElement (packages/date-picker/src/vaadin-month-calendar.js:214:13)
        at get focusableDateElement/< (packages/date-picker/src/vaadin-date-picker-overlay-content.js:251:45)
        at get focusableDateElement (packages/date-picker/src/vaadin-date-picker-overlay-content.js:251:27)
        at __tryFocusDate (packages/date-picker/src/vaadin-date-picker-overlay-content.js:937:27)
        at focusDateElement (packages/date-picker/src/vaadin-date-picker-overlay-content.js:980:10)
        at async*_onOverlayOpened (packages/date-picker/src/vaadin-date-picker-mixin.js:813:30)
```

## Type of change

- Tests