### PR TITLE
fix: make select renderer owner argument required (#4981) (CP: 23.1)

### DIFF
--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -32,7 +32,7 @@ export type SelectChangeEvent = Event & {
  *   DOM element. Append your content to it.
  * - `select` The reference to the `<vaadin-select>` element.
  */
-export type SelectRenderer = (root: HTMLElement, select?: Select) => void;
+export type SelectRenderer = (root: HTMLElement, select: Select) => void;
 
 /**
  * Fired when the `opened` property changes.

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -56,3 +56,10 @@ select.addEventListener('value-changed', (event) => {
   assertType<SelectValueChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
+
+const renderer: SelectRenderer = (root, owner) => {
+  assertType<HTMLElement>(root);
+  assertType<Select>(owner);
+};
+
+select.renderer = renderer;


### PR DESCRIPTION
## Description

Cherry-pick of #4981 to `23.1` branch. 
The automated cherry-pick failed due to `validated` event types present on master but missing in `23.1`.

## Type of change

- Cherry-pick