### PR TITLE
refactor!: restructure SlotController constructor arguments

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -280,18 +280,20 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(ControllerMixin
   ready() {
     super.ready();
 
-    this._overflowController = new SlotController(this, 'overflow', 'vaadin-avatar', (overflow) => {
-      overflow.setAttribute('aria-haspopup', 'listbox');
-      overflow.setAttribute('aria-expanded', 'false');
-      overflow.addEventListener('click', (e) => this._onOverflowClick(e));
-      overflow.addEventListener('keydown', (e) => this._onOverflowKeyDown(e));
+    this._overflowController = new SlotController(this, 'overflow', 'vaadin-avatar', {
+      initializer: (overflow) => {
+        overflow.setAttribute('aria-haspopup', 'listbox');
+        overflow.setAttribute('aria-expanded', 'false');
+        overflow.addEventListener('click', (e) => this._onOverflowClick(e));
+        overflow.addEventListener('keydown', (e) => this._onOverflowKeyDown(e));
 
-      const tooltip = document.createElement('vaadin-tooltip');
-      tooltip.setAttribute('slot', 'tooltip');
-      overflow.appendChild(tooltip);
+        const tooltip = document.createElement('vaadin-tooltip');
+        tooltip.setAttribute('slot', 'tooltip');
+        overflow.appendChild(tooltip);
 
-      this._overflow = overflow;
-      this._overflowTooltip = tooltip;
+        this._overflow = overflow;
+        this._overflowTooltip = tooltip;
+      },
     });
     this.addController(this._overflowController);
 

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -280,24 +280,19 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(ControllerMixin
   ready() {
     super.ready();
 
-    this._overflowController = new SlotController(
-      this,
-      'overflow',
-      () => document.createElement('vaadin-avatar'),
-      (overflow) => {
-        overflow.setAttribute('aria-haspopup', 'listbox');
-        overflow.setAttribute('aria-expanded', 'false');
-        overflow.addEventListener('click', (e) => this._onOverflowClick(e));
-        overflow.addEventListener('keydown', (e) => this._onOverflowKeyDown(e));
+    this._overflowController = new SlotController(this, 'overflow', 'vaadin-avatar', (overflow) => {
+      overflow.setAttribute('aria-haspopup', 'listbox');
+      overflow.setAttribute('aria-expanded', 'false');
+      overflow.addEventListener('click', (e) => this._onOverflowClick(e));
+      overflow.addEventListener('keydown', (e) => this._onOverflowKeyDown(e));
 
-        const tooltip = document.createElement('vaadin-tooltip');
-        tooltip.setAttribute('slot', 'tooltip');
-        overflow.appendChild(tooltip);
+      const tooltip = document.createElement('vaadin-tooltip');
+      tooltip.setAttribute('slot', 'tooltip');
+      overflow.appendChild(tooltip);
 
-        this._overflow = overflow;
-        this._overflowTooltip = tooltip;
-      },
-    );
+      this._overflow = overflow;
+      this._overflowTooltip = tooltip;
+    });
     this.addController(this._overflowController);
 
     this.$.overlay.renderer = this.__overlayRenderer.bind(this);

--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -26,8 +26,10 @@ export class SlotController extends EventTarget implements ReactiveController {
     host: HTMLElement,
     slotName: string,
     tagName?: string,
-    slotInitializer?: (host: HTMLElement, node: HTMLElement) => void,
-    useUniqueId?: boolean,
+    config?: {
+      useUniqueId?: boolean;
+      initializer?(host: HTMLElement, node: HTMLElement): void;
+    },
   );
 
   hostConnected(): void;

--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -25,7 +25,7 @@ export class SlotController extends EventTarget implements ReactiveController {
   constructor(
     host: HTMLElement,
     slotName: string,
-    slotFactory?: () => HTMLElement,
+    tagName?: string,
     slotInitializer?: (host: HTMLElement, node: HTMLElement) => void,
     useUniqueId?: boolean,
   );

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -23,13 +23,15 @@ export class SlotController extends EventTarget {
     return `${prefix}-${host.localName}-${generateUniqueId()}`;
   }
 
-  constructor(host, slotName, tagName, slotInitializer, useUniqueId) {
+  constructor(host, slotName, tagName, config = {}) {
     super();
+
+    const { initializer, useUniqueId } = config;
 
     this.host = host;
     this.slotName = slotName;
     this.tagName = tagName;
-    this.slotInitializer = slotInitializer;
+    this.slotInitializer = initializer;
 
     // Only generate the default ID if requested by the controller.
     if (useUniqueId) {

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -23,12 +23,12 @@ export class SlotController extends EventTarget {
     return `${prefix}-${host.localName}-${generateUniqueId()}`;
   }
 
-  constructor(host, slotName, slotFactory, slotInitializer, useUniqueId) {
+  constructor(host, slotName, tagName, slotInitializer, useUniqueId) {
     super();
 
     this.host = host;
     this.slotName = slotName;
-    this.slotFactory = slotFactory;
+    this.tagName = tagName;
     this.slotInitializer = slotInitializer;
 
     // Only generate the default ID if requested by the controller.
@@ -63,14 +63,14 @@ export class SlotController extends EventTarget {
    * @protected
    */
   attachDefaultNode() {
-    const { host, slotName, slotFactory } = this;
+    const { host, slotName, tagName } = this;
 
     // Check if the node was created previously and if so, reuse it.
     let node = this.defaultNode;
 
     // Slot factory is optional, some slots don't have default content.
-    if (!node && slotFactory) {
-      node = slotFactory(host);
+    if (!node && tagName) {
+      node = document.createElement(tagName);
       if (node instanceof Element) {
         if (slotName !== '') {
           node.setAttribute('slot', slotName);

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -24,17 +24,10 @@ describe('slot-controller', () => {
     describe('default content', () => {
       beforeEach(() => {
         element = fixtureSync('<slot-controller-element></slot-controller-element>');
-        initializeSpy = sinon.spy();
-        controller = new SlotController(
-          element,
-          'foo',
-          () => {
-            const div = document.createElement('div');
-            div.textContent = 'foo';
-            return div;
-          },
-          initializeSpy,
-        );
+        initializeSpy = sinon.stub().callsFake((node) => {
+          node.textContent = 'foo';
+        });
+        controller = new SlotController(element, 'foo', 'div', initializeSpy);
         element.addController(controller);
         child = element.querySelector('[slot="foo"]');
       });
@@ -69,16 +62,7 @@ describe('slot-controller', () => {
         // Get element reference before adding the controller
         child = element.querySelector('[slot="foo"]');
         initializeSpy = sinon.spy();
-        controller = new SlotController(
-          element,
-          'foo',
-          () => {
-            const div = document.createElement('div');
-            div.textContent = 'foo';
-            return div;
-          },
-          initializeSpy,
-        );
+        controller = new SlotController(element, 'foo', 'div', initializeSpy);
         element.addController(controller);
       });
 
@@ -107,17 +91,10 @@ describe('slot-controller', () => {
     describe('default content', () => {
       beforeEach(() => {
         element = fixtureSync('<slot-controller-element></slot-controller-element>');
-        initializeSpy = sinon.spy();
-        controller = new SlotController(
-          element,
-          '',
-          () => {
-            const div = document.createElement('div');
-            div.textContent = 'bar';
-            return div;
-          },
-          initializeSpy,
-        );
+        initializeSpy = sinon.stub().callsFake((node) => {
+          node.textContent = 'bar';
+        });
+        controller = new SlotController(element, '', 'div', initializeSpy);
         element.addController(controller);
         child = element.querySelector(':not([slot])');
       });
@@ -152,16 +129,7 @@ describe('slot-controller', () => {
         // Get element reference before adding the controller
         child = element.querySelector(':not([slot])');
         initializeSpy = sinon.spy();
-        controller = new SlotController(
-          element,
-          '',
-          () => {
-            const div = document.createElement('div');
-            div.textContent = 'bar';
-            return div;
-          },
-          initializeSpy,
-        );
+        controller = new SlotController(element, '', 'div', initializeSpy);
         element.addController(controller);
       });
 
@@ -189,16 +157,7 @@ describe('slot-controller', () => {
       beforeEach(() => {
         element = fixtureSync('<slot-controller-element>baz</slot-controller-element>');
         initializeSpy = sinon.spy();
-        controller = new SlotController(
-          element,
-          '',
-          () => {
-            const div = document.createElement('div');
-            div.textContent = 'bar';
-            return div;
-          },
-          initializeSpy,
-        );
+        controller = new SlotController(element, '', 'div', initializeSpy);
         element.addController(controller);
         // Check last child to ensure no custom node is added.
         child = element.lastChild;
@@ -231,10 +190,8 @@ describe('slot-controller', () => {
       });
 
       it('should override an empty text node passed to un-named slot', () => {
-        controller = new SlotController(element, '', () => {
-          const div = document.createElement('div');
-          div.textContent = 'bar';
-          return div;
+        controller = new SlotController(element, '', 'div', (node) => {
+          node.textContent = 'bar';
         });
         element.addController(controller);
         expect(controller.getSlotChild().textContent).to.equal('bar');
@@ -247,10 +204,8 @@ describe('slot-controller', () => {
 
     beforeEach(async () => {
       element = fixtureSync('<slot-controller-element></slot-controller-element>');
-      controller = new SlotController(element, 'foo', () => {
-        const div = document.createElement('div');
-        div.textContent = 'foo';
-        return div;
+      controller = new SlotController(element, 'foo', 'div', (node) => {
+        node.textContent = 'foo';
       });
       element.addController(controller);
       defaultNode = element.querySelector('[slot="foo"]');

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -27,7 +27,7 @@ describe('slot-controller', () => {
         initializeSpy = sinon.stub().callsFake((node) => {
           node.textContent = 'foo';
         });
-        controller = new SlotController(element, 'foo', 'div', initializeSpy);
+        controller = new SlotController(element, 'foo', 'div', { initializer: initializeSpy });
         element.addController(controller);
         child = element.querySelector('[slot="foo"]');
       });
@@ -62,7 +62,7 @@ describe('slot-controller', () => {
         // Get element reference before adding the controller
         child = element.querySelector('[slot="foo"]');
         initializeSpy = sinon.spy();
-        controller = new SlotController(element, 'foo', 'div', initializeSpy);
+        controller = new SlotController(element, 'foo', 'div', { initializer: initializeSpy });
         element.addController(controller);
       });
 
@@ -94,7 +94,7 @@ describe('slot-controller', () => {
         initializeSpy = sinon.stub().callsFake((node) => {
           node.textContent = 'bar';
         });
-        controller = new SlotController(element, '', 'div', initializeSpy);
+        controller = new SlotController(element, '', 'div', { initializer: initializeSpy });
         element.addController(controller);
         child = element.querySelector(':not([slot])');
       });
@@ -129,7 +129,7 @@ describe('slot-controller', () => {
         // Get element reference before adding the controller
         child = element.querySelector(':not([slot])');
         initializeSpy = sinon.spy();
-        controller = new SlotController(element, '', 'div', initializeSpy);
+        controller = new SlotController(element, '', 'div', { initializer: initializeSpy });
         element.addController(controller);
       });
 
@@ -157,7 +157,7 @@ describe('slot-controller', () => {
       beforeEach(() => {
         element = fixtureSync('<slot-controller-element>baz</slot-controller-element>');
         initializeSpy = sinon.spy();
-        controller = new SlotController(element, '', 'div', initializeSpy);
+        controller = new SlotController(element, '', 'div', { initializer: initializeSpy });
         element.addController(controller);
         // Check last child to ensure no custom node is added.
         child = element.lastChild;
@@ -190,8 +190,10 @@ describe('slot-controller', () => {
       });
 
       it('should override an empty text node passed to un-named slot', () => {
-        controller = new SlotController(element, '', 'div', (node) => {
-          node.textContent = 'bar';
+        controller = new SlotController(element, '', 'div', {
+          initializer: (node) => {
+            node.textContent = 'bar';
+          },
         });
         element.addController(controller);
         expect(controller.getSlotChild().textContent).to.equal('bar');
@@ -204,8 +206,10 @@ describe('slot-controller', () => {
 
     beforeEach(async () => {
       element = fixtureSync('<slot-controller-element></slot-controller-element>');
-      controller = new SlotController(element, 'foo', 'div', (node) => {
-        node.textContent = 'foo';
+      controller = new SlotController(element, 'foo', 'div', {
+        initializer: (node) => {
+          node.textContent = 'bar';
+        },
       });
       element.addController(controller);
       defaultNode = element.querySelector('[slot="foo"]');

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -272,20 +272,24 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     );
 
     this.addController(
-      new SlotController(this, 'today-button', 'vaadin-button', (btn) => {
-        btn.setAttribute('theme', 'tertiary');
-        btn.addEventListener('keydown', (e) => this.__onTodayButtonKeyDown(e));
-        addListener(btn, 'tap', this._onTodayTap.bind(this));
-        this._todayButton = btn;
+      new SlotController(this, 'today-button', 'vaadin-button', {
+        initializer: (btn) => {
+          btn.setAttribute('theme', 'tertiary');
+          btn.addEventListener('keydown', (e) => this.__onTodayButtonKeyDown(e));
+          addListener(btn, 'tap', this._onTodayTap.bind(this));
+          this._todayButton = btn;
+        },
       }),
     );
 
     this.addController(
-      new SlotController(this, 'cancel-button', 'vaadin-button', (btn) => {
-        btn.setAttribute('theme', 'tertiary');
-        btn.addEventListener('keydown', (e) => this.__onCancelButtonKeyDown(e));
-        addListener(btn, 'tap', this._cancel.bind(this));
-        this._cancelButton = btn;
+      new SlotController(this, 'cancel-button', 'vaadin-button', {
+        initializer: (btn) => {
+          btn.setAttribute('theme', 'tertiary');
+          btn.addEventListener('keydown', (e) => this.__onCancelButtonKeyDown(e));
+          addListener(btn, 'tap', this._cancel.bind(this));
+          this._cancelButton = btn;
+        },
       }),
     );
 
@@ -325,59 +329,63 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
   __initMonthScroller() {
     this.addController(
-      new SlotController(this, 'months', 'vaadin-date-picker-month-scroller', (scroller) => {
-        scroller.addEventListener('custom-scroll', () => {
-          this._onMonthScroll();
-        });
-
-        scroller.addEventListener('touchstart', () => {
-          this._onMonthScrollTouchStart();
-        });
-
-        scroller.addEventListener('keydown', (e) => {
-          this.__onMonthCalendarKeyDown(e);
-        });
-
-        scroller.addEventListener('init-done', () => {
-          const calendars = [...this.querySelectorAll('vaadin-month-calendar')];
-
-          // Two-way binding for selectedDate property
-          calendars.forEach((calendar) => {
-            calendar.addEventListener('selected-date-changed', (e) => {
-              this.selectedDate = e.detail.value;
-            });
+      new SlotController(this, 'months', 'vaadin-date-picker-month-scroller', {
+        initializer: (scroller) => {
+          scroller.addEventListener('custom-scroll', () => {
+            this._onMonthScroll();
           });
 
-          this.calendars = calendars;
-        });
+          scroller.addEventListener('touchstart', () => {
+            this._onMonthScrollTouchStart();
+          });
 
-        this._monthScroller = scroller;
+          scroller.addEventListener('keydown', (e) => {
+            this.__onMonthCalendarKeyDown(e);
+          });
+
+          scroller.addEventListener('init-done', () => {
+            const calendars = [...this.querySelectorAll('vaadin-month-calendar')];
+
+            // Two-way binding for selectedDate property
+            calendars.forEach((calendar) => {
+              calendar.addEventListener('selected-date-changed', (e) => {
+                this.selectedDate = e.detail.value;
+              });
+            });
+
+            this.calendars = calendars;
+          });
+
+          this._monthScroller = scroller;
+        },
       }),
     );
   }
 
   __initYearScroller() {
     this.addController(
-      new SlotController(this, 'years', 'vaadin-date-picker-year-scroller', (scroller) => {
-        scroller.setAttribute('aria-hidden', 'true');
+      new SlotController(this, 'years', 'vaadin-date-picker-year-scroller', {
+        initializer: (scroller) => {
+          scroller.setAttribute('aria-hidden', 'true');
 
-        addListener(scroller, 'tap', (e) => {
-          this._onYearTap(e);
-        });
+          addListener(scroller, 'tap', (e) => {
+            this._onYearTap(e);
+          });
 
-        scroller.addEventListener('custom-scroll', () => {
-          this._onYearScroll();
-        });
+          scroller.addEventListener('custom-scroll', () => {
+            this._onYearScroll();
+          });
 
-        scroller.addEventListener('touchstart', () => {
-          this._onYearScrollTouchStart();
-        });
+          scroller.addEventListener('touchstart', () => {
+            this._onYearScrollTouchStart();
+          });
 
-        scroller.addEventListener('init-done', () => {
-          this.years = [...this.querySelectorAll('vaadin-date-picker-year')];
-        });
+          scroller.addEventListener('init-done', () => {
+            this.years = [...this.querySelectorAll('vaadin-date-picker-year')];
+          });
 
-        this._yearScroller = scroller;
+          this._yearScroller = scroller;
+        },
       }),
     );
   }

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -272,31 +272,21 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     );
 
     this.addController(
-      new SlotController(
-        this,
-        'today-button',
-        () => document.createElement('vaadin-button'),
-        (btn) => {
-          btn.setAttribute('theme', 'tertiary');
-          btn.addEventListener('keydown', (e) => this.__onTodayButtonKeyDown(e));
-          addListener(btn, 'tap', this._onTodayTap.bind(this));
-          this._todayButton = btn;
-        },
-      ),
+      new SlotController(this, 'today-button', 'vaadin-button', (btn) => {
+        btn.setAttribute('theme', 'tertiary');
+        btn.addEventListener('keydown', (e) => this.__onTodayButtonKeyDown(e));
+        addListener(btn, 'tap', this._onTodayTap.bind(this));
+        this._todayButton = btn;
+      }),
     );
 
     this.addController(
-      new SlotController(
-        this,
-        'cancel-button',
-        () => document.createElement('vaadin-button'),
-        (btn) => {
-          btn.setAttribute('theme', 'tertiary');
-          btn.addEventListener('keydown', (e) => this.__onCancelButtonKeyDown(e));
-          addListener(btn, 'tap', this._cancel.bind(this));
-          this._cancelButton = btn;
-        },
-      ),
+      new SlotController(this, 'cancel-button', 'vaadin-button', (btn) => {
+        btn.setAttribute('theme', 'tertiary');
+        btn.addEventListener('keydown', (e) => this.__onCancelButtonKeyDown(e));
+        addListener(btn, 'tap', this._cancel.bind(this));
+        this._cancelButton = btn;
+      }),
     );
 
     this.__initMonthScroller();
@@ -335,70 +325,60 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
   __initMonthScroller() {
     this.addController(
-      new SlotController(
-        this,
-        'months',
-        () => document.createElement('vaadin-date-picker-month-scroller'),
-        (scroller) => {
-          scroller.addEventListener('custom-scroll', () => {
-            this._onMonthScroll();
-          });
+      new SlotController(this, 'months', 'vaadin-date-picker-month-scroller', (scroller) => {
+        scroller.addEventListener('custom-scroll', () => {
+          this._onMonthScroll();
+        });
 
-          scroller.addEventListener('touchstart', () => {
-            this._onMonthScrollTouchStart();
-          });
+        scroller.addEventListener('touchstart', () => {
+          this._onMonthScrollTouchStart();
+        });
 
-          scroller.addEventListener('keydown', (e) => {
-            this.__onMonthCalendarKeyDown(e);
-          });
+        scroller.addEventListener('keydown', (e) => {
+          this.__onMonthCalendarKeyDown(e);
+        });
 
-          scroller.addEventListener('init-done', () => {
-            const calendars = [...this.querySelectorAll('vaadin-month-calendar')];
+        scroller.addEventListener('init-done', () => {
+          const calendars = [...this.querySelectorAll('vaadin-month-calendar')];
 
-            // Two-way binding for selectedDate property
-            calendars.forEach((calendar) => {
-              calendar.addEventListener('selected-date-changed', (e) => {
-                this.selectedDate = e.detail.value;
-              });
+          // Two-way binding for selectedDate property
+          calendars.forEach((calendar) => {
+            calendar.addEventListener('selected-date-changed', (e) => {
+              this.selectedDate = e.detail.value;
             });
-
-            this.calendars = calendars;
           });
 
-          this._monthScroller = scroller;
-        },
-      ),
+          this.calendars = calendars;
+        });
+
+        this._monthScroller = scroller;
+      }),
     );
   }
 
   __initYearScroller() {
     this.addController(
-      new SlotController(
-        this,
-        'years',
-        () => document.createElement('vaadin-date-picker-year-scroller'),
-        (scroller) => {
-          scroller.setAttribute('aria-hidden', 'true');
+      new SlotController(this, 'years', 'vaadin-date-picker-year-scroller', (scroller) => {
+        scroller.setAttribute('aria-hidden', 'true');
 
-          addListener(scroller, 'tap', (e) => {
-            this._onYearTap(e);
-          });
+        addListener(scroller, 'tap', (e) => {
+          this._onYearTap(e);
+        });
 
-          scroller.addEventListener('custom-scroll', () => {
-            this._onYearScroll();
-          });
+        scroller.addEventListener('custom-scroll', () => {
+          this._onYearScroll();
+        });
 
-          scroller.addEventListener('touchstart', () => {
-            this._onYearScrollTouchStart();
-          });
+        scroller.addEventListener('touchstart', () => {
+          this._onYearScrollTouchStart();
+        });
 
-          scroller.addEventListener('init-done', () => {
-            this.years = [...this.querySelectorAll('vaadin-date-picker-year')];
-          });
+        scroller.addEventListener('init-done', () => {
+          this.years = [...this.querySelectorAll('vaadin-date-picker-year')];
+        });
 
-          this._yearScroller = scroller;
-        },
-      ),
+        this._yearScroller = scroller;
+      }),
     );
   }
 

--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -13,7 +13,7 @@ export class ErrorController extends SlotController {
     super(
       host,
       'error-message',
-      () => document.createElement('div'),
+      'div',
       (node) => {
         this.__updateErrorId(node);
 

--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -10,17 +10,14 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  */
 export class ErrorController extends SlotController {
   constructor(host) {
-    super(
-      host,
-      'error-message',
-      'div',
-      (node) => {
+    super(host, 'error-message', 'div', {
+      initializer: (node) => {
         this.__updateErrorId(node);
 
         this.__updateHasError();
       },
-      true,
-    );
+      useUniqueId: true,
+    });
   }
 
   /**

--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -106,8 +106,8 @@ export class HelperController extends SlotController {
     const hasHelperText = this.__isNotEmpty(helperText);
 
     if (hasHelperText && !helperNode) {
-      // Set slot factory lazily to only create helper node when needed.
-      this.slotFactory = () => document.createElement('div');
+      // Set tag name lazily to only create helper node when needed.
+      this.tagName = 'div';
 
       helperNode = this.attachDefaultNode();
 

--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -10,8 +10,10 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  */
 export class HelperController extends SlotController {
   constructor(host) {
-    // Do not provide slot factory, as only create helper lazily.
-    super(host, 'helper', null, null, true);
+    // Do not provide tag name, as we create helper lazily.
+    super(host, 'helper', null, {
+      useUniqueId: true,
+    });
   }
 
   get helperId() {

--- a/packages/field-base/src/input-controller.js
+++ b/packages/field-base/src/input-controller.js
@@ -10,11 +10,8 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  */
 export class InputController extends SlotController {
   constructor(host, callback) {
-    super(
-      host,
-      'input',
-      'input',
-      (node, host) => {
+    super(host, 'input', 'input', {
+      initializer: (node, host) => {
         if (host.value) {
           node.setAttribute('value', host.value);
         }
@@ -29,7 +26,7 @@ export class InputController extends SlotController {
           callback(node);
         }
       },
-      true,
-    );
+      useUniqueId: true,
+    });
   }
 }

--- a/packages/field-base/src/input-controller.js
+++ b/packages/field-base/src/input-controller.js
@@ -13,7 +13,7 @@ export class InputController extends SlotController {
     super(
       host,
       'input',
-      () => document.createElement('input'),
+      'input',
       (node, host) => {
         if (host.value) {
           node.setAttribute('value', host.value);

--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -13,7 +13,7 @@ export class LabelController extends SlotController {
     super(
       host,
       'label',
-      () => document.createElement('label'),
+      'label',
       (node) => {
         // Set ID attribute or use the existing one.
         this.__updateLabelId(node);

--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -10,11 +10,8 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  */
 export class LabelController extends SlotController {
   constructor(host) {
-    super(
-      host,
-      'label',
-      'label',
-      (node) => {
+    super(host, 'label', 'label', {
+      initializer: (node) => {
         // Set ID attribute or use the existing one.
         this.__updateLabelId(node);
 
@@ -23,8 +20,8 @@ export class LabelController extends SlotController {
 
         this.__observeLabel(node);
       },
-      true,
-    );
+      useUniqueId: true,
+    });
   }
 
   /**

--- a/packages/field-base/src/text-area-controller.js
+++ b/packages/field-base/src/text-area-controller.js
@@ -10,11 +10,8 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  */
 export class TextAreaController extends SlotController {
   constructor(host, callback) {
-    super(
-      host,
-      'textarea',
-      'textarea',
-      (node, host) => {
+    super(host, 'textarea', 'textarea', {
+      initializer: (node, host) => {
         const value = host.getAttribute('value');
         if (value) {
           node.value = value;
@@ -31,7 +28,7 @@ export class TextAreaController extends SlotController {
           callback(node);
         }
       },
-      true,
-    );
+      useUniqueId: true,
+    });
   }
 }

--- a/packages/field-base/src/text-area-controller.js
+++ b/packages/field-base/src/text-area-controller.js
@@ -13,7 +13,7 @@ export class TextAreaController extends SlotController {
     super(
       host,
       'textarea',
-      () => document.createElement('textarea'),
+      'textarea',
       (node, host) => {
         const value = host.getAttribute('value');
         if (value) {

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -56,16 +56,18 @@ export const ButtonsMixin = (superClass) =>
 
       this.setAttribute('role', 'menubar');
 
-      this._overflowController = new SlotController(this, 'overflow', 'vaadin-menu-bar-button', (btn) => {
-        btn.setAttribute('hidden', '');
+      this._overflowController = new SlotController(this, 'overflow', 'vaadin-menu-bar-button', {
+        initializer: (btn) => {
+          btn.setAttribute('hidden', '');
 
-        const dots = document.createElement('div');
-        dots.setAttribute('aria-hidden', 'true');
-        dots.textContent = '···';
-        btn.appendChild(dots);
+          const dots = document.createElement('div');
+          dots.setAttribute('aria-hidden', 'true');
+          dots.textContent = '···';
+          btn.appendChild(dots);
 
-        this._overflow = btn;
-        this._initButtonAttrs(btn);
+          this._overflow = btn;
+          this._initButtonAttrs(btn);
+        },
       });
       this.addController(this._overflowController);
     }

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -56,22 +56,17 @@ export const ButtonsMixin = (superClass) =>
 
       this.setAttribute('role', 'menubar');
 
-      this._overflowController = new SlotController(
-        this,
-        'overflow',
-        () => document.createElement('vaadin-menu-bar-button'),
-        (btn) => {
-          btn.setAttribute('hidden', '');
+      this._overflowController = new SlotController(this, 'overflow', 'vaadin-menu-bar-button', (btn) => {
+        btn.setAttribute('hidden', '');
 
-          const dots = document.createElement('div');
-          dots.setAttribute('aria-hidden', 'true');
-          dots.textContent = '···';
-          btn.appendChild(dots);
+        const dots = document.createElement('div');
+        dots.setAttribute('aria-hidden', 'true');
+        dots.textContent = '···';
+        btn.appendChild(dots);
 
-          this._overflow = btn;
-          this._initButtonAttrs(btn);
-        },
-      );
+        this._overflow = btn;
+        this._initButtonAttrs(btn);
+      });
       this.addController(this._overflowController);
     }
 

--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -138,38 +138,42 @@ class MessageInput extends ElementMixin(ThemableMixin(ControllerMixin(PolymerEle
   ready() {
     super.ready();
 
-    this._buttonController = new SlotController(this, 'button', 'vaadin-button', (btn) => {
-      btn.setAttribute('theme', 'primary contained');
+    this._buttonController = new SlotController(this, 'button', 'vaadin-button', {
+      initializer: (btn) => {
+        btn.setAttribute('theme', 'primary contained');
 
-      btn.addEventListener('click', () => {
-        this.__submit();
-      });
+        btn.addEventListener('click', () => {
+          this.__submit();
+        });
 
-      this._button = btn;
+        this._button = btn;
+      },
     });
     this.addController(this._buttonController);
 
-    this._textAreaController = new SlotController(this, 'textarea', 'vaadin-text-area', (textarea) => {
-      textarea.addEventListener('value-changed', (event) => {
-        this.value = event.detail.value;
-      });
+    this._textAreaController = new SlotController(this, 'textarea', 'vaadin-text-area', {
+      initializer: (textarea) => {
+        textarea.addEventListener('value-changed', (event) => {
+          this.value = event.detail.value;
+        });
 
-      textarea.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' && !event.shiftKey) {
-          event.preventDefault();
-          event.stopImmediatePropagation();
-          this.__submit();
-        }
-      });
+        textarea.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            this.__submit();
+          }
+        });
 
-      const input = textarea.inputElement;
-      input.removeAttribute('aria-labelledby');
+        const input = textarea.inputElement;
+        input.removeAttribute('aria-labelledby');
 
-      // Set initial height to one row
-      input.setAttribute('rows', 1);
-      input.style.minHeight = '0';
+        // Set initial height to one row
+        input.setAttribute('rows', 1);
+        input.style.minHeight = '0';
 
-      this._textArea = textarea;
+        this._textArea = textarea;
+      },
     });
     this.addController(this._textAreaController);
 

--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -138,49 +138,39 @@ class MessageInput extends ElementMixin(ThemableMixin(ControllerMixin(PolymerEle
   ready() {
     super.ready();
 
-    this._buttonController = new SlotController(
-      this,
-      'button',
-      () => document.createElement('vaadin-button'),
-      (btn) => {
-        btn.setAttribute('theme', 'primary contained');
+    this._buttonController = new SlotController(this, 'button', 'vaadin-button', (btn) => {
+      btn.setAttribute('theme', 'primary contained');
 
-        btn.addEventListener('click', () => {
-          this.__submit();
-        });
+      btn.addEventListener('click', () => {
+        this.__submit();
+      });
 
-        this._button = btn;
-      },
-    );
+      this._button = btn;
+    });
     this.addController(this._buttonController);
 
-    this._textAreaController = new SlotController(
-      this,
-      'textarea',
-      () => document.createElement('vaadin-text-area'),
-      (textarea) => {
-        textarea.addEventListener('value-changed', (event) => {
-          this.value = event.detail.value;
-        });
+    this._textAreaController = new SlotController(this, 'textarea', 'vaadin-text-area', (textarea) => {
+      textarea.addEventListener('value-changed', (event) => {
+        this.value = event.detail.value;
+      });
 
-        textarea.addEventListener('keydown', (event) => {
-          if (event.key === 'Enter' && !event.shiftKey) {
-            event.preventDefault();
-            event.stopImmediatePropagation();
-            this.__submit();
-          }
-        });
+      textarea.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' && !event.shiftKey) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          this.__submit();
+        }
+      });
 
-        const input = textarea.inputElement;
-        input.removeAttribute('aria-labelledby');
+      const input = textarea.inputElement;
+      input.removeAttribute('aria-labelledby');
 
-        // Set initial height to one row
-        input.setAttribute('rows', 1);
-        input.style.minHeight = '0';
+      // Set initial height to one row
+      input.setAttribute('rows', 1);
+      input.style.minHeight = '0';
 
-        this._textArea = textarea;
-      },
-    );
+      this._textArea = textarea;
+    });
     this.addController(this._textAreaController);
 
     this._tooltipController = new TooltipController(this);

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -182,10 +182,12 @@ class Message extends FocusMixin(ElementMixin(ThemableMixin(ControllerMixin(Poly
   ready() {
     super.ready();
 
-    this._avatarController = new SlotController(this, 'avatar', 'vaadin-avatar', (avatar) => {
-      avatar.setAttribute('tabindex', '-1');
-      avatar.setAttribute('aria-hidden', 'true');
-      this._avatar = avatar;
+    this._avatarController = new SlotController(this, 'avatar', 'vaadin-avatar', {
+      initializer: (avatar) => {
+        avatar.setAttribute('tabindex', '-1');
+        avatar.setAttribute('aria-hidden', 'true');
+        this._avatar = avatar;
+      },
     });
     this.addController(this._avatarController);
   }

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -182,16 +182,11 @@ class Message extends FocusMixin(ElementMixin(ThemableMixin(ControllerMixin(Poly
   ready() {
     super.ready();
 
-    this._avatarController = new SlotController(
-      this,
-      'avatar',
-      () => document.createElement('vaadin-avatar'),
-      (avatar) => {
-        avatar.setAttribute('tabindex', '-1');
-        avatar.setAttribute('aria-hidden', 'true');
-        this._avatar = avatar;
-      },
-    );
+    this._avatarController = new SlotController(this, 'avatar', 'vaadin-avatar', (avatar) => {
+      avatar.setAttribute('tabindex', '-1');
+      avatar.setAttribute('aria-hidden', 'true');
+      this._avatar = avatar;
+    });
     this.addController(this._avatarController);
   }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -509,15 +509,10 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     this._inputField = this.shadowRoot.querySelector('[part="input-field"]');
 
-    this._overflowController = new SlotController(
-      this,
-      'overflow',
-      () => document.createElement('vaadin-multi-select-combo-box-chip'),
-      (chip) => {
-        chip.addEventListener('mousedown', (e) => this._preventBlur(e));
-        this._overflow = chip;
-      },
-    );
+    this._overflowController = new SlotController(this, 'overflow', 'vaadin-multi-select-combo-box-chip', (chip) => {
+      chip.addEventListener('mousedown', (e) => this._preventBlur(e));
+      this._overflow = chip;
+    });
     this.addController(this._overflowController);
 
     this.__updateChips();

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -509,9 +509,11 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     this._inputField = this.shadowRoot.querySelector('[part="input-field"]');
 
-    this._overflowController = new SlotController(this, 'overflow', 'vaadin-multi-select-combo-box-chip', (chip) => {
-      chip.addEventListener('mousedown', (e) => this._preventBlur(e));
-      this._overflow = chip;
+    this._overflowController = new SlotController(this, 'overflow', 'vaadin-multi-select-combo-box-chip', {
+      initializer: (chip) => {
+        chip.addEventListener('mousedown', (e) => this._preventBlur(e));
+        this._overflow = chip;
+      },
     });
     this.addController(this._overflowController);
 

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -152,11 +152,13 @@ export class PasswordField extends TextField {
 
     this._revealPart = this.shadowRoot.querySelector('[part="reveal-button"]');
 
-    this._revealButtonController = new SlotController(this, 'reveal', 'vaadin-password-field-button', (btn) => {
-      btn.disabled = this.disabled;
+    this._revealButtonController = new SlotController(this, 'reveal', 'vaadin-password-field-button', {
+      initializer: (btn) => {
+        btn.disabled = this.disabled;
 
-      btn.addEventListener('click', this.__boundRevealButtonClick);
-      btn.addEventListener('touchend', this.__boundRevealButtonTouchend);
+        btn.addEventListener('click', this.__boundRevealButtonClick);
+        btn.addEventListener('touchend', this.__boundRevealButtonTouchend);
+      },
     });
     this.addController(this._revealButtonController);
 

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -152,17 +152,12 @@ export class PasswordField extends TextField {
 
     this._revealPart = this.shadowRoot.querySelector('[part="reveal-button"]');
 
-    this._revealButtonController = new SlotController(
-      this,
-      'reveal',
-      () => document.createElement('vaadin-password-field-button'),
-      (btn) => {
-        btn.disabled = this.disabled;
+    this._revealButtonController = new SlotController(this, 'reveal', 'vaadin-password-field-button', (btn) => {
+      btn.disabled = this.disabled;
 
-        btn.addEventListener('click', this.__boundRevealButtonClick);
-        btn.addEventListener('touchend', this.__boundRevealButtonTouchend);
-      },
-    );
+      btn.addEventListener('click', this.__boundRevealButtonClick);
+      btn.addEventListener('touchend', this.__boundRevealButtonTouchend);
+    });
     this.addController(this._revealButtonController);
 
     this.__updateAriaLabel(this.i18n);

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -348,23 +348,18 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
     this._overlayElement = this.shadowRoot.querySelector('vaadin-select-overlay');
     this._inputContainer = this.shadowRoot.querySelector('[part~="input-field"]');
 
-    this._valueButtonController = new SlotController(
-      this,
-      'value',
-      () => document.createElement('vaadin-select-value-button'),
-      (btn) => {
-        this._setFocusElement(btn);
-        this.ariaTarget = btn;
-        this.stateTarget = btn;
+    this._valueButtonController = new SlotController(this, 'value', 'vaadin-select-value-button', (btn) => {
+      this._setFocusElement(btn);
+      this.ariaTarget = btn;
+      this.stateTarget = btn;
 
-        btn.setAttribute('aria-haspopup', 'listbox');
-        btn.setAttribute('aria-labelledby', `${this._labelId} ${this._fieldId}`);
+      btn.setAttribute('aria-haspopup', 'listbox');
+      btn.setAttribute('aria-labelledby', `${this._labelId} ${this._fieldId}`);
 
-        this._updateAriaExpanded(this.opened);
+      this._updateAriaExpanded(this.opened);
 
-        btn.addEventListener('keydown', this._boundOnKeyDown);
-      },
-    );
+      btn.addEventListener('keydown', this._boundOnKeyDown);
+    });
     this.addController(this._valueButtonController);
 
     this.addController(

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -348,17 +348,19 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
     this._overlayElement = this.shadowRoot.querySelector('vaadin-select-overlay');
     this._inputContainer = this.shadowRoot.querySelector('[part~="input-field"]');
 
-    this._valueButtonController = new SlotController(this, 'value', 'vaadin-select-value-button', (btn) => {
-      this._setFocusElement(btn);
-      this.ariaTarget = btn;
-      this.stateTarget = btn;
+    this._valueButtonController = new SlotController(this, 'value', 'vaadin-select-value-button', {
+      initializer: (btn) => {
+        this._setFocusElement(btn);
+        this.ariaTarget = btn;
+        this.stateTarget = btn;
 
-      btn.setAttribute('aria-haspopup', 'listbox');
-      btn.setAttribute('aria-labelledby', `${this._labelId} ${this._fieldId}`);
+        btn.setAttribute('aria-haspopup', 'listbox');
+        btn.setAttribute('aria-labelledby', `${this._labelId} ${this._fieldId}`);
 
-      this._updateAriaExpanded(this.opened);
+        this._updateAriaExpanded(this.opened);
 
-      btn.addEventListener('keydown', this._boundOnKeyDown);
+        btn.addEventListener('keydown', this._boundOnKeyDown);
+      },
     });
     this.addController(this._valueButtonController);
 

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -236,14 +236,9 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
     super.ready();
 
     this.addController(
-      new SlotController(
-        this,
-        'progress',
-        () => document.createElement('vaadin-progress-bar'),
-        (progress) => {
-          this._progress = progress;
-        },
-      ),
+      new SlotController(this, 'progress', 'vaadin-progress-bar', (progress) => {
+        this._progress = progress;
+      }),
     );
 
     // Handle moving focus to the button on Tab.

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -236,8 +236,10 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
     super.ready();
 
     this.addController(
-      new SlotController(this, 'progress', 'vaadin-progress-bar', (progress) => {
-        this._progress = progress;
+      new SlotController(this, 'progress', 'vaadin-progress-bar', {
+        initializer: (progress) => {
+          this._progress = progress;
+        },
       }),
     );
 

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -454,45 +454,30 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
     this.addEventListener('upload-error', this._onUploadError.bind(this));
 
     this.addController(
-      new SlotController(
-        this,
-        'add-button',
-        () => document.createElement('vaadin-button'),
-        (button) => {
-          button.addEventListener('touchend', (e) => {
-            this._onAddFilesTouchEnd(e);
-          });
-          button.addEventListener('click', (e) => {
-            this._onAddFilesClick(e);
-          });
-          this._addButton = button;
-        },
-      ),
+      new SlotController(this, 'add-button', 'vaadin-button', (button) => {
+        button.addEventListener('touchend', (e) => {
+          this._onAddFilesTouchEnd(e);
+        });
+        button.addEventListener('click', (e) => {
+          this._onAddFilesClick(e);
+        });
+        this._addButton = button;
+      }),
     );
 
     this.addController(
-      new SlotController(
-        this,
-        'drop-label',
-        () => document.createElement('span'),
-        (label) => {
-          this._dropLabel = label;
-        },
-      ),
+      new SlotController(this, 'drop-label', 'span', (label) => {
+        this._dropLabel = label;
+      }),
     );
 
     this.addController(
-      new SlotController(
-        this,
-        'file-list',
-        () => document.createElement('vaadin-upload-file-list'),
-        (list) => {
-          this._fileList = list;
-        },
-      ),
+      new SlotController(this, 'file-list', 'vaadin-upload-file-list', (list) => {
+        this._fileList = list;
+      }),
     );
 
-    this.addController(new SlotController(this, 'drop-label-icon', () => document.createElement('vaadin-upload-icon')));
+    this.addController(new SlotController(this, 'drop-label-icon', 'vaadin-upload-icon'));
   }
 
   /** @private */

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -454,26 +454,32 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
     this.addEventListener('upload-error', this._onUploadError.bind(this));
 
     this.addController(
-      new SlotController(this, 'add-button', 'vaadin-button', (button) => {
-        button.addEventListener('touchend', (e) => {
-          this._onAddFilesTouchEnd(e);
-        });
-        button.addEventListener('click', (e) => {
-          this._onAddFilesClick(e);
-        });
-        this._addButton = button;
+      new SlotController(this, 'add-button', 'vaadin-button', {
+        initializer: (button) => {
+          button.addEventListener('touchend', (e) => {
+            this._onAddFilesTouchEnd(e);
+          });
+          button.addEventListener('click', (e) => {
+            this._onAddFilesClick(e);
+          });
+          this._addButton = button;
+        },
       }),
     );
 
     this.addController(
-      new SlotController(this, 'drop-label', 'span', (label) => {
-        this._dropLabel = label;
+      new SlotController(this, 'drop-label', 'span', {
+        initializer: (label) => {
+          this._dropLabel = label;
+        },
       }),
     );
 
     this.addController(
-      new SlotController(this, 'file-list', 'vaadin-upload-file-list', (list) => {
-        this._fileList = list;
+      new SlotController(this, 'file-list', 'vaadin-upload-file-list', {
+        initializer: (list) => {
+          this._fileList = list;
+        },
       }),
     );
 


### PR DESCRIPTION
## Description

This is a yet another breaking change intended to make usage of `SlotController` slightly less verbose.

1. Replaced the `slotFactory` function with `tagName` string to specify which element to create.
2. Moved remaining arguments `slotInitializer` and `useUniqueId` to a single `config` object.

## Type of change

- Breaking change