### PR TITLE
fix: set aria-hidden="true" on prefix and suffix

### DIFF
--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -98,13 +98,13 @@ class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(Poly
         }
       </style>
       <div class="vaadin-button-container">
-        <span part="prefix">
+        <span part="prefix" aria-hidden="true">
           <slot name="prefix"></slot>
         </span>
         <span part="label">
           <slot></slot>
         </span>
-        <span part="suffix">
+        <span part="suffix" aria-hidden="true">
           <slot name="suffix"></slot>
         </span>
       </div>

--- a/packages/button/test/dom/__snapshots__/button.test.snap.js
+++ b/packages/button/test/dom/__snapshots__/button.test.snap.js
@@ -79,7 +79,10 @@ snapshots["vaadin-button host active"] =
 
 snapshots["vaadin-button shadow default"] = 
 `<div class="vaadin-button-container">
-  <span part="prefix">
+  <span
+    aria-hidden="true"
+    part="prefix"
+  >
     <slot name="prefix">
     </slot>
   </span>
@@ -87,7 +90,10 @@ snapshots["vaadin-button shadow default"] =
     <slot>
     </slot>
   </span>
-  <span part="suffix">
+  <span
+    aria-hidden="true"
+    part="suffix"
+  >
     <slot name="suffix">
     </slot>
   </span>


### PR DESCRIPTION
## Description

Fixes #2924

See https://github.com/vaadin/web-components/issues/2924#issuecomment-1319655434 for a confirmation by @knoobie that this approach works in NVDA.

Given that prefix and suffix are not announced in [field components](https://vaadin.com/docs/latest/components/text-field/#prefix-and-suffix) and are typically used for icons (or supplementary content, e.g. `$` currency sign in case of the money field), let's change `vaadin-button` to work the same way.

## Type of change

- Bugfix