### PR TITLE
fix: do not propagate theme attribute to custom grid

### DIFF
--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -954,14 +954,12 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
    */
   // eslint-disable-next-line max-params
   __gridPropsChanged(grid, theme, include, exclude, noFilter, noHead, noSort) {
-    if (grid) {
-      if (grid === this._gridController.defaultNode) {
-        grid.include = include;
-        grid.exclude = exclude;
-        grid.noFilter = noFilter;
-        grid.noHead = noHead;
-        grid.noSort = noSort;
-      }
+    if (grid && grid === this._gridController.defaultNode) {
+      grid.include = include;
+      grid.exclude = exclude;
+      grid.noFilter = noFilter;
+      grid.noHead = noHead;
+      grid.noSort = noSort;
 
       if (theme) {
         grid.setAttribute('theme', theme);

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -327,6 +327,13 @@ describe('crud', () => {
       crud.editorOpened = false;
       expect(crud._grid.selectedItems).to.eql([crud.items[0]]);
     });
+
+    it('should not propagate theme attribute to a custom grid', async () => {
+      crud.setAttribute('theme', 'foo');
+      crud.appendChild(grid);
+      await nextRender(crud);
+      expect(grid.hasAttribute('theme')).to.be.false;
+    });
   });
 
   describe('validation', () => {


### PR DESCRIPTION
## Description

This PR fixes a regression from #4948 where the logic was changed, see also https://github.com/vaadin/web-components/pull/4948#discussion_r1017777791
Check out [`customGridDoesNotReactToThemeVariantChanges`](https://github.com/vaadin/flow-components/blob/d0ffddd50f3e8e6ec6e56d82f13423400ee2e203/vaadin-crud-flow-parent/vaadin-crud-flow-integration-tests/src/test/java/com/vaadin/flow/component/crud/tests/CustomGridIT.java#L65) IT that fails with 24.0.0-alpha3.

## Type of change

- Bugfix