### PR TITLE
refactor!: move upload file progress bar to light DOM

### DIFF
--- a/packages/upload/test/dom/__snapshots__/vaadin-upload-file.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload-file.test.snap.js
@@ -63,17 +63,8 @@ snapshots["vaadin-upload-file shadow default"] =
     </button>
   </div>
 </div>
-<vaadin-progress-bar
-  aria-valuemax="1"
-  aria-valuemin="0"
-  aria-valuenow="0.6"
-  id="progress"
-  part="progress"
-  role="progressbar"
-  style="--vaadin-progress-value:0.6;"
-  value="0.6"
->
-</vaadin-progress-bar>
+<slot name="progress">
+</slot>
 `;
 /* end snapshot vaadin-upload-file shadow default */
 

--- a/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
@@ -64,10 +64,28 @@ snapshots["vaadin-upload shadow default"] =
         complete=""
         tabindex="0"
       >
+        <vaadin-progress-bar
+          aria-valuemax="1"
+          aria-valuemin="0"
+          aria-valuenow="0"
+          role="progressbar"
+          slot="progress"
+          style="--vaadin-progress-value:0;"
+        >
+        </vaadin-progress-bar>
       </vaadin-upload-file>
     </li>
     <li>
       <vaadin-upload-file tabindex="0">
+        <vaadin-progress-bar
+          aria-valuemax="1"
+          aria-valuemin="0"
+          aria-valuenow="0.6"
+          role="progressbar"
+          slot="progress"
+          style="--vaadin-progress-value:0.6;"
+        >
+        </vaadin-progress-bar>
       </vaadin-upload-file>
     </li>
     <li>
@@ -75,6 +93,15 @@ snapshots["vaadin-upload shadow default"] =
         error=""
         tabindex="0"
       >
+        <vaadin-progress-bar
+          aria-valuemax="1"
+          aria-valuemin="0"
+          aria-valuenow="0"
+          role="progressbar"
+          slot="progress"
+          style="--vaadin-progress-value:0;"
+        >
+        </vaadin-progress-bar>
       </vaadin-upload-file>
     </li>
     <dom-repeat

--- a/packages/upload/theme/lumo/vaadin-upload-styles.js
+++ b/packages/upload/theme/lumo/vaadin-upload-styles.js
@@ -169,7 +169,7 @@ const uploadFile = css`
     color: var(--lumo-error-text-color);
   }
 
-  [part='progress'] {
+  ::slotted([slot='progress']) {
     width: auto;
     margin-left: calc(var(--lumo-icon-size-m) + var(--lumo-space-xs));
     margin-right: calc(var(--lumo-icon-size-m) + var(--lumo-space-xs));

--- a/packages/upload/theme/material/vaadin-upload-styles.js
+++ b/packages/upload/theme/material/vaadin-upload-styles.js
@@ -235,7 +235,7 @@ registerStyles(
       color: var(--material-error-text-color);
     }
 
-    [part='progress'] {
+    ::slotted([slot='progress']) {
       width: auto;
       margin-left: 28px;
     }


### PR DESCRIPTION
## Description

Extracted from #4870 so that this change could be separately mentioned in the release notes.
Moved the `vaadin-progress-bar` element to light DOM so it can be styled with global CSS.

## Type of change

- Breaking change