### PR TITLE
feat: add root entrypoint for vaadin-chart-series

### DIFF
--- a/packages/charts/test/typings/chart.types.ts
+++ b/packages/charts/test/typings/chart.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-chart.js';
-import type { Axis, Chart as HighchartsChart, Point, Series } from 'highcharts';
+import type { Axis, Chart as HighchartsChart, Point, Series, SeriesOptionsType } from 'highcharts';
 import type {
   ChartAddSeriesEvent,
   ChartAfterExportEvent,
@@ -32,6 +32,7 @@ import type {
   ChartXaxesExtremesSetEvent,
   ChartYaxesExtremesSetEvent,
 } from '../../vaadin-chart.js';
+import type { ChartSeries, ChartSeriesOptions, ChartSeriesValues } from '../../vaadin-chart-series.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -228,3 +229,18 @@ chart.addEventListener('yaxes-extremes-set', (event) => {
   assertType<number>(event.detail.originalEvent.dataMin);
   assertType<number>(event.detail.originalEvent.dataMax);
 });
+
+// Series properties
+const series: ChartSeries = document.createElement('vaadin-chart-series');
+assertType<ChartSeriesOptions>(series.options);
+assertType<ChartSeriesValues | null>(series.values);
+assertType<number | null | undefined>(series.valueMin);
+assertType<number | null | undefined>(series.valueMax);
+assertType<string>(series.title);
+assertType<string | null | undefined>(series.type);
+assertType<string | null | undefined>(series.unit);
+assertType<number | string>(series.stack);
+assertType<number | string>(series.neckPosition);
+assertType<number | string>(series.neckWidth);
+assertType<SeriesOptionsType | null | undefined>(series.additionalOptions);
+assertType<(highChartsSeries: Series) => void>(series.setSeries);

--- a/packages/charts/vaadin-chart-series.d.ts
+++ b/packages/charts/vaadin-chart-series.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-chart-series.js';

--- a/packages/charts/vaadin-chart-series.js
+++ b/packages/charts/vaadin-chart-series.js
@@ -1,0 +1,1 @@
+export * from './src/vaadin-chart-series.js';


### PR DESCRIPTION
## Description

Related to #4900

Added the root level entrypoint to make it possible importing like this:

```ts
import type { ChartSeries } from '@vaadin/charts/vaadin-chart-series.js';
```

This addresses the following finding from React wrappers:

> This component uses the library which has an imperative interface to update the series etc. So for make it declarative, there is a ChartSeries component. However, it doesn't have a place in the package's root, so the algorithm ignores it because considers it private. Could we put it to the root to make sure it is public?

## Type of change

- Feature