### PR TITLE
feat: add missing PositionMixin type definitions

### DIFF
--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -34,6 +34,7 @@
     "polymer"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "24.0.0-alpha4",
     "@vaadin/vaadin-lumo-styles": "24.0.0-alpha4",

--- a/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+export declare function PositionMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<PositionMixinClass> & T;
+
+export declare class PositionMixinClass {
+  /**
+   * The element next to which this overlay should be aligned.
+   * The position of the overlay relative to the positionTarget can be adjusted
+   * with properties `horizontalAlign`, `verticalAlign`, `noHorizontalOverlap`
+   * and `noVerticalOverlap`.
+   */
+  positionTarget: HTMLElement;
+
+  /**
+   * When `positionTarget` is set, this property defines whether to align the overlay's
+   * left or right side to the target element by default.
+   * Possible values are `start` and `end`.
+   * RTL is taken into account when interpreting the value.
+   * The overlay is automatically flipped to the opposite side when it doesn't fit into
+   * the default side defined by this property.
+   *
+   * @attr {start|end} horizontal-align
+   */
+  horizontalAlign: 'end' | 'start';
+
+  /**
+   * When `positionTarget` is set, this property defines whether to align the overlay's
+   * top or bottom side to the target element by default.
+   * Possible values are `top` and `bottom`.
+   * The overlay is automatically flipped to the opposite side when it doesn't fit into
+   * the default side defined by this property.
+   *
+   * @attr {top|bottom} vertical-align
+   */
+  verticalAlign: 'bottom' | 'top';
+
+  /**
+   * When `positionTarget` is set, this property defines whether the overlay should overlap
+   * the target element in the x-axis, or be positioned right next to it.
+   *
+   * @attr {boolean} no-horizontal-overlap
+   */
+  noHorizontalOverlap: boolean;
+
+  /**
+   * When `positionTarget` is set, this property defines whether the overlay should overlap
+   * the target element in the y-axis, or be positioned right above/below it.
+   *
+   * @attr {boolean} no-vertical-overlap
+   */
+  noVerticalOverlap: boolean;
+}

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -50,6 +50,8 @@ export const PositionMixin = (superClass) =>
          * RTL is taken into account when interpreting the value.
          * The overlay is automatically flipped to the opposite side when it doesn't fit into
          * the default side defined by this property.
+         *
+         * @attr {start|end} horizontal-align
          */
         horizontalAlign: {
           type: String,
@@ -62,6 +64,8 @@ export const PositionMixin = (superClass) =>
          * Possible values are `top` and `bottom`.
          * The overlay is automatically flipped to the opposite side when it doesn't fit into
          * the default side defined by this property.
+         *
+         * @attr {top|bottom} vertical-align
          */
         verticalAlign: {
           type: String,
@@ -71,6 +75,8 @@ export const PositionMixin = (superClass) =>
         /**
          * When `positionTarget` is set, this property defines whether the overlay should overlap
          * the target element in the x-axis, or be positioned right next to it.
+         *
+         * @attr {boolean} no-horizontal-overlap
          */
         noHorizontalOverlap: {
           type: Boolean,
@@ -80,6 +86,8 @@ export const PositionMixin = (superClass) =>
         /**
          * When `positionTarget` is set, this property defines whether the overlay should overlap
          * the target element in the y-axis, or be positioned right above/below it.
+         *
+         * @attr {boolean} no-vertical-overlap
          */
         noVerticalOverlap: {
           type: Boolean,

--- a/packages/overlay/test/typings/overlay.types.ts
+++ b/packages/overlay/test/typings/overlay.types.ts
@@ -1,7 +1,8 @@
-import '../../vaadin-overlay.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { PositionMixinClass } from '../../src/vaadin-overlay-position-mixin.js';
+import { PositionMixin } from '../../src/vaadin-overlay-position-mixin.js';
 import type {
   OverlayCloseEvent,
   OverlayClosingEvent,
@@ -10,6 +11,7 @@ import type {
   OverlayOpenEvent,
   OverlayOutsideClickEvent,
 } from '../../vaadin-overlay.js';
+import { Overlay } from '../../vaadin-overlay.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -47,3 +49,20 @@ overlay.addEventListener('vaadin-overlay-outside-click', (event) => {
   assertType<OverlayOutsideClickEvent>(event);
   assertType<MouseEvent>(event.detail.sourceEvent);
 });
+
+class CustomOverlay extends PositionMixin(Overlay) {
+  static get is() {
+    return 'custom-overlay';
+  }
+}
+
+customElements.define('custom-overlay', CustomOverlay);
+
+const customOverlay = new CustomOverlay();
+
+assertType<PositionMixinClass>(customOverlay);
+assertType<boolean>(customOverlay.noHorizontalOverlap);
+assertType<boolean>(customOverlay.noVerticalOverlap);
+assertType<'end' | 'start'>(customOverlay.horizontalAlign);
+assertType<'bottom' | 'top'>(customOverlay.verticalAlign);
+assertType<HTMLElement>(customOverlay.positionTarget);


### PR DESCRIPTION
## Description

Anyone who wants to extend `vaadin-overlay` and use TS will likely encounter a problem with missing typings.
Now when this mixin is no longer experimental, let's consider adding type definitions to make it work in TS.

## Type of change

- Feature