### PR TITLE
refactor: move slotted node observing to separate controller

### DIFF
--- a/packages/component-base/src/slot-observe-controller.d.ts
+++ b/packages/component-base/src/slot-observe-controller.d.ts
@@ -11,13 +11,18 @@ import { SlotController } from './slot-controller.js';
  */
 export class SlotObserveController extends SlotController {
   /**
-   * Override to update default node, e.g. when restoring it.
-   */
-  protected applyDefaultNode(node: Node): void;
-
-  /**
    * Setup the mutation observer on the node to update ID and notify host.
    * Node doesn't get observed automatically until this method is called.
    */
   protected observeNode(node: Node): void;
+
+  /**
+   * Override to restore default node when a custom one is removed.
+   */
+  protected restoreDefaultNode(): void;
+
+  /**
+   * Override to update default node text on property change.
+   */
+  protected updateDefaultNode(node: Node): void;
 }

--- a/packages/component-base/src/slot-observe-controller.d.ts
+++ b/packages/component-base/src/slot-observe-controller.d.ts
@@ -16,7 +16,8 @@ export class SlotObserveController extends SlotController {
   protected applyDefaultNode(node: Node): void;
 
   /**
-   * Setup the mutation observer on the node and update its ID.
+   * Setup the mutation observer on the node to update ID and notify host.
+   * Node doesn't get observed automatically until this method is called.
    */
-  protected observeNodeId(node: Node): void;
+  protected observeNode(node: Node): void;
 }

--- a/packages/component-base/src/slot-observe-controller.d.ts
+++ b/packages/component-base/src/slot-observe-controller.d.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright (c) 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotController } from './slot-controller.js';
+
+/**
+ * A controller that observes slotted element mutations, especially ID attribute
+ * and the text content, and fires an event to notify host element about those.
+ */
+export class SlotObserveController extends SlotController {
+  /**
+   * Override to update default node, e.g. when restoring it.
+   */
+  protected applyDefaultNode(node: Node): void;
+
+  /**
+   * Setup the mutation observer on the node and update its ID.
+   */
+  protected observeNodeId(node: Node): void;
+}

--- a/packages/component-base/src/slot-observe-controller.js
+++ b/packages/component-base/src/slot-observe-controller.js
@@ -22,8 +22,7 @@ export class SlotObserveController extends SlotController {
    * @override
    */
   initCustomNode(node) {
-    this.observeNode(node);
-
+    this.__updateNodeId(node);
     this.__toggleHasNode(node);
   }
 
@@ -49,32 +48,25 @@ export class SlotObserveController extends SlotController {
   /**
    * Override to update default node, e.g. when restoring it.
    *
-   * @param {Node} node
+   * @param {Node | undefined} node
    * @protected
    */
   applyDefaultNode(node) {
+    if (node) {
+      this.__updateNodeId(node);
+    }
+
     this.__toggleHasNode(node);
   }
 
   /**
-   * Setup the mutation observer on the node and update its ID.
+   * Setup the mutation observer on the node to update ID and notify host.
+   * Node doesn't get observed automatically until this method is called.
    *
    * @param {Node} node
    * @protected
    */
   observeNode(node) {
-    this.__updateNodeId(node);
-
-    this.__observeNode(node);
-  }
-
-  /**
-   * Setup the mutation observer on the node to update ID and notify host.
-   *
-   * @param {HTMLElement} node
-   * @protected
-   */
-  __observeNode(node) {
     // Stop observing the previous node, if any.
     if (this.__nodeObserver) {
       this.__nodeObserver.disconnect();

--- a/packages/component-base/src/slot-observe-controller.js
+++ b/packages/component-base/src/slot-observe-controller.js
@@ -41,21 +41,45 @@ export class SlotObserveController extends SlotController {
     if (node && node !== this.defaultNode) {
       this.__notifyChange(node);
     } else {
-      this.applyDefaultNode(node);
+      this.restoreDefaultNode();
+      this.updateDefaultNode(this.node);
     }
   }
 
   /**
-   * Override to update default node, e.g. when restoring it.
+   * Override method inherited from `SlotMixin`
+   * to set ID attribute on the default node.
    *
-   * @param {Node | undefined} node
+   * @return {Node}
    * @protected
+   * @override
    */
-  applyDefaultNode(node) {
+  attachDefaultNode() {
+    const node = super.attachDefaultNode();
+
     if (node) {
       this.__updateNodeId(node);
     }
 
+    return node;
+  }
+
+  /**
+   * Override to restore default node when a custom one is removed.
+   *
+   * @protected
+   */
+  restoreDefaultNode() {
+    // To be implemented
+  }
+
+  /**
+   * Override to update default node text on property change.
+   *
+   * @param {Node} node
+   * @protected
+   */
+  updateDefaultNode(node) {
     this.__notifyChange(node);
   }
 

--- a/packages/component-base/src/slot-observe-controller.js
+++ b/packages/component-base/src/slot-observe-controller.js
@@ -23,7 +23,7 @@ export class SlotObserveController extends SlotController {
    */
   initCustomNode(node) {
     this.__updateNodeId(node);
-    this.__toggleHasNode(node);
+    this.__notifyChange(node);
   }
 
   /**
@@ -39,7 +39,7 @@ export class SlotObserveController extends SlotController {
 
     // Custom node is added to the slot
     if (node && node !== this.defaultNode) {
-      this.__toggleHasNode(node);
+      this.__notifyChange(node);
     } else {
       this.applyDefaultNode(node);
     }
@@ -56,7 +56,7 @@ export class SlotObserveController extends SlotController {
       this.__updateNodeId(node);
     }
 
-    this.__toggleHasNode(node);
+    this.__notifyChange(node);
   }
 
   /**
@@ -88,7 +88,7 @@ export class SlotObserveController extends SlotController {
           }
         } else if (isCurrentNodeMutation || target.parentElement === this.node) {
           // Node text content has changed.
-          this.__toggleHasNode(this.node);
+          this.__notifyChange(this.node);
         }
       });
     });
@@ -111,7 +111,7 @@ export class SlotObserveController extends SlotController {
    * @return {boolean}
    * @private
    */
-  __hasNode(node) {
+  __hasContent(node) {
     if (!node) {
       return false;
     }
@@ -129,12 +129,10 @@ export class SlotObserveController extends SlotController {
    * @param {Node} node
    * @private
    */
-  __toggleHasNode(node) {
-    const hasNode = this.__hasNode(node);
-
+  __notifyChange(node) {
     this.dispatchEvent(
-      new CustomEvent('node-changed', {
-        detail: { hasNode, node },
+      new CustomEvent('slot-content-changed', {
+        detail: { hasContent: this.__hasContent(node), node },
       }),
     );
   }

--- a/packages/component-base/src/slot-observe-controller.js
+++ b/packages/component-base/src/slot-observe-controller.js
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright (c) 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotController } from './slot-controller.js';
+
+/**
+ * A controller that observes slotted element mutations, especially ID attribute
+ * and the text content, and fires an event to notify host element about those.
+ */
+export class SlotObserveController extends SlotController {
+  constructor(host, slot, tagName, config = {}) {
+    super(host, slot, tagName, { ...config, useUniqueId: true });
+  }
+
+  /**
+   * Override to initialize the newly added custom node.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  initCustomNode(node) {
+    this.observeNode(node);
+
+    this.__toggleHasNode(node);
+  }
+
+  /**
+   * Override to notify the controller host about removal of
+   * the custom node, and to apply the default one if needed.
+   *
+   * @param {Node} _node
+   * @protected
+   * @override
+   */
+  teardownNode(_node) {
+    const node = this.getSlotChild();
+
+    // Custom node is added to the slot
+    if (node && node !== this.defaultNode) {
+      this.__toggleHasNode(node);
+    } else {
+      this.applyDefaultNode(node);
+    }
+  }
+
+  /**
+   * Override to update default node, e.g. when restoring it.
+   *
+   * @param {Node} node
+   * @protected
+   */
+  applyDefaultNode(node) {
+    this.__toggleHasNode(node);
+  }
+
+  /**
+   * Setup the mutation observer on the node and update its ID.
+   *
+   * @param {Node} node
+   * @protected
+   */
+  observeNode(node) {
+    this.__updateNodeId(node);
+
+    this.__observeNode(node);
+  }
+
+  /**
+   * Setup the mutation observer on the node to update ID and notify host.
+   *
+   * @param {HTMLElement} node
+   * @protected
+   */
+  __observeNode(node) {
+    // Stop observing the previous node, if any.
+    if (this.__nodeObserver) {
+      this.__nodeObserver.disconnect();
+    }
+
+    this.__nodeObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        const target = mutation.target;
+
+        // Ensure the mutation target is the currently connected node
+        // to ignore async mutations dispatched for removed element.
+        const isCurrentNodeMutation = target === this.node;
+
+        if (mutation.type === 'attributes') {
+          // We use attributeFilter to only observe ID mutation,
+          // no need to check for attribute name separately.
+          if (isCurrentNodeMutation && target.id !== this.defaultId) {
+            this.__updateNodeId(target);
+          }
+        } else if (isCurrentNodeMutation || target.parentElement === this.node) {
+          // Node text content has changed.
+          this.__toggleHasNode(this.node);
+        }
+      });
+    });
+
+    // Observe changes to node ID attribute, text content and children.
+    this.__nodeObserver.observe(node, {
+      attributes: true,
+      attributeFilter: ['id'],
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+
+  /**
+   * Returns true if a node is an HTML element with children,
+   * or is a defined custom element, or has non-empty text.
+   *
+   * @param {Node} node
+   * @return {boolean}
+   * @private
+   */
+  __hasNode(node) {
+    if (!node) {
+      return false;
+    }
+
+    return (
+      node.children.length > 0 ||
+      (node.nodeType === Node.ELEMENT_NODE && customElements.get(node.localName)) ||
+      (node.textContent && node.textContent.trim() !== '')
+    );
+  }
+
+  /**
+   * Fire an event to notify the controller host about node changes.
+   *
+   * @param {Node} node
+   * @private
+   */
+  __toggleHasNode(node) {
+    const hasNode = this.__hasNode(node);
+
+    this.dispatchEvent(
+      new CustomEvent('node-changed', {
+        detail: { hasNode, node },
+      }),
+    );
+  }
+
+  /**
+   * Set default ID on the node in case it is an HTML element.
+   *
+   * @param {Node} node
+   * @private
+   */
+  __updateNodeId(node) {
+    if (node.nodeType === Node.ELEMENT_NODE && !node.id) {
+      node.id = this.defaultId;
+    }
+  }
+}

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -79,15 +79,15 @@ export const FieldMixin = (superclass) =>
       this._helperController = new HelperController(this);
       this._errorController = new ErrorController(this);
 
-      this._labelController.addEventListener('node-changed', (event) => {
-        const { hasNode, node } = event.detail;
-        this.__labelChanged(hasNode, node);
+      this._labelController.addEventListener('slot-content-changed', (event) => {
+        const { hasContent, node } = event.detail;
+        this.__labelChanged(hasContent, node);
       });
 
-      this._helperController.addEventListener('node-changed', (event) => {
-        const { hasNode, node } = event.detail;
-        this.toggleAttribute('has-helper', hasNode);
-        this.__helperChanged(hasNode, node);
+      this._helperController.addEventListener('slot-content-changed', (event) => {
+        const { hasContent, node } = event.detail;
+        this.toggleAttribute('has-helper', hasContent);
+        this.__helperChanged(hasContent, node);
       });
     }
 

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -84,9 +84,10 @@ export const FieldMixin = (superclass) =>
         this.__labelChanged(hasLabel, node);
       });
 
-      this._helperController.addEventListener('helper-changed', (event) => {
-        const { hasHelper, node } = event.detail;
-        this.__helperChanged(hasHelper, node);
+      this._helperController.addEventListener('node-changed', (event) => {
+        const { hasNode, node } = event.detail;
+        this.toggleAttribute('has-helper', hasNode);
+        this.__helperChanged(hasNode, node);
       });
     }
 

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -79,9 +79,9 @@ export const FieldMixin = (superclass) =>
       this._helperController = new HelperController(this);
       this._errorController = new ErrorController(this);
 
-      this._labelController.addEventListener('label-changed', (event) => {
-        const { hasLabel, node } = event.detail;
-        this.__labelChanged(hasLabel, node);
+      this._labelController.addEventListener('node-changed', (event) => {
+        const { hasNode, node } = event.detail;
+        this.__labelChanged(hasNode, node);
       });
 
       this._helperController.addEventListener('node-changed', (event) => {

--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -22,41 +22,55 @@ export class HelperController extends SlotObserveController {
   setHelperText(helperText) {
     this.helperText = helperText;
 
+    // Restore the default helper, if needed.
     const helperNode = this.getSlotChild();
-    if (!helperNode || helperNode === this.defaultNode) {
-      this.applyDefaultNode(helperNode);
+    if (!helperNode) {
+      this.restoreDefaultNode();
+    }
+
+    // When default helper is used, update it.
+    if (this.node === this.defaultNode) {
+      this.updateDefaultNode(this.node);
     }
   }
 
   /**
-   * Override method inherited from `SlotMutationController`
+   * Override method inherited from `SlotObserveController`
    * to create the default helper element lazily as needed.
    *
    * @param {Node | undefined} node
    * @protected
    * @override
    */
-  applyDefaultNode(node) {
+  restoreDefaultNode() {
     const { helperText } = this;
-    const hasHelperText = helperText && helperText.trim() !== '';
-    let helperNode = node;
 
     // No helper yet, create one.
-    if (hasHelperText && !node) {
+    if (helperText && helperText.trim() !== '') {
       this.tagName = 'div';
 
-      helperNode = this.attachDefaultNode();
+      const helperNode = this.attachDefaultNode();
 
       // Observe the default node.
       this.observeNode(helperNode);
     }
+  }
 
-    if (helperNode) {
-      helperNode.textContent = helperText;
+  /**
+   * Override method inherited from `SlotObserveController`
+   * to update the default helper element text content.
+   *
+   * @param {Node | undefined} node
+   * @protected
+   * @override
+   */
+  updateDefaultNode(node) {
+    if (node) {
+      node.textContent = this.helperText;
     }
 
-    // Notify the host after node is created.
-    super.applyDefaultNode(helperNode);
+    // Notify the host after update.
+    super.updateDefaultNode(node);
   }
 
   /**

--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -47,6 +47,7 @@ export class HelperController extends SlotObserveController {
 
       helperNode = this.attachDefaultNode();
 
+      // Observe the default node.
       this.observeNode(helperNode);
     }
 
@@ -54,7 +55,21 @@ export class HelperController extends SlotObserveController {
       helperNode.textContent = helperText;
     }
 
-    // Call super to notify the controller host.
+    // Notify the host after node is created.
     super.applyDefaultNode(helperNode);
+  }
+
+  /**
+   * Override to observe the newly added custom node.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  initCustomNode(node) {
+    // Notify the host about a custom slotted helper.
+    super.initCustomNode(node);
+
+    this.observeNode(node);
   }
 }

--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -3,62 +3,20 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
 
 /**
  * A controller that manages the helper node content.
  */
-export class HelperController extends SlotController {
+export class HelperController extends SlotObserveController {
   constructor(host) {
     // Do not provide tag name, as we create helper lazily.
-    super(host, 'helper', null, {
-      useUniqueId: true,
-    });
-  }
-
-  /**
-   * Override to initialize the newly added custom helper.
-   *
-   * @param {Node} helperNode
-   * @protected
-   * @override
-   */
-  initCustomNode(helperNode) {
-    this.__updateHelperId(helperNode);
-
-    this.__observeHelper(helperNode);
-
-    const hasHelper = this.__hasHelper(helperNode);
-    this.__toggleHasHelper(hasHelper);
-  }
-
-  /**
-   * Override to cleanup helper node when it's removed.
-   *
-   * @param {Node} _node
-   * @protected
-   * @override
-   */
-  teardownNode(_node) {
-    // The observer does not exist when the default helper is removed.
-    if (this.__helperIdObserver) {
-      this.__helperIdObserver.disconnect();
-    }
-
-    const helperNode = this.getSlotChild();
-
-    // Custom node is added to helper slot
-    if (helperNode && helperNode !== this.defaultNode) {
-      const hasHelper = this.__hasHelper(helperNode);
-      this.__toggleHasHelper(hasHelper);
-    } else {
-      // Restore default helper if needed
-      this.__applyDefaultHelper(this.helperText, helperNode);
-    }
+    super(host, 'helper', null);
   }
 
   /**
    * Set helper text based on corresponding host property.
+   *
    * @param {string} helperText
    */
   setHelperText(helperText) {
@@ -66,122 +24,37 @@ export class HelperController extends SlotController {
 
     const helperNode = this.getSlotChild();
     if (!helperNode || helperNode === this.defaultNode) {
-      this.__applyDefaultHelper(helperText, helperNode);
+      this.applyDefaultNode(helperNode);
     }
   }
 
   /**
-   * @param {HTMLElement} helperNode
-   * @return {boolean}
-   * @private
+   * Override method inherited from `SlotMutationController`
+   * to create the default helper element lazily as needed.
+   *
+   * @param {Node | undefined} node
+   * @protected
+   * @override
    */
-  __hasHelper(helperNode) {
-    if (!helperNode) {
-      return false;
-    }
+  applyDefaultNode(node) {
+    const { helperText } = this;
+    const hasHelperText = helperText && helperText.trim() !== '';
+    let helperNode = node;
 
-    return (
-      helperNode.children.length > 0 ||
-      (helperNode.nodeType === Node.ELEMENT_NODE && customElements.get(helperNode.localName)) ||
-      this.__isNotEmpty(helperNode.textContent)
-    );
-  }
-
-  /**
-   * @param {string} helperText
-   * @private
-   */
-  __isNotEmpty(helperText) {
-    return helperText && helperText.trim() !== '';
-  }
-
-  /**
-   * @param {string} helperText
-   * @param {Node} helperNode
-   * @private
-   */
-  __applyDefaultHelper(helperText, helperNode) {
-    const hasHelperText = this.__isNotEmpty(helperText);
-
-    if (hasHelperText && !helperNode) {
-      // Set tag name lazily to only create helper node when needed.
+    // No helper yet, create one.
+    if (hasHelperText && !node) {
       this.tagName = 'div';
 
       helperNode = this.attachDefaultNode();
 
-      this.__updateHelperId(helperNode);
-      this.__observeHelper(helperNode);
+      this.observeNode(helperNode);
     }
 
     if (helperNode) {
       helperNode.textContent = helperText;
     }
 
-    this.__toggleHasHelper(hasHelperText);
-  }
-
-  /**
-   * @param {HTMLElement} helperNode
-   * @private
-   */
-  __observeHelper(helperNode) {
-    this.__helperObserver = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        const target = mutation.target;
-
-        // Ensure the mutation target is the currently connected helper
-        // to ignore async mutations dispatched for removed element.
-        const isHelperMutation = target === this.node;
-
-        if (mutation.type === 'attributes') {
-          // We use attributeFilter to only observe ID mutation,
-          // no need to check for attribute name separately.
-          if (isHelperMutation && target.id !== this.defaultId) {
-            this.__updateHelperId(target);
-          }
-        } else if (isHelperMutation || target.parentElement === this.node) {
-          // Update has-helper when textContent changes
-          const hasHelper = this.__hasHelper(this.node);
-          this.__toggleHasHelper(hasHelper);
-        }
-      });
-    });
-
-    // Observe changes to helper ID attribute, text content and children.
-    this.__helperObserver.observe(helperNode, {
-      attributes: true,
-      attributeFilter: ['id'],
-      childList: true,
-      subtree: true,
-      characterData: true,
-    });
-  }
-
-  /**
-   * @param {boolean} hasHelper
-   * @private
-   */
-  __toggleHasHelper(hasHelper) {
-    this.host.toggleAttribute('has-helper', hasHelper);
-
-    // Make it possible for other mixins to observe change
-    this.dispatchEvent(
-      new CustomEvent('helper-changed', {
-        detail: {
-          hasHelper,
-          node: this.node,
-        },
-      }),
-    );
-  }
-
-  /**
-   * @param {HTMLElement} helperNode
-   * @private
-   */
-  __updateHelperId(helperNode) {
-    if (!helperNode.id) {
-      helperNode.id = this.defaultId;
-    }
+    // Call super to notify the controller host.
+    super.applyDefaultNode(helperNode);
   }
 }

--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -3,65 +3,14 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
 
 /**
  * A controller to manage the label element.
  */
-export class LabelController extends SlotController {
+export class LabelController extends SlotObserveController {
   constructor(host) {
-    super(host, 'label', 'label', {
-      initializer: (node) => {
-        // Set ID attribute or use the existing one.
-        this.__updateLabelId(node);
-
-        // Set text content for the default label.
-        this.__updateDefaultLabel(this.label);
-
-        this.__observeLabel(node);
-      },
-      useUniqueId: true,
-    });
-  }
-
-  /**
-   * Override to initialize the newly added custom label.
-   *
-   * @param {Node} labelNode
-   * @protected
-   * @override
-   */
-  initCustomNode(labelNode) {
-    this.__updateLabelId(labelNode);
-
-    const hasLabel = this.__hasLabel(labelNode);
-    this.__toggleHasLabel(hasLabel);
-  }
-
-  /**
-   * Override to cleanup label node when it's removed.
-   *
-   * @param {Node} node
-   * @protected
-   * @override
-   */
-  teardownNode(node) {
-    if (this.__labelObserver) {
-      this.__labelObserver.disconnect();
-    }
-
-    let labelNode = this.getSlotChild();
-
-    // If custom label was removed, restore the default one.
-    if (!labelNode && node !== this.defaultNode) {
-      labelNode = this.attachDefaultNode();
-
-      // Run initializer to update default label and ID.
-      this.initNode(labelNode);
-    }
-
-    const hasLabel = this.__hasLabel(labelNode);
-    this.__toggleHasLabel(hasLabel);
+    super(host, 'label', 'label');
   }
 
   /**
@@ -72,108 +21,68 @@ export class LabelController extends SlotController {
   setLabel(label) {
     this.label = label;
 
-    this.__updateDefaultLabel(label);
-  }
-
-  /**
-   * @param {HTMLElement} labelNode
-   * @return {boolean}
-   * @private
-   */
-  __hasLabel(labelNode) {
-    if (!labelNode) {
-      return false;
-    }
-
-    return labelNode.children.length > 0 || this.__isNotEmpty(labelNode.textContent);
-  }
-
-  /**
-   * @param {string} label
-   * @private
-   */
-  __isNotEmpty(label) {
-    return Boolean(label && label.trim() !== '');
-  }
-
-  /**
-   * @param {HTMLElement} labelNode
-   * @private
-   */
-  __observeLabel(labelNode) {
-    this.__labelObserver = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        const target = mutation.target;
-
-        // Ensure the mutation target is the currently connected label
-        // to ignore async mutations dispatched for removed element.
-        const isLabelMutation = target === this.node;
-
-        if (mutation.type === 'attributes') {
-          // We use attributeFilter to only observe ID mutation,
-          // no need to check for attribute name separately.
-          if (isLabelMutation && target.id !== this.defaultId) {
-            this.__updateLabelId(target);
-          }
-        } else if (isLabelMutation || target.parentElement === this.node) {
-          // Update has-label when textContent changes
-          const hasLabel = this.__hasLabel(this.node);
-          this.__toggleHasLabel(hasLabel);
-        }
-      });
-    });
-
-    // Observe changes to label ID attribute, text content and children.
-    this.__labelObserver.observe(labelNode, {
-      attributes: true,
-      attributeFilter: ['id'],
-      childList: true,
-      subtree: true,
-      characterData: true,
-    });
-  }
-
-  /**
-   * @param {boolean} hasLabel
-   * @private
-   */
-  __toggleHasLabel(hasLabel) {
-    this.host.toggleAttribute('has-label', hasLabel);
-
-    // Make it possible for other mixins to observe change
-    this.dispatchEvent(
-      new CustomEvent('label-changed', {
-        detail: {
-          hasLabel,
-          node: this.node,
-        },
-      }),
-    );
-  }
-
-  /**
-   * @param {string} label
-   * @private
-   */
-  __updateDefaultLabel(label) {
-    if (this.defaultNode) {
-      this.defaultNode.textContent = label;
-
-      // Update has-label if default label is used
-      if (this.defaultNode === this.node) {
-        const hasLabel = this.__isNotEmpty(label);
-        this.__toggleHasLabel(hasLabel);
-      }
+    const labelNode = this.getSlotChild();
+    if (!labelNode || labelNode === this.defaultNode) {
+      this.applyDefaultNode(labelNode);
     }
   }
 
   /**
-   * @param {HTMLElement} labelNode
-   * @private
+   * Override method inherited from `SlotMutationController`
+   * to update the default label text based on the `label`.
+   *
+   * @param {Node | undefined} node
+   * @protected
+   * @override
    */
-  __updateLabelId(labelNode) {
-    if (!labelNode.id) {
-      labelNode.id = this.defaultId;
+  applyDefaultNode(node) {
+    const { label } = this;
+
+    const hasLabel = label && label.trim() !== '';
+    let labelNode = node;
+
+    // Restore the default label.
+    if (hasLabel && !node) {
+      labelNode = this.attachDefaultNode();
+
+      // Observe the default label.
+      this.observeNode(labelNode);
     }
+
+    if (labelNode) {
+      labelNode.textContent = label;
+    }
+
+    // Notify the host after node is updated.
+    super.applyDefaultNode(labelNode);
+  }
+
+  /**
+   * Override method inherited from `SlotMixin` to observe
+   * the default label node, but not the custom one.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  initNode(node) {
+    if (node === this.defaultNode) {
+      this.applyDefaultNode(node);
+      this.observeNode(node);
+    }
+  }
+
+  /**
+   * Override to observe the newly added custom node.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  initCustomNode(node) {
+    // Notify the host about adding a custom node.
+    super.initCustomNode(node);
+
+    this.observeNode(node);
   }
 }

--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -21,40 +21,52 @@ export class LabelController extends SlotObserveController {
   setLabel(label) {
     this.label = label;
 
+    // Restore the default label, if needed.
     const labelNode = this.getSlotChild();
-    if (!labelNode || labelNode === this.defaultNode) {
-      this.applyDefaultNode(labelNode);
+    if (!labelNode) {
+      this.restoreDefaultNode();
+    }
+
+    // When default label is used, update it.
+    if (this.node === this.defaultNode) {
+      this.updateDefaultNode(this.node);
     }
   }
 
   /**
-   * Override method inherited from `SlotMutationController`
-   * to update the default label text based on the `label`.
+   * Override method inherited from `SlotObserveController`
+   * to restore and observe the default label element.
+   *
+   * @protected
+   * @override
+   */
+  restoreDefaultNode() {
+    const { label } = this;
+
+    // Restore the default label.
+    if (label && label.trim() !== '') {
+      const labelNode = this.attachDefaultNode();
+
+      // Observe the default label.
+      this.observeNode(labelNode);
+    }
+  }
+
+  /**
+   * Override method inherited from `SlotObserveController`
+   * to update the default label element text content.
    *
    * @param {Node | undefined} node
    * @protected
    * @override
    */
-  applyDefaultNode(node) {
-    const { label } = this;
-
-    const hasLabel = label && label.trim() !== '';
-    let labelNode = node;
-
-    // Restore the default label.
-    if (hasLabel && !node) {
-      labelNode = this.attachDefaultNode();
-
-      // Observe the default label.
-      this.observeNode(labelNode);
+  updateDefaultNode(node) {
+    if (node) {
+      node.textContent = this.label;
     }
 
-    if (labelNode) {
-      labelNode.textContent = label;
-    }
-
-    // Notify the host after node is updated.
-    super.applyDefaultNode(labelNode);
+    // Notify the host after update.
+    super.updateDefaultNode(node);
   }
 
   /**
@@ -67,7 +79,7 @@ export class LabelController extends SlotObserveController {
    */
   initNode(node) {
     if (node === this.defaultNode) {
-      this.applyDefaultNode(node);
+      this.updateDefaultNode(node);
       this.observeNode(node);
     }
   }

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -45,9 +45,8 @@ export const LabelMixin = dedupingMixin(
 
         this._labelController = new LabelController(this);
 
-        this._labelController.addEventListener('node-changed', (event) => {
-          const { hasNode } = event.detail;
-          this.toggleAttribute('has-label', hasNode);
+        this._labelController.addEventListener('slot-content-changed', (event) => {
+          this.toggleAttribute('has-label', event.detail.hasContent);
         });
       }
 

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -44,6 +44,11 @@ export const LabelMixin = dedupingMixin(
         super();
 
         this._labelController = new LabelController(this);
+
+        this._labelController.addEventListener('node-changed', (event) => {
+          const { hasNode } = event.detail;
+          this.toggleAttribute('has-label', hasNode);
+        });
       }
 
       /** @protected */

--- a/packages/field-base/src/labelled-input-controller.js
+++ b/packages/field-base/src/labelled-input-controller.js
@@ -12,7 +12,7 @@ export class LabelledInputController {
     this.input = input;
     this.__preventDuplicateLabelClick = this.__preventDuplicateLabelClick.bind(this);
 
-    labelController.addEventListener('label-changed', (event) => {
+    labelController.addEventListener('node-changed', (event) => {
       this.__initLabel(event.detail.node);
     });
 

--- a/packages/field-base/src/labelled-input-controller.js
+++ b/packages/field-base/src/labelled-input-controller.js
@@ -12,7 +12,7 @@ export class LabelledInputController {
     this.input = input;
     this.__preventDuplicateLabelClick = this.__preventDuplicateLabelClick.bind(this);
 
-    labelController.addEventListener('node-changed', (event) => {
+    labelController.addEventListener('slot-content-changed', (event) => {
       this.__initLabel(event.detail.node);
     });
 


### PR DESCRIPTION
## Description

Extracted some logic from `LabelController` and `HelperController` that is responsible for observing node mutations.
This is a pre-requisite for handling ARIA attributes on the slotted content planned to be done in #5093.

Note: unit tests for the new controller are missing, but we don't have them for `LabelController` and `HelperController` either as those are supposed to be used in combination with respective mixins, and are covered by their tests.

## Type of change

- Refactor