### PR TITLE
perf: improve grid column group auto-width performance

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -570,6 +570,18 @@ class Grid extends ElementMixin(
 
   /** @private */
   __getIntrinsicWidth(col) {
+    if (this.__intrinsicWidthCache.has(col)) {
+      return this.__intrinsicWidthCache.get(col);
+    }
+
+    const width = this.__calculateIntrinsicWidth(col);
+    this.__intrinsicWidthCache.set(col, width);
+
+    return width;
+  }
+
+  /** @private */
+  __calculateIntrinsicWidth(col) {
     const initialWidth = col.width;
     const initialFlexGrow = col.flexGrow;
 
@@ -641,6 +653,8 @@ class Grid extends ElementMixin(
     if (this._debouncerHiddenChanged) {
       this._debouncerHiddenChanged.flush();
     }
+
+    this.__intrinsicWidthCache = new Map();
 
     cols.forEach((col) => {
       col.width = `${this.__getDistributedWidth(col)}px`;

--- a/packages/grid/test/column-auto-width.test.js
+++ b/packages/grid/test/column-auto-width.test.js
@@ -148,6 +148,18 @@ describe('column auto-width', () => {
     await recalculateWidths();
     expectColumnWidthsToBeOk(columns);
   });
+
+  it('should update column width when recalculating widths', async () => {
+    grid.items = testItems;
+    await recalculateWidths();
+    expectColumnWidthsToBeOk(columns, [74]);
+
+    // Update item text in first column
+    grid.items = [{ a: 'foo bar baz' }];
+    await nextFrame();
+    grid.recalculateColumnWidths();
+    expectColumnWidthsToBeOk(columns, [114]);
+  });
 });
 
 describe('tree column', () => {


### PR DESCRIPTION
## Description

When using `auto-size` in combination with column groups the performance of the grid decreases significantly. The reason for that is that `__getDistributedWidth` runs `__getIntrinsicWidth` several times for nested columns when measuring a group:

https://github.com/vaadin/web-components/blob/542c8e1991444e0ca97be8a54bff0fe2785698fc/packages/grid/src/vaadin-grid.js#L627-L629
https://github.com/vaadin/web-components/blob/542c8e1991444e0ca97be8a54bff0fe2785698fc/packages/grid/src/vaadin-grid.js#L638-L641

This change adds a cache that gets populated with the intrinsic width of columns after they have been measured, so that they don't need to be measured again. The cache is reset when `recalculateColumnWidths` is called again.

Testing this with the grid benchmark tests in `flow-components`, using 50 columns, 10 groups, results in the following rendering times (avg of 20 measurements):
- without cache: 636ms
- with cache: 253ms

The logic could probably also be rewritten to do measurement in multiple phases, however this solution seems like a reasonable alternative in the meanwhile.

## Type of change

- Performance improvement
