### PR TITLE
test: update tests for removing files to use helper

### DIFF
--- a/packages/upload/test/common.js
+++ b/packages/upload/test/common.js
@@ -102,3 +102,12 @@ export function xhrCreator(c) {
     return xhr;
   };
 }
+
+/**
+ * Removes a file at given index.
+ */
+export function removeFile(upload, idx = 0) {
+  const files = upload.shadowRoot.querySelectorAll('vaadin-upload-file');
+  const file = files[idx];
+  file.shadowRoot.querySelector('[part="remove-button"]').click();
+}

--- a/packages/upload/test/file-list.test.js
+++ b/packages/upload/test/file-list.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../vaadin-upload.js';
-import { createFiles, xhrCreator } from './common.js';
+import { createFiles, removeFile, xhrCreator } from './common.js';
 
 describe('file list', () => {
   let upload;
@@ -35,13 +35,11 @@ describe('file list', () => {
     files.forEach((file) => upload._addFile(file));
     await nextFrame();
 
-    const removeButton1 = getFileListItems(upload)[0].shadowRoot.querySelector('[part="remove-button"]');
-    removeButton1.click();
+    removeFile(upload, 1);
     await nextFrame();
     expect(getFileListItems(upload).length).to.equal(1);
 
-    const removeButton2 = getFileListItems(upload)[0].shadowRoot.querySelector('[part="remove-button"]');
-    removeButton2.click();
+    removeFile(upload, 0);
     await nextFrame();
     expect(getFileListItems(upload).length).to.equal(0);
   });


### PR DESCRIPTION
## Description

Extracted from #4870. 
Added `removeFile` helper and updated tests to use it instead of calling a private method.

## Type of change

- Tests