### PR TITLE
fix: adapt field highlighter to date-picker change

### DIFF
--- a/packages/field-highlighter/src/fields/vaadin-date-picker-observer.js
+++ b/packages/field-highlighter/src/fields/vaadin-date-picker-observer.js
@@ -36,15 +36,19 @@ export class DatePickerObserver extends ComponentObserver {
     datePicker.addEventListener('focusout', (event) => this.onFocusOut(event));
   }
 
+  isEventInOverlay(node) {
+    return this.datePicker._overlayContent && this.datePicker._overlayContent.contains(node);
+  }
+
   onBlur(event) {
     const datePicker = this.datePicker;
-    if (datePicker._fullscreen && event.relatedTarget !== this.overlay) {
+    if (datePicker._fullscreen && !this.isEventInOverlay(event.relatedTarget)) {
       this.fullscreenFocus = true;
     }
   }
 
   onFocusIn(event) {
-    if (event.relatedTarget === this.overlay) {
+    if (this.isEventInOverlay(event.relatedTarget)) {
       // Focus returns from the overlay, do nothing.
       return;
     }
@@ -59,7 +63,7 @@ export class DatePickerObserver extends ComponentObserver {
   }
 
   onFocusOut(event) {
-    if (this.fullscreenFocus || event.relatedTarget === this.overlay) {
+    if (this.fullscreenFocus || this.isEventInOverlay(event.relatedTarget)) {
       // Do nothing, overlay is opening.
     } else if (!this.datePicker.opened) {
       // Field blur when closed.

--- a/packages/field-highlighter/test/field-components.test.js
+++ b/packages/field-highlighter/test/field-components.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDown, fixtureSync, focusin, focusout, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { arrowDown, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '@vaadin/checkbox-group';
@@ -11,7 +11,7 @@ import '@vaadin/radio-group';
 import '@vaadin/select';
 import '@vaadin/text-field';
 import { html, render } from 'lit';
-import { close, waitForOverlayRender } from '@vaadin/date-picker/test/common.js';
+import { close, outsideClick, waitForOverlayRender } from '@vaadin/date-picker/test/common.js';
 import { FieldHighlighter } from '../src/vaadin-field-highlighter.js';
 
 async function waitForIntersectionObserver() {
@@ -100,8 +100,10 @@ describe('field components', () => {
       it('should not dispatch vaadin-highlight-hide event on close with focus moved to the field', async () => {
         await open(field);
         await waitForOverlayRender();
+
         field.focus();
         await close(field);
+
         expect(hideSpy.callCount).to.equal(0);
       });
 
@@ -109,8 +111,11 @@ describe('field components', () => {
         field.focus();
         await open(field);
         await waitForOverlayRender();
-        focusin(field, overlay);
+
+        await field._overlayContent.focusDateElement();
+        field.focus();
         await nextRender();
+
         expect(hideSpy.callCount).to.equal(0);
       });
 
@@ -119,8 +124,8 @@ describe('field components', () => {
         await open(field);
         await waitForOverlayRender();
 
-        focusout(field);
-        focusin(field);
+        await field._overlayContent.focusDateElement();
+        field.focus();
         await nextRender();
 
         expect(showSpy.callCount).to.equal(1);
@@ -131,7 +136,7 @@ describe('field components', () => {
         await open(field);
         await waitForOverlayRender();
 
-        focusout(field);
+        field.blur();
         field.focus();
         await nextRender();
 
@@ -143,9 +148,9 @@ describe('field components', () => {
         await open(field);
         await waitForOverlayRender();
 
-        overlay.focus();
-        focusout(overlay);
-        await close(field);
+        await field._overlayContent.focusDateElement();
+        outsideClick();
+        await nextRender();
 
         expect(hideSpy.callCount).to.equal(1);
       });
@@ -230,8 +235,7 @@ describe('field components', () => {
         field.focus();
         await open(field);
 
-        overlay.querySelector('vaadin-item').blur();
-        document.body.click();
+        outsideClick();
         await nextRender();
 
         expect(hideSpy.callCount).to.equal(0);
@@ -241,8 +245,7 @@ describe('field components', () => {
         field.focus();
         await open(field);
 
-        overlay.querySelector('vaadin-item').blur();
-        document.body.click();
+        outsideClick();
         await nextRender();
 
         expect(showSpy.callCount).to.equal(1);
@@ -257,8 +260,7 @@ describe('field components', () => {
       it('should dispatch vaadin-highlight-hide event on outside click', async () => {
         await open(field);
 
-        focusout(overlay);
-        document.body.click();
+        outsideClick();
         await nextRender();
 
         expect(hideSpy.callCount).to.equal(1);


### PR DESCRIPTION
## Description

Updated logic in the `field-highlighter` to adapt to moving focus to the date-picker overlay content.
This is similar to what has been previously done for `vaadin-date-time-picker` - see this code:

https://github.com/vaadin/web-components/blob/427527c27c4b27822d61fd41d38d7b170134770b/packages/date-time-picker/src/vaadin-date-time-picker.js#L462-L469

Also updated tests to use `async` / `await` and wait for overlay rendering to avoid this error:

```
packages/field-highlighter/test/field-components.test.js:

 🚧 Browser logs:
      An error was thrown in a Promise outside a test. Did you forget to await a function or assertion?
      TypeError: null is not an object (evaluating 'this.shadowRoot.querySelectorAll')
        at focusableDateElement (packages/date-picker/src/vaadin-month-calendar.js:214:31)
        at packages/date-picker/src/vaadin-date-picker-overlay-content.js:251:53
        at focusableDateElement (packages/date-picker/src/vaadin-date-picker-overlay-content.js:251:30)
        at __tryFocusDate (packages/date-picker/src/vaadin-date-picker-overlay-content.js:937:31)
        at packages/date-picker/src/vaadin-date-picker-overlay-content.js:980:24
```

Note: most of the tests check that the event is NOT fired, so they were silently passing on master 🙈 
However, there is now one test that fails without changes to the `DatePickerObserver` class:

```
packages/field-highlighter/test/field-components.test.js:

 ❌ field components > date picker > default > should not dispatch vaadin-highlight-hide event on close without blur
      AssertionError: expected 1 to equal 0
      + expected - actual
```

## Type of change

- Bugfix