### PR TITLE
refactor!: rename cancel and reject properties of confirm dialog

### DIFF
--- a/dev/confirm-dialog.html
+++ b/dev/confirm-dialog.html
@@ -14,7 +14,13 @@
   <body>
     <vaadin-button id="open">Open</vaadin-button>
 
-    <vaadin-confirm-dialog header="Unsaved changes" confirm-text="Save" reject-text="Discard" cancel reject>
+    <vaadin-confirm-dialog
+      header="Unsaved changes"
+      confirm-text="Save"
+      reject-text="Discard"
+      cancel-button-visible
+      reject-button-visible
+    >
       Do you want to save or discard the changes?
     </vaadin-confirm-dialog>
 

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -109,9 +109,10 @@ declare class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMi
   noCloseOnEsc: boolean;
 
   /**
-   * Whether to show cancel button or not.
+   * Whether to show reject button or not.
+   * @attr {boolean} reject-button-visible
    */
-  reject: boolean;
+  rejectButtonVisible: boolean;
 
   /**
    * Text displayed on reject-button.
@@ -129,8 +130,9 @@ declare class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMi
 
   /**
    * Whether to show cancel button or not.
+   * @attr {boolean} cancel-button-visible
    */
-  cancel: boolean;
+  cancelButtonVisible: boolean;
 
   /**
    * Text displayed on cancel-button.

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -28,7 +28,7 @@ export type ConfirmDialogEventMap = ConfirmDialogCustomEventMap & HTMLElementEve
  * `<vaadin-confirm-dialog>` is a Web Component for showing alerts and asking for user confirmation.
  *
  * ```
- * <vaadin-confirm-dialog cancel>
+ * <vaadin-confirm-dialog cancel-button-visible>
  *   There are unsaved changes. Do you really want to leave?
  * </vaadin-confirm-dialog>
  * ```

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -14,7 +14,7 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
  * `<vaadin-confirm-dialog>` is a Web Component for showing alerts and asking for user confirmation.
  *
  * ```
- * <vaadin-confirm-dialog cancel>
+ * <vaadin-confirm-dialog cancel-button-visible>
  *   There are unsaved changes. Do you really want to leave?
  * </vaadin-confirm-dialog>
  * ```

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -158,10 +158,11 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
       },
 
       /**
-       * Whether to show cancel button or not.
+       * Whether to show reject button or not.
+       * @attr {boolean} reject-button-visible
        * @type {boolean}
        */
-      reject: {
+      rejectButtonVisible: {
         type: Boolean,
         reflectToAttribute: true,
         value: false,
@@ -191,9 +192,10 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
 
       /**
        * Whether to show cancel button or not.
+       * @attr {boolean} cancel-button-visible
        * @type {boolean}
        */
-      cancel: {
+      cancelButtonVisible: {
         type: Boolean,
         reflectToAttribute: true,
         value: false,
@@ -267,10 +269,10 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
   static get observers() {
     return [
       '__updateConfirmButton(_confirmButton, confirmText, confirmTheme)',
-      '__updateCancelButton(_cancelButton, cancelText, cancelTheme, cancel)',
+      '__updateCancelButton(_cancelButton, cancelText, cancelTheme, cancelButtonVisible)',
       '__updateHeaderNode(_headerNode, header)',
       '__updateMessageNodes(_messageNodes, message)',
-      '__updateRejectButton(_rejectButton, rejectText, rejectTheme, reject)',
+      '__updateRejectButton(_rejectButton, rejectText, rejectTheme, rejectButtonVisible)',
     ];
   }
 

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -250,17 +250,17 @@ describe('vaadin-confirm-dialog', () => {
       });
 
       it('should show reject button when reject is true', () => {
-        confirm.reject = true;
+        confirm.rejectButtonVisible = true;
         expect(rejectButton.hasAttribute('hidden')).to.be.false;
       });
 
-      it('should reflect reject property to attribute', () => {
-        confirm.reject = true;
-        expect(confirm.hasAttribute('reject')).to.be.true;
+      it('should reflect rejectButtonVisible property to attribute', () => {
+        confirm.rejectButtonVisible = true;
+        expect(confirm.hasAttribute('reject-button-visible')).to.be.true;
       });
 
       it('should close dialog on reject button click', () => {
-        confirm.reject = true;
+        confirm.rejectButtonVisible = true;
         rejectButton.click();
         expect(confirm.opened).to.be.false;
       });
@@ -296,17 +296,17 @@ describe('vaadin-confirm-dialog', () => {
       });
 
       it('should show cancel button when cancel is true', () => {
-        confirm.cancel = true;
+        confirm.cancelButtonVisible = true;
         expect(cancelButton.hasAttribute('hidden')).to.be.false;
       });
 
-      it('should reflect cancel property to attribute', () => {
-        confirm.cancel = true;
-        expect(confirm.hasAttribute('cancel')).to.be.true;
+      it('should reflect cancelButtonVisible property to attribute', () => {
+        confirm.cancelButtonVisible = true;
+        expect(confirm.hasAttribute('cancel-button-visible')).to.be.true;
       });
 
       it('should close dialog on cancel button click', () => {
-        confirm.cancel = true;
+        confirm.cancelButtonVisible = true;
         cancelButton.click();
         expect(confirm.opened).to.be.false;
       });
@@ -408,7 +408,7 @@ describe('vaadin-confirm-dialog', () => {
     });
 
     it('should dispatch cancel event on cancel button click', () => {
-      confirm.cancel = true;
+      confirm.cancelButtonVisible = true;
       const spy = sinon.spy();
       confirm.addEventListener('cancel', spy);
       overlay.querySelector('[slot="cancel-button"]').click();
@@ -416,7 +416,7 @@ describe('vaadin-confirm-dialog', () => {
     });
 
     it('should dispatch reject event on reject button click', () => {
-      confirm.reject = true;
+      confirm.rejectButtonVisible = true;
       const spy = sinon.spy();
       confirm.addEventListener('reject', spy);
       overlay.querySelector('[slot="reject-button"]').click();

--- a/packages/confirm-dialog/test/visual/lumo/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/visual/lumo/confirm-dialog.test.js
@@ -27,18 +27,18 @@ describe('confirm-dialog', () => {
   });
 
   it('cancel', async () => {
-    element.cancel = true;
+    element.cancelButtonVisible = true;
     await visualDiff(div, 'cancel');
   });
 
   it('reject', async () => {
-    element.reject = true;
+    element.rejectButtonVisible = true;
     await visualDiff(div, 'reject');
   });
 
   it('cancel reject', async () => {
-    element.cancel = true;
-    element.reject = true;
+    element.cancelButtonVisible = true;
+    element.rejectButtonVisible = true;
     await visualDiff(div, 'cancel-reject');
   });
 });

--- a/packages/confirm-dialog/test/visual/material/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/visual/material/confirm-dialog.test.js
@@ -27,18 +27,18 @@ describe('confirm-dialog', () => {
   });
 
   it('cancel', async () => {
-    element.cancel = true;
+    element.cancelButtonVisible = true;
     await visualDiff(div, 'cancel');
   });
 
   it('reject', async () => {
-    element.reject = true;
+    element.rejectButtonVisible = true;
     await visualDiff(div, 'reject');
   });
 
   it('cancel reject', async () => {
-    element.cancel = true;
-    element.reject = true;
+    element.cancelButtonVisible = true;
+    element.rejectButtonVisible = true;
     await visualDiff(div, 'cancel-reject');
   });
 });

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -308,7 +308,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
         theme$="[[_theme]]"
         id="confirmCancel"
         on-confirm="__confirmCancel"
-        cancel
+        cancel-button-visible
         confirm-text="[[i18n.confirm.cancel.button.confirm]]"
         cancel-text="[[i18n.confirm.cancel.button.dismiss]]"
         header="[[i18n.confirm.cancel.title]]"
@@ -320,7 +320,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
         theme$="[[_theme]]"
         id="confirmDelete"
         on-confirm="__confirmDelete"
-        cancel
+        cancel-button-visible
         confirm-text="[[i18n.confirm.delete.button.confirm]]"
         cancel-text="[[i18n.confirm.delete.button.dismiss]]"
         header="[[i18n.confirm.delete.title]]"

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -230,7 +230,7 @@ snapshots["vaadin-crud shadow default"] =
 <vaadin-crud-dialog id="dialog">
 </vaadin-crud-dialog>
 <vaadin-confirm-dialog
-  cancel=""
+  cancel-button-visible=""
   confirm-theme="primary"
   id="confirmCancel"
 >
@@ -267,7 +267,7 @@ snapshots["vaadin-crud shadow default"] =
   </vaadin-button>
 </vaadin-confirm-dialog>
 <vaadin-confirm-dialog
-  cancel=""
+  cancel-button-visible=""
   confirm-theme="primary error"
   id="confirmDelete"
 >

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -230,7 +230,7 @@ snapshots["vaadin-crud shadow default"] =
 <vaadin-crud-dialog id="dialog">
 </vaadin-crud-dialog>
 <vaadin-confirm-dialog
-  cancel-button-visible=""
+  cancel=""
   confirm-theme="primary"
   id="confirmCancel"
 >
@@ -267,7 +267,7 @@ snapshots["vaadin-crud shadow default"] =
   </vaadin-button>
 </vaadin-confirm-dialog>
 <vaadin-confirm-dialog
-  cancel-button-visible=""
+  cancel=""
   confirm-theme="primary error"
   id="confirmDelete"
 >


### PR DESCRIPTION
## Description

The following properties for confirm dialog were renamed:

- `reject` -> `rejectButtonVisible`
- `cancel` -> `cancelButtonVisible`

This is a breaking change.

Fixes #597 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.