### PR TITLE
fix: add missing types for properties notify events

### DIFF
--- a/packages/login/src/vaadin-login-form.d.ts
+++ b/packages/login/src/vaadin-login-form.d.ts
@@ -9,11 +9,25 @@ import { LoginMixin } from './vaadin-login-mixin.js';
 export { LoginI18n } from './vaadin-login-mixin.js';
 
 /**
+ * Fired when the `disabled` property changes.
+ */
+export type LoginFormDisabledChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
+ * Fired when the `error` property changes.
+ */
+export type LoginFormErrorChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when a user submits the login.
  */
 export type LoginFormLoginEvent = CustomEvent<{ username: string; password: string }>;
 
 export interface LoginFormCustomEventMap {
+  'disabled-changed': LoginFormDisabledChangedEvent;
+
+  'error-changed': LoginFormErrorChangedEvent;
+
   'forgot-password': Event;
 
   login: LoginFormLoginEvent;
@@ -50,6 +64,8 @@ export interface LoginFormEventMap extends HTMLElementEventMap, LoginFormCustomE
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *
+ * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
+ * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  */

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -40,6 +40,8 @@ import { LoginMixin } from './vaadin-login-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *
+ * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
+ * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  *

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -9,6 +9,11 @@ import { LoginMixin } from './vaadin-login-mixin.js';
 export { LoginI18n } from './vaadin-login-mixin.js';
 
 /**
+ * Fired when the `description` property changes.
+ */
+export type LoginOverlayDescriptionChangedEvent = CustomEvent<{ value: string }>;
+
+/**
  * Fired when the `disabled` property changes.
  */
 export type LoginOverlayDisabledChangedEvent = CustomEvent<{ value: boolean }>;
@@ -24,6 +29,8 @@ export type LoginOverlayErrorChangedEvent = CustomEvent<{ value: boolean }>;
 export type LoginOverlayLoginEvent = CustomEvent<{ username: string; password: string }>;
 
 export interface LoginOverlayCustomEventMap {
+  'description-changed': LoginOverlayDescriptionChangedEvent;
+
   'disabled-changed': LoginOverlayDisabledChangedEvent;
 
   'error-changed': LoginOverlayErrorChangedEvent;
@@ -62,6 +69,7 @@ export interface LoginOverlayEventMap extends HTMLElementEventMap, LoginOverlayC
  * See [`<vaadin-login-form>`](#/elements/vaadin-login-form)
  * documentation for  `<vaadin-login-form-wrapper>` stylable parts.
  *
+ * @fires {CustomEvent} description-changed - Fired when the `description` property changes.
  * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
  * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -9,11 +9,25 @@ import { LoginMixin } from './vaadin-login-mixin.js';
 export { LoginI18n } from './vaadin-login-mixin.js';
 
 /**
+ * Fired when the `disabled` property changes.
+ */
+export type LoginOverlayDisabledChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
+ * Fired when the `error` property changes.
+ */
+export type LoginOverlayErrorChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when a user submits the login.
  */
 export type LoginOverlayLoginEvent = CustomEvent<{ username: string; password: string }>;
 
 export interface LoginOverlayCustomEventMap {
+  'disabled-changed': LoginOverlayDisabledChangedEvent;
+
+  'error-changed': LoginOverlayErrorChangedEvent;
+
   'forgot-password': Event;
 
   login: LoginOverlayLoginEvent;
@@ -48,6 +62,8 @@ export interface LoginOverlayEventMap extends HTMLElementEventMap, LoginOverlayC
  * See [`<vaadin-login-form>`](#/elements/vaadin-login-form)
  * documentation for  `<vaadin-login-form-wrapper>` stylable parts.
  *
+ * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
+ * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  */

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -37,6 +37,7 @@ import { LoginMixin } from './vaadin-login-mixin.js';
  * See [`<vaadin-login-form>`](#/elements/vaadin-login-form)
  * documentation for  `<vaadin-login-form-wrapper>` stylable parts.
  *
+ * @fires {CustomEvent} description-changed - Fired when the `description` property changes.
  * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
  * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -37,6 +37,8 @@ import { LoginMixin } from './vaadin-login-mixin.js';
  * See [`<vaadin-login-form>`](#/elements/vaadin-login-form)
  * documentation for  `<vaadin-login-form-wrapper>` stylable parts.
  *
+ * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
+ * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  *

--- a/packages/login/test/typings/login.types.ts
+++ b/packages/login/test/typings/login.types.ts
@@ -5,6 +5,7 @@ import type {
   LoginFormLoginEvent,
 } from '../../vaadin-login-form.js';
 import type {
+  LoginOverlayDescriptionChangedEvent,
   LoginOverlayDisabledChangedEvent,
   LoginOverlayErrorChangedEvent,
   LoginOverlayLoginEvent,
@@ -28,6 +29,11 @@ overlay.addEventListener('error-changed', (event) => {
 overlay.addEventListener('disabled-changed', (event) => {
   assertType<LoginOverlayErrorChangedEvent>(event);
   assertType<boolean>(event.detail.value);
+});
+
+overlay.addEventListener('description-changed', (event) => {
+  assertType<LoginOverlayDescriptionChangedEvent>(event);
+  assertType<string>(event.detail.value);
 });
 
 const form = document.createElement('vaadin-login-form');

--- a/packages/login/test/typings/login.types.ts
+++ b/packages/login/test/typings/login.types.ts
@@ -1,6 +1,14 @@
 import '../../vaadin-login-form.js';
-import type { LoginFormLoginEvent } from '../../vaadin-login-form.js';
-import type { LoginOverlayLoginEvent } from '../../vaadin-login-overlay.js';
+import type {
+  LoginFormDisabledChangedEvent,
+  LoginFormErrorChangedEvent,
+  LoginFormLoginEvent,
+} from '../../vaadin-login-form.js';
+import type {
+  LoginOverlayDisabledChangedEvent,
+  LoginOverlayErrorChangedEvent,
+  LoginOverlayLoginEvent,
+} from '../../vaadin-login-overlay.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -12,10 +20,30 @@ overlay.addEventListener('login', (event) => {
   assertType<string>(event.detail.password);
 });
 
+overlay.addEventListener('error-changed', (event) => {
+  assertType<LoginOverlayDisabledChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+overlay.addEventListener('disabled-changed', (event) => {
+  assertType<LoginOverlayErrorChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
 const form = document.createElement('vaadin-login-form');
 
 form.addEventListener('login', (event) => {
   assertType<LoginFormLoginEvent>(event);
   assertType<string>(event.detail.username);
   assertType<string>(event.detail.password);
+});
+
+overlay.addEventListener('error-changed', (event) => {
+  assertType<LoginFormErrorChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+overlay.addEventListener('disabled-changed', (event) => {
+  assertType<LoginFormDisabledChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });

--- a/packages/login/test/typings/login.types.ts
+++ b/packages/login/test/typings/login.types.ts
@@ -44,12 +44,12 @@ form.addEventListener('login', (event) => {
   assertType<string>(event.detail.password);
 });
 
-overlay.addEventListener('error-changed', (event) => {
+form.addEventListener('error-changed', (event) => {
   assertType<LoginFormErrorChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
-overlay.addEventListener('disabled-changed', (event) => {
+form.addEventListener('disabled-changed', (event) => {
   assertType<LoginFormDisabledChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });


### PR DESCRIPTION
## Description

Related to #4900

Added missing type definitions for custom events that are present in API docs:

![Screenshot 2022-11-03 at 14 18 08](https://user-images.githubusercontent.com/10589913/199718411-37194328-44eb-42a7-a87e-d1c1ea67842b.png)

These properties are modified by the `vaadin-login-form` so it makes sense to document these events:

https://github.com/vaadin/web-components/blob/993e7a9f46aeadc5eee40fb79740499700f23dd6/packages/login/src/vaadin-login-form.js#L130-L132

https://github.com/vaadin/web-components/blob/993e7a9f46aeadc5eee40fb79740499700f23dd6/packages/login/src/vaadin-login-form.js#L143-L144

Note, setting `error` to `true` is only possible from outside, but maybe we can keep the event.

UPD: also added `description-changed` event because this property is calculated based on `i18n`:
https://github.com/vaadin/web-components/blob/db1460e9e71a9512b5d9b330ff15a84799cb1fa8/packages/login/src/vaadin-login-overlay.js#L156

## Type of change

- Bugfix