### PR TITLE
refactor!: remove deprecated default slot support (radio-button)

### DIFF
--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -12,7 +12,6 @@ import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { LabelMixin } from '@vaadin/field-base/src/label-mixin.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
-import { SlotTargetController } from '@vaadin/field-base/src/slot-target-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
@@ -111,10 +110,6 @@ class RadioButton extends LabelMixin(
         </div>
 
         <slot name="label"></slot>
-
-        <div style="display: none !important">
-          <slot id="noop"></slot>
-        </div>
       </div>
     `;
   }
@@ -161,21 +156,6 @@ class RadioButton extends LabelMixin(
       }),
     );
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
-    this.addController(
-      new SlotTargetController(
-        this.$.noop,
-        () => this._labelController.node,
-        () => this.__warnDeprecated(),
-      ),
-    );
-  }
-
-  /** @private */
-  __warnDeprecated() {
-    console.warn(
-      `WARNING: Since Vaadin 22, placing the label as a direct child of a <vaadin-radio-button> is deprecated.
-  Please use <label slot="label"> wrapper or the label property instead.`,
-    );
   }
 }
 

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -265,25 +265,4 @@ describe('radio-button', () => {
       expect(radio.hasAttribute('has-label')).to.be.true;
     });
   });
-
-  describe('warnings', () => {
-    beforeEach(() => {
-      sinon.stub(console, 'warn');
-    });
-
-    afterEach(() => {
-      console.warn.restore();
-    });
-
-    it('should warn about using default slot label', async () => {
-      fixtureSync('<vaadin-radio-button>label</vaadin-radio-button>');
-      // Wait for MutationObserver
-      await nextFrame();
-
-      expect(console.warn.calledOnce).to.be.true;
-      expect(console.warn.args[0][0]).to.include(
-        'WARNING: Since Vaadin 22, placing the label as a direct child of a <vaadin-radio-button> is deprecated.',
-      );
-    });
-  });
 });

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -250,16 +250,10 @@ describe('radio-button', () => {
       expect(radio.hasAttribute('has-label')).to.be.false;
     });
 
-    it('should not set has-label attribute when only one empty text node added', async () => {
-      const textNode = document.createTextNode(' ');
-      radio.appendChild(textNode);
-      await nextFrame();
-      expect(radio.hasAttribute('has-label')).to.be.false;
-    });
-
     it('should set has-label attribute when the label is added', async () => {
       const paragraph = document.createElement('p');
       paragraph.textContent = 'Added label';
+      paragraph.setAttribute('slot', 'label');
       radio.appendChild(paragraph);
       await nextFrame();
       expect(radio.hasAttribute('has-label')).to.be.true;


### PR DESCRIPTION
## Description

Removed default `<slot>` support from `vaadin-radio-button`.

## Type of change

- Breaking change