### PR TITLE
refactor: add require-unicode-regexp rule to ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -178,6 +178,7 @@
     "prefer-spread": "error",
     "prefer-template": "error",
     "require-await": "error",
+    "require-unicode-regexp": "error",
     "space-in-parens": ["error", "never"],
     "spaced-comment": ["error", "always"]
   },

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -384,7 +384,7 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(ControllerMixin
   /** @private */
   _onOverflowKeyDown(e) {
     if (!this._opened) {
-      if (/^(Enter|SpaceBar|\s)$/.test(e.key)) {
+      if (/^(Enter|SpaceBar|\s)$/u.test(e.key)) {
         e.preventDefault();
         this._opened = true;
       }
@@ -393,7 +393,7 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(ControllerMixin
 
   /** @private */
   _onListKeyDown(event) {
-    if (event.key === 'Escape' || event.key === 'Esc' || /^(Tab)$/.test(event.key)) {
+    if (event.key === 'Escape' || event.key === 'Esc' || /^(Tab)$/u.test(event.key)) {
       this._opened = false;
     }
   }

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -393,7 +393,7 @@ class AvatarGroup extends ResizeMixin(ElementMixin(ThemableMixin(ControllerMixin
 
   /** @private */
   _onListKeyDown(event) {
-    if (event.key === 'Escape' || event.key === 'Esc' || /^(Tab)$/u.test(event.key)) {
+    if (event.key === 'Escape' || event.key === 'Tab') {
       this._opened = false;
     }
   }

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1321,7 +1321,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
               }
 
               // Strip off host selectors that target individual instances
-              effectiveCss = effectiveCss.replace(/:host\(.+?\)/g, (match) => {
+              effectiveCss = effectiveCss.replace(/:host\(.+?\)/gu, (match) => {
                 const selector = match.substr(6, match.length - 7);
                 return this.matches(selector) ? '' : match;
               });

--- a/packages/component-base/src/browser-utils.js
+++ b/packages/component-base/src/browser-utils.js
@@ -10,20 +10,20 @@ const testPlatform = (regexp) => regexp.test(navigator.platform);
 
 const testVendor = (regexp) => regexp.test(navigator.vendor);
 
-export const isAndroid = testUserAgent(/Android/);
+export const isAndroid = testUserAgent(/Android/u);
 
-export const isChrome = testUserAgent(/Chrome/) && testVendor(/Google Inc/);
+export const isChrome = testUserAgent(/Chrome/u) && testVendor(/Google Inc/u);
 
-export const isFirefox = testUserAgent(/Firefox/);
+export const isFirefox = testUserAgent(/Firefox/u);
 
 // IPadOS 13 lies and says it's a Mac, but we can distinguish by detecting touch support.
-export const isIPad = testPlatform(/^iPad/) || (testPlatform(/^Mac/) && navigator.maxTouchPoints > 1);
+export const isIPad = testPlatform(/^iPad/u) || (testPlatform(/^Mac/u) && navigator.maxTouchPoints > 1);
 
-export const isIPhone = testPlatform(/^iPhone/);
+export const isIPhone = testPlatform(/^iPhone/u);
 
 export const isIOS = isIPhone || isIPad;
 
-export const isSafari = testUserAgent(/^((?!chrome|android).)*safari/i);
+export const isSafari = testUserAgent(/^((?!chrome|android).)*safari/iu);
 
 export const isTouch = (() => {
   try {

--- a/packages/component-base/src/gestures.js
+++ b/packages/component-base/src/gestures.js
@@ -90,7 +90,7 @@ function PASSIVE_TOUCH(eventName) {
 }
 
 // Check for touch-only devices
-const IS_TOUCH_ONLY = navigator.userAgent.match(/iP(?:[oa]d|hone)|Android/);
+const IS_TOUCH_ONLY = navigator.userAgent.match(/iP(?:[oa]d|hone)|Android/u);
 
 // Defined at https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute
 /** @type {!Object<boolean>} */

--- a/packages/component-base/src/iron-list-core.js
+++ b/packages/component-base/src/iron-list-core.js
@@ -10,7 +10,7 @@
 import { animationFrame, idlePeriod, microTask } from './async.js';
 import { Debouncer, enqueueDebouncer, flush } from './debounce.js';
 
-const IOS = navigator.userAgent.match(/iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/);
+const IOS = navigator.userAgent.match(/iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/u);
 const IOS_TOUCH_SCROLLING = IOS && IOS[1] >= 8;
 const DEFAULT_PHYSICAL_COUNT = 3;
 

--- a/packages/component-base/src/list-mixin.js
+++ b/packages/component-base/src/list-mixin.js
@@ -213,7 +213,7 @@ export const ListMixin = (superClass) =>
       const key = event.key;
 
       const currentIdx = this.items.indexOf(this.focused);
-      if (/[a-zA-Z0-9]/.test(key) && key.length === 1) {
+      if (/[a-zA-Z0-9]/u.test(key) && key.length === 1) {
         const idx = this._searchKey(currentIdx, key);
         if (idx >= 0) {
           this._focus(idx);

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -7,7 +7,7 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 const caseMap = {};
 
-const CAMEL_TO_DASH = /([A-Z])/g;
+const CAMEL_TO_DASH = /([A-Z])/gu;
 
 function camelToDash(camel) {
   caseMap[camel] ||= camel.replace(CAMEL_TO_DASH, '-$1').toLowerCase();

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -48,7 +48,7 @@ describe('ElementMixin', () => {
     });
 
     it('should have a valid version number', () => {
-      expect(XElement.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/);
+      expect(XElement.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/u);
     });
   });
 

--- a/packages/crud/src/vaadin-crud-form.js
+++ b/packages/crud/src/vaadin-crud-form.js
@@ -92,9 +92,9 @@ class CrudForm extends IncludedMixin(FormLayout) {
   __capitalize(path) {
     return path
       .toLowerCase()
-      .replace(/([^\w]+)/g, ' ')
+      .replace(/([^\w]+)/gu, ' ')
       .trim()
-      .replace(/^./, (c) => c.toUpperCase());
+      .replace(/^./u, (c) => c.toUpperCase());
   }
 
   /** @private */

--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -148,10 +148,10 @@ class CrudGrid extends IncludedMixin(Grid) {
   _generateHeader(path) {
     return path
       .substr(path.lastIndexOf('.') + 1)
-      .replace(/([A-Z])/g, '-$1')
+      .replace(/([A-Z])/gu, '-$1')
       .toLowerCase()
-      .replace(/-/g, ' ')
-      .replace(/^./, (match) => match.toUpperCase());
+      .replace(/-/gu, ' ')
+      .replace(/^./u, (match) => match.toUpperCase());
   }
 
   /** @private */
@@ -277,9 +277,9 @@ class CrudGrid extends IncludedMixin(Grid) {
   __capitalize(path) {
     return path
       .toLowerCase()
-      .replace(/([^\w]+)/g, ' ')
+      .replace(/([^\w]+)/gu, ' ')
       .trim()
-      .replace(/^./, (c) => c.toUpperCase());
+      .replace(/^./u, (c) => c.toUpperCase());
   }
 
   /** @private */

--- a/packages/crud/src/vaadin-crud-include-mixin.js
+++ b/packages/crud/src/vaadin-crud-include-mixin.js
@@ -46,14 +46,14 @@ export const IncludedMixin = (superClass) =>
     /** @private */
     __onExcludeChange(exclude) {
       if (typeof exclude === 'string') {
-        this.exclude = exclude ? RegExp(exclude.replace(/, */g, '|'), 'i') : undefined;
+        this.exclude = exclude ? RegExp(exclude.replace(/, */gu, '|'), 'iu') : undefined;
       }
     }
 
     /** @private */
     __onIncludeChange(include) {
       if (typeof include === 'string') {
-        this.include = include ? include.split(/, */) : undefined;
+        this.include = include ? include.split(/, */u) : undefined;
       } else if (!this._fields && Array.isArray(include)) {
         const item = {};
         this.include.forEach((path) => this.__set(path, null, item));

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -74,7 +74,7 @@ describe('crud', () => {
         crud.$.dialog.$.overlay,
         crud.$.confirmCancel,
         crud.$.confirmDelete,
-      ].forEach((e) => expect(e.getAttribute('theme')).to.be.match(/foo/));
+      ].forEach((e) => expect(e.getAttribute('theme')).to.be.match(/foo/u));
     });
   });
 

--- a/packages/date-picker/src/vaadin-date-picker-helper.js
+++ b/packages/date-picker/src/vaadin-date-picker-helper.js
@@ -153,7 +153,7 @@ export function getAdjustedYear(referenceDate, year, month = 0, day = 1) {
  */
 export function parseDate(str) {
   // Parsing with RegExp to ensure correct format
-  const parts = /^([-+]\d{1}|\d{2,4}|[-+]\d{6})-(\d{1,2})-(\d{1,2})$/.exec(str);
+  const parts = /^([-+]\d{1}|\d{2,4}|[-+]\d{6})-(\d{1,2})-(\d{1,2})$/u.exec(str);
   if (!parts) {
     return undefined;
   }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -222,7 +222,7 @@ export const DatePickerMixin = (subclass) =>
               cancel: 'Cancel',
               referenceDate: '',
               formatDate(d) {
-                const yearStr = String(d.year).replace(/\d+/, (y) => '0000'.substr(y.length) + y);
+                const yearStr = String(d.year).replace(/\d+/u, (y) => '0000'.substr(y.length) + y);
                 return [d.month + 1, d.day, yearStr].join('/');
               },
               parseDate(text) {

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -81,7 +81,7 @@ describe('WAI-ARIA', () => {
       monthCalendar.month = new Date();
       await nextFrame();
       const todayElement = monthCalendar.shadowRoot.querySelector('[part~="today"]');
-      expect(todayElement.getAttribute('aria-label')).to.match(/, Today$/);
+      expect(todayElement.getAttribute('aria-label')).to.match(/, Today$/u);
     });
   });
 });

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -128,13 +128,13 @@ describe('vaadin-details', () => {
     });
 
     it('should set aria-controls on toggle button', () => {
-      const idRegex = /^content-vaadin-details-\d+$/;
+      const idRegex = /^content-vaadin-details-\d+$/u;
       expect(idRegex.test(toggle.getAttribute('aria-controls'))).to.be.true;
     });
   });
 
   describe('unique IDs', () => {
-    const idRegex = /^content-vaadin-details-\d+$/;
+    const idRegex = /^content-vaadin-details-\d+$/u;
     let container, details;
 
     beforeEach(() => {

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -315,8 +315,8 @@ export const InputControlMixin = (superclass) =>
     _allowedCharPatternChanged(charPattern) {
       if (charPattern) {
         try {
-          this.__allowedCharRegExp = new RegExp(`^${charPattern}$`);
-          this.__allowedTextRegExp = new RegExp(`^${charPattern}*$`);
+          this.__allowedCharRegExp = new RegExp(`^${charPattern}$`, 'u');
+          this.__allowedTextRegExp = new RegExp(`^${charPattern}*$`, 'u');
         } catch (e) {
           console.error(e);
         }

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -70,7 +70,7 @@ const runTests = (baseClass) => {
   let element, label, error, helper, input;
 
   describe('error message', () => {
-    const ID_REGEX = new RegExp(`^error-message-${tag}-\\d+$`);
+    const ID_REGEX = new RegExp(`^error-message-${tag}-\\d+$`, 'u');
 
     describe('default', () => {
       beforeEach(async () => {
@@ -242,7 +242,7 @@ const runTests = (baseClass) => {
   describe('helper', () => {
     let element, helper;
 
-    const ID_REGEX = new RegExp(`^helper-${tag}-\\d+$`);
+    const ID_REGEX = new RegExp(`^helper-${tag}-\\d+$`, 'u');
 
     describe('default', () => {
       beforeEach(async () => {

--- a/packages/field-base/test/input-controller.test.js
+++ b/packages/field-base/test/input-controller.test.js
@@ -91,7 +91,7 @@ describe('input-controller', () => {
   describe('unique id', () => {
     let wrapper, elements;
 
-    const ID_REGEX = /^input-input-controller-element-\d+$/;
+    const ID_REGEX = /^input-input-controller-element-\d+$/u;
 
     beforeEach(() => {
       wrapper = fixtureSync(`

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -12,7 +12,7 @@ const runTests = (baseClass) => {
 
   let element, label;
 
-  const ID_REGEX = new RegExp(`^label-${tag}-\\d+$`);
+  const ID_REGEX = new RegExp(`^label-${tag}-\\d+$`, 'u');
 
   describe('default', () => {
     beforeEach(async () => {

--- a/packages/field-base/test/text-area-controller.test.js
+++ b/packages/field-base/test/text-area-controller.test.js
@@ -75,7 +75,7 @@ describe('text-area-controller', () => {
   describe('unique id', () => {
     let wrapper, elements;
 
-    const ID_REGEX = /^textarea-textarea-controller-element-\d+$/;
+    const ID_REGEX = /^textarea-textarea-controller-element-\d+$/u;
 
     beforeEach(() => {
       wrapper = fixtureSync(`

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -92,7 +92,7 @@ describe('form-item', () => {
     });
 
     it('should set a unique id on the label element', () => {
-      const ID_REGEX = /^label-vaadin-form-item-\d+$/;
+      const ID_REGEX = /^label-vaadin-form-item-\d+$/u;
       expect(label1.id).to.not.equal(label2.id);
       expect(label1.id).to.match(ID_REGEX);
       expect(label2.id).to.match(ID_REGEX);

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -64,7 +64,7 @@ customElements.define(
 
 function getParsedWidth(el) {
   const width = el.style.getPropertyValue('width');
-  const components = width.replace(/^calc\((.*)\)$/, '$1').split(/ [+-] /);
+  const components = width.replace(/^calc\((.*)\)$/u, '$1').split(/ [+-] /u);
   const [percentage, spacing] = components.sort((a, b) => b.indexOf('%'));
   return { percentage, spacing };
 }
@@ -294,7 +294,7 @@ describe('form layout', () => {
       layout.responsiveSteps = [{ columns: 3 }];
 
       const parsedWidth = getParsedWidth(layout.firstElementChild);
-      expect(parsedWidth.percentage).to.match(/%$/);
+      expect(parsedWidth.percentage).to.match(/%$/u);
       expect(parseFloat(parsedWidth.percentage)).to.be.closeTo(33, 0.5);
     });
 

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
@@ -53,7 +53,7 @@ class GridProEditSelect extends Select {
   _onKeyDown(e) {
     super._onKeyDown(e);
 
-    if (this.options.length === 0 && /^(ArrowDown|Down|ArrowUp|Up|Enter|SpaceBar| )$/.test(e.key)) {
+    if (this.options.length === 0 && /^(ArrowDown|Down|ArrowUp|Up|Enter|SpaceBar| )$/u.test(e.key)) {
       console.warn('Missing "editorOptions" for <vaadin-grid-pro-edit-column> select editor!');
     }
     // Event handled in select, stop here

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -312,7 +312,7 @@ export const InlineEditingMixin = (superClass) =>
       if (edited) {
         // Detect focus moving to e.g. vaadin-select-overlay
         const overlay = Array.from(e.composedPath()).filter(
-          (node) => node.nodeType === Node.ELEMENT_NODE && /^vaadin-(?!dialog).*-overlay$/i.test(node.localName),
+          (node) => node.nodeType === Node.ELEMENT_NODE && /^vaadin-(?!dialog).*-overlay$/iu.test(node.localName),
         )[0];
 
         if (overlay) {

--- a/packages/grid/src/array-data-provider.js
+++ b/packages/grid/src/array-data-provider.js
@@ -28,7 +28,7 @@ function checkPaths(arrayToCheck, action, items) {
       return;
     }
 
-    const parentProperty = path.replace(/\.[^.]*$/, ''); // A.b.c -> a.b
+    const parentProperty = path.replace(/\.[^.]*$/u, ''); // A.b.c -> a.b
     if (get(parentProperty, items[0]) === undefined) {
       console.warn(`Path "${path}" used for ${action} does not exist in all of the items, ${action} is disabled.`);
       result = false;

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -126,7 +126,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
       this._preventHiddenSynchronization = false;
     }
 
-    if (/flexGrow|width|hidden|_childColumns/.test(path)) {
+    if (/flexGrow|width|hidden|_childColumns/u.test(path)) {
       this._updateFlexAndWidth();
     }
 
@@ -169,7 +169,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
       // [1110] | [1120] | [1210] | [1220]
 
       // Trailing zeros are counted so we know the level on which we're working on.
-      const trailingZeros = /(0+)$/.exec(order).pop().length;
+      const trailingZeros = /(0+)$/u.exec(order).pop().length;
 
       // In an unlikely situation where a group has more than 9 child columns,
       // the child scope must have 1 digit less...
@@ -247,7 +247,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
   __scheduleAutoFreezeWarning(columns, frozenProp) {
     if (this._grid) {
       // Derive the attribute name from the property name
-      const frozenAttr = frozenProp.replace(/([A-Z])/g, '-$1').toLowerCase();
+      const frozenAttr = frozenProp.replace(/([A-Z])/gu, '-$1').toLowerCase();
 
       // Check if all the columns have the same frozen value
       const firstColumnFrozen = columns[0][frozenProp] || columns[0].hasAttribute(frozenAttr);
@@ -394,7 +394,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
    * @protected
    */
   _isColumnElement(node) {
-    return node.nodeType === Node.ELEMENT_NODE && /\bcolumn\b/.test(node.localName);
+    return node.nodeType === Node.ELEMENT_NODE && /\bcolumn\b/u.test(node.localName);
   }
 }
 

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -305,7 +305,7 @@ export const ColumnReorderingMixin = (superClass) =>
      */
     _setSiblingsReorderStatus(column, status) {
       iterateChildren(column.parentNode, (sibling) => {
-        if (/column/.test(sibling.localName) && this._isSwapAllowed(sibling, column)) {
+        if (/column/u.test(sibling.localName) && this._isSwapAllowed(sibling, column)) {
           sibling._reorderStatus = status;
         }
       });

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -271,7 +271,7 @@ export const ColumnBaseMixin = (superClass) =>
       // eslint-disable-next-line @typescript-eslint/no-this-alias, consistent-this
       let el = this;
       // Custom elements extending grid must have a specific localName
-      while (el && !/^vaadin.*grid(-pro)?$/.test(el.localName)) {
+      while (el && !/^vaadin.*grid(-pro)?$/u.test(el.localName)) {
         el = el.assignedSlot ? el.assignedSlot.parentNode : el.parentNode;
       }
       return el || undefined;
@@ -406,10 +406,10 @@ export const ColumnBaseMixin = (superClass) =>
     _generateHeader(path) {
       return path
         .substr(path.lastIndexOf('.') + 1)
-        .replace(/([A-Z])/g, '-$1')
+        .replace(/([A-Z])/gu, '-$1')
         .toLowerCase()
-        .replace(/-/g, ' ')
-        .replace(/^./, (match) => match.toUpperCase());
+        .replace(/-/gu, ' ')
+        .replace(/^./u, (match) => match.toUpperCase());
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -128,7 +128,7 @@ export const DragAndDropMixin = (superClass) =>
           // Safari doesn't position drag images from transformed
           // elements properly so we need to switch to use top temporarily
           const transform = row.style.transform;
-          row.style.top = /translateY\((.*)\)/.exec(transform)[1];
+          row.style.top = /translateY\((.*)\)/u.exec(transform)[1];
           row.style.transform = 'none';
           requestAnimationFrame(() => {
             row.style.top = '';

--- a/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -172,6 +172,6 @@ export const DynamicColumnsMixin = (superClass) =>
      * @protected
      */
     _isColumnElement(node) {
-      return node.nodeType === Node.ELEMENT_NODE && /\bcolumn\b/.test(node.localName);
+      return node.nodeType === Node.ELEMENT_NODE && /\bcolumn\b/u.test(node.localName);
     }
   };

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -586,7 +586,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       const localTarget = e.composedPath()[0];
       const localTargetIsTextInput =
         localTarget.localName === 'input' &&
-        !/^(button|checkbox|color|file|image|radio|range|reset|submit)$/i.test(localTarget.type);
+        !/^(button|checkbox|color|file|image|radio|range|reset|submit)$/iu.test(localTarget.type);
 
       let wantInteracting;
       switch (key) {
@@ -724,7 +724,7 @@ export const KeyboardNavigationMixin = (superClass) =>
 
     /** @private */
     _onKeyUp(e) {
-      if (!/^( |SpaceBar)$/.test(e.key) || this.interacting) {
+      if (!/^( |SpaceBar)$/u.test(e.key) || this.interacting) {
         return;
       }
 

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -167,7 +167,7 @@ export const ScrollMixin = (superClass) =>
       }
 
       if (this.__isRTL) {
-        overflow = overflow.replace(/start|end/gi, (matched) => {
+        overflow = overflow.replace(/start|end/giu, (matched) => {
           return matched === 'start' ? 'end' : 'start';
         });
       }

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -1049,7 +1049,7 @@ class Grid extends ElementMixin(
   /** @private */
   __updateFooterPositioning() {
     // TODO: fixed in Firefox 99, remove when we can drop Firefox ESR 91 support
-    if (this._firefox && parseFloat(navigator.userAgent.match(/Firefox\/(\d{2,3}.\d)/)[1]) < 99) {
+    if (this._firefox && parseFloat(navigator.userAgent.match(/Firefox\/(\d{2,3}.\d)/u)[1]) < 99) {
       // Sticky (or translated) footer in a flexbox host doesn't get included in
       // the scroll height calculation on FF. This is a workaround for the issue.
       this.$.items.style.paddingBottom = 0;

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -256,7 +256,7 @@ describe('drag and drop', () => {
       });
 
       // The test only concerns Safari
-      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+      const isSafari = /^((?!chrome|android).)*safari/iu.test(navigator.userAgent);
       (isSafari ? it : it.skip)('should use top on Safari for drag image', async () => {
         const row = getRows(grid.$.items)[0];
         const originalTransform = row.style.transform;

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -13,7 +13,7 @@ describe('vaadin-icon', () => {
   let icon, svgElement;
 
   function expectIcon(content) {
-    expect(svgElement.innerHTML.trim().replace(/<!--[^>]*-->/g, '')).to.equal(content);
+    expect(svgElement.innerHTML.trim().replace(/<!--[^>]*-->/gu, '')).to.equal(content);
   }
 
   describe('custom element definition', () => {
@@ -144,7 +144,7 @@ describe('vaadin-icon', () => {
       it('should render icon from the iconset', () => {
         icons.forEach((svgIcon) => {
           icon.icon = svgIcon.getAttribute('id');
-          expectIcon(svgIcon.outerHTML.replace(/ id="[^\s]+"/, ''));
+          expectIcon(svgIcon.outerHTML.replace(/ id="[^\s]+"/u, ''));
         });
       });
 

--- a/packages/icons/test/visual/vaadin-iconset.test.js
+++ b/packages/icons/test/visual/vaadin-iconset.test.js
@@ -7,7 +7,7 @@ describe('vaadin-iconset', () => {
 
   before(async () => {
     const { origin, pathname } = new URL(import.meta.url);
-    const file = pathname.replace(/test\/.+/, 'assets/vaadin-font-icons.json');
+    const file = pathname.replace(/test\/.+/u, 'assets/vaadin-font-icons.json');
     const data = await fetch(`${origin}${file}`);
     const icons = await data.json();
     wrapper = fixtureSync(`

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -84,12 +84,12 @@ export class IntegerField extends NumberField {
 
   /** @private */
   __isInteger(value) {
-    return /^(-\d)?\d*$/.test(String(value));
+    return /^(-\d)?\d*$/u.test(String(value));
   }
 
   /** @private */
   __hasOnlyDigits(value) {
-    return /^\d+$/.test(String(value));
+    return /^\d+$/u.test(String(value));
   }
 }
 

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -491,7 +491,7 @@ class Notification extends ThemePropertyMixin(ElementMixin(PolymerElement)) {
     }
 
     this._card.slot = this.position;
-    if (this._container.firstElementChild && /top/.test(this.position)) {
+    if (this._container.firstElementChild && /top/u.test(this.position)) {
       this._container.insertBefore(this._card, this._container.firstElementChild);
     } else {
       this._container.appendChild(this._card);

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -96,7 +96,7 @@ describe('vaadin-notification', () => {
       document.body.click();
     });
 
-    const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+    const iOS = /iPad|iPhone|iPod/u.test(navigator.userAgent);
     (iOS ? describe : describe.skip)('iOS incorrect viewport height workaround', () => {
       let container;
 

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, listenOnce } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, isIOS, listenOnce } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
@@ -96,8 +96,7 @@ describe('vaadin-notification', () => {
       document.body.click();
     });
 
-    const iOS = /iPad|iPhone|iPod/u.test(navigator.userAgent);
-    (iOS ? describe : describe.skip)('iOS incorrect viewport height workaround', () => {
+    (isIOS ? describe : describe.skip)('iOS incorrect viewport height workaround', () => {
       let container;
 
       beforeEach(() => {

--- a/packages/overlay/test/overlay.test.js
+++ b/packages/overlay/test/overlay.test.js
@@ -1,5 +1,14 @@
 import { expect } from '@esm-bundle/chai';
-import { click, enterKeyDown, escKeyDown, fixtureSync, mousedown, mouseup, oneEvent } from '@vaadin/testing-helpers';
+import {
+  click,
+  enterKeyDown,
+  escKeyDown,
+  fixtureSync,
+  isIOS,
+  mousedown,
+  mouseup,
+  oneEvent,
+} from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/text-field/vaadin-text-field.js';
@@ -498,8 +507,7 @@ describe('vaadin-overlay', () => {
     });
   });
 
-  const iOS = /iPad|iPhone|iPod/u.test(navigator.userAgent);
-  (iOS ? describe : describe.skip)('iOS incorrect viewport height workaround', () => {
+  (isIOS ? describe : describe.skip)('iOS incorrect viewport height workaround', () => {
     let overlay;
 
     beforeEach(async () => {

--- a/packages/overlay/test/overlay.test.js
+++ b/packages/overlay/test/overlay.test.js
@@ -498,7 +498,7 @@ describe('vaadin-overlay', () => {
     });
   });
 
-  const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const iOS = /iPad|iPhone|iPod/u.test(navigator.userAgent);
   (iOS ? describe : describe.skip)('iOS incorrect viewport height workaround', () => {
     let overlay;
 

--- a/packages/polymer-legacy-adapter/src/template-renderer-grid-templatizer.js
+++ b/packages/polymer-legacy-adapter/src/template-renderer-grid-templatizer.js
@@ -36,7 +36,7 @@ export class GridTemplatizer extends Templatizer {
 
     const index = this.__grid.items.indexOf(instance.item);
 
-    path = path.replace(/^item\./, '');
+    path = path.replace(/^item\./u, '');
     path = `items.${index}.${path}`;
 
     this.__grid.notifyPath(path, value);

--- a/packages/polymer-legacy-adapter/test/grid-body.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-body.test.js
@@ -33,7 +33,7 @@ describe('grid body template', () => {
     column.renderer = () => {};
 
     expect(() => window.Vaadin.templateRendererCallback(column)).to.throw(
-      /^Cannot use both a template and a renderer for <vaadin-grid-column \/>\.$/,
+      /^Cannot use both a template and a renderer for <vaadin-grid-column \/>\.$/u,
     );
   });
 });

--- a/packages/polymer-legacy-adapter/test/grid-editor.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-editor.test.js
@@ -33,7 +33,7 @@ describe('grid editor template', () => {
     column.editModeRenderer = () => {};
 
     expect(() => window.Vaadin.templateRendererCallback(column)).to.throw(
-      /^Cannot use both a template and a renderer for <vaadin-grid-pro-edit-column \/>\.$/,
+      /^Cannot use both a template and a renderer for <vaadin-grid-pro-edit-column \/>\.$/u,
     );
   });
 });

--- a/packages/polymer-legacy-adapter/test/grid-footer.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-footer.test.js
@@ -42,7 +42,7 @@ describe('grid footer template', () => {
     column.footerRenderer = () => {};
 
     expect(() => window.Vaadin.templateRendererCallback(column)).to.throw(
-      /^Cannot use both a template and a renderer for <vaadin-grid-column \/>\.$/,
+      /^Cannot use both a template and a renderer for <vaadin-grid-column \/>\.$/u,
     );
   });
 });

--- a/packages/polymer-legacy-adapter/test/grid-header.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-header.test.js
@@ -42,7 +42,7 @@ describe('grid header template', () => {
     column.headerRenderer = () => {};
 
     expect(() => window.Vaadin.templateRendererCallback(column)).to.throw(
-      /^Cannot use both a template and a renderer for <vaadin-grid-column \/>\.$/,
+      /^Cannot use both a template and a renderer for <vaadin-grid-column \/>\.$/u,
     );
   });
 });

--- a/packages/polymer-legacy-adapter/test/grid-row-details.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-row-details.test.js
@@ -30,7 +30,7 @@ describe('row details template', () => {
     grid.rowDetailsRenderer = () => {};
 
     expect(() => window.Vaadin.templateRendererCallback(grid)).to.throw(
-      /^Cannot use both a template and a renderer for <vaadin-grid \/>\.$/,
+      /^Cannot use both a template and a renderer for <vaadin-grid \/>\.$/u,
     );
   });
 });

--- a/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
+++ b/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
@@ -81,7 +81,7 @@ describe('vaadin-template-renderer', () => {
     component.renderer = () => {};
 
     expect(() => window.Vaadin.templateRendererCallback(component)).to.throw(
-      /^Cannot use both a template and a renderer for <mock-component \/>\.$/,
+      /^Cannot use both a template and a renderer for <mock-component \/>\.$/u,
     );
   });
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -906,17 +906,17 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     let content = editor.innerHTML;
 
     // Remove Quill classes, e.g. ql-syntax, except for align
-    content = content.replace(/\s*ql-(?!align)[\w-]*\s*/g, '');
+    content = content.replace(/\s*ql-(?!align)[\w-]*\s*/gu, '');
 
     // Replace Quill align classes with inline styles
     [this.__dir === 'rtl' ? 'left' : 'right', 'center', 'justify'].forEach((align) => {
       content = content.replace(
-        new RegExp(` class=[\\\\]?"\\s?ql-align-${align}[\\\\]?"`, 'g'),
+        new RegExp(` class=[\\\\]?"\\s?ql-align-${align}[\\\\]?"`, 'gu'),
         ` style="text-align: ${align}"`,
       );
     });
 
-    content = content.replace(/ class=""/g, '');
+    content = content.replace(/ class=""/gu, '');
 
     this._setHtmlValue(content);
   }

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -515,7 +515,7 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
    */
   _onKeyDown(e) {
     if (!this.readonly && !this.opened) {
-      if (/^(Enter|SpaceBar|\s|ArrowDown|Down|ArrowUp|Up)$/.test(e.key)) {
+      if (/^(Enter|SpaceBar|\s|ArrowDown|Down|ArrowUp|Up)$/u.test(e.key)) {
         e.preventDefault();
         this.opened = true;
       } else if (/[\p{L}\p{Nd}]/u.test(e.key) && e.key.length === 1) {
@@ -538,7 +538,7 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
    * @protected
    */
   _onKeyDownInside(e) {
-    if (/^(Tab)$/.test(e.key)) {
+    if (/^(Tab)$/u.test(e.key)) {
       this.opened = false;
     }
   }

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -253,7 +253,7 @@ class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(PolymerEleme
     overflow += scrollPosition + this._scrollOffset < scrollSize ? ' end' : '';
 
     if (this.__direction === 1) {
-      overflow = overflow.replace(/start|end/gi, (matched) => {
+      overflow = overflow.replace(/start|end/giu, (matched) => {
         return matched === 'start' ? 'end' : 'start';
       });
     }

--- a/packages/tabs/test/tabs.test.js
+++ b/packages/tabs/test/tabs.test.js
@@ -128,7 +128,7 @@ describe('tabs', () => {
           });
 
           // TODO: passes locally but fails in GitHub Actions due to 1px difference.
-          const chrome = /HeadlessChrome/.test(navigator.userAgent);
+          const chrome = /HeadlessChrome/u.test(navigator.userAgent);
           (horizontalRtl && chrome ? it.skip : it)(
             `when orientation=${orientation} should have overflow="start" if scroll is at the end`,
             (done) => {

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -297,6 +297,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
               const MATCH_MILLISECONDS = '(\\d{1,3})';
               const re = new RegExp(
                 `^${MATCH_HOURS}(?::${MATCH_MINUTES}(?::${MATCH_SECONDS}(?:\\.${MATCH_MILLISECONDS})?)?)?$`,
+                'u',
               );
               const parts = re.exec(text);
               if (parts) {

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -880,11 +880,11 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       );
       return;
     }
-    const fileExt = file.name.match(/\.[^.]*$|$/)[0];
+    const fileExt = file.name.match(/\.[^.]*$|$/u)[0];
     // Escape regex operators common to mime types
-    const escapedAccept = this.accept.replace(/[+.]/g, '\\$&');
+    const escapedAccept = this.accept.replace(/[+.]/gu, '\\$&');
     // Create accept regex that can match comma separated patterns, star (*) wildcards
-    const re = new RegExp(`^(${escapedAccept.replace(/[, ]+/g, '|').replace(/\/\*/g, '/.*')})$`, 'i');
+    const re = new RegExp(`^(${escapedAccept.replace(/[, ]+/gu, '|').replace(/\/\*/gu, '/.*')})$`, 'iu');
     if (this.accept && !(re.test(file.type) || re.test(fileExt))) {
       this.dispatchEvent(
         new CustomEvent('file-reject', {

--- a/packages/upload/test/mock-http-request.js
+++ b/packages/upload/test/mock-http-request.js
@@ -394,7 +394,7 @@ MockHttpRequest.prototype = {
   // See http://blog.stevenlevithan.com/archives/parseuri
   parseUri(str) {
     const pattern =
-      /^(?:([^:/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:/?#]*)(?::(\d*))?))?((((?:[^?#/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/;
+      /^(?:([^:/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:/?#]*)(?::(\d*))?))?((((?:[^?#/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/u;
     const key = [
       'source',
       'protocol',
@@ -411,7 +411,7 @@ MockHttpRequest.prototype = {
       'query',
       'anchor',
     ];
-    const querypattern = /(?:^|&)([^&=]*)=?([^&]*)/g;
+    const querypattern = /(?:^|&)([^&=]*)=?([^&]*)/gu;
 
     const match = pattern.exec(str);
     const uri = {};

--- a/packages/vaadin-lumo-styles/test/visual/font-icons.test.js
+++ b/packages/vaadin-lumo-styles/test/visual/font-icons.test.js
@@ -7,7 +7,7 @@ describe('font-icons', () => {
 
   before(async () => {
     const { origin, pathname } = new URL(import.meta.url);
-    const file = pathname.replace(/visual\/.+/, 'glyphs.json');
+    const file = pathname.replace(/visual\/.+/u, 'glyphs.json');
     const data = await fetch(`${origin}${file}`);
     const icons = await data.json();
     wrapper = fixtureSync(`

--- a/packages/vaadin-lumo-styles/test/visual/vaadin-iconset.test.js
+++ b/packages/vaadin-lumo-styles/test/visual/vaadin-iconset.test.js
@@ -8,7 +8,7 @@ describe('vaadin-iconset', () => {
 
   before(async () => {
     const { origin, pathname } = new URL(import.meta.url);
-    const file = pathname.replace(/visual\/.+/, 'glyphs.json');
+    const file = pathname.replace(/visual\/.+/u, 'glyphs.json');
     const data = await fetch(`${origin}${file}`);
     const icons = await data.json();
     wrapper = fixtureSync(`

--- a/packages/vaadin-material-styles/test/visual/font-icons.test.js
+++ b/packages/vaadin-material-styles/test/visual/font-icons.test.js
@@ -7,7 +7,7 @@ describe('font-icons', () => {
 
   before(async () => {
     const { origin, pathname } = new URL(import.meta.url);
-    const file = pathname.replace(/visual\/.+/, 'glyphs.json');
+    const file = pathname.replace(/visual\/.+/u, 'glyphs.json');
     const data = await fetch(`${origin}${file}`);
     const icons = await data.json();
     wrapper = fixtureSync(`

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -77,7 +77,7 @@ function getAllThemes() {
  */
 function matchesThemeFor(themeFor, tagName) {
   return (themeFor || '').split(' ').some((themeForToken) => {
-    return new RegExp(`^${themeForToken.split('*').join('.*')}$`).test(tagName);
+    return new RegExp(`^${themeForToken.split('*').join('.*')}$`, 'u').test(tagName);
   });
 }
 

--- a/scripts/buildWebtypes.js
+++ b/scripts/buildWebtypes.js
@@ -9,14 +9,14 @@ const LIT_WEB_TYPES_FILE = 'web-types.lit.json';
 const API_DOCS_BASE_PATH = 'https://cdn.vaadin.com/vaadin-web-components';
 
 const blacklistedPackages = [
-  /^vaadin-/,
-  /^component-base/,
-  /^field-base/,
-  /^field-highlighter/,
-  /^icons/,
-  /^input-container/,
-  /^lit-renderer/,
-  /^polymer-legacy-adapter/,
+  /^vaadin-/u,
+  /^component-base/u,
+  /^field-base/u,
+  /^field-highlighter/u,
+  /^icons/u,
+  /^input-container/u,
+  /^lit-renderer/u,
+  /^polymer-legacy-adapter/u,
 ];
 
 // Additional attributes that will be added to all components
@@ -56,7 +56,7 @@ function loadAnalysis() {
  * @returns {string[]}
  */
 function mapType(typeString) {
-  const sanitizedTypeString = (typeString || '').replace(/[!()]/g, '');
+  const sanitizedTypeString = (typeString || '').replace(/[!()]/gu, '');
   const types = sanitizedTypeString.split('|');
   return types.map((type) => type.trim());
 }
@@ -71,19 +71,19 @@ function mapType(typeString) {
 function transformDescription(packageJson, description) {
   // Transform relative documentation links to absolute ones
   description = description.replace(
-    /\(#\/elements\/(.*)\)/g, // Matches "(#/elements/$1)"
+    /\(#\/elements\/(.*)\)/gu, // Matches "(#/elements/$1)"
     `(${API_DOCS_BASE_PATH}/${packageJson.version}/#/elements/$1)`,
   );
   // Remove multiple newlines between subsequent code examples,
   // The IntelliJ markdown renderer will otherwise collapse
   // both examples into one
-  description = description.replace(/```(\n)+```/g, '```\n```');
+  description = description.replace(/```(\n)+```/gu, '```\n```');
 
   return description;
 }
 
 function camelize(text) {
-  return text.replace(/-./g, (x) => x[1].toUpperCase());
+  return text.replace(/-./gu, (x) => x[1].toUpperCase());
 }
 
 function isWritablePrimitiveAttribute(elementAnalysis, attribute) {

--- a/scripts/cherryPick.js
+++ b/scripts/cherryPick.js
@@ -69,7 +69,7 @@ function filterCommits(commits) {
     }
     if (target === true && picked === false) {
       commit.labels.forEach((label) => {
-        const branch = /target\/(.*)/.exec(label.name);
+        const branch = /target\/(.*)/u.exec(label.name);
         if (branch) {
           console.log(commit.number, commit.user.login, commit.url, commit.merge_commit_sha, branch[1]);
           arrPR.push(commit.number);

--- a/scripts/generateLumoAutoCompleteCss.js
+++ b/scripts/generateLumoAutoCompleteCss.js
@@ -11,7 +11,7 @@ function getCustomProperties() {
 
   styleModules.forEach((module) => {
     const content = fs.readFileSync(path.join(PACKAGE_BASE, `${module}.js`), 'utf8');
-    const customPropertyDeclarationRegex = /--[\w\d-]+:.*;/g;
+    const customPropertyDeclarationRegex = /--[\w\d-]+:.*;/gu;
     const propertyDeclarations = content.match(customPropertyDeclarationRegex);
     propertyDeclarations.forEach((propertyDeclaration) => {
       // Avoid duplicate property declarations from dark theme
@@ -34,15 +34,15 @@ function getUtilityClasses() {
     .filter((module) => module.endsWith('.js'))
     .forEach((module) => {
       const content = fs.readFileSync(path.join(PACKAGE_BASE, 'utilities', module), 'utf8');
-      const cssSectionRegex = /css`((.|\s)*?)`/gm;
+      const cssSectionRegex = /css`((.|\s)*?)`/gmu;
       let match;
 
       while ((match = cssSectionRegex.exec(content))) {
         let section = match[1];
         // Remove escape backslash
-        section = section.replace(/\\\\/g, '\\');
+        section = section.replace(/\\\\/gu, '\\');
         // Unindent
-        section = section.replace(/\n\s{2}/g, '\n');
+        section = section.replace(/\n\s{2}/gu, '\n');
         result.push(section);
       }
     });
@@ -53,14 +53,14 @@ function getUtilityClasses() {
 const customProperties = getCustomProperties();
 const utilityClasses = getUtilityClasses();
 
-let result = `/* This file contains declarations for CSS custom properties and utility 
- * classes of the Lumo theme in order to provide auto-complete support 
+let result = `/* This file contains declarations for CSS custom properties and utility
+ * classes of the Lumo theme in order to provide auto-complete support
  * for IDEs.
- * 
+ *
  * NOTE: This file is only intended to provide auto-complete support,
  * do not include it into an HTML page!
  */
- 
+
  `;
 result += '/* Custom CSS properties */\n';
 result += ':host {\n';

--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -75,7 +75,7 @@ function parseLog(log) {
           pos = 'title';
           break;
         }
-        result = /^(\w+): +(.+)$/.exec(line);
+        result = /^(\w+): +(.+)$/u.exec(line);
         if (result) {
           commit.head[result[1]] = result[2];
           break;
@@ -86,12 +86,12 @@ function parseLog(log) {
           pos = 'body';
           break;
         }
-        result = /^ +(\w+)(!?): +(.*)$/.exec(line);
+        result = /^ +(\w+)(!?): +(.*)$/u.exec(line);
         if (result) {
           commit.type = result[1].toLowerCase();
           commit.breaking = !!result[2];
           commit.isBreaking = commit.breaking;
-          commit.skip = !commit.breaking && !/(feat|fix|perf)/.test(commit.type);
+          commit.skip = !commit.breaking && !/(feat|fix|perf)/u.test(commit.type);
           commit.isIncluded = !commit.skip;
           commit.title += result[3];
         } else {
@@ -99,15 +99,15 @@ function parseLog(log) {
         }
         break;
       case 'body':
-        result = /^ +([A-Z][\w-]+): +(.*)$/.exec(line);
+        result = /^ +([A-Z][\w-]+): +(.*)$/u.exec(line);
         if (result) {
           const k = result[1].toLowerCase();
           if (k === 'warranty') {
             commit.bfp = true;
           }
-          if (/(fixes|fix|related-to|connected-to|warranty)/i.test(k)) {
+          if (/(fixes|fix|related-to|connected-to|warranty)/iu.test(k)) {
             commit.footers.fixes ||= [];
-            commit.footers.fixes.push(...result[2].split(/[, ]+/).filter((s) => /\d+/.test(s)));
+            commit.footers.fixes.push(...result[2].split(/[, ]+/u).filter((s) => /\d+/u.test(s)));
           } else {
             commit.footers[k] ||= [];
             commit.footers[k].push(result[2]);
@@ -116,7 +116,7 @@ function parseLog(log) {
         }
       // eslint-disable-next-line no-fallthrough
       default:
-        result = /^commit (.+)$/.exec(line);
+        result = /^commit (.+)$/u.exec(line);
         if (result) {
           if (commit) {
             commit.body = commit.body.trim();
@@ -136,7 +136,7 @@ function parseLog(log) {
           pos = 'head';
         } else if (line.startsWith(' ')) {
           commit.body = String(commit.body);
-        } else if (/^packages\/.*/.test(line)) {
+        } else if (/^packages\/.*/u.test(line)) {
           const wc = line.split('/')[1];
           if (!commit.components.includes(wc)) {
             commit.components.push(wc);
@@ -160,8 +160,8 @@ function createLink(type, id, char) {
 // Convert GH internal links to absolute links
 function parseLinks(message) {
   message = message.trim();
-  message = message.replace(/^([\da-f]+) /, `${createLink('commit', '$1', '⧉')} `);
-  message = message.replace(/ *\(#(\d+)\)$/g, ` (${createLink('pull', '$1', '#$1')})`);
+  message = message.replace(/^([\da-f]+) /u, `${createLink('commit', '$1', '⧉')} `);
+  message = message.replace(/ *\(#(\d+)\)$/gu, ` (${createLink('pull', '$1', '#$1')})`);
   return message;
 }
 
@@ -178,12 +178,12 @@ function getTickets(c) {
     const ticket = `Ticket${c.footers.fixes.length > 1 ? 's' : ''}`;
     const links = c.footers.fixes.reduce((prev, f) => {
       let link = f;
-      if (/^#?\d/.test(f)) {
-        f = f.replace(/^#/, '');
+      if (/^#?\d/u.test(f)) {
+        f = f.replace(/^#/u, '');
         link = `${createLink('issues', f)}`;
-      } else if (/^(vaadin\/|https:\/\/github.com\/vaadin\/).*\d+$/.test(f)) {
-        const n = f.replace(/^.*?(\d+)$/, '$1');
-        f = f.replace(/^(https:\/\/github.com\/vaadin|vaadin)\//, '').replace('#', '/issues/');
+      } else if (/^(vaadin\/|https:\/\/github.com\/vaadin\/).*\d+$/u.test(f)) {
+        const n = f.replace(/^.*?(\d+)$/u, '$1');
+        f = f.replace(/^(https:\/\/github.com\/vaadin|vaadin)\//u, '').replace('#', '/issues/');
         link = `[${n}](${createGHLink(f)})`;
       }
       return (prev ? `${prev}, ` : '') + link;
@@ -274,7 +274,7 @@ function logCommitsByComponent(commits) {
           log += `. ${tickets}`;
         }
       });
-      console.log(log.replace(/^\s*[\r\n]/gm, ''));
+      console.log(log.replace(/^\s*[\r\n]/gmu, ''));
     });
 }
 

--- a/scripts/prepareDocs.js
+++ b/scripts/prepareDocs.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const fs = require('fs');
 
-const CAMEL_TO_DASH = /([A-Z])/g;
+const CAMEL_TO_DASH = /([A-Z])/gu;
 
 function generateChangeEventName(property) {
   return `${property.name.replace(CAMEL_TO_DASH, '-$1').toLowerCase()}-changed`;

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -9,7 +9,7 @@ const oldVersion = require('../lerna.json').version;
  * order to be passed in the resolved promise.
  */
 function exe(cmd, quiet) {
-  const args = cmd.split(/ +/);
+  const args = cmd.split(/ +/u);
   const child = spawn(args[0], args.slice(1));
 
   let out = '';
@@ -41,8 +41,8 @@ if (!version) {
 }
 
 async function main() {
-  const fromRegex = new RegExp(`'${oldVersion.split('.').join('\\.')}'`, 'g');
-  const newVersion = `'${version.replace(/^v/, '')}'`;
+  const fromRegex = new RegExp(`'${oldVersion.split('.').join('\\.')}'`, 'gu');
+  const newVersion = `'${version.replace(/^v/u, '')}'`;
   const results = await replace({
     files: ['packages/**/version.{js,ts}', 'packages/component-base/src/*.{js,ts}'],
     from: fromRegex,

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -27,7 +27,7 @@ module.exports = {
           let body = context.body;
 
           // Fouc prevention
-          body = body.replace(/<\/body>/, `${preventFouc}\n</body>`);
+          body = body.replace(/<\/body>/u, `${preventFouc}\n</body>`);
 
           // Index page listing
           if (['/dev/index.html', '/dev', '/dev/'].includes(context.path)) {
@@ -41,7 +41,7 @@ module.exports = {
                   .join('')}
               </ul>`;
 
-            body = body.replace(/<ul id="listing">.*<\/ul>/, listing);
+            body = body.replace(/<ul id="listing">.*<\/ul>/u, listing);
           }
 
           return { body };

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -10,8 +10,8 @@ const { visualRegressionPlugin } = require('@web/test-runner-visual-regression/p
 const HIDDEN_WARNINGS = [
   '<vaadin-crud> Unable to autoconfigure form because the data structure is unknown. Either specify `include` or ensure at least one item is available beforehand.',
   'The <vaadin-grid> needs the total number of items in order to display rows. Set the total number of items to the `size` property, or provide the total number of items in the second argument of the `dataProvider`’s `callback` call.',
-  /^WARNING: Since Vaadin .* is deprecated.*/,
-  /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/,
+  /^WARNING: Since Vaadin .* is deprecated.*/u,
+  /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/u,
 ];
 
 const filterBrowserLogs = (log) => {
@@ -200,13 +200,13 @@ const getTestRunnerHtml = (theme) => (testFramework) =>
 const getScreenshotFileName = ({ name, testFile }, type, diff) => {
   let folder;
   if (testFile.includes('-styles')) {
-    const match = testFile.match(/\/packages\/(vaadin-(lumo|material)-styles\/test\/visual\/)(.+)/);
+    const match = testFile.match(/\/packages\/(vaadin-(lumo|material)-styles\/test\/visual\/)(.+)/u);
     folder = `${match[1]}screenshots`;
   } else if (testFile.includes('icons')) {
     folder = 'icons/test/visual/screenshots';
   } else {
-    const match = testFile.match(/\/packages\/(.+)\.test\.js/);
-    folder = match[1].replace(/(lumo|material)/, '$1/screenshots');
+    const match = testFile.match(/\/packages\/(.+)\.test\.js/u);
+    folder = match[1].replace(/(lumo|material)/u, '$1/screenshots');
   }
   return path.join(folder, type, diff ? `${name}-diff` : name);
 };


### PR DESCRIPTION
This PR adds the `require-unicode-regexp` rule to the ESLint config and fixes all the errors related to that rule.
