### PR TITLE
refactor!: remove `colorLegacy` module from Lumo

### DIFF
--- a/packages/vaadin-lumo-styles/color.d.ts
+++ b/packages/vaadin-lumo-styles/color.d.ts
@@ -3,5 +3,3 @@ import type { CSSResult } from 'lit';
 export const colorBase: CSSResult;
 
 export const color: CSSResult;
-
-export const colorLegacy: CSSResult;

--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -197,13 +197,4 @@ const color = css`
 
 registerStyles('', color, { moduleId: 'lumo-color' });
 
-const colorLegacy = css`
-  :host {
-    color: var(--lumo-body-text-color) !important;
-    background-color: var(--lumo-base-color) !important;
-  }
-`;
-
-registerStyles('', [color, colorLegacy], { moduleId: 'lumo-color-legacy' });
-
-export { colorBase, color, colorLegacy };
+export { colorBase, color };


### PR DESCRIPTION
I assume this legacy style sheet is no longer needed, and has been deprecated for a while now. I don't know if the deprecation has been communicated in any way to users, so I’m not entirely sure we can remove it in v24.