### PR TITLE
fix!: don't override root em

### DIFF
--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -29,7 +29,7 @@ const font = css`
 `;
 
 const typography = css`
-  html,
+  body,
   :host {
     font-family: var(--lumo-font-family);
     font-size: var(--lumo-font-size, var(--lumo-font-size-m));

--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -32,7 +32,7 @@ const typography = css`
   body,
   :host {
     font-family: var(--lumo-font-family);
-    font-size: var(--lumo-font-size, var(--lumo-font-size-m));
+    font-size: var(--lumo-font-size-m);
     line-height: var(--lumo-line-height-m);
     -webkit-text-size-adjust: 100%;
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
The initial implementation of Lumo was problematic from the start, as we set the font-size of the `html` element and therefore redefined the root em `rem` size.

We should instead target the `body` element, and preserve the `16px` default root em size.

Remove the use of the deprecated `--lumo-font-size` custom property as well.