### PR TITLE
refactor: do not use unnecessary mixins in form wrapper

### DIFF
--- a/packages/login/src/vaadin-login-form-wrapper.js
+++ b/packages/login/src/vaadin-login-form-wrapper.js
@@ -4,18 +4,16 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
  * An element used internally by `<vaadin-login-form>`. Not intended to be used separately.
  *
  * @extends HTMLElement
- * @mixes ElementMixin
  * @mixes ThemableMixin
  * @private
  */
-class LoginFormWrapper extends ElementMixin(ThemableMixin(PolymerElement)) {
+class LoginFormWrapper extends ThemableMixin(PolymerElement) {
   static get template() {
     return html`
       <style>

--- a/packages/login/src/vaadin-login-form-wrapper.js
+++ b/packages/login/src/vaadin-login-form-wrapper.js
@@ -6,7 +6,6 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { LoginMixin } from './vaadin-login-mixin.js';
 
 /**
  * An element used internally by `<vaadin-login-form>`. Not intended to be used separately.
@@ -14,10 +13,9 @@ import { LoginMixin } from './vaadin-login-mixin.js';
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin
- * @mixes LoginMixin
  * @private
  */
-class LoginFormWrapper extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) {
+class LoginFormWrapper extends ElementMixin(ThemableMixin(PolymerElement)) {
   static get template() {
     return html`
       <style>
@@ -65,6 +63,28 @@ class LoginFormWrapper extends LoginMixin(ElementMixin(ThemableMixin(PolymerElem
 
   static get is() {
     return 'vaadin-login-form-wrapper';
+  }
+
+  static get properties() {
+    return {
+      /**
+       * If set, the error message is shown. The message is hidden by default.
+       * When set, it changes the disabled state of the submit button.
+       * @type {boolean}
+       */
+      error: {
+        type: Boolean,
+        value: false,
+        reflectToAttribute: true,
+      },
+
+      /**
+       * The object used to localize this component.
+       */
+      i18n: {
+        type: Object,
+      },
+    };
   }
 }
 


### PR DESCRIPTION
## Description

The `vaadin-login-form-wrapper` is an internal component not supposed to be used publicly.
Also, most of the properties defined in `LoginMixin` are not used by this component.

Updated to remove `LoginMixin` and only list `error` and `i18n` properties explicitly.
Also removed usage of `ElementMixin` because this component doesn't need it either.

## Type of change

- Refactor