### PR TITLE
refactor!: move grid filter text field to light DOM

### DIFF
--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -196,7 +196,6 @@ class CrudGrid extends IncludedMixin(Grid) {
 
           const textField = window.document.createElement('vaadin-text-field');
           textField.setAttribute('theme', 'small');
-          textField.setAttribute('slot', 'filter');
           textField.setAttribute('focus-target', true);
           textField.style.width = '100%';
           if (this.noSort) {

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -33,12 +33,11 @@ snapshots["vaadin-crud host default"] =
       >
         <vaadin-text-field
           focus-target="true"
-          slot="filter"
           style="width: 100%;"
           theme="small"
         >
           <label
-            for="input-vaadin-text-field-10"
+            for="input-vaadin-text-field-6"
             id="label-vaadin-text-field-0"
             slot="label"
           >
@@ -50,7 +49,7 @@ snapshots["vaadin-crud host default"] =
           >
           </div>
           <input
-            id="input-vaadin-text-field-10"
+            id="input-vaadin-text-field-6"
             slot="input"
             type="text"
           >
@@ -65,12 +64,11 @@ snapshots["vaadin-crud host default"] =
       >
         <vaadin-text-field
           focus-target="true"
-          slot="filter"
           style="width: 100%;"
           theme="small"
         >
           <label
-            for="input-vaadin-text-field-15"
+            for="input-vaadin-text-field-7"
             id="label-vaadin-text-field-3"
             slot="label"
           >
@@ -82,7 +80,7 @@ snapshots["vaadin-crud host default"] =
           >
           </div>
           <input
-            id="input-vaadin-text-field-15"
+            id="input-vaadin-text-field-7"
             slot="input"
             type="text"
           >

--- a/packages/grid/src/vaadin-grid-filter-column.js
+++ b/packages/grid/src/vaadin-grid-filter-column.js
@@ -60,7 +60,6 @@ class GridFilterColumn extends GridColumn {
     if (!filter) {
       filter = document.createElement('vaadin-grid-filter');
       textField = document.createElement('vaadin-text-field');
-      textField.setAttribute('slot', 'filter');
       textField.setAttribute('theme', 'small');
       textField.setAttribute('style', 'max-width: 100%;');
       textField.setAttribute('focus-target', '');

--- a/packages/grid/src/vaadin-grid-filter.d.ts
+++ b/packages/grid/src/vaadin-grid-filter.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 
 /**
  * Fired when the `value` property changes.
@@ -40,7 +41,7 @@ export interface GridFilterEventMap extends HTMLElementEventMap, GridFilterCusto
  *
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class GridFilter extends HTMLElement {
+declare class GridFilter extends ControllerMixin(HTMLElement) {
   /**
    * JS Path of the property in the item used for filtering the data.
    */


### PR DESCRIPTION
## Description

Fixes #1495

1. Changed `vaadin-grid-filter` to use default slot instead of the named `slot="filter"`,
2. Updated to use `SlotController` to move the default `vaadin-text-field` to light DOM.

Note, the `vaadin-grid-filter-column` already renders the text field in filter light DOM.
So this PR also makes these two components produce consistent DOM structure.

## Type of change

- Breaking change