### PR TITLE
fix: make notification renderer argument required (#4934) (CP: 23.1)

### DIFF
--- a/packages/notification/src/vaadin-notification.d.ts
+++ b/packages/notification/src/vaadin-notification.d.ts
@@ -19,7 +19,7 @@ export type NotificationPosition =
   | 'top-start'
   | 'top-stretch';
 
-export type NotificationRenderer = (root: HTMLElement, notification?: Notification) => void;
+export type NotificationRenderer = (root: HTMLElement, notification: Notification) => void;
 
 /**
  * Fired when the `opened` property changes.

--- a/packages/notification/test/typings/notification.types.ts
+++ b/packages/notification/test/typings/notification.types.ts
@@ -1,5 +1,6 @@
 import '../../vaadin-notification.js';
-import { Notification, NotificationOpenedChangedEvent } from '../../vaadin-notification.js';
+import { NotificationOpenedChangedEvent, NotificationRenderer } from '../../vaadin-notification.js';
+import { Notification } from '../../vaadin-notification.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 
@@ -11,3 +12,10 @@ notification.addEventListener('opened-changed', (event) => {
 });
 
 Notification.show('Hello world', { position: 'middle', duration: 7000, theme: 'error' });
+
+const renderer: NotificationRenderer = (root, owner) => {
+  assertType<HTMLElement>(root);
+  assertType<Notification>(owner);
+};
+
+notification.renderer = renderer;


### PR DESCRIPTION
## Description

Cherry-pick of #4934 to `23.1` branch. The automated cherry-pick failed due to `import type` usage on master.

## Type of change

- Cherry-pick