### PR TITLE
chore: upgrade playwright version to 1.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "npm-run-all": "^4.1.5",
     "octokit": "^2.0.10",
     "patch-package": "^6.5.0",
-    "playwright": "1.25.0",
+    "playwright": "1.28.0",
     "postcss-lit": "^0.5.0",
     "prettier": "^2.7.1",
     "prettier-plugin-package": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "npm-run-all": "^4.1.5",
     "octokit": "^2.0.10",
     "patch-package": "^6.5.0",
+    "playwright": "1.25.0",
     "postcss-lit": "^0.5.0",
     "prettier": "^2.7.1",
     "prettier-plugin-package": "^1.3.0",

--- a/packages/app-layout/test/keyboard-navigation.test.js
+++ b/packages/app-layout/test/keyboard-navigation.test.js
@@ -1,11 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import { sendKeys } from '@web/test-runner-commands';
+import { sendKeys, setViewport } from '@web/test-runner-commands';
 import '../vaadin-app-layout.js';
 import '../vaadin-drawer-toggle.js';
 
 describe('keyboard navigation', () => {
-  let layout, toggle, drawer, drawerLink, contentLink;
+  let layout, toggle, drawer, drawerLink, contentLink, savedViewport;
 
   async function tab() {
     await sendKeys({ press: 'Tab' });
@@ -17,11 +17,9 @@ describe('keyboard navigation', () => {
     await sendKeys({ up: 'Shift' });
   }
 
-  async function fixtureLayout(layoutMode) {
-    const overlayMode = String(layoutMode === 'mobile');
-
+  async function fixtureLayout() {
     layout = fixtureSync(`
-      <vaadin-app-layout style="--vaadin-app-layout-drawer-overlay: ${overlayMode}; --vaadin-app-layout-transition: none;">
+      <vaadin-app-layout style="--vaadin-app-layout-transition: none;">
         <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
         <section slot="drawer">
           <a href="#">Drawer Link</a>
@@ -38,9 +36,21 @@ describe('keyboard navigation', () => {
     contentLink = layout.querySelector(':scope > :not([slot]) > a');
   }
 
+  before(() => {
+    savedViewport = { width: window.innerWidth, height: window.innerHeight };
+  });
+
+  after(async () => {
+    await setViewport(savedViewport);
+  });
+
   describe('desktop layout', () => {
+    before(async () => {
+      await setViewport({ width: 1000, height: 1000 });
+    });
+
     beforeEach(async () => {
-      await fixtureLayout('desktop');
+      await fixtureLayout();
     });
 
     it('should have focus outside the layout by default', () => {
@@ -86,8 +96,12 @@ describe('keyboard navigation', () => {
   });
 
   describe('mobile layout', () => {
+    before(async () => {
+      await setViewport({ width: 500, height: 500 });
+    });
+
     beforeEach(async () => {
-      await fixtureLayout('mobile');
+      await fixtureLayout();
     });
 
     it('should have focus outside the layout by default', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9341,17 +9341,17 @@ pkg-dir@4.2.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.25.0.tgz#54dc867c6c2cc5e4233905e249206a02914d14f1"
-  integrity sha512-kZ3Jwaf3wlu0GgU0nB8UMQ+mXFTqBIFz9h1svTlNduNKjnbPXFxw7mJanLVjqxHJRn62uBfmgBj93YHidk2N5Q==
+playwright-core@1.28.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.0.tgz#61df5c714f45139cca07095eccb4891e520e06f2"
+  integrity sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==
 
-playwright@1.25.0, playwright@^1.22.2:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.25.0.tgz#a5e317c8c207b921e7da17507ef9ec2983367970"
-  integrity sha512-Z+pQNWI17Qx/tHhnmgMmPsptsisXpKgAnUvYv98kctlHUJaqMt2400P8kTw9vEPoC0xdxqu0JhxO7pDTmaaIKw==
+playwright@1.28.0, playwright@^1.22.2:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.28.0.tgz#eaec2e607858bd4c0bd7434ac01042720e6a39e3"
+  integrity sha512-kyOXGc5y1mgi+hgEcCIyE1P1+JumLrxS09nFHo5sdJNzrucxPRAGwM4A2X3u3SDOfdgJqx61yIoR6Av+5plJPg==
   dependencies:
-    playwright-core "1.25.0"
+    playwright-core "1.28.0"
 
 plexer@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9341,17 +9341,17 @@ pkg-dir@4.2.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.24.2:
-  version "1.24.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.24.2.tgz#47bc5adf3dcfcc297a5a7a332449c9009987db26"
-  integrity sha512-zfAoDoPY/0sDLsgSgLZwWmSCevIg1ym7CppBwllguVBNiHeixZkc1AdMuYUPZC6AdEYc4CxWEyLMBTw2YcmRrA==
+playwright-core@1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.25.0.tgz#54dc867c6c2cc5e4233905e249206a02914d14f1"
+  integrity sha512-kZ3Jwaf3wlu0GgU0nB8UMQ+mXFTqBIFz9h1svTlNduNKjnbPXFxw7mJanLVjqxHJRn62uBfmgBj93YHidk2N5Q==
 
-playwright@^1.22.2:
-  version "1.24.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.24.2.tgz#51e60f128b386023e5ee83deca23453aaf73ba6d"
-  integrity sha512-iMWDLgaFRT+7dXsNeYwgl8nhLHsUrzFyaRVC+ftr++P1dVs70mPrFKBZrGp1fOKigHV9d1syC03IpPbqLKlPsg==
+playwright@1.25.0, playwright@^1.22.2:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.25.0.tgz#a5e317c8c207b921e7da17507ef9ec2983367970"
+  integrity sha512-Z+pQNWI17Qx/tHhnmgMmPsptsisXpKgAnUvYv98kctlHUJaqMt2400P8kTw9vEPoC0xdxqu0JhxO7pDTmaaIKw==
   dependencies:
-    playwright-core "1.24.2"
+    playwright-core "1.25.0"
 
 plexer@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

Related to #4846

Bump version of `playwright` to see which tests fail with the new version.

## Type of change

- Internal change