### PR TITLE
refactor!: remove upload file progress bar attributes

### DIFF
--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -74,7 +74,7 @@ class UploadFile extends FocusMixin(ThemableMixin(PolymerElement)) {
 
         :host([complete]) [part='progress'],
         :host([error]) [part='progress'] {
-          display: none;
+          display: none !important;
         }
       </style>
 

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -71,6 +71,11 @@ class UploadFile extends FocusMixin(ThemableMixin(PolymerElement)) {
           border: none;
           box-shadow: none;
         }
+
+        :host([complete]) [part='progress'],
+        :host([error]) [part='progress'] {
+          display: none;
+        }
       </style>
 
       <div part="row">
@@ -118,10 +123,7 @@ class UploadFile extends FocusMixin(ThemableMixin(PolymerElement)) {
         part="progress"
         id="progress"
         value$="[[_formatProgressValue(file.progress)]]"
-        error$="[[file.error]]"
         indeterminate$="[[file.indeterminate]]"
-        uploading$="[[file.uploading]]"
-        complete$="[[file.complete]]"
       ></vaadin-progress-bar>
     `;
   }

--- a/packages/upload/theme/lumo/vaadin-upload-styles.js
+++ b/packages/upload/theme/lumo/vaadin-upload-styles.js
@@ -174,11 +174,6 @@ const uploadFile = css`
     margin-left: calc(var(--lumo-icon-size-m) + var(--lumo-space-xs));
     margin-right: calc(var(--lumo-icon-size-m) + var(--lumo-space-xs));
   }
-
-  [part='progress'][complete],
-  [part='progress'][error] {
-    display: none;
-  }
 `;
 
 registerStyles('vaadin-upload-file', [fieldButton, uploadFile], { moduleId: 'lumo-upload-file' });

--- a/packages/upload/theme/material/vaadin-upload-styles.js
+++ b/packages/upload/theme/material/vaadin-upload-styles.js
@@ -239,11 +239,6 @@ registerStyles(
       width: auto;
       margin-left: 28px;
     }
-
-    [part='progress'][complete],
-    [part='progress'][error] {
-      display: none;
-    }
   `,
   { moduleId: 'material-upload-file' },
 );


### PR DESCRIPTION
## Description

Extracted from #4870 so that this change could be separately mentioned in the release notes.
Removed attributes from `vaadin-progress-bar` as they are duplicates of host attributes.

Also, moved corresponding CSS from themes to core styles to avoid duplication.

## Type of change

- Breaking change