### PR TITLE
refactor: use helper function to iterate DOM children

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { iterateChildren } from './vaadin-grid-helpers.js';
 
 /**
  * @polymerMixin
@@ -42,16 +43,16 @@ export const A11yMixin = (superClass) =>
 
     /** @protected */
     _a11yUpdateHeaderRows() {
-      Array.from(this.$.header.children).forEach((headerRow, index) =>
-        headerRow.setAttribute('aria-rowindex', index + 1),
-      );
+      iterateChildren(this.$.header, (headerRow, index) => {
+        headerRow.setAttribute('aria-rowindex', index + 1);
+      });
     }
 
     /** @protected */
     _a11yUpdateFooterRows() {
-      Array.from(this.$.footer.children).forEach((footerRow, index) =>
-        footerRow.setAttribute('aria-rowindex', this._a11yGetHeaderRowCount(this._columnTree) + this.size + index + 1),
-      );
+      iterateChildren(this.$.footer, (footerRow, index) => {
+        footerRow.setAttribute('aria-rowindex', this._a11yGetHeaderRowCount(this._columnTree) + this.size + index + 1);
+      });
     }
 
     /**
@@ -71,7 +72,9 @@ export const A11yMixin = (superClass) =>
     _a11yUpdateRowSelected(row, selected) {
       // Jaws reads selection only for rows, NVDA only for cells
       row.setAttribute('aria-selected', Boolean(selected));
-      Array.from(row.children).forEach((cell) => cell.setAttribute('aria-selected', Boolean(selected)));
+      iterateChildren(row, (cell) => {
+        cell.setAttribute('aria-selected', Boolean(selected));
+      });
     }
 
     /**
@@ -108,7 +111,7 @@ export const A11yMixin = (superClass) =>
      * @protected
      */
     _a11ySetRowDetailsCell(row, detailsCell) {
-      Array.from(row.children).forEach((cell) => {
+      iterateChildren(row, (cell) => {
         if (cell !== detailsCell) {
           cell.setAttribute('aria-controls', detailsCell.id);
         }

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { addListener } from '@vaadin/component-base/src/gestures.js';
-import { updateColumnOrders } from './vaadin-grid-helpers.js';
+import { iterateChildren, updateColumnOrders } from './vaadin-grid-helpers.js';
 
 /**
  * @polymerMixin
@@ -304,11 +304,11 @@ export const ColumnReorderingMixin = (superClass) =>
      * @protected
      */
     _setSiblingsReorderStatus(column, status) {
-      Array.from(column.parentNode.children)
-        .filter((child) => /column/.test(child.localName) && this._isSwapAllowed(child, column))
-        .forEach((sibling) => {
+      iterateChildren(column.parentNode, (sibling) => {
+        if (/column/.test(sibling.localName) && this._isSwapAllowed(sibling, column)) {
           sibling._reorderStatus = status;
-        });
+        }
+      });
     }
 
     /** @protected */

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -5,7 +5,7 @@
  */
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
-import { updateRowAndCells } from './vaadin-grid-helpers.js';
+import { iterateChildren, updateRowAndCells } from './vaadin-grid-helpers.js';
 
 /**
  * @private
@@ -400,14 +400,14 @@ export const DataProviderMixin = (superClass) =>
             this._cache.updateSize();
             this._effectiveSize = this._cache.effectiveSize;
 
-            Array.from(this.$.items.children)
-              .filter((row) => !row.hidden)
-              .forEach((row) => {
+            iterateChildren(this.$.items, (row) => {
+              if (!row.hidden) {
                 const cachedItem = this._cache.getItemForIndex(row.index);
                 if (cachedItem) {
                   this._getItem(row.index, row);
                 }
-              });
+              }
+            });
 
             this.__scrollToPendingIndex();
           });

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { updateRowAndCells } from './vaadin-grid-helpers.js';
+import { iterateChildren, updateRowAndCells } from './vaadin-grid-helpers.js';
 
 const DropMode = {
   BETWEEN: 'between',
@@ -373,11 +373,11 @@ export const DragAndDropMixin = (superClass) =>
      * the conditions change.
      */
     filterDragAndDrop() {
-      Array.from(this.$.items.children)
-        .filter((row) => !row.hidden)
-        .forEach((row) => {
+      iterateChildren(this.$.items, (row) => {
+        if (!row.hidden) {
           this._filterDragAndDrop(row, this.__getRowModel(row));
-        });
+        }
+      });
     }
 
     /**
@@ -390,13 +390,11 @@ export const DragAndDropMixin = (superClass) =>
       const dragDisabled = !this.rowsDraggable || loading || (this.dragFilter && !this.dragFilter(model));
       const dropDisabled = !this.dropMode || loading || (this.dropFilter && !this.dropFilter(model));
 
-      const draggableElements = Array.from(row.children).map((cell) => cell._content);
-
-      draggableElements.forEach((e) => {
+      iterateChildren(row, (cell) => {
         if (dragDisabled) {
-          e.removeAttribute('draggable');
+          cell._content.removeAttribute('draggable');
         } else {
-          e.setAttribute('draggable', true);
+          cell._content.setAttribute('draggable', true);
         }
       });
 

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -309,7 +309,7 @@ export const DragAndDropMixin = (superClass) =>
     /** @protected */
     _clearDragStyles() {
       this.removeAttribute('dragover');
-      Array.from(this.$.items.children).forEach((row) => {
+      iterateChildren(this.$.items, (row) => {
         updateRowAndCells(row, 'dragover', null, true);
       });
     }

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -6,6 +6,14 @@
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 
 /**
+ * @param {HTMLElement} container the DOM element with children
+ * @param {Function} callback function to call on each child
+ */
+export function iterateChildren(container, callback) {
+  [...container.children].forEach(callback);
+}
+
+/**
  * @param {Array<Object>} columns array of columns to be modified
  * @param {number} scope multiplier added to base order for each column
  * @param {number} baseOrder base number used for order

--- a/packages/grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { iterateChildren } from './vaadin-grid-helpers.js';
 
 /**
  * @polymerMixin
@@ -78,7 +79,7 @@ export const RowDetailsMixin = (superClass) =>
 
       if (this._columnTree) {
         // Only update the rows if the column tree has already been initialized
-        Array.from(this.$.items.children).forEach((row) => {
+        iterateChildren(this.$.items, (row) => {
           if (!row.querySelector('[part~=details-cell]')) {
             this._updateRow(row, this._columnTree[this._columnTree.length - 1]);
             const isDetailsOpened = this._isDetailsOpened(row._item);
@@ -95,7 +96,7 @@ export const RowDetailsMixin = (superClass) =>
         return;
       }
 
-      [...this.$.items.children].forEach((row) => {
+      iterateChildren(this.$.items, (row) => {
         // Re-renders the row to possibly close the previously opened details.
         if (row.hasAttribute('details-opened')) {
           this._updateItem(row, row._item);
@@ -162,7 +163,7 @@ export const RowDetailsMixin = (superClass) =>
 
     /** @protected */
     _updateDetailsCellHeights() {
-      [...this.$.items.children].forEach((row) => {
+      iterateChildren(this.$.items, (row) => {
         this._updateDetailsCellHeight(row);
       });
     }

--- a/packages/grid/src/vaadin-grid-styling-mixin.js
+++ b/packages/grid/src/vaadin-grid-styling-mixin.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { iterateChildren } from './vaadin-grid-helpers.js';
 
 /**
  * @polymerMixin
@@ -49,14 +50,16 @@ export const StylingMixin = (superClass) =>
      * the conditions change.
      */
     generateCellClassNames() {
-      Array.from(this.$.items.children)
-        .filter((row) => !row.hidden && !row.hasAttribute('loading'))
-        .forEach((row) => this._generateCellClassNames(row, this.__getRowModel(row)));
+      iterateChildren(this.$.items, (row) => {
+        if (!row.hidden && !row.hasAttribute('loading')) {
+          this._generateCellClassNames(row, this.__getRowModel(row));
+        }
+      });
     }
 
     /** @private */
     _generateCellClassNames(row, model) {
-      Array.from(row.children).forEach((cell) => {
+      iterateChildren(row, (cell) => {
         if (cell.__generatedClasses) {
           cell.__generatedClasses.forEach((className) => cell.classList.remove(className));
         }

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -25,7 +25,7 @@ import { DragAndDropMixin } from './vaadin-grid-drag-and-drop-mixin.js';
 import { DynamicColumnsMixin } from './vaadin-grid-dynamic-columns-mixin.js';
 import { EventContextMixin } from './vaadin-grid-event-context-mixin.js';
 import { FilterMixin } from './vaadin-grid-filter-mixin.js';
-import { updateRowAndCells, updateRowBodyCellsPart } from './vaadin-grid-helpers.js';
+import { iterateChildren, updateRowAndCells, updateRowBodyCellsPart } from './vaadin-grid-helpers.js';
 import { KeyboardNavigationMixin } from './vaadin-grid-keyboard-navigation-mixin.js';
 import { RowDetailsMixin } from './vaadin-grid-row-details-mixin.js';
 import { ScrollMixin } from './vaadin-grid-scroll-mixin.js';
@@ -788,7 +788,7 @@ class Grid extends ElementMixin(
 
     const contentsFragment = document.createDocumentFragment();
 
-    Array.from(row.children).forEach((cell) => {
+    iterateChildren(row, (cell) => {
       cell._vacant = true;
     });
     row.innerHTML = '';
@@ -937,9 +937,9 @@ class Grid extends ElementMixin(
    * @protected
    */
   _renderColumnTree(columnTree) {
-    Array.from(this.$.items.children).forEach((row) =>
-      this._updateRow(row, columnTree[columnTree.length - 1], null, false, true),
-    );
+    iterateChildren(this.$.items, (row) => {
+      this._updateRow(row, columnTree[columnTree.length - 1], null, false, true);
+    });
 
     while (this.$.header.children.length < columnTree.length) {
       const headerRow = document.createElement('tr');
@@ -959,14 +959,14 @@ class Grid extends ElementMixin(
       this.$.footer.removeChild(this.$.footer.firstElementChild);
     }
 
-    Array.from(this.$.header.children).forEach((headerRow, index, rows) => {
+    iterateChildren(this.$.header, (headerRow, index, rows) => {
       this._updateRow(headerRow, columnTree[index], 'header', index === columnTree.length - 1);
 
       updateRowBodyCellsPart(headerRow, 'first-header-row-cell', index === 0);
       updateRowBodyCellsPart(headerRow, 'last-header-row-cell', index === rows.length - 1);
     });
 
-    Array.from(this.$.footer.children).forEach((footerRow, index, rows) => {
+    iterateChildren(this.$.footer, (footerRow, index, rows) => {
       this._updateRow(footerRow, columnTree[columnTree.length - 1 - index], 'footer', index === 0);
 
       updateRowBodyCellsPart(footerRow, 'first-footer-row-cell', index === 0);
@@ -1020,7 +1020,7 @@ class Grid extends ElementMixin(
     this._generateCellClassNames(row, model);
     this._filterDragAndDrop(row, model);
 
-    Array.from(row.children).forEach((cell) => {
+    iterateChildren(row, (cell) => {
       if (cell._renderer) {
         const owner = cell._column || this;
         cell._renderer.call(owner, cell._content, owner, model);


### PR DESCRIPTION
## Description

While working on #5020, I noticed that we use `Array.from(row.children)` and `[...row.children]` in grid quite a lot.
Created a small helper function to make the code a bit cleaner and updated a couple of occurrences to use it.

## Type of change

- Refactor