### PR TITLE
fix: update parts when toggling column visibility

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -5,7 +5,7 @@
  */
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
-import { iterateChildren, updateRowAndCells } from './vaadin-grid-helpers.js';
+import { getBodyRowCells, iterateChildren, updateCellsPart, updateState } from './vaadin-grid-helpers.js';
 
 /**
  * @private
@@ -278,8 +278,13 @@ export const DataProviderMixin = (superClass) =>
      * @private
      */
     __updateLoading(row, loading) {
-      // Toggle row state (but not part), and set part for all the row body cells.
-      updateRowAndCells(row, 'loading', loading, false, null);
+      const cells = getBodyRowCells(row);
+
+      // Row state attribute
+      updateState(row, 'loading', loading);
+
+      // Cells part attribute
+      updateCellsPart(cells, 'loading-row-cell', loading);
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { iterateChildren, updateRowAndCells } from './vaadin-grid-helpers.js';
+import { iterateChildren, updateRowStates } from './vaadin-grid-helpers.js';
 
 const DropMode = {
   BETWEEN: 'between',
@@ -156,12 +156,12 @@ export const DragAndDropMixin = (superClass) =>
         // Set the default transfer data
         e.dataTransfer.setData('text', this.__formatDefaultTransferData(rows));
 
-        updateRowAndCells(row, 'dragstart', rows.length > 1 ? `${rows.length}` : '');
+        updateRowStates(row, { dragstart: rows.length > 1 ? `${rows.length}` : '' });
         this.style.setProperty('--_grid-drag-start-x', `${e.clientX - rowRect.left + 20}px`);
         this.style.setProperty('--_grid-drag-start-y', `${e.clientY - rowRect.top + 10}px`);
 
         requestAnimationFrame(() => {
-          updateRowAndCells(row, 'dragstart', null);
+          updateRowStates(row, { dragstart: null });
           this.style.setProperty('--_grid-drag-start-x', '');
           this.style.setProperty('--_grid-drag-start-y', '');
         });
@@ -255,7 +255,7 @@ export const DragAndDropMixin = (superClass) =>
         } else if (row) {
           this._dragOverItem = row._item;
           if (row.getAttribute('dragover') !== this._dropLocation) {
-            updateRowAndCells(row, 'dragover', this._dropLocation, true);
+            updateRowStates(row, { dragover: this._dropLocation }, true);
           }
         } else {
           this._clearDragStyles();
@@ -310,7 +310,7 @@ export const DragAndDropMixin = (superClass) =>
     _clearDragStyles() {
       this.removeAttribute('dragover');
       iterateChildren(this.$.items, (row) => {
-        updateRowAndCells(row, 'dragover', null, true);
+        updateRowStates(row, { dragover: null }, true);
       });
     }
 
@@ -398,8 +398,10 @@ export const DragAndDropMixin = (superClass) =>
         }
       });
 
-      updateRowAndCells(row, 'drag-disabled', !!dragDisabled);
-      updateRowAndCells(row, 'drop-disabled', !!dropDisabled);
+      updateRowStates(row, {
+        'drag-disabled': !!dragDisabled,
+        'drop-disabled': !!dropDisabled,
+      });
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -44,7 +44,7 @@ export function updateColumnOrders(columns, scope, baseOrder) {
  * @param {string} attribute
  * @param {boolean | string | null | undefined} value
  */
-function updateState(element, attribute, value) {
+export function updateState(element, attribute, value) {
   switch (typeof value) {
     case 'boolean':
       element.toggleAttribute(attribute, value);
@@ -85,25 +85,24 @@ export function updateCellsPart(cells, part, value) {
 
 /**
  * @param {!HTMLElement} row
- * @param {string} state
- * @param {boolean | string | null | undefined} value
+ * @param {Object} states
  * @param {boolean} appendValue
- * @param {string | null} setRowPart
  */
-export function updateRowAndCells(row, state, value, appendValue, setRowPart = true) {
-  // Toggle state attribute on the row
-  updateState(row, state, value);
-
-  const rowPart = appendValue ? `${state}-${value}-row` : `${state}-row`;
-
-  // Toggle part on the row if needed
-  if (setRowPart) {
-    updatePart(row, value, rowPart);
-  }
-
-  // Toggle part on the row body cells
+export function updateRowStates(row, states, appendValue) {
   const cells = getBodyRowCells(row);
-  updateCellsPart(cells, `${rowPart}-cell`, value);
+
+  Object.entries(states).forEach(([state, value]) => {
+    // Row state attribute
+    updateState(row, state, value);
+
+    const rowPart = appendValue ? `${state}-${value}-row` : `${state}-row`;
+
+    // Row part attribute
+    updatePart(row, value, rowPart);
+
+    // Cells part attribute
+    updateCellsPart(cells, `${rowPart}-cell`, value);
+  });
 }
 
 /**

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -6,6 +6,14 @@
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 
 /**
+ * @param {HTMLTableRowElement} row the table row
+ * @return {HTMLTableCellElement[]} array of cells
+ */
+export function getBodyRowCells(row) {
+  return Array.from(row.querySelectorAll('[part~="cell"]:not([part~="details-cell"])'));
+}
+
+/**
  * @param {HTMLElement} container the DOM element with children
  * @param {Function} callback function to call on each child
  */
@@ -65,12 +73,12 @@ function updatePart(element, value, part) {
 }
 
 /**
- * @param {!HTMLElement} row
+ * @param {HTMLTableCellElement[]} cells
  * @param {string} part
  * @param {boolean | string | null | undefined} value
  */
-export function updateRowBodyCellsPart(row, part, value) {
-  Array.from(row.querySelectorAll('[part~="cell"]:not([part~="details-cell"])')).forEach((cell) => {
+export function updateCellsPart(cells, part, value) {
+  cells.forEach((cell) => {
     updatePart(cell, value, part);
   });
 }
@@ -94,7 +102,8 @@ export function updateRowAndCells(row, state, value, appendValue, setRowPart = t
   }
 
   // Toggle part on the row body cells
-  updateRowBodyCellsPart(row, `${rowPart}-cell`, value);
+  const cells = getBodyRowCells(row);
+  updateCellsPart(cells, `${rowPart}-cell`, value);
 }
 
 /**

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -911,8 +911,6 @@ class Grid extends ElementMixin(
 
   /** @private */
   _updateScrollerItem(row, index) {
-    row._index = index;
-
     this._preventScrollerRotatingCellFocus(row, index);
 
     if (!this._columnTree) {
@@ -932,11 +930,18 @@ class Grid extends ElementMixin(
   }
 
   /** @private */
-  _updateRowOrderParts(row, index = row._index) {
+  _updateRowOrderParts(row, index = row.index) {
     updateRowAndCells(row, 'first', index === 0);
     updateRowAndCells(row, 'last', index === this._effectiveSize - 1);
     updateRowAndCells(row, 'odd', index % 2);
     updateRowAndCells(row, 'even', index % 2 === 0);
+  }
+
+  /** @private */
+  _updateRowStateParts(row, model) {
+    updateRowAndCells(row, 'expanded', model.expanded);
+    updateRowAndCells(row, 'selected', model.selected);
+    updateRowAndCells(row, 'details-opened', model.detailsOpened);
   }
 
   /**
@@ -946,8 +951,11 @@ class Grid extends ElementMixin(
   _renderColumnTree(columnTree) {
     iterateChildren(this.$.items, (row) => {
       this._updateRow(row, columnTree[columnTree.length - 1], null, false, true);
+
+      const model = this.__getRowModel(row);
       this._updateRowOrderParts(row);
-      this._filterDragAndDrop(row, this.__getRowModel(row));
+      this._updateRowStateParts(row, model);
+      this._filterDragAndDrop(row, model);
     });
 
     while (this.$.header.children.length < columnTree.length) {
@@ -1022,9 +1030,7 @@ class Grid extends ElementMixin(
     this._a11yUpdateRowLevel(row, model.level);
     this._a11yUpdateRowSelected(row, model.selected);
 
-    updateRowAndCells(row, 'expanded', model.expanded);
-    updateRowAndCells(row, 'selected', model.selected);
-    updateRowAndCells(row, 'details-opened', model.detailsOpened);
+    this._updateRowStateParts(row, model);
 
     this._generateCellClassNames(row, model);
     this._filterDragAndDrop(row, model);

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -25,7 +25,7 @@ import { DragAndDropMixin } from './vaadin-grid-drag-and-drop-mixin.js';
 import { DynamicColumnsMixin } from './vaadin-grid-dynamic-columns-mixin.js';
 import { EventContextMixin } from './vaadin-grid-event-context-mixin.js';
 import { FilterMixin } from './vaadin-grid-filter-mixin.js';
-import { getBodyRowCells, iterateChildren, updateCellsPart, updateRowAndCells } from './vaadin-grid-helpers.js';
+import { getBodyRowCells, iterateChildren, updateCellsPart, updateRowStates } from './vaadin-grid-helpers.js';
 import { KeyboardNavigationMixin } from './vaadin-grid-keyboard-navigation-mixin.js';
 import { RowDetailsMixin } from './vaadin-grid-row-details-mixin.js';
 import { ScrollMixin } from './vaadin-grid-scroll-mixin.js';
@@ -931,17 +931,21 @@ class Grid extends ElementMixin(
 
   /** @private */
   _updateRowOrderParts(row, index = row.index) {
-    updateRowAndCells(row, 'first', index === 0);
-    updateRowAndCells(row, 'last', index === this._effectiveSize - 1);
-    updateRowAndCells(row, 'odd', index % 2);
-    updateRowAndCells(row, 'even', index % 2 === 0);
+    updateRowStates(row, {
+      first: index === 0,
+      last: index === this._effectiveSize - 1,
+      odd: index % 2,
+      even: index % 2 === 0,
+    });
   }
 
   /** @private */
-  _updateRowStateParts(row, model) {
-    updateRowAndCells(row, 'expanded', model.expanded);
-    updateRowAndCells(row, 'selected', model.selected);
-    updateRowAndCells(row, 'details-opened', model.detailsOpened);
+  _updateRowStateParts(row, { expanded, selected, detailsOpened }) {
+    updateRowStates(row, {
+      expanded,
+      selected,
+      'details-opened': detailsOpened,
+    });
   }
 
   /**

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -911,16 +911,15 @@ class Grid extends ElementMixin(
 
   /** @private */
   _updateScrollerItem(row, index) {
+    row._index = index;
+
     this._preventScrollerRotatingCellFocus(row, index);
 
     if (!this._columnTree) {
       return;
     }
 
-    updateRowAndCells(row, 'first', index === 0);
-    updateRowAndCells(row, 'last', index === this._effectiveSize - 1);
-    updateRowAndCells(row, 'odd', index % 2);
-    updateRowAndCells(row, 'even', index % 2 === 0);
+    this._updateRowOrderParts(row, index);
 
     this._a11yUpdateRowRowindex(row, index);
     this._getItem(index, row);
@@ -932,6 +931,14 @@ class Grid extends ElementMixin(
     this.recalculateColumnWidths();
   }
 
+  /** @private */
+  _updateRowOrderParts(row, index = row._index) {
+    updateRowAndCells(row, 'first', index === 0);
+    updateRowAndCells(row, 'last', index === this._effectiveSize - 1);
+    updateRowAndCells(row, 'odd', index % 2);
+    updateRowAndCells(row, 'even', index % 2 === 0);
+  }
+
   /**
    * @param {!Array<!GridColumn>} columnTree
    * @protected
@@ -939,6 +946,8 @@ class Grid extends ElementMixin(
   _renderColumnTree(columnTree) {
     iterateChildren(this.$.items, (row) => {
       this._updateRow(row, columnTree[columnTree.length - 1], null, false, true);
+      this._updateRowOrderParts(row);
+      this._filterDragAndDrop(row, this.__getRowModel(row));
     });
 
     while (this.$.header.children.length < columnTree.length) {

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -25,7 +25,7 @@ import { DragAndDropMixin } from './vaadin-grid-drag-and-drop-mixin.js';
 import { DynamicColumnsMixin } from './vaadin-grid-dynamic-columns-mixin.js';
 import { EventContextMixin } from './vaadin-grid-event-context-mixin.js';
 import { FilterMixin } from './vaadin-grid-filter-mixin.js';
-import { iterateChildren, updateRowAndCells, updateRowBodyCellsPart } from './vaadin-grid-helpers.js';
+import { getBodyRowCells, iterateChildren, updateCellsPart, updateRowAndCells } from './vaadin-grid-helpers.js';
 import { KeyboardNavigationMixin } from './vaadin-grid-keyboard-navigation-mixin.js';
 import { RowDetailsMixin } from './vaadin-grid-row-details-mixin.js';
 import { ScrollMixin } from './vaadin-grid-scroll-mixin.js';
@@ -979,15 +979,17 @@ class Grid extends ElementMixin(
     iterateChildren(this.$.header, (headerRow, index, rows) => {
       this._updateRow(headerRow, columnTree[index], 'header', index === columnTree.length - 1);
 
-      updateRowBodyCellsPart(headerRow, 'first-header-row-cell', index === 0);
-      updateRowBodyCellsPart(headerRow, 'last-header-row-cell', index === rows.length - 1);
+      const cells = getBodyRowCells(headerRow);
+      updateCellsPart(cells, 'first-header-row-cell', index === 0);
+      updateCellsPart(cells, 'last-header-row-cell', index === rows.length - 1);
     });
 
     iterateChildren(this.$.footer, (footerRow, index, rows) => {
       this._updateRow(footerRow, columnTree[columnTree.length - 1 - index], 'footer', index === 0);
 
-      updateRowBodyCellsPart(footerRow, 'first-footer-row-cell', index === 0);
-      updateRowBodyCellsPart(footerRow, 'last-footer-row-cell', index === rows.length - 1);
+      const cells = getBodyRowCells(footerRow);
+      updateCellsPart(cells, 'first-footer-row-cell', index === 0);
+      updateCellsPart(cells, 'last-footer-row-cell', index === rows.length - 1);
     });
 
     // Sizer rows

--- a/packages/grid/test/basic.test.js
+++ b/packages/grid/test/basic.test.js
@@ -207,7 +207,7 @@ describe('basic features', () => {
     expect(window.getComputedStyle(grid).getPropertyValue('flex-basis')).to.equal('auto');
   });
 
-  it('should have attribute last on the last body row', () => {
+  it.only('should have attribute last on the last body row', () => {
     grid.scrollToIndex(grid.size - 1);
     const lastRowSlot = grid.shadowRoot.querySelector('[part~="row"][last] slot');
     expect(lastRowSlot.assignedNodes()[0].textContent).to.equal(String(grid.size - 1));

--- a/packages/grid/test/basic.test.js
+++ b/packages/grid/test/basic.test.js
@@ -207,7 +207,7 @@ describe('basic features', () => {
     expect(window.getComputedStyle(grid).getPropertyValue('flex-basis')).to.equal('auto');
   });
 
-  it.only('should have attribute last on the last body row', () => {
+  it('should have attribute last on the last body row', () => {
     grid.scrollToIndex(grid.size - 1);
     const lastRowSlot = grid.shadowRoot.querySelector('[part~="row"][last] slot');
     expect(lastRowSlot.assignedNodes()[0].textContent).to.equal(String(grid.size - 1));

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -661,3 +661,160 @@ snapshots["vaadin-grid shadow details opened"] =
 `;
 /* end snapshot vaadin-grid shadow details opened */
 
+snapshots["vaadin-grid shadow hidden column"] = 
+`<div
+  id="scroller"
+  scrolling=""
+  style="touch-action: none;"
+>
+  <table
+    aria-colcount="2"
+    aria-multiselectable="true"
+    aria-rowcount="3"
+    id="table"
+    role="treegrid"
+    tabindex="0"
+  >
+    <caption
+      id="sizer"
+      part="row"
+    >
+    </caption>
+    <tbody>
+      <tr>
+        <td
+          first-column=""
+          id="vaadin-grid-cell-5"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-5">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <thead
+      id="header"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="1"
+        part="row"
+        role="row"
+        tabindex="-1"
+      >
+        <th
+          first-column=""
+          id="vaadin-grid-cell-1"
+          last-column=""
+          part="cell header-cell first-column-cell last-column-cell first-header-row-cell last-header-row-cell"
+          role="columnheader"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-1">
+          </slot>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      id="items"
+      role="rowgroup"
+      style="transform: translate(0px, 0px); height: 71px;"
+    >
+      <tr
+        aria-rowindex="2"
+        aria-selected="false"
+        drag-disabled=""
+        drop-disabled=""
+        even=""
+        first=""
+        part="row first-row even-row drag-disabled-row drop-disabled-row"
+        role="row"
+        style="position: absolute; transform: translateY(0px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="false"
+          first-column=""
+          id="vaadin-grid-cell-7"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-7">
+          </slot>
+        </td>
+      </tr>
+      <tr
+        aria-rowindex="3"
+        aria-selected="false"
+        drag-disabled=""
+        drop-disabled=""
+        last=""
+        part="row last-row odd-row drag-disabled-row drop-disabled-row"
+        role="row"
+        style="position: absolute; transform: translateY(35px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="false"
+          first-column=""
+          id="vaadin-grid-cell-9"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-9">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      id="footer"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="4"
+        hidden=""
+        part="row"
+        role="row"
+        tabindex="-1"
+      >
+        <td
+          first-column=""
+          id="vaadin-grid-cell-3"
+          last-column=""
+          part="cell footer-cell first-column-cell last-column-cell first-footer-row-cell last-footer-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-3">
+          </slot>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <div part="reorder-ghost">
+  </div>
+</div>
+<slot name="tooltip">
+</slot>
+<div
+  id="focusexit"
+  tabindex="0"
+>
+</div>
+`;
+/* end snapshot vaadin-grid shadow hidden column */
+

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -331,21 +331,22 @@ snapshots["vaadin-grid shadow selected"] =
     >
       <tr
         aria-rowindex="2"
-        aria-selected="false"
+        aria-selected="true"
         drag-disabled=""
         drop-disabled=""
         even=""
         first=""
-        part="row first-row even-row drag-disabled-row drop-disabled-row"
+        part="row first-row even-row drag-disabled-row drop-disabled-row selected-row"
         role="row"
+        selected=""
         style="position: absolute; transform: translateY(0px);"
         tabindex="-1"
       >
         <td
-          aria-selected="false"
+          aria-selected="true"
           first-column=""
           id="vaadin-grid-cell-6"
-          part="cell body-cell first-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          part="cell body-cell first-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell selected-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1; order: 10000000;"
           tabindex="0"
@@ -354,10 +355,10 @@ snapshots["vaadin-grid shadow selected"] =
           </slot>
         </td>
         <td
-          aria-selected="false"
+          aria-selected="true"
           id="vaadin-grid-cell-7"
           last-column=""
-          part="cell body-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          part="cell body-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell selected-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1; order: 20000000;"
           tabindex="-1"
@@ -817,4 +818,162 @@ snapshots["vaadin-grid shadow hidden column"] =
 </div>
 `;
 /* end snapshot vaadin-grid shadow hidden column */
+
+snapshots["vaadin-grid shadow hidden column selected"] = 
+`<div
+  id="scroller"
+  scrolling=""
+  style="touch-action: none;"
+>
+  <table
+    aria-colcount="2"
+    aria-multiselectable="true"
+    aria-rowcount="3"
+    id="table"
+    role="treegrid"
+    tabindex="0"
+  >
+    <caption
+      id="sizer"
+      part="row"
+    >
+    </caption>
+    <tbody>
+      <tr>
+        <td
+          first-column=""
+          id="vaadin-grid-cell-5"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-5">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <thead
+      id="header"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="1"
+        part="row"
+        role="row"
+        tabindex="-1"
+      >
+        <th
+          first-column=""
+          id="vaadin-grid-cell-1"
+          last-column=""
+          part="cell header-cell first-column-cell last-column-cell first-header-row-cell last-header-row-cell"
+          role="columnheader"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-1">
+          </slot>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      id="items"
+      role="rowgroup"
+      style="transform: translate(0px, 0px); height: 71px;"
+    >
+      <tr
+        aria-rowindex="2"
+        aria-selected="true"
+        drag-disabled=""
+        drop-disabled=""
+        even=""
+        first=""
+        part="row first-row even-row drag-disabled-row drop-disabled-row selected-row"
+        role="row"
+        selected=""
+        style="position: absolute; transform: translateY(0px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="true"
+          first-column=""
+          id="vaadin-grid-cell-7"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell first-row-cell even-row-cell selected-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-7">
+          </slot>
+        </td>
+      </tr>
+      <tr
+        aria-rowindex="3"
+        aria-selected="false"
+        drag-disabled=""
+        drop-disabled=""
+        last=""
+        part="row last-row odd-row drag-disabled-row drop-disabled-row"
+        role="row"
+        style="position: absolute; transform: translateY(35px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="false"
+          first-column=""
+          id="vaadin-grid-cell-9"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-9">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      id="footer"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="4"
+        hidden=""
+        part="row"
+        role="row"
+        tabindex="-1"
+      >
+        <td
+          first-column=""
+          id="vaadin-grid-cell-3"
+          last-column=""
+          part="cell footer-cell first-column-cell last-column-cell first-footer-row-cell last-footer-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1; order: 20000000;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-3">
+          </slot>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <div part="reorder-ghost">
+  </div>
+</div>
+<slot name="tooltip">
+</slot>
+<div
+  id="focusexit"
+  tabindex="0"
+>
+</div>
+`;
+/* end snapshot vaadin-grid shadow hidden column selected */
 

--- a/packages/grid/test/dom/grid.test.js
+++ b/packages/grid/test/dom/grid.test.js
@@ -29,7 +29,7 @@ describe('vaadin-grid', () => {
     });
 
     it('selected', async () => {
-      grid.selected = [grid.items[0]];
+      grid.selectedItems = [grid.items[0]];
       await expect(grid).shadowDom.to.equalSnapshot();
     });
 
@@ -39,6 +39,13 @@ describe('vaadin-grid', () => {
     });
 
     it('hidden column', async () => {
+      grid.querySelector('vaadin-grid-column').hidden = true;
+      await nextFrame();
+      await expect(grid).shadowDom.to.equalSnapshot();
+    });
+
+    it('hidden column selected', async () => {
+      grid.selectedItems = [grid.items[0]];
       grid.querySelector('vaadin-grid-column').hidden = true;
       await nextFrame();
       await expect(grid).shadowDom.to.equalSnapshot();

--- a/packages/grid/test/dom/grid.test.js
+++ b/packages/grid/test/dom/grid.test.js
@@ -37,5 +37,11 @@ describe('vaadin-grid', () => {
       grid.detailsOpenedItems = [grid.items[0]];
       await expect(grid).shadowDom.to.equalSnapshot();
     });
+
+    it('hidden column', async () => {
+      grid.querySelector('vaadin-grid-column').hidden = true;
+      await nextFrame();
+      await expect(grid).shadowDom.to.equalSnapshot();
+    });
   });
 });


### PR DESCRIPTION
## Description

While working on #5067, I found an issue: some cell parts are reset when setting `hidden` on the column element.
In particular, the following part names related to various row states are currently affected by this problem:

- `first-row-cell` 
- `even-row-cell` 
- `last-row-cell` 
- `odd-row-cell`
- `drag-disabled-row-cell`
- `drop-disabled-row-cell`
- `selected-row-cell`
- `expanded-row-cell`
- `details-opened-row-cell`

Previously, this wasn't a problem as `<tr>` element is always there. Now we need to also update `<td>` elements.

## Type of change

- Bugfix