### PR TITLE
fix: check for bad input when updating _hasInputValue (CP: 23.3) (#5092)

### DIFF
--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -56,4 +56,6 @@ export declare class InputMixinClass {
   protected _toggleHasValue(hasValue: boolean): void;
 
   protected _valueChanged(value?: string, oldValue?: string): void;
+
+  protected _setHasInputValue(event: InputEvent): void;
 }

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -155,11 +155,7 @@ export const InputMixin = dedupingMixin(
        * @private
        */
       __onInput(event) {
-        // In the case a custom web component is passed as `inputElement`,
-        // the actual native input element, on which the event occurred,
-        // can be inside shadow trees.
-        const target = event.composedPath()[0];
-        this._hasInputValue = target.value.length > 0;
+        this._setHasInputValue(event);
         this._onInput(event);
       }
 
@@ -229,6 +225,20 @@ export const InputMixin = dedupingMixin(
        */
       get _hasValue() {
         return this.value != null && this.value !== '';
+      }
+
+      /**
+       * Sets the `_hasInputValue` property based on the `input` event.
+       *
+       * @param {InputEvent} event
+       * @protected
+       */
+      _setHasInputValue(event) {
+        // In the case a custom web component is passed as `inputElement`,
+        // the actual native input element, on which the event occurred,
+        // can be inside shadow trees.
+        const target = event.composedPath()[0];
+        this._hasInputValue = target.value.length > 0;
       }
     },
 );

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -451,6 +451,22 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
   _isStepButtonVisible(hasControls, stepButtonsVisible) {
     return hasControls || stepButtonsVisible;
   }
+
+  /**
+   * Native [type=number] inputs don't update their value
+   * when you are entering input that the browser is unable to parse
+   * e.g. "--5", hence we have to override this method from `InputMixin`
+   * so that, when value is empty, it would additionally check
+   * for bad input based on the native `validity.badInput` property.
+   *
+   * @param {InputEvent} event
+   * @protected
+   * @override
+   */
+  _setHasInputValue(event) {
+    const target = event.composedPath()[0];
+    this._hasInputValue = target.value.length > 0 || target.validity.badInput;
+  }
 }
 
 customElements.define(NumberField.is, NumberField);

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { arrowDown, arrowUp, fixtureSync } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-number-field.js';
 
@@ -641,6 +642,38 @@ describe('number-field', () => {
 
         expect(numberField.value).to.be.equal('-6');
       });
+    });
+  });
+
+  describe('has-input-value-changed event', () => {
+    let hasInputValueChangedSpy;
+
+    beforeEach(() => {
+      hasInputValueChangedSpy = sinon.spy();
+      numberField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+      input.focus();
+    });
+
+    it('should fire the event when entering and removing a valid number', async () => {
+      await sendKeys({ type: '555' });
+      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+
+      hasInputValueChangedSpy.resetHistory();
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+    });
+
+    it('should fire the event when entering and removing an invalid number', async () => {
+      await sendKeys({ type: '--5' });
+      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+
+      hasInputValueChangedSpy.resetHistory();
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
     });
   });
 });


### PR DESCRIPTION
This PR cherry-picks the following fix to the `23.3` branch:

- https://github.com/vaadin/web-components/pull/5092
