### PR TITLE
refactor!: move vaadin-crud new item button to light DOM

### DIFF
--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -160,7 +160,8 @@ export type CrudEventMap<T> = CrudCustomEventMap<T> & HTMLElementEventMap;
  * `save-button`  | To replace the "Save" button.
  * `cancel-button`| To replace the "Cancel" button.
  * `delete-button`| To replace the "Delete" button.
- * `toolbar`      | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
+ * `toolbar`      | To provide the toolbar content (by default, it's empty).
+ * `new-button`   | To replace the "New item" button.
  *
  * #### Example:
  *
@@ -181,10 +182,8 @@ export type CrudEventMap<T> = CrudCustomEventMap<T> & HTMLElementEventMap;
  *     <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
  *   </vaadin-form-layout>
  *
- *   <div slot="toolbar">
- *     Total singers: [[size]]
- *     <button new-button>New singer</button>
- *   </div>
+ *   <div slot="toolbar">Total singers: 2</div>
+ *   <button slot="new-button">New singer</button>
  *
  *   <button slot="save-button">Save changes</button>
  *   <button slot="cancel-button">Discard changes</button>

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -77,7 +77,8 @@ class ButtonSlotController extends SlotController {
  * `save-button`  | To replace the "Save" button.
  * `cancel-button`| To replace the "Cancel" button.
  * `delete-button`| To replace the "Delete" button.
- * `toolbar`      | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
+ * `toolbar`      | To provide the toolbar content (by default, it's empty).
+ * `new-button`   | To replace the "New item" button.
  *
  * #### Example:
  *
@@ -98,10 +99,8 @@ class ButtonSlotController extends SlotController {
  *     <vaadin-text-field label="Surname" path="surname"></vaadin-text-field>
  *   </vaadin-form-layout>
  *
- *   <div slot="toolbar">
- *     Total singers: [[size]]
- *     <button new-button>New singer</button>
- *   </div>
+ *   <div slot="toolbar">Total singers: 2</div>
+ *   <button slot="new-button">New singer</button>
  *
  *   <button slot="save-button">Save changes</button>
  *   <button slot="cancel-button">Discard changes</button>
@@ -255,10 +254,9 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
         <div id="main">
           <slot name="grid"></slot>
 
-          <div id="toolbar" part="toolbar" on-click="__new">
-            <slot name="toolbar">
-              <vaadin-button new-button="" id="new" theme="primary">[[i18n.newItem]]</vaadin-button>
-            </slot>
+          <div id="toolbar" part="toolbar">
+            <slot name="toolbar"></slot>
+            <slot name="new-button"></slot>
           </div>
         </div>
 
@@ -371,6 +369,14 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
        * @private
        */
       _defaultHeader: {
+        type: Object,
+      },
+
+      /**
+       * A reference to the "New item" button
+       * @private
+       */
+      _newButton: {
         type: Object,
       },
 
@@ -618,6 +624,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       '__saveButtonPropsChanged(_saveButton, i18n.saveItem, __isDirty)',
       '__cancelButtonPropsChanged(_cancelButton, i18n.cancel)',
       '__deleteButtonPropsChanged(_deleteButton, i18n.deleteItem, __isNew)',
+      '__newButtonPropsChanged(_newButton, i18n.newItem)',
     ];
   }
 
@@ -637,6 +644,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     this.__cancel = this.__cancel.bind(this);
     this.__delete = this.__delete.bind(this);
     this.__save = this.__save.bind(this);
+    this.__new = this.__new.bind(this);
     this.__onFormChange = this.__onFormChange.bind(this);
     this.__onGridEdit = this.__onGridEdit.bind(this);
     this.__onGridSizeChanged = this.__onGridSizeChanged.bind(this);
@@ -665,6 +673,8 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     this.addController(this._gridController);
 
     this.addController(new SlotController(this, 'form', 'vaadin-crud-form'));
+
+    this.addController(new ButtonSlotController(this, 'new', 'primary'));
 
     // NOTE: order in which buttons are added should match the order of slots in template
     this.addController(new ButtonSlotController(this, 'save', 'primary'));
@@ -999,6 +1009,17 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
   }
 
   /**
+   * @param {HTMLElement | undefined} newButton
+   * @param {string} i18nNewItem
+   * @private
+   */
+  __newButtonPropsChanged(newButton, i18nNewItem) {
+    if (newButton) {
+      newButton.textContent = i18nNewItem;
+    }
+  }
+
+  /**
    * @param {string} type
    * @param {HTMLElement} newButton
    * @private
@@ -1178,11 +1199,8 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
   }
 
   /** @private */
-  __new(event) {
-    // This allows listening to parent element and fire only when clicking on default or custom new-button.
-    if (event.composedPath().some((e) => e.nodeType === 1 && e.hasAttribute('new-button'))) {
-      this.__confirmBeforeChangingEditedItem(null, true);
-    }
+  __new() {
+    this.__confirmBeforeChangingEditedItem(null, true);
   }
 
   /** @private */

--- a/packages/crud/test/crud-buttons.test.js
+++ b/packages/crud/test/crud-buttons.test.js
@@ -77,7 +77,7 @@ describe('crud buttons', () => {
         });
 
         it('should save a new item', () => {
-          crud.$.new.click();
+          crud._newButton.click();
           crud._form._fields[0].value = 'baz';
           change(crud._form);
           saveButton.click();
@@ -169,7 +169,7 @@ describe('crud buttons', () => {
 
           it('should not ask for confirmation on cancel when not modified - click out', () => {
             edit(crud.items[0]);
-            crud.$.new.click();
+            crud._newButton.click();
             expect(confirmCancelDialog.opened).not.to.be.ok;
           });
 
@@ -189,7 +189,7 @@ describe('crud buttons', () => {
           it('should ask for confirmation on cancel when modified - click out', () => {
             edit(crud.items[0]);
             change(crud._form);
-            crud.$.new.click();
+            crud._newButton.click();
             expect(confirmCancelDialog.opened).to.be.true;
           });
 
@@ -239,13 +239,7 @@ describe('crud buttons', () => {
             crud.addEventListener('cancel', cancelSpyListener);
 
             crud._grid.activeItem = crud.items[0];
-            crud.$.new.dispatchEvent(
-              new CustomEvent('click', {
-                bubbles: true,
-                cancelable: true,
-                composed: true,
-              }),
-            );
+            crud._newButton.click();
 
             await aTimeout(0);
             expect(cancelSpyListener.calledOnce).to.be.ok;
@@ -323,7 +317,7 @@ describe('crud buttons', () => {
         });
 
         it('should configure dirty and new flags on new', () => {
-          crud.$.new.click();
+          crud._newButton.click();
           expect(crud.__isDirty).not.to.be.true;
           expect(crud.__isNew).to.be.true;
         });
@@ -348,7 +342,7 @@ describe('crud buttons', () => {
         });
 
         it('should hide delete button on new', async () => {
-          crud.$.new.click();
+          crud._newButton.click();
           await nextRender(crud.$.dialog.$.overlay);
           expect(deleteButton.hasAttribute('hidden')).to.be.true;
         });
@@ -402,7 +396,7 @@ describe('crud buttons', () => {
             expect(crud.editorOpened).to.be.true;
 
             change(crud._form);
-            crud.$.new.click();
+            crud._newButton.click();
             expect(confirmCancelDialog.opened).to.be.true;
           });
 
@@ -411,7 +405,7 @@ describe('crud buttons', () => {
             expect(crud.editorOpened).to.be.true;
 
             change(crud._form);
-            crud.$.new.click();
+            crud._newButton.click();
             await oneEvent(confirmCancelOverlay, 'vaadin-overlay-open');
 
             confirmCancelOverlay.querySelector('[slot^="confirm"]').click();
@@ -440,19 +434,19 @@ describe('crud buttons', () => {
         describe('new', () => {
           it('should fire the new event', (done) => {
             listenOnce(crud, 'new', () => done());
-            crud.$.new.click();
+            crud._newButton.click();
           });
 
           it('on new should set the item and open dialog if not default prevented', () => {
             expect(crud.editedItem).not.to.be.ok;
-            crud.$.new.click();
+            crud._newButton.click();
             expect(crud.editedItem).to.be.ok;
             expect(crud.editorOpened).to.be.true;
           });
 
           it('on new should not set the item but open dialog if default prevented', () => {
             listenOnce(crud, 'new', (e) => e.preventDefault());
-            crud.$.new.click();
+            crud._newButton.click();
             expect(crud.editedItem).not.to.be.ok;
             expect(crud.editorOpened).to.be.true;
           });
@@ -645,7 +639,7 @@ describe('crud buttons', () => {
     });
 
     it('should hide delete button on new', async () => {
-      crud.$.new.click();
+      crud._newButton.click();
       await nextRender(crud.$.dialog.$.overlay);
       expect(deleteButton.hasAttribute('hidden')).to.be.true;
     });

--- a/packages/crud/test/crud-editor.test.js
+++ b/packages/crud/test/crud-editor.test.js
@@ -17,7 +17,7 @@ describe('crud editor', () => {
     });
 
     it('should have new item title', () => {
-      crud.$.new.click();
+      crud._newButton.click();
       expect(header.textContent).to.be.equal('New item');
     });
 
@@ -29,7 +29,7 @@ describe('crud editor', () => {
     it('should change to new item title', () => {
       crud.editedItem = crud.items[0];
       expect(header.textContent).to.be.equal('Edit item');
-      crud.$.new.click();
+      crud._newButton.click();
       expect(header.textContent).to.be.equal('New item');
     });
   });

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, change, fire, fixtureSync, isIOS, listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, change, fire, fixtureSync, listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '../src/vaadin-crud.js';
 import { flushGrid, getBodyCellContent } from './helpers.js';
 
@@ -56,10 +56,10 @@ describe('crud', () => {
     });
 
     it('should be able to internationalize via `i18n` property', async () => {
-      expect(crud.$.new.textContent).to.be.equal('New item');
+      expect(crud._newButton.textContent).to.be.equal('New item');
       crud.i18n = { ...crud.i18n, newItem: 'Nueva entidad', editLabel: 'Editar entidad' };
       await nextRender(crud._grid);
-      expect(crud.$.new.textContent).to.be.equal('Nueva entidad');
+      expect(crud._newButton.textContent).to.be.equal('Nueva entidad');
       expect(crud._grid.querySelector('vaadin-crud-edit-column').ariaLabel).to.be.equal('Editar entidad');
       expect(crud._grid.querySelector('vaadin-crud-edit').getAttribute('aria-label')).to.be.equal('Editar entidad');
     });
@@ -92,7 +92,7 @@ describe('crud', () => {
         done();
       });
 
-      crud.$.new.click();
+      crud._newButton.click();
       crud._form._fields[0].value = 'baz';
       change(crud._form);
       btnSave.click();
@@ -107,14 +107,14 @@ describe('crud', () => {
     it('should have an empty form if no item is present', async () => {
       crud.dataProvider = (_, callback) => callback([], 0);
       await nextRender(crud);
-      crud.$.new.click();
+      crud._newButton.click();
       expect(crud._form._fields).to.be.not.ok;
     });
 
     it('should have an empty form if no item is present', async () => {
       crud.dataProvider = (_, callback) => callback([], 0);
       await nextRender(crud);
-      crud.$.new.click();
+      crud._newButton.click();
       expect(crud._form._fields).to.be.not.ok;
     });
   });
@@ -188,7 +188,7 @@ describe('crud', () => {
           expect(e.detail.item.foo).to.be.equal('baz');
           done();
         });
-        crud.$.new.click();
+        crud._newButton.click();
         crud._form._fields[0].value = 'baz';
         change(crud._form);
         btnSave.click();
@@ -379,9 +379,10 @@ describe('crud', () => {
   describe('editor-position', () => {
     let crud, editorDialog;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
       editorDialog = crud.$.dialog;
+      await nextRender();
     });
 
     afterEach(() => {
@@ -404,17 +405,15 @@ describe('crud', () => {
       expect(crud.editorPosition).to.be.equal('aside');
     });
 
-    (isIOS ? it.skip : it)('should hide toolbar when editor position is "bottom" and opened', async () => {
+    it('should hide toolbar when editor position is "bottom" and opened', () => {
       crud.editorPosition = 'bottom';
       crud._fullscreen = false;
-      crud.$.new.click();
-      await oneEvent(crud, 'editor-opened-changed');
+      crud._newButton.click();
       expect(crud.$.toolbar.style.display).to.be.equal('none');
     });
 
     it('should show toolbar with default editor position and opened', () => {
-      crud.$.new.click();
-
+      crud._newButton.click();
       expect(crud.$.toolbar.style.display).to.be.not.equal('none');
     });
 
@@ -435,29 +434,24 @@ describe('crud', () => {
     });
 
     it('should always show the editor in dialog on mobile', () => {
-      if (isIOS) {
-        // Only setting crud._fullscreen = true is not working on iOS test
-        crud._fullscreenMediaQuery = '(max-width: 1000px), (max-height: 1000px)';
-      }
       crud._fullscreen = true;
       crud.editorPosition = 'bottom';
-      crud.$.new.click();
+      crud._newButton.click();
 
       expect(crud._fullscreen).to.be.true;
     });
 
-    (isIOS ? it.skip : it)('should not open dialog on desktop if not in default editor position', () => {
+    it('should not open dialog on desktop if not in default editor position', () => {
       crud.editorPosition = 'bottom';
       crud._fullscreen = false;
-      crud.$.new.click();
+      crud._newButton.click();
       expect(editorDialog.opened).to.be.false;
     });
 
-    (isIOS ? it.skip : it)('should switch from overlay to below grid if resize happens', async () => {
+    it('should switch from overlay to below grid if resize happens', () => {
       crud.editorPosition = 'bottom';
       crud._fullscreen = true;
-      crud.$.new.click();
-      await oneEvent(crud, 'editor-opened-changed');
+      crud._newButton.click();
       expect(editorDialog.opened).to.be.true;
       crud._fullscreen = false;
       expect(editorDialog.opened).to.be.false;
@@ -535,7 +529,7 @@ describe('crud', () => {
 
       fakeClickOnRow(0);
       expect(crud.editorOpened).to.be.true;
-      crud.$.new.click();
+      crud._newButton.click();
       await aTimeout(0);
       expect(crud.editorOpened).to.be.true;
       await aTimeout(0);
@@ -551,7 +545,7 @@ describe('crud', () => {
       fakeClickOnRow(0);
       expect(crud.editorOpened).to.be.true;
       crud.__isDirty = true;
-      crud.$.new.click();
+      crud._newButton.click();
       await oneEvent(confirmCancelOverlay, 'vaadin-overlay-open');
       confirmCancelOverlay.querySelector('[slot^="confirm"]').click();
       expect(crud.editorOpened).to.be.true;

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -142,6 +142,14 @@ snapshots["vaadin-crud host default"] =
   <vaadin-crud-form slot="form">
   </vaadin-crud-form>
   <vaadin-button
+    role="button"
+    slot="new-button"
+    tabindex="0"
+    theme="primary"
+  >
+    New item
+  </vaadin-button>
+  <vaadin-button
     aria-disabled="true"
     disabled=""
     role="button"
@@ -182,15 +190,8 @@ snapshots["vaadin-crud shadow default"] =
       part="toolbar"
     >
       <slot name="toolbar">
-        <vaadin-button
-          id="new"
-          new-button=""
-          role="button"
-          tabindex="0"
-          theme="primary"
-        >
-          New item
-        </vaadin-button>
+      </slot>
+      <slot name="new-button">
       </slot>
     </div>
   </div>


### PR DESCRIPTION
## Description

Fixes #4940

Updated the "New item" button in `vaadin-crud` to use its own dedicated slot, instead of "toolbar" slot in combination with `new-item` attribute. This would be aligned with other button slots, and should generally make things easier.

Note, the [docs example](https://github.com/vaadin/docs/blob/419e2e36c864991c53753426e2c2914731b9feb0/frontend/demo/component/crud/crud-toolbar.ts#L37-L46) using `vaadin-horizontal-layout` will need to be updated. I don't see a big problem as`toolbar` part is already a flex container, so users could apply `::part()` selector e.g. to set spacing between toolbar items.

Also, we might want to add `setNewButton()` API to Flow component (in addition to existing `setToolbar()` API).

## Type of change

- Breaking change