### PR TITLE
feat: add IntelliJ auto-complete support for Lumo theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ packages/icons/test/visual/screenshots/failed
 # Generated web-types JSON files
 web-types.json
 web-types.lit.json
+
+# Generated auto-complete CSS file for Lumo theme
+packages/vaadin-lumo-styles/auto-complete.css

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Vaadin Ltd",
   "scripts": {
-    "analyze": "polymer analyze packages/**/vaadin-*.js > analysis.json && node scripts/prepareDocs.js && node scripts/buildWebtypes.js",
+    "analyze": "polymer analyze packages/**/vaadin-*.js > analysis.json && node scripts/prepareDocs.js && node scripts/buildWebtypes.js && node scripts/generateLumoAutoCompleteCss.js",
     "debug": "web-test-runner --watch",
     "debug:it": "web-test-runner --watch --config web-test-runner-it.config.js",
     "dist": "rimraf dist && yarn analyze && rollup -c rollup.config.js && cp analysis.json dist",

--- a/packages/vaadin-lumo-styles/.gitignore
+++ b/packages/vaadin-lumo-styles/.gitignore
@@ -1,0 +1,1 @@
+auto-complete.css

--- a/packages/vaadin-lumo-styles/.gitignore
+++ b/packages/vaadin-lumo-styles/.gitignore
@@ -1,1 +1,0 @@
-auto-complete.css

--- a/packages/vaadin-lumo-styles/package.json
+++ b/packages/vaadin-lumo-styles/package.json
@@ -25,6 +25,7 @@
   "files": [
     "*.d.ts",
     "*.js",
+    "auto-complete.css",
     "mixins/*.d.ts",
     "mixins/*.js",
     "presets/*.js",

--- a/scripts/generateLumoAutoCompleteCss.js
+++ b/scripts/generateLumoAutoCompleteCss.js
@@ -4,17 +4,6 @@ const path = require('path');
 const PACKAGE_BASE = 'packages/vaadin-lumo-styles';
 
 const styleModules = ['color', 'sizing', 'spacing', 'style', 'typography', 'user-colors'];
-const utilityModules = [
-  'accessibility',
-  'background',
-  'border',
-  'flexbox-grid',
-  'layout',
-  'shadows',
-  'sizing',
-  'spacing',
-  'typography',
-];
 
 function getCustomProperties() {
   const result = [];
@@ -40,20 +29,23 @@ function getCustomProperties() {
 function getUtilityClasses() {
   const result = [];
 
-  utilityModules.forEach((module) => {
-    const content = fs.readFileSync(path.join(PACKAGE_BASE, 'utilities', `${module}.js`), 'utf8');
-    const cssSectionRegex = /css`((.|\s)*?)`/gm;
-    let match;
+  const modules = fs.readdirSync(path.join(PACKAGE_BASE, 'utilities'));
+  modules
+    .filter((module) => module.endsWith('.js'))
+    .forEach((module) => {
+      const content = fs.readFileSync(path.join(PACKAGE_BASE, 'utilities', module), 'utf8');
+      const cssSectionRegex = /css`((.|\s)*?)`/gm;
+      let match;
 
-    while ((match = cssSectionRegex.exec(content))) {
-      let section = match[1];
-      // Remove escape backslash
-      section = section.replace(/\\\\/g, '\\');
-      // Unindent
-      section = section.replace(/\n\s{2}/g, '\n');
-      result.push(section);
-    }
-  });
+      while ((match = cssSectionRegex.exec(content))) {
+        let section = match[1];
+        // Remove escape backslash
+        section = section.replace(/\\\\/g, '\\');
+        // Unindent
+        section = section.replace(/\n\s{2}/g, '\n');
+        result.push(section);
+      }
+    });
 
   return result;
 }

--- a/scripts/generateLumoAutoCompleteCss.js
+++ b/scripts/generateLumoAutoCompleteCss.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGE_BASE = 'packages/vaadin-lumo-styles';
+
+const styleModules = ['color', 'sizing', 'spacing', 'style', 'typography', 'user-colors'];
+const utilityModules = [
+  'accessibility',
+  'background',
+  'border',
+  'flexbox-grid',
+  'layout',
+  'shadows',
+  'sizing',
+  'spacing',
+  'typography',
+];
+
+function getCustomProperties() {
+  const result = [];
+  const uniqueProperties = [];
+
+  styleModules.forEach((module) => {
+    const content = fs.readFileSync(path.join(PACKAGE_BASE, `${module}.js`), 'utf8');
+    const customPropertyDeclarationRegex = /--[\w\d-]+:.*;/g;
+    const propertyDeclarations = content.match(customPropertyDeclarationRegex);
+    propertyDeclarations.forEach((propertyDeclaration) => {
+      // Avoid duplicate property declarations from dark theme
+      const propertyName = propertyDeclaration.split(':')[0];
+      if (!uniqueProperties.includes(propertyName)) {
+        result.push(propertyDeclaration);
+        uniqueProperties.push(propertyName);
+      }
+    });
+  });
+
+  return result;
+}
+
+function getUtilityClasses() {
+  const result = [];
+
+  utilityModules.forEach((module) => {
+    const content = fs.readFileSync(path.join(PACKAGE_BASE, 'utilities', `${module}.js`), 'utf8');
+    const cssSectionRegex = /css`((.|\s)*?)`/gm;
+    let match;
+
+    while ((match = cssSectionRegex.exec(content))) {
+      let section = match[1];
+      // Remove escape backslash
+      section = section.replace(/\\\\/g, '\\');
+      // Unindent
+      section = section.replace(/\n\s{2}/g, '\n');
+      result.push(section);
+    }
+  });
+
+  return result;
+}
+
+const customProperties = getCustomProperties();
+const utilityClasses = getUtilityClasses();
+
+let result = `/* This file contains declarations for CSS custom properties and utility 
+ * classes of the Lumo theme in order to provide auto-complete support 
+ * for IDEs.
+ * 
+ * NOTE: This file is only intended to provide auto-complete support,
+ * do not include it into an HTML page!
+ */
+ 
+ `;
+result += '/* Custom CSS properties */\n';
+result += ':host {\n';
+customProperties.forEach((customProperty) => {
+  result += `  ${customProperty}\n`;
+});
+result += '}\n\n';
+
+result += '/* Utility classes */\n';
+result += utilityClasses.join('');
+
+fs.writeFileSync(path.join(PACKAGE_BASE, 'auto-complete.css'), result, 'utf8');


### PR DESCRIPTION
## Description

Adds auto-complete support for CSS custom properties and utility classes of the Lumo theme for IntelliJ.

The change adds a script for generating an `auto-complete.css` file in the Lumo theme package that contains all necessary declarations. The CSS file is only intended to support auto-complete, and should not be loaded into an actual HTML page, a comment at the top of the file clarifies its purpose. The file will be included into the NPM package and should thus be picked up by IDEs.

I put the script into the root script folder, but we can also consider moving it into the package. I extended the `yarn analyze` command to run the script, which would be the easiest way without adding additional steps to the CI build.

Auto-complete works as expected in IntelliJ, in VS Code I could not get anything to show up, even if the file was explicitly imported. Might require some additional plugins.

Closes #1627

<details>
<summary>Auto-complete for CSS custom properties:</summary>

![Bildschirmfoto 2022-11-04 um 10 58 10](https://user-images.githubusercontent.com/357820/199953280-4c08ed9e-fa2e-4732-83dd-152877452bde.png)

</details>

<details>
<summary>Auto-complete for utility classes:</summary>

![Bildschirmfoto 2022-11-04 um 10 57 42](https://user-images.githubusercontent.com/357820/199953290-7da4ffa2-5cff-48a1-9823-13ca81126099.png)

</details>

<details>
<summary>Color preview visible in the gutter (uses light theme colors):</summary>

![Bildschirmfoto 2022-11-04 um 10 56 27](https://user-images.githubusercontent.com/357820/199953294-88c48dd9-a0a7-434f-b1c2-db7f21521a6c.png)

</details>

## Type of change

- Feature
