### PR TITLE
refactor!: move button and drop label to light DOM

### DIFF
--- a/packages/upload/src/vaadin-upload-icon.js
+++ b/packages/upload/src/vaadin-upload-icon.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-upload>`. Not intended to be used separately.
+ *
+ * @extends HTMLElement
+ * @private
+ */
+class UploadIcon extends ThemableMixin(PolymerElement) {
+  static get is() {
+    return 'vaadin-upload-icon';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: inline-block;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+      </style>
+    `;
+  }
+}
+
+customElements.define(UploadIcon.is, UploadIcon);
+
+export { UploadIcon };

--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -184,7 +184,6 @@ export interface UploadEventMap extends HTMLElementEventMap, UploadCustomEventMa
  * Part name          | Description
  * -------------------|-------------------------------------
  * `primary-buttons`  | Upload container
- * `upload-button`    | Upload button
  * `drop-label`       | Element wrapping drop label and icon
  * `file-list`        | File list container
  *

--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -180,13 +181,12 @@ export interface UploadEventMap extends HTMLElementEventMap, UploadCustomEventMa
  *
  * The following shadow DOM parts are available for styling:
  *
- * Part name | Description
- * ---|---
- * `primary-buttons` | Upload container
- * `upload-button` | Upload button
- * `drop-label` | Label for drop indicator
- * `drop-label-icon` | Icon for drop indicator
- * `file-list` | File list container
+ * Part name          | Description
+ * -------------------|-------------------------------------
+ * `primary-buttons`  | Upload container
+ * `upload-button`    | Upload button
+ * `drop-label`       | Element wrapping drop label and icon
+ * `file-list`        | File list container
  *
  * The following state attributes are available for styling:
  *
@@ -212,7 +212,7 @@ export interface UploadEventMap extends HTMLElementEventMap, UploadCustomEventMa
  * @fires {CustomEvent} upload-retry - Fired when retry upload is requested.
  * @fires {CustomEvent} upload-abort - Fired when upload abort is requested.
  */
-declare class Upload extends ThemableMixin(ElementMixin(HTMLElement)) {
+declare class Upload extends ThemableMixin(ElementMixin(ControllerMixin(HTMLElement))) {
   /**
    * Define whether the element supports dropping files on it for uploading.
    * By default it's enabled in desktop and disabled in touch devices

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -32,7 +32,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * Part name          | Description
  * -------------------|-------------------------------------
  * `primary-buttons`  | Upload container
- * `upload-button`    | Upload button
  * `drop-label`       | Element wrapping drop label and icon
  * `file-list`        | File list container
  *
@@ -425,7 +424,12 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
         },
       },
 
-      /** @private  */
+      /** @private */
+      _addButton: {
+        type: Object,
+      },
+
+      /** @private */
       _dropLabel: {
         type: Object,
       },

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -91,9 +91,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       </style>
 
       <div part="primary-buttons">
-        <div id="addFiles" on-touchend="_onAddFilesTouchEnd" on-click="_onAddFilesClick">
-          <slot name="add-button"></slot>
-        </div>
+        <slot name="add-button"></slot>
         <div part="drop-label" hidden$="[[nodrop]]" id="dropLabelContainer" aria-hidden="true">
           <slot name="drop-label-icon"></slot>
           <slot name="drop-label"></slot>
@@ -462,6 +460,12 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
         'add-button',
         () => document.createElement('vaadin-button'),
         (_, button) => {
+          button.addEventListener('touchend', (e) => {
+            this._onAddFilesTouchEnd(e);
+          });
+          button.addEventListener('click', (e) => {
+            this._onAddFilesClick(e);
+          });
           this._addButton = button;
         },
       ),

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -5,12 +5,15 @@
  */
 import '@polymer/polymer/lib/elements/dom-repeat.js';
 import '@vaadin/button/src/vaadin-button.js';
+import './vaadin-upload-icon.js';
 import './vaadin-upload-icons.js';
 import './vaadin-upload-file.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { announce } from '@vaadin/component-base/src/a11y-announcer.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
@@ -26,13 +29,12 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * The following shadow DOM parts are available for styling:
  *
- * Part name | Description
- * ---|---
- * `primary-buttons` | Upload container
- * `upload-button` | Upload button
- * `drop-label` | Label for drop indicator
- * `drop-label-icon` | Icon for drop indicator
- * `file-list` | File list container
+ * Part name          | Description
+ * -------------------|-------------------------------------
+ * `primary-buttons`  | Upload container
+ * `upload-button`    | Upload button
+ * `drop-label`       | Element wrapping drop label and icon
+ * `file-list`        | File list container
  *
  * The following state attributes are available for styling:
  *
@@ -59,10 +61,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @fires {CustomEvent} upload-abort - Fired when upload abort is requested.
  *
  * @extends HTMLElement
+ * @mixes ControllerMixin
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
+class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))) {
   static get template() {
     return html`
       <style>
@@ -89,17 +92,11 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
 
       <div part="primary-buttons">
         <div id="addFiles" on-touchend="_onAddFilesTouchEnd" on-click="_onAddFilesClick">
-          <slot name="add-button">
-            <vaadin-button part="upload-button" id="addButton" disabled="[[maxFilesReached]]">
-              [[_i18nPlural(maxFiles, i18n.addFiles, i18n.addFiles.*)]]
-            </vaadin-button>
-          </slot>
+          <slot name="add-button"></slot>
         </div>
         <div part="drop-label" hidden$="[[nodrop]]" id="dropLabelContainer" aria-hidden="true">
-          <slot name="drop-label-icon">
-            <div part="drop-label-icon"></div>
-          </slot>
-          <slot name="drop-label" id="dropLabel"> [[_i18nPlural(maxFiles, i18n.dropFiles, i18n.dropFiles.*)]]</slot>
+          <slot name="drop-label-icon"></slot>
+          <slot name="drop-label"></slot>
         </div>
       </div>
       <slot name="file-list">
@@ -429,7 +426,19 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
           };
         },
       },
+
+      /** @private  */
+      _dropLabel: {
+        type: Object,
+      },
     };
+  }
+
+  static get observers() {
+    return [
+      '__updateAddButton(_addButton, maxFiles, i18n, maxFilesReached)',
+      '__updateDropLabel(_dropLabel, maxFiles, i18n)',
+    ];
   }
 
   /** @protected */
@@ -446,6 +455,30 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
     this.addEventListener('upload-start', this._onUploadStart.bind(this));
     this.addEventListener('upload-success', this._onUploadSuccess.bind(this));
     this.addEventListener('upload-error', this._onUploadError.bind(this));
+
+    this.addController(
+      new SlotController(
+        this,
+        'add-button',
+        () => document.createElement('vaadin-button'),
+        (_, button) => {
+          this._addButton = button;
+        },
+      ),
+    );
+
+    this.addController(
+      new SlotController(
+        this,
+        'drop-label',
+        () => document.createElement('span'),
+        (_, label) => {
+          this._dropLabel = label;
+        },
+      ),
+    );
+
+    this.addController(new SlotController(this, 'drop-label-icon', () => document.createElement('vaadin-upload-icon')));
   }
 
   /** @private */
@@ -507,6 +540,21 @@ class Upload extends ElementMixin(ThemableMixin(PolymerElement)) {
   /** @private */
   _maxFilesAdded(maxFiles, numFiles) {
     return maxFiles >= 0 && numFiles >= maxFiles;
+  }
+
+  /** @private */
+  __updateAddButton(addButton, maxFiles, i18n, maxFilesReached) {
+    if (addButton) {
+      addButton.disabled = maxFilesReached;
+      addButton.textContent = this._i18nPlural(maxFiles, i18n.addFiles);
+    }
+  }
+
+  /** @private */
+  __updateDropLabel(dropLabel, maxFiles, i18n) {
+    if (dropLabel) {
+      dropLabel.textContent = this._i18nPlural(maxFiles, i18n.dropFiles);
+    }
   }
 
   /** @private */

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -35,11 +35,11 @@ describe('file list', () => {
 
   describe('with add button', () => {
     let input;
-    let addFiles;
+    let addButton;
     let inputClickSpy;
 
     beforeEach(() => {
-      addFiles = upload.$.addFiles;
+      addButton = upload.querySelector('[slot="add-button"]');
       input = upload.$.fileInput;
       // While the synthetic "Add Files" button click event is not trusted and
       // it should generate a non-trusted click event on the hidden file input,
@@ -50,12 +50,12 @@ describe('file list', () => {
     });
 
     it('should open file dialog by click', () => {
-      click(addFiles);
+      click(addButton);
       expect(inputClickSpy.calledOnce).to.be.true;
     });
 
     it('should open file dialog by touchend', () => {
-      const event = makeSoloTouchEvent('touchend', null, addFiles);
+      const event = makeSoloTouchEvent('touchend', null, addButton);
       expect(inputClickSpy.calledOnce).to.be.true;
       expect(event.defaultPrevented).to.be.true;
     });
@@ -67,7 +67,7 @@ describe('file list', () => {
       delete input.value;
       input.value = 'foo';
 
-      click(addFiles);
+      click(addButton);
       expect(input.value).to.be.empty;
     });
 
@@ -84,8 +84,6 @@ describe('file list', () => {
     });
 
     it('should disable add button when max files added', () => {
-      const addButton = upload.querySelector('[slot="add-button"]');
-
       // Enabled with default maxFiles value
       expect(addButton.disabled).to.be.false;
 
@@ -98,7 +96,7 @@ describe('file list', () => {
 
     it('should not open upload dialog when max files added', () => {
       upload.maxFiles = 0;
-      click(addFiles);
+      click(addButton);
       expect(inputClickSpy.called).to.be.false;
     });
 

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -39,7 +39,7 @@ describe('file list', () => {
     let inputClickSpy;
 
     beforeEach(() => {
-      addButton = upload.querySelector('[slot="add-button"]');
+      addButton = upload._addButton;
       input = upload.$.fileInput;
       // While the synthetic "Add Files" button click event is not trusted and
       // it should generate a non-trusted click event on the hidden file input,

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -84,7 +84,7 @@ describe('file list', () => {
     });
 
     it('should disable add button when max files added', () => {
-      const addButton = upload.$.addButton;
+      const addButton = upload.querySelector('[slot="add-button"]');
 
       // Enabled with default maxFiles value
       expect(addButton.disabled).to.be.false;

--- a/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
@@ -41,10 +41,8 @@ snapshots["vaadin-upload host max files"] =
 
 snapshots["vaadin-upload shadow default"] = 
 `<div part="primary-buttons">
-  <div id="addFiles">
-    <slot name="add-button">
-    </slot>
-  </div>
+  <slot name="add-button">
+  </slot>
   <div
     aria-hidden="true"
     id="dropLabelContainer"

--- a/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
@@ -1,18 +1,48 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-upload host default"] = 
+`<vaadin-upload>
+  <vaadin-button
+    role="button"
+    slot="add-button"
+    tabindex="0"
+  >
+    Upload Files...
+  </vaadin-button>
+  <span slot="drop-label">
+    Drop files here
+  </span>
+  <vaadin-upload-icon slot="drop-label-icon">
+  </vaadin-upload-icon>
+</vaadin-upload>
+`;
+/* end snapshot vaadin-upload host default */
+
+snapshots["vaadin-upload host max files"] = 
+`<vaadin-upload max-files-reached="">
+  <vaadin-button
+    aria-disabled="true"
+    disabled=""
+    role="button"
+    slot="add-button"
+    tabindex="-1"
+  >
+    Upload File...
+  </vaadin-button>
+  <span slot="drop-label">
+    Drop file here
+  </span>
+  <vaadin-upload-icon slot="drop-label-icon">
+  </vaadin-upload-icon>
+</vaadin-upload>
+`;
+/* end snapshot vaadin-upload host max files */
+
 snapshots["vaadin-upload shadow default"] = 
 `<div part="primary-buttons">
   <div id="addFiles">
     <slot name="add-button">
-      <vaadin-button
-        id="addButton"
-        part="upload-button"
-        role="button"
-        tabindex="0"
-      >
-        Upload Files...
-      </vaadin-button>
     </slot>
   </div>
   <div
@@ -21,14 +51,8 @@ snapshots["vaadin-upload shadow default"] =
     part="drop-label"
   >
     <slot name="drop-label-icon">
-      <div part="drop-label-icon">
-      </div>
     </slot>
-    <slot
-      id="dropLabel"
-      name="drop-label"
-    >
-      Drop files here
+    <slot name="drop-label">
     </slot>
   </div>
 </div>

--- a/packages/upload/test/dom/vaadin-upload.test.js
+++ b/packages/upload/test/dom/vaadin-upload.test.js
@@ -19,6 +19,17 @@ describe('vaadin-upload', () => {
     await nextFrame();
   });
 
+  describe('host', () => {
+    it('default', async () => {
+      await expect(upload).dom.to.equalSnapshot();
+    });
+
+    it('max files', async () => {
+      upload.maxFiles = 1;
+      await expect(upload).dom.to.equalSnapshot();
+    });
+  });
+
   describe('shadow', () => {
     it('default', async () => {
       await expect(upload).shadowDom.to.equalSnapshot();

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -540,25 +540,4 @@ describe('upload', () => {
       removeFirst();
     });
   });
-
-  describe('maxFiles change', () => {
-    let addButton, dropLabel;
-
-    beforeEach(() => {
-      addButton = upload.querySelector('[slot="add-button"]');
-      dropLabel = upload.querySelector('[slot="drop-label"]');
-    });
-
-    it('should show `Add Files` labels in plural when maxFiles is not 1', () => {
-      upload.maxFiles = 3;
-      expect(dropLabel.textContent.indexOf(upload.i18n.dropFiles.many) >= 0).to.be.true;
-      expect(addButton.textContent.indexOf(upload.i18n.addFiles.many) >= 0).to.be.true;
-    });
-
-    it('should show `Add File` labels in singular when maxFiles is 1', () => {
-      upload.maxFiles = 1;
-      expect(dropLabel.textContent.indexOf(upload.i18n.dropFiles.one) >= 0).to.be.true;
-      expect(addButton.textContent.indexOf(upload.i18n.addFiles.one) >= 0).to.be.true;
-    });
-  });
 });

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -542,16 +542,23 @@ describe('upload', () => {
   });
 
   describe('maxFiles change', () => {
+    let addButton, dropLabel;
+
+    beforeEach(() => {
+      addButton = upload.querySelector('[slot="add-button"]');
+      dropLabel = upload.querySelector('[slot="drop-label"]');
+    });
+
     it('should show `Add Files` labels in plural when maxFiles is not 1', () => {
       upload.maxFiles = 3;
-      expect(upload.$.dropLabel.textContent.indexOf(upload.i18n.dropFiles.many) >= 0).to.be.true;
-      expect(upload.$.addButton.textContent.indexOf(upload.i18n.addFiles.many) >= 0).to.be.true;
+      expect(dropLabel.textContent.indexOf(upload.i18n.dropFiles.many) >= 0).to.be.true;
+      expect(addButton.textContent.indexOf(upload.i18n.addFiles.many) >= 0).to.be.true;
     });
 
     it('should show `Add File` labels in singular when maxFiles is 1', () => {
       upload.maxFiles = 1;
-      expect(upload.$.dropLabel.textContent.indexOf(upload.i18n.dropFiles.one) >= 0).to.be.true;
-      expect(upload.$.addButton.textContent.indexOf(upload.i18n.addFiles.one) >= 0).to.be.true;
+      expect(dropLabel.textContent.indexOf(upload.i18n.dropFiles.one) >= 0).to.be.true;
+      expect(addButton.textContent.indexOf(upload.i18n.addFiles.one) >= 0).to.be.true;
     });
   });
 });

--- a/packages/upload/test/visual/lumo/upload.test.js
+++ b/packages/upload/test/visual/lumo/upload.test.js
@@ -54,7 +54,7 @@ describe('upload', () => {
       element.files[0].held = true;
       // To show the retry button
       element.files[0].error = 'Could not upload file';
-      element.shadowRoot.querySelector('[part=upload-button]').focus();
+      element.querySelector('[slot="add-button"]').focus();
     });
 
     it('file', async () => {

--- a/packages/upload/test/visual/material/upload.test.js
+++ b/packages/upload/test/visual/material/upload.test.js
@@ -54,7 +54,7 @@ describe('upload', () => {
       element.files[0].held = true;
       // To show the retry button
       element.files[0].error = 'Could not upload file';
-      element.shadowRoot.querySelector('[part=upload-button]').focus();
+      element.querySelector('[slot="add-button"]').focus();
     });
 
     it('file', async () => {

--- a/packages/upload/theme/lumo/vaadin-upload-styles.js
+++ b/packages/upload/theme/lumo/vaadin-upload-styles.js
@@ -24,11 +24,6 @@ registerStyles(
       transition: background-color 0.6s, border-color 0.6s;
     }
 
-    [part='primary-buttons'] > * {
-      display: inline-block;
-      white-space: nowrap;
-    }
-
     [part='drop-label'] {
       display: inline-block;
       white-space: normal;

--- a/packages/upload/theme/lumo/vaadin-upload-styles.js
+++ b/packages/upload/theme/lumo/vaadin-upload-styles.js
@@ -51,23 +51,25 @@ registerStyles(
       color: var(--lumo-disabled-text-color);
     }
 
-    [part='drop-label-icon'] {
-      display: inline-block;
+    [part='file-list'] > *:not(:first-child) > * {
+      border-top: 1px solid var(--lumo-contrast-10pct);
     }
+  `,
+  { moduleId: 'lumo-upload' },
+);
 
-    [part='drop-label-icon']::before {
+registerStyles(
+  'vaadin-upload-icon',
+  css`
+    :host::before {
       content: var(--lumo-icons-upload);
       font-family: lumo-icons;
       font-size: var(--lumo-icon-size-m);
       line-height: 1;
       vertical-align: -0.25em;
     }
-
-    [part='file-list'] > *:not(:first-child) > * {
-      border-top: 1px solid var(--lumo-contrast-10pct);
-    }
   `,
-  { moduleId: 'lumo-upload' },
+  { moduleId: 'lumo-upload-icon' },
 );
 
 const uploadFile = css`

--- a/packages/upload/theme/material/vaadin-upload-styles.js
+++ b/packages/upload/theme/material/vaadin-upload-styles.js
@@ -29,8 +29,7 @@ registerStyles(
       flex-grow: 1;
     }
 
-    [part='upload-button'] {
-      display: block;
+    ::slotted([slot='add-button']) {
       margin: 0 -8px;
     }
 
@@ -54,18 +53,6 @@ registerStyles(
 
     :host([max-files-reached]) [part='drop-label'] {
       color: var(--material-disabled-text-color);
-    }
-
-    [part='drop-label-icon'] {
-      display: inline-block;
-      margin-right: 8px;
-    }
-
-    [part='drop-label-icon']::before {
-      content: var(--material-icons-upload);
-      font-family: material-icons;
-      font-size: var(--material-icon-font-size);
-      line-height: 1;
     }
 
     /* Ripple */
@@ -94,6 +81,24 @@ registerStyles(
     }
   `,
   { moduleId: 'material-upload' },
+);
+
+registerStyles(
+  'vaadin-upload-icon',
+  css`
+    :host {
+      display: inline-block;
+      margin-right: 8px;
+    }
+
+    :host::before {
+      content: var(--material-icons-upload);
+      font-family: material-icons;
+      font-size: var(--material-icon-font-size);
+      line-height: 1;
+    }
+  `,
+  { moduleId: 'material-upload-icon' },
 );
 
 registerStyles(

--- a/packages/upload/theme/material/vaadin-upload-styles.js
+++ b/packages/upload/theme/material/vaadin-upload-styles.js
@@ -23,12 +23,6 @@ registerStyles(
       align-items: baseline;
     }
 
-    /* TODO(jouni): unsupported selector (not sure why there's #addFiles element wrapping the upload button) */
-    [part='primary-buttons'] > * {
-      display: block;
-      flex-grow: 1;
-    }
-
     ::slotted([slot='add-button']) {
       margin: 0 -8px;
     }

--- a/packages/upload/theme/material/vaadin-upload-styles.js
+++ b/packages/upload/theme/material/vaadin-upload-styles.js
@@ -81,7 +81,6 @@ registerStyles(
   'vaadin-upload-icon',
   css`
     :host {
-      display: inline-block;
       margin-right: 8px;
     }
 


### PR DESCRIPTION
## Description

Fixes #4281

1. Moved `add-button`, `drop-label` and `drop-label-icon` elements to slots using `SlotController`,
2. Created `vaadin-upload-icon` element for default upload icon (so that we can apply styles to it),
3. Removed an extra `<div id="addFiles">` wrapping the button, as it doesn't seem to be needed.

## Type of change

- Breaking change