### PR TITLE
refactor: reduce grid updateFrozenColumn call count

### DIFF
--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -374,7 +374,7 @@ export const ColumnReorderingMixin = (superClass) =>
      */
     _swapColumnOrders(column1, column2) {
       [column1._order, column2._order] = [column2._order, column1._order];
-      this._updateFrozenColumn();
+      this._debounceUpdateFrozenColumn();
       this._updateFirstAndLastColumn();
     }
 

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { animationFrame, microTask } from '@vaadin/component-base/src/async.js';
+import { animationFrame } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
@@ -504,8 +504,8 @@ export const ColumnBaseMixin = (superClass) =>
           },
         );
 
-        if (this._grid._updateFrozenColumn) {
-          this._grid._updateFrozenColumn();
+        if (this._grid._debounceUpdateFrozenColumn) {
+          this._grid._debounceUpdateFrozenColumn();
         }
 
         if (this._grid._resetKeyboardNavigation) {
@@ -586,12 +586,7 @@ export const ColumnBaseMixin = (superClass) =>
 
       this.__renderCellsContent(headerRenderer, [headerCell]);
       if (this._grid) {
-        const row = headerCell.parentElement;
-        row.__debounceUpdateHeaderFooterRowVisibility = Debouncer.debounce(
-          row.__debounceUpdateHeaderFooterRowVisibility,
-          microTask,
-          () => this._grid.__updateHeaderFooterRowVisibility(row),
-        );
+        this._grid.__debounceUpdateHeaderFooterRowVisibility(headerCell.parentElement);
       }
     }
 
@@ -632,12 +627,7 @@ export const ColumnBaseMixin = (superClass) =>
 
       this.__renderCellsContent(footerRenderer, [footerCell]);
       if (this._grid) {
-        const row = footerCell.parentElement;
-        row.__debounceUpdateHeaderFooterRowVisibility = Debouncer.debounce(
-          row.__debounceUpdateHeaderFooterRowVisibility,
-          microTask,
-          () => this._grid.__updateHeaderFooterRowVisibility(row),
-        );
+        this._grid.__debounceUpdateHeaderFooterRowVisibility(footerCell.parentElement);
       }
     }
 

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -201,10 +201,17 @@ export const ScrollMixin = (superClass) =>
         this._frozenToEndCells = Array.prototype.slice.call(this.$.table.querySelectorAll('[frozen-to-end]'));
         this.__updateHorizontalScrollPosition();
       });
-      this._updateFrozenColumn();
+      this._debounceUpdateFrozenColumn();
     }
 
     /** @protected */
+    _debounceUpdateFrozenColumn() {
+      this.__debounceUpdateFrozenColumn = Debouncer.debounce(this.__debounceUpdateFrozenColumn, microTask, () =>
+        this._updateFrozenColumn(),
+      );
+    }
+
+    /** @private */
     _updateFrozenColumn() {
       if (!this._columnTree) {
         return;

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -877,11 +877,7 @@ class Grid extends ElementMixin(
       });
 
     if (section !== 'body') {
-      row.__debounceUpdateHeaderFooterRowVisibility = Debouncer.debounce(
-        row.__debounceUpdateHeaderFooterRowVisibility,
-        microTask,
-        () => this.__updateHeaderFooterRowVisibility(row),
-      );
+      this.__debounceUpdateHeaderFooterRowVisibility(row);
     }
 
     // Might be empty if only cache was used
@@ -889,6 +885,18 @@ class Grid extends ElementMixin(
 
     this._frozenCellsChanged();
     this._updateFirstAndLastColumnForRow(row);
+  }
+
+  /**
+   * @param {HTMLTableRowElement} row
+   * @protected
+   */
+  __debounceUpdateHeaderFooterRowVisibility(row) {
+    row.__debounceUpdateHeaderFooterRowVisibility = Debouncer.debounce(
+      row.__debounceUpdateHeaderFooterRowVisibility,
+      microTask,
+      () => this.__updateHeaderFooterRowVisibility(row),
+    );
   }
 
   /**

--- a/packages/grid/test/column-reordering.test.js
+++ b/packages/grid/test/column-reordering.test.js
@@ -374,6 +374,7 @@ describe('reordering simple grid', () => {
       const cell = getCellByCellContent(headerContent[0]);
       expect(cell.hasAttribute('last-frozen')).to.be.false;
       dragOver(headerContent[0], headerContent[1]);
+      flushGrid(grid);
       expect(cell.hasAttribute('last-frozen')).to.be.true;
     });
 
@@ -411,6 +412,7 @@ describe('reordering simple grid', () => {
       const cell = getCellByCellContent(headerContent[3]);
       expect(cell.hasAttribute('first-frozen-to-end')).to.be.false;
       dragOver(headerContent[3], headerContent[2]);
+      flushGrid(grid);
       expect(cell.hasAttribute('first-frozen-to-end')).to.be.true;
     });
 

--- a/packages/grid/test/column-resizing.test.js
+++ b/packages/grid/test/column-resizing.test.js
@@ -76,6 +76,7 @@ describe('column resizing', () => {
       const column = grid._columnTree[0][1];
       column.resizable = true;
       column.frozenToEnd = true;
+      flushGrid(grid);
       handle = headerCells[1].querySelector('[part~="resize-handle"]');
 
       const options = { node: handle };

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, listenOnce, nextRender } from '@vaadin/testing-helpers';
 import { resetMouse, sendMouse } from '@web/test-runner-commands';
+import sinon from 'sinon';
 import '../vaadin-grid.js';
 import { isElementFocused } from '@vaadin/component-base/src/focus-utils.js';
 import {
@@ -41,6 +42,8 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
     };
   });
 
+  sinon.spy(grid, '_updateFrozenColumn');
+
   grid.dataProvider = infiniteDataProvider;
   return [grid, columns];
 };
@@ -65,8 +68,13 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
       expect(columns[0]._lastFrozen).to.be.true;
 
       columns[0].frozen = false;
+      flushGrid(grid);
 
       expect(columns[0]._lastFrozen).to.be.false;
+    });
+
+    it('should update frozen columns once on init', () => {
+      expect(grid._updateFrozenColumn.callCount).to.equal(1);
     });
 
     ['header', 'body'].forEach((container) => {
@@ -88,6 +96,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
 
         it('should have a frozen cell in a row', () => {
           const cells = getRowCells(containerRows[0]);
+          flushGrid(grid);
           expect(cells[0].hasAttribute('frozen')).to.be.true;
           expect(cells[1].hasAttribute('frozen')).not.to.be.true;
           expect(cells[2].hasAttribute('frozen')).not.to.be.true;
@@ -97,6 +106,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
           grid._columnTree[0][1].frozen = true;
           containerRows = getRows(containerElement);
           const cells = getRowCells(containerRows[0]);
+          flushGrid(grid);
           expect(cells[0].hasAttribute('last-frozen')).not.to.be.true;
           expect(cells[1].hasAttribute('last-frozen')).to.be.true;
           expect(cells[2].hasAttribute('last-frozen')).not.to.be.true;
@@ -106,6 +116,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
           grid._columnTree[0][1].frozen = true;
           containerRows = getRows(containerElement);
           const cells = getRowCells(containerRows[0]);
+          flushGrid(grid);
           expect(cells[0].getAttribute('part')).to.not.contain('last-frozen-cell');
           expect(cells[1].getAttribute('part')).to.contain('last-frozen-cell');
           expect(cells[2].getAttribute('part')).to.not.contain('last-frozen-cell');
@@ -162,12 +173,14 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
           containerRows = getRows(containerElement);
           const cells = getRowCells(containerRows[0]);
 
+          flushGrid(grid);
           expect(cells[0].hasAttribute('last-frozen')).not.to.be.true;
           expect(cells[1].hasAttribute('last-frozen')).not.to.be.true;
           expect(cells[2].hasAttribute('last-frozen')).to.be.true;
 
           grid._columnTree[0][2].hidden = true;
 
+          flushGrid(grid);
           expect(cells[0].hasAttribute('last-frozen')).not.to.be.true;
           expect(cells[1].hasAttribute('last-frozen')).to.be.true;
           expect(cells[2].hasAttribute('last-frozen')).not.to.be.true;
@@ -193,6 +206,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
       expect(columns[2]._firstFrozenToEnd).to.be.true;
 
       columns[2].frozenToEnd = false;
+      flushGrid(grid);
 
       expect(columns[2]._firstFrozenToEnd).to.be.false;
     });
@@ -241,6 +255,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
           grid._columnTree[0][1].frozenToEnd = true;
           containerRows = getRows(containerElement);
           const cells = getRowCells(containerRows[0]);
+          flushGrid(grid);
           expect(cells[0].hasAttribute('first-frozen-to-end')).not.to.be.true;
           expect(cells[1].hasAttribute('first-frozen-to-end')).to.be.true;
           expect(cells[2].hasAttribute('first-frozen-to-end')).not.to.be.true;
@@ -250,6 +265,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
           grid._columnTree[0][1].frozenToEnd = true;
           containerRows = getRows(containerElement);
           const cells = getRowCells(containerRows[0]);
+          flushGrid(grid);
           expect(cells[0].getAttribute('part')).to.not.contain('first-frozen-to-end-cell');
           expect(cells[1].getAttribute('part')).to.contain('first-frozen-to-end-cell');
           expect(cells[2].getAttribute('part')).to.not.contain('first-frozen-to-end-cell');
@@ -291,12 +307,15 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
           containerRows = getRows(containerElement);
           const cells = getRowCells(containerRows[0]);
 
+          flushGrid(grid);
+
           expect(cells[0].hasAttribute('first-frozen-to-end')).to.be.true;
           expect(cells[1].hasAttribute('first-frozen-to-end')).not.to.be.true;
           expect(cells[2].hasAttribute('first-frozen-to-end')).not.to.be.true;
 
           grid._columnTree[0][0].hidden = true;
 
+          flushGrid(grid);
           expect(cells[0].hasAttribute('first-frozen-to-end')).not.to.be.true;
           expect(cells[1].hasAttribute('first-frozen-to-end')).to.be.true;
           expect(cells[2].hasAttribute('first-frozen-to-end')).not.to.be.true;

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -15,6 +15,9 @@ export const flushGrid = (grid) => {
   if (grid._debouncerApplyCachedData) {
     grid._debouncerApplyCachedData.flush();
   }
+  if (grid.__debounceUpdateFrozenColumn) {
+    grid.__debounceUpdateFrozenColumn.flush();
+  }
 
   grid.__virtualizer.flush();
 };


### PR DESCRIPTION
## Description

Reduces the number of calls to the `grid._updateFrozenColumn` function on init by utilizing a debouncer.

On the `grid-performance.html` dev page, with a 200-column grid
- the number of calls to the function dropped from 4420 to 1
- the initial render time dropped by roughly 10% (with a single body row).

The performance improvement isn't as dramatic for grids that have fewer columns.

The PR also includes cleanup for the [previous related PR](https://github.com/vaadin/web-components/pull/5128)

## Type of change

Performance enhancement