### PR TITLE
refactor!: render upload file elements in light DOM

### DIFF
--- a/packages/upload/src/vaadin-upload-file-list.js
+++ b/packages/upload/src/vaadin-upload-file-list.js
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import './vaadin-upload-file.js';
+import { html as legacyHtml, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { html, render } from 'lit';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-upload>`. Not intended to be used separately.
+ *
+ * @extends HTMLElement
+ * @mixes FocusMixin
+ * @private
+ */
+class UploadFileList extends ThemableMixin(PolymerElement) {
+  static get is() {
+    return 'vaadin-upload-file-list';
+  }
+
+  static get template() {
+    return legacyHtml`
+      <style>
+        :host {
+          display: block;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+
+        [part='list'] {
+          padding: 0;
+          margin: 0;
+          list-style-type: none;
+        }
+      </style>
+      <ul part="list">
+        <slot></slot>
+      </ul>
+    `;
+  }
+
+  static get properties() {
+    return {
+      /**
+       * The array of files being processed, or already uploaded.
+       */
+      items: {
+        type: Array,
+      },
+
+      /**
+       * The object used to localize upload files.
+       */
+      i18n: {
+        type: Object,
+      },
+    };
+  }
+
+  static get observers() {
+    return ['__updateItems(items, i18n)'];
+  }
+
+  /** @private */
+  __updateItems(items, i18n) {
+    if (items && i18n) {
+      this.requestContentUpdate();
+    }
+  }
+
+  /**
+   * Requests an update for the `vaadin-upload-file` elements.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   */
+  requestContentUpdate() {
+    const { items, i18n } = this;
+
+    render(
+      html`
+        ${items.map(
+          (file) => html`
+            <li>
+              <vaadin-upload-file
+                .file="${file}"
+                .complete="${file.complete}"
+                .errorMessage="${file.error}"
+                .fileName="${file.name}"
+                .held="${file.held}"
+                .indeterminate="${file.indeterminate}"
+                .progress="${file.progress}"
+                .status="${file.status}"
+                .uploading="${file.uploading}"
+                .i18n="${i18n}"
+              ></vaadin-upload-file>
+            </li>
+          `,
+        )}
+      `,
+      this,
+    );
+  }
+}
+
+customElements.define(UploadFileList.is, UploadFileList);
+
+export { UploadFileList };

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -82,13 +82,13 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
 
       <div part="row">
         <div part="info">
-          <div part="done-icon" hidden$="[[!file.complete]]" aria-hidden="true"></div>
-          <div part="warning-icon" hidden$="[[!file.error]]" aria-hidden="true"></div>
+          <div part="done-icon" hidden$="[[!complete]]" aria-hidden="true"></div>
+          <div part="warning-icon" hidden$="[[!errorMessage]]" aria-hidden="true"></div>
 
           <div part="meta">
-            <div part="name" id="name">[[file.name]]</div>
-            <div part="status" hidden$="[[!file.status]]" id="status">[[file.status]]</div>
-            <div part="error" id="error" hidden$="[[!file.error]]">[[file.error]]</div>
+            <div part="name" id="name">[[fileName]]</div>
+            <div part="status" hidden$="[[!status]]" id="status">[[status]]</div>
+            <div part="error" id="error" hidden$="[[!errorMessage]]">[[errorMessage]]</div>
           </div>
         </div>
         <div part="commands">
@@ -97,7 +97,7 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
             part="start-button"
             file-event="file-start"
             on-click="_fireFileEvent"
-            hidden$="[[!file.held]]"
+            hidden$="[[!held]]"
             aria-label$="[[i18n.file.start]]"
             aria-describedby="name"
           ></button>
@@ -106,7 +106,7 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
             part="retry-button"
             file-event="file-retry"
             on-click="_fireFileEvent"
-            hidden$="[[!file.error]]"
+            hidden$="[[!errorMessage]]"
             aria-label$="[[i18n.file.retry]]"
             aria-describedby="name"
           ></button>
@@ -131,9 +131,75 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
 
   static get properties() {
     return {
-      file: Object,
+      /**
+       * True if uploading is completed, false otherwise.
+       */
+      complete: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true,
+      },
 
-      i18n: Object,
+      /**
+       * Error message returned by the server, if any.
+       */
+      errorMessage: {
+        type: String,
+        value: '',
+        observer: '_errorMessageChanged',
+      },
+
+      /**
+       * The object representing a file.
+       */
+      file: {
+        type: Object,
+      },
+
+      /**
+       * Name of the uploading file.
+       */
+      fileName: {
+        type: String,
+      },
+
+      /**
+       * True if uploading is not started, false otherwise.
+       */
+      held: {
+        type: Boolean,
+        value: false,
+      },
+
+      /**
+       * True if remaining time is unknown, false otherwise.
+       */
+      indeterminate: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true,
+      },
+
+      /**
+       * The object used to localize this component.
+       */
+      i18n: {
+        type: Object,
+      },
+
+      /**
+       * Number representing the uploading progress.
+       */
+      progress: {
+        type: Number,
+      },
+
+      /**
+       * Uploading status.
+       */
+      status: {
+        type: String,
+      },
 
       /**
        * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
@@ -145,6 +211,15 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
         reflectToAttribute: true,
       },
 
+      /**
+       * True if uploading is in progress, false otherwise.
+       */
+      uploading: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true,
+      },
+
       /** @private */
       _progress: {
         type: Object,
@@ -153,13 +228,7 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
   }
 
   static get observers() {
-    return [
-      '_toggleHostAttribute(file.error, "error")',
-      '_toggleHostAttribute(file.indeterminate, "indeterminate")',
-      '_toggleHostAttribute(file.uploading, "uploading")',
-      '_toggleHostAttribute(file.complete, "complete")',
-      '__updateProgress(_progress, file.progress, file.indeterminate)',
-    ];
+    return ['__updateProgress(_progress, progress, indeterminate)'];
   }
 
   /** @protected */
@@ -206,6 +275,11 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
   }
 
   /** @private */
+  _errorMessageChanged(errorMessage) {
+    this.toggleAttribute('error', Boolean(errorMessage));
+  }
+
+  /** @private */
   __updateProgress(progress, value, indeterminate) {
     if (progress) {
       progress.value = isNaN(value) ? 0 : value / 100;
@@ -223,19 +297,6 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
         composed: true,
       }),
     );
-  }
-
-  /** @private */
-  _toggleHostAttribute(value, attributeName) {
-    const shouldHave = Boolean(value);
-    const has = this.hasAttribute(attributeName);
-    if (has !== shouldHave) {
-      if (shouldHave) {
-        this.setAttribute(attributeName, '');
-      } else {
-        this.removeAttribute(attributeName);
-      }
-    }
   }
 
   /**

--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -185,7 +185,6 @@ export interface UploadEventMap extends HTMLElementEventMap, UploadCustomEventMa
  * -------------------|-------------------------------------
  * `primary-buttons`  | Upload container
  * `drop-label`       | Element wrapping drop label and icon
- * `file-list`        | File list container
  *
  * The following state attributes are available for styling:
  *

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -7,7 +7,7 @@ import '@polymer/polymer/lib/elements/dom-repeat.js';
 import '@vaadin/button/src/vaadin-button.js';
 import './vaadin-upload-icon.js';
 import './vaadin-upload-icons.js';
-import './vaadin-upload-file.js';
+import './vaadin-upload-file-list.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { announce } from '@vaadin/component-base/src/a11y-announcer.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
@@ -33,7 +33,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * -------------------|-------------------------------------
  * `primary-buttons`  | Upload container
  * `drop-label`       | Element wrapping drop label and icon
- * `file-list`        | File list container
  *
  * The following state attributes are available for styling:
  *
@@ -81,12 +80,6 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
         [hidden] {
           display: none !important;
         }
-
-        [part='file-list'] {
-          padding: 0;
-          margin: 0;
-          list-style-type: none;
-        }
       </style>
 
       <div part="primary-buttons">
@@ -96,15 +89,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
           <slot name="drop-label"></slot>
         </div>
       </div>
-      <slot name="file-list">
-        <ul id="fileList" part="file-list">
-          <template is="dom-repeat" items="[[files]]" as="file">
-            <li>
-              <vaadin-upload-file file="[[file]]" i18n="[[i18n]]"></vaadin-upload-file>
-            </li>
-          </template>
-        </ul>
-      </slot>
+      <slot name="file-list"></slot>
       <slot></slot>
       <input
         type="file"
@@ -215,6 +200,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       files: {
         type: Array,
         notify: true,
+        observer: '_filesChanged',
         value: () => [],
       },
 
@@ -433,6 +419,16 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       _dropLabel: {
         type: Object,
       },
+
+      /** @private */
+      _fileList: {
+        type: Object,
+      },
+
+      /** @private */
+      _files: {
+        type: Array,
+      },
     };
   }
 
@@ -440,6 +436,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
     return [
       '__updateAddButton(_addButton, maxFiles, i18n, maxFilesReached)',
       '__updateDropLabel(_dropLabel, maxFiles, i18n)',
+      '__updateFileList(_fileList, _files, i18n)',
     ];
   }
 
@@ -481,6 +478,17 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
         () => document.createElement('span'),
         (_, label) => {
           this._dropLabel = label;
+        },
+      ),
+    );
+
+    this.addController(
+      new SlotController(
+        this,
+        'file-list',
+        () => document.createElement('vaadin-upload-file-list'),
+        (_, list) => {
+          this._fileList = list;
         },
       ),
     );
@@ -550,6 +558,11 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
   }
 
   /** @private */
+  _filesChanged() {
+    this._updateFileList();
+  }
+
+  /** @private */
   __updateAddButton(addButton, maxFiles, i18n, maxFilesReached) {
     if (addButton) {
       addButton.disabled = maxFilesReached;
@@ -561,6 +574,14 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
   __updateDropLabel(dropLabel, maxFiles, i18n) {
     if (dropLabel) {
       dropLabel.textContent = this._i18nPlural(maxFiles, i18n.dropFiles);
+    }
+  }
+
+  /** @private */
+  __updateFileList(list, files, i18n) {
+    if (list) {
+      list.items = files;
+      list.i18n = i18n;
     }
   }
 
@@ -670,7 +691,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
           this._setStatus(file, total, loaded, elapsed);
           stalledId = setTimeout(() => {
             file.status = this.i18n.uploading.status.stalled;
-            this._notifyFileChanges(file);
+            this._updateFileList();
           }, 2000);
         } else {
           file.loadedStr = file.totalStr;
@@ -678,7 +699,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
         }
       }
 
-      this._notifyFileChanges(file);
+      this._updateFileList();
       this.dispatchEvent(new CustomEvent('upload-progress', { detail: { file, xhr } }));
     };
 
@@ -688,7 +709,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
         clearTimeout(stalledId);
         file.indeterminate = file.uploading = false;
         if (file.abort) {
-          this._notifyFileChanges(file);
+          this._updateFileList();
           return;
         }
         file.status = '';
@@ -718,7 +739,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
             detail: { file, xhr },
           }),
         );
-        this._notifyFileChanges(file);
+        this._updateFileList();
       }
     };
 
@@ -752,7 +773,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
           detail: { file, xhr },
         }),
       );
-      this._notifyFileChanges(file);
+      this._updateFileList();
     };
 
     // Custom listener could modify the xhr just before sending it
@@ -799,11 +820,11 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
   }
 
   /** @private */
-  _notifyFileChanges(file) {
-    const p = `files.${this.files.indexOf(file)}.`;
-    Object.keys(file).forEach((i) => {
-      this.notifyPath(p + i, file[i]);
-    });
+  _updateFileList() {
+    const files = [...this.files];
+    // Re-render file list DOM without re-assigning `files`
+    // to avoid dispatching `files-changed` notify event.
+    this._files = files;
   }
 
   /** @private */

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -815,9 +815,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
   /** @private */
   _renderFileList() {
     if (this._fileList) {
-      // Re-render file list DOM without re-assigning `files`
-      // to avoid dispatching `files-changed` notify event.
-      this._fileList.items = [...this.files];
+      this._fileList.requestContentUpdate();
     }
   }
 

--- a/packages/upload/test/common.js
+++ b/packages/upload/test/common.js
@@ -107,7 +107,7 @@ export function xhrCreator(c) {
  * Removes a file at given index.
  */
 export function removeFile(upload, idx = 0) {
-  const files = upload.shadowRoot.querySelectorAll('vaadin-upload-file');
+  const files = upload.querySelectorAll('vaadin-upload-file');
   const file = files[idx];
   file.shadowRoot.querySelector('[part="remove-button"]').click();
 }

--- a/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
@@ -13,52 +13,7 @@ snapshots["vaadin-upload host default"] =
   <span slot="drop-label">
     Drop files here
   </span>
-  <vaadin-upload-icon slot="drop-label-icon">
-  </vaadin-upload-icon>
-</vaadin-upload>
-`;
-/* end snapshot vaadin-upload host default */
-
-snapshots["vaadin-upload host max files"] = 
-`<vaadin-upload max-files-reached="">
-  <vaadin-button
-    aria-disabled="true"
-    disabled=""
-    role="button"
-    slot="add-button"
-    tabindex="-1"
-  >
-    Upload File...
-  </vaadin-button>
-  <span slot="drop-label">
-    Drop file here
-  </span>
-  <vaadin-upload-icon slot="drop-label-icon">
-  </vaadin-upload-icon>
-</vaadin-upload>
-`;
-/* end snapshot vaadin-upload host max files */
-
-snapshots["vaadin-upload shadow default"] = 
-`<div part="primary-buttons">
-  <slot name="add-button">
-  </slot>
-  <div
-    aria-hidden="true"
-    id="dropLabelContainer"
-    part="drop-label"
-  >
-    <slot name="drop-label-icon">
-    </slot>
-    <slot name="drop-label">
-    </slot>
-  </div>
-</div>
-<slot name="file-list">
-  <ul
-    id="fileList"
-    part="file-list"
-  >
+  <vaadin-upload-file-list slot="file-list">
     <li>
       <vaadin-upload-file
         complete=""
@@ -104,14 +59,96 @@ snapshots["vaadin-upload shadow default"] =
         </vaadin-progress-bar>
       </vaadin-upload-file>
     </li>
-    <dom-repeat
-      as="file"
-      style="display: none;"
-    >
-      <template is="dom-repeat">
-      </template>
-    </dom-repeat>
-  </ul>
+  </vaadin-upload-file-list>
+  <vaadin-upload-icon slot="drop-label-icon">
+  </vaadin-upload-icon>
+</vaadin-upload>
+`;
+/* end snapshot vaadin-upload host default */
+
+snapshots["vaadin-upload host max files"] = 
+`<vaadin-upload max-files-reached="">
+  <vaadin-button
+    aria-disabled="true"
+    disabled=""
+    role="button"
+    slot="add-button"
+    tabindex="-1"
+  >
+    Upload File...
+  </vaadin-button>
+  <span slot="drop-label">
+    Drop file here
+  </span>
+  <vaadin-upload-file-list slot="file-list">
+    <li>
+      <vaadin-upload-file
+        complete=""
+        tabindex="0"
+      >
+        <vaadin-progress-bar
+          aria-valuemax="1"
+          aria-valuemin="0"
+          aria-valuenow="0"
+          role="progressbar"
+          slot="progress"
+          style="--vaadin-progress-value:0;"
+        >
+        </vaadin-progress-bar>
+      </vaadin-upload-file>
+    </li>
+    <li>
+      <vaadin-upload-file tabindex="0">
+        <vaadin-progress-bar
+          aria-valuemax="1"
+          aria-valuemin="0"
+          aria-valuenow="0.6"
+          role="progressbar"
+          slot="progress"
+          style="--vaadin-progress-value:0.6;"
+        >
+        </vaadin-progress-bar>
+      </vaadin-upload-file>
+    </li>
+    <li>
+      <vaadin-upload-file
+        error=""
+        tabindex="0"
+      >
+        <vaadin-progress-bar
+          aria-valuemax="1"
+          aria-valuemin="0"
+          aria-valuenow="0"
+          role="progressbar"
+          slot="progress"
+          style="--vaadin-progress-value:0;"
+        >
+        </vaadin-progress-bar>
+      </vaadin-upload-file>
+    </li>
+  </vaadin-upload-file-list>
+  <vaadin-upload-icon slot="drop-label-icon">
+  </vaadin-upload-icon>
+</vaadin-upload>
+`;
+/* end snapshot vaadin-upload host max files */
+
+snapshots["vaadin-upload shadow default"] = 
+`<div part="primary-buttons">
+  <slot name="add-button">
+  </slot>
+  <div
+    aria-hidden="true"
+    id="dropLabelContainer"
+    part="drop-label"
+  >
+    <slot name="drop-label-icon">
+    </slot>
+    <slot name="drop-label">
+    </slot>
+  </div>
+</div>
+<slot name="file-list">
 </slot>
 <slot>
 </slot>

--- a/packages/upload/test/dom/vaadin-upload-file.test.js
+++ b/packages/upload/test/dom/vaadin-upload-file.test.js
@@ -7,11 +7,15 @@ describe('vaadin-upload-file', () => {
 
   beforeEach(() => {
     uploadFile = fixtureSync('<vaadin-upload-file></vaadin-upload-file>');
-    uploadFile.file = {
-      name: 'Workflow.pdf',
-      progress: 60,
-      status: '19.7 MB: 60% (remaining time: 00:12:34)',
-    };
+
+    const name = 'Workflow.pdf';
+    const progress = 60;
+    const status = '19.7 MB: 60% (remaining time: 00:12:34)';
+
+    uploadFile.file = { name, progress, status };
+    uploadFile.fileName = name;
+    uploadFile.progress = progress;
+    uploadFile.status = status;
   });
 
   describe('shadow', () => {

--- a/packages/upload/test/file-list.test.js
+++ b/packages/upload/test/file-list.test.js
@@ -7,7 +7,7 @@ describe('file list', () => {
   let upload;
 
   const getFileListItems = (upload) => {
-    return upload.$.fileList.querySelectorAll('vaadin-upload-file');
+    return upload._fileList.querySelectorAll('vaadin-upload-file');
   };
 
   beforeEach(() => {

--- a/packages/upload/test/file.test.js
+++ b/packages/upload/test/file.test.js
@@ -19,7 +19,7 @@ describe('<vaadin-upload-file> element', () => {
     });
 
     it('should reflect uploading', () => {
-      fileElement.set('file.uploading', true);
+      fileElement.uploading = true;
       expect(fileElement.hasAttribute('uploading')).to.be.true;
     });
 
@@ -28,7 +28,7 @@ describe('<vaadin-upload-file> element', () => {
     });
 
     it('should reflect indeterminate', () => {
-      fileElement.set('file.indeterminate', true);
+      fileElement.indeterminate = true;
       expect(fileElement.hasAttribute('indeterminate')).to.be.true;
     });
 
@@ -37,7 +37,7 @@ describe('<vaadin-upload-file> element', () => {
     });
 
     it('should reflect complete', () => {
-      fileElement.set('file.complete', true);
+      fileElement.complete = true;
       expect(fileElement.hasAttribute('complete')).to.be.true;
     });
 
@@ -46,7 +46,7 @@ describe('<vaadin-upload-file> element', () => {
     });
 
     it('should reflect error', () => {
-      fileElement.set('file.error', true);
+      fileElement.errorMessage = 'Server error';
       expect(fileElement.hasAttribute('error')).to.be.true;
     });
   });
@@ -54,7 +54,7 @@ describe('<vaadin-upload-file> element', () => {
   describe('focus', () => {
     beforeEach(() => {
       // Show the "Start" button
-      fileElement.set('file.held', true);
+      fileElement.held = true;
     });
 
     it('should not add focus-ring to the host on programmatic focus', () => {

--- a/packages/upload/test/keyboard-navigation.test.js
+++ b/packages/upload/test/keyboard-navigation.test.js
@@ -33,7 +33,7 @@ describe('keyboard navigation', () => {
 
     await nextRender();
 
-    fileElement = uploadElement.shadowRoot.querySelector('vaadin-upload-file');
+    fileElement = uploadElement.querySelector('vaadin-upload-file');
   });
 
   afterEach(() => {
@@ -51,7 +51,7 @@ describe('keyboard navigation', () => {
   it('should focus on the file', async () => {
     await repeatTab(2);
 
-    expect(uploadElement.shadowRoot.activeElement).to.equal(fileElement);
+    expect(document.activeElement).to.equal(fileElement);
   });
 
   describe('file', () => {

--- a/packages/upload/theme/lumo/vaadin-upload-styles.js
+++ b/packages/upload/theme/lumo/vaadin-upload-styles.js
@@ -45,10 +45,6 @@ registerStyles(
     :host([max-files-reached]) [part='drop-label'] {
       color: var(--lumo-disabled-text-color);
     }
-
-    [part='file-list'] > *:not(:first-child) > * {
-      border-top: 1px solid var(--lumo-contrast-10pct);
-    }
   `,
   { moduleId: 'lumo-upload' },
 );
@@ -65,6 +61,16 @@ registerStyles(
     }
   `,
   { moduleId: 'lumo-upload-icon' },
+);
+
+registerStyles(
+  'vaadin-upload-file-list',
+  css`
+    ::slotted(li:not(:first-of-type)) {
+      border-top: 1px solid var(--lumo-contrast-10pct);
+    }
+  `,
+  { moduleId: 'lumo-upload-file-list' },
 );
 
 const uploadFile = css`


### PR DESCRIPTION
## Description

1. Created `vaadin-upload-file-list` element to render `vaadin-upload-files` with Lit instead of `dom-repeat`,
2. Moved the file list component to light DOM and changed how files are updated to not use Polymer `.set()`,
3. Changed `vaadin-upload-file` elements to set individual properties in addition to `file` object property. This is needed because we no longer use Polymer-specific `notifyPath()` to trigger rendering on sub property mutation.

Fixes #4282

## Type of change

- Breaking change

## Note

The fact that `<ul>` and `<li>` are now in different shadow scopes doesn't seem to break a11y.
Screen reader announcements when navigating files with <kbd>Tab</kbd> look the same as previously:

### NVDA

![nvda-upload](https://user-images.githubusercontent.com/10589913/199236344-6b8d65a1-c765-41bd-a562-906272781bfb.png)

### JAWS

![jaws-upload](https://user-images.githubusercontent.com/10589913/199236359-8381952e-ef2c-4c34-a472-7a459d71820d.png)