### PR TITLE
refactor: deprecate custom field i18n object

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -112,6 +112,39 @@ declare class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMi
   readonly inputs: HTMLElement[] | undefined;
 
   /**
+   * A function to format the values of the individual fields contained by
+   * the custom field into a single component value. The function receives
+   * an array of all values of the individual fields in the order of their
+   * presence in the DOM, and must return a single component value.
+   * This function is called each time a value of an internal field is
+   * changed.
+   *
+   * Example:
+   * ```js
+   * customField.formatValue = (fieldValues) => {
+   *   return fieldValues.join("-");
+   * }
+   * ```
+   */
+  formatValue: CustomFieldFormatValueFn | undefined;
+
+  /**
+   * A function to parse the component value into values for the individual
+   * fields contained by the custom field. The function receives the
+   * component value, and must return an array of values for the individual
+   * fields in the order of their presence in the DOM.
+   * The function is called each time the value of the component changes.
+   *
+   * Example:
+   * ```js
+   * customField.parseValue = (componentValue) => {
+   *   return componentValue.split("-");
+   * }
+   * ```
+   */
+  parseValue: CustomFieldParseValueFn | undefined;
+
+  /**
    * The object used to localize this component.
    * To change the default localization, replace the entire
    * _i18n_ object or just the property you want to modify.
@@ -140,6 +173,9 @@ declare class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMi
    *   }
    * }
    * ```
+   * @deprecated Since 23.3
+   * Use the [`formatValue`](#/elements/vaadin-custom-field#property-formatValue)
+   * and [`parseValue`](#/elements/vaadin-custom-field#property-parseValue) properties instead
    */
   i18n: CustomFieldI18n;
 
@@ -151,8 +187,10 @@ declare class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMi
   /**
    * The value of the field. When wrapping several inputs, it will contain `\t`
    * (Tab character) as a delimiter indicating parts intended to be used as the
-   * corresponding inputs values. Use the [`i18n`](#/elements/vaadin-custom-field#property-i18n)
-   * property to customize this behavior.
+   * corresponding inputs values.
+   * Use the [`formatValue`](#/elements/vaadin-custom-field#property-formatValue)
+   * and [`parseValue`](#/elements/vaadin-custom-field#property-parseValue)
+   * properties to customize this behavior.
    */
   value: string | null | undefined;
 

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -130,8 +130,10 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
       /**
        * The value of the field. When wrapping several inputs, it will contain `\t`
        * (Tab character) as a delimiter indicating parts intended to be used as the
-       * corresponding inputs values. Use the [`i18n`](#/elements/vaadin-custom-field#property-i18n)
-       * property to customize this behavior.
+       * corresponding inputs values.
+       * Use the [`formatValue`](#/elements/vaadin-custom-field#property-formatValue)
+       * and [`parseValue`](#/elements/vaadin-custom-field#property-parseValue)
+       * properties to customize this behavior.
        */
       value: {
         type: String,
@@ -146,6 +148,45 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
       inputs: {
         type: Array,
         readOnly: true,
+      },
+
+      /**
+       * A function to format the values of the individual fields contained by
+       * the custom field into a single component value. The function receives
+       * an array of all values of the individual fields in the order of their
+       * presence in the DOM, and must return a single component value.
+       * This function is called each time a value of an internal field is
+       * changed.
+       *
+       * Example:
+       * ```js
+       * customField.formatValue = (fieldValues) => {
+       *   return fieldValues.join("-");
+       * }
+       * ```
+       * @type {!CustomFieldFormatValueFn | undefined}
+       */
+      formatValue: {
+        type: Function,
+      },
+
+      /**
+       * A function to parse the component value into values for the individual
+       * fields contained by the custom field. The function receives the
+       * component value, and must return an array of values for the individual
+       * fields in the order of their presence in the DOM.
+       * The function is called each time the value of the component changes.
+       *
+       * Example:
+       * ```js
+       * customField.parseValue = (componentValue) => {
+       *   return componentValue.split("-");
+       * }
+       * ```
+       * @type {!CustomFieldParseValueFn | undefined}
+       */
+      parseValue: {
+        type: Function,
       },
 
       /**
@@ -179,6 +220,9 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
        * ```
        *
        * @type {!CustomFieldI18n}
+       * @deprecated Since 23.3
+       * Use the [`formatValue`](#/elements/vaadin-custom-field#property-formatValue)
+       * and [`parseValue`](#/elements/vaadin-custom-field#property-parseValue) properties instead
        */
       i18n: {
         type: Object,
@@ -324,7 +368,8 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
   /** @private */
   __setValue() {
     this.__settingValue = true;
-    this.value = this.i18n.formatValue.apply(this, [this.inputs.map((input) => input.value)]);
+    const formatFn = this.formatValue || this.i18n.formatValue;
+    this.value = formatFn.apply(this, [this.inputs.map((input) => input.value)]);
     this.__settingValue = false;
   }
 
@@ -375,7 +420,8 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
 
     this.__toggleHasValue(value);
 
-    const valuesArray = this.i18n.parseValue(value);
+    const parseFn = this.parseValue || this.i18n.parseValue;
+    const valuesArray = parseFn.apply(this, [value]);
     if (!valuesArray || valuesArray.length === 0) {
       console.warn('Value parser has not provided values array');
       return;

--- a/packages/custom-field/test/custom-field.test.js
+++ b/packages/custom-field/test/custom-field.test.js
@@ -163,13 +163,10 @@ describe('custom field', () => {
   });
 
   describe('custom parser and formatter', () => {
-    it('should use custom parser if that exists', () => {
-      customField.set(
-        'i18n.parseValue',
-        sinon.stub().callsFake((value) => {
-          return value.split(' ').map((value) => parseInt(value) + 1);
-        }),
-      );
+    it('should use custom parser from I18N object if that exists', () => {
+      customField.i18n.parseValue = (value) => {
+        return value.split(' ').map((value) => parseInt(value) + 1);
+      };
 
       customField.value = '1 1';
 
@@ -178,13 +175,66 @@ describe('custom field', () => {
       });
     });
 
-    it('should use custom formatter if that exists', () => {
-      customField.set(
-        'i18n.formatValue',
-        sinon.stub().callsFake((inputValues) => {
-          return inputValues.map((value) => parseInt(value) + 1 || '').join(' ');
-        }),
-      );
+    it('should use custom parseValue property if that exists', () => {
+      customField.parseValue = (value) => {
+        return value.split(' ').map((value) => parseInt(value) + 1);
+      };
+
+      customField.value = '1 1';
+
+      customField.inputs.forEach((el) => {
+        expect(el.value).to.equal('2');
+      });
+    });
+
+    it('should use prefer the custom parseValue property over i18n object', () => {
+      customField.parseValue = (value) => {
+        return value.split(' ').map((value) => parseInt(value) + 1);
+      };
+      customField.i18n.parseValue = (value) => {
+        return value.split(' ').map((value) => parseInt(value) + 2);
+      };
+
+      customField.value = '1 1';
+
+      customField.inputs.forEach((el) => {
+        expect(el.value).to.equal('2');
+      });
+    });
+
+    it('should use custom formatter from I18N object if that exists', () => {
+      customField.i18n.formatValue = (inputValues) => {
+        return inputValues.map((value) => parseInt(value) + 1 || '').join(' ');
+      };
+
+      customField.inputs.forEach((el) => {
+        el.value = '1';
+        dispatchChange(el);
+      });
+
+      expect(customField.value).to.be.equal('2 2');
+    });
+
+    it('should use custom formatValue property if that exists', () => {
+      customField.formatValue = (inputValues) => {
+        return inputValues.map((value) => parseInt(value) + 1 || '').join(' ');
+      };
+
+      customField.inputs.forEach((el) => {
+        el.value = '1';
+        dispatchChange(el);
+      });
+
+      expect(customField.value).to.be.equal('2 2');
+    });
+
+    it('should prefer the custom formatValue property over the i18n object', () => {
+      customField.formatValue = (inputValues) => {
+        return inputValues.map((value) => parseInt(value) + 1 || '').join(' ');
+      };
+      customField.i18n.formatValue = (inputValues) => {
+        return inputValues.map((value) => parseInt(value) + 2 || '').join(' ');
+      };
 
       customField.inputs.forEach((el) => {
         el.value = '1';
@@ -203,8 +253,15 @@ describe('custom field', () => {
         console.warn.restore();
       });
 
-      it('should warn if custom parser has not returned array of values', () => {
-        customField.set('i18n.parseValue', () => '');
+      it('should warn if custom parser from I18N object has not returned array of values', () => {
+        customField.i18n.parseValue = () => '';
+
+        customField.value = 'foo';
+        expect(console.warn.callCount).to.equal(1);
+      });
+
+      it('should warn if custom parseValue property has not returned array of values', () => {
+        customField.parseValue = () => '';
 
         customField.value = 'foo';
         expect(console.warn.callCount).to.equal(1);


### PR DESCRIPTION
## Description

Deprecates the `i18n` property of `vaadin-custom-field` and introduces the `parseValue` / `formatValue` properties as an alternative.

Fixes https://github.com/vaadin/web-components/issues/831

## Type of change

- Refactoring
