### PR TITLE
refactor!: remove no longer supported iron-icon styles

### DIFF
--- a/packages/button/theme/lumo/vaadin-button-styles.js
+++ b/packages/button/theme/lumo/vaadin-button-styles.js
@@ -203,16 +203,14 @@ const button = css`
 
   /* Icons */
 
-  [part] ::slotted(vaadin-icon),
-  [part] ::slotted(iron-icon) {
+  [part] ::slotted(vaadin-icon) {
     display: inline-block;
     width: var(--lumo-icon-size-m);
     height: var(--lumo-icon-size-m);
   }
 
   /* Vaadin icons are based on a 16x16 grid (unlike Lumo and Material icons with 24x24), so they look too big by default */
-  [part] ::slotted(vaadin-icon[icon^='vaadin:']),
-  [part] ::slotted(iron-icon[icon^='vaadin:']) {
+  [part] ::slotted(vaadin-icon[icon^='vaadin:']) {
     padding: 0.25em;
     box-sizing: border-box !important;
   }

--- a/packages/button/theme/material/vaadin-button-styles.js
+++ b/packages/button/theme/material/vaadin-button-styles.js
@@ -116,21 +116,18 @@ const button = css`
 
   /* Icon alignment */
 
-  [part] ::slotted(vaadin-icon),
-  [part] ::slotted(iron-icon) {
+  [part] ::slotted(vaadin-icon) {
     display: block;
     width: 18px;
     height: 18px;
   }
 
-  [part='prefix'] ::slotted(vaadin-icon),
-  [part='prefix'] ::slotted(iron-icon) {
+  [part='prefix'] ::slotted(vaadin-icon) {
     margin-right: 8px;
     margin-left: -4px;
   }
 
-  [part='suffix'] ::slotted(vaadin-icon),
-  [part='suffix'] ::slotted(iron-icon) {
+  [part='suffix'] ::slotted(vaadin-icon) {
     margin-left: 8px;
     margin-right: -4px;
   }
@@ -156,14 +153,12 @@ const button = css`
     transform: translate(50%, -50%) scale(1);
   }
 
-  :host([dir='rtl']) [part='prefix'] ::slotted(vaadin-icon),
-  :host([dir='rtl']) [part='prefix'] ::slotted(iron-icon) {
+  :host([dir='rtl']) [part='prefix'] ::slotted(vaadin-icon) {
     margin-right: -4px;
     margin-left: 8px;
   }
 
-  :host([dir='rtl']) [part='suffix'] ::slotted(vaadin-icon),
-  :host([dir='rtl']) [part='suffix'] ::slotted(iron-icon) {
+  :host([dir='rtl']) [part='suffix'] ::slotted(vaadin-icon) {
     margin-left: -4px;
     margin-right: 8px;
   }

--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -76,7 +76,6 @@ registerStyles(
     }
 
     /* Slotted icons */
-    ::slotted(iron-icon),
     ::slotted(vaadin-icon) {
       color: var(--lumo-contrast-60pct);
       width: var(--lumo-icon-size-m);
@@ -84,7 +83,6 @@ registerStyles(
     }
 
     /* Vaadin icons are based on a 16x16 grid (unlike Lumo and Material icons with 24x24), so they look too big by default */
-    ::slotted(iron-icon[icon^='vaadin:']),
     ::slotted(vaadin-icon[icon^='vaadin:']) {
       padding: 0.25em;
       box-sizing: border-box !important;

--- a/packages/item/theme/lumo/vaadin-item-styles.js
+++ b/packages/item/theme/lumo/vaadin-item-styles.js
@@ -80,8 +80,7 @@ const item = css`
   }
 
   /* Slotted icons */
-  :host ::slotted(vaadin-icon),
-  :host ::slotted(iron-icon) {
+  :host ::slotted(vaadin-icon) {
     width: var(--lumo-icon-size-m);
     height: var(--lumo-icon-size-m);
   }

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-item-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-item-styles.js
@@ -12,15 +12,13 @@ registerStyles(
       justify-content: inherit;
     }
 
-    :host([theme='menu-bar-item']) [part='content'] ::slotted(vaadin-icon),
-    :host([theme='menu-bar-item']) [part='content'] ::slotted(iron-icon) {
+    :host([theme='menu-bar-item']) [part='content'] ::slotted(vaadin-icon) {
       display: inline-block;
       width: var(--lumo-icon-size-m);
       height: var(--lumo-icon-size-m);
     }
 
-    :host([theme='menu-bar-item']) [part='content'] ::slotted(vaadin-icon[icon^='vaadin:']),
-    :host([theme='menu-bar-item']) [part='content'] ::slotted(iron-icon[icon^='vaadin:']) {
+    :host([theme='menu-bar-item']) [part='content'] ::slotted(vaadin-icon[icon^='vaadin:']) {
       padding: var(--lumo-space-xs);
       box-sizing: border-box !important;
     }

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-item-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-item-styles.js
@@ -12,8 +12,7 @@ registerStyles(
       font-size: var(--material-button-font-size);
     }
 
-    :host([theme='menu-bar-item']) [part='content'] ::slotted(vaadin-icon[icon^='vaadin:']),
-    :host([theme='menu-bar-item']) [part='content'] ::slotted(iron-icon[icon^='vaadin:']) {
+    :host([theme='menu-bar-item']) [part='content'] ::slotted(vaadin-icon[icon^='vaadin:']) {
       display: inline-block;
       width: 18px;
       height: 18px;

--- a/packages/tabs/theme/lumo/vaadin-tab-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tab-styles.js
@@ -134,27 +134,23 @@ registerStyles(
       color: inherit !important;
     }
 
-    :host ::slotted(vaadin-icon),
-    :host ::slotted(iron-icon) {
+    :host ::slotted(vaadin-icon) {
       margin: 0 4px;
       width: var(--lumo-icon-size-m);
       height: var(--lumo-icon-size-m);
     }
 
     /* Vaadin icons are based on a 16x16 grid (unlike Lumo and Material icons with 24x24), so they look too big by default */
-    :host ::slotted(vaadin-icon[icon^='vaadin:']),
-    :host ::slotted(iron-icon[icon^='vaadin:']) {
+    :host ::slotted(vaadin-icon[icon^='vaadin:']) {
       padding: 0.25rem;
       box-sizing: border-box !important;
     }
 
-    :host(:not([dir='rtl'])) ::slotted(vaadin-icon:first-child),
-    :host(:not([dir='rtl'])) ::slotted(iron-icon:first-child) {
+    :host(:not([dir='rtl'])) ::slotted(vaadin-icon:first-child) {
       margin-left: 0;
     }
 
-    :host(:not([dir='rtl'])) ::slotted(vaadin-icon:last-child),
-    :host(:not([dir='rtl'])) ::slotted(iron-icon:last-child) {
+    :host(:not([dir='rtl'])) ::slotted(vaadin-icon:last-child) {
       margin-right: 0;
     }
 
@@ -175,8 +171,7 @@ registerStyles(
       padding-top: 0.25rem;
     }
 
-    :host([theme~='icon-on-top']) ::slotted(vaadin-icon),
-    :host([theme~='icon-on-top']) ::slotted(iron-icon) {
+    :host([theme~='icon-on-top']) ::slotted(vaadin-icon) {
       margin: 0;
     }
 
@@ -209,13 +204,11 @@ registerStyles(
       transform: translateX(50%) scale(1);
     }
 
-    :host([dir='rtl']) ::slotted(vaadin-icon:first-child),
-    :host([dir='rtl']) ::slotted(iron-icon:first-child) {
+    :host([dir='rtl']) ::slotted(vaadin-icon:first-child) {
       margin-right: 0;
     }
 
-    :host([dir='rtl']) ::slotted(vaadin-icon:last-child),
-    :host([dir='rtl']) ::slotted(iron-icon:last-child) {
+    :host([dir='rtl']) ::slotted(vaadin-icon:last-child) {
       margin-left: 0;
     }
 

--- a/packages/tabs/theme/material/vaadin-tab-styles.js
+++ b/packages/tabs/theme/material/vaadin-tab-styles.js
@@ -128,8 +128,7 @@ registerStyles(
     }
 
     /* Small space between icon and label */
-    ::slotted(vaadin-icon:not(:only-child)),
-    ::slotted(iron-icon:not(:only-child)) {
+    ::slotted(vaadin-icon:not(:only-child)) {
       margin-bottom: 8px;
     }
 

--- a/packages/text-area/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area-styles.js
@@ -56,7 +56,6 @@ const textArea = css`
   }
 
   /* Vertically align icon prefix/suffix with the first line of text */
-  [part='input-field'] ::slotted(iron-icon),
   [part='input-field'] ::slotted(vaadin-icon) {
     margin-top: calc((var(--lumo-icon-size-m) - 1em * var(--lumo-line-height-s)) / -2);
   }

--- a/packages/vaadin-lumo-styles/badge.js
+++ b/packages/vaadin-lumo-styles/badge.js
@@ -86,24 +86,20 @@ const badge = css`
 
   /* Icon */
 
-  [theme~='badge'] vaadin-icon,
-  [theme~='badge'] iron-icon {
+  [theme~='badge'] vaadin-icon {
     margin: -0.25em 0;
-    --iron-icon-width: 1.5em;
-    --iron-icon-height: 1.5em;
+    width: 1.5em;
+    height: 1.5em;
   }
 
-  [theme~='badge'] vaadin-icon:first-child,
-  [theme~='badge'] iron-icon:first-child {
+  [theme~='badge'] vaadin-icon:first-child {
     margin-left: -0.375em;
   }
 
-  [theme~='badge'] vaadin-icon:last-child,
-  [theme~='badge'] iron-icon:last-child {
+  [theme~='badge'] vaadin-icon:last-child {
     margin-right: -0.375em;
   }
 
-  iron-icon[theme~='badge'][icon],
   vaadin-icon[theme~='badge'][icon] {
     min-width: 0;
     padding: 0;
@@ -112,7 +108,6 @@ const badge = css`
     height: var(--lumo-icon-size-m);
   }
 
-  iron-icon[theme~='badge'][icon][theme~='small'],
   vaadin-icon[theme~='badge'][icon][theme~='small'] {
     width: var(--lumo-icon-size-s);
     height: var(--lumo-icon-size-s);
@@ -154,14 +149,12 @@ const badge = css`
 
   /* RTL specific styles */
 
-  [dir='rtl'][theme~='badge'] vaadin-icon:first-child,
-  [dir='rtl'][theme~='badge'] iron-icon:first-child {
+  [dir='rtl'][theme~='badge'] vaadin-icon:first-child {
     margin-right: -0.375em;
     margin-left: 0;
   }
 
-  [dir='rtl'][theme~='badge'] vaadin-icon:last-child,
-  [dir='rtl'][theme~='badge'] iron-icon:last-child {
+  [dir='rtl'][theme~='badge'] vaadin-icon:last-child {
     margin-left: -0.375em;
     margin-right: 0;
   }

--- a/packages/vaadin-lumo-styles/badge.js
+++ b/packages/vaadin-lumo-styles/badge.js
@@ -88,8 +88,6 @@ const badge = css`
 
   [theme~='badge'] vaadin-icon {
     margin: -0.25em 0;
-    width: 1.5em;
-    height: 1.5em;
   }
 
   [theme~='badge'] vaadin-icon:first-child {

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -130,7 +130,7 @@ const inputField = css`
   }
 
   /* Slotted content */
-  [part='input-field'] ::slotted(:not(iron-icon):not(vaadin-icon):not(input):not(textarea)) {
+  [part='input-field'] ::slotted(:not(vaadin-icon):not(input):not(textarea)) {
     color: var(--lumo-secondary-text-color);
     font-weight: 400;
   }


### PR DESCRIPTION
## Description

We no longer support `iron-icon`, so let's remove related styles from components. Some of these styles were removed when adding `vaadin-icon` but then we agreed to restore those in #2399. Now it's time to finally drop them.

## Type of change

- Breaking change