### PR TITLE
fix: make context menu renderer arguments required

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -16,8 +16,8 @@ export interface ContextMenuRendererContext {
 
 export type ContextMenuRenderer = (
   root: HTMLElement,
-  contextMenu?: ContextMenu,
-  context?: ContextMenuRendererContext,
+  contextMenu: ContextMenu,
+  context: ContextMenuRendererContext,
 ) => void;
 
 /**

--- a/packages/context-menu/test/typings/context-menu.types.ts
+++ b/packages/context-menu/test/typings/context-menu.types.ts
@@ -1,8 +1,11 @@
 import '../../vaadin-context-menu.js';
 import type {
+  ContextMenu,
   ContextMenuItem,
   ContextMenuItemSelectedEvent,
   ContextMenuOpenedChangedEvent,
+  ContextMenuRenderer,
+  ContextMenuRendererContext,
 } from '../../vaadin-context-menu.js';
 
 const menu = document.createElement('vaadin-context-menu');
@@ -18,3 +21,12 @@ menu.addEventListener('item-selected', (event) => {
   assertType<ContextMenuItemSelectedEvent>(event);
   assertType<ContextMenuItem>(event.detail.value);
 });
+
+const renderer: ContextMenuRenderer = (root, contextMenu, context) => {
+  assertType<HTMLElement>(root);
+  assertType<ContextMenu>(contextMenu);
+  assertType<ContextMenuRendererContext>(context);
+  assertType<HTMLElement>(context.target);
+};
+
+menu.renderer = renderer;


### PR DESCRIPTION
## Description

Related to #4900

Fixed the `ContextMenuRenderer` to apply the same change that we previously made in #2097 for grid renderers.
This addresses the following finding from React wrappers mentioned in the above issue:

> As in @vaadin/grid, it has nullable model and element in renderer.

## Type of change

- Bugfix
