### PR TITLE
fix: add missing types for properties notify events (#4904) (CP: 23.1)

### DIFF
--- a/packages/login/src/vaadin-login-form.d.ts
+++ b/packages/login/src/vaadin-login-form.d.ts
@@ -9,11 +9,25 @@ import { LoginMixin } from './vaadin-login-mixin.js';
 export { LoginI18n } from './vaadin-login-mixin.js';
 
 /**
+ * Fired when the `disabled` property changes.
+ */
+export type LoginFormDisabledChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
+ * Fired when the `error` property changes.
+ */
+export type LoginFormErrorChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when a user submits the login.
  */
 export type LoginFormLoginEvent = CustomEvent<{ username: string; password: string }>;
 
 export interface LoginFormCustomEventMap {
+  'disabled-changed': LoginFormDisabledChangedEvent;
+
+  'error-changed': LoginFormErrorChangedEvent;
+
   'forgot-password': Event;
 
   login: LoginFormLoginEvent;
@@ -50,6 +64,8 @@ export interface LoginFormEventMap extends HTMLElementEventMap, LoginFormCustomE
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
+ * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
+ * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  */

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -40,6 +40,8 @@ import { LoginMixin } from './vaadin-login-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/ds/customization/styling-components) documentation.
  *
+ * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
+ * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  *

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -9,11 +9,32 @@ import { LoginMixin } from './vaadin-login-mixin.js';
 export { LoginI18n } from './vaadin-login-mixin.js';
 
 /**
+ * Fired when the `description` property changes.
+ */
+export type LoginOverlayDescriptionChangedEvent = CustomEvent<{ value: string }>;
+
+/**
+ * Fired when the `disabled` property changes.
+ */
+export type LoginOverlayDisabledChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
+ * Fired when the `error` property changes.
+ */
+export type LoginOverlayErrorChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when a user submits the login.
  */
 export type LoginOverlayLoginEvent = CustomEvent<{ username: string; password: string }>;
 
 export interface LoginOverlayCustomEventMap {
+  'description-changed': LoginOverlayDescriptionChangedEvent;
+
+  'disabled-changed': LoginOverlayDisabledChangedEvent;
+
+  'error-changed': LoginOverlayErrorChangedEvent;
+
   'forgot-password': Event;
 
   login: LoginOverlayLoginEvent;
@@ -48,6 +69,9 @@ export interface LoginOverlayEventMap extends HTMLElementEventMap, LoginOverlayC
  * See [`<vaadin-login-form>`](#/elements/vaadin-login-form)
  * documentation for  `<vaadin-login-form-wrapper>` stylable parts.
  *
+ * @fires {CustomEvent} description-changed - Fired when the `description` property changes.
+ * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
+ * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  */

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -37,6 +37,9 @@ import { LoginMixin } from './vaadin-login-mixin.js';
  * See [`<vaadin-login-form>`](#/elements/vaadin-login-form)
  * documentation for  `<vaadin-login-form-wrapper>` stylable parts.
  *
+ * @fires {CustomEvent} description-changed - Fired when the `description` property changes.
+ * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
+ * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  *

--- a/packages/login/test/typings/login.types.ts
+++ b/packages/login/test/typings/login.types.ts
@@ -1,6 +1,15 @@
 import '../../vaadin-login-form.js';
-import { LoginFormLoginEvent } from '../../vaadin-login-form.js';
-import { LoginOverlayLoginEvent } from '../../vaadin-login-overlay.js';
+import {
+  LoginFormDisabledChangedEvent,
+  LoginFormErrorChangedEvent,
+  LoginFormLoginEvent,
+} from '../../vaadin-login-form.js';
+import {
+  LoginOverlayDescriptionChangedEvent,
+  LoginOverlayDisabledChangedEvent,
+  LoginOverlayErrorChangedEvent,
+  LoginOverlayLoginEvent,
+} from '../../vaadin-login-overlay.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -12,10 +21,35 @@ overlay.addEventListener('login', (event) => {
   assertType<string>(event.detail.password);
 });
 
+overlay.addEventListener('error-changed', (event) => {
+  assertType<LoginOverlayDisabledChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+overlay.addEventListener('disabled-changed', (event) => {
+  assertType<LoginOverlayErrorChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+overlay.addEventListener('description-changed', (event) => {
+  assertType<LoginOverlayDescriptionChangedEvent>(event);
+  assertType<string>(event.detail.value);
+});
+
 const form = document.createElement('vaadin-login-form');
 
 form.addEventListener('login', (event) => {
   assertType<LoginFormLoginEvent>(event);
   assertType<string>(event.detail.username);
   assertType<string>(event.detail.password);
+});
+
+form.addEventListener('error-changed', (event) => {
+  assertType<LoginFormErrorChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+form.addEventListener('disabled-changed', (event) => {
+  assertType<LoginFormDisabledChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });


### PR DESCRIPTION
## Description

Cherry-pick of #4904 to `23.1` branch. The automated cherry-pick failed due to `import type` usage on master.

## Type of change

- Cherry-pick