### PR TITLE
fix: make context menu renderer arguments required (#4918) (CP: 23.1)

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -16,8 +16,8 @@ export interface ContextMenuRendererContext {
 
 export type ContextMenuRenderer = (
   root: HTMLElement,
-  contextMenu?: ContextMenu,
-  context?: ContextMenuRendererContext,
+  contextMenu: ContextMenu,
+  context: ContextMenuRendererContext,
 ) => void;
 
 /**

--- a/packages/context-menu/test/typings/context-menu.types.ts
+++ b/packages/context-menu/test/typings/context-menu.types.ts
@@ -1,8 +1,11 @@
 import '../../vaadin-context-menu.js';
 import {
+  ContextMenu,
   ContextMenuItem,
   ContextMenuItemSelectedEvent,
   ContextMenuOpenedChangedEvent,
+  ContextMenuRenderer,
+  ContextMenuRendererContext,
 } from '../../vaadin-context-menu.js';
 
 const menu = document.createElement('vaadin-context-menu');
@@ -18,3 +21,12 @@ menu.addEventListener('item-selected', (event) => {
   assertType<ContextMenuItemSelectedEvent>(event);
   assertType<ContextMenuItem>(event.detail.value);
 });
+
+const renderer: ContextMenuRenderer = (root, contextMenu, context) => {
+  assertType<HTMLElement>(root);
+  assertType<ContextMenu>(contextMenu);
+  assertType<ContextMenuRendererContext>(context);
+  assertType<HTMLElement>(context.target);
+};
+
+menu.renderer = renderer;


### PR DESCRIPTION
## Description

Cherry-pick of #4918 to `23.1` branch. The automated cherry-pick failed due to `import type` usage on master.

## Type of change

- Cherry-pick