### PR TITLE
test: skip flaky virtualizer test in WebKit

### DIFF
--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, isDesktopSafari } from '@vaadin/testing-helpers';
 import { Virtualizer } from '../src/virtualizer.js';
 
 describe('virtualizer - item height', () => {
@@ -55,7 +55,8 @@ describe('virtualizer - item height', () => {
     expect(firstItem.offsetHeight).to.equal(EVEN_ITEM_HEIGHT);
   });
 
-  it('should adjust the placeholder height', async () => {
+  // FIXME: often fails in CI with error "expected 200 to be below 40"
+  (isDesktopSafari ? it.skip : it)('should adjust the placeholder height', async () => {
     // Wait for the content to update
     await aTimeout(100);
     // Scroll down


### PR DESCRIPTION
## Description

This test is especially flaky in Playwright WebKit when running in CI. Locally it doesn't fail that often.
In Firefox it also failed locally once, but at least in CI it seems more stable than in WebKit.

## Type of change

- Test