### PR TITLE
refactor!: swap SlotController initializer parameters

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -284,7 +284,7 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(ControllerMixin
       this,
       'overflow',
       () => document.createElement('vaadin-avatar'),
-      (_, overflow) => {
+      (overflow) => {
         overflow.setAttribute('aria-haspopup', 'listbox');
         overflow.setAttribute('aria-expanded', 'false');
         overflow.addEventListener('click', (e) => this._onOverflowClick(e));

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -111,7 +111,7 @@ export class SlotController extends EventTarget {
     // Don't try to bind `this` to initializer (normally it's arrow function).
     // Instead, pass the host as a first argument to access component's state.
     if (slotInitializer) {
-      slotInitializer(this.host, node);
+      slotInitializer(node, this.host);
     }
   }
 

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -54,8 +54,8 @@ describe('slot-controller', () => {
 
       it('should run initializer for named slot child', () => {
         expect(initializeSpy.calledOnce).to.be.true;
-        expect(initializeSpy.firstCall.args[0]).to.equal(element);
-        expect(initializeSpy.firstCall.args[1]).to.equal(child);
+        expect(initializeSpy.firstCall.args[0]).to.equal(child);
+        expect(initializeSpy.firstCall.args[1]).to.equal(element);
       });
     });
 
@@ -97,8 +97,8 @@ describe('slot-controller', () => {
 
       it('should run initializer for custom named slot child', () => {
         expect(initializeSpy.calledOnce).to.be.true;
-        expect(initializeSpy.firstCall.args[0]).to.equal(element);
-        expect(initializeSpy.firstCall.args[1]).to.equal(child);
+        expect(initializeSpy.firstCall.args[0]).to.equal(child);
+        expect(initializeSpy.firstCall.args[1]).to.equal(element);
       });
     });
   });
@@ -137,8 +137,8 @@ describe('slot-controller', () => {
 
       it('should run initializer for un-named slot child', () => {
         expect(initializeSpy.calledOnce).to.be.true;
-        expect(initializeSpy.firstCall.args[0]).to.equal(element);
-        expect(initializeSpy.firstCall.args[1]).to.equal(child);
+        expect(initializeSpy.firstCall.args[0]).to.equal(child);
+        expect(initializeSpy.firstCall.args[1]).to.equal(element);
       });
     });
 
@@ -180,8 +180,8 @@ describe('slot-controller', () => {
 
       it('should run initializer for un-named slot element', () => {
         expect(initializeSpy.calledOnce).to.be.true;
-        expect(initializeSpy.firstCall.args[0]).to.equal(element);
-        expect(initializeSpy.firstCall.args[1]).to.equal(child);
+        expect(initializeSpy.firstCall.args[0]).to.equal(child);
+        expect(initializeSpy.firstCall.args[1]).to.equal(element);
       });
     });
 
@@ -219,8 +219,8 @@ describe('slot-controller', () => {
 
       it('should run initializer for the slotted text node', () => {
         expect(initializeSpy.calledOnce).to.be.true;
-        expect(initializeSpy.firstCall.args[0]).to.equal(element);
-        expect(initializeSpy.firstCall.args[1]).to.equal(child);
+        expect(initializeSpy.firstCall.args[0]).to.equal(child);
+        expect(initializeSpy.firstCall.args[1]).to.equal(element);
       });
     });
 
@@ -237,6 +237,7 @@ describe('slot-controller', () => {
           return div;
         });
         element.addController(controller);
+        expect(controller.getSlotChild().textContent).to.equal('bar');
       });
     });
   });

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -276,7 +276,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
         this,
         'today-button',
         () => document.createElement('vaadin-button'),
-        (_, btn) => {
+        (btn) => {
           btn.setAttribute('theme', 'tertiary');
           btn.addEventListener('keydown', (e) => this.__onTodayButtonKeyDown(e));
           addListener(btn, 'tap', this._onTodayTap.bind(this));
@@ -290,7 +290,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
         this,
         'cancel-button',
         () => document.createElement('vaadin-button'),
-        (_, btn) => {
+        (btn) => {
           btn.setAttribute('theme', 'tertiary');
           btn.addEventListener('keydown', (e) => this.__onCancelButtonKeyDown(e));
           addListener(btn, 'tap', this._cancel.bind(this));
@@ -339,7 +339,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
         this,
         'months',
         () => document.createElement('vaadin-date-picker-month-scroller'),
-        (_, scroller) => {
+        (scroller) => {
           scroller.addEventListener('custom-scroll', () => {
             this._onMonthScroll();
           });
@@ -377,7 +377,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
         this,
         'years',
         () => document.createElement('vaadin-date-picker-year-scroller'),
-        (_, scroller) => {
+        (scroller) => {
           scroller.setAttribute('aria-hidden', 'true');
 
           addListener(scroller, 'tap', (e) => {

--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -14,7 +14,7 @@ export class ErrorController extends SlotController {
       host,
       'error-message',
       () => document.createElement('div'),
-      (_host, node) => {
+      (node) => {
         this.__updateErrorId(node);
 
         this.__updateHasError();

--- a/packages/field-base/src/input-controller.js
+++ b/packages/field-base/src/input-controller.js
@@ -14,7 +14,7 @@ export class InputController extends SlotController {
       host,
       'input',
       () => document.createElement('input'),
-      (host, node) => {
+      (node, host) => {
         if (host.value) {
           node.setAttribute('value', host.value);
         }

--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -14,7 +14,7 @@ export class LabelController extends SlotController {
       host,
       'label',
       () => document.createElement('label'),
-      (_host, node) => {
+      (node) => {
         // Set ID attribute or use the existing one.
         this.__updateLabelId(node);
 

--- a/packages/field-base/src/text-area-controller.js
+++ b/packages/field-base/src/text-area-controller.js
@@ -14,7 +14,7 @@ export class TextAreaController extends SlotController {
       host,
       'textarea',
       () => document.createElement('textarea'),
-      (host, node) => {
+      (node, host) => {
         const value = host.getAttribute('value');
         if (value) {
           node.value = value;

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -60,7 +60,7 @@ export const ButtonsMixin = (superClass) =>
         this,
         'overflow',
         () => document.createElement('vaadin-menu-bar-button'),
-        (_, btn) => {
+        (btn) => {
           btn.setAttribute('hidden', '');
 
           const dots = document.createElement('div');

--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -142,7 +142,7 @@ class MessageInput extends ElementMixin(ThemableMixin(ControllerMixin(PolymerEle
       this,
       'button',
       () => document.createElement('vaadin-button'),
-      (_, btn) => {
+      (btn) => {
         btn.setAttribute('theme', 'primary contained');
 
         btn.addEventListener('click', () => {
@@ -158,7 +158,7 @@ class MessageInput extends ElementMixin(ThemableMixin(ControllerMixin(PolymerEle
       this,
       'textarea',
       () => document.createElement('vaadin-text-area'),
-      (_, textarea) => {
+      (textarea) => {
         textarea.addEventListener('value-changed', (event) => {
           this.value = event.detail.value;
         });

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -186,7 +186,7 @@ class Message extends FocusMixin(ElementMixin(ThemableMixin(ControllerMixin(Poly
       this,
       'avatar',
       () => document.createElement('vaadin-avatar'),
-      (_, avatar) => {
+      (avatar) => {
         avatar.setAttribute('tabindex', '-1');
         avatar.setAttribute('aria-hidden', 'true');
         this._avatar = avatar;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -513,7 +513,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       this,
       'overflow',
       () => document.createElement('vaadin-multi-select-combo-box-chip'),
-      (_, chip) => {
+      (chip) => {
         chip.addEventListener('mousedown', (e) => this._preventBlur(e));
         this._overflow = chip;
       },

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -156,11 +156,11 @@ export class PasswordField extends TextField {
       this,
       'reveal',
       () => document.createElement('vaadin-password-field-button'),
-      (host, btn) => {
-        btn.disabled = host.disabled;
+      (btn) => {
+        btn.disabled = this.disabled;
 
-        btn.addEventListener('click', host.__boundRevealButtonClick);
-        btn.addEventListener('touchend', host.__boundRevealButtonTouchend);
+        btn.addEventListener('click', this.__boundRevealButtonClick);
+        btn.addEventListener('touchend', this.__boundRevealButtonTouchend);
       },
     );
     this.addController(this._revealButtonController);

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -352,7 +352,7 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
       this,
       'value',
       () => document.createElement('vaadin-select-value-button'),
-      (host, btn) => {
+      (btn) => {
         this._setFocusElement(btn);
         this.ariaTarget = btn;
         this.stateTarget = btn;
@@ -360,7 +360,7 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
         btn.setAttribute('aria-haspopup', 'listbox');
         btn.setAttribute('aria-labelledby', `${this._labelId} ${this._fieldId}`);
 
-        this._updateAriaExpanded(host.opened);
+        this._updateAriaExpanded(this.opened);
 
         btn.addEventListener('keydown', this._boundOnKeyDown);
       },

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -240,7 +240,7 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
         this,
         'progress',
         () => document.createElement('vaadin-progress-bar'),
-        (_, progress) => {
+        (progress) => {
           this._progress = progress;
         },
       ),

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -458,7 +458,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
         this,
         'add-button',
         () => document.createElement('vaadin-button'),
-        (_, button) => {
+        (button) => {
           button.addEventListener('touchend', (e) => {
             this._onAddFilesTouchEnd(e);
           });
@@ -475,7 +475,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
         this,
         'drop-label',
         () => document.createElement('span'),
-        (_, label) => {
+        (label) => {
           this._dropLabel = label;
         },
       ),
@@ -486,7 +486,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
         this,
         'file-list',
         () => document.createElement('vaadin-upload-file-list'),
-        (_, list) => {
+        (list) => {
           this._fileList = list;
         },
       ),


### PR DESCRIPTION
## Description

This is a minor breaking change intended to make usage of `SlotController` slightly less verbose.

Originally, the `host` parameter was added when creating `InputController` where it's needed.
However, in most of cases we have a reference to `this` that can be used instead.

Changed the order of `host` and `node`, and removed unused parameter where possible.

## Type of change

- Breaking change