### PR TITLE
test: update grid filter tests to use LitElement

### DIFF
--- a/packages/grid/test/filtering.test.js
+++ b/packages/grid/test/filtering.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-grid.js';
 import '../vaadin-grid-filter.js';
@@ -86,12 +86,9 @@ describe('filter', () => {
   });
 
   it('should update filter value on input event', async () => {
-    const spy = sinon.spy();
-    filter.addEventListener('filter-changed', spy);
-
     const input = filter.querySelector('input');
     input.value = 'foo';
-    input.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
+    fire(input, 'input');
 
     await clock.tickAsync(200);
     expect(filter.value).to.equal('foo');


### PR DESCRIPTION
## Description

Based on #5072

Updated tests for `vaadin-grid-filter` to verify the fix for `SlotController` (without the fix, two tests would fail).
Also changed to use fake timers instead of waiting for `_debouncerFilterChanged` or calling `flush()`manually.

## Type of change

- Tests