### PR TITLE
fix: add missing type definitions for all-imports.js (#4875) (CP: 22.0)

### DIFF
--- a/packages/grid/all-imports.d.ts
+++ b/packages/grid/all-imports.d.ts
@@ -1,5 +1,3 @@
-import './theme/lumo/all-imports.js';
-
 export * from './vaadin-grid-column-group.js';
 export * from './vaadin-grid-column.js';
 export * from './vaadin-grid-filter.js';

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -19,6 +19,7 @@
   "main": "vaadin-grid.js",
   "module": "vaadin-grid.js",
   "files": [
+    "all-imports.d.ts",
     "all-imports.js",
     "src",
     "theme",

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -1,5 +1,20 @@
 import { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
+import {
+  GridColumnGroup,
+  GridFilter,
+  GridFilterColumn,
+  GridFilterValueChangedEvent,
+  GridSelectionColumn,
+  GridSelectionColumnSelectAllChangedEvent,
+  GridSortColumn,
+  GridSortColumnDirectionChangedEvent,
+  GridSorter,
+  GridSorterDirectionChangedEvent,
+  GridTreeColumn,
+  GridTreeToggle,
+  GridTreeToggleExpandedChangedEvent,
+} from '../../all-imports.js';
 import { ActiveItemMixinClass } from '../../src/vaadin-grid-active-item-mixin';
 import { ArrayDataProviderMixinClass } from '../../src/vaadin-grid-array-data-provider-mixin';
 import { ColumnReorderingMixinClass } from '../../src/vaadin-grid-column-reordering-mixin';
@@ -39,14 +54,6 @@ import {
   GridSorterDefinition,
   GridSorterDirection,
 } from '../../vaadin-grid.js';
-import { GridColumnGroup } from '../../vaadin-grid-column-group';
-import { GridFilter, GridFilterValueChangedEvent } from '../../vaadin-grid-filter.js';
-import { GridFilterColumn } from '../../vaadin-grid-filter-column';
-import { GridSelectionColumn, GridSelectionColumnSelectAllChangedEvent } from '../../vaadin-grid-selection-column.js';
-import { GridSortColumn, GridSortColumnDirectionChangedEvent } from '../../vaadin-grid-sort-column.js';
-import { GridSorter, GridSorterDirectionChangedEvent } from '../../vaadin-grid-sorter.js';
-import { GridTreeColumn } from '../../vaadin-grid-tree-column';
-import { GridTreeToggle, GridTreeToggleExpandedChangedEvent } from '../../vaadin-grid-tree-toggle.js';
 
 interface TestGridItem {
   testProperty: string;


### PR DESCRIPTION
## Description

Manual cherry-pick of #4875 to `22.0` branch. The merge conflict was caused by `import type` usage on master.

## Type of change

- Cherry-pick