### PR TITLE
refactor!: remove file immediately after upload abort

### DIFF
--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -264,15 +264,6 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
    * @param {Object} detail
    * @param {Object} detail.file file to abort upload of
    */
-
-  /**
-   * Fired after the upload is aborted. It is listened by `vaadin-upload` which
-   * will actually remove the file from the upload file list.
-   *
-   * @event file-remove
-   * @param {Object} detail
-   * @param {Object} detail.file file to remove from the list
-   */
 }
 
 customElements.define(UploadFile.is, UploadFile);

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -154,7 +154,6 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
 
   static get observers() {
     return [
-      '_fileAborted(file.abort)',
       '_toggleHostAttribute(file.error, "error")',
       '_toggleHostAttribute(file.indeterminate, "indeterminate")',
       '_toggleHostAttribute(file.uploading, "uploading")',
@@ -204,24 +203,6 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
    */
   _shouldSetFocus(event) {
     return event.composedPath()[0] === this;
-  }
-
-  /** @private */
-  _fileAborted(abort) {
-    if (abort) {
-      this._remove();
-    }
-  }
-
-  /** @private */
-  _remove() {
-    this.dispatchEvent(
-      new CustomEvent('file-remove', {
-        detail: { file: this.file },
-        bubbles: true,
-        composed: true,
-      }),
-    );
   }
 
   /** @private */
@@ -277,8 +258,7 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
 
   /**
    * Fired when abort button is pressed. It is listened by `vaadin-upload` which
-   * will abort the upload in progress, but will not remove the file from the list
-   * to allow the animation to hide the element to be run.
+   * will abort the upload in progress, and then remove the file from the list.
    *
    * @event file-abort
    * @param {Object} detail
@@ -286,13 +266,12 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
    */
 
   /**
-   * Fired after the animation to hide the element has finished. It is listened
-   * by `vaadin-upload` which will actually remove the file from the upload
-   * file list.
+   * Fired after the upload is aborted. It is listened by `vaadin-upload` which
+   * will actually remove the file from the upload file list.
    *
    * @event file-remove
    * @param {Object} detail
-   * @param {Object} detail.file file to remove from the  upload of
+   * @param {Object} detail.file file to remove from the list
    */
 }
 

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -783,7 +783,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
   }
 
   /** @private */
-  _abortFileUpload(file) {
+  _abortFileUpload(file, fileElement) {
     const evt = this.dispatchEvent(
       new CustomEvent('upload-abort', {
         detail: { file, xhr: file.xhr },
@@ -795,7 +795,13 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       if (file.xhr) {
         file.xhr.abort();
       }
-      this._notifyFileChanges(file);
+      fileElement.dispatchEvent(
+        new CustomEvent('file-remove', {
+          detail: { file },
+          bubbles: true,
+          composed: true,
+        }),
+      );
     }
   }
 
@@ -904,7 +910,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
 
   /** @private */
   _onFileAbort(event) {
-    this._abortFileUpload(event.detail.file);
+    this._abortFileUpload(event.detail.file, event.composedPath()[0]);
   }
 
   /** @private */

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -451,7 +451,6 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
     this.addEventListener('drop', this._onDrop.bind(this));
     this.addEventListener('file-retry', this._onFileRetry.bind(this));
     this.addEventListener('file-abort', this._onFileAbort.bind(this));
-    this.addEventListener('file-remove', this._onFileRemove.bind(this));
     this.addEventListener('file-start', this._onFileStart.bind(this));
     this.addEventListener('file-reject', this._onFileReject.bind(this));
     this.addEventListener('upload-start', this._onUploadStart.bind(this));
@@ -783,7 +782,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
   }
 
   /** @private */
-  _abortFileUpload(file, fileElement) {
+  _abortFileUpload(file) {
     const evt = this.dispatchEvent(
       new CustomEvent('upload-abort', {
         detail: { file, xhr: file.xhr },
@@ -795,13 +794,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       if (file.xhr) {
         file.xhr.abort();
       }
-      fileElement.dispatchEvent(
-        new CustomEvent('file-remove', {
-          detail: { file },
-          bubbles: true,
-          composed: true,
-        }),
-      );
+      this._removeFile(file);
     }
   }
 
@@ -872,6 +865,14 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
   _removeFile(file) {
     if (this.files.indexOf(file) > -1) {
       this.files = this.files.filter((i) => i !== file);
+
+      this.dispatchEvent(
+        new CustomEvent('file-remove', {
+          detail: { file },
+          bubbles: true,
+          composed: true,
+        }),
+      );
     }
   }
 
@@ -910,12 +911,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
 
   /** @private */
   _onFileAbort(event) {
-    this._abortFileUpload(event.detail.file, event.composedPath()[0]);
-  }
-
-  /** @private */
-  _onFileRemove(event) {
-    this._removeFile(event.detail.file);
+    this._abortFileUpload(event.detail.file);
   }
 
   /** @private */


### PR DESCRIPTION
## Description

Closes #2313

This PR improves the file removal logic to get rid of two subsequent list updates described in https://github.com/vaadin/web-components/pull/4870#discussion_r1011927794
Note, both `file-abort` and `file-remove` events are preserved and fired on `vaadin-upload-file`.

We could alternatively consider dropping `file-abort` as suggested by https://github.com/vaadin/web-components/issues/2313#issuecomment-895872666

## Type of change

- Behavior altering change