### PR TITLE
fix: clear value when committing invalid input

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -399,10 +399,7 @@ export const DatePickerMixin = (subclass) =>
 
       if (!this.opened) {
         if (this.autoOpenDisabled) {
-          const parsedDate = this._getParsedDate();
-          if (this._isValidDate(parsedDate)) {
-            this._selectDate(parsedDate);
-          }
+          this._selectParsedOrFocusedDate();
         }
 
         this.validate();
@@ -1023,21 +1020,15 @@ export const DatePickerMixin = (subclass) =>
      * @override
      */
     _onEnter(_event) {
-      const parsedDate = this._getParsedDate();
-      const isValidDate = this._isValidDate(parsedDate);
+      const oldValue = this.value;
       if (this.opened) {
-        if (this._overlayContent && this._overlayContent.focusedDate && isValidDate) {
-          this._selectDate(this._overlayContent.focusedDate);
-        }
+        // Closing will implicitly select parsed or focused date
         this.close();
-      } else if (!isValidDate && this.inputElement.value !== '') {
-        this.validate();
       } else {
-        const oldValue = this.value;
         this._selectParsedOrFocusedDate();
-        if (oldValue === this.value) {
-          this.validate();
-        }
+      }
+      if (oldValue === this.value) {
+        this.validate();
       }
     }
 

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -913,7 +913,7 @@ describe('keyboard', () => {
           input.select();
           await sendKeys({ press: 'Backspace' });
           await sendKeys({ press: 'Tab' });
-          expect(validateSpy.calledOnce).to.be.true;
+          expect(validateSpy.called).to.be.true;
           expect(changeSpy.calledOnce).to.be.true;
           expect(changeSpy.calledAfter(validateSpy)).to.be.true;
         });

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -262,18 +262,44 @@ describe('validation', () => {
       expect(datePicker.inputElement.value).to.equal('foo');
     });
 
-    it('should be valid on blur after entering a valid date', () => {
-      datePicker.autoOpenDisabled = true;
-      setInputValue(datePicker, '1/1/2022');
-      datePicker.inputElement.blur();
-      expect(datePicker.invalid).to.be.false;
-    });
+    describe('auto-open disabled', () => {
+      beforeEach(() => {
+        datePicker.autoOpenDisabled = true;
+      });
 
-    it('should be invalid on blur after entering an invalid date', () => {
-      datePicker.autoOpenDisabled = true;
-      setInputValue(datePicker, 'foo');
-      datePicker.inputElement.blur();
-      expect(datePicker.invalid).to.be.true;
+      it('should set an empty value when trying to commit an invalid date with enter', () => {
+        datePicker.autoOpenDisabled = true;
+        datePicker.value = '2020-01-01';
+        setInputValue(datePicker, 'foo');
+        enter(datePicker.inputElement);
+        expect(datePicker.value).to.equal('');
+        expect(datePicker.inputElement.value).to.equal('foo');
+        expect(datePicker.invalid).to.be.true;
+      });
+
+      it('should set an empty value when trying to commit an invalid date with blur', () => {
+        datePicker.autoOpenDisabled = true;
+        datePicker.value = '2020-01-01';
+        setInputValue(datePicker, 'foo');
+        datePicker.inputElement.blur();
+        expect(datePicker.value).to.equal('');
+        expect(datePicker.inputElement.value).to.equal('foo');
+        expect(datePicker.invalid).to.be.true;
+      });
+
+      it('should be valid on blur after entering a valid date', () => {
+        datePicker.autoOpenDisabled = true;
+        setInputValue(datePicker, '1/1/2022');
+        datePicker.inputElement.blur();
+        expect(datePicker.invalid).to.be.false;
+      });
+
+      it('should be invalid on blur after entering an invalid date', () => {
+        datePicker.autoOpenDisabled = true;
+        setInputValue(datePicker, 'foo');
+        datePicker.inputElement.blur();
+        expect(datePicker.invalid).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

By default, the date picker clears the value when trying to commit an invalid input. This fix applies the same behavior when using `auto-open-disabled`.

Fixes https://github.com/vaadin/web-components/issues/5066

## Type of change

- Bugfix