### PR TITLE
refactor!: remove theme property in favor of attribute

### DIFF
--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -125,7 +125,6 @@ assertType<string>(narrowedComboBox.value);
 assertType<boolean>(narrowedComboBox.required);
 assertType<string>(narrowedComboBox.name);
 assertType<string>(narrowedComboBox.allowedCharPattern);
-assertType<string | null | undefined>(narrowedComboBox.theme);
 
 // ComboBox mixins
 assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBox);
@@ -203,7 +202,6 @@ assertType<boolean>(narrowedComboBoxLight.invalid);
 assertType<boolean>(narrowedComboBoxLight.disabled);
 assertType<boolean>(narrowedComboBoxLight.readonly);
 assertType<string>(narrowedComboBoxLight.value);
-assertType<string | null | undefined>(narrowedComboBoxLight.theme);
 
 // ComboBoxLight mixins
 assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -211,8 +211,6 @@ assertType<boolean>(narrowedGrid.allRowsVisible);
 assertType<() => void>(narrowedGrid.recalculateColumnWidths);
 assertType<() => void>(narrowedGrid.requestContentUpdate);
 
-assertType<string | null | undefined>(narrowedGrid.theme);
-
 /* GridColumn */
 const genericColumn = document.createElement('vaadin-grid-column');
 assertType<GridColumn>(genericColumn);

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -90,7 +90,6 @@ assertType<string | null | undefined>(narrowedComboBox.helperText);
 assertType<boolean>(narrowedComboBox.readonly);
 assertType<string | null | undefined>(narrowedComboBox.label);
 assertType<boolean>(narrowedComboBox.required);
-assertType<string | null | undefined>(narrowedComboBox.theme);
 
 // Mixins
 assertType<ControllerMixinClass>(narrowedComboBox);

--- a/packages/vaadin-themable-mixin/test/theme-property-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/theme-property-mixin.test.js
@@ -72,22 +72,4 @@ describe('ThemePropertyMixin', () => {
       expect(target.getAttribute('theme')).to.be.null;
     });
   });
-
-  describe('deprecated theme property', () => {
-    beforeEach(() => {
-      host = fixtureSync('<theme-host theme="initial"></theme-host>');
-      target = host.$.target;
-    });
-
-    it('should have the initial value', () => {
-      expect(host.theme).to.equal('initial');
-    });
-
-    it('should reflect the value to the theme attribute', () => {
-      host.theme = 'custom';
-      expect(host.getAttribute('theme')).to.equal('custom');
-      host.theme = null;
-      expect(host.hasAttribute('theme')).to.be.false;
-    });
-  });
 });

--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
@@ -27,5 +27,5 @@ export declare class ThemePropertyMixinClass {
    *
    * @protected
    */
-  readonly _theme: string | null | undefined;
+  protected readonly _theme: string | null | undefined;
 }

--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
@@ -25,27 +25,6 @@ export declare class ThemePropertyMixinClass {
    * See [Styling Components: Sub-components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components/#sub-components).
    * page for more information.
    *
-   * @deprecated The `theme` property is not supposed for public use and will be dropped in Vaadin 24.
-   * Please, use the `theme` attribute instead.
-   * @protected
-   */
-  theme: string | null | undefined;
-
-  /**
-   * Helper property with theme attribute value facilitating propagation
-   * in shadow DOM.
-   *
-   * Enables the component implementation to propagate the `theme`
-   * attribute value to the sub-components in Shadow DOM by binding
-   * the sub-component’s "theme" attribute to the `theme` property of
-   * the host.
-   *
-   * **NOTE:** Extending the mixin only provides the property for binding,
-   * and does not make the propagation alone.
-   *
-   * See [Styling Components: Sub-components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components/#sub-components).
-   * page for more information.
-   *
    * @protected
    */
   readonly _theme: string | null | undefined;

--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
@@ -25,31 +25,6 @@ export const ThemePropertyMixin = (superClass) =>
          * See [Styling Components: Sub-components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components/#sub-components).
          * page for more information.
          *
-         * @deprecated The `theme` property is not supposed for public use and will be dropped in Vaadin 24.
-         * Please, use the `theme` attribute instead.
-         * @protected
-         */
-        theme: {
-          type: String,
-          reflectToAttribute: true,
-          observer: '__deprecatedThemePropertyChanged',
-        },
-
-        /**
-         * Helper property with theme attribute value facilitating propagation
-         * in shadow DOM.
-         *
-         * Enables the component implementation to propagate the `theme`
-         * attribute value to the sub-components in Shadow DOM by binding
-         * the sub-component’s "theme" attribute to the `theme` property of
-         * the host.
-         *
-         * **NOTE:** Extending the mixin only provides the property for binding,
-         * and does not make the propagation alone.
-         *
-         * See [Styling Components: Sub-components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components/#sub-components).
-         * page for more information.
-         *
          * @protected
          */
         _theme: {
@@ -59,8 +34,16 @@ export const ThemePropertyMixin = (superClass) =>
       };
     }
 
-    /** @private */
-    __deprecatedThemePropertyChanged(theme) {
-      this._set_theme(theme);
+    static get observedAttributes() {
+      return [...super.observedAttributes, 'theme'];
+    }
+
+    /** @protected */
+    attributeChangedCallback(name, oldValue, newValue) {
+      super.attributeChangedCallback(name, oldValue, newValue);
+
+      if (name === 'theme') {
+        this._set_theme(newValue);
+      }
     }
   };


### PR DESCRIPTION
## Description

Removed `theme` property, which was previously deprecated. See #3529 for background.

## Type of change

- Breaking change