### PR TITLE
fix: ignore sorter click if event is canceled

### DIFF
--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -224,6 +224,11 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
 
   /** @private */
   _onClick(e) {
+    if (e.defaultPrevented) {
+      // Something else has already handled the click event, do nothing.
+      return;
+    }
+
     const activeElement = this.getRootNode().activeElement;
     if (this !== activeElement && this.contains(activeElement)) {
       // Some focusable content inside the sorter was clicked, do nothing.

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -16,7 +16,7 @@ import {
 
 describe('sorting', () => {
   describe('sorter', () => {
-    let sorter, button, orderIndicator;
+    let sorter, title, button, orderIndicator;
 
     beforeEach(() => {
       sorter = fixtureSync(`
@@ -25,6 +25,7 @@ describe('sorting', () => {
         </vaadin-grid-sorter>
       `);
       button = sorter.querySelector('button');
+      title = sorter.querySelector('.title');
       orderIndicator = sorter.shadowRoot.querySelector('[part="order"]');
     });
 
@@ -44,6 +45,12 @@ describe('sorting', () => {
     it('should not toggle on focusable click', () => {
       button.focus();
       click(button);
+      expect(sorter.direction).to.equal(null);
+    });
+
+    it('should not toggle if click event is already consumed', () => {
+      title.addEventListener('click', (e) => e.preventDefault());
+      click(title);
       expect(sorter.direction).to.equal(null);
     });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/4170

In the case of clicking a `<vaadin-select>` (wrapped inside a `<vaadin-grid-sorter>`), the native focus is moved right away inside the select overlay

https://user-images.githubusercontent.com/1222264/204773246-fd4c4f6c-5c84-42ea-af1d-734b164ad0da.mp4

...so [the existing check that reacts on internal focusable clicks](https://github.com/vaadin/web-components/blob/c37e4da6a1afa4c78371bba121373f62458e69cf/packages/grid/src/vaadin-grid-sorter.js#L227-L231) didn't stop the event from being consumed by the sorter. 

This PR fixes the issue by adding another check which stops the processing in case something else has already canceled the event.

## Type of change

Bugfix