### PR TITLE
fix: propagate text-align to column groups

### DIFF
--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -473,11 +473,29 @@ export const ColumnBaseMixin = (superClass) =>
       }
 
       this._allCells.forEach((cell) => {
-        cell._content.style.textAlign = textAlign;
-        if (getComputedStyle(cell._content).textAlign !== textAlign) {
-          cell._content.style.textAlign = textAlignFallback;
-        }
+        this.__setCellTextAlign(cell, textAlign, textAlignFallback);
       });
+
+      let parentGroup = this.parentElement;
+      while (parentGroup.tagName === 'VAADIN-GRID-COLUMN-GROUP') {
+        if (parentGroup._colSpan === 1) {
+          if (parentGroup._headerCell) {
+            this.__setCellTextAlign(parentGroup._headerCell, textAlign, textAlignFallback);
+          }
+          if (parentGroup._footerCell) {
+            this.__setCellTextAlign(parentGroup._footerCell, textAlign, textAlignFallback);
+          }
+        }
+        parentGroup = parentGroup.parentElement;
+      }
+    }
+
+    /** @private */
+    __setCellTextAlign(cell, textAlign, textAlignFallback) {
+      cell._content.style.textAlign = textAlign;
+      if (getComputedStyle(cell).textAlign !== textAlign) {
+        cell._content.style.textAlign = textAlignFallback;
+      }
     }
 
     /** @private */


### PR DESCRIPTION
## Description

Propagate the `text-align` attribute to parent column groups. It will only apply the same `text-align` value if the parent group does not span to multiple columns.

Fixes https://github.com/vaadin/flow-components/issues/1673

## Type of change

- [X] Bugfix
- [ ] Feature
