### PR TITLE
chore: add eslint-plugin-no-only-tests to ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
   "plugins": [
     "prettier",
     "@typescript-eslint",
+    "no-only-tests",
     "simple-import-sort"
   ],
   "extends": [
@@ -19,6 +20,7 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
+    "no-only-tests/no-only-tests": "error",
     "simple-import-sort/imports": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dotenv": "^16.0.3",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-simple-import-sort": "^8.0.0",
     "glob": "^8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4753,6 +4753,11 @@ eslint-config-prettier@^8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
+eslint-plugin-no-only-tests@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz#f38e4935c6c6c4842bf158b64aaa20c366fe171b"
+  integrity sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==
+
 eslint-plugin-prettier@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"


### PR DESCRIPTION
## Description

Sometimes I tend to push commits containing `it.only` debugging leftovers. Added a plugin to catch these.

## Type of change

- Internal change