### PR TITLE
refactor!: remove parts from elements in global scope

### DIFF
--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -91,7 +91,7 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
             <input type="password" slot="input" on-keyup="_handleInputKeyup" />
           </vaadin-password-field>
 
-          <vaadin-button theme="primary contained" on-click="submit" disabled$="[[disabled]]">
+          <vaadin-button theme="primary contained submit" on-click="submit" disabled$="[[disabled]]">
             [[i18n.form.submit]]
           </vaadin-button>
         </form>

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -52,20 +52,19 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
   static get template() {
     return html`
       <style>
-        [part='vaadin-login-native-form'] * {
+        vaadin-login-form-wrapper > form > * {
           width: 100%;
         }
       </style>
       <vaadin-login-form-wrapper
         theme$="[[_theme]]"
-        part="vaadin-login-native-form-wrapper"
         error="[[error]]"
         no-forgot-password="[[noForgotPassword]]"
         i18n="[[i18n]]"
         on-login="_retargetEvent"
         on-forgot-password="_retargetEvent"
       >
-        <form part="vaadin-login-native-form" method="POST" action$="[[action]]" slot="form">
+        <form method="POST" action$="[[action]]" slot="form">
           <input id="csrf" type="hidden" />
           <vaadin-text-field
             name="username"
@@ -92,9 +91,9 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
             <input type="password" slot="input" on-keyup="_handleInputKeyup" />
           </vaadin-password-field>
 
-          <vaadin-button part="vaadin-login-submit" theme="primary contained" on-click="submit" disabled$="[[disabled]]"
-            >[[i18n.form.submit]]</vaadin-button
-          >
+          <vaadin-button theme="primary contained" on-click="submit" disabled$="[[disabled]]">
+            [[i18n.form.submit]]
+          </vaadin-button>
         </form>
       </vaadin-login-form-wrapper>
     `;
@@ -161,7 +160,7 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
         this.$.csrf.name = csrfMetaName.content;
         this.$.csrf.value = csrfMetaValue.content;
       }
-      this.querySelector('[part="vaadin-login-native-form"]').submit();
+      this.querySelector('form').submit();
     }
   }
 

--- a/packages/login/test/login-form.test.js
+++ b/packages/login/test/login-form.test.js
@@ -61,7 +61,7 @@ describe('login form', () => {
 
   beforeEach(() => {
     login = fixtureSync('<vaadin-login-form action="login-action"></vaadin-login-form>');
-    formWrapper = login.querySelector('[part="vaadin-login-native-form-wrapper"]');
+    formWrapper = login.querySelector('vaadin-login-form-wrapper');
   });
 
   afterEach(() => {
@@ -75,7 +75,7 @@ describe('login form', () => {
 
     const usernameElement = login.querySelector('#vaadinLoginUsername');
     const passwordElement = login.querySelector('#vaadinLoginPassword');
-    const submitElement = login.querySelector('vaadin-button[part="vaadin-login-submit"]');
+    const submitElement = login.querySelector('vaadin-button');
     const forgotElement = formWrapper.shadowRoot.querySelector('#forgotPasswordButton');
 
     const footerElement = formWrapper.shadowRoot.querySelector('[part="footer"] p');
@@ -86,7 +86,7 @@ describe('login form', () => {
 
     expect(usernameElement.label).to.be.equal(login.i18n.form.username);
     expect(passwordElement.label).to.be.equal(login.i18n.form.password);
-    expect(submitElement.textContent).to.be.equal(login.i18n.form.submit);
+    expect(submitElement.textContent.trim()).to.be.equal(login.i18n.form.submit);
     expect(forgotElement.textContent).to.be.equal(login.i18n.form.forgotPassword);
 
     expect(footerElement.textContent).to.be.equal('');
@@ -169,14 +169,14 @@ describe('login form', () => {
   });
 
   it('should disable button after submitting form', () => {
-    const submit = login.querySelector('vaadin-button[part="vaadin-login-submit"]');
+    const submit = login.querySelector('vaadin-button');
     const { vaadinLoginPassword } = fillUsernameAndPassword(login);
     enter(vaadinLoginPassword);
     expect(submit.disabled).to.be.true;
   });
 
   it('should prevent submit call when login is disabled', () => {
-    const submit = login.querySelector('vaadin-button[part="vaadin-login-submit"]');
+    const submit = login.querySelector('vaadin-button');
     const { vaadinLoginPassword } = fillUsernameAndPassword(login);
 
     login.setAttribute('disabled', 'disabled');
@@ -188,14 +188,14 @@ describe('login form', () => {
   });
 
   it('should not disable button on button click if form is invalid', () => {
-    const submit = login.querySelector('vaadin-button[part="vaadin-login-submit"]');
+    const submit = login.querySelector('vaadin-button');
     expect(submit.disabled).to.not.be.true;
     tap(submit);
     expect(submit.disabled).to.not.be.true;
   });
 
   it('should disable button on button click if form is valid', () => {
-    const submit = login.querySelector('vaadin-button[part="vaadin-login-submit"]');
+    const submit = login.querySelector('vaadin-button');
     fillUsernameAndPassword(login);
     tap(submit);
     expect(submit.disabled).to.be.true;
@@ -273,7 +273,7 @@ describe('no forgot password', () => {
   });
 
   it('should hide forgot password button', () => {
-    const formWrapper = login.querySelector('[part="vaadin-login-native-form-wrapper"]');
+    const formWrapper = login.querySelector('vaadin-login-form-wrapper');
     expect(formWrapper.$.forgotPasswordButton.hidden).to.be.true;
   });
 });
@@ -296,7 +296,7 @@ describe('error message', () => {
 
   beforeEach(() => {
     login = fixtureSync('<vaadin-login-form error></vaadin-login-form>');
-    formWrapper = login.querySelector('[part="vaadin-login-native-form-wrapper"]');
+    formWrapper = login.querySelector('vaadin-login-form-wrapper');
   });
 
   it('should show error message if the error attribute is set', () => {
@@ -321,7 +321,7 @@ describe('stylable parts', () => {
 
   beforeEach(() => {
     login = fixtureSync('<vaadin-login-form theme="green"></vaadin-login-form>');
-    formWrapper = login.querySelector('[part="vaadin-login-native-form-wrapper"]');
+    formWrapper = login.querySelector('vaadin-login-form-wrapper');
   });
 
   it('should be possible to style parts', () => {

--- a/packages/login/test/login-submit.test.js
+++ b/packages/login/test/login-submit.test.js
@@ -11,7 +11,7 @@ describe('login form submit', () => {
   function testFormSubmitValues(preventDefault, expectation, done) {
     fillUsernameAndPassword(login);
 
-    const loginForm = login.querySelector('[part="vaadin-login-native-form"]');
+    const loginForm = login.querySelector('form');
     loginForm.setAttribute('method', 'GET');
     loginForm.setAttribute('target', iframe.getAttribute('name'));
 
@@ -23,7 +23,7 @@ describe('login form submit', () => {
       done();
     };
 
-    login.querySelector('vaadin-button[part="vaadin-login-submit"]').click();
+    login.querySelector('vaadin-button').click();
     expect(submitSpy.called).to.equal(expectation);
 
     if (preventDefault) {

--- a/packages/login/theme/lumo/vaadin-login-form-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-form-styles.js
@@ -4,7 +4,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-login-form',
   css`
-    vaadin-button {
+    form > vaadin-button[theme~='submit'] {
       margin-top: var(--lumo-space-l);
       margin-bottom: var(--lumo-space-s);
     }

--- a/packages/login/theme/lumo/vaadin-login-form-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-form-styles.js
@@ -4,7 +4,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-login-form',
   css`
-    vaadin-button[part='vaadin-login-submit'] {
+    vaadin-button {
       margin-top: var(--lumo-space-l);
       margin-bottom: var(--lumo-space-s);
     }

--- a/packages/login/theme/material/vaadin-login-form-styles.js
+++ b/packages/login/theme/material/vaadin-login-form-styles.js
@@ -3,7 +3,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-login-form',
   css`
-    vaadin-button {
+    form > vaadin-button[theme~='submit'] {
       margin-top: 3em;
       margin-bottom: 2em;
       flex-grow: 0;
@@ -11,7 +11,7 @@ registerStyles(
 
     /* Small screen */
     @media only screen and (max-width: 1023px) {
-      vaadin-button {
+      form > vaadin-button[theme~='submit'] {
         margin-top: 2.5em;
         margin-bottom: 1em;
       }

--- a/packages/login/theme/material/vaadin-login-form-styles.js
+++ b/packages/login/theme/material/vaadin-login-form-styles.js
@@ -3,7 +3,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-login-form',
   css`
-    vaadin-button[part='vaadin-login-submit'] {
+    vaadin-button {
       margin-top: 3em;
       margin-bottom: 2em;
       flex-grow: 0;
@@ -11,7 +11,7 @@ registerStyles(
 
     /* Small screen */
     @media only screen and (max-width: 1023px) {
-      vaadin-button[part='vaadin-login-submit'] {
+      vaadin-button {
         margin-top: 2.5em;
         margin-bottom: 1em;
       }


### PR DESCRIPTION
## Description

Removed `part` attribute from the components that are in global scope and can't be styled with `::part()`:

- `vaadin-login-native-form-wrapper`
- `vaadin-login-native-form`
- `vaadin-login-submit`

These are not in Shadow DOM because `vaadin-login-form` disables it using the Polymer protected API:

https://github.com/vaadin/web-components/blob/5004363edf7456af0703d3dc1e75593ca4f76b99/packages/login/src/vaadin-login-form.js#L124-L126

This is equivalent to [implementing `createRenderRoot()`](https://lit.dev/docs/components/shadow-dom/#implementing-createrenderroot) when using LitElement.

## Type of change

- Breaking change

## Comparison

### Before

![login-before](https://user-images.githubusercontent.com/10589913/199498221-4bd746fa-b1db-4f2d-85d5-c11b4cc0c666.png)

### After

![login-after](https://user-images.githubusercontent.com/10589913/199498250-2b426528-3f90-4d11-b233-92e2e482b167.png)
