### PR TITLE
test: remove usage of updateStyles from overlay

### DIFF
--- a/packages/context-menu/test/overlay.test.js
+++ b/packages/context-menu/test/overlay.test.js
@@ -318,7 +318,6 @@ describe('overlay', () => {
         contextmenu();
         await oneEvent(overlay, 'vaadin-overlay-open');
         overlay.style.setProperty('--vaadin-overlay-viewport-bottom', '50px');
-        overlay.updateStyles({ '--vaadin-overlay-viewport-bottom': '50px' });
         expect(getComputedStyle(overlay).bottom).to.equal('50px');
       });
     });


### PR DESCRIPTION
## Description

Removed usage of Polymer specific `udpateStyles()` from `vaadin-overlay` test.

## Type of change

- Test