### PR TITLE
fix: do not set form theme attribute to undefined

### DIFF
--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -928,7 +928,12 @@ class Crud extends SlotMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
     if (form) {
       form.include = include;
       form.exclude = exclude;
-      form.setAttribute('theme', theme);
+
+      if (theme) {
+        form.setAttribute('theme', theme);
+      } else {
+        form.removeAttribute('theme');
+      }
     }
   }
 

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -9,10 +9,7 @@ snapshots["vaadin-crud host default"] =
   <h3 slot="header">
     Edit item
   </h3>
-  <vaadin-crud-form
-    slot="form"
-    theme="undefined"
-  >
+  <vaadin-crud-form slot="form">
   </vaadin-crud-form>
   <vaadin-button
     aria-disabled="true"


### PR DESCRIPTION
## Description

This is a small fix to align logic for `theme` attribute propagation with other components that use it.
See the snapshot test update where the weird `theme="undefined"` has been removed 😅 

## Type of change

- Bugfix / Refactor