### PR TITLE
docs: add missing private JSDoc annotations

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -510,6 +510,7 @@ export const DataProviderMixin = (superClass) =>
       }
     }
 
+    /** @private */
     __scrollToPendingIndex() {
       if (this.__pendingScrollToIndex && this.$.items.children.length) {
         const index = this.__pendingScrollToIndex;

--- a/packages/grid/src/vaadin-grid-styling-mixin.js
+++ b/packages/grid/src/vaadin-grid-styling-mixin.js
@@ -37,6 +37,7 @@ export const StylingMixin = (superClass) =>
       return ['__cellClassNameGeneratorChanged(cellClassNameGenerator)'];
     }
 
+    /** @private */
     __cellClassNameGeneratorChanged() {
       this.generateCellClassNames();
     }

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -951,6 +951,7 @@ class Grid extends ElementMixin(
     this.generateCellClassNames();
   }
 
+  /** @private */
   __updateFooterPositioning() {
     // TODO: fixed in Firefox 99, remove when we can drop Firefox ESR 91 support
     if (this._firefox && parseFloat(navigator.userAgent.match(/Firefox\/(\d{2,3}.\d)/)[1]) < 99) {


### PR DESCRIPTION
## Description

Added `@private` annotation to some methods that were missing it.

## Type of change

- Documentation