### PR TITLE
refactor: move private RTL direction getter to DirMixin

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -656,10 +656,9 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(ControllerMixin
     // Take negative margin into account
     const { marginLeft, marginRight } = getComputedStyle(avatars[1]);
 
-    const offset =
-      this.getAttribute('dir') === 'rtl'
-        ? parseInt(marginRight, 0) - parseInt(marginLeft, 0)
-        : parseInt(marginLeft, 0) - parseInt(marginRight, 0);
+    const offset = this.__isRTL
+      ? parseInt(marginRight, 0) - parseInt(marginLeft, 0)
+      : parseInt(marginLeft, 0) - parseInt(marginRight, 0);
 
     return Math.floor((this.$.container.offsetWidth - avatarWidth) / (avatarWidth + offset));
   }

--- a/packages/component-base/src/dir-mixin.d.ts
+++ b/packages/component-base/src/dir-mixin.d.ts
@@ -11,6 +11,8 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 export declare function DirMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<DirMixinClass> & T;
 
 export declare class DirMixinClass {
+  protected readonly __isRTL: boolean;
+
   protected __getNormalizedScrollLeft(element: Element | null): number;
 
   protected __setNormalizedScrollLeft(element: Element | null, scrollLeft: number): void;

--- a/packages/component-base/src/dir-mixin.js
+++ b/packages/component-base/src/dir-mixin.js
@@ -112,6 +112,14 @@ export const DirMixin = (superClass) =>
       this.__unsubscribe();
     }
 
+    /**
+     * @return {boolean}
+     * @protected
+     */
+    get __isRTL() {
+      return this.getAttribute('dir') === 'rtl';
+    }
+
     /** @protected */
     _valueToNodeAttribute(node, value, attribute) {
       // Override default Polymer attribute reflection to match native behavior of HTMLElement.dir property

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -69,6 +69,4 @@ export declare class ItemsMixinClass {
    * ```
    */
   items: ContextMenuItem[] | undefined;
-
-  protected readonly __isRTL: boolean;
 }

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -126,14 +126,6 @@ export const ItemsMixin = (superClass) =>
       document.documentElement.removeEventListener('click', this.__itemsOutsideClickListener);
     }
 
-    /**
-     * @return {boolean}
-     * @protected
-     */
-    get __isRTL() {
-      return this.getAttribute('dir') === 'rtl';
-    }
-
     /** @protected */
     __forwardFocus() {
       const overlay = this.$.overlay;

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -231,10 +231,6 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     ];
   }
 
-  get __isRTL() {
-    return this.getAttribute('dir') === 'rtl';
-  }
-
   /**
    * Whether to scroll to a sub-month position when scrolling to a date.
    * This is active if the month scroller is not large enough to fit a

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -50,6 +50,7 @@ export const ColumnResizingMixin = (superClass) =>
             .pop();
         }
 
+        const isRTL = this.__isRTL;
         const eventX = e.detail.x;
         const columnRowCells = Array.from(this.$.header.querySelectorAll('[part~="row"]:last-child [part~="cell"]'));
         const targetCell = columnRowCells.find((cell) => cell._column === column);
@@ -72,9 +73,9 @@ export const ColumnResizingMixin = (superClass) =>
 
           // For cells frozen to end, resize handle is flipped horizontally.
           if (targetCell.hasAttribute('frozen-to-end')) {
-            maxWidth = cellWidth + (this.__isRTL ? eventX - cellRect.right : cellRect.left - eventX);
+            maxWidth = cellWidth + (isRTL ? eventX - cellRect.right : cellRect.left - eventX);
           } else {
-            maxWidth = cellWidth + (this.__isRTL ? cellRect.left - eventX : eventX - cellRect.right);
+            maxWidth = cellWidth + (isRTL ? cellRect.left - eventX : eventX - cellRect.right);
           }
 
           column.width = `${Math.max(minWidth, maxWidth)}px`;
@@ -95,9 +96,9 @@ export const ColumnResizingMixin = (superClass) =>
         // When handle moves below the cell frozen to end, scroll into view.
         if (cellFrozenToEnd && this.$.table.scrollWidth > this.$.table.offsetWidth) {
           const frozenRect = cellFrozenToEnd.getBoundingClientRect();
-          const offset = eventX - (this.__isRTL ? frozenRect.right : frozenRect.left);
+          const offset = eventX - (isRTL ? frozenRect.right : frozenRect.left);
 
-          if ((this.__isRTL && offset <= 0) || (!this.__isRTL && offset >= 0)) {
+          if ((isRTL && offset <= 0) || (!isRTL && offset >= 0)) {
             this.$.table.scrollLeft += offset;
           }
         }

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -300,6 +300,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       e.preventDefault();
 
       const visibleItemsCount = this._lastVisibleIndex - this._firstVisibleIndex - 1;
+      const isRTL = this.__isRTL;
 
       // Handle keyboard interaction as defined in:
       // https://w3c.github.io/aria-practices/#keyboard-interaction-24
@@ -308,10 +309,10 @@ export const KeyboardNavigationMixin = (superClass) =>
         dy = 0;
       switch (key) {
         case 'ArrowRight':
-          dx = this.__isRTL ? -1 : 1;
+          dx = isRTL ? -1 : 1;
           break;
         case 'ArrowLeft':
-          dx = this.__isRTL ? 1 : -1;
+          dx = isRTL ? 1 : -1;
           break;
         case 'Home':
           if (this.__rowFocusMode) {
@@ -361,8 +362,8 @@ export const KeyboardNavigationMixin = (superClass) =>
         return;
       }
 
-      const forwardsKey = this.__isRTL ? 'ArrowLeft' : 'ArrowRight';
-      const backwardsKey = this.__isRTL ? 'ArrowRight' : 'ArrowLeft';
+      const forwardsKey = isRTL ? 'ArrowLeft' : 'ArrowRight';
+      const backwardsKey = isRTL ? 'ArrowRight' : 'ArrowLeft';
       if (key === forwardsKey) {
         // "Right Arrow:"
         if (this.__rowFocusMode) {

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -482,19 +482,6 @@ class Grid extends ElementMixin(
     this._tooltipController.setManual(true);
   }
 
-  /**
-   * @param {string} name
-   * @param {?string} oldValue
-   * @param {?string} newValue
-   * @protected
-   */
-  attributeChangedCallback(name, oldValue, newValue) {
-    super.attributeChangedCallback(name, oldValue, newValue);
-    if (name === 'dir') {
-      this.__isRTL = newValue === 'rtl';
-    }
-  }
-
   /** @private */
   __getBodyCellCoordinates(cell) {
     if (this.$.items.contains(cell) && cell.localName === 'td') {

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -155,7 +155,7 @@ export const ButtonsMixin = (superClass) =>
       if (container.offsetWidth < container.scrollWidth) {
         this._hasOverflow = true;
 
-        const isRTL = this.getAttribute('dir') === 'rtl';
+        const isRTL = this.__isRTL;
 
         let i;
         for (i = buttons.length; i > 0; i--) {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -979,7 +979,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     }
     let newIdx;
 
-    if (this.getAttribute('dir') !== 'rtl') {
+    if (!this.__isRTL) {
       if (idx === -1) {
         // Focus last chip
         newIdx = chips.length - 1;
@@ -1012,7 +1012,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     }
     let newIdx;
 
-    if (this.getAttribute('dir') === 'rtl') {
+    if (this.__isRTL) {
       if (idx === -1) {
         // Focus last chip
         newIdx = chips.length - 1;

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -170,10 +170,6 @@ export const PositionMixin = (superClass) =>
       }
     }
 
-    get __isRTL() {
-      return this.getAttribute('dir') === 'rtl';
-    }
-
     __positionSettingsChanged() {
       this._updatePosition();
     }
@@ -197,9 +193,9 @@ export const PositionMixin = (superClass) =>
       const shouldAlignStartVertically = this.__shouldAlignStartVertically(targetRect);
       this.style.justifyContent = shouldAlignStartVertically ? 'flex-start' : 'flex-end';
 
-      const shouldAlignStartHorizontally = this.__shouldAlignStartHorizontally(targetRect, this.__isRTL);
-      const flexStart =
-        (!this.__isRTL && shouldAlignStartHorizontally) || (this.__isRTL && !shouldAlignStartHorizontally);
+      const isRTL = this.__isRTL;
+      const shouldAlignStartHorizontally = this.__shouldAlignStartHorizontally(targetRect, isRTL);
+      const flexStart = (!isRTL && shouldAlignStartHorizontally) || (isRTL && !shouldAlignStartHorizontally);
       this.style.alignItems = flexStart ? 'flex-start' : 'flex-end';
 
       // Get the overlay rect after possible overlay alignment changes

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -227,7 +227,7 @@ class RadioGroup extends FieldMixin(
    * @private
    */
   get isHorizontalRTL() {
-    return this.getAttribute('dir') === 'rtl' && this._theme !== 'vertical';
+    return this.__isRTL && this._theme !== 'vertical';
   }
 
   /**

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -319,7 +319,7 @@ class SplitLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
 
     const distance = this.orientation === 'vertical' ? event.detail.dy : event.detail.dx;
-    const isRtl = this.orientation !== 'vertical' && this.getAttribute('dir') === 'rtl';
+    const isRtl = this.orientation !== 'vertical' && this.__isRTL;
     const dirDistance = isRtl ? -distance : distance;
 
     this._setFlexBasis(this._primaryChild, this._startSize.primary + dirDistance, this._startSize.container);

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -239,7 +239,7 @@ class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(PolymerEleme
 
   /** @private */
   get __direction() {
-    return !this._vertical && this.getAttribute('dir') === 'rtl' ? 1 : -1;
+    return !this._vertical && this.__isRTL ? 1 : -1;
   }
 
   /** @private */


### PR DESCRIPTION
## Description

Moved `__isRTL` getter to `DirMixin` to reduce code duplication in components that use this mixin.
Also removed `attributeChangedCallback()` from `vaadin-grid`, it's not needed since #2396.

## Type of change

- Refactor