### PR TITLE
fix: update MultiSelectListMixin type definitions (#5027) (CP: 23.1)

### DIFF
--- a/packages/list-box/test/typings/list-box.types.ts
+++ b/packages/list-box/test/typings/list-box.types.ts
@@ -1,4 +1,6 @@
 import '../../vaadin-list-box.js';
+import { ListMixinClass } from '@vaadin/vaadin-list-mixin/vaadin-list-mixin.js';
+import { MultiSelectListMixinClass } from '@vaadin/vaadin-list-mixin/vaadin-multi-select-list-mixin.js';
 import {
   ListBoxItemsChangedEvent,
   ListBoxSelectedChangedEvent,
@@ -23,3 +25,10 @@ listBox.addEventListener('selected-values-changed', (event) => {
   assertType<ListBoxSelectedValuesChangedEvent>(event);
   assertType<number[]>(event.detail.value);
 });
+
+assertType<ListMixinClass>(listBox);
+assertType<MultiSelectListMixinClass>(listBox);
+
+assertType<number | null | undefined>(listBox.selected);
+assertType<boolean | null | undefined>(listBox.multiple);
+assertType<number[] | null | undefined>(listBox.selectedValues);

--- a/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.d.ts
+++ b/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.d.ts
@@ -11,7 +11,7 @@ import { ListMixinClass } from './vaadin-list-mixin.js';
  */
 export declare function MultiSelectListMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<ListMixinClass> & Constructor<ListMixinClass> & T;
+): Constructor<ListMixinClass> & Constructor<MultiSelectListMixinClass> & T;
 
 export declare class MultiSelectListMixinClass {
   /**


### PR DESCRIPTION
## Description

Manual cherry-pick of #5027 to `23.1` branch. The automated cherry-pick failed due to `import type` usage on master.

## Type of change

- Cherry-pick