### PR TITLE
refactor!: re-implement details and accordion structure

### DIFF
--- a/dev/accordion.html
+++ b/dev/accordion.html
@@ -9,21 +9,22 @@
 
     <script type="module">
       import '@vaadin/accordion';
+      // import '@vaadin/accordion/theme/material/vaadin-accordion.js';
     </script>
   </head>
 
   <body>
     <vaadin-accordion>
       <vaadin-accordion-panel>
-        <div slot="summary">Panel 1</div>
+        <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>
         Panel 1 content
       </vaadin-accordion-panel>
       <vaadin-accordion-panel>
-        <div slot="summary">Panel 2</div>
+        <vaadin-accordion-heading slot="summary">Panel 2</vaadin-accordion-heading>
         Panel 2 content
       </vaadin-accordion-panel>
       <vaadin-accordion-panel>
-        <div slot="summary">Panel 3</div>
+        <vaadin-accordion-heading slot="summary">Panel 3</vaadin-accordion-heading>
         Panel 3 content
       </vaadin-accordion-panel>
     </vaadin-accordion>

--- a/dev/details.html
+++ b/dev/details.html
@@ -10,13 +10,15 @@
     <script type="module">
       import '@vaadin/details';
       import '@vaadin/tooltip';
+      // import '@vaadin/details/theme/material/vaadin-details.js';
+      // import '@vaadin/tooltip/theme/material/vaadin-tooltip.js';
     </script>
   </head>
 
   <body>
     <vaadin-details>
-      <div slot="summary">Expandable Details</div>
-      Toggle using mouse, Enter and Space keys.
+      <vaadin-details-summary slot="summary">Expandable Details</vaadin-details-summary>
+      <div>Toggle using mouse, Enter and Space keys.</div>
       <vaadin-tooltip slot="tooltip" text="Click to toggle"></vaadin-tooltip>
     </vaadin-details>
   </body>

--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -49,7 +49,12 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
     position: 'top',
     applyShouldNotShowCondition: (element) => element.querySelector('input').click(),
   },
-  { tagName: Details.is, targetSelector: '[part="summary"]', position: 'bottom-start' },
+  {
+    tagName: Details.is,
+    children: '<vaadin-details-summary slot="summary"></vaadin-details-summary>',
+    targetSelector: '[slot="summary"]',
+    position: 'bottom-start',
+  },
   { tagName: EmailField.is, position: 'top' },
   { tagName: Icon.is },
   { tagName: IntegerField.is, position: 'top' },
@@ -88,7 +93,7 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
     });
 
     it('should set tooltip target', () => {
-      const target = targetSelector ? element.shadowRoot.querySelector(targetSelector) : element;
+      const target = targetSelector ? element.querySelector(targetSelector) : element;
       expect(tooltip.target).to.equal(target);
     });
 

--- a/integration/tests/dialog-accordion.test.js
+++ b/integration/tests/dialog-accordion.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';
 import '@vaadin/accordion';
@@ -14,12 +14,14 @@ describe('accordion in dialog', () => {
       root.innerHTML = `
         <vaadin-accordion>
           <vaadin-accordion-panel>
-            <div slot="summary">Panel 1</div>
-            <button>Button 1</button>
+            <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>
+            <div>
+              <input type="text" placeholder="Input 1" />
+            </div>
           </vaadin-accordion-panel>
           <vaadin-accordion-panel>
-            <div slot="summary">Panel 2</div>
-            <button>Button 2</button>
+            <vaadin-accordion-heading slot="summary">Panel 2</vaadin-accordion-heading>
+            <div>Content 2</div>
           </vaadin-accordion-panel>
         </vaadin-accordion>
       `;
@@ -27,7 +29,7 @@ describe('accordion in dialog', () => {
     dialog.opened = true;
     overlay = dialog.$.overlay;
     await oneEvent(overlay, 'vaadin-overlay-open');
-    await nextFrame();
+    await nextRender();
     accordion = overlay.querySelector('vaadin-accordion');
     panels = accordion.items;
   });
@@ -35,23 +37,23 @@ describe('accordion in dialog', () => {
   it('should move focus from panel heading to content on Tab', async () => {
     // Focus first panel (opened)
     await sendKeys({ press: 'Tab' });
-    expect(document.activeElement).to.equal(panels[0]);
+    expect(document.activeElement).to.equal(panels[0].focusElement);
 
     // Move focus to the content
     await sendKeys({ press: 'Tab' });
-    expect(document.activeElement).to.equal(panels[0].querySelector('button'));
+    expect(document.activeElement).to.equal(panels[0].querySelector('input'));
   });
 
   it('should move focus from panel content to heading on Shift + Tab', async () => {
     // Focus the first panel content
-    panels[0].querySelector('button').focus();
+    panels[0].querySelector('input').focus();
 
     // Move focus back to heading
     await sendKeys({ down: 'Shift' });
     await sendKeys({ press: 'Tab' });
     await sendKeys({ up: 'Shift' });
 
-    expect(document.activeElement).to.equal(panels[0]);
+    expect(document.activeElement).to.equal(panels[0].focusElement);
   });
 
   it('should skip focusable element in closed panel on Tab', async () => {
@@ -59,11 +61,11 @@ describe('accordion in dialog', () => {
 
     // Focus first panel (closed)
     await sendKeys({ press: 'Tab' });
-    expect(document.activeElement).to.equal(panels[0]);
+    expect(document.activeElement).to.equal(panels[0].focusElement);
 
     // Focus second panel (opened)
     await sendKeys({ press: 'Tab' });
-    expect(document.activeElement).to.equal(panels[1]);
+    expect(document.activeElement).to.equal(panels[1].focusElement);
   });
 
   it('should skip focusable element in closed panel on Shift + Tab', async () => {
@@ -77,6 +79,6 @@ describe('accordion in dialog', () => {
     await sendKeys({ press: 'Tab' });
     await sendKeys({ up: 'Shift' });
 
-    expect(document.activeElement).to.equal(panels[0]);
+    expect(document.activeElement).to.equal(panels[0].focusElement);
   });
 });

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -10,11 +10,11 @@ A web component for displaying a vertically stacked set of expandable panels.
 ```html
 <vaadin-accordion>
   <vaadin-accordion-panel theme="filled">
-    <div slot="summary">Accordion Panel 1</div>
+    <vaadin-accordion-heading slot="summary">Accordion Panel 1</vaadin-accordion-heading>
     <div>Accordion is a set of expandable sections.</div>
   </vaadin-accordion-panel>
   <vaadin-accordion-panel theme="filled">
-    <div slot="summary">Accordion Panel 2</div>
+    <vaadin-accordion-heading slot="summary">Accordion Panel 2</vaadin-accordion-heading>
     <div>Only one accordion panel can be opened.</div>
   </vaadin-accordion-panel>
 </vaadin-accordion>

--- a/packages/accordion/src/vaadin-accordion-heading.d.ts
+++ b/packages/accordion/src/vaadin-accordion-heading.d.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * The accordion heading element.
+ *
+ * `vaadin-accordion-heading` is the element for the headings in the accordion.
+ * As recommended by the WAI ARIA Best Practices, each heading needs to wrap a
+ * `<button>`. This element puts that button in the Shadow DOM, as it is more
+ * convenient to use and doesn’t make styling of the heading more problematic.
+ *
+ * The WAI ARIA Best Practices also recommend setting `aria-level` depending
+ * on what level the headings are. It is hard to determine the level of a heading
+ * algorithmically, and setting it is not strictly required to have an accessible
+ * accordion. To keep things easier to use, this element does not set `aria-level`
+ * attribute but leaves that to the developer creating an accordion.
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are exposed for styling:
+ *
+ * Part name  | Description
+ * -----------|-------------------
+ * `toggle`   | The icon element
+ * `content`  | The content wrapper
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute    | Description
+ * -------------| -----------
+ * `active`     | Set when the element is pressed down, either with mouse, touch or the keyboard.
+ * `opened`     | Set when the collapsible content is expanded and visible.
+ * `disabled`   | Set when the element is disabled.
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
+ *
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ */
+declare class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(HTMLElement))) {
+  /**
+   * When true, the element is opened.
+   */
+  opened: boolean;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-accordion-heading': AccordionHeading;
+  }
+}
+
+export { AccordionHeading };

--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * The accordion heading element.
+ *
+ * `vaadin-accordion-heading` is the element for the headings in the accordion.
+ * As recommended by the WAI ARIA Best Practices, each heading needs to wrap a
+ * `<button>`. This element puts that button in the Shadow DOM, as it is more
+ * convenient to use and doesn’t make styling of the heading more problematic.
+ *
+ * The WAI ARIA Best Practices also recommend setting `aria-level` depending
+ * on what level the headings are. It is hard to determine the level of a heading
+ * algorithmically, and setting it is not strictly required to have an accessible
+ * accordion. To keep things easier to use, this element does not set `aria-level`
+ * attribute but leaves that to the developer creating an accordion.
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are exposed for styling:
+ *
+ * Part name  | Description
+ * -----------|-------------------
+ * `toggle`   | The icon element
+ * `content`  | The content wrapper
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute    | Description
+ * -------------| -----------
+ * `active`     | Set when the element is pressed down, either with mouse, touch or the keyboard.
+ * `opened`     | Set when the collapsible content is expanded and visible.
+ * `disabled`   | Set when the element is disabled.
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
+ *
+ * @extends HTMLElement
+ * @mixes ActiveMixin
+ * @mixes DirMixin
+ * @mixes ThemableMixin
+ */
+class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolymerElement))) {
+  static get is() {
+    return 'vaadin-accordion-heading';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: block;
+          outline: none;
+          -webkit-user-select: none;
+          -moz-user-select: none;
+          user-select: none;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+
+        button {
+          display: flex;
+          align-items: center;
+          width: 100%;
+          margin: 0;
+          padding: 0;
+          background-color: initial;
+          color: inherit;
+          border: initial;
+          outline: none;
+          font: inherit;
+          text-align: inherit;
+        }
+      </style>
+      <button id="button" part="content">
+        <span part="toggle" aria-hidden="true"></span>
+        <slot></slot>
+      </button>
+    `;
+  }
+
+  static get properties() {
+    return {
+      /**
+       * When true, the element is opened.
+       */
+      opened: {
+        type: Boolean,
+        reflectToAttribute: true,
+      },
+    };
+  }
+
+  /**
+   * @param {DocumentFragment} dom
+   * @return {null}
+   * @protected
+   * @override
+   */
+  _attachDom(dom) {
+    const root = this.attachShadow({ mode: 'open', delegatesFocus: true });
+    root.appendChild(dom);
+    return root;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    // By default, if the user hasn't provided a custom role,
+    // the role attribute is set to "heading".
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'heading');
+    }
+  }
+}
+
+customElements.define(AccordionHeading.is, AccordionHeading);
+
+export { AccordionHeading };

--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -80,7 +80,7 @@ class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolymerElement
           text-align: inherit;
         }
       </style>
-      <button id="button" part="content">
+      <button id="button" part="content" disabled$="[[disabled]]">
         <span part="toggle" aria-hidden="true"></span>
         <slot></slot>
       </button>

--- a/packages/accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/accordion/src/vaadin-accordion-panel.d.ts
@@ -3,7 +3,10 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Details } from '@vaadin/details/src/vaadin-details.js';
+import { DetailsMixin } from '@vaadin/details/src/vaadin-details-mixin.js';
+import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import { DelegateStateMixin } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
  * Fired when the `opened` property changes.
@@ -25,9 +28,6 @@ export type AccordionPanelEventMap = AccordionPanelCustomEventMap & HTMLElementE
  *
  * Part name        | Description
  * -----------------|----------------
- * `summary`        | The element used to open and close collapsible content.
- * `toggle`         | The element used as indicator, can represent an icon.
- * `summary-content`| The wrapper for the slotted summary content.
  * `content`        | The wrapper for the collapsible panel content.
  *
  * The following attributes are exposed for styling:
@@ -43,7 +43,7 @@ export type AccordionPanelEventMap = AccordionPanelCustomEventMap & HTMLElementE
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
-declare class AccordionPanel extends Details {
+declare class AccordionPanel extends DetailsMixin(DelegateFocusMixin(DelegateStateMixin(ThemableMixin(HTMLElement)))) {
   addEventListener<K extends keyof AccordionPanelEventMap>(
     type: K,
     listener: (this: AccordionPanel, ev: AccordionPanelEventMap[K]) => void,

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -3,7 +3,28 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Details } from '@vaadin/details/src/vaadin-details.js';
+import './vaadin-accordion-heading.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { DetailsMixin } from '@vaadin/details/src/vaadin-details-mixin.js';
+import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import { DelegateStateMixin } from '@vaadin/field-base/src/delegate-state-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+class SummaryController extends SlotController {
+  constructor(host) {
+    super(host, 'summary', 'vaadin-accordion-heading', {
+      useUniqueId: true,
+      initializer: (node, host) => {
+        host._setFocusElement(node);
+        host.stateTarget = node;
+      },
+    });
+  }
+}
 
 /**
  * The accordion panel element.
@@ -14,9 +35,6 @@ import { Details } from '@vaadin/details/src/vaadin-details.js';
  *
  * Part name        | Description
  * -----------------|----------------
- * `summary`        | The element used to open and close collapsible content.
- * `toggle`         | The element used as indicator, can represent an icon.
- * `summary-content`| The wrapper for the slotted summary content.
  * `content`        | The wrapper for the collapsible panel content.
  *
  * The following attributes are exposed for styling:
@@ -32,9 +50,86 @@ import { Details } from '@vaadin/details/src/vaadin-details.js';
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
-class AccordionPanel extends Details {
+class AccordionPanel extends DetailsMixin(
+  DelegateFocusMixin(DelegateStateMixin(ThemableMixin(ControllerMixin(PolymerElement)))),
+) {
   static get is() {
     return 'vaadin-accordion-panel';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: block;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+
+        [part='content'] {
+          display: none;
+          overflow: hidden;
+        }
+
+        :host([opened]) [part='content'] {
+          display: block;
+          overflow: visible;
+        }
+      </style>
+
+      <slot name="summary"></slot>
+
+      <div part="content">
+        <slot></slot>
+      </div>
+
+      <slot name="tooltip"></slot>
+    `;
+  }
+
+  static get properties() {
+    return {
+      /**
+       * A content element.
+       *
+       * @protected
+       */
+      _collapsible: {
+        type: Object,
+      },
+    };
+  }
+
+  static get observers() {
+    return ['_openedOrCollapsibleChanged(opened, _collapsible)'];
+  }
+
+  static get delegateProps() {
+    return ['disabled', 'opened'];
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    // TODO: Generate unique IDs for a heading and a content panel when added to the slot,
+    // and use them to set `aria-controls` and `aria-labelledby` attributes, respectively.
+
+    this._collapsible = this.shadowRoot.querySelector('[part="content"]');
+    this.addController(new SummaryController(this));
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+
+    this._tooltipController.setTarget(this._toggleElement);
+    this._tooltipController.setPosition('bottom-start');
+
+    // Wait for heading element render to complete
+    afterNextRender(this, () => {
+      this._toggleElement = this.focusElement.$.button;
+    });
   }
 }
 

--- a/packages/accordion/src/vaadin-accordion.d.ts
+++ b/packages/accordion/src/vaadin-accordion.d.ts
@@ -41,12 +41,12 @@ export type AccordionEventMap = AccordionCustomEventMap & HTMLElementEventMap;
  * ```
  * <vaadin-accordion>
  *   <vaadin-accordion-panel>
- *     <div slot="summary">Panel 1</div>
- *     This panel is opened, so the text is visible by default.
+ *     <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>
+ *     <div>This panel is opened, so the text is visible by default.</div>
  *   </vaadin-accordion-panel>
  *   <vaadin-accordion-panel>
- *     <div slot="summary">Panel 2</div>
- *     After opening this panel, the first one becomes closed.
+ *     <vaadin-accordion-heading slot="summary">Panel 2</vaadin-accordion-heading>
+ *     <div>After opening this panel, the first one becomes closed.</div>
  *   </vaadin-accordion-panel>
  * </vaadin-accordion>
  * ```

--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -6,6 +6,7 @@
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { isElementFocused } from '@vaadin/component-base/src/focus-utils.js';
 import { KeyboardDirectionMixin } from '@vaadin/component-base/src/keyboard-direction-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { AccordionPanel } from './vaadin-accordion-panel.js';
@@ -25,12 +26,12 @@ import { AccordionPanel } from './vaadin-accordion-panel.js';
  * ```
  * <vaadin-accordion>
  *   <vaadin-accordion-panel>
- *     <div slot="summary">Panel 1</div>
- *     This panel is opened, so the text is visible by default.
+ *     <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>
+ *     <div>This panel is opened, so the text is visible by default.</div>
  *   </vaadin-accordion-panel>
  *   <vaadin-accordion-panel>
- *     <div slot="summary">Panel 2</div>
- *     After opening this panel, the first one becomes closed.
+ *     <vaadin-accordion-heading slot="summary">Panel 2</vaadin-accordion-heading>
+ *     <div>After opening this panel, the first one becomes closed.</div>
  *   </vaadin-accordion-panel>
  * </vaadin-accordion>
  * ```
@@ -142,6 +143,18 @@ class Accordion extends KeyboardDirectionMixin(ThemableMixin(ElementMixin(Polyme
   }
 
   /**
+   * Override getter from `KeyboardDirectionMixin`
+   * to check if the heading element has focus.
+   *
+   * @return {Element | null}
+   * @protected
+   * @override
+   */
+  get focused() {
+    return (this._getItems() || []).find((item) => isElementFocused(item._toggleElement));
+  }
+
+  /**
    * Override method inherited from `KeyboardDirectionMixin`
    * to use the stored list of accordion panels as items.
    *
@@ -182,8 +195,9 @@ class Accordion extends KeyboardDirectionMixin(ThemableMixin(ElementMixin(Polyme
    */
   _onKeyDown(event) {
     // Only check keyboard events on details toggle buttons
-    const item = event.composedPath()[0];
-    if (!this.items.some((el) => el.focusElement === item)) {
+    const target = event.composedPath()[0];
+
+    if (!this.items.some((item) => item._toggleElement === target)) {
       return;
     }
 

--- a/packages/accordion/test/accordion.test.js
+++ b/packages/accordion/test/accordion.test.js
@@ -5,9 +5,8 @@ import {
   endKeyDown,
   fixtureSync,
   homeKeyDown,
-  isIOS,
   keyboardEventFor,
-  nextFrame,
+  nextRender,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-accordion.js';
@@ -16,27 +15,29 @@ describe('vaadin-accordion', () => {
   let accordion, heading;
 
   function getHeading(idx) {
-    return accordion.items[idx].focusElement;
+    return accordion.items[idx]._toggleElement;
   }
 
   beforeEach(async () => {
     accordion = fixtureSync(`
       <vaadin-accordion>
         <vaadin-accordion-panel>
-          <div slot="summary">Panel 1</div>
-          <input />
+          <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>
+          <div>
+            <input />
+          </div>
         </vaadin-accordion-panel>
         <vaadin-accordion-panel>
-          <div slot="summary">Panel 2</div>
-          Content 2
+          <vaadin-accordion-heading slot="summary">Panel 2</vaadin-accordion-heading>
+          <div>Content 2</div>
         </vaadin-accordion-panel>
         <vaadin-accordion-panel>
-          <div slot="summary">Panel 3</div>
-          Content 3
+          <vaadin-accordion-heading slot="summary">Panel 3</vaadin-accordion-heading>
+          <div>Content 3</div>
         </vaadin-accordion-panel>
       </vaadin-accordion>
     `);
-    await nextFrame();
+    await nextRender();
   });
 
   describe('custom element definition', () => {
@@ -132,7 +133,7 @@ describe('vaadin-accordion', () => {
     });
   });
 
-  (isIOS ? describe.skip : describe)('focus', () => {
+  describe('focus', () => {
     it('should focus the first panel heading by default', () => {
       accordion.focus();
       expect(accordion.items[0].hasAttribute('focused')).to.be.true;
@@ -162,7 +163,7 @@ describe('vaadin-accordion', () => {
     });
   });
 
-  (isIOS ? describe.skip : describe)('keyboard navigation', () => {
+  describe('keyboard navigation', () => {
     beforeEach(() => {
       accordion.focus();
     });

--- a/packages/accordion/test/accordion.test.js
+++ b/packages/accordion/test/accordion.test.js
@@ -100,6 +100,13 @@ describe('vaadin-accordion', () => {
       expect(accordion.opened).to.equal(1);
     });
 
+    it('should not update opened to new index when clicking disabled panel', () => {
+      accordion.items[1].disabled = true;
+      getHeading(1).click();
+      expect(accordion.items[1].opened).to.be.false;
+      expect(accordion.opened).to.equal(0);
+    });
+
     it('should close currently opened panel when another one is opened', () => {
       getHeading(1).click();
       expect(accordion.items[1].opened).to.be.true;

--- a/packages/accordion/test/visual/lumo/accordion.test.js
+++ b/packages/accordion/test/visual/lumo/accordion.test.js
@@ -13,15 +13,15 @@ describe('accordion', () => {
       `
         <vaadin-accordion>
           <vaadin-accordion-panel>
-            <div slot="summary">Panel 1</div>
+            <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>
             <div>Content 1</div>
           </vaadin-accordion-panel>
           <vaadin-accordion-panel>
-            <div slot="summary">Panel 2</div>
+            <vaadin-accordion-heading slot="summary">Panel 2</vaadin-accordion-heading>
             <div>Content 2</div>
           </vaadin-accordion-panel>
           <vaadin-accordion-panel>
-            <div slot="summary">Panel 3</div>
+            <vaadin-accordion-heading slot="summary">Panel 3</vaadin-accordion-heading>
             <div>Content 3</div>
           </vaadin-accordion-panel>
         </vaadin-accordion>

--- a/packages/accordion/test/visual/material/accordion.test.js
+++ b/packages/accordion/test/visual/material/accordion.test.js
@@ -13,15 +13,15 @@ describe('accordion', () => {
       `
         <vaadin-accordion>
           <vaadin-accordion-panel>
-            <div slot="summary">Panel 1</div>
+            <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>
             <div>Content 1</div>
           </vaadin-accordion-panel>
           <vaadin-accordion-panel>
-            <div slot="summary">Panel 2</div>
+            <vaadin-accordion-heading slot="summary">Panel 2</vaadin-accordion-heading>
             <div>Content 2</div>
           </vaadin-accordion-panel>
           <vaadin-accordion-panel>
-            <div slot="summary">Panel 3</div>
+            <vaadin-accordion-heading slot="summary">Panel 3</vaadin-accordion-heading>
             <div>Content 3</div>
           </vaadin-accordion-panel>
         </vaadin-accordion>

--- a/packages/accordion/theme/lumo/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/theme/lumo/vaadin-accordion-heading-styles.js
@@ -1,0 +1,4 @@
+import { detailsSummary } from '@vaadin/details/theme/lumo/vaadin-details-summary-styles.js';
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles('vaadin-accordion-heading', detailsSummary, { moduleId: 'lumo-accordion-heading' });

--- a/packages/accordion/theme/lumo/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/theme/lumo/vaadin-accordion-heading-styles.js
@@ -1,4 +1,14 @@
 import { detailsSummary } from '@vaadin/details/theme/lumo/vaadin-details-summary-styles.js';
-import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles('vaadin-accordion-heading', detailsSummary, { moduleId: 'lumo-accordion-heading' });
+const accordionHeading = css`
+  :host {
+    padding: 0;
+  }
+
+  [part='content'] {
+    padding: var(--lumo-space-s) 0;
+  }
+`;
+
+registerStyles('vaadin-accordion-heading', [detailsSummary, accordionHeading], { moduleId: 'lumo-accordion-heading' });

--- a/packages/accordion/theme/lumo/vaadin-accordion-panel.js
+++ b/packages/accordion/theme/lumo/vaadin-accordion-panel.js
@@ -1,2 +1,3 @@
+import './vaadin-accordion-heading-styles.js';
 import './vaadin-accordion-panel-styles.js';
 import '../../src/vaadin-accordion-panel.js';

--- a/packages/accordion/theme/material/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/theme/material/vaadin-accordion-heading-styles.js
@@ -1,0 +1,44 @@
+import '@vaadin/vaadin-material-styles/color.js';
+import { detailsSummary } from '@vaadin/details/theme/material/vaadin-details-summary-styles.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const accordionPanel = css`
+  :host(:not([opened]))::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 1px;
+    opacity: 1;
+    z-index: 1;
+    background-color: var(--material-divider-color);
+  }
+
+  :host([opened])::before {
+    opacity: 0;
+  }
+
+  [part='content'] {
+    font-weight: normal;
+  }
+
+  [part='content'] ::slotted(*) {
+    display: flex;
+    margin-right: 16px;
+    color: var(--material-body-text-color);
+  }
+
+  [part='content'] ::slotted([theme='primary']) {
+    flex-basis: 33.33%;
+    flex-shrink: 0;
+  }
+
+  [part='content'] ::slotted([theme='secondary']) {
+    color: var(--material-secondary-text-color);
+  }
+`;
+
+registerStyles('vaadin-accordion-heading', [detailsSummary, accordionPanel], {
+  moduleId: 'material-accordion-heading',
+});

--- a/packages/accordion/theme/material/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/theme/material/vaadin-accordion-heading-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-material-styles/color.js';
 import { detailsSummary } from '@vaadin/details/theme/material/vaadin-details-summary-styles.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-const accordionPanel = css`
+const accordionHeading = css`
   :host(:not([opened]))::after {
     content: '';
     position: absolute;
@@ -39,6 +39,6 @@ const accordionPanel = css`
   }
 `;
 
-registerStyles('vaadin-accordion-heading', [detailsSummary, accordionPanel], {
+registerStyles('vaadin-accordion-heading', [detailsSummary, accordionHeading], {
   moduleId: 'material-accordion-heading',
 });

--- a/packages/accordion/theme/material/vaadin-accordion-panel-styles.js
+++ b/packages/accordion/theme/material/vaadin-accordion-panel-styles.js
@@ -3,49 +3,12 @@ import { details } from '@vaadin/details/theme/material/vaadin-details-styles.js
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const accordionPanel = css`
-  :host(:not([opened])) [part='summary']::after {
-    content: '';
-    position: absolute;
-    bottom: -1px;
-    left: 0;
-    right: 0;
-    height: 1px;
-    opacity: 1;
-    z-index: 1;
-    background-color: var(--material-divider-color);
-  }
-
-  :host([opened]) [part='summary']::before {
-    opacity: 0;
-  }
-
   :host([opened]:not(:first-child)) {
     margin-top: 16px;
   }
 
   :host([opened]:not(:last-child)) {
     margin-bottom: 16px;
-  }
-
-  [part='summary-content'] {
-    display: flex;
-    width: 100%;
-    font-weight: normal;
-  }
-
-  [part='summary-content'] ::slotted(*) {
-    display: flex;
-    margin-right: 16px;
-    color: var(--material-body-text-color);
-  }
-
-  [part='summary-content'] ::slotted([theme='primary']) {
-    flex-basis: 33.33%;
-    flex-shrink: 0;
-  }
-
-  [part='summary-content'] ::slotted([theme='secondary']) {
-    color: var(--material-secondary-text-color);
   }
 `;
 

--- a/packages/accordion/theme/material/vaadin-accordion-panel.js
+++ b/packages/accordion/theme/material/vaadin-accordion-panel.js
@@ -1,2 +1,3 @@
+import './vaadin-accordion-heading-styles.js';
 import './vaadin-accordion-panel-styles.js';
 import '../../src/vaadin-accordion-panel.js';

--- a/packages/details/README.md
+++ b/packages/details/README.md
@@ -9,8 +9,8 @@ A web component that provides an expandable panel for showing and hiding content
 
 ```html
 <vaadin-details opened>
-  <div slot="summary">Expandable Details</div>
-  Toggle using mouse, Enter and Space keys.
+  <vaadin-details-summary slot="summary">Expandable Details</vaadin-details-summary>
+  <div>Toggle using mouse, Enter and Space keys.</div>
 </vaadin-details>
 ```
 

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -35,7 +35,9 @@
     "polymer"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
+    "@vaadin/button": "24.0.0-alpha5",
     "@vaadin/component-base": "24.0.0-alpha5",
     "@vaadin/field-base": "24.0.0-alpha5",
     "@vaadin/vaadin-lumo-styles": "24.0.0-alpha5",

--- a/packages/details/src/vaadin-details-mixin.d.ts
+++ b/packages/details/src/vaadin-details-mixin.d.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+/**
+ * A mixin providing common details functionality.
+ */
+export declare function DetailsMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<DetailsMixinClass> & T;
+
+export declare class DetailsMixinClass {
+  /**
+   * If true, the collapsible content is visible.
+   */
+  opened: boolean;
+
+  /**
+   * A content area controlled by the toggle element.
+   */
+  protected _collapsible: HTMLElement;
+
+  /**
+   * An element used to toggle the content visibility.
+   */
+  protected _toggleElement: HTMLElement;
+}

--- a/packages/details/src/vaadin-details-mixin.js
+++ b/packages/details/src/vaadin-details-mixin.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A mixin providing common details functionality.
+ *
+ * @polymerMixin
+ */
+export const DetailsMixin = (superClass) =>
+  class DetailsMixinClass extends superClass {
+    static get properties() {
+      return {
+        /**
+         * If true, the collapsible content is visible.
+         * @type {boolean}
+         */
+        opened: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+          notify: true,
+        },
+
+        /**
+         * A content area controlled by the toggle element.
+         *
+         * @protected
+         */
+        _collapsible: {
+          type: Object,
+        },
+
+        /**
+         * An element used to toggle the content visibility.
+         *
+         * @type {!HTMLElement | undefined}
+         * @protected
+         */
+        _toggleElement: {
+          type: Object,
+          observer: '_toggleElementChanged',
+        },
+      };
+    }
+
+    static get observers() {
+      return ['_openedOrToggleChanged(opened, _toggleElement)', '_openedOrCollapsibleChanged(opened, _collapsible)'];
+    }
+
+    /** @private */
+    _openedOrCollapsibleChanged(opened, collapsible) {
+      if (collapsible) {
+        collapsible.setAttribute('aria-hidden', opened ? 'false' : 'true');
+        collapsible.style.maxHeight = opened ? '' : '0px';
+      }
+    }
+
+    /** @private */
+    _openedOrToggleChanged(opened, toggleElement) {
+      if (toggleElement) {
+        toggleElement.setAttribute('aria-expanded', opened ? 'true' : 'false');
+      }
+    }
+
+    /** @private */
+    _toggleElementChanged(toggleElement) {
+      if (toggleElement) {
+        // Only handle click and not keydown, because `vaadin-details-summary` uses `ButtonMixin`
+        // that already covers this logic, and `vaadin-accordion-heading` uses native `<button>`.
+        toggleElement.addEventListener('click', () => {
+          this._toggle();
+        });
+      }
+    }
+
+    /** @private */
+    _toggle() {
+      this.opened = !this.opened;
+    }
+  };

--- a/packages/details/src/vaadin-details-mixin.js
+++ b/packages/details/src/vaadin-details-mixin.js
@@ -54,7 +54,6 @@ export const DetailsMixin = (superClass) =>
     _openedOrCollapsibleChanged(opened, collapsible) {
       if (collapsible) {
         collapsible.setAttribute('aria-hidden', opened ? 'false' : 'true');
-        collapsible.style.maxHeight = opened ? '' : '0px';
       }
     }
 

--- a/packages/details/src/vaadin-details-summary.js
+++ b/packages/details/src/vaadin-details-summary.js
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ButtonMixin } from '@vaadin/button/src/vaadin-button-mixin.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * The details summary element.
+ *
+ * @extends HTMLElement
+ * @mixes ButtonMixin
+ * @mixes DirMixin
+ * @mixes ThemableMixin
+ */
+class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolymerElement))) {
+  static get is() {
+    return 'vaadin-details-summary';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: block;
+          outline: none;
+          white-space: nowrap;
+          -webkit-user-select: none;
+          -moz-user-select: none;
+          user-select: none;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+
+        :host([disabled]) {
+          pointer-events: none;
+        }
+      </style>
+      <span part="toggle" aria-hidden="true"></span>
+      <div part="content"><slot></slot></div>
+    `;
+  }
+
+  static get properties() {
+    return {
+      /**
+       * When true, the element is opened.
+       */
+      opened: {
+        type: Boolean,
+        reflectToAttribute: true,
+      },
+    };
+  }
+}
+
+customElements.define(DetailsSummary.is, DetailsSummary);

--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -27,8 +27,10 @@ export type DetailsEventMap = DetailsCustomEventMap & HTMLElementEventMap;
  *
  * ```
  * <vaadin-details>
- *   <div slot="summary">Expandable Details</div>
- *   Toggle using mouse, Enter and Space keys.
+ *   <vaadin-details-summary slot="summary">Expandable Details</vaadin-details-summary>
+ *   <div>
+ *     Toggle using mouse, Enter and Space keys.
+ *   </div>
  * </vaadin-details>
  * ```
  *

--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -5,8 +5,10 @@
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { ShadowFocusMixin } from '@vaadin/field-base/src/shadow-focus-mixin.js';
+import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import { DelegateStateMixin } from '@vaadin/field-base/src/delegate-state-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { DetailsMixin } from './vaadin-details-mixin.js';
 
 /**
  * Fired when the `opened` property changes.
@@ -54,12 +56,9 @@ export type DetailsEventMap = DetailsCustomEventMap & HTMLElementEventMap;
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
-declare class Details extends ShadowFocusMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {
-  /**
-   * If true, the details content is visible.
-   */
-  opened: boolean;
-
+declare class Details extends DetailsMixin(
+  DelegateStateMixin(DelegateFocusMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement))))),
+) {
   addEventListener<K extends keyof DetailsEventMap>(
     type: K,
     listener: (this: Details, ev: DetailsEventMap[K]) => void,

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -135,6 +135,17 @@ class Details extends DetailsMixin(
     this._tooltipController.setTarget(this._toggleElement);
     this._tooltipController.setPosition('bottom-start');
   }
+
+  /**
+   * Override method inherited from `DisabledMixin`
+   * to not set `aria-disabled` on the host element.
+   *
+   * @protected
+   * @override
+   */
+  _setAriaDisabled() {
+    // The `aria-disabled` is set on the details summary.
+  }
 }
 
 customElements.define(Details.is, Details);

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -3,13 +3,29 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import './vaadin-details-summary.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
-import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
-import { ShadowFocusMixin } from '@vaadin/field-base/src/shadow-focus-mixin.js';
+import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.js';
+import { DelegateStateMixin } from '@vaadin/field-base/src/delegate-state-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { DetailsMixin } from './vaadin-details-mixin.js';
+
+class SummaryController extends SlotController {
+  constructor(host) {
+    super(host, 'summary', 'vaadin-details-summary', {
+      useUniqueId: true,
+      initializer: (node, host) => {
+        host._toggleElement = node;
+        host._setFocusElement(node);
+        host.stateTarget = node;
+      },
+    });
+  }
+}
 
 /**
  * `<vaadin-details>` is a Web Component which the creates an
@@ -17,8 +33,10 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * ```
  * <vaadin-details>
- *   <div slot="summary">Expandable Details</div>
- *   Toggle using mouse, Enter and Space keys.
+ *   <vaadin-details-summary slot="summary">Expandable Details</vaadin-details-summary>
+ *   <div>
+ *     Toggle using mouse, Enter and Space keys.
+ *   </div>
  * </vaadin-details>
  * ```
  *
@@ -48,11 +66,14 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * @extends HTMLElement
  * @mixes ControllerMixin
- * @mixes ShadowFocusMixin
+ * @mixes DelegateFocusMixin
+ * @mixes DelegateStateMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class Details extends ShadowFocusMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement)))) {
+class Details extends DetailsMixin(
+  DelegateStateMixin(DelegateFocusMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))))),
+) {
   static get template() {
     return html`
       <style>
@@ -69,33 +90,19 @@ class Details extends ShadowFocusMixin(ElementMixin(ThemableMixin(ControllerMixi
           overflow: hidden;
         }
 
-        [part='summary'][disabled] {
-          pointer-events: none;
-        }
-
         :host([opened]) [part='content'] {
           display: block;
           overflow: visible;
         }
       </style>
-      <div role="heading">
-        <div
-          role="button"
-          part="summary"
-          on-click="_onToggleClick"
-          on-keydown="_onToggleKeyDown"
-          disabled$="[[disabled]]"
-          aria-expanded$="[[_getAriaExpanded(opened)]]"
-          aria-controls$="[[_contentId]]"
-        >
-          <span part="toggle" aria-hidden="true"></span>
-          <span part="summary-content"><slot name="summary"></slot></span>
-        </div>
-        <slot name="tooltip"></slot>
-      </div>
-      <section id$="[[_contentId]]" part="content" aria-hidden$="[[_getAriaHidden(opened)]]">
+
+      <slot name="summary"></slot>
+
+      <div part="content">
         <slot></slot>
-      </section>
+      </div>
+
+      <slot name="tooltip"></slot>
     `;
   }
 
@@ -103,83 +110,30 @@ class Details extends ShadowFocusMixin(ElementMixin(ThemableMixin(ControllerMixi
     return 'vaadin-details';
   }
 
-  static get properties() {
-    return {
-      /**
-       * If true, the details content is visible.
-       * @type {boolean}
-       */
-      opened: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true,
-        notify: true,
-        observer: '_openedChanged',
-      },
-    };
+  static get delegateAttrs() {
+    return ['theme'];
   }
 
-  /**
-   * @return {!HTMLElement}
-   * @protected
-   */
-  get _collapsible() {
-    return this.shadowRoot.querySelector('[part="content"]');
-  }
-
-  /**
-   * Focusable element used by `ShadowFocusMixin`.
-   * @return {!HTMLElement}
-   * @protected
-   */
-  get focusElement() {
-    return this.shadowRoot.querySelector('[part="summary"]');
+  static get delegateProps() {
+    return ['disabled', 'opened'];
   }
 
   /** @protected */
   ready() {
     super.ready();
-    this._contentId = `${this.constructor.is}-content-${generateUniqueId()}`;
-    // Prevent Shift + Tab on content from host blur
-    this._collapsible.addEventListener('keydown', (e) => {
-      if (e.shiftKey && e.keyCode === 9) {
-        e.stopPropagation();
-      }
-    });
+
+    // TODO: Generate unique IDs for a summary and a content panel when added to the slot,
+    // and use them to set `aria-controls` and `aria-labelledby` attributes, respectively.
+
+    this._collapsible = this.shadowRoot.querySelector('[part="content"]');
+
+    this.addController(new SummaryController(this));
 
     this._tooltipController = new TooltipController(this);
     this.addController(this._tooltipController);
 
-    this._tooltipController.setTarget(this.focusElement);
+    this._tooltipController.setTarget(this._toggleElement);
     this._tooltipController.setPosition('bottom-start');
-  }
-
-  /** @private */
-  _getAriaExpanded(opened) {
-    return opened ? 'true' : 'false';
-  }
-
-  /** @private */
-  _getAriaHidden(opened) {
-    return opened ? 'false' : 'true';
-  }
-
-  /** @private */
-  _openedChanged(opened) {
-    this._collapsible.style.maxHeight = opened ? '' : '0px';
-  }
-
-  /** @private */
-  _onToggleClick() {
-    this.opened = !this.opened;
-  }
-
-  /** @private */
-  _onToggleKeyDown(e) {
-    if ([13, 32].indexOf(e.keyCode) > -1) {
-      e.preventDefault();
-      this.opened = !this.opened;
-    }
   }
 }
 

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -87,12 +87,10 @@ class Details extends DetailsMixin(
 
         [part='content'] {
           display: none;
-          overflow: hidden;
         }
 
         :host([opened]) [part='content'] {
           display: block;
-          overflow: visible;
         }
       </style>
 

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -88,18 +88,12 @@ describe('vaadin-details', () => {
     });
 
     it('should hide the content when opened is false', () => {
-      const style = getComputedStyle(content);
-      expect(style.display).to.equal('none');
-      expect(style.overflow).to.equal('hidden');
-      expect(style.maxHeight).to.equal('0px');
+      expect(getComputedStyle(content).display).to.equal('none');
     });
 
     it('should show the content when `opened` is true', () => {
       details.opened = true;
-      const style = getComputedStyle(content);
-      expect(style.display).to.equal('block');
-      expect(style.overflow).to.equal('visible');
-      expect(style.maxHeight).to.equal('none');
+      expect(getComputedStyle(content).display).to.equal('block');
     });
 
     it('should dispatch opened-changed event when opened changes', () => {

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -143,12 +143,12 @@ describe('vaadin-details', () => {
       container = fixtureSync(`
         <div>
           <vaadin-details>
-            <div slot="summary">Summary</div>
-            <input>
+            <vaadin-details-summary slot="summary">Summary 1</vaadin-details-summary>
+            <div>Content 1</div>
           </vaadin-details>
           <vaadin-details>
-            <div slot="summary">Summary</div>
-            <input>
+          <vaadin-details-summary slot="summary">Summary 2</vaadin-details-summary>
+            <div>Content 2</div>
           </vaadin-details>
         </div>
       `);

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, keyboardEventFor, keyDownOn } from '@vaadin/testing-helpers';
+import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-details.js';
 
@@ -9,11 +9,13 @@ describe('vaadin-details', () => {
   beforeEach(() => {
     details = fixtureSync(`
       <vaadin-details>
-        <div slot="summary">Summary</div>
-        <input>
+        <vaadin-details-summary slot="summary">Summary</vaadin-details-summary>
+        <div>
+          <input type="text" />
+        </div>
       </vaadin-details>
     `);
-    toggle = details.focusElement;
+    toggle = details._toggleElement;
     content = details._collapsible;
   });
 
@@ -33,9 +35,9 @@ describe('vaadin-details', () => {
     });
   });
 
-  describe('toggle button', () => {
-    it('should have summary slot inside toggle button', () => {
-      const slot = toggle.querySelector('slot[name="summary"]');
+  describe('summary', () => {
+    it('should have unnamed slot inside the summary element', () => {
+      const slot = toggle.shadowRoot.querySelector('slot');
       expect(slot).to.be.ok;
       expect(slot.assignedNodes()[0].textContent).to.equal('Summary');
     });
@@ -113,10 +115,6 @@ describe('vaadin-details', () => {
       expect(toggle.getAttribute('role')).to.equal('button');
     });
 
-    it('should set role="heading" on the toggle button wrapper', () => {
-      expect(toggle.parentElement.getAttribute('role')).to.equal('heading');
-    });
-
     it('should set aria-expanded on toggle button to false by default', () => {
       expect(toggle.getAttribute('aria-expanded')).to.equal('false');
     });
@@ -135,13 +133,15 @@ describe('vaadin-details', () => {
       expect(content.getAttribute('aria-hidden')).to.equal('false');
     });
 
-    it('should set aria-controls on toggle button', () => {
+    // TODO: implement new mechanism for setting ID
+    it.skip('should set aria-controls on toggle button', () => {
       const idRegex = /^vaadin-details-content-\d+$/;
       expect(idRegex.test(toggle.getAttribute('aria-controls'))).to.be.true;
     });
   });
 
-  describe('unique IDs', () => {
+  // TODO: implement new mechanism for setting ID
+  describe.skip('unique IDs', () => {
     const idRegex = /^vaadin-details-content-\d+$/;
     let container, details;
 
@@ -167,28 +167,6 @@ describe('vaadin-details', () => {
       expect(idRegex.test(detailsId1)).to.be.true;
       expect(idRegex.test(detailsId2)).to.be.true;
       expect(detailsId1).to.not.equal(detailsId2);
-    });
-  });
-
-  describe('keyboard events', () => {
-    let input;
-
-    beforeEach(() => {
-      input = details.querySelector('input');
-    });
-
-    it('should stop Shift + Tab on the content from propagating to the host', () => {
-      const event = keyboardEventFor('keydown', 9, 'shift', 'Tab');
-      const spy = sinon.spy(event, 'stopPropagation');
-      input.dispatchEvent(event);
-      expect(spy.called).to.be.true;
-    });
-
-    it('should not stop Tab on the content from propagating to the host', () => {
-      const event = keyboardEventFor('keydown', 9, [], 'Tab');
-      const spy = sinon.spy(event, 'stopPropagation');
-      input.dispatchEvent(event);
-      expect(spy.called).to.be.false;
     });
   });
 });

--- a/packages/details/test/dom/__snapshots__/details.test.snap.js
+++ b/packages/details/test/dom/__snapshots__/details.test.snap.js
@@ -1,22 +1,24 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-crud host default"] = 
+snapshots["vaadin-details host default"] = 
 `<vaadin-details>
-  <vaadin-details-heading
+  <vaadin-details-summary
     aria-expanded="false"
+    role="button"
     slot="summary"
+    tabindex="0"
   >
     Summary
-  </vaadin-details-heading>
+  </vaadin-details-summary>
   <div>
-    <input>
+    Content
   </div>
 </vaadin-details>
 `;
-/* end snapshot vaadin-crud host default */
+/* end snapshot vaadin-details host default */
 
-snapshots["vaadin-crud shadow default"] = 
+snapshots["vaadin-details shadow default"] = 
 `<slot name="summary">
 </slot>
 <div
@@ -30,9 +32,9 @@ snapshots["vaadin-crud shadow default"] =
 <slot name="tooltip">
 </slot>
 `;
-/* end snapshot vaadin-crud shadow default */
+/* end snapshot vaadin-details shadow default */
 
-snapshots["vaadin-crud shadow opened"] = 
+snapshots["vaadin-details shadow opened"] = 
 `<slot name="summary">
 </slot>
 <div
@@ -46,5 +48,5 @@ snapshots["vaadin-crud shadow opened"] =
 <slot name="tooltip">
 </slot>
 `;
-/* end snapshot vaadin-crud shadow opened */
+/* end snapshot vaadin-details shadow opened */
 

--- a/packages/details/test/dom/__snapshots__/details.test.snap.js
+++ b/packages/details/test/dom/__snapshots__/details.test.snap.js
@@ -37,10 +37,7 @@ snapshots["vaadin-details host opened"] =
 /* end snapshot vaadin-details host opened */
 
 snapshots["vaadin-details host disabled"] = 
-`<vaadin-details
-  aria-disabled="true"
-  disabled=""
->
+`<vaadin-details disabled="">
   <vaadin-details-summary
     aria-disabled="true"
     aria-expanded="false"

--- a/packages/details/test/dom/__snapshots__/details.test.snap.js
+++ b/packages/details/test/dom/__snapshots__/details.test.snap.js
@@ -18,6 +18,64 @@ snapshots["vaadin-details host default"] =
 `;
 /* end snapshot vaadin-details host default */
 
+snapshots["vaadin-details host opened"] = 
+`<vaadin-details opened="">
+  <vaadin-details-summary
+    aria-expanded="true"
+    opened=""
+    role="button"
+    slot="summary"
+    tabindex="0"
+  >
+    Summary
+  </vaadin-details-summary>
+  <div>
+    Content
+  </div>
+</vaadin-details>
+`;
+/* end snapshot vaadin-details host opened */
+
+snapshots["vaadin-details host disabled"] = 
+`<vaadin-details
+  aria-disabled="true"
+  disabled=""
+>
+  <vaadin-details-summary
+    aria-disabled="true"
+    aria-expanded="false"
+    disabled=""
+    role="button"
+    slot="summary"
+    tabindex="-1"
+  >
+    Summary
+  </vaadin-details-summary>
+  <div>
+    Content
+  </div>
+</vaadin-details>
+`;
+/* end snapshot vaadin-details host disabled */
+
+snapshots["vaadin-details host theme"] = 
+`<vaadin-details theme="filled">
+  <vaadin-details-summary
+    aria-expanded="false"
+    role="button"
+    slot="summary"
+    tabindex="0"
+    theme="filled"
+  >
+    Summary
+  </vaadin-details-summary>
+  <div>
+    Content
+  </div>
+</vaadin-details>
+`;
+/* end snapshot vaadin-details host theme */
+
 snapshots["vaadin-details shadow default"] = 
 `<slot name="summary">
 </slot>

--- a/packages/details/test/dom/__snapshots__/details.test.snap.js
+++ b/packages/details/test/dom/__snapshots__/details.test.snap.js
@@ -2,80 +2,49 @@
 export const snapshots = {};
 
 snapshots["vaadin-crud host default"] = 
-`<vaadin-details tabindex="0">
-  <div slot="summary">
+`<vaadin-details>
+  <vaadin-details-heading
+    aria-expanded="false"
+    slot="summary"
+  >
     Summary
+  </vaadin-details-heading>
+  <div>
+    <input>
   </div>
-  <input>
 </vaadin-details>
 `;
 /* end snapshot vaadin-crud host default */
 
 snapshots["vaadin-crud shadow default"] = 
-`<div role="heading">
-  <div
-    aria-controls="vaadin-details-content-1"
-    aria-expanded="false"
-    part="summary"
-    role="button"
-    tabindex="0"
-  >
-    <span
-      aria-hidden="true"
-      part="toggle"
-    >
-    </span>
-    <span part="summary-content">
-      <slot name="summary">
-      </slot>
-    </span>
-  </div>
-  <slot name="tooltip">
-  </slot>
-</div>
-<section
+`<slot name="summary">
+</slot>
+<div
   aria-hidden="true"
-  id="vaadin-details-content-1"
   part="content"
   style="max-height: 0px;"
 >
   <slot>
   </slot>
-</section>
+</div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-crud shadow default */
 
 snapshots["vaadin-crud shadow opened"] = 
-`<div role="heading">
-  <div
-    aria-controls="vaadin-details-content-2"
-    aria-expanded="true"
-    part="summary"
-    role="button"
-    tabindex="0"
-  >
-    <span
-      aria-hidden="true"
-      part="toggle"
-    >
-    </span>
-    <span part="summary-content">
-      <slot name="summary">
-      </slot>
-    </span>
-  </div>
-  <slot name="tooltip">
-  </slot>
-</div>
-<section
+`<slot name="summary">
+</slot>
+<div
   aria-hidden="false"
-  id="vaadin-details-content-2"
   part="content"
   style=""
 >
   <slot>
   </slot>
-</section>
+</div>
+<slot name="tooltip">
+</slot>
 `;
 /* end snapshot vaadin-crud shadow opened */
 

--- a/packages/details/test/dom/__snapshots__/details.test.snap.js
+++ b/packages/details/test/dom/__snapshots__/details.test.snap.js
@@ -79,7 +79,6 @@ snapshots["vaadin-details shadow default"] =
 <div
   aria-hidden="true"
   part="content"
-  style="max-height: 0px;"
 >
   <slot>
   </slot>
@@ -95,7 +94,6 @@ snapshots["vaadin-details shadow opened"] =
 <div
   aria-hidden="false"
   part="content"
-  style=""
 >
   <slot>
   </slot>

--- a/packages/details/test/dom/details.test.js
+++ b/packages/details/test/dom/details.test.js
@@ -18,6 +18,21 @@ describe('vaadin-details', () => {
     it('default', async () => {
       await expect(details).dom.to.equalSnapshot();
     });
+
+    it('opened', async () => {
+      details.opened = true;
+      await expect(details).dom.to.equalSnapshot();
+    });
+
+    it('disabled', async () => {
+      details.disabled = true;
+      await expect(details).dom.to.equalSnapshot();
+    });
+
+    it('theme', async () => {
+      details.setAttribute('theme', 'filled');
+      await expect(details).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/details/test/dom/details.test.js
+++ b/packages/details/test/dom/details.test.js
@@ -2,16 +2,14 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../vaadin-details.js';
 
-describe('vaadin-crud', () => {
+describe('vaadin-details', () => {
   let details;
 
   beforeEach(() => {
     details = fixtureSync(`
       <vaadin-details>
-        <vaadin-details-heading slot="summary">Summary</vaadin-details-heading>
-        <div>
-          <input>
-        </div>
+        <vaadin-details-summary slot="summary">Summary</vaadin-details-summary>
+        <div>Content</div>
       </vaadin-details>
     `);
   });

--- a/packages/details/test/dom/details.test.js
+++ b/packages/details/test/dom/details.test.js
@@ -8,8 +8,10 @@ describe('vaadin-crud', () => {
   beforeEach(() => {
     details = fixtureSync(`
       <vaadin-details>
-        <div slot="summary">Summary</div>
-        <input>
+        <vaadin-details-heading slot="summary">Summary</vaadin-details-heading>
+        <div>
+          <input>
+        </div>
       </vaadin-details>
     `);
   });

--- a/packages/details/test/visual/lumo/details.test.js
+++ b/packages/details/test/visual/lumo/details.test.js
@@ -12,7 +12,7 @@ describe('details', () => {
     element = fixtureSync(
       `
       <vaadin-details>
-        <div slot="summary">Summary</div>
+        <vaadin-details-summary slot="summary">Summary</vaadin-details-summary>
         <span>Content</span>
       </vaadin-details>
       `,

--- a/packages/details/test/visual/material/details.test.js
+++ b/packages/details/test/visual/material/details.test.js
@@ -12,7 +12,7 @@ describe('details', () => {
     element = fixtureSync(
       `
       <vaadin-details>
-        <div slot="summary">Summary</div>
+        <vaadin-details-summary slot="summary">Summary</vaadin-details-summary>
         <span>Content</span>
       </vaadin-details>
       `,

--- a/packages/details/theme/lumo/vaadin-details-styles.js
+++ b/packages/details/theme/lumo/vaadin-details-styles.js
@@ -1,6 +1,4 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
-import '@vaadin/vaadin-lumo-styles/font-icons.js';
-import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
@@ -12,62 +10,8 @@ const details = css`
     outline: none;
   }
 
-  [part='summary'] {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    outline: none;
-    padding: var(--lumo-space-s) 0;
-    box-sizing: border-box;
-    font-family: var(--lumo-font-family);
-    font-size: var(--lumo-font-size-m);
-    font-weight: 500;
-    line-height: var(--lumo-line-height-xs);
-    color: var(--lumo-secondary-text-color);
-    background-color: inherit;
-    border-radius: var(--lumo-border-radius-m);
-    cursor: var(--lumo-clickable-cursor);
-    -webkit-tap-highlight-color: transparent;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
-  :host([focus-ring]) [part='summary'] {
+  :host([focus-ring]) ::slotted([slot='summary']) {
     box-shadow: 0 0 0 2px var(--lumo-primary-color-50pct);
-  }
-
-  [part='toggle'] {
-    display: block;
-    width: 1em;
-    height: 1em;
-    margin-left: calc(var(--lumo-space-xs) * -1);
-    margin-right: var(--lumo-space-xs);
-    font-size: var(--lumo-icon-size-s);
-    line-height: 1;
-    color: var(--lumo-contrast-60pct);
-    font-family: 'lumo-icons';
-    cursor: var(--lumo-clickable-cursor);
-  }
-
-  :host([disabled]) [part='summary'],
-  :host([disabled]) [part='toggle'] {
-    color: var(--lumo-disabled-text-color);
-    cursor: default;
-  }
-
-  @media (hover: hover) {
-    :host(:not([disabled])) [part='summary']:hover,
-    :host(:not([disabled])) [part='summary']:hover [part='toggle'] {
-      color: var(--lumo-contrast-80pct);
-    }
-  }
-
-  [part='toggle']::before {
-    content: var(--lumo-icons-angle-right);
-  }
-
-  :host([opened]) [part='toggle'] {
-    transform: rotate(90deg);
   }
 
   [part='content'] {
@@ -81,65 +25,13 @@ const details = css`
     border-radius: var(--lumo-border-radius-m);
   }
 
-  :host([theme~='filled']) [part='summary'] {
-    padding: var(--lumo-space-s) calc(var(--lumo-space-s) + var(--lumo-space-xs) / 2);
-  }
-
   :host([theme~='filled']) [part='content'] {
     padding-left: var(--lumo-space-m);
     padding-right: var(--lumo-space-m);
   }
 
-  :host([theme~='small']) [part='summary'] {
-    padding-top: var(--lumo-space-xs);
-    padding-bottom: var(--lumo-space-xs);
-  }
-
-  :host([theme~='small']) [part='toggle'] {
-    margin-right: calc(var(--lumo-space-xs) / 2);
-  }
-
-  :host([theme~='small']) [part\$='content'] {
+  :host([theme~='small']) [part$='content'] {
     font-size: var(--lumo-font-size-s);
-  }
-
-  :host([theme~='reverse']) [part='summary'] {
-    justify-content: space-between;
-  }
-
-  :host([theme~='reverse']) [part='toggle'] {
-    order: 1;
-    margin-right: 0;
-  }
-
-  :host([theme~='reverse'][theme~='filled']) [part='summary'] {
-    padding-left: var(--lumo-space-m);
-  }
-
-  /* RTL specific styles */
-  :host([dir='rtl']) [part='toggle'] {
-    margin-left: var(--lumo-space-xs);
-    margin-right: calc(var(--lumo-space-xs) * -1);
-  }
-
-  :host([dir='rtl']) [part='toggle']::before {
-    content: var(--lumo-icons-angle-left);
-  }
-
-  :host([opened][dir='rtl']) [part='toggle'] {
-    transform: rotate(-90deg);
-  }
-
-  :host([theme~='small'][dir='rtl']) [part='toggle'] {
-    margin-left: calc(var(--lumo-space-xs) / 2);
-  }
-
-  :host([theme~='reverse'][dir='rtl']) [part='toggle'] {
-    margin-left: 0;
-  }
-
-  :host([theme~='reverse'][theme~='filled'][dir='rtl']) [part='summary'] {
-    padding-right: var(--lumo-space-m);
   }
 `;
 

--- a/packages/details/theme/lumo/vaadin-details-summary-styles.js
+++ b/packages/details/theme/lumo/vaadin-details-summary-styles.js
@@ -1,0 +1,123 @@
+import '@vaadin/vaadin-lumo-styles/color.js';
+import '@vaadin/vaadin-lumo-styles/font-icons.js';
+import '@vaadin/vaadin-lumo-styles/sizing.js';
+import '@vaadin/vaadin-lumo-styles/spacing.js';
+import '@vaadin/vaadin-lumo-styles/style.js';
+import '@vaadin/vaadin-lumo-styles/typography.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const detailsSummary = css`
+  :host {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    outline: none;
+    padding: var(--lumo-space-s) 0;
+    box-sizing: border-box;
+    font-family: var(--lumo-font-family);
+    font-size: var(--lumo-font-size-m);
+    font-weight: 500;
+    line-height: var(--lumo-line-height-xs);
+    color: var(--lumo-secondary-text-color);
+    background-color: inherit;
+    border-radius: var(--lumo-border-radius-m);
+    cursor: var(--lumo-clickable-cursor);
+    -webkit-tap-highlight-color: transparent;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  :host([disabled]),
+  :host([disabled]) [part='toggle'] {
+    color: var(--lumo-disabled-text-color);
+    cursor: default;
+  }
+
+  @media (hover: hover) {
+    :host(:hover:not([disabled])),
+    :host(:hover:not([disabled])) [part='toggle'] {
+      color: var(--lumo-contrast-80pct);
+    }
+  }
+
+  [part='toggle'] {
+    display: block;
+    width: 1em;
+    height: 1em;
+    margin-left: calc(var(--lumo-space-xs) * -1);
+    margin-right: var(--lumo-space-xs);
+    font-size: var(--lumo-icon-size-s);
+    line-height: 1;
+    color: var(--lumo-contrast-60pct);
+    font-family: 'lumo-icons';
+    cursor: var(--lumo-clickable-cursor);
+  }
+
+  [part='toggle']::before {
+    content: var(--lumo-icons-angle-right);
+  }
+
+  :host([opened]) [part='toggle'] {
+    transform: rotate(90deg);
+  }
+
+  /* RTL styles */
+  :host([dir='rtl']) [part='toggle'] {
+    margin-left: var(--lumo-space-xs);
+    margin-right: calc(var(--lumo-space-xs) * -1);
+  }
+
+  :host([dir='rtl']) [part='toggle']::before {
+    content: var(--lumo-icons-angle-left);
+  }
+
+  :host([opened][dir='rtl']) [part='toggle'] {
+    transform: rotate(-90deg);
+  }
+
+  /* Small */
+  :host([theme~='small']) {
+    padding-top: var(--lumo-space-xs);
+    padding-bottom: var(--lumo-space-xs);
+  }
+
+  :host([theme~='small']) [part='toggle'] {
+    margin-right: calc(var(--lumo-space-xs) / 2);
+  }
+
+  :host([theme~='small'][dir='rtl']) [part='toggle'] {
+    margin-left: calc(var(--lumo-space-xs) / 2);
+  }
+
+  /* Filled */
+  :host([theme~='filled']) {
+    padding: var(--lumo-space-s) calc(var(--lumo-space-s) + var(--lumo-space-xs) / 2);
+  }
+
+  /* Reverse */
+  :host([theme~='reverse']) {
+    justify-content: space-between;
+  }
+
+  :host([theme~='reverse']) [part='toggle'] {
+    order: 1;
+    margin-right: 0;
+  }
+
+  :host([theme~='reverse'][dir='rtl']) [part='toggle'] {
+    margin-left: 0;
+  }
+
+  /* Filled reverse */
+  :host([theme~='reverse'][theme~='filled']) {
+    padding-left: var(--lumo-space-m);
+  }
+
+  :host([theme~='reverse'][theme~='filled'][dir='rtl']) {
+    padding-right: var(--lumo-space-m);
+  }
+`;
+
+registerStyles('vaadin-details-summary', detailsSummary, { moduleId: 'lumo-details-summary' });
+
+export { detailsSummary };

--- a/packages/details/theme/lumo/vaadin-details.js
+++ b/packages/details/theme/lumo/vaadin-details.js
@@ -1,2 +1,3 @@
+import './vaadin-details-summary-styles.js';
 import './vaadin-details-styles.js';
 import '../../src/vaadin-details.js';

--- a/packages/details/theme/material/vaadin-details-styles.js
+++ b/packages/details/theme/material/vaadin-details-styles.js
@@ -1,5 +1,4 @@
 import '@vaadin/vaadin-material-styles/color.js';
-import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -11,105 +10,12 @@ const details = css`
     outline: none;
   }
 
-  [part='summary'] {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    position: relative;
-    outline: none;
-    min-height: 48px;
-    padding: 0 24px;
-    box-sizing: border-box;
-    font-weight: 500;
-    font-size: var(--material-small-font-size);
-    background-color: var(--material-background-color);
-    color: var(--material-body-text-color);
-    cursor: default;
-    -webkit-tap-highlight-color: transparent;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
-  :host([disabled]) [part='summary'] {
-    color: var(--material-disabled-text-color);
-    background: var(--material-disabled-color);
-  }
-
-  :host([focus-ring]) [part='summary'] {
-    background: var(--material-secondary-background-color);
-  }
-
-  [part='summary-content'] {
-    margin: 12px 0;
-  }
-
-  [part='toggle'] {
-    position: relative;
-    order: 1;
-    margin-right: -8px;
-    width: 24px;
-    height: 24px;
-    padding: 4px;
-    color: var(--material-secondary-text-color);
-    line-height: 24px;
-    text-align: center;
-    transform: rotate(90deg);
-    transition: transform 0.1s cubic-bezier(0.4, 0, 0.2, 0.1);
-  }
-
-  [part='toggle']::before {
-    font-family: 'material-icons';
-    font-size: 24px;
-    width: 24px;
-    display: inline-block;
-    content: var(--material-icons-chevron-right);
-  }
-
-  [part='toggle']::after {
-    display: inline-block;
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-    background-color: var(--material-disabled-text-color);
-    transform: scale(0);
-    opacity: 0;
-    transition: transform 0s 0.8s, opacity 0.8s;
-    will-change: transform, opacity;
-  }
-
-  :host([disabled]) [part='toggle'] {
-    color: var(--material-disabled-color);
-  }
-
-  :host(:not([disabled])) [part='summary']:active [part='toggle']::after {
-    transition-duration: 0.08s, 0.01s;
-    transition-delay: 0s, 0s;
-    transform: scale(1.25);
-    opacity: 0.15;
-  }
-
-  :host([opened]) [part='toggle'] {
-    transform: rotate(270deg);
+  :host([focus-ring]) ::slotted([slot='summary']) {
+    background-color: var(--material-secondary-background-color);
   }
 
   [part='content'] {
     padding: 8px 24px 24px;
-  }
-
-  /* RTL specific styles */
-  :host([dir='rtl']) [part='toggle'] {
-    margin-left: -8px;
-    margin-right: 0;
-  }
-
-  :host([dir='rtl']) [part='toggle']::after {
-    left: auto;
-    right: 0;
   }
 `;
 

--- a/packages/details/theme/material/vaadin-details-summary-styles.js
+++ b/packages/details/theme/material/vaadin-details-summary-styles.js
@@ -1,0 +1,104 @@
+import '@vaadin/vaadin-material-styles/color.js';
+import '@vaadin/vaadin-material-styles/font-icons.js';
+import '@vaadin/vaadin-material-styles/typography.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const detailsSummary = css`
+  :host {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    position: relative;
+    outline: none;
+    min-height: 48px;
+    padding: 0 24px;
+    box-sizing: border-box;
+    font-weight: 500;
+    font-size: var(--material-small-font-size);
+    background-color: var(--material-background-color);
+    color: var(--material-body-text-color);
+    cursor: default;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  :host([disabled]) {
+    color: var(--material-disabled-text-color);
+    background-color: var(--material-disabled-color);
+  }
+
+  [part='content'] {
+    margin: 0;
+    position: relative;
+  }
+
+  [part='toggle'] {
+    position: relative;
+    order: 1;
+    margin-inline-start: auto;
+    right: -8px;
+    width: 24px;
+    height: 24px;
+    padding: 4px;
+    color: var(--material-secondary-text-color);
+    line-height: 24px;
+    text-align: center;
+    transform: rotate(90deg);
+    transition: transform 0.1s cubic-bezier(0.4, 0, 0.2, 0.1);
+  }
+
+  [part='toggle']::before {
+    font-family: 'material-icons';
+    font-size: 24px;
+    width: 24px;
+    display: inline-block;
+    content: var(--material-icons-chevron-right);
+  }
+
+  [part='toggle']::after {
+    display: inline-block;
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-color: var(--material-disabled-text-color);
+    transform: scale(0);
+    opacity: 0;
+    transition: transform 0s 0.8s, opacity 0.8s;
+    will-change: transform, opacity;
+  }
+
+  :host([disabled]) [part='toggle'] {
+    color: var(--material-disabled-color);
+  }
+
+  :host([active]:not([disabled])) [part='toggle']::after {
+    transition-duration: 0.08s, 0.01s;
+    transition-delay: 0s, 0s;
+    transform: scale(1.25);
+    opacity: 0.15;
+  }
+
+  :host([opened]) [part='toggle'] {
+    transform: rotate(270deg);
+  }
+
+  /* RTL specific styles */
+  :host([dir='rtl']) [part='toggle'] {
+    right: 8px;
+  }
+
+  :host([dir='rtl']) [part='toggle']::after {
+    left: auto;
+    right: 0;
+  }
+`;
+
+registerStyles('vaadin-details-summary', detailsSummary, { moduleId: 'material-details-summary' });
+
+export { detailsSummary };

--- a/packages/details/theme/material/vaadin-details.js
+++ b/packages/details/theme/material/vaadin-details.js
@@ -1,2 +1,3 @@
+import './vaadin-details-summary-styles.js';
 import './vaadin-details-styles.js';
 import '../../src/vaadin-details.js';


### PR DESCRIPTION
## Description

This is a first part of re-implementing the `vaadin-details` and `vaadin-accordion` components for V24.

Some things are still marked as TODOs, especially logic for setting `aria-controls` + `aria-labelledby`.
I'm going to address those in a separate PR because this one is already way too big.

Part of #5077
Fixes #412
Fixes #90

## Overview

This PR contains several breaking changes that aim to improve accessibility for two components.

### `<vaadin-details>`

1. Added `vaadin-details-summary` which has `role="button"` and uses `ButtonMixin` internally,
2. Removed element with `role="heading"` from Shadow DOM of `vaadin-details` as not needed,
3. TODO: add `summary` property that can be used as `label` property in `vaadin-checkbox` etc.

### `<vaadin-accordion>`

1. Decoupled `vaadin-accordion-panel` from `vaadin-details` so that styles won't apply to both,
2. Changed to use `vaadin-accordion-heading` element with `role="heading"` in the `summary` slot,
3. The heading element now uses native `<button>` in Shadow DOM with `delegatesFocus: true`.

## Type of change

- Breaking change

## Note

Decided to keep `summary` slot in case of `vaadin-accordion-panel` in order to ensure that on the Flow side, the `AccordionPanel` can still have the backwards compatible API, and maybe even extend `Details` if needed.