### PR TITLE
refactor: add logical-assignment-operators rule to ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -130,6 +130,7 @@
     "func-style": ["error", "declaration", { "allowArrowFunctions": true }],
     "grouped-accessor-pairs": ["error", "getBeforeSet"],
     "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
+    "logical-assignment-operators": "error",
     "max-classes-per-file": ["error", 3],
     "max-params": ["error", 5],
     "no-bitwise": "off",

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -549,12 +549,12 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     deepMerge(options, this.additionalOptions);
 
     if (this.type) {
-      options.chart = options.chart || {};
+      options.chart ||= {};
       options.chart.type = this.type;
     }
 
     if (this.polar) {
-      options.chart = options.chart || {};
+      options.chart ||= {};
       options.chart.polar = true;
     }
 
@@ -579,7 +579,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (this.categories) {
-      options.xAxis = options.xAxis || {};
+      options.xAxis ||= {};
       if (Array.isArray(options.xAxis)) {
         // Set categories on first X axis
         options.xAxis[0].categories = this.categories;
@@ -589,7 +589,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (isFinite(this.categoryMin)) {
-      options.xAxis = options.xAxis || {};
+      options.xAxis ||= {};
       if (Array.isArray(options.xAxis)) {
         // Set category-min on first X axis
         options.xAxis[0].min = this.categoryMin;
@@ -599,7 +599,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (isFinite(this.categoryMax)) {
-      options.xAxis = options.xAxis || {};
+      options.xAxis ||= {};
       if (Array.isArray(options.xAxis)) {
         // Set category-max on first x axis
         options.xAxis[0].max = this.categoryMax;
@@ -615,12 +615,12 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (this.emptyText) {
-      options.lang = options.lang || {};
+      options.lang ||= {};
       options.lang.noData = this.emptyText;
     }
 
     if (this.categoryPosition) {
-      options.chart = options.chart || {};
+      options.chart ||= {};
 
       options.chart.inverted = this.__shouldInvert();
 
@@ -634,13 +634,13 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (this.stacking) {
-      options.plotOptions = options.plotOptions || {};
-      options.plotOptions.series = options.plotOptions.series || {};
+      options.plotOptions ||= {};
+      options.plotOptions.series ||= {};
       options.plotOptions.series.stacking = this.stacking;
     }
 
     if (this.chart3d) {
-      options.chart = options.chart || {};
+      options.chart ||= {};
 
       options.chart.options3d = { ...this._baseChart3d, ...options.chart.options3d };
     }
@@ -1372,7 +1372,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
     path = path.split('.');
     return path.reduce((obj, key) => {
-      obj[key] = obj[key] || {};
+      obj[key] ||= {};
       return obj[key];
     }, object);
   }

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -78,14 +78,12 @@ describe('vaadin-chart exporting', () => {
 
     // Track style movement into the document body
     const observer = new MutationObserver((mutations) => {
-      styleCopiedToBody =
-        styleCopiedToBody ||
-        mutations.some(
-          (mutation) =>
-            Array.from(mutation.addedNodes)
-              .map((node) => node.tagName.toLowerCase())
-              .indexOf('style') >= 0,
-        );
+      styleCopiedToBody ||= mutations.some(
+        (mutation) =>
+          Array.from(mutation.addedNodes)
+            .map((node) => node.tagName.toLowerCase())
+            .indexOf('style') >= 0,
+      );
     });
 
     observer.observe(document.body, { childList: true });
@@ -107,14 +105,12 @@ describe('vaadin-chart exporting', () => {
 
     // Track style removal from the document body
     const observer = new MutationObserver((mutations) => {
-      styleRemovedFromBody =
-        styleRemovedFromBody ||
-        mutations.some(
-          (mutation) =>
-            Array.from(mutation.removedNodes)
-              .map((node) => node.tagName.toLowerCase())
-              .indexOf('style') >= 0,
-        );
+      styleRemovedFromBody ||= mutations.some(
+        (mutation) =>
+          Array.from(mutation.removedNodes)
+            .map((node) => node.tagName.toLowerCase())
+            .indexOf('style') >= 0,
+      );
     });
 
     observer.observe(document.body, { childList: true });
@@ -143,9 +139,9 @@ describe('vaadin-chart exporting', () => {
 
     // Track styled-mode attribute addition and removal from the document body
     const observer = new MutationObserver((mutations) => {
-      styledModeAddedToBody =
-        styledModeAddedToBody ||
-        mutations.some((mutation) => mutation.attributeName === attributeName && mutation.oldValue === '');
+      styledModeAddedToBody ||= mutations.some(
+        (mutation) => mutation.attributeName === attributeName && mutation.oldValue === '',
+      );
     });
 
     observer.observe(targetNode, config);
@@ -175,9 +171,9 @@ describe('vaadin-chart exporting', () => {
 
     // Track styled-mode attribute addition and removal from the document body
     const observer = new MutationObserver((mutations) => {
-      styledModeAddedToBody =
-        styledModeAddedToBody ||
-        mutations.some((mutation) => mutation.attributeName === attributeName && mutation.oldValue === '');
+      styledModeAddedToBody ||= mutations.some(
+        (mutation) => mutation.attributeName === attributeName && mutation.oldValue === '',
+      );
     });
 
     observer.observe(targetNode, config);

--- a/packages/component-base/src/element-mixin.js
+++ b/packages/component-base/src/element-mixin.js
@@ -15,14 +15,14 @@ import { DirMixin } from './dir-mixin.js';
 // for buttons that are based on `[role=button]` e.g vaadin-button.
 setCancelSyntheticClickEvents(false);
 
-window.Vaadin = window.Vaadin || {};
+window.Vaadin ||= {};
 
 /**
  * Array of Vaadin custom element classes that have been finalized.
  */
-window.Vaadin.registrations = window.Vaadin.registrations || [];
+window.Vaadin.registrations ||= [];
 
-window.Vaadin.developmentModeCallback = window.Vaadin.developmentModeCallback || {};
+window.Vaadin.developmentModeCallback ||= {};
 
 window.Vaadin.developmentModeCallback['vaadin-usage-statistics'] = function () {
   usageStatistics();

--- a/packages/component-base/src/iron-list-core.js
+++ b/packages/component-base/src/iron-list-core.js
@@ -491,9 +491,9 @@ export const ironList = {
       this._physicalIndexForKey = {};
       this._firstVisibleIndexVal = null;
       this._lastVisibleIndexVal = null;
-      this._physicalCount = this._physicalCount || 0;
-      this._physicalItems = this._physicalItems || [];
-      this._physicalSizes = this._physicalSizes || [];
+      this._physicalCount ||= 0;
+      this._physicalItems ||= [];
+      this._physicalSizes ||= [];
       this._physicalStart = 0;
       if (this._scrollTop > this._scrollOffset) {
         this._resetScrollPosition(0);
@@ -639,8 +639,8 @@ export const ironList = {
       this._physicalBottom +
       Math.max(this._virtualCount - this._physicalCount - this._virtualStart, 0) * this._physicalAverage;
 
-    forceUpdate = forceUpdate || this._scrollHeight === 0;
-    forceUpdate = forceUpdate || this._scrollPosition >= this._estScrollHeight - this._physicalSize;
+    forceUpdate ||= this._scrollHeight === 0;
+    forceUpdate ||= this._scrollPosition >= this._estScrollHeight - this._physicalSize;
     // Amortize height adjustment, so it won't trigger large repaints too often.
     if (forceUpdate || Math.abs(this._estScrollHeight - this._scrollHeight) >= this._viewportHeight) {
       this.$.items.style.height = `${this._estScrollHeight}px`;
@@ -740,7 +740,7 @@ export const ironList = {
   },
 
   _debounce(name, cb, asyncModule) {
-    this._debouncers = this._debouncers || {};
+    this._debouncers ||= {};
     this._debouncers[name] = Debouncer.debounce(this._debouncers[name], asyncModule, cb.bind(this));
     enqueueDebouncer(this._debouncers[name]);
   },

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -10,7 +10,7 @@ const caseMap = {};
 const CAMEL_TO_DASH = /([A-Z])/g;
 
 function camelToDash(camel) {
-  caseMap[camel] = caseMap[camel] || camel.replace(CAMEL_TO_DASH, '-$1').toLowerCase();
+  caseMap[camel] ||= camel.replace(CAMEL_TO_DASH, '-$1').toLowerCase();
   return caseMap[camel];
 }
 
@@ -169,7 +169,7 @@ const PolylitMixinImplementation = (superclass) => {
     firstUpdated() {
       super.firstUpdated();
 
-      this.$ = this.$ || {};
+      this.$ ||= {};
       this.shadowRoot.querySelectorAll('[id]').forEach((node) => {
         this.$[node.id] = node;
       });

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -376,7 +376,7 @@ export class IronListAdapter {
       deltaY *= this._scrollPageHeight;
     }
 
-    this._deltaYAcc = this._deltaYAcc || 0;
+    this._deltaYAcc ||= 0;
 
     if (this._wheelAnimationFrame) {
       // Accumulate wheel delta while a frame is being processed

--- a/packages/component-base/test/templates.test.js
+++ b/packages/component-base/test/templates.test.js
@@ -29,7 +29,7 @@ describe('process templates', () => {
 
   describe('with template renderer', () => {
     beforeEach(() => {
-      window.Vaadin = window.Vaadin || {};
+      window.Vaadin ||= {};
       window.Vaadin.templateRendererCallback = sinon.spy();
     });
 

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -470,7 +470,7 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
     if (this._overlayElement) {
       this._setDimension(name, value);
     } else {
-      this._dimensions = this._dimensions || {};
+      this._dimensions ||= {};
       this._dimensions[name] = value;
     }
   }

--- a/packages/context-menu/test/overlay.test.js
+++ b/packages/context-menu/test/overlay.test.js
@@ -29,7 +29,7 @@ describe('overlay', () => {
   });
 
   function contextmenu(x, y, shiftKey, target) {
-    shiftKey = shiftKey || false;
+    shiftKey ||= false;
     const e = new MouseEvent('contextmenu', {
       bubbles: true,
       cancelable: true,

--- a/packages/crud/src/vaadin-crud-form.js
+++ b/packages/crud/src/vaadin-crud-form.js
@@ -104,7 +104,7 @@ class CrudForm extends IncludedMixin(FormLayout) {
         .split('.')
         .slice(0, -1)
         .reduce((o, p) => {
-          o[p] = o[p] || {};
+          o[p] ||= {};
           return o[p];
         }, obj);
       this.set(path, val, obj);

--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -289,7 +289,7 @@ class CrudGrid extends IncludedMixin(Grid) {
         .split('.')
         .slice(0, -1)
         .reduce((o, p) => {
-          o[p] = o[p] || {};
+          o[p] ||= {};
           return o[p];
         }, obj);
       this.set(path, val, obj);

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -1264,7 +1264,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
           this.items.push(item);
         }
       } else {
-        this.editedItem = this.editedItem || {};
+        this.editedItem ||= {};
         Object.assign(this.editedItem, item);
       }
       this._grid.clearCache();
@@ -1316,7 +1316,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
         .split('.')
         .slice(0, -1)
         .reduce((o, p) => {
-          o[p] = o[p] || {};
+          o[p] ||= {};
           return o[p];
         }, obj);
       this.set(path, val, obj);

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -805,7 +805,7 @@ export const DatePickerMixin = (subclass) =>
       this._overlayContent.scrollToDate(this._overlayContent.focusedDate || this._overlayContent.initialPosition);
       // Have a default focused date
       this._ignoreFocusedDateChange = true;
-      this._overlayContent.focusedDate = this._overlayContent.focusedDate || this._overlayContent.initialPosition;
+      this._overlayContent.focusedDate ||= this._overlayContent.initialPosition;
       this._ignoreFocusedDateChange = false;
 
       window.addEventListener('scroll', this._boundOnScroll, true);

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -644,7 +644,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     const initialPosition = this._monthScroller.position;
 
     const smoothScroll = (timestamp) => {
-      start = start || timestamp;
+      start ||= timestamp;
       const currentTime = timestamp - start;
 
       if (currentTime < this.scrollDuration) {
@@ -1004,7 +1004,7 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
 
     const targetMonth = dateToFocus.getMonth();
 
-    dateToFocus.setDate(this._focusedMonthDate || (this._focusedMonthDate = focus.getDate()));
+    dateToFocus.setDate((this._focusedMonthDate ||= focus.getDate()));
     if (dateToFocus.getMonth() !== targetMonth) {
       dateToFocus.setDate(0);
     }

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -108,7 +108,7 @@ export function monthsEqual(date1, date2) {
 
 export function getFirstVisibleItem(scroller, bufferOffset) {
   const children = [];
-  bufferOffset = bufferOffset || 0;
+  bufferOffset ||= 0;
 
   scroller._buffers.forEach((buffer) => {
     [...buffer.children].forEach((slot) => {

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -469,7 +469,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
 
   /** @private */
   __syncI18n(target, source, props) {
-    props = props || Object.keys(source.i18n);
+    props ||= Object.keys(source.i18n);
     props.forEach((prop) => {
       // eslint-disable-next-line no-prototype-builtins
       if (source.i18n && source.i18n.hasOwnProperty(prop)) {

--- a/packages/field-base/src/slot-target-controller.js
+++ b/packages/field-base/src/slot-target-controller.js
@@ -97,7 +97,7 @@ export class SlotTargetController {
    * @private
    */
   __copyNodesToSlotTarget(nodes, slotTarget) {
-    this.__slotTargetClones = this.__slotTargetClones || [];
+    this.__slotTargetClones ||= [];
 
     nodes.forEach((node) => {
       // Clone the nodes and append the clones to the target

--- a/packages/grid-pro/test/helpers.js
+++ b/packages/grid-pro/test/helpers.js
@@ -13,7 +13,7 @@ export const infiniteDataProvider = (params, callback) => {
 };
 
 export const fire = (type, detail, options) => {
-  options = options || {};
+  options ||= {};
   detail = detail === null || detail === undefined ? {} : detail;
   const event = new Event(type, {
     bubbles: options.bubbles === undefined ? true : options.bubbles,

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -132,22 +132,22 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
 
     if (path === 'frozen') {
       // Don’t unfreeze the frozen group because of a non-frozen child
-      this.frozen = this.frozen || value;
+      this.frozen ||= value;
     }
 
     if (path === 'lastFrozen') {
       // Don’t unfreeze the frozen group because of a non-frozen child
-      this._lastFrozen = this._lastFrozen || value;
+      this._lastFrozen ||= value;
     }
 
     if (path === 'frozenToEnd') {
       // Don’t unfreeze the frozen group because of a non-frozen child
-      this.frozenToEnd = this.frozenToEnd || value;
+      this.frozenToEnd ||= value;
     }
 
     if (path === 'firstFrozenToEnd') {
       // Don’t unfreeze the frozen group because of a non-frozen child
-      this._firstFrozenToEnd = this._firstFrozenToEnd || value;
+      this._firstFrozenToEnd ||= value;
     }
   }
 

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -225,8 +225,8 @@ export const ColumnReorderingMixin = (superClass) =>
      * @protected
      */
     _cellFromPoint(x, y) {
-      x = x || 0;
-      y = y || 0;
+      x ||= 0;
+      y ||= 0;
       if (!this._draggedColumn) {
         this.$.scroller.toggleAttribute('no-content-pointer-events', true);
       }

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -805,7 +805,7 @@ class Grid extends ElementMixin(
    */
   // eslint-disable-next-line max-params
   _updateRow(row, columns, section, isColumnRow, noNotify) {
-    section = section || 'body';
+    section ||= 'body';
 
     const contentsFragment = document.createDocumentFragment();
 
@@ -821,7 +821,7 @@ class Grid extends ElementMixin(
 
         if (section === 'body') {
           // Body
-          column._cells = column._cells || [];
+          column._cells ||= [];
           cell = column._cells.find((cell) => cell._vacant);
           if (!cell) {
             cell = this._createCell('td', column);
@@ -832,7 +832,7 @@ class Grid extends ElementMixin(
 
           if (index === cols.length - 1 && this.rowDetailsRenderer) {
             // Add details cell as last cell to body rows
-            this._detailsCells = this._detailsCells || [];
+            this._detailsCells ||= [];
             const detailsCell = this._detailsCells.find((cell) => cell._vacant) || this._createCell('td');
             if (this._detailsCells.indexOf(detailsCell) === -1) {
               this._detailsCells.push(detailsCell);
@@ -858,7 +858,7 @@ class Grid extends ElementMixin(
             row.appendChild(cell);
             column[`_${section}Cell`] = cell;
           } else {
-            column._emptyCells = column._emptyCells || [];
+            column._emptyCells ||= [];
             cell = column._emptyCells.find((cell) => cell._vacant) || this._createCell(tagName);
             cell._column = column;
             row.appendChild(cell);

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -238,7 +238,7 @@ export const makeSoloTouchEvent = (type, xy, node) => {
 };
 
 export const fire = (type, detail, options) => {
-  options = options || {};
+  options ||= {};
   detail = detail === null || detail === undefined ? {} : detail;
   const event = new Event(type, {
     bubbles: options.bubbles === undefined ? true : options.bubbles,

--- a/packages/grid/test/keyboard-navigation-row-focus.test.js
+++ b/packages/grid/test/keyboard-navigation-row-focus.test.js
@@ -74,7 +74,7 @@ function getFirstHeaderCell() {
 }
 
 function focusWithMouse(element, mouseTarget) {
-  mouseTarget = mouseTarget || element;
+  mouseTarget ||= element;
   mouseDown(mouseTarget);
   element.focus();
   mouseUp(mouseTarget);

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -140,7 +140,7 @@ function getFirstHeaderCell() {
 }
 
 function focusWithMouse(element, mouseTarget) {
-  mouseTarget = mouseTarget || element;
+  mouseTarget ||= element;
   mouseDown(mouseTarget);
   element.focus();
   mouseUp(mouseTarget);

--- a/packages/grid/test/light-dom-observing.test.js
+++ b/packages/grid/test/light-dom-observing.test.js
@@ -330,12 +330,12 @@ describe('light dom observing', () => {
   }
 
   function expectFirstColumnHeader(columnName, level) {
-    level = level || 0;
+    level ||= 0;
     expect(getCellContent(getRows(header)[level].cells[0]).textContent).to.contain(`${columnName} header`);
   }
 
   function expectFirstColumnFooter(columnName, level) {
-    level = level || 0;
+    level ||= 0;
     const lastLevel = getRows(header).length - 1;
     expect(getCellContent(getRows(footer)[lastLevel - level].cells[0]).textContent).to.contain(`${columnName} footer`);
   }

--- a/packages/icon/src/vaadin-iconset.js
+++ b/packages/icon/src/vaadin-iconset.js
@@ -81,7 +81,7 @@ class Iconset extends ElementMixin(PolymerElement) {
   applyIcon(name) {
     // Create the icon map on-demand, since the iconset itself has no discrete
     // signal to know when it's children are fully parsed
-    this._icons = this._icons || this.__createIconMap();
+    this._icons ||= this.__createIconMap();
     const icon = this._icons[this.__getIconId(name)];
     return {
       svg: cloneSvgNode(icon),

--- a/packages/polymer-legacy-adapter/src/style-modules.js
+++ b/packages/polymer-legacy-adapter/src/style-modules.js
@@ -97,7 +97,7 @@ function getAllThemes() {
     /** @type {DomModuleWithCachedStyles} */
     const module = modules[moduleId];
     const themeFor = module.getAttribute('theme-for');
-    module.__allStyles = module.__allStyles || getModuleStyles(module).concat(module.__partialStyles || []);
+    module.__allStyles ||= getModuleStyles(module).concat(module.__partialStyles || []);
 
     return {
       themeFor,
@@ -107,7 +107,7 @@ function getAllThemes() {
   });
 }
 
-window.Vaadin = window.Vaadin || {};
+window.Vaadin ||= {};
 window.Vaadin.styleModules = {
   getAllThemes,
   registerStyles,

--- a/packages/polymer-legacy-adapter/src/template-renderer.js
+++ b/packages/polymer-legacy-adapter/src/template-renderer.js
@@ -123,7 +123,7 @@ function observeTemplates(component) {
 /**
  * Public API
  */
-window.Vaadin = window.Vaadin || {};
+window.Vaadin ||= {};
 window.Vaadin.templateRendererCallback = (component) => {
   processTemplates(component);
   observeTemplates(component);

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -242,7 +242,7 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
       const panel = panels.find((panel) => panel.getAttribute('tab') === tabItem.id);
       if (panel) {
         panel.role = 'tabpanel';
-        panel.id = panel.id || `tabsheet-panel-${generateUniqueId()}`;
+        panel.id ||= `tabsheet-panel-${generateUniqueId()}`;
         panel.setAttribute('aria-labelledby', tabItem.id);
 
         tabItem.setAttribute('aria-controls', panel.id);

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -559,7 +559,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     const generatedList = [];
 
     // Default step in overlay items is 1 hour
-    step = step || 3600;
+    step ||= 3600;
 
     let time = -step + minSec;
     while (time + step >= minSec && time + step <= maxSec) {

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -641,7 +641,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
     if (files && !Array.isArray(files)) {
       files = [files];
     }
-    files = files || this.files;
+    files ||= this.files;
     files = files.filter((file) => !file.complete);
     Array.prototype.forEach.call(files, this._uploadFile.bind(this));
   }

--- a/packages/upload/test/common.js
+++ b/packages/upload/test/common.js
@@ -50,7 +50,7 @@ export function createFiles(arraySize, fileSize, contentType) {
  *     serverValidation: a function run once the file has been sent.
  */
 export function xhrCreator(c) {
-  c = c || {};
+  c ||= {};
   const cfg = {
     size: c.size || 100,
     connectTime: c.connectTime || 10,

--- a/packages/upload/test/mock-http-request.js
+++ b/packages/upload/test/mock-http-request.js
@@ -265,7 +265,7 @@ MockHttpRequest.prototype = {
     //  2. If final MIME type is not null, text/xml, application/xml,
     //     and does not end in +xml terminate these steps and return null.
     let mimetype = this.getResponseHeader('Content-Type');
-    mimetype = mimetype && mimetype.split(';', 1)[0];
+    mimetype &&= mimetype.split(';', 1)[0];
     if (
       mimetype == null ||
       mimetype === 'text/xml' ||

--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -106,10 +106,10 @@ function parseLog(log) {
             commit.bfp = true;
           }
           if (/(fixes|fix|related-to|connected-to|warranty)/i.test(k)) {
-            commit.footers.fixes = commit.footers.fixes || [];
+            commit.footers.fixes ||= [];
             commit.footers.fixes.push(...result[2].split(/[, ]+/).filter((s) => /\d+/.test(s)));
           } else {
-            commit.footers[k] = commit.footers[k] || [];
+            commit.footers[k] ||= [];
             commit.footers[k].push(result[2]);
           }
           break;

--- a/scripts/prepareDocs.js
+++ b/scripts/prepareDocs.js
@@ -42,7 +42,7 @@ function addMissingChangeEventDeclarations(analysis) {
         description: `Fired when the \`${property.name}\` property changes.`,
         metadata: {},
       };
-      element.events = element.events || [];
+      element.events ||= [];
       element.events.push(eventDeclaration);
     });
   });


### PR DESCRIPTION
This PR adds the `logical-assignment-operators` rule to the ESLint config and fixes all the errors related to that rule.
