### PR TITLE
refactor!: do not notify properties set from outside

### DIFF
--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -128,7 +128,6 @@ export const LoginMixin = (superClass) =>
               },
             };
           },
-          notify: true,
         },
 
         /**

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -32,7 +32,6 @@ export const LoginMixin = (superClass) =>
         action: {
           type: String,
           value: null,
-          notify: true,
         },
 
         /**
@@ -67,7 +66,6 @@ export const LoginMixin = (superClass) =>
         noForgotPassword: {
           type: Boolean,
           value: false,
-          notify: true,
         },
 
         /**

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -60,11 +60,11 @@ class LoginOverlay extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement)
         <vaadin-login-form
           theme="with-overlay"
           id="vaadinLoginForm"
-          action="{{action}}"
+          action="[[action]]"
           disabled="{{disabled}}"
           error="{{error}}"
           no-autofocus="[[noAutofocus]]"
-          no-forgot-password="{{noForgotPassword}}"
+          no-forgot-password="[[noForgotPassword]]"
           i18n="{{i18n}}"
           on-login="_retargetEvent"
           on-forgot-password="_retargetEvent"


### PR DESCRIPTION
## Description

Related to #4900

Removed `notify: true` from some properties that are not modified by the component internally:

- `action`
- `noForgotPassword`
- `i18n`

This affects Flow counterpart as we would need to remove [`@Synchronize`](https://github.com/vaadin/flow-components/blob/d0ffddd50f3e8e6ec6e56d82f13423400ee2e203/vaadin-login-flow-parent/vaadin-login-flow/src/main/java/com/vaadin/flow/component/login/AbstractLogin.java#L100) from `getAction()`.
However, the change is so small that we can probably backport it at least to Vaadin 23.3.

## Type of change

- Behavior altering change