### PR TITLE
refactor!: move forgot password button to light DOM

### DIFF
--- a/packages/login/src/vaadin-login-form-wrapper.js
+++ b/packages/login/src/vaadin-login-form-wrapper.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/button/src/vaadin-button.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -55,13 +54,7 @@ class LoginFormWrapper extends LoginMixin(ElementMixin(ThemableMixin(PolymerElem
 
         <slot name="form"></slot>
 
-        <vaadin-button
-          id="forgotPasswordButton"
-          theme="tertiary small forgot-password"
-          on-click="_forgotPassword"
-          hidden$="[[noForgotPassword]]"
-          >[[i18n.form.forgotPassword]]</vaadin-button
-        >
+        <slot name="forgot-password"></slot>
 
         <div part="footer">
           <p>[[i18n.additionalInformation]]</p>
@@ -72,10 +65,6 @@ class LoginFormWrapper extends LoginMixin(ElementMixin(ThemableMixin(PolymerElem
 
   static get is() {
     return 'vaadin-login-form-wrapper';
-  }
-
-  _forgotPassword() {
-    this.dispatchEvent(new CustomEvent('forgot-password'));
   }
 }
 

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2018 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/button/src/vaadin-button.js';
 import '@vaadin/text-field/src/vaadin-text-field.js';
 import '@vaadin/password-field/src/vaadin-password-field.js';
 import './vaadin-login-form-wrapper.js';
@@ -58,14 +59,7 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
           width: 100%;
         }
       </style>
-      <vaadin-login-form-wrapper
-        theme$="[[_theme]]"
-        error="[[error]]"
-        no-forgot-password="[[noForgotPassword]]"
-        i18n="[[i18n]]"
-        on-login="_retargetEvent"
-        on-forgot-password="_retargetEvent"
-      >
+      <vaadin-login-form-wrapper theme$="[[_theme]]" error="[[error]]" i18n="[[i18n]]">
         <form method="POST" action$="[[action]]" slot="form">
           <input id="csrf" type="hidden" />
           <vaadin-text-field
@@ -97,6 +91,15 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
             [[i18n.form.submit]]
           </vaadin-button>
         </form>
+
+        <vaadin-button
+          slot="forgot-password"
+          theme="tertiary small"
+          on-click="_onForgotPasswordClick"
+          hidden$="[[noForgotPassword]]"
+        >
+          [[i18n.form.forgotPassword]]
+        </vaadin-button>
       </vaadin-login-form-wrapper>
     `;
   }
@@ -188,6 +191,11 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     if (e.key === 'Tab' && input instanceof HTMLInputElement) {
       input.select();
     }
+  }
+
+  /** @private */
+  _onForgotPasswordClick() {
+    this.dispatchEvent(new CustomEvent('forgot-password'));
   }
 }
 

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -93,6 +93,14 @@ snapshots["vaadin-login-form host default"] =
         Log in
       </vaadin-button>
     </form>
+    <vaadin-button
+      role="button"
+      slot="forgot-password"
+      tabindex="0"
+      theme="tertiary small"
+    >
+      Forgot password
+    </vaadin-button>
   </vaadin-login-form-wrapper>
 </vaadin-login-form>
 `;
@@ -190,10 +198,124 @@ snapshots["vaadin-login-form host i18n"] =
         Kirjaudu sisään
       </vaadin-button>
     </form>
+    <vaadin-button
+      role="button"
+      slot="forgot-password"
+      tabindex="0"
+      theme="tertiary small"
+    >
+      Unohtuiko salasana?
+    </vaadin-button>
   </vaadin-login-form-wrapper>
 </vaadin-login-form>
 `;
 /* end snapshot vaadin-login-form host i18n */
+
+snapshots["vaadin-login-form host noForgotPassword"] = 
+`<vaadin-login-form>
+  <vaadin-login-form-wrapper>
+    <form
+      method="POST"
+      slot="form"
+    >
+      <input
+        id="csrf"
+        type="hidden"
+      >
+      <vaadin-text-field
+        autocapitalize="none"
+        autocorrect="off"
+        focused=""
+        has-label=""
+        id="vaadinLoginUsername"
+        name="username"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-labelledby="label-vaadin-text-field-0"
+          autocorrect="off"
+          id="input-vaadin-text-field-6"
+          name="username"
+          required=""
+          slot="input"
+          type="text"
+        >
+        <label
+          for="input-vaadin-text-field-6"
+          id="label-vaadin-text-field-0"
+          slot="label"
+        >
+          Username
+        </label>
+        <div
+          hidden=""
+          id="error-message-vaadin-text-field-2"
+          slot="error-message"
+        >
+        </div>
+      </vaadin-text-field>
+      <vaadin-password-field
+        autocomplete="current-password"
+        has-label=""
+        id="vaadinLoginPassword"
+        name="password"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-labelledby="label-vaadin-password-field-3"
+          autocapitalize="off"
+          autocomplete="current-password"
+          id="input-vaadin-password-field-7"
+          name="password"
+          required=""
+          slot="input"
+          type="password"
+        >
+        <label
+          for="input-vaadin-password-field-7"
+          id="label-vaadin-password-field-3"
+          slot="label"
+        >
+          Password
+        </label>
+        <div
+          hidden=""
+          id="error-message-vaadin-password-field-5"
+          slot="error-message"
+        >
+        </div>
+        <vaadin-password-field-button
+          aria-label="Show password"
+          aria-pressed="false"
+          role="button"
+          slot="reveal"
+          tabindex="0"
+        >
+        </vaadin-password-field-button>
+      </vaadin-password-field>
+      <vaadin-button
+        role="button"
+        tabindex="0"
+        theme="primary contained submit"
+      >
+        Log in
+      </vaadin-button>
+    </form>
+    <vaadin-button
+      hidden=""
+      role="button"
+      slot="forgot-password"
+      tabindex="0"
+      theme="tertiary small"
+    >
+      Forgot password
+    </vaadin-button>
+  </vaadin-login-form-wrapper>
+</vaadin-login-form>
+`;
+/* end snapshot vaadin-login-form host noForgotPassword */
 
 snapshots["vaadin-login-form shadow default"] = 
 `<section part="form">
@@ -213,14 +335,8 @@ snapshots["vaadin-login-form shadow default"] =
   </div>
   <slot name="form">
   </slot>
-  <vaadin-button
-    id="forgotPasswordButton"
-    role="button"
-    tabindex="0"
-    theme="tertiary small forgot-password"
-  >
-    Forgot password
-  </vaadin-button>
+  <slot name="forgot-password">
+  </slot>
   <div part="footer">
     <p>
     </p>
@@ -244,14 +360,8 @@ snapshots["vaadin-login-form shadow error"] =
   </div>
   <slot name="form">
   </slot>
-  <vaadin-button
-    id="forgotPasswordButton"
-    role="button"
-    tabindex="0"
-    theme="tertiary small forgot-password"
-  >
-    Forgot password
-  </vaadin-button>
+  <slot name="forgot-password">
+  </slot>
   <div part="footer">
     <p>
     </p>
@@ -259,41 +369,6 @@ snapshots["vaadin-login-form shadow error"] =
 </section>
 `;
 /* end snapshot vaadin-login-form shadow error */
-
-snapshots["vaadin-login-form shadow noForgotPassword"] = 
-`<section part="form">
-  <h2 part="form-title">
-    Log in
-  </h2>
-  <div
-    hidden=""
-    part="error-message"
-  >
-    <h5 part="error-message-title">
-      Incorrect username or password
-    </h5>
-    <p part="error-message-description">
-      Check that you have entered the correct username and password and try again.
-    </p>
-  </div>
-  <slot name="form">
-  </slot>
-  <vaadin-button
-    hidden=""
-    id="forgotPasswordButton"
-    role="button"
-    tabindex="0"
-    theme="tertiary small forgot-password"
-  >
-    Forgot password
-  </vaadin-button>
-  <div part="footer">
-    <p>
-    </p>
-  </div>
-</section>
-`;
-/* end snapshot vaadin-login-form shadow noForgotPassword */
 
 snapshots["vaadin-login-form shadow i18n"] = 
 `<section part="form">
@@ -313,14 +388,8 @@ snapshots["vaadin-login-form shadow i18n"] =
   </div>
   <slot name="form">
   </slot>
-  <vaadin-button
-    id="forgotPasswordButton"
-    role="button"
-    tabindex="0"
-    theme="tertiary small forgot-password"
-  >
-    Unohtuiko salasana?
-  </vaadin-button>
+  <slot name="forgot-password">
+  </slot>
   <div part="footer">
     <p>
       Jos tarvitset lisätietoja käyttäjälle.

--- a/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
@@ -102,6 +102,14 @@ snapshots["vaadin-login-overlay host default"] =
           Log in
         </vaadin-button>
       </form>
+      <vaadin-button
+        role="button"
+        slot="forgot-password"
+        tabindex="0"
+        theme="tertiary small"
+      >
+        Forgot password
+      </vaadin-button>
     </vaadin-login-form-wrapper>
   </vaadin-login-form>
 </vaadin-login-overlay-wrapper>
@@ -209,6 +217,14 @@ snapshots["vaadin-login-overlay host i18n"] =
           Kirjaudu sisään
         </vaadin-button>
       </form>
+      <vaadin-button
+        role="button"
+        slot="forgot-password"
+        tabindex="0"
+        theme="tertiary small"
+      >
+        Unohtuiko salasana?
+      </vaadin-button>
     </vaadin-login-form-wrapper>
   </vaadin-login-form>
 </vaadin-login-overlay-wrapper>

--- a/packages/login/test/dom/login-form.test.js
+++ b/packages/login/test/dom/login-form.test.js
@@ -35,6 +35,11 @@ describe('vaadin-login-form', () => {
       form.i18n = I18N_FINNISH;
       await expect(form).dom.to.equalSnapshot();
     });
+
+    it('noForgotPassword', async () => {
+      form.noForgotPassword = true;
+      await expect(form).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {
@@ -50,11 +55,6 @@ describe('vaadin-login-form', () => {
 
     it('error', async () => {
       form.error = true;
-      await expect(wrapper).shadowDom.to.equalSnapshot();
-    });
-
-    it('noForgotPassword', async () => {
-      form.noForgotPassword = true;
       await expect(wrapper).shadowDom.to.equalSnapshot();
     });
 

--- a/packages/login/test/login-form.test.js
+++ b/packages/login/test/login-form.test.js
@@ -69,13 +69,11 @@ describe('login form', () => {
   });
 
   it('should emit forgot password event', () => {
-    let eventWasCaught = false;
-    login.addEventListener('forgot-password', () => {
-      eventWasCaught = true;
-    });
-
-    formWrapper.$.forgotPasswordButton.click();
-    expect(eventWasCaught).to.be.true;
+    const spy = sinon.spy();
+    login.addEventListener('forgot-password', spy);
+    const forgotElement = login.querySelector('vaadin-button[slot="forgot-password"]');
+    forgotElement.click();
+    expect(spy.calledOnce).to.be.true;
   });
 
   it('should mark only username as invalid if user hits ENTER when field is empty', () => {

--- a/packages/login/theme/lumo/vaadin-login-form-wrapper-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-form-wrapper-styles.js
@@ -17,7 +17,7 @@ const loginFormWrapper = css`
     margin-top: calc(var(--lumo-font-size-xxxl) - var(--lumo-font-size-xxl));
   }
 
-  #forgotPasswordButton {
+  ::slotted([slot='forgot-password']) {
     margin: var(--lumo-space-s) auto;
   }
 

--- a/packages/login/theme/lumo/vaadin-login-form-wrapper.js
+++ b/packages/login/theme/lumo/vaadin-login-form-wrapper.js
@@ -1,3 +1,0 @@
-import '@vaadin/button/theme/lumo/vaadin-button.js';
-import './vaadin-login-form-wrapper-styles.js';
-import '../../src/vaadin-login-form-wrapper.js';

--- a/packages/login/theme/lumo/vaadin-login-form.js
+++ b/packages/login/theme/lumo/vaadin-login-form.js
@@ -1,5 +1,6 @@
+import '@vaadin/button/theme/lumo/vaadin-button.js';
 import '@vaadin/text-field/theme/lumo/vaadin-text-field.js';
 import '@vaadin/password-field/theme/lumo/vaadin-password-field.js';
-import './vaadin-login-form-wrapper.js';
+import './vaadin-login-form-wrapper-styles.js';
 import './vaadin-login-form-styles.js';
 import '../../src/vaadin-login-form.js';

--- a/packages/login/theme/material/vaadin-login-form-wrapper-styles.js
+++ b/packages/login/theme/material/vaadin-login-form-wrapper-styles.js
@@ -22,7 +22,7 @@ const loginFormWrapper = css`
     font-size: var(--material-h5-font-size);
   }
 
-  #forgotPasswordButton {
+  ::slotted([slot='forgot-password']) {
     margin: 0.5rem auto;
     padding-bottom: 12px;
     padding-top: 12px;

--- a/packages/login/theme/material/vaadin-login-form-wrapper.js
+++ b/packages/login/theme/material/vaadin-login-form-wrapper.js
@@ -1,3 +1,0 @@
-import '@vaadin/button/theme/material/vaadin-button.js';
-import './vaadin-login-form-wrapper-styles.js';
-import '../../src/vaadin-login-form-wrapper.js';

--- a/packages/login/theme/material/vaadin-login-form.js
+++ b/packages/login/theme/material/vaadin-login-form.js
@@ -1,5 +1,6 @@
+import '@vaadin/button/theme/material/vaadin-button.js';
 import '@vaadin/text-field/theme/material/vaadin-text-field.js';
 import '@vaadin/password-field/theme/material/vaadin-password-field.js';
-import './vaadin-login-form-wrapper.js';
+import './vaadin-login-form-wrapper-styles.js';
 import './vaadin-login-form-styles.js';
 import '../../src/vaadin-login-form.js';


### PR DESCRIPTION
## Description

Moved "forgot password" button to `vaadin-login-form` light DOM, so it can be styled using global CSS.

Fixes #4699

## Type of change

- Breaking change