### PR TITLE
docs: fix incorrect mixin and controller JSDoc

### DIFF
--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -52,7 +52,7 @@ export class ErrorController extends SlotController {
   }
 
   /**
-   * Override to initialize the newly added custom label.
+   * Override to initialize the newly added custom error message.
    *
    * @param {Node} errorNode
    * @protected
@@ -70,7 +70,7 @@ export class ErrorController extends SlotController {
   }
 
   /**
-   * Override to cleanup label node when it's removed.
+   * Override to cleanup error message node when it's removed.
    *
    * @param {Node} node
    * @protected
@@ -83,7 +83,7 @@ export class ErrorController extends SlotController {
     if (!errorNode && node !== this.defaultNode) {
       errorNode = this.attachDefaultNode();
 
-      // Run initializer to update default label and ID.
+      // Run initializer to update default error message ID.
       this.initNode(errorNode);
     }
 

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -11,7 +11,7 @@ import { LabelController } from './label-controller.js';
  * A mixin to provide label via corresponding property or named slot.
  *
  * @polymerMixin
- * @mixes SlotMixin
+ * @mixes ControllerMixin
  */
 export const LabelMixin = dedupingMixin(
   (superclass) =>


### PR DESCRIPTION
## Description

1. Fixed `LabelMixin` to use correct mixin in `@mixes` annotation,
2. Fixed copy-paste leftovers in `ErrorController` comments.

## Type of change

- Documentation