### PR TITLE
refactor: use SlotController in date-time-picker

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -6,7 +6,6 @@
 import { DisabledMixin } from '@vaadin/component-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { FocusMixin } from '@vaadin/component-base/src/focus-mixin.js';
-import { SlotMixin } from '@vaadin/component-base/src/slot-mixin.js';
 import type { DatePickerI18n } from '@vaadin/date-picker/src/vaadin-date-picker.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import type { TimePickerI18n } from '@vaadin/time-picker/src/vaadin-time-picker.js';
@@ -104,9 +103,7 @@ export interface DateTimePickerEventMap extends DateTimePickerCustomEventMap, HT
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
-declare class DateTimePicker extends FieldMixin(
-  SlotMixin(DisabledMixin(FocusMixin(ThemableMixin(ElementMixin(HTMLElement))))),
-) {
+declare class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(ElementMixin(HTMLElement))))) {
   /**
    * The name of the control, which is submitted with the form data.
    */

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -26,16 +26,19 @@ customElements.define(
       return {
         i18n: {
           type: Object,
-          value: () => {
-            return {
-              cancel: 'Peruuta', // For date picker
-
-              // formatTime and parseTime are needed so that time picker doesn't throw errors on init
-              formatTime,
-              parseTime,
-            };
-          },
         },
+      };
+    }
+
+    ready() {
+      super.ready();
+
+      this.i18n = {
+        cancel: 'Peruuta', // For date picker
+
+        // formatTime and parseTime are needed so that time picker doesn't throw errors on init
+        formatTime,
+        parseTime,
       };
     }
   },

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -26,19 +26,16 @@ customElements.define(
       return {
         i18n: {
           type: Object,
+          value: () => {
+            return {
+              cancel: 'Peruuta', // For date picker
+
+              // formatTime and parseTime are needed so that time picker doesn't throw errors on init
+              formatTime,
+              parseTime,
+            };
+          },
         },
-      };
-    }
-
-    ready() {
-      super.ready();
-
-      this.i18n = {
-        cancel: 'Peruuta', // For date picker
-
-        // formatTime and parseTime are needed so that time picker doesn't throw errors on init
-        formatTime,
-        parseTime,
       };
     }
   },

--- a/packages/date-time-picker/test/properties.test.js
+++ b/packages/date-time-picker/test/properties.test.js
@@ -264,8 +264,8 @@ function getTimePicker(dateTimePicker) {
       expect(dateTimePicker.i18n).to.have.property('parseTime').that.is.a('function');
     });
 
-    it('should propagate i18n properties observably to date picker', () => {
-      dateTimePicker.set('i18n.cancel', 'Peruuta');
+    it('should propagate i18n properties to the date picker', () => {
+      dateTimePicker.i18n = { ...dateTimePicker.i18n, cancel: 'Peruuta' };
       expect(datePicker.i18n.cancel).to.equal('Peruuta');
     });
   });


### PR DESCRIPTION
## Description

Updated `vaadin-date-time-picker` to use `SlotController` instead of `SlotMixin`.
This is the last component where the mixin is used, so we will be able to remove it.

## Type of change

- Refactor