### PR TITLE
fix: do not set pointer events on rows and cells

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -820,7 +820,11 @@ export const KeyboardNavigationMixin = (superClass) =>
      * @private
      */
     __getFocusable(row, cell) {
-      return this.__rowFocusMode ? row : cell._focusButton || cell;
+      if (this.__rowFocusMode) {
+        return row;
+      }
+
+      return cell && cell._focusButton ? cell._focusButton : cell;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -781,6 +781,11 @@ export const KeyboardNavigationMixin = (superClass) =>
     /** @private */
     _onContentFocusIn(e) {
       const { section, cell, row } = this._getGridEventLocation(e);
+
+      if (!cell && !this.__rowFocusMode) {
+        return;
+      }
+
       this._detectInteracting(e);
 
       if (section && (cell || row)) {
@@ -820,11 +825,7 @@ export const KeyboardNavigationMixin = (superClass) =>
      * @private
      */
     __getFocusable(row, cell) {
-      if (this.__rowFocusMode) {
-        return row;
-      }
-
-      return cell && cell._focusButton ? cell._focusButton : cell;
+      return this.__rowFocusMode ? row : cell._focusButton || cell;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -116,7 +116,6 @@ registerStyles(
       width: 100%;
       box-sizing: border-box;
       margin: 0;
-      pointer-events: none;
     }
 
     [part~='row'][loading] [part~='body-cell'] ::slotted(vaadin-grid-cell-content) {
@@ -168,10 +167,6 @@ registerStyles(
       box-sizing: border-box;
       overflow: hidden;
       text-overflow: ellipsis;
-    }
-
-    [part~='cell'] {
-      pointer-events: initial;
     }
 
     [hidden] {


### PR DESCRIPTION
## Description

Fixed a regression from #4969 related to `pointer-events` issues when using `GridContextMenu` in Flow.
Note, this prevents an error from being thrown but doesn't fix the original issue from https://github.com/vaadin/web-components/pull/4969#discussion_r1019992767

UPD: the commit added by Tomi improves the PR so now it should be in good shape.

## Type of change

- Bugfix