### PR TITLE
docs: clarify and extend SlotController methods JSDoc

### DIFF
--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -54,10 +54,19 @@ export class SlotController extends EventTarget implements ReactiveController {
    */
   getSlotChild(): Node;
 
+  /**
+   * Create and attach default node using the provided tag name, if any.
+   */
   protected attachDefaultNode(): Node | undefined;
 
+  /**
+   * Run both `initCustomNode` and `initNode` for a custom slotted node.
+   */
   protected initAddedNode(node: Node): void;
 
+  /**
+   * Call `slotInitializer` on the node managed by the controller.
+   */
   protected initNode(node: Node): void;
 
   /**

--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -65,7 +65,7 @@ export class SlotController extends EventTarget implements ReactiveController {
   protected initAddedNode(node: Node): void;
 
   /**
-   * Call `slotInitializer` on the node managed by the controller.
+   * Run `slotInitializer` for the node managed by the controller.
    */
   protected initNode(node: Node): void;
 

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -145,7 +145,7 @@ export class SlotController extends EventTarget {
   }
 
   /**
-   * Call `slotInitializer` on the node managed by the controller.
+   * Run `slotInitializer` for the node managed by the controller.
    *
    * @param {Node} node
    * @protected

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -92,7 +92,7 @@ export class SlotController extends EventTarget {
   }
 
   /**
-   * Create and attach default node using the slot factory.
+   * Create and attach default node using the provided tag name, if any.
    * @return {Node | undefined}
    * @protected
    */
@@ -102,7 +102,7 @@ export class SlotController extends EventTarget {
     // Check if the node was created previously and if so, reuse it.
     let node = this.defaultNode;
 
-    // Slot factory is optional, some slots don't have default content.
+    // Tag name is optional, sometimes we don't init default content.
     if (!node && tagName) {
       node = document.createElement(tagName);
       if (node instanceof Element) {
@@ -145,6 +145,8 @@ export class SlotController extends EventTarget {
   }
 
   /**
+   * Call `slotInitializer` on the node managed by the controller.
+   *
    * @param {Node} node
    * @protected
    */
@@ -173,7 +175,12 @@ export class SlotController extends EventTarget {
    */
   teardownNode(_node) {}
 
-  /** @protected */
+  /**
+   * Run both `initCustomNode` and `initNode` for a custom slotted node.
+   *
+   * @param {Node} node
+   * @protected
+   */
   initAddedNode(node) {
     if (node !== this.defaultNode) {
       this.initCustomNode(node);


### PR DESCRIPTION
## Description

Added missing JSDoc comments to some methods in `SlotController` those names are not self-explanatory.
Also fixed a few remaining mentions of the `slot factory` as it has been replaced with tag name for V24.

## Type of change

- Documentation