### PR TITLE
fix: add missing event map to vaadin-accordion-panel (#4906) (CP: 23.1)

### DIFF
--- a/packages/accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/accordion/src/vaadin-accordion-panel.d.ts
@@ -6,6 +6,17 @@
 import { Details } from '@vaadin/details/src/vaadin-details.js';
 
 /**
+ * Fired when the `opened` property changes.
+ */
+export type AccordionPanelOpenedChangedEvent = CustomEvent<{ value: boolean }>;
+
+export interface AccordionPanelCustomEventMap {
+  'opened-changed': AccordionPanelOpenedChangedEvent;
+}
+
+export type AccordionPanelEventMap = AccordionPanelCustomEventMap & HTMLElementEventMap;
+
+/**
  * The accordion panel element.
  *
  * ### Styling
@@ -32,7 +43,19 @@ import { Details } from '@vaadin/details/src/vaadin-details.js';
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
-declare class AccordionPanel extends Details {}
+declare class AccordionPanel extends Details {
+  addEventListener<K extends keyof AccordionPanelEventMap>(
+    type: K,
+    listener: (this: AccordionPanel, ev: AccordionPanelEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof AccordionPanelEventMap>(
+    type: K,
+    listener: (this: AccordionPanel, ev: AccordionPanelEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/accordion/test/typings/accordion.types.ts
+++ b/packages/accordion/test/typings/accordion.types.ts
@@ -1,6 +1,6 @@
 import '../../vaadin-accordion.js';
 import { AccordionItemsChangedEvent, AccordionOpenedChangedEvent } from '../../vaadin-accordion.js';
-import { AccordionPanel } from '../../vaadin-accordion-panel';
+import { AccordionPanel, AccordionPanelOpenedChangedEvent } from '../../vaadin-accordion-panel';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -21,5 +21,6 @@ accordion.addEventListener('items-changed', (event) => {
 const panel = document.createElement('vaadin-accordion-panel');
 
 panel.addEventListener('opened-changed', (event) => {
+  assertType<AccordionPanelOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });


### PR DESCRIPTION
## Description

Cherry-pick of #4906 to `23.1` branch. The automated cherry-pick failed due to `import type` usage on master.

## Type of change

- Cherry-pick