### PR TITLE
refactor!: expose date element states as parts names

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -85,8 +85,6 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  * Attribute  | Description                                      | Part name
  * -----------|--------------------------------------------------|-----------
  * `opened`   | Set when the date selector overlay is opened     | :host
- * `today`    | Set on the date corresponding to the current day | date
- * `selected` | Set on the selected date                         | date
  *
  * If you want to replace the default `<input>` and its container with a custom implementation to get full control
  * over the input field, consider using the [`<vaadin-date-picker-light>`](#/elements/vaadin-date-picker-light) element.
@@ -133,6 +131,10 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  * `week-numbers`        | Week numbers container
  * `week-number`         | Week number element
  * `date`                | Date element
+ * `disabled`            | Disabled date element
+ * `focused`             | Focused date element
+ * `selected`            | Selected date element
+ * `today`               | Date element corresponding to the current day
  *
  * In order to style year scroller elements, use `<vaadin-date-picker-year>` shadow DOM parts:
  *

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -53,8 +53,6 @@ registerStyles('vaadin-date-picker', inputFieldShared, { moduleId: 'vaadin-date-
  * Attribute  | Description                                      | Part name
  * -----------|--------------------------------------------------|-----------
  * `opened`   | Set when the date selector overlay is opened     | :host
- * `today`    | Set on the date corresponding to the current day | date
- * `selected` | Set on the selected date                         | date
  *
  * If you want to replace the default `<input>` and its container with a custom implementation to get full control
  * over the input field, consider using the [`<vaadin-date-picker-light>`](#/elements/vaadin-date-picker-light) element.
@@ -101,6 +99,10 @@ registerStyles('vaadin-date-picker', inputFieldShared, { moduleId: 'vaadin-date-
  * `week-numbers`        | Week numbers container
  * `week-number`         | Week number element
  * `date`                | Date element
+ * `disabled`            | Disabled date element
+ * `focused`             | Focused date element
+ * `selected`            | Selected date element
+ * `today`               | Date element corresponding to the current day
  *
  * In order to style year scroller elements, use `<vaadin-date-picker-year>` shadow DOM parts:
  *

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -32,8 +32,12 @@ class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
           display: flex;
         }
 
-        [part='date'] {
+        [part~='date'] {
           outline: none;
+        }
+
+        [part~='disabled'] {
+          pointer-events: none;
         }
 
         [part='week-number'][hidden],
@@ -42,7 +46,7 @@ class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
         }
 
         [part='weekday'],
-        [part='date'] {
+        [part~='date'] {
           width: calc(100% / 7);
           padding: 0;
           font-weight: normal;
@@ -56,7 +60,7 @@ class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
         }
 
         :host([week-numbers]) [part='weekday']:not(:empty),
-        :host([week-numbers]) [part='date'] {
+        :host([week-numbers]) [part~='date'] {
           width: 12.5%;
         }
       </style>
@@ -99,12 +103,9 @@ class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
               <template is="dom-repeat" items="[[week]]">
                 <td
                   role="gridcell"
-                  part="date"
+                  part$="[[__getDatePart(item, focusedDate, selectedDate, minDate, maxDate)]]"
                   date="[[item]]"
-                  today$="[[_isToday(item)]]"
-                  focused$="[[__isDayFocused(item, focusedDate)]]"
                   tabindex$="[[__getDayTabindex(item, focusedDate)]]"
-                  selected$="[[__isDaySelected(item, selectedDate)]]"
                   disabled$="[[__isDayDisabled(item, minDate, maxDate)]]"
                   aria-selected$="[[__getDayAriaSelected(item, selectedDate)]]"
                   aria-disabled$="[[__getDayAriaDisabled(item, minDate, maxDate)]]"
@@ -211,7 +212,7 @@ class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
   }
 
   get focusableDateElement() {
-    return [...this.shadowRoot.querySelectorAll('[part=date]')].find((datePart) => {
+    return [...this.shadowRoot.querySelectorAll('[part~=date]')].find((datePart) => {
       return dateEquals(datePart.date, this.focusedDate);
     });
   }
@@ -367,6 +368,28 @@ class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
 
   _preventDefault(e) {
     e.preventDefault();
+  }
+
+  __getDatePart(date, focusedDate, selectedDate, minDate, maxDate) {
+    const result = ['date'];
+
+    if (this.__isDayDisabled(date, minDate, maxDate)) {
+      result.push('disabled');
+    }
+
+    if (this.__isDayFocused(date, focusedDate)) {
+      result.push('focused');
+    }
+
+    if (this.__isDaySelected(date, selectedDate)) {
+      result.push('selected');
+    }
+
+    if (this._isToday(date)) {
+      result.push('today');
+    }
+
+    return result.join(' ');
   }
 
   __getWeekNumber(days) {

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -122,7 +122,7 @@ export function getFirstVisibleItem(scroller, bufferOffset) {
 export function getFocusedMonth(overlayContent) {
   const months = Array.from(overlayContent.querySelectorAll('vaadin-month-calendar'));
   return months.find((month) => {
-    const focused = month.shadowRoot.querySelector('[part="date"][focused]');
+    const focused = month.shadowRoot.querySelector('[part~="focused"]');
     return !!focused;
   });
 }
@@ -134,7 +134,7 @@ export function getFocusedCell(overlayContent) {
   let focusedCell;
 
   for (let i = 0; i < months.length; i++) {
-    focusedCell = months[i].shadowRoot.querySelector('[part="date"][focused]');
+    focusedCell = months[i].shadowRoot.querySelector('[part~="focused"]');
 
     if (focusedCell) {
       break;

--- a/packages/date-picker/test/dom/__snapshots__/month-calendar.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/month-calendar.test.snap.js
@@ -646,7 +646,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="11 February 2016, Thursday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -656,7 +656,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="12 February 2016, Friday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -666,7 +666,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="13 February 2016, Saturday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -685,7 +685,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="14 February 2016, Sunday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -695,7 +695,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="15 February 2016, Monday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -705,7 +705,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="16 February 2016, Tuesday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -715,7 +715,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="17 February 2016, Wednesday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -725,7 +725,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="18 February 2016, Thursday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -735,7 +735,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="19 February 2016, Friday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -745,7 +745,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="20 February 2016, Saturday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -764,7 +764,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="21 February 2016, Sunday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -774,7 +774,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="22 February 2016, Monday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -784,7 +784,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="23 February 2016, Tuesday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -794,7 +794,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="24 February 2016, Wednesday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -804,7 +804,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="25 February 2016, Thursday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -814,7 +814,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="26 February 2016, Friday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -824,7 +824,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="27 February 2016, Saturday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -843,7 +843,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="28 February 2016, Sunday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >
@@ -853,7 +853,7 @@ snapshots["vaadin-month-calendar shadow max date"] =
         aria-disabled="true"
         aria-label="29 February 2016, Monday"
         disabled=""
-        part="date"
+        part="date disabled"
         role="gridcell"
         tabindex="-1"
       >

--- a/packages/date-picker/test/fullscreen.test.js
+++ b/packages/date-picker/test/fullscreen.test.js
@@ -68,7 +68,7 @@ describe('fullscreen mode', () => {
         await open(datepicker);
         const cell = getFocusedCell(datepicker._overlayContent);
         expect(cell).to.be.instanceOf(HTMLTableCellElement);
-        expect(cell.hasAttribute('today')).to.be.true;
+        expect(cell.getAttribute('part')).to.include('today');
       });
     });
 

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -287,7 +287,7 @@ describe('keyboard', () => {
 
         const cell = getFocusedCell(overlayContent);
         expect(cell).to.be.instanceOf(HTMLTableCellElement);
-        expect(cell.hasAttribute('today')).to.be.true;
+        expect(cell.getAttribute('part')).to.contain('today');
       });
 
       it('should focus date scrolled out of the view on Today button Shift Tab', async () => {
@@ -303,7 +303,7 @@ describe('keyboard', () => {
 
         const cell = getFocusedCell(overlayContent);
         expect(cell).to.be.instanceOf(HTMLTableCellElement);
-        expect(cell.hasAttribute('today')).to.be.true;
+        expect(cell.getAttribute('part')).to.contain('today');
       });
     });
   });

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -8,7 +8,7 @@ describe('vaadin-month-calendar', () => {
   let monthCalendar, valueChangedSpy;
 
   function getDateCells(calendar) {
-    return [...calendar.shadowRoot.querySelectorAll('[part="date"]:not(:empty)')];
+    return [...calendar.shadowRoot.querySelectorAll('[part~="date"]:not(:empty)')];
   }
 
   function getWeekDayCells(calendar) {
@@ -82,7 +82,7 @@ describe('vaadin-month-calendar', () => {
   });
 
   it('should not fire value change on tapping an empty cell', () => {
-    const emptyDateElement = monthCalendar.shadowRoot.querySelector('[part="date"]:empty');
+    const emptyDateElement = monthCalendar.shadowRoot.querySelector('[part~="date"]:empty');
     tap(emptyDateElement);
     expect(valueChangedSpy.called).to.be.false;
   });
@@ -181,7 +181,7 @@ describe('vaadin-month-calendar', () => {
     it('should label today in correct locale', async () => {
       monthCalendar.month = new Date();
       await nextRender();
-      const today = getDateCells(monthCalendar).find((date) => date.hasAttribute('today'));
+      const today = getDateCells(monthCalendar).find((date) => date.getAttribute('part').includes('today'));
       expect(today.getAttribute('aria-label').split(', ').pop()).to.equal('Tänään');
     });
 

--- a/packages/date-picker/test/visual/common.js
+++ b/packages/date-picker/test/visual/common.js
@@ -15,7 +15,7 @@ registerStyles(
 registerStyles(
   'vaadin-month-calendar',
   css`
-    [part='date'][focused]::before {
+    [part~='focused']::before {
       animation: none !important;
     }
   `,

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -25,7 +25,7 @@ describe('WAI-ARIA', () => {
       await nextRender(datepicker);
       const calendars = datepicker._overlayContent.querySelectorAll('vaadin-month-calendar');
       calendars.forEach((calendar) => {
-        const focused = calendar.shadowRoot.querySelector('[part="date"][focused]');
+        const focused = calendar.shadowRoot.querySelector('[part~="focused"]');
         expect(calendar.getAttribute('aria-hidden')).to.equal(focused ? null : 'true');
       });
     });
@@ -80,7 +80,7 @@ describe('WAI-ARIA', () => {
     it('should indicate today on date cells', async () => {
       monthCalendar.month = new Date();
       await nextFrame();
-      const todayElement = monthCalendar.shadowRoot.querySelector('[part="date"]:not(:empty)[today]');
+      const todayElement = monthCalendar.shadowRoot.querySelector('[part~="today"]');
       expect(todayElement.getAttribute('aria-label')).to.match(/, Today$/);
     });
   });

--- a/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
@@ -50,7 +50,7 @@ registerStyles(
 
     /* Date and week number cells */
 
-    [part='date'],
+    [part~='date'],
     [part='week-number'] {
       box-sizing: border-box;
       display: inline-flex;
@@ -60,28 +60,28 @@ registerStyles(
       position: relative;
     }
 
-    [part='date'] {
+    [part~='date'] {
       transition: color 0.1s;
     }
 
-    [part='date']:not(:empty) {
+    [part~='date']:not(:empty) {
       cursor: var(--lumo-clickable-cursor);
     }
 
     :host([week-numbers]) [part='weekday']:not(:empty),
-    :host([week-numbers]) [part='date'] {
+    :host([week-numbers]) [part~='date'] {
       width: calc((100% - var(--lumo-size-xs)) / 7);
     }
 
     /* Today date */
 
-    [part='date'][today] {
+    [part~='date'][part~='today'] {
       color: var(--lumo-primary-text-color);
     }
 
     /* Focused date */
 
-    [part='date']::before {
+    [part~='date']::before {
       content: '';
       position: absolute;
       z-index: -1;
@@ -97,11 +97,11 @@ registerStyles(
       border-radius: var(--lumo-border-radius-m);
     }
 
-    [part='date'][focused]::before {
+    [part~='date'][part~='focused']::before {
       box-shadow: 0 0 0 1px var(--lumo-base-color), 0 0 0 3px var(--lumo-primary-color-50pct);
     }
 
-    :host(:not([focused])) [part='date'][focused]::before {
+    :host(:not([focused])) [part~='date'][part~='focused']::before {
       animation: vaadin-date-picker-month-calendar-focus-date 1.4s infinite;
     }
 
@@ -111,33 +111,33 @@ registerStyles(
       }
     }
 
-    [part='date']:not(:empty):not([disabled]):not([selected]):hover::before {
+    [part~='date']:not(:empty):not([part~='disabled']):not([part~='selected']):hover::before {
       background-color: var(--lumo-primary-color-10pct);
     }
 
-    [part='date'][selected] {
+    [part~='date'][part~='selected'] {
       color: var(--lumo-primary-contrast-color);
     }
 
-    [part='date'][selected]::before {
+    [part~='date'][part~='selected']::before {
       background-color: var(--lumo-primary-color);
     }
 
-    [part='date'][disabled] {
+    [part~='date'][part~='disabled'] {
       color: var(--lumo-disabled-text-color);
     }
 
     @media (pointer: coarse) {
-      [part='date']:hover:not([selected])::before,
-      [part='date'][focused]:not([selected])::before {
+      [part~='date']:hover:not([part~='selected'])::before,
+      [part~='focused']:not([part~='selected'])::before {
         display: none;
       }
 
-      [part='date']:not(:empty):not([disabled]):active::before {
+      [part~='date']:not(:empty):not([part~='disabled']):active::before {
         display: block;
       }
 
-      [part='date'][selected]::before {
+      [part~='date'][part~='selected']::before {
         box-shadow: none;
       }
     }

--- a/packages/date-picker/theme/material/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/material/vaadin-month-calendar-styles.js
@@ -35,7 +35,7 @@ registerStyles(
       color: var(--material-disabled-text-color);
     }
 
-    [part='date'] {
+    [part~='date'] {
       position: relative;
       font-size: var(--material-body-font-size);
       line-height: 42px;
@@ -43,7 +43,7 @@ registerStyles(
       cursor: default;
     }
 
-    [part='date']::after {
+    [part~='date']::after {
       content: '';
       position: absolute;
       z-index: -4;
@@ -59,13 +59,13 @@ registerStyles(
 
     /* Today */
 
-    [part='date'][today] {
+    [part~='date'][part~='today'] {
       color: var(--material-primary-text-color);
     }
 
     /* Hover */
 
-    [part='date']:not([disabled]):hover::after {
+    [part~='date']:not([part~='disabled']):hover::after {
       background-color: var(--material-secondary-background-color);
       border-color: var(--material-secondary-background-color);
       z-index: -3;
@@ -73,7 +73,7 @@ registerStyles(
 
     /* Hide for touch devices */
     @media (hover: none) {
-      [part='date']:not([disabled]):hover::after {
+      [part~='date']:not([part~='disabled']):hover::after {
         background-color: transparent;
         border-color: transparent;
         z-index: -4;
@@ -82,12 +82,12 @@ registerStyles(
 
     /* Selected */
 
-    [part='date'][selected] {
+    [part~='date'][part~='selected'] {
       font-weight: 500;
     }
 
-    [part='date']:not([disabled])[selected]::after,
-    [part='date'][selected]::after {
+    [part~='date']:not([part~='disabled'])[part~='selected']::after,
+    [part~='date'][part~='selected']::after {
       background-color: transparent;
       border-color: currentColor;
       z-index: -2;
@@ -95,24 +95,24 @@ registerStyles(
 
     /* Focused */
 
-    [part='date']:not([disabled])[focused],
-    [part='date']:not([disabled]):active {
+    [part~='date']:not([part~='disabled'])[part~='focused'],
+    [part~='date']:not([part~='disabled']):active {
       color: var(--material-primary-contrast-color);
     }
 
-    [part='date']:not([disabled])[focused]::after,
-    [part='date']:not([disabled]):active::after {
+    [part~='date']:not([part~='disabled'])[part~='focused']::after,
+    [part~='date']:not([part~='disabled']):active::after {
       opacity: 0.7;
       background-color: var(--material-primary-color);
       border-color: var(--material-primary-color);
       z-index: -1;
     }
 
-    [part='date'][disabled] {
+    [part~='date'][part~='disabled'] {
       color: var(--material-disabled-text-color);
     }
 
-    :host([focused]) [part='date']:not([disabled])[focused]::after {
+    :host([focused]) [part~='date']:not([part~='disabled'])[part~='focused']::after {
       opacity: 1;
     }
   `,


### PR DESCRIPTION
## Description

Fixes #4836

Changed state attributes used on the date elements in `vaadin-month-calendar` to use `part` names.
The `disabled` attribute is not removed:  we have tests for disabled date tap that fail without it.
https://github.com/vaadin/web-components/blob/61a03c90b7b60b7dd7cb3042cca4735a2a363932/packages/date-picker/test/month-calendar.test.js#L137


## Type of change

- Breaking change

## Note

We could probably reduce some selectors complexity by changing it like this:

```diff
-    [part='date'][selected] {
+    [part~='selected'] {
``` 

But maybe we should avoid that as long as the current CSS order works. @jouni WDYT?