### PR TITLE
fix: add missing index property to CrudEditEvent

### DIFF
--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -76,7 +76,7 @@ export type CrudNewEvent = CustomEvent<{ item: null }>;
 /**
  * Fired when user wants to edit an existing item.
  */
-export type CrudEditEvent<T> = CustomEvent<{ item: T }>;
+export type CrudEditEvent<T> = CustomEvent<{ item: T; index: number }>;
 
 /**
  * Fired when user wants to delete item.

--- a/packages/crud/test/typings/crud.types.ts
+++ b/packages/crud/test/typings/crud.types.ts
@@ -51,6 +51,7 @@ crud.addEventListener('new', (event) => {
 crud.addEventListener('edit', (event) => {
   assertType<CrudEditEvent<User>>(event);
   assertType<User>(event.detail.item);
+  assertType<number>(event.detail.index);
 });
 
 crud.addEventListener('delete', (event) => {


### PR DESCRIPTION
## Description

~~While we have `CrudEditEvent` currently on `vaadin-crud`, in fact it bubbles from the `vaadin-crud-edit` element.~~

The `index` numeric property was missing from the `event.detail` type of `CrudEditEvent`, so I added it there.

## Type of change

- Bugfix