### PR TITLE
feat: expose row loading state as part name

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -260,13 +260,13 @@ export const DataProviderMixin = (superClass) =>
       const { cache, scaledIndex } = this._cache.getCacheAndIndex(index);
       const item = cache.items[scaledIndex];
       if (item) {
-        el.toggleAttribute('loading', false);
+        this._updateRowState(el, 'loading', false);
         this._updateItem(el, item);
         if (this._isExpanded(item)) {
           cache.ensureSubCacheForScaledIndex(scaledIndex);
         }
       } else {
-        el.toggleAttribute('loading', true);
+        this._updateRowState(el, 'loading', true);
         this._loadPage(this._getPageForIndex(scaledIndex), cache);
       }
     }

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -305,6 +305,7 @@ export interface GridEventMap<TItem> extends HTMLElementEventMap, GridCustomEven
  * `expanded-row`         | Expanded row
  * `selected-row`         | Selected row
  * `details-opened-row`   | Row with details open
+ * `loading-row`          | Row that is waiting for data from data provider
  * `odd-row`              | Odd row
  * `first-row`            | The first body row
  * `last-row`             | The last body row

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -179,6 +179,7 @@ import { StylingMixin } from './vaadin-grid-styling-mixin.js';
  * `expanded-row`         | Expanded row
  * `selected-row`         | Selected row
  * `details-opened-row`   | Row with details open
+ * `loading-row`          | Row that is waiting for data from data provider
  * `odd-row`              | Odd row
  * `first-row`            | The first body row
  * `last-row`             | The last body row

--- a/packages/grid/test/data-provider.test.js
+++ b/packages/grid/test/data-provider.test.js
@@ -758,11 +758,23 @@ describe('wrapped grid', () => {
       expect(getRows(grid.$.items)[0].hasAttribute('loading')).to.be.true;
     });
 
+    it('should add loading to row part attribute', () => {
+      container.dataProvider = () => {};
+      expect(getRows(grid.$.items)[0].getAttribute('part')).to.contain('loading-row');
+    });
+
     it('should clear loading attribute from rows when data received', () => {
       container.dataProvider = (params, callback) => {
         callback([{}]);
       };
       expect(getRows(grid.$.items)[0].hasAttribute('loading')).to.be.false;
+    });
+
+    it('should remove loading from row part attribute when data received', () => {
+      container.dataProvider = (params, callback) => {
+        callback([{}]);
+      };
+      expect(getRows(grid.$.items)[0].getAttribute('part')).to.not.contain('loading-row');
     });
 
     it('should clear loading attribute from rows when scrolled to previously loaded rows', () => {


### PR DESCRIPTION
## Description

Related to #4297

Follow-up to #4988. The row `loading` state was missing from that PR, so I added it.

## Type of change

- Feature