### PR TITLE
fix: apply overflow attribute values correctly even with sub-pixel values

### DIFF
--- a/packages/component-base/src/overflow-controller.js
+++ b/packages/component-base/src/overflow-controller.js
@@ -92,7 +92,7 @@ export class OverflowController {
       overflow += ' top';
     }
 
-    if (target.scrollTop < target.scrollHeight - target.clientHeight) {
+    if (Math.ceil(target.scrollTop) < Math.ceil(target.scrollHeight - target.clientHeight)) {
       overflow += ' bottom';
     }
 
@@ -101,7 +101,7 @@ export class OverflowController {
       overflow += ' start';
     }
 
-    if (scrollLeft < target.scrollWidth - target.clientWidth) {
+    if (Math.ceil(scrollLeft) < Math.ceil(target.scrollWidth - target.clientWidth)) {
       overflow += ' end';
     }
 

--- a/packages/scroller/test/scroller.test.js
+++ b/packages/scroller/test/scroller.test.js
@@ -80,11 +80,12 @@ describe('vaadin-scroller', () => {
     describe('horizontal', () => {
       beforeEach(async () => {
         scroller.scrollDirection = 'horizontal';
-        scroller.style.maxWidth = '100px';
+        scroller.style.fontSize = '15px';
+        scroller.style.maxWidth = '6.75em';
 
         const div = document.createElement('div');
         div.textContent = 'Long text that does not fit';
-        div.style.width = '200px';
+        div.style.fontSize = '1.25em';
         div.style.whiteSpace = 'nowrap';
         scroller.appendChild(div);
 
@@ -112,10 +113,11 @@ describe('vaadin-scroller', () => {
   describe('vertical', () => {
     beforeEach(async () => {
       scroller.scrollDirection = 'vertical';
-      scroller.style.maxHeight = '50px';
+      scroller.style.fontSize = '15px';
+      scroller.style.maxHeight = '3.75em';
 
       const div = document.createElement('div');
-      div.innerHTML = 'Long<br>text<br>that<br>has<br>many<br>lines';
+      div.innerHTML = '<div style="font-size: 1.25em;">Long<br>text<br>that<br>has<br>many<br>lines</div>';
       scroller.appendChild(div);
 
       await nextRender();


### PR DESCRIPTION
In the rare case, when the overflow container and the contents inside it have non-integer sizes, the `overflow` attribute values are not set correctly. Specifically, when scrolled all the way to the end or bottom, the `end` or `bottom` value is not removed.

Fixed by always rounding up the compared values.

Added a tests. Verified locally that the tests fail without the fix.