### PR TITLE
perf: reduce grid updateHeaderFooterRowVisibility call count

### DIFF
--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { animationFrame } from '@vaadin/component-base/src/async.js';
+import { animationFrame, microTask } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
@@ -586,7 +586,12 @@ export const ColumnBaseMixin = (superClass) =>
 
       this.__renderCellsContent(headerRenderer, [headerCell]);
       if (this._grid) {
-        this._grid.__updateHeaderFooterRowVisibility(headerCell.parentElement);
+        const row = headerCell.parentElement;
+        row.__debounceUpdateHeaderFooterRowVisibility = Debouncer.debounce(
+          row.__debounceUpdateHeaderFooterRowVisibility,
+          microTask,
+          () => this._grid.__updateHeaderFooterRowVisibility(row),
+        );
       }
     }
 
@@ -627,7 +632,12 @@ export const ColumnBaseMixin = (superClass) =>
 
       this.__renderCellsContent(footerRenderer, [footerCell]);
       if (this._grid) {
-        this._grid.__updateHeaderFooterRowVisibility(footerCell.parentElement);
+        const row = footerCell.parentElement;
+        row.__debounceUpdateHeaderFooterRowVisibility = Debouncer.debounce(
+          row.__debounceUpdateHeaderFooterRowVisibility,
+          microTask,
+          () => this._grid.__updateHeaderFooterRowVisibility(row),
+        );
       }
     }
 

--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -166,6 +166,7 @@ describe('column groups', () => {
 
   function init(fixture) {
     grid = fixtureSync(fixtures[fixture]);
+    sinon.spy(grid, '__updateHeaderFooterRowVisibility');
     header = grid.$.header;
     body = grid.$.items;
     footer = grid.$.footer;
@@ -398,6 +399,11 @@ describe('column groups', () => {
       //  | group-0             | group-1                                  |          |
       init('nested');
       await nextResize(grid);
+    });
+
+    it('should update header and footer rows visibility once', () => {
+      // 6 header and footer rows are created
+      expect(grid.__updateHeaderFooterRowVisibility.callCount).to.equal(6);
     });
 
     it('should have right content in header', () => {

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -213,7 +213,7 @@ snapshots["vaadin-grid shadow default"] =
           part="cell footer-cell first-column-cell first-footer-row-cell last-footer-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1; order: 10000000;"
-          tabindex="-1"
+          tabindex="0"
         >
           <slot name="vaadin-grid-cell-content-2">
           </slot>
@@ -422,7 +422,7 @@ snapshots["vaadin-grid shadow selected"] =
           part="cell footer-cell first-column-cell first-footer-row-cell last-footer-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1; order: 10000000;"
-          tabindex="-1"
+          tabindex="0"
         >
           <slot name="vaadin-grid-cell-content-2">
           </slot>
@@ -630,7 +630,7 @@ snapshots["vaadin-grid shadow details opened"] =
           part="cell footer-cell first-column-cell first-footer-row-cell last-footer-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1; order: 10000000;"
-          tabindex="-1"
+          tabindex="0"
         >
           <slot name="vaadin-grid-cell-content-2">
           </slot>


### PR DESCRIPTION
## Description

Reduces the number of calls to the `grid.__updateHeaderFooterRowVisibility` function on init by utilizing a debouncer.

On the `grid-performance.html` dev page, with a 200-column grid
- the number of calls to the function dropped from 800 to 2
- the initial render time dropped by roughly 10% (with a single body row).

The performance improvement isn't as dramatic for grids that have fewer columns.

## Type of change

Performance enhancement