### PR TITLE
fix: close tooltip when opening another overlay

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -472,6 +472,7 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     this.__onMouseEnter = this.__onMouseEnter.bind(this);
     this.__onMouseLeave = this.__onMouseLeave.bind(this);
     this.__onKeyDown = this.__onKeyDown.bind(this);
+    this.__onOverlayOpen = this.__onOverlayOpen.bind(this);
 
     this.__targetVisibilityObserver = new IntersectionObserver(
       ([entry]) => {
@@ -488,6 +489,8 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     super.connectedCallback();
 
     this._isConnected = true;
+
+    document.body.addEventListener('vaadin-overlay-open', this.__onOverlayOpen);
   }
 
   /** @protected */
@@ -498,6 +501,8 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
       this._stateController.close(true);
     }
     this._isConnected = false;
+
+    document.body.removeEventListener('vaadin-overlay-open', this.__onOverlayOpen);
   }
 
   /** @private */
@@ -691,6 +696,18 @@ class Tooltip extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
 
     if (!this.__focusInside) {
       this._stateController.close();
+    }
+  }
+
+  /** @private */
+  __onOverlayOpen() {
+    if (this.manual) {
+      return;
+    }
+
+    // Close tooltip if another overlay is opened on top of the tooltip's overlay
+    if (this._overlayElement.opened && !this._overlayElement._last) {
+      this._stateController.close(true);
     }
   }
 

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -7,6 +7,7 @@ import {
   keyboardEventFor,
   mousedown,
   nextFrame,
+  nextRender,
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
@@ -415,6 +416,18 @@ describe('vaadin-tooltip', () => {
       tabKeyDown(target);
       focusout(target, input);
       focusin(input, target);
+
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close overlay when another overlay opens', async () => {
+      tabKeyDown(target);
+      target.focus();
+      expect(overlay.opened).to.be.true;
+
+      const otherOverlay = fixtureSync('<vaadin-overlay></vaadin-overlay>');
+      otherOverlay.opened = true;
+      await nextRender();
 
       expect(overlay.opened).to.be.false;
     });

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -669,6 +669,17 @@ describe('vaadin-tooltip', () => {
       document.body.append(tooltip);
       expect(overlay.opened).to.be.true;
     });
+
+    it('should not close overlay when another overlay opens', async () => {
+      tooltip.opened = true;
+      expect(overlay.opened).to.be.true;
+
+      const otherOverlay = fixtureSync('<vaadin-overlay></vaadin-overlay>');
+      otherOverlay.opened = true;
+      await nextRender();
+
+      expect(overlay.opened).to.be.true;
+    });
   });
 });
 


### PR DESCRIPTION
## Description

Ensures that an auto-opened, slotted tooltip closes when another overlay is opened. The tooltip now listens for overlay open events, and closes itself if it is not the last overlay anymore.

Fixes #4737 
Closes #4566

## Type of change

- Bugfix