### PR TITLE
docs: add slots for editor buttons to JSDoc

### DIFF
--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -153,11 +153,14 @@ export type CrudEventMap<T> = CrudCustomEventMap<T> & HTMLElementEventMap;
  *
  * Alternatively you can fully configure the component by using `slot` names.
  *
- * Slot name | Description
- * ----------------|----------------
- * `grid` | To replace the auto-generated grid with a custom one.
- * `form` | To replace the auto-generated form.
- * `toolbar` | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
+ * Slot name      | Description
+ * ---------------|----------------
+ * `grid`         | To replace the auto-generated grid with a custom one.
+ * `form`         | To replace the auto-generated form.
+ * `save-button`  | To replace the "Save" button.
+ * `cancel-button`| To replace the "Cancel" button.
+ * `delete-button`| To replace the "Delete" button.
+ * `toolbar`      | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
  *
  * #### Example:
  *
@@ -182,6 +185,10 @@ export type CrudEventMap<T> = CrudCustomEventMap<T> & HTMLElementEventMap;
  *     Total singers: [[size]]
  *     <button new-button>New singer</button>
  *   </div>
+ *
+ *   <button slot="save-button">Save changes</button>
+ *   <button slot="cancel-button">Discard changes</button>
+ *   <button slot="delete-button">Delete singer</button>
  * </vaadin-crud>
  * ```
  * ```js

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -70,11 +70,14 @@ class ButtonSlotController extends SlotController {
  *
  * Alternatively you can fully configure the component by using `slot` names.
  *
- * Slot name | Description
- * ----------------|----------------
- * `grid` | To replace the auto-generated grid with a custom one.
- * `form` | To replace the auto-generated form.
- * `toolbar` | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
+ * Slot name      | Description
+ * ---------------|----------------
+ * `grid`         | To replace the auto-generated grid with a custom one.
+ * `form`         | To replace the auto-generated form.
+ * `save-button`  | To replace the "Save" button.
+ * `cancel-button`| To replace the "Cancel" button.
+ * `delete-button`| To replace the "Delete" button.
+ * `toolbar`      | To replace the toolbar content. Add an element with the attribute `new-button` for the new item action.
  *
  * #### Example:
  *
@@ -99,6 +102,10 @@ class ButtonSlotController extends SlotController {
  *     Total singers: [[size]]
  *     <button new-button>New singer</button>
  *   </div>
+ *
+ *   <button slot="save-button">Save changes</button>
+ *   <button slot="cancel-button">Discard changes</button>
+ *   <button slot="delete-button">Delete singer</button>
  * </vaadin-crud>
  * ```
  * ```js


### PR DESCRIPTION
## Description

Extracted from #4959. These buttons were missing from the list of slots, let's add them.

## Type of change

- Documentation