### PR TITLE
refactor: remove node ID getters from controllers

### DIFF
--- a/packages/field-base/src/error-controller.d.ts
+++ b/packages/field-base/src/error-controller.d.ts
@@ -10,11 +10,6 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  */
 export class ErrorController extends SlotController {
   /**
-   * ID attribute value set on the error message element.
-   */
-  readonly errorId: string;
-
-  /**
    * String used for the error message text content.
    */
   protected errorMessage: string | null | undefined;

--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -21,15 +21,6 @@ export class ErrorController extends SlotController {
   }
 
   /**
-   * ID attribute value set on the error message element.
-   *
-   * @return {string}
-   */
-  get errorId() {
-    return this.node && this.node.id;
-  }
-
-  /**
    * Set the error message element text content.
    *
    * @param {string} errorMessage

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -56,22 +56,12 @@ export const FieldMixin = (superclass) =>
       return ['_invalidChanged(invalid)', '_requiredChanged(required)'];
     }
 
-    /** @protected */
-    get _errorId() {
-      return this._errorController.errorId;
-    }
-
     /**
      * @protected
      * @return {HTMLElement}
      */
     get _errorNode() {
       return this._errorController.node;
-    }
-
-    /** @protected */
-    get _helperId() {
-      return this._helperController.helperId;
     }
 
     /**
@@ -178,7 +168,8 @@ export const FieldMixin = (superclass) =>
         // Error message ID needs to be dynamically added / removed based on the validity
         // Otherwise assistive technologies would announce the error, even if we hide it.
         if (invalid) {
-          this._fieldAriaController.setErrorId(this._errorController.errorId);
+          const node = this._errorNode;
+          this._fieldAriaController.setErrorId(node && node.id);
         } else {
           this._fieldAriaController.setErrorId(null);
         }

--- a/packages/field-base/src/helper-controller.d.ts
+++ b/packages/field-base/src/helper-controller.d.ts
@@ -14,8 +14,6 @@ export class HelperController extends SlotController {
    */
   helperText: string | null | undefined;
 
-  helperId: string;
-
   /**
    * Set helper text based on corresponding host property.
    */

--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -16,10 +16,6 @@ export class HelperController extends SlotController {
     });
   }
 
-  get helperId() {
-    return this.node && this.node.id;
-  }
-
   /**
    * Override to initialize the newly added custom helper.
    *

--- a/packages/field-base/src/label-controller.d.ts
+++ b/packages/field-base/src/label-controller.d.ts
@@ -10,11 +10,6 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  */
 export class LabelController extends SlotController {
   /**
-   * ID attribute value set on the label element.
-   */
-  labelId: string;
-
-  /**
    * String used for the label.
    */
   protected label: string | null | undefined;

--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -25,13 +25,6 @@ export class LabelController extends SlotController {
   }
 
   /**
-   * @return {string}
-   */
-  get labelId() {
-    return this.node.id;
-  }
-
-  /**
    * Override to initialize the newly added custom label.
    *
    * @param {Node} labelNode

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -31,7 +31,8 @@ export const LabelMixin = dedupingMixin(
 
       /** @protected */
       get _labelId() {
-        return this._labelController.labelId;
+        const node = this._labelNode;
+        return node && node.id;
       }
 
       /** @protected */


### PR DESCRIPTION
## Description

Some field controllers have protected ID getters that are either unused or can be easily replaced. Let's remove them.

## Type of change

- Refactor