### PR TITLE
refactor: move private mixin method to login overlay

### DIFF
--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -89,6 +89,4 @@ export declare class LoginMixinClass {
    * ```
    */
   i18n: LoginI18n;
-
-  protected _retargetEvent(e: Event): void;
 }

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -140,19 +140,4 @@ export const LoginMixin = (superClass) =>
         },
       };
     }
-
-    /**
-     * @param {!Event} e
-     * @protected
-     */
-    _retargetEvent(e) {
-      e.stopPropagation();
-      const { detail, composed, cancelable, bubbles } = e;
-
-      const firedEvent = this.dispatchEvent(new CustomEvent(e.type, { bubbles, cancelable, composed, detail }));
-      // Check if `eventTarget.preventDefault()` was called to prevent default in the original event
-      if (!firedEvent) {
-        e.preventDefault();
-      }
-    }
   };

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -164,6 +164,21 @@ class LoginOverlay extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement)
     e.preventDefault();
   }
 
+  /**
+   * @param {!Event} e
+   * @private
+   */
+  _retargetEvent(e) {
+    e.stopPropagation();
+    const { detail, composed, cancelable, bubbles } = e;
+
+    const firedEvent = this.dispatchEvent(new CustomEvent(e.type, { bubbles, cancelable, composed, detail }));
+    // Check if `eventTarget.preventDefault()` was called to prevent default in the original event
+    if (!firedEvent) {
+      e.preventDefault();
+    }
+  }
+
   /** @private */
   _onOpenedChange() {
     if (!this.opened) {


### PR DESCRIPTION
## Description

After moving "forgot password" button to light DOM, this method is only used in `vaadin-login-overlay`.
Moved it from the `LoginMixin` to this component and marked as private so we can change / remove it.

## Type of change

- Refactor