### PR TITLE
fix: make dialog renderer owner argument required (#4919) (CP: 23.1)

### DIFF
--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -14,7 +14,7 @@ import { DialogResizableMixin } from './vaadin-dialog-resizable-mixin.js';
  */
 export class DialogOverlay extends OverlayElement {}
 
-export type DialogRenderer = (root: HTMLElement, dialog?: Dialog) => void;
+export type DialogRenderer = (root: HTMLElement, dialog: Dialog) => void;
 
 export type DialogResizableDirection = 'e' | 'n' | 'ne' | 'nw' | 's' | 'se' | 'sw' | 'w';
 

--- a/packages/dialog/test/typings/dialog.types.ts
+++ b/packages/dialog/test/typings/dialog.types.ts
@@ -1,5 +1,6 @@
 import '../../vaadin-dialog.js';
 import {
+  Dialog,
   DialogOpenedChangedEvent,
   DialogRenderer,
   DialogResizeDimensions,
@@ -26,3 +27,10 @@ assertType<DialogRenderer | null | undefined>(dialog.renderer);
 assertType<DialogRenderer | null | undefined>(dialog.headerRenderer);
 assertType<DialogRenderer | null | undefined>(dialog.footerRenderer);
 assertType<() => void>(dialog.requestContentUpdate);
+
+const renderer: DialogRenderer = (root, owner) => {
+  assertType<HTMLElement>(root);
+  assertType<Dialog>(owner);
+};
+
+dialog.renderer = renderer;


### PR DESCRIPTION
## Description

Cherry-pick of #4919 to `23.1` branch. The automated cherry-pick failed due to `import type` usage on master.

## Type of change

- Cherry-pick