### PR TITLE
test: update grid tests to use renderers instead of templates

### DIFF
--- a/packages/grid/test/basic.test.js
+++ b/packages/grid/test/basic.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import {
   flushGrid,
@@ -23,12 +22,13 @@ describe('basic features', () => {
   beforeEach(() => {
     grid = fixtureSync(`
       <vaadin-grid style="width: 200px; height: 300px;" size="1000">
-        <vaadin-grid-column>
-          <template>[[index]]</template>
-        </vaadin-grid-column>
+        <vaadin-grid-column></vaadin-grid-column>
       </vaadin-grid>
     `);
     grid.dataProvider = infiniteDataProvider;
+    grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
     flushGrid(grid);
   });
 
@@ -221,21 +221,22 @@ describe('basic features', () => {
 });
 
 describe('flex child', () => {
-  let layout;
-  let grid;
+  let layout, grid, column;
 
   beforeEach(() => {
     layout = fixtureSync(`
       <div style="display: flex; width: 300px; height: 300px;">
         <div style="width: 100px; height: 100px; flex-shrink: 0;">Layout sibling</div>
         <vaadin-grid size="1000">
-          <vaadin-grid-column>
-            <template>[[index]]</template>
-          </vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
       </div>
     `);
     grid = layout.querySelector('vaadin-grid');
+    column = grid.querySelector('vaadin-grid-column');
+    column.renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
     grid.dataProvider = infiniteDataProvider;
     flushGrid(grid);
   });
@@ -267,7 +268,7 @@ describe('flex child', () => {
     });
 
     it('should have a visible header after row reorder', async () => {
-      grid.querySelector('vaadin-grid-column').header = 'header';
+      column.header = 'header';
       grid.scrollToIndex(300);
       await aTimeout(0);
       flushGrid(grid);

--- a/packages/grid/test/column-resizing.test.js
+++ b/packages/grid/test/column-resizing.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, listenOnce, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
 import {
@@ -24,16 +23,15 @@ describe('column resizing', () => {
   beforeEach(async () => {
     grid = fixtureSync(`
       <vaadin-grid size="1" style="width: 300px; height: 400px" column-reordering-allowed>
-        <vaadin-grid-column resizable>
-          <template class="header">0</template>
-          <template>0</template>
-        </vaadin-grid-column>
-        <vaadin-grid-column>
-          <template class="header">1</template>
-          <template>1</template>
-        </vaadin-grid-column>
+        <vaadin-grid-column resizable header="0"></vaadin-grid-column>
+        <vaadin-grid-column header="1"></vaadin-grid-column>
       </vaadin-grid>
     `);
+    grid.querySelectorAll('vaadin-grid-column').forEach((col, idx) => {
+      col.renderer = (root) => {
+        root.textContent = idx;
+      };
+    });
     grid.dataProvider = infiniteDataProvider;
     flushGrid(grid);
     headerCells = getRowCells(getRows(grid.$.header)[0]);
@@ -235,22 +233,20 @@ describe('column group resizing', () => {
   beforeEach(async () => {
     grid = fixtureSync(`
       <vaadin-grid size="1" style="width: 300px; height: 400px">
-        <vaadin-grid-column-group resizable>
-          <template class="header">0</template>
-          <vaadin-grid-column flex-grow="0">
-            <template class="header">0</template>
-            <template>0</template>
-          </vaadin-grid-column>
-          <vaadin-grid-column flex-grow="0">
-            <template class="header">1</template>
-            <template>1</template>
-          </vaadin-grid-column>
+        <vaadin-grid-column-group resizable header="0">
+          <vaadin-grid-column flex-grow="0" header="0"></vaadin-grid-column>
+          <vaadin-grid-column flex-grow="0" header="1"></vaadin-grid-column>
         </vaadin-grid-column-group>
       </vaadin-grid>
     `);
+    grid.querySelectorAll('vaadin-grid-column').forEach((col, idx) => {
+      col.renderer = (root) => {
+        root.textContent = idx;
+      };
+    });
     grid.dataProvider = infiniteDataProvider;
     flushGrid(grid);
-    await nextFrame();
+    await nextRender();
   });
 
   it('should cascade resizable property to child columns', () => {
@@ -322,31 +318,26 @@ describe('group inside group', () => {
   beforeEach(async () => {
     grid = fixtureSync(`
       <vaadin-grid size="1" style="width: 300px; height: 400px">
-        <vaadin-grid-column-group resizable>
-          <template class="header">0</template>
-          <vaadin-grid-column-group resizable>
-            <template class="header">1</template>
-            <vaadin-grid-column resizable>
-              <template class="header">2</template>
-              <template>2</template>
-            </vaadin-grid-column>
+        <vaadin-grid-column-group resizable header="0">
+          <vaadin-grid-column-group resizable header="1">
+            <vaadin-grid-column header="2"></vaadin-grid-column>
           </vaadin-grid-column-group>
         </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <template class="header">3</template>
-          <vaadin-grid-column-group>
-            <template class="header">4</template>
-            <vaadin-grid-column>
-              <template class="header">5</template>
-              <template>5</template>
-            </vaadin-grid-column>
+        <vaadin-grid-column-group header="3">
+          <vaadin-grid-column-group header="4">
+            <vaadin-grid-column header="5"></vaadin-grid-column>
           </vaadin-grid-column-group>
         </vaadin-grid-column-group>
       </vaadin-grid>
     `);
+    grid.querySelectorAll('vaadin-grid-column').forEach((col, idx) => {
+      col.renderer = (root) => {
+        root.textContent = idx === 0 ? 2 : 5;
+      };
+    });
     grid.dataProvider = infiniteDataProvider;
     flushGrid(grid);
-    await nextFrame();
+    await nextRender();
   });
 
   it('should resize the child groups child column', () => {

--- a/packages/grid/test/dynamic-item-size.test.js
+++ b/packages/grid/test/dynamic-item-size.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { flushGrid, getFirstVisibleItem, infiniteDataProvider } from './helpers.js';
@@ -29,11 +28,12 @@ describe('dynamic item size', () => {
   beforeEach(() => {
     grid = fixtureSync(`
       <vaadin-grid style="width: 200px; height: 200px;" size="1000">
-        <vaadin-grid-column>
-          <template>[[index]]</template>
-        </vaadin-grid-column>
+        <vaadin-grid-column></vaadin-grid-column>
       </vaadin-grid>
     `);
+    grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
     grid.dataProvider = infiniteDataProvider;
     flushGrid(grid);
   });

--- a/packages/grid/test/event-context.test.js
+++ b/packages/grid/test/event-context.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { click, fixtureSync } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
 import { flushGrid, getContainerCell } from './helpers.js';
@@ -10,22 +9,21 @@ describe('event context', () => {
 
   beforeEach(() => {
     grid = fixtureSync(`
-      <vaadin-grid items='[{"foo": "bar"}]'>
+      <vaadin-grid>
         <vaadin-grid-column-group header="column group header">
-          <template class="footer">
-            column group footer
-          </template>
-          <vaadin-grid-column path="foo" header="column header">
-            <template class="footer">
-              column footer
-            </template>
-          </vaadin-grid-column>
+          <vaadin-grid-column path="foo" header="column header"></vaadin-grid-column>
         </vaadin-grid-column-group>
       </vaadin-grid>
     `);
     column = grid.querySelector('vaadin-grid-column');
+    column.footerRenderer = (root) => {
+      root.textContent = 'column footer';
+    };
     columnGroup = grid.querySelector('vaadin-grid-column-group');
-
+    columnGroup.footerRenderer = (root) => {
+      root.textContent = 'column group footer';
+    };
+    grid.items = [{ foo: 'bar' }];
     grid.rowDetailsRenderer = (root) => {
       root.innerHTML = '<div>details</div>';
     };

--- a/packages/grid/test/filtering.test.js
+++ b/packages/grid/test/filtering.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, listenOnce, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-filter.js';
 import '../vaadin-grid-filter-column.js';
@@ -72,30 +71,38 @@ describe('filter', () => {
   });
 });
 
+function gridFiltersFixture() {
+  const grid = fixtureSync(`
+    <vaadin-grid>
+      <vaadin-grid-column path="first"></vaadin-grid-column>
+      <vaadin-grid-column path="last"></vaadin-grid-column>
+      <vaadin-grid-filter-column></vaadin-grid-filter-column>
+    </vaadin-grid>
+  `);
+
+  const columns = grid.querySelectorAll('vaadin-grid-column');
+  columns[0].headerRenderer = (root) => {
+    if (!root.firstChild) {
+      root.innerHTML = `
+        <vaadin-grid-filter path="first" value="bar"></vaadin-grid-filter>
+        <vaadin-grid-sorter path="first"></vaadin-grid-sorter>
+      `;
+    }
+  };
+  columns[1].headerRenderer = (root) => {
+    if (!root.firstChild) {
+      root.innerHTML = '<vaadin-grid-filter path="last" value="qux"></vaadin-grid-filter>';
+    }
+  };
+
+  return grid;
+}
+
 describe('filtering', () => {
   let grid, filter;
 
   beforeEach(() => {
-    grid = fixtureSync(`
-      <vaadin-grid>
-        <vaadin-grid-column>
-          <template class="header">
-            <vaadin-grid-filter path="first" value="bar">
-            </vaadin-grid-filter>
-            <vaadin-grid-sorter path="first"></vaadin-grid-sorter>
-          </template>
-          <template>[[item.first]]</template>
-        </vaadin-grid-column>
-        <vaadin-grid-column>
-          <template class="header">
-            <vaadin-grid-filter path="last" value="qux">
-            </vaadin-grid-filter>
-          </template>
-          <template>[[item.last]]</template>
-        </vaadin-grid-column>
-        <vaadin-grid-filter-column></vaadin-grid-filter-column>
-      </vaadin-grid>
-    `);
+    grid = gridFiltersFixture();
     flushGrid(grid);
     flushFilters(grid);
     if (grid._observer.flush) {
@@ -225,26 +232,7 @@ describe('array data provider', () => {
   let grid, filterFirst, filterSecond;
 
   beforeEach(() => {
-    grid = fixtureSync(`
-      <vaadin-grid>
-        <vaadin-grid-column>
-          <template class="header">
-            <vaadin-grid-filter path="first" value="bar">
-            </vaadin-grid-filter>
-            <vaadin-grid-sorter path="first"></vaadin-grid-sorter>
-          </template>
-          <template>[[item.first]]</template>
-        </vaadin-grid-column>
-        <vaadin-grid-column>
-          <template class="header">
-            <vaadin-grid-filter path="last" value="qux">
-            </vaadin-grid-filter>
-          </template>
-          <template>[[item.last]]</template>
-        </vaadin-grid-column>
-        <vaadin-grid-filter-column></vaadin-grid-filter-column>
-      </vaadin-grid>
-    `);
+    grid = gridFiltersFixture();
     flushGrid(grid);
 
     flushFilters(grid);
@@ -324,26 +312,7 @@ describe('array data provider', () => {
 
 describe('lazy init', () => {
   it('should not filter if there is no data yet', () => {
-    const grid = fixtureSync(`
-    <vaadin-grid>
-      <vaadin-grid-column>
-        <template class="header">
-          <vaadin-grid-filter path="first" value="bar">
-          </vaadin-grid-filter>
-          <vaadin-grid-sorter path="first"></vaadin-grid-sorter>
-        </template>
-        <template>[[item.first]]</template>
-      </vaadin-grid-column>
-      <vaadin-grid-column>
-        <template class="header">
-          <vaadin-grid-filter path="last" value="qux">
-          </vaadin-grid-filter>
-        </template>
-        <template>[[item.last]]</template>
-      </vaadin-grid-column>
-      <vaadin-grid-filter-column></vaadin-grid-filter-column>
-    </vaadin-grid>
-  `);
+    const grid = gridFiltersFixture();
     grid.size = 100;
     grid.dataProvider = () => {
       // Don't provide any data

--- a/packages/grid/test/hidden-grid.test.js
+++ b/packages/grid/test/hidden-grid.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import { flushGrid, getBodyCellContent, infiniteDataProvider } from './helpers.js';
 
@@ -10,12 +9,12 @@ describe('hidden grid', () => {
   beforeEach(() => {
     grid = fixtureSync(`
       <vaadin-grid style="height: 200px; width: 200px;" hidden size="1">
-        <vaadin-grid-column>
-          <template class="header">foo</template>
-          <template>[[index]]</template>
-        </vaadin-grid-column>
+        <vaadin-grid-column header="foo"></vaadin-grid-column>
       </vaadin-grid>
     `);
+    grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
     grid.dataProvider = infiniteDataProvider;
     flushGrid(grid);
   });

--- a/packages/grid/test/physical-count.test.js
+++ b/packages/grid/test/physical-count.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import {
@@ -38,11 +37,12 @@ describe('dynamic physical count', () => {
   beforeEach(() => {
     grid = fixtureSync(`
       <vaadin-grid style="width: 200px; height: 200px;" size="200" theme="no-border">
-        <vaadin-grid-column>
-          <template>[[index]]</template>
-        </vaadin-grid-column>
+        <vaadin-grid-column></vaadin-grid-column>
       </vaadin-grid>
     `);
+    grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
     grid.dataProvider = infiniteDataProvider;
     scroller = grid.$.scroller;
     flushGrid(grid);

--- a/packages/grid/test/resizing.test.js
+++ b/packages/grid/test/resizing.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -26,14 +25,23 @@ class TestComponent extends PolymerElement {
       </style>
 
       <vaadin-grid id="grid" style="width: 200px; height: 400px;" size="10" hidden>
-        <template class="row-details"> [[index]] </template>
-        <vaadin-grid-column>
-          <template class="header">header</template>
-          <template>[[index]]</template>
-          <template class="footer">footer</template>
-        </vaadin-grid-column>
+        <vaadin-grid-column id="column" header="header"></vaadin-grid-column>
       </vaadin-grid>
     `;
+  }
+
+  ready() {
+    super.ready();
+
+    this.$.grid.rowDetailsRenderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
+    this.$.column.renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
+    this.$.column.footerRenderer = (root) => {
+      root.textContent = 'footer';
+    };
   }
 }
 
@@ -157,15 +165,16 @@ describe('resizing', () => {
 describe('all rows visible', () => {
   let grid;
 
-  describe('template', () => {
+  describe('renderer', () => {
     beforeEach(() => {
       grid = fixtureSync(`
         <vaadin-grid>
-          <vaadin-grid-column>
-            <template>[[index]]</template>
-          </vaadin-grid-column>
+          <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
       `);
+      grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+        root.textContent = model.index;
+      };
     });
 
     it('should align height with number of rows after first render', () => {

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, listenOnce, nextFrame } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
 import {
@@ -12,28 +11,21 @@ import {
   infiniteDataProvider,
 } from './helpers.js';
 
+const createGrid = (height, size) => {
+  const grid = fixtureSync(`
+    <vaadin-grid style="width: 200px; height: ${height}px;" size="${size}">
+      <vaadin-grid-column header="foo"></vaadin-grid-column>
+    </vaadin-grid>
+  `);
+  grid.firstElementChild.renderer = (root, _, model) => {
+    root.textContent = model.index;
+  };
+  return grid;
+};
+
 const fixtures = {
-  small: `
-    <vaadin-grid style="width: 200px; height: 200px;" size="100">
-      <vaadin-grid-column>
-        <template class="header">foo</template>
-        <template>[[index]]</template>
-      </vaadin-grid-column>
-    </vaadin-grid>
-  `,
-  large: `
-    <vaadin-grid style="width: 200px; height: 500px;" size="500000000">
-      <vaadin-grid-column>
-        <template class="header">foo</template>
-        <template>[[index]]</template>
-      </vaadin-grid-column>
-    </vaadin-grid>
-  `,
-  treeGrid: `
-    <vaadin-grid style="width: 200px; height: 500px;" item-has-children-path="hasChildren">
-      <vaadin-grid-tree-column path="name" header="foo"></vaadin-grid-tree-column>
-    </vaadin-grid>
-  `,
+  small: () => createGrid(200, 200),
+  large: () => createGrid(500, 500000000),
 };
 
 describe('scroll to index', () => {
@@ -42,7 +34,7 @@ describe('scroll to index', () => {
       let grid;
 
       beforeEach(async () => {
-        grid = fixtureSync(fixtures[scale]);
+        grid = fixtures[scale]();
         grid.dataProvider = infiniteDataProvider;
         flushGrid(grid);
         await nextFrame();
@@ -103,7 +95,7 @@ describe('scroll to index', () => {
     let grid;
 
     beforeEach(async () => {
-      grid = fixtureSync(fixtures.large);
+      grid = fixtures.large();
       grid.dataProvider = infiniteDataProvider;
       flushGrid(grid);
       grid.scrollToIndex(10);
@@ -195,7 +187,7 @@ describe('scroll to index', () => {
     let grid, data;
 
     beforeEach(() => {
-      grid = fixtureSync(fixtures.large);
+      grid = fixtures.large();
       data = Array(...new Array(10)).map((_, i) => {
         return { index: i };
       });
@@ -221,7 +213,11 @@ describe('scroll to index', () => {
     let grid;
 
     beforeEach(() => {
-      grid = fixtureSync(fixtures.treeGrid);
+      grid = fixtureSync(`
+        <vaadin-grid style="width: 200px; height: 500px;" item-has-children-path="hasChildren">
+          <vaadin-grid-tree-column path="name" header="foo"></vaadin-grid-tree-column>
+        </vaadin-grid>
+      `);
     });
 
     // Issue https://github.com/vaadin/vaadin-grid/issues/2107

--- a/packages/grid/test/scrolling-mode.test.js
+++ b/packages/grid/test/scrolling-mode.test.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, isDesktopSafari, isFirefox, listenOnce, nextFrame } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import { fixtureSync, isDesktopSafari, isFirefox, listenOnce, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../vaadin-grid.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { flushGrid, infiniteDataProvider, onceResized, scrollToEnd } from './helpers.js';
 
 describe('scrolling mode', () => {
@@ -11,11 +9,12 @@ describe('scrolling mode', () => {
   beforeEach(() => {
     grid = fixtureSync(`
       <vaadin-grid style="width: 50px; height: 400px;" size="1000">
-        <vaadin-grid-column>
-          <template>[[index]]</template>
-        </vaadin-grid-column>
+        <vaadin-grid-column></vaadin-grid-column>
       </vaadin-grid>
     `);
+    grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
     grid.dataProvider = infiniteDataProvider;
     flushGrid(grid);
   });
@@ -143,19 +142,18 @@ describe('empty grid', () => {
   beforeEach(() => {
     grid = fixtureSync(`
       <vaadin-grid style="width: 50px; height: 400px;" size="1000">
-        <vaadin-grid-column>
-          <template>[[index]]</template>
-        </vaadin-grid-column>
+        <vaadin-grid-column></vaadin-grid-column>
       </vaadin-grid>
     `);
+    grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
     flushGrid(grid);
   });
 
-  it('should not have vertical scroll bars', (done) => {
-    afterNextRender(grid, () => {
-      expect(grid.clientHeight).not.to.be.below(grid.$.header.clientHeight + grid.$.items.clientHeight);
-      done();
-    });
+  it('should not have vertical scroll bars', async () => {
+    await nextRender();
+    expect(grid.clientHeight).not.to.be.below(grid.$.header.clientHeight + grid.$.items.clientHeight);
   });
 });
 
@@ -164,13 +162,14 @@ describe('scroll on attach', () => {
     document.body.style.paddingTop = '10000px';
     document.documentElement.scrollTop = 10000;
     const scrollTop = document.documentElement.scrollTop;
-    fixtureSync(`
+    const grid = fixtureSync(`
       <vaadin-grid style="width: 50px; height: 400px;" size="1000">
-        <vaadin-grid-column>
-          <template>[[index]]</template>
-        </vaadin-grid-column>
+        <vaadin-grid-column></vaadin-grid-column>
       </vaadin-grid>
     `);
+    grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
     const newScrollTop = document.documentElement.scrollTop;
     // Cleanup
     document.body.style.paddingTop = '';

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { click, fixtureSync, keyUpOn, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid-sorter.js';
 import '../vaadin-grid-sort-column.js';
 import { Grid } from '../vaadin-grid.js';
@@ -11,7 +10,6 @@ import {
   getBodyCellContent,
   getContainerCell,
   getHeaderCellContent,
-  getRowCells,
   getRows,
   shiftClick,
 } from './helpers.js';
@@ -187,26 +185,32 @@ describe('sorting', () => {
     beforeEach(async () => {
       grid = fixtureSync(`
         <vaadin-grid style="width: 200px; height: 200px;" multi-sort>
-          <vaadin-grid-column>
-            <template class="header">
-              <vaadin-grid-sorter path="first" direction="asc">
-                <span class="title">first</span>
-              </vaadin-grid-sorter>
-            </template>
-            <template>[[item.first]]</template>
-          </vaadin-grid-column>
-          <vaadin-grid-column>
-            <template class="header">
-              <vaadin-grid-sorter path="last" direction="desc">
-                <span class="title">last</span>
-              </vaadin-grid-sorter>
-            </template>
-            <template>[[item.last]]</template>
-          </vaadin-grid-column>
+          <vaadin-grid-column path="first"></vaadin-grid-column>
+          <vaadin-grid-column path="last"></vaadin-grid-column>
           <vaadin-grid-sort-column></vaadin-grid-sort-column>
         </vaadin-grid>
       `);
+      const columns = document.querySelectorAll('vaadin-grid-column');
+      columns[0].headerRenderer = (root) => {
+        if (!root.firstChild) {
+          root.innerHTML = `
+            <vaadin-grid-sorter path="first" direction="asc">
+              <span class="title">first</span>
+            </vaadin-grid-sorter>
+          `;
+        }
+      };
+      columns[1].headerRenderer = (root) => {
+        if (!root.firstChild) {
+          root.innerHTML = `
+            <vaadin-grid-sorter path="last" direction="desc">
+              <span class="title">last</span>
+            </vaadin-grid-sorter>
+          `;
+        }
+      };
       await nextFrame();
+
       sorterFirst = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-grid-sorter');
       sorterLast = getHeaderCellContent(grid, 0, 1).querySelector('vaadin-grid-sorter');
 
@@ -334,8 +338,7 @@ describe('sorting', () => {
         sorterLast.direction = null;
         grid.items = buildDataSet(100);
         const bodyRows = getRows(grid.$.items);
-        const cells = getRowCells(bodyRows[0]);
-        expect(cells[0]._content.__templateInstance.item).to.equal(grid.items[0]);
+        expect(grid.__getRowModel(bodyRows[0]).item).to.equal(grid.items[0]);
       });
 
       it('should sort empty values', () => {
@@ -615,24 +618,28 @@ describe('sorting', () => {
     beforeEach(() => {
       grid = fixtureSync(`
         <vaadin-grid style="width: 200px; height: 200px;">
-          <vaadin-grid-column>
-            <template class="header">
-              <vaadin-grid-sorter path="first" direction="asc">
-                <span class="title">first</span>
-              </vaadin-grid-sorter>
-            </template>
-            <template>[[item.first]]</template>
-          </vaadin-grid-column>
-          <vaadin-grid-column>
-            <template class="header">
-              <span class="title">last</span>
-              <vaadin-grid-sorter path="last">
-              </vaadin-grid-sorter>
-            </template>
-            <template>[[item.last]]</template>
-          </vaadin-grid-column>
+          <vaadin-grid-column path="first"></vaadin-grid-column>
+          <vaadin-grid-column path="last"></vaadin-grid-column>
         </vaadin-grid>
       `);
+      const columns = document.querySelectorAll('vaadin-grid-column');
+      columns[0].headerRenderer = (root) => {
+        if (!root.firstChild) {
+          root.innerHTML = `
+            <vaadin-grid-sorter path="first" direction="asc">
+              <span class="title">first</span>
+            </vaadin-grid-sorter>
+          `;
+        }
+      };
+      columns[1].headerRenderer = (root) => {
+        if (!root.firstChild) {
+          root.innerHTML = `
+            <span class="title">last</span>
+            <vaadin-grid-sorter path="last"></vaadin-grid-sorter>
+          `;
+        }
+      };
       flushGrid(grid);
     });
 

--- a/packages/grid/test/tree-toggle.test.js
+++ b/packages/grid/test/tree-toggle.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { click, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-tree-toggle.js';
 import '../vaadin-grid-tree-column.js';


### PR DESCRIPTION
## Description

Updated most of the grid unit tests to replace `<template>` with `path` / `header` or `renderer`.
There are still some test suites that would require more effort, so let's handle them later.

## Type of change

- Tests