### PR TITLE
fix: add missing type definitions for all-imports.js

### DIFF
--- a/packages/grid/all-imports.d.ts
+++ b/packages/grid/all-imports.d.ts
@@ -1,5 +1,3 @@
-import './theme/lumo/all-imports.js';
-
 export * from './vaadin-grid-column-group.js';
 export * from './vaadin-grid-column.js';
 export * from './vaadin-grid-filter.js';

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -20,6 +20,7 @@
   "module": "vaadin-grid.js",
   "type": "module",
   "files": [
+    "all-imports.d.ts",
     "all-imports.js",
     "lit.d.ts",
     "lit.js",

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -1,6 +1,21 @@
 import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
+import type {
+  GridColumnGroup,
+  GridFilter,
+  GridFilterColumn,
+  GridFilterValueChangedEvent,
+  GridSelectionColumn,
+  GridSelectionColumnSelectAllChangedEvent,
+  GridSortColumn,
+  GridSortColumnDirectionChangedEvent,
+  GridSorter,
+  GridSorterDirectionChangedEvent,
+  GridTreeColumn,
+  GridTreeToggle,
+  GridTreeToggleExpandedChangedEvent,
+} from '../../all-imports.js';
 import type { ActiveItemMixinClass } from '../../src/vaadin-grid-active-item-mixin';
 import type { ArrayDataProviderMixinClass } from '../../src/vaadin-grid-array-data-provider-mixin';
 import type { ColumnReorderingMixinClass } from '../../src/vaadin-grid-column-reordering-mixin';
@@ -40,17 +55,6 @@ import type {
   GridSorterDefinition,
   GridSorterDirection,
 } from '../../vaadin-grid.js';
-import type { GridColumnGroup } from '../../vaadin-grid-column-group';
-import type { GridFilter, GridFilterValueChangedEvent } from '../../vaadin-grid-filter.js';
-import type { GridFilterColumn } from '../../vaadin-grid-filter-column';
-import type {
-  GridSelectionColumn,
-  GridSelectionColumnSelectAllChangedEvent,
-} from '../../vaadin-grid-selection-column.js';
-import type { GridSortColumn, GridSortColumnDirectionChangedEvent } from '../../vaadin-grid-sort-column.js';
-import type { GridSorter, GridSorterDirectionChangedEvent } from '../../vaadin-grid-sorter.js';
-import type { GridTreeColumn } from '../../vaadin-grid-tree-column';
-import type { GridTreeToggle, GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
 
 interface TestGridItem {
   testProperty: string;


### PR DESCRIPTION
## Description

Fixes #4874

Added missing `all-imports.d.ts` file to enable importing  `all-imports.js` in TS without errors.
Also, updated corresponding `all-imports.js` to re-export from root entrypoints.

## Type of change

- Bugfix