### PR TITLE
test: fix tooltip ITs to get rid of delay flakiness

### DIFF
--- a/integration/tests/grid-tooltip.test.js
+++ b/integration/tests/grid-tooltip.test.js
@@ -58,29 +58,10 @@ describe('tooltip', () => {
     expect(tooltip.opened).to.be.true;
   });
 
-  it('should use hover delay on cell mouseenter', async () => {
-    tooltip.hoverDelay = 10;
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-    expect(tooltip.opened).to.be.false;
-    await aTimeout(10);
-    expect(tooltip.opened).to.be.true;
-  });
-
   it('should hide tooltip on cell mouseleave', () => {
     const cell = getCell(grid, 0);
     mouseenter(cell);
     mouseleave(cell);
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should use hide delay on cell mouseleave', async () => {
-    tooltip.hideDelay = 10;
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-    mouseleave(cell);
-    expect(tooltip.opened).to.be.true;
-    await aTimeout(10);
     expect(tooltip.opened).to.be.false;
   });
 
@@ -115,28 +96,10 @@ describe('tooltip', () => {
     expect(tooltip.opened).to.be.false;
   });
 
-  it('should not use hide delay on cell mousedown', () => {
-    tooltip.hideDelay = 10;
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-    mousedown(cell);
-    expect(tooltip.opened).to.be.false;
-  });
-
   it('should show tooltip on cell keyboard focus', () => {
     const cell = getCell(grid, 0);
     tabKeyDown(document.body);
     focusin(cell);
-    expect(tooltip.opened).to.be.true;
-  });
-
-  it('should use focus delay on cell keyboard focus', async () => {
-    tooltip.focusDelay = 10;
-    const cell = getCell(grid, 0);
-    tabKeyDown(document.body);
-    focusin(cell);
-    expect(tooltip.opened).to.be.false;
-    await aTimeout(10);
     expect(tooltip.opened).to.be.true;
   });
 
@@ -186,15 +149,6 @@ describe('tooltip', () => {
   });
 
   it('should hide tooltip on grid cell content Esc', () => {
-    const cell = getCell(grid, 0);
-    tabKeyDown(document.body);
-    focusin(cell._content);
-    escKeyDown(cell._content);
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should not use hide delay on grid cell content Esc', () => {
-    tooltip.hideDelay = 10;
     const cell = getCell(grid, 0);
     tabKeyDown(document.body);
     focusin(cell._content);
@@ -278,5 +232,58 @@ describe('tooltip', () => {
     mouseenter(cell);
 
     expect(spy.calledOnce).to.be.false;
+  });
+
+  describe('delay', () => {
+    afterEach(async () => {
+      // Wait for cooldown timeout.
+      await aTimeout(1);
+    });
+
+    it('should use hover delay on cell mouseenter', async () => {
+      tooltip.hoverDelay = 1;
+      const cell = getCell(grid, 0);
+      mouseenter(cell);
+      expect(tooltip.opened).to.be.false;
+      await aTimeout(1);
+      expect(tooltip.opened).to.be.true;
+    });
+
+    it('should use hide delay on cell mouseleave', async () => {
+      tooltip.hideDelay = 1;
+      const cell = getCell(grid, 0);
+      mouseenter(cell);
+      mouseleave(cell);
+      expect(tooltip.opened).to.be.true;
+      await aTimeout(1);
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should not use hide delay on cell mousedown', () => {
+      tooltip.hideDelay = 1;
+      const cell = getCell(grid, 0);
+      mouseenter(cell);
+      mousedown(cell);
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should use focus delay on cell keyboard focus', async () => {
+      tooltip.focusDelay = 1;
+      const cell = getCell(grid, 0);
+      tabKeyDown(document.body);
+      focusin(cell);
+      expect(tooltip.opened).to.be.false;
+      await aTimeout(1);
+      expect(tooltip.opened).to.be.true;
+    });
+
+    it('should not use hide delay on grid cell content Esc', () => {
+      tooltip.hideDelay = 1;
+      const cell = getCell(grid, 0);
+      tabKeyDown(document.body);
+      focusin(cell._content);
+      escKeyDown(cell._content);
+      expect(tooltip.opened).to.be.false;
+    });
   });
 });

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -63,14 +63,6 @@ describe('menu-bar with tooltip', () => {
     expect(tooltip.opened).to.be.true;
   });
 
-  it('should use hover delay on menu button mouseover', async () => {
-    tooltip.hoverDelay = 10;
-    mouseover(buttons[0]);
-    expect(tooltip.opened).to.be.false;
-    await aTimeout(10);
-    expect(tooltip.opened).to.be.true;
-  });
-
   it('should use the tooltip property of an item as tooltip', () => {
     mouseover(buttons[0]);
     expect(getTooltipText()).to.equal('Edit tooltip');
@@ -93,15 +85,6 @@ describe('menu-bar with tooltip', () => {
   it('should hide tooltip on menu bar mouseleave', () => {
     mouseover(buttons[0]);
     mouseleave(menuBar);
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should use hide delay on menu button mouseleave', async () => {
-    tooltip.hideDelay = 10;
-    mouseover(buttons[0]);
-    mouseleave(menuBar);
-    expect(tooltip.opened).to.be.true;
-    await aTimeout(10);
     expect(tooltip.opened).to.be.false;
   });
 
@@ -141,13 +124,6 @@ describe('menu-bar with tooltip', () => {
     expect(tooltip.opened).to.be.false;
   });
 
-  it('should not use hide delay on menu button mousedown', () => {
-    tooltip.hideDelay = 10;
-    mouseover(buttons[0]);
-    mousedown(buttons[0]);
-    expect(tooltip.opened).to.be.false;
-  });
-
   it('should not show tooltip on focus without keyboard interaction', async () => {
     buttons[0].focus();
     await nextRender();
@@ -157,15 +133,6 @@ describe('menu-bar with tooltip', () => {
   it('should show tooltip on menu button keyboard focus', () => {
     tabKeyDown(document.body);
     focusin(buttons[0]);
-    expect(tooltip.opened).to.be.true;
-  });
-
-  it('should use focus delay on menu button keyboard focus', async () => {
-    tooltip.focusDelay = 10;
-    tabKeyDown(document.body);
-    focusin(buttons[0]);
-    expect(tooltip.opened).to.be.false;
-    await aTimeout(10);
     expect(tooltip.opened).to.be.true;
   });
 
@@ -199,14 +166,6 @@ describe('menu-bar with tooltip', () => {
   });
 
   it('should hide tooltip on menuBar menu button content Esc', () => {
-    tabKeyDown(document.body);
-    focusin(buttons[0]);
-    escKeyDown(buttons[0]);
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should not use hide delay on menu button Esc', () => {
-    tooltip.hideDelay = 10;
     tabKeyDown(document.body);
     focusin(buttons[0]);
     escKeyDown(buttons[0]);
@@ -298,6 +257,54 @@ describe('menu-bar with tooltip', () => {
     it('should not show tooltip on mouseover for button with children', () => {
       menuBar.openOnHover = true;
       mouseover(buttons[1]);
+      expect(tooltip.opened).to.be.false;
+    });
+  });
+
+  describe('delay', () => {
+    afterEach(async () => {
+      // Wait for cooldown timeout.
+      await aTimeout(1);
+    });
+
+    it('should use hover delay on menu button mouseover', async () => {
+      tooltip.hoverDelay = 1;
+      mouseover(buttons[0]);
+      expect(tooltip.opened).to.be.false;
+      await aTimeout(1);
+      expect(tooltip.opened).to.be.true;
+    });
+
+    it('should use hide delay on menu button mouseleave', async () => {
+      tooltip.hideDelay = 1;
+      mouseover(buttons[0]);
+      mouseleave(menuBar);
+      expect(tooltip.opened).to.be.true;
+      await aTimeout(1);
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should not use hide delay on menu button mousedown', () => {
+      tooltip.hideDelay = 1;
+      mouseover(buttons[0]);
+      mousedown(buttons[0]);
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should use focus delay on menu button keyboard focus', async () => {
+      tooltip.focusDelay = 1;
+      tabKeyDown(document.body);
+      focusin(buttons[0]);
+      expect(tooltip.opened).to.be.false;
+      await aTimeout(1);
+      expect(tooltip.opened).to.be.true;
+    });
+
+    it('should not use hide delay on menu button Esc', () => {
+      tooltip.hideDelay = 1;
+      tabKeyDown(document.body);
+      focusin(buttons[0]);
+      escKeyDown(buttons[0]);
       expect(tooltip.opened).to.be.false;
     });
   });


### PR DESCRIPTION
## Description

Fixes #4739

There was a problem with some tooltip ITs, especially for grid, because of not waiting for cooldown timers:

```
integration/tests/grid-tooltip.test.js:

 ❌ tooltip > should use hover delay on cell mouseenter
      AssertionError: expected true to be false
      + expected - actual
      
      -true
      +false
      
      at o.<anonymous> (integration/tests/grid-tooltip.test.js:65:33)

 ❌ tooltip > should use focus delay on cell keyboard focus
      AssertionError: expected true to be false
      + expected - actual
      
      -true
      +false
      
      at o.<anonymous> (integration/tests/grid-tooltip.test.js:138:[33](https://github.com/vaadin/web-components/actions/runs/3367852744/jobs/5585856655#step:5:34))


integration/tests/menu-bar-tooltip.test.js:

 ❌ menu-bar with tooltip > should use hover delay on menu button mouseover
      AssertionError: expected true to be false
      + expected - actual
      
      -true
      +false
      
      at qy.<anonymous> (integration/tests/menu-bar-tooltip.test.js:69:33)
```

Fixed this by moving corresponding tests to separate suites and adding `afterEach` like the one here:

https://github.com/vaadin/web-components/blob/bc172cca777b8a6a2ffd26d879f41d7535175c2c/packages/tooltip/test/tooltip-timers.test.js#L28-L31

## Type of change

- Tests