### PR TITLE
fix: make select renderer owner argument required

### DIFF
--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -31,7 +31,7 @@ export type SelectChangeEvent = Event & {
  *   DOM element. Append your content to it.
  * - `select` The reference to the `<vaadin-select>` element.
  */
-export type SelectRenderer = (root: HTMLElement, select?: Select) => void;
+export type SelectRenderer = (root: HTMLElement, select: Select) => void;
 
 /**
  * Fired when the `opened` property changes.

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -62,3 +62,10 @@ select.addEventListener('validated', (event) => {
   assertType<SelectValidatedEvent>(event);
   assertType<boolean>(event.detail.valid);
 });
+
+const renderer: SelectRenderer = (root, owner) => {
+  assertType<HTMLElement>(root);
+  assertType<Select>(owner);
+};
+
+select.renderer = renderer;


### PR DESCRIPTION
## Description

Related to #4900

Fixed the `DialogRenderer` to apply the same change that we previously made in #2097 for grid renderers.
This addresses the following finding from React wrappers mentioned in the above issue:

>As in @vaadin/notification, the renderer definition accepts an undefined original element.

## Type of change

- Bugfix
