### PR TITLE
chore: use nice note admonition in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,8 @@ export default overrideVaadinConfig(customConfig);
 
 </details>
 
-**NOTE:** Make sure that the path you provide is an absolute one and that it points to the `node_modules` directory in the web components monorepo.
+> **Note**
+> Make sure that the path you provide is an absolute one and that it points to the `node_modules` directory in the web components monorepo.
 
 Then run the following command in the web components monorepo:
 


### PR DESCRIPTION
## Description

Replace the old admonition with a new nicer looking admonition. GitHub now has nice admonitions for warning and note messages. Here's a preview:

> **Note**
> Body text

> **Warning**
> Body text

Here's the syntax:

```markdown
> **Note**
> Body text
```

I'm not fixing an issue with this PR.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
