### PR TITLE
feat: add option to disable observing slot changes

### DIFF
--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -27,6 +27,7 @@ export class SlotController extends EventTarget implements ReactiveController {
     slotName: string,
     tagName?: string,
     config?: {
+      observe?: boolean;
       useUniqueId?: boolean;
       initializer?(host: HTMLElement, node: HTMLElement): void;
     },
@@ -56,5 +57,5 @@ export class SlotController extends EventTarget implements ReactiveController {
   /**
    * Setup the observer to manage slot content changes.
    */
-  protected observe(): void;
+  protected observeSlot(): void;
 }

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -26,11 +26,12 @@ export class SlotController extends EventTarget {
   constructor(host, slotName, tagName, config = {}) {
     super();
 
-    const { initializer, useUniqueId } = config;
+    const { initializer, observe, useUniqueId } = config;
 
     this.host = host;
     this.slotName = slotName;
     this.tagName = tagName;
+    this.observe = typeof observe === 'boolean' ? observe : true;
     this.slotInitializer = initializer;
 
     // Only generate the default ID if requested by the controller.
@@ -52,8 +53,9 @@ export class SlotController extends EventTarget {
 
       this.initNode(node);
 
-      // TODO: Consider making this behavior opt-in to improve performance.
-      this.observe();
+      if (this.observe) {
+        this.observeSlot();
+      }
 
       this.initialized = true;
     }
@@ -137,7 +139,7 @@ export class SlotController extends EventTarget {
    * Setup the observer to manage slot content changes.
    * @protected
    */
-  observe() {
+  observeSlot() {
     const { slotName } = this;
     const selector = slotName === '' ? 'slot:not([name])' : `slot[name=${slotName}]`;
     const slot = this.host.shadowRoot.querySelector(selector);


### PR DESCRIPTION
## Description

Updated `SlotController` config, added an option to opt-out from observing slot changes.

This would be useful for components where slotted content is not supposed to change.
For example, `vaadin-date-picker-overlay-content` with its scrollers and buttons.

## Type of change

- Internal feature