### PR TITLE
fix: inflate functions passed to __callXXXFunction methods

### DIFF
--- a/packages/charts/src/helpers.js
+++ b/packages/charts/src/helpers.js
@@ -1,0 +1,24 @@
+export function inflateFunctions(config) {
+  if (
+    // Check if param is a primitive/null/undefined value
+    !(config instanceof Object) ||
+    // Check if param is a plain object (not an array or HC object)
+    config.constructor !== Object
+  ) {
+    return;
+  }
+  Object.entries(config).forEach(([attr, targetProperty]) => {
+    if (attr.startsWith('_fn_') && (typeof targetProperty === 'string' || targetProperty instanceof String)) {
+      try {
+        // eslint-disable-next-line no-eval
+        config[attr.substr(4)] = eval(`(${targetProperty})`);
+      } catch (e) {
+        // eslint-disable-next-line no-eval
+        config[attr.substr(4)] = eval(`(function(){${targetProperty}})`);
+      }
+      delete config[attr];
+    } else if (targetProperty instanceof Object) {
+      inflateFunctions(targetProperty);
+    }
+  });
+}


### PR DESCRIPTION
## Description

Make the objects passed to the `__callXXXFunction` method go through the same "inflate" process done with the configuration object sent from the server. That is needed because objects containing properties with the `_fn_` format might be passed to these functions.

Some refactoring done in the process:
- Move the `__inflateFunctions` method to a helper file to make it easier to be used by both instance and static methods
- Add some checks to `inflateFunctions` to make the logic to be performed only on plain objects (avoiding primitives/`null`/`undefined` and HighCharts instances that may contain circular reference)
- Make the necessary changes on the tests 

Part of #3867

## Type of change

- [X] Bugfix
- [ ] Feature
