### PR TITLE
fix: make notification renderer argument required

### DIFF
--- a/packages/notification/src/vaadin-notification.d.ts
+++ b/packages/notification/src/vaadin-notification.d.ts
@@ -19,7 +19,7 @@ export type NotificationPosition =
   | 'top-start'
   | 'top-stretch';
 
-export type NotificationRenderer = (root: HTMLElement, notification?: Notification) => void;
+export type NotificationRenderer = (root: HTMLElement, notification: Notification) => void;
 
 /**
  * Fired when the `opened` property changes.

--- a/packages/notification/test/typings/notification.types.ts
+++ b/packages/notification/test/typings/notification.types.ts
@@ -1,5 +1,5 @@
 import '../../vaadin-notification.js';
-import type { NotificationOpenedChangedEvent } from '../../vaadin-notification.js';
+import type { NotificationOpenedChangedEvent, NotificationRenderer } from '../../vaadin-notification.js';
 import { Notification } from '../../vaadin-notification.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
@@ -12,3 +12,10 @@ notification.addEventListener('opened-changed', (event) => {
 });
 
 Notification.show('Hello world', { position: 'middle', duration: 7000, theme: 'error' });
+
+const renderer: NotificationRenderer = (root, owner) => {
+  assertType<HTMLElement>(root);
+  assertType<Notification>(owner);
+};
+
+notification.renderer = renderer;


### PR DESCRIPTION
## Description

Related to #4900

Fixed the `NotificationRenderer` to apply the same change that we previously made in #2097 for grid renderers.
This addresses the following finding from React wrappers mentioned in the above issue:

> Looks like a bug because Lit implementation doesn't care about nullability of notification

## Type of change

- Bugfix
