### PR TITLE
feat: add multiSortOnShiftClick property

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -732,7 +732,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       const cell = e.composedPath()[0];
       if (cell._content && cell._content.firstElementChild) {
         const wasNavigating = this.hasAttribute('navigating');
-        cell._content.firstElementChild.click();
+        cell._content.firstElementChild.dispatchEvent(new MouseEvent('click', { shiftKey: e.shiftKey }));
         this.toggleAttribute('navigating', wasNavigating);
       }
     }

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -732,7 +732,14 @@ export const KeyboardNavigationMixin = (superClass) =>
       const cell = e.composedPath()[0];
       if (cell._content && cell._content.firstElementChild) {
         const wasNavigating = this.hasAttribute('navigating');
-        cell._content.firstElementChild.dispatchEvent(new MouseEvent('click', { shiftKey: e.shiftKey }));
+        cell._content.firstElementChild.dispatchEvent(
+          new MouseEvent('click', {
+            shiftKey: e.shiftKey,
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+          }),
+        );
         this.toggleAttribute('navigating', wasNavigating);
       }
     }

--- a/packages/grid/src/vaadin-grid-sort-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-mixin.d.ts
@@ -36,4 +36,13 @@ export declare class SortMixinClass {
    * @attr {string} multi-sort-priority
    */
   multiSortPriority: 'append' | 'prepend';
+
+  /**
+   * When `true`, Shift-clicking an unsorted column's sorter adds it to the multi-sort.
+   * Shift + Space does the same action via keyboard. This property has precedence over the
+   * `multiSort` property. If `multiSortOnShiftClick` is true, the multiSort property is effectively ignored.
+   *
+   * @attr {boolean} multi-sort-on-shift-click
+   */
+  multiSortOnShiftClick: boolean;
 }

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -146,7 +146,7 @@ export const SortMixin = (superClass) =>
 
       sorter._order = null;
 
-      if (this.multiSort || (this.multiSortOnShiftClick && shiftClick)) {
+      if ((this.multiSort && !this.multiSortOnShiftClick) || (this.multiSortOnShiftClick && shiftClick)) {
         if (this.multiSortPriority === 'append') {
           this.__appendSorter(sorter);
         } else {

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -43,6 +43,19 @@ export const SortMixin = (superClass) =>
         },
 
         /**
+         * When `true`, Shift-clicking an unsorted column's sorter adds it to the multi-sort.
+         * Shift + Space does the same action via keyboard. This property has precedence over the
+         * `multiSort` property. If `multiSortOnShiftClick` is true, the multiSort property is effectively ignored.
+         *
+         * @attr {boolean} multi-sort-on-shift-click
+         * @type {boolean}
+         */
+        multiSortOnShiftClick: {
+          type: Boolean,
+          value: false,
+        },
+
+        /**
          * @type {!Array<!GridSorterDefinition>}
          * @protected
          */
@@ -81,7 +94,7 @@ export const SortMixin = (superClass) =>
       const sorter = e.target;
       e.stopPropagation();
       sorter._grid = this;
-      this.__updateSorter(sorter);
+      this.__updateSorter(sorter, e.detail.shiftClick);
       this.__applySorters();
     }
 
@@ -126,22 +139,22 @@ export const SortMixin = (superClass) =>
     }
 
     /** @private */
-    __updateSorter(sorter) {
+    __updateSorter(sorter, shiftClick) {
       if (!sorter.direction && this._sorters.indexOf(sorter) === -1) {
         return;
       }
 
       sorter._order = null;
 
-      if (this.multiSort) {
+      if (this.multiSort || (this.multiSortOnShiftClick && shiftClick)) {
         if (this.multiSortPriority === 'append') {
           this.__appendSorter(sorter);
         } else {
           this.__prependSorter(sorter);
         }
-      } else if (sorter.direction) {
+      } else if (sorter.direction || this.multiSortOnShiftClick) {
         const otherSorters = this._sorters.filter((s) => s !== sorter);
-        this._sorters = [sorter];
+        this._sorters = sorter.direction ? [sorter] : [];
         otherSorters.forEach((sorter) => {
           sorter._order = null;
           sorter.direction = null;

--- a/packages/grid/src/vaadin-grid-sorter.d.ts
+++ b/packages/grid/src/vaadin-grid-sorter.d.ts
@@ -9,12 +9,17 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 export type GridSorterDirection = 'asc' | 'desc' | null;
 
 /**
+ * Fired when the `path` or `direction` property changes.
+ */
+export type GridSorterChangedEvent = CustomEvent<{ shiftClick: boolean }>;
+
+/**
  * Fired when the `direction` property changes.
  */
 export type GridSorterDirectionChangedEvent = CustomEvent<{ value: GridSorterDirection }>;
 
 export interface GridSorterCustomEventMap {
-  'sorter-changed': Event;
+  'sorter-changed': GridSorterChangedEvent;
 
   'direction-changed': GridSorterDirectionChangedEvent;
 }

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -153,6 +153,12 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
         type: Boolean,
         observer: '__isConnectedChanged',
       },
+
+      /** @private */
+      _shiftClick: {
+        type: Boolean,
+        value: false,
+      },
     };
   }
 
@@ -202,7 +208,13 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
       return;
     }
 
-    this.dispatchEvent(new CustomEvent('sorter-changed', { bubbles: true, composed: true }));
+    this.dispatchEvent(
+      new CustomEvent('sorter-changed', {
+        detail: { shiftClick: this._shiftClick },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   /** @private */
@@ -219,6 +231,7 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
     }
 
     e.preventDefault();
+    this._shiftClick = e.shiftKey;
     if (this.direction === 'asc') {
       this.direction = 'desc';
     } else if (this.direction === 'desc') {

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -269,3 +269,7 @@ function onceInvoked(object, functionName) {
 export async function onceResized(grid) {
   await onceInvoked(grid, '_onResize');
 }
+
+export const shiftClick = (node) => {
+  node.dispatchEvent(new MouseEvent('click', { shiftKey: true }));
+};

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1388,25 +1388,27 @@ describe('keyboard navigation', () => {
         right();
       });
 
-      it('should click first cell child on space keyup', () => {
+      it('should dispatch click event on first cell child on space keyup', () => {
         const firstChild = getCellContent(header.children[0].children[2]).children[0];
-        const clickStub = sinon.stub(firstChild, 'click');
+        const dispatchEventStub = sinon.stub(firstChild, 'dispatchEvent');
 
         spaceDown();
-        expect(clickStub.called).to.be.false;
+        expect(dispatchEventStub.called).to.be.false;
 
         spaceUp();
-        expect(clickStub.called).to.be.true;
+        expect(dispatchEventStub.called).to.be.true;
+        expect(dispatchEventStub.args[0][0] instanceof MouseEvent).to.be.true;
+        expect(dispatchEventStub.args[0][0].type).to.equal('click');
       });
 
-      it('should not click other cell children on space keyup', () => {
+      it('should not dispatch click event on other cell children on space keyup', () => {
         const secondChild = getCellContent(header.children[0].children[2]).children[1];
-        const clickStub = sinon.stub(secondChild, 'click');
+        const dispatchEventStub = sinon.stub(secondChild, 'dispatchEvent');
 
         spaceDown();
         spaceUp();
 
-        expect(clickStub.called).to.be.false;
+        expect(dispatchEventStub.called).to.be.false;
       });
 
       it('should prevent default keydown action when clicking on space', () => {

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -245,7 +245,7 @@ describe('sorting', () => {
       expect(sorterLast._order).to.equal(null);
     });
 
-    describe('multi-sort-on-shift-click=true', () => {
+    describe('multiSortOnShiftClick', () => {
       beforeEach(() => {
         grid.multiSort = false;
         grid.multiSortOnShiftClick = true;
@@ -271,10 +271,34 @@ describe('sorting', () => {
         expect(sorterLast._order).to.equal(1);
       });
 
+      it('should single-sort on shift-click if multi-sort-on-shift-click not enabled', () => {
+        grid.multiSortOnShiftClick = false;
+        sorterLast.direction = null;
+        sorterFirst.direction = null;
+        shiftClick(sorterLast);
+        shiftClick(sorterFirst);
+        expect(sorterLast._order).to.equal(null);
+        expect(sorterFirst._order).to.equal(null);
+        expect(sorterLast.direction).to.equal(null);
+        expect(sorterFirst.direction).to.equal('asc');
+      });
+
       it('should clear multi-sort on regular click', () => {
-        click(sorterFirst);
+        click(sorterLast);
+        expect(sorterFirst.direction).to.be.null;
+        expect(sorterLast.direction).to.be.null;
         expect(sorterFirst._order).to.equal(null);
         expect(sorterLast._order).to.equal(null);
+      });
+
+      it('should add to active sorters on regular click if sorter has direction', () => {
+        click(sorterFirst);
+        expect(grid._sorters.length).to.equal(1);
+      });
+
+      it('should not add to active sorters on regular click if sorter has no direction', () => {
+        click(sorterLast);
+        expect(grid._sorters).to.be.empty;
       });
     });
 

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -1,11 +1,20 @@
 import { expect } from '@esm-bundle/chai';
-import { click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { click, fixtureSync, keyUpOn, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid-sorter.js';
 import '../vaadin-grid-sort-column.js';
 import { Grid } from '../vaadin-grid.js';
-import { buildDataSet, flushGrid, getBodyCellContent, getHeaderCellContent, getRowCells, getRows } from './helpers.js';
+import {
+  buildDataSet,
+  flushGrid,
+  getBodyCellContent,
+  getContainerCell,
+  getHeaderCellContent,
+  getRowCells,
+  getRows,
+  shiftClick,
+} from './helpers.js';
 
 describe('sorting', () => {
   describe('sorter', () => {
@@ -47,6 +56,22 @@ describe('sorting', () => {
       sorter.direction = 'asc';
 
       expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should add shiftClick detail on sorter-changed event', () => {
+      const clickSpy = sinon.spy();
+      sorter.addEventListener('sorter-changed', clickSpy);
+      click(sorter);
+
+      const clickEvent = clickSpy.args[0][0];
+      expect(clickEvent.detail.shiftClick).to.be.false;
+
+      const shiftClickSpy = sinon.spy();
+      sorter.addEventListener('sorter-changed', shiftClickSpy);
+      shiftClick(sorter);
+
+      const shiftClickEvent = shiftClickSpy.args[0][0];
+      expect(shiftClickEvent.detail.shiftClick).to.be.true;
     });
 
     it('should show order indicator', () => {
@@ -172,8 +197,8 @@ describe('sorting', () => {
           </vaadin-grid-column>
           <vaadin-grid-column>
             <template class="header">
-              <span class="title">last</span>
               <vaadin-grid-sorter path="last" direction="desc">
+                <span class="title">last</span>
               </vaadin-grid-sorter>
             </template>
             <template>[[item.last]]</template>
@@ -218,6 +243,39 @@ describe('sorting', () => {
       sorterLast.direction = null;
       expect(sorterFirst._order).to.equal(null);
       expect(sorterLast._order).to.equal(null);
+    });
+
+    describe('multi-sort-on-shift-click=true', () => {
+      beforeEach(() => {
+        grid.multiSort = false;
+        grid.multiSortOnShiftClick = true;
+      });
+
+      it('should add to sort on shift-click', () => {
+        sorterLast.direction = null;
+        sorterFirst.direction = null;
+        shiftClick(sorterLast);
+        shiftClick(sorterFirst);
+        expect(sorterFirst._order).to.equal(0);
+        expect(sorterLast._order).to.equal(1);
+      });
+
+      it('should add to sort on Shift+Space', () => {
+        sorterFirst.direction = null;
+        sorterLast.direction = null;
+        const lastCell = getContainerCell(grid.$.header, 0, 1);
+        const firstCell = getContainerCell(grid.$.header, 0, 0);
+        keyUpOn(lastCell, 32, 'shift', ' ');
+        keyUpOn(firstCell, 32, 'shift', ' ');
+        expect(sorterFirst._order).to.equal(0);
+        expect(sorterLast._order).to.equal(1);
+      });
+
+      it('should clear multi-sort on regular click', () => {
+        click(sorterFirst);
+        expect(sorterFirst._order).to.equal(null);
+        expect(sorterLast._order).to.equal(null);
+      });
     });
 
     describe('array data provider', () => {

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -291,6 +291,15 @@ describe('sorting', () => {
         expect(sorterLast._order).to.equal(null);
       });
 
+      it('should clear multi-sort on regular click when multi-sort enabled', () => {
+        grid.multiSort = true;
+        click(sorterLast);
+        expect(sorterFirst.direction).to.be.null;
+        expect(sorterLast.direction).to.be.null;
+        expect(sorterFirst._order).to.equal(null);
+        expect(sorterLast._order).to.equal(null);
+      });
+
       it('should add to active sorters on regular click if sorter has direction', () => {
         click(sorterFirst);
         expect(grid._sorters.length).to.equal(1);

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -181,6 +181,7 @@ assertType<(arg0: TestGridItem) => void>(narrowedGrid.deselectItem);
 
 assertType<boolean>(narrowedGrid.multiSort);
 assertType<'append' | 'prepend'>(narrowedGrid.multiSortPriority);
+assertType<boolean>(narrowedGrid.multiSortOnShiftClick);
 
 assertType<GridCellClassNameGenerator<TestGridItem> | null | undefined>(narrowedGrid.cellClassNameGenerator);
 assertType<() => void>(narrowedGrid.generateCellClassNames);

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -11,6 +11,7 @@ import type {
   GridSortColumn,
   GridSortColumnDirectionChangedEvent,
   GridSorter,
+  GridSorterChangedEvent,
   GridSorterDirectionChangedEvent,
   GridTreeColumn,
   GridTreeToggle,
@@ -291,6 +292,11 @@ narrowedSortColumn.addEventListener('direction-changed', (event) => {
 /* GridSorter */
 const sorter = document.createElement('vaadin-grid-sorter');
 assertType<GridSorter>(sorter);
+
+sorter.addEventListener('sorter-changed', (event) => {
+  assertType<GridSorterChangedEvent>(event);
+  assertType<boolean>(event.detail.shiftClick);
+});
 
 sorter.addEventListener('direction-changed', (event) => {
   assertType<GridSorterDirectionChangedEvent>(event);


### PR DESCRIPTION
## Description

Adds a multi-sort mode for Grid where multi-sorting is achieved by shift-clicking column sorters.

Related to vaadin/platform#3378

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
