### PR TITLE
fix: make row details renderer arguments required

### DIFF
--- a/packages/grid/src/vaadin-grid-row-details-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.d.ts
@@ -6,11 +6,7 @@
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { Grid, GridItemModel } from './vaadin-grid.js';
 
-export type GridRowDetailsRenderer<TItem> = (
-  root: HTMLElement,
-  grid?: Grid<TItem>,
-  model?: GridItemModel<TItem>,
-) => void;
+export type GridRowDetailsRenderer<TItem> = (root: HTMLElement, grid: Grid<TItem>, model: GridItemModel<TItem>) => void;
 
 export declare function RowDetailsMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -173,6 +173,13 @@ assertType<() => void>(narrowedGrid.filterDragAndDrop);
 assertType<(arg0: Event) => GridEventContext<TestGridItem>>(narrowedGrid.getEventContext);
 
 assertType<GridRowDetailsRenderer<TestGridItem> | null | undefined>(narrowedGrid.rowDetailsRenderer);
+const rowDetailsRenderer: GridRowDetailsRenderer<TestGridItem> = (root, grid, model) => {
+  assertType<HTMLElement>(root);
+  assertType<Grid>(grid);
+  assertType<TestGridItem>(model.item);
+};
+narrowedGrid.rowDetailsRenderer = rowDetailsRenderer;
+
 assertType<(arg0: TestGridItem) => void>(narrowedGrid.openItemDetails);
 assertType<(arg0: TestGridItem) => void>(narrowedGrid.closeItemDetails);
 assertType<(arg0: number) => void>(narrowedGrid.scrollToIndex);


### PR DESCRIPTION
## Description

Related to #4900

Fixed the `GridRowDetailsRenderer` to apply the same change that we previously made in #2097 for column renderers.
This addresses the following finding from React wrappers mentioned in the above issue:

> Again, the nullability for grid and model seem to be a mistake because Lit doesn't consider it.

## Type of change

- Bugfix
