### PR TITLE
fix: allow navigating and removing chips while opened

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -972,7 +972,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   /** @private */
   _onArrowLeft(chips) {
-    if (this.inputElement.value !== '' || this.opened) {
+    if (this.inputElement.selectionStart !== 0) {
       return;
     }
 
@@ -1002,7 +1002,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   /** @private */
   _onArrowRight(chips) {
-    if (this.inputElement.value !== '' || this.opened) {
+    if (this.inputElement.selectionStart !== 0) {
       return;
     }
 
@@ -1032,7 +1032,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   /** @private */
   _onBackSpace(chips) {
-    if (this.inputElement.value !== '' || this.opened) {
+    if (this.inputElement.selectionStart !== 0) {
       return;
     }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -958,10 +958,10 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           this._onBackSpace(chips);
           break;
         case 'ArrowLeft':
-          this._onArrowLeft(chips);
+          this._onArrowLeft(chips, event);
           break;
         case 'ArrowRight':
-          this._onArrowRight(chips);
+          this._onArrowRight(chips, event);
           break;
         default:
           this._focusedChipIndex = -1;
@@ -971,12 +971,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /** @private */
-  _onArrowLeft(chips) {
+  _onArrowLeft(chips, event) {
     if (this.inputElement.selectionStart !== 0) {
       return;
     }
 
     const idx = this._focusedChipIndex;
+    if (idx !== -1) {
+      event.preventDefault();
+    }
     let newIdx;
 
     if (this.getAttribute('dir') !== 'rtl') {
@@ -1001,12 +1004,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /** @private */
-  _onArrowRight(chips) {
+  _onArrowRight(chips, event) {
     if (this.inputElement.selectionStart !== 0) {
       return;
     }
 
     const idx = this._focusedChipIndex;
+    if (idx !== -1) {
+      event.preventDefault();
+    }
     let newIdx;
 
     if (this.getAttribute('dir') === 'rtl') {

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -495,12 +495,12 @@ describe('basic', () => {
           expect(chips[2].hasAttribute('focused')).to.be.false;
         });
 
-        it('should not mark last chip on Backspace as focused when dropdown is opened', async () => {
+        it('should mark last chip on Backspace as focused when dropdown is opened', async () => {
           await sendKeys({ press: 'ArrowDown' });
           await sendKeys({ press: 'Backspace' });
           const chips = getChips(comboBox);
           expect(chips[1].hasAttribute('focused')).to.be.false;
-          expect(chips[2].hasAttribute('focused')).to.be.false;
+          expect(chips[2].hasAttribute('focused')).to.be.true;
         });
 
         it('should not mark last chip on Backspace as focused when readonly', async () => {
@@ -542,7 +542,7 @@ describe('basic', () => {
               expect(chips[2].hasAttribute('focused')).to.be.true;
             });
 
-            it(`should not mark last chip on ${PREV_KEY} as focused when input has value`, async () => {
+            it(`should not mark last chip on ${PREV_KEY} as focused when input has value and caret is not in starting position`, async () => {
               await sendKeys({ type: 'lemon' });
               await sendKeys({ press: PREV_KEY });
               const chips = getChips(comboBox);
@@ -550,12 +550,26 @@ describe('basic', () => {
               expect(chips[2].hasAttribute('focused')).to.be.false;
             });
 
-            it(`should not mark last chip on ${PREV_KEY} as focused when dropdown is opened`, async () => {
+            it(`should mark last chip on ${PREV_KEY} as focused when input has value and caret is in starting position`, async () => {
+              const inputValue = 'lemon';
+              await sendKeys({ type: inputValue });
+              for (let i = 0; i < inputValue.length; i++) {
+                await sendKeys({ press: PREV_KEY });
+              }
+              const chips = getChips(comboBox);
+              expect(chips[1].hasAttribute('focused')).to.be.false;
+              expect(chips[2].hasAttribute('focused')).to.be.false;
+              await sendKeys({ press: PREV_KEY });
+              expect(chips[1].hasAttribute('focused')).to.be.false;
+              expect(chips[2].hasAttribute('focused')).to.be.true;
+            });
+
+            it(`should mark last chip on ${PREV_KEY} as focused when dropdown is opened`, async () => {
               await sendKeys({ press: 'ArrowDown' });
               await sendKeys({ press: PREV_KEY });
               const chips = getChips(comboBox);
               expect(chips[1].hasAttribute('focused')).to.be.false;
-              expect(chips[2].hasAttribute('focused')).to.be.false;
+              expect(chips[2].hasAttribute('focused')).to.be.true;
             });
 
             it(`should mark previous chip on ${PREV_KEY} as focused when a chip is focused`, async () => {

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -575,6 +575,17 @@ describe('basic', () => {
               expect(chips[2].hasAttribute('focused')).to.be.false;
             });
 
+            it(`should not change caret position after ${PREV_KEY} when a chip is focused`, async () => {
+              await sendKeys({ type: 'lemon' });
+              inputElement.blur();
+              const chips = getChips(comboBox);
+              chips[2].toggleAttribute('focused');
+              expect(chips[1].hasAttribute('focused')).to.be.false;
+              expect(chips[2].hasAttribute('focused')).to.be.true;
+              await sendKeys({ press: PREV_KEY });
+              expect(inputElement.selectionStart).to.equal(0);
+            });
+
             it(`should mark next chip on ${NEXT_KEY} as focused when a chip is focused`, async () => {
               await sendKeys({ press: PREV_KEY });
               await sendKeys({ press: PREV_KEY });
@@ -598,6 +609,17 @@ describe('basic', () => {
               const chips = getChips(comboBox);
               expect(chips[1].hasAttribute('focused')).to.be.false;
               expect(chips[2].hasAttribute('focused')).to.be.false;
+            });
+
+            it(`should not change caret position after ${NEXT_KEY} when a chip is focused`, async () => {
+              await sendKeys({ type: 'lemon' });
+              inputElement.blur();
+              const chips = getChips(comboBox);
+              chips[1].toggleAttribute('focused');
+              expect(chips[1].hasAttribute('focused')).to.be.true;
+              expect(chips[2].hasAttribute('focused')).to.be.false;
+              await sendKeys({ press: NEXT_KEY });
+              expect(inputElement.selectionStart).to.equal(0);
             });
           });
         });

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -542,7 +542,7 @@ describe('basic', () => {
               expect(chips[2].hasAttribute('focused')).to.be.true;
             });
 
-            it(`should not mark last chip on ${PREV_KEY} as focused when input has value and caret is not in starting position`, async () => {
+            it(`should not mark last chip on ${PREV_KEY} as focused when caret is not in starting position`, async () => {
               await sendKeys({ type: 'lemon' });
               await sendKeys({ press: PREV_KEY });
               const chips = getChips(comboBox);
@@ -550,16 +550,11 @@ describe('basic', () => {
               expect(chips[2].hasAttribute('focused')).to.be.false;
             });
 
-            it(`should mark last chip on ${PREV_KEY} as focused when input has value and caret is in starting position`, async () => {
-              const inputValue = 'lemon';
-              await sendKeys({ type: inputValue });
-              for (let i = 0; i < inputValue.length; i++) {
-                await sendKeys({ press: PREV_KEY });
-              }
-              const chips = getChips(comboBox);
-              expect(chips[1].hasAttribute('focused')).to.be.false;
-              expect(chips[2].hasAttribute('focused')).to.be.false;
+            it(`should mark last chip on ${PREV_KEY} as focused when caret is in starting position`, async () => {
+              await sendKeys({ type: 'lemon' });
+              inputElement.setSelectionRange(0, 0);
               await sendKeys({ press: PREV_KEY });
+              const chips = getChips(comboBox);
               expect(chips[1].hasAttribute('focused')).to.be.false;
               expect(chips[2].hasAttribute('focused')).to.be.true;
             });


### PR DESCRIPTION
## Description

Make backspace, arrowLeft and arrowRight keys work when overlay is opened or input value is not empty.

Caret anywhere except the start of the text input: 
- backspace removes preceding character
- arrowLeft moves caret to the left
- arrowRight moves caret to the right if there is text

Caret at start text input (whether empty or not):
- backspace focuses last chip
- arrowLeft focuses last chip
- arrowRight moves caret to the right if there is text

Last chip focused:
- backspace removes that item
- arrowLeft focuses preceding chip
- arrowRight  focuses following chip (if last chip: moves caret to the right if there is text, else removes focus from the last chip)

Fixes #4820 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
