### PR TITLE
fix: add missing event map to vaadin-accordion-panel

### DIFF
--- a/packages/accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/accordion/src/vaadin-accordion-panel.d.ts
@@ -6,6 +6,17 @@
 import { Details } from '@vaadin/details/src/vaadin-details.js';
 
 /**
+ * Fired when the `opened` property changes.
+ */
+export type AccordionPanelOpenedChangedEvent = CustomEvent<{ value: boolean }>;
+
+export interface AccordionPanelCustomEventMap {
+  'opened-changed': AccordionPanelOpenedChangedEvent;
+}
+
+export type AccordionPanelEventMap = AccordionPanelCustomEventMap & HTMLElementEventMap;
+
+/**
  * The accordion panel element.
  *
  * ### Styling
@@ -32,7 +43,19 @@ import { Details } from '@vaadin/details/src/vaadin-details.js';
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
-declare class AccordionPanel extends Details {}
+declare class AccordionPanel extends Details {
+  addEventListener<K extends keyof AccordionPanelEventMap>(
+    type: K,
+    listener: (this: AccordionPanel, ev: AccordionPanelEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof AccordionPanelEventMap>(
+    type: K,
+    listener: (this: AccordionPanel, ev: AccordionPanelEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/accordion/test/typings/accordion.types.ts
+++ b/packages/accordion/test/typings/accordion.types.ts
@@ -1,6 +1,6 @@
 import '../../vaadin-accordion.js';
 import type { AccordionItemsChangedEvent, AccordionOpenedChangedEvent } from '../../vaadin-accordion.js';
-import type { AccordionPanel } from '../../vaadin-accordion-panel';
+import type { AccordionPanel, AccordionPanelOpenedChangedEvent } from '../../vaadin-accordion-panel';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -21,5 +21,6 @@ accordion.addEventListener('items-changed', (event) => {
 const panel = document.createElement('vaadin-accordion-panel');
 
 panel.addEventListener('opened-changed', (event) => {
+  assertType<AccordionPanelOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });


### PR DESCRIPTION
## Description

Added missing `AccordionPanelEventMap` with custom type for `opened-changed` event.
While this event is inherited from `Details`, the lack of proper type is a bit inconvenient.

This is different from e.g. `vaadin-email-field` that extends `vaadin-text-field` but has own event map:

https://github.com/vaadin/web-components/blob/993e7a9f46aeadc5eee40fb79740499700f23dd6/packages/email-field/src/vaadin-email-field.d.ts#L38

Let's add this event map so that users don't have to import the event type from `@vaadin/details`.

## Type of change

- Bugfix