### PR TITLE
fix: ignore empty text nodes passed to default slot

### DIFF
--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -192,6 +192,9 @@ export class SlotController extends EventTarget {
 
     this.__slotObserver = new FlattenedNodesObserver(slot, (info) => {
       const current = this.multiple ? this.nodes : [this.node];
+
+      // Calling `slot.assignedNodes()` includes whitespace text nodes in case of default slot:
+      // unlike comment nodes, they are not filtered out. So we need to manually ignore them.
       const newNodes = info.addedNodes.filter((node) => !isEmptyTextNode(node) && !current.includes(node));
 
       if (info.removedNodes.length) {

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
+import { isEmptyTextNode } from './dom-utils.js';
 import { generateUniqueId } from './unique-id-utils.js';
 
 /**
@@ -191,7 +192,7 @@ export class SlotController extends EventTarget {
 
     this.__slotObserver = new FlattenedNodesObserver(slot, (info) => {
       const current = this.multiple ? this.nodes : [this.node];
-      const newNodes = info.addedNodes.filter((node) => !current.includes(node));
+      const newNodes = info.addedNodes.filter((node) => !isEmptyTextNode(node) && !current.includes(node));
 
       if (info.removedNodes.length) {
         info.removedNodes.forEach((node) => {

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -146,7 +146,9 @@ describe('slot-controller', () => {
           render() {
             return html`
               <default-slot-element>
+                <!-- Keep this comment and surrounding whitespace text nodes -->
                 <div>baz</div>
+                <!-- Keep this comment and surrounding whitespace text nodes -->
               </default-slot-element>
             `;
           }


### PR DESCRIPTION
## Description

Fixed an issue with empty text nodes causing an element to be removed from the default slot.
This is currently the case with `vaadin-grid-filter`, see [internal Slack thread](https://vaadin.slack.com/archives/C3TGRP4HY/p1669190392554569?thread_ts=1669104945.546699&cid=C3TGRP4HY).

## Type of change

- Bugfix