### PR TITLE
test: override files array instead of mutating items

### DIFF
--- a/packages/upload/test/keyboard-navigation.test.js
+++ b/packages/upload/test/keyboard-navigation.test.js
@@ -56,11 +56,13 @@ describe('keyboard navigation', () => {
 
   describe('file', () => {
     beforeEach(() => {
-      // To show the start button
-      uploadElement.files[0].held = true;
-      // To show the retry button
-      uploadElement.files[0].error = 'Error';
-      uploadElement._notifyFileChanges(uploadElement.files[0]);
+      uploadElement.files = [
+        {
+          ...FAKE_FILE,
+          held: true, // Show the start button
+          error: 'Error', // Show the retry button
+        },
+      ];
     });
 
     it('should focus on the start button', async () => {

--- a/packages/upload/test/visual/lumo/upload.test.js
+++ b/packages/upload/test/visual/lumo/upload.test.js
@@ -49,11 +49,14 @@ describe('upload', () => {
   describe('focus', () => {
     beforeEach(() => {
       element = fixtureSync('<vaadin-upload></vaadin-upload>', div);
-      element.files = [{ name: 'Don Quixote.pdf' }, { name: 'Hamlet.pdf', progress: 100, complete: true }];
-      // To show the start button
-      element.files[0].held = true;
-      // To show the retry button
-      element.files[0].error = 'Could not upload file';
+      element.files = [
+        {
+          name: 'Don Quixote.pdf',
+          held: true, // Show the start button
+          error: 'Could not upload file', // Show the retry button
+        },
+        { name: 'Hamlet.pdf', progress: 100, complete: true },
+      ];
       element.querySelector('[slot="add-button"]').focus();
     });
 

--- a/packages/upload/test/visual/material/upload.test.js
+++ b/packages/upload/test/visual/material/upload.test.js
@@ -49,11 +49,14 @@ describe('upload', () => {
   describe('focus', () => {
     beforeEach(() => {
       element = fixtureSync('<vaadin-upload></vaadin-upload>', div);
-      element.files = [{ name: 'Don Quixote.pdf' }, { name: 'Hamlet.pdf', progress: 100, complete: true }];
-      // To show the start button
-      element.files[0].held = true;
-      // To show the retry button
-      element.files[0].error = 'Could not upload file';
+      element.files = [
+        {
+          name: 'Don Quixote.pdf',
+          held: true, // Show the start button
+          error: 'Could not upload file', // Show the retry button
+        },
+        { name: 'Hamlet.pdf', progress: 100, complete: true },
+      ];
       element.querySelector('[slot="add-button"]').focus();
     });
 


### PR DESCRIPTION
## Description

Extracted from #4870. 
Changed to set `files` property, as the new logic might not use `notifyPath` internally.

## Type of change

- Tests