### PR TITLE
fix!: change default tooltip delay from 0 to 500ms

### DIFF
--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, tabKeyDown } from '@vaadin/testing-helpers';
-import '@vaadin/tooltip';
 import { Button } from '@vaadin/button';
 import { Checkbox } from '@vaadin/checkbox';
 import { CheckboxGroup } from '@vaadin/checkbox-group';
@@ -23,6 +22,7 @@ import { Tab } from '@vaadin/tabs/vaadin-tab.js';
 import { TextArea } from '@vaadin/text-area';
 import { TextField } from '@vaadin/text-field';
 import { TimePicker } from '@vaadin/time-picker';
+import { Tooltip } from '@vaadin/tooltip';
 import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
 
 [
@@ -80,6 +80,12 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
 ].forEach(({ tagName, targetSelector, position, applyShouldNotShowCondition, children = '' }) => {
   describe(`${tagName} with a slotted tooltip`, () => {
     let element, tooltip, tooltipOverlay;
+
+    before(() => {
+      Tooltip.setDefaultFocusDelay(0);
+      Tooltip.setDefaultHoverDelay(0);
+      Tooltip.setDefaultHideDelay(0);
+    });
 
     beforeEach(() => {
       element = fixtureSync(`

--- a/integration/tests/grid-tooltip.test.js
+++ b/integration/tests/grid-tooltip.test.js
@@ -16,8 +16,8 @@ import {
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '@vaadin/grid/vaadin-grid.js';
-import '@vaadin/tooltip/vaadin-tooltip.js';
 import { flushGrid, getCell, getContainerCell } from '@vaadin/grid/test/helpers.js';
+import { Tooltip } from '@vaadin/tooltip';
 import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
 
 function getHeaderCell(grid, index = 0) {
@@ -48,241 +48,337 @@ describe('tooltip', () => {
     await nextRender();
   });
 
-  it('should set manual on the tooltip to true', () => {
-    expect(tooltip.manual).to.be.true;
+  describe('properties', () => {
+    it('should set manual on the tooltip to true', () => {
+      expect(tooltip.manual).to.be.true;
+    });
+
+    it('should set tooltip opened to false when the grid is removed', () => {
+      tooltip.opened = true;
+
+      grid.remove();
+
+      expect(tooltip.opened).to.be.false;
+    });
   });
 
-  it('should show tooltip on cell mouseenter', () => {
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-    expect(tooltip.opened).to.be.true;
+  describe('mouse', () => {
+    const DEFAULT_DELAY = 500;
+
+    let cell, clock;
+
+    beforeEach(() => {
+      cell = getCell(grid, 0);
+
+      clock = sinon.useFakeTimers({
+        shouldClearNativeTimers: true,
+      });
+    });
+
+    afterEach(() => {
+      // Wait for cooldown
+      clock.tick(DEFAULT_DELAY);
+      clock.restore();
+    });
+
+    it('should show tooltip on cell mouseenter', () => {
+      mouseenter(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.opened).to.be.true;
+    });
+
+    it('should hide tooltip on cell mouseleave', () => {
+      mouseenter(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      mouseleave(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should set tooltip target on cell mouseenter', () => {
+      mouseenter(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.target).to.be.equal(cell);
+    });
+
+    it('should set tooltip context on cell mouseenter', () => {
+      mouseenter(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.context).to.be.instanceOf(Object);
+      expect(tooltip.context.item.firstName).to.equal('John');
+      expect(tooltip.context.item.lastName).to.equal('Doe');
+    });
+
+    it('should change tooltip context on header cell mouseenter', () => {
+      mouseenter(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      mouseleave(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      mouseenter(getHeaderCell(grid, 0));
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.context.item).to.be.not.ok;
+    });
+
+    it('should hide tooltip on cell mousedown', () => {
+      mouseenter(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      mousedown(cell);
+      expect(tooltip.opened).to.be.false;
+    });
   });
 
-  it('should hide tooltip on cell mouseleave', () => {
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-    mouseleave(cell);
-    expect(tooltip.opened).to.be.false;
+  describe('focus', () => {
+    const DEFAULT_DELAY = 500;
+
+    let cell, clock;
+
+    beforeEach(() => {
+      cell = getCell(grid, 0);
+
+      clock = sinon.useFakeTimers({
+        shouldClearNativeTimers: true,
+      });
+    });
+
+    afterEach(() => {
+      // Wait for cooldown
+      clock.tick(DEFAULT_DELAY);
+      clock.restore();
+    });
+
+    it('should show tooltip on cell keyboard focus', () => {
+      tabKeyDown(document.body);
+      focusin(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.opened).to.be.true;
+    });
+
+    it('should set tooltip target on cell keyboard focus', () => {
+      tabKeyDown(document.body);
+      focusin(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.target).to.be.equal(cell);
+    });
+
+    it('should set tooltip context on cell keyboard focus', () => {
+      tabKeyDown(document.body);
+      focusin(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.context).to.be.instanceOf(Object);
+      expect(tooltip.context.item.firstName).to.equal('John');
+      expect(tooltip.context.item.lastName).to.equal('Doe');
+    });
+
+    it('should hide tooltip on cell content keyboard focus', () => {
+      // Make the first column render inputs
+      grid.firstElementChild.renderer = (root) => {
+        root.innerHTML = '<input>';
+      };
+
+      tabKeyDown(document.body);
+      focusin(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      arrowDown(cell);
+      expect(tooltip.opened).to.be.true;
+
+      // Enter interaction mode (the input gets focus)
+      const focusedCell = getContainerCell(grid.$.items, 1, 0);
+      enter(focusedCell);
+
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should hide tooltip on grid focusout', () => {
+      tabKeyDown(document.body);
+      focusin(cell);
+      clock.tick(DEFAULT_DELAY);
+
+      focusout(grid);
+      clock.tick(DEFAULT_DELAY);
+
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should hide tooltip on grid cell content Esc', () => {
+      tabKeyDown(document.body);
+      focusin(cell._content);
+      clock.tick(DEFAULT_DELAY);
+
+      escKeyDown(cell._content);
+      expect(tooltip.opened).to.be.false;
+    });
   });
 
-  it('should set tooltip target on cell mouseenter', () => {
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-    expect(tooltip.target).to.be.equal(cell);
-  });
+  describe('no tooltip', () => {
+    it('should not set tooltip target if there is no tooltip', async () => {
+      const spy = sinon.spy(grid._tooltipController, 'setTarget');
 
-  it('should set tooltip context on cell mouseenter', () => {
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-    expect(tooltip.context).to.be.instanceOf(Object);
-    expect(tooltip.context.item.firstName).to.equal('John');
-    expect(tooltip.context.item.lastName).to.equal('Doe');
-  });
+      tooltip.remove();
+      await nextFrame();
 
-  it('should change tooltip context on header cell mouseenter', () => {
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
+      const cell = getCell(grid, 0);
+      mouseenter(cell);
 
-    mouseleave(cell);
-    mouseenter(getHeaderCell(grid, 0));
+      expect(spy.calledOnce).to.be.false;
+    });
 
-    expect(tooltip.context.item).to.be.not.ok;
-  });
+    it('should not set tooltip context if there is no tooltip', async () => {
+      const spy = sinon.spy(grid._tooltipController, 'setContext');
 
-  it('should hide tooltip on cell mousedown', () => {
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-    mousedown(cell);
-    expect(tooltip.opened).to.be.false;
-  });
+      tooltip.remove();
+      await nextFrame();
 
-  it('should show tooltip on cell keyboard focus', () => {
-    const cell = getCell(grid, 0);
-    tabKeyDown(document.body);
-    focusin(cell);
-    expect(tooltip.opened).to.be.true;
-  });
+      const cell = getCell(grid, 0);
+      mouseenter(cell);
 
-  it('should set tooltip target on cell keyboard focus', () => {
-    const cell = getCell(grid, 0);
-    tabKeyDown(document.body);
-    focusin(cell);
-    expect(tooltip.target).to.be.equal(cell);
-  });
+      expect(spy.calledOnce).to.be.false;
+    });
 
-  it('should set tooltip context on cell keyboard focus', () => {
-    const cell = getCell(grid, 0);
-    tabKeyDown(document.body);
-    focusin(cell);
-    expect(tooltip.context).to.be.instanceOf(Object);
-    expect(tooltip.context.item.firstName).to.equal('John');
-    expect(tooltip.context.item.lastName).to.equal('Doe');
-  });
+    it('should not set tooltip opened if there is no tooltip', async () => {
+      const spy = sinon.spy(grid._tooltipController, 'setOpened');
 
-  it('should hide tooltip on cell content keyboard focus', () => {
-    // Make the first column render inputs
-    grid.firstElementChild.renderer = (root) => {
-      root.innerHTML = '<input>';
-    };
+      tooltip.remove();
+      await nextFrame();
 
-    // Navigate to the first cell of second row
-    const cell = getCell(grid, 0);
-    tabKeyDown(document.body);
-    focusin(cell);
-    arrowDown(cell);
+      const cell = getCell(grid, 0);
+      mouseenter(cell);
 
-    expect(tooltip.opened).to.be.true;
-
-    // Enter interaction mode (the input gets focus)
-    const focusedCell = getContainerCell(grid.$.items, 1, 0);
-    enter(focusedCell);
-
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should hide tooltip on grid focusout', () => {
-    const cell = getCell(grid, 0);
-    tabKeyDown(document.body);
-    focusin(cell);
-    focusout(grid);
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should hide tooltip on grid cell content Esc', () => {
-    const cell = getCell(grid, 0);
-    tabKeyDown(document.body);
-    focusin(cell._content);
-    escKeyDown(cell._content);
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should set tooltip opened to false when the grid is removed', () => {
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-
-    grid.remove();
-
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should hide the tooltip when starting scrolling', async () => {
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-
-    fire(grid.$.table, 'scroll');
-    await nextFrame();
-
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should not hide the tooltip when scrolling using keyboard navigation', async () => {
-    const cell = getCell(grid, 0);
-    tabKeyDown(document.body);
-    focusin(cell);
-    expect(tooltip.opened).to.be.true;
-
-    await sendKeys({ press: 'ArrowDown' });
-    fire(grid.$.table, 'scroll');
-    await nextFrame();
-
-    expect(tooltip.opened).to.be.true;
-  });
-
-  it('should not show the tooltip on mouseenter while scrolling', async () => {
-    fire(grid.$.table, 'scroll');
-    await nextFrame();
-
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-
-    expect(tooltip.opened).to.be.false;
-  });
-
-  it('should not set tooltip target if there is no tooltip', async () => {
-    const spy = sinon.spy(grid._tooltipController, 'setTarget');
-
-    tooltip.remove();
-    await nextFrame();
-
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-
-    expect(spy.calledOnce).to.be.false;
-  });
-
-  it('should not set tooltip context if there is no tooltip', async () => {
-    const spy = sinon.spy(grid._tooltipController, 'setContext');
-
-    tooltip.remove();
-    await nextFrame();
-
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-
-    expect(spy.calledOnce).to.be.false;
-  });
-
-  it('should not set tooltip opened if there is no tooltip', async () => {
-    const spy = sinon.spy(grid._tooltipController, 'setOpened');
-
-    tooltip.remove();
-    await nextFrame();
-
-    const cell = getCell(grid, 0);
-    mouseenter(cell);
-
-    expect(spy.calledOnce).to.be.false;
+      expect(spy.calledOnce).to.be.false;
+    });
   });
 
   describe('delay', () => {
+    before(() => {
+      Tooltip.setDefaultFocusDelay(0);
+      Tooltip.setDefaultHoverDelay(0);
+      Tooltip.setDefaultHideDelay(0);
+    });
+
+    let cell;
+
+    beforeEach(() => {
+      cell = getCell(grid, 0);
+    });
+
     afterEach(async () => {
-      // Wait for cooldown timeout.
+      // Wait for cooldown
       await aTimeout(1);
     });
 
     it('should use hover delay on cell mouseenter', async () => {
       tooltip.hoverDelay = 1;
-      const cell = getCell(grid, 0);
+
       mouseenter(cell);
       expect(tooltip.opened).to.be.false;
+
       await aTimeout(1);
       expect(tooltip.opened).to.be.true;
     });
 
     it('should use hide delay on cell mouseleave', async () => {
       tooltip.hideDelay = 1;
-      const cell = getCell(grid, 0);
+
       mouseenter(cell);
+
       mouseleave(cell);
       expect(tooltip.opened).to.be.true;
+
       await aTimeout(1);
       expect(tooltip.opened).to.be.false;
     });
 
     it('should not use hide delay on cell mousedown', () => {
       tooltip.hideDelay = 1;
-      const cell = getCell(grid, 0);
+
       mouseenter(cell);
+
       mousedown(cell);
       expect(tooltip.opened).to.be.false;
     });
 
     it('should use focus delay on cell keyboard focus', async () => {
       tooltip.focusDelay = 1;
-      const cell = getCell(grid, 0);
+
       tabKeyDown(document.body);
       focusin(cell);
       expect(tooltip.opened).to.be.false;
+
       await aTimeout(1);
       expect(tooltip.opened).to.be.true;
     });
 
     it('should not use hide delay on grid cell content Esc', () => {
       tooltip.hideDelay = 1;
-      const cell = getCell(grid, 0);
+
       tabKeyDown(document.body);
       focusin(cell._content);
+
       escKeyDown(cell._content);
+      expect(tooltip.opened).to.be.false;
+    });
+  });
+
+  describe('scrolling', () => {
+    before(() => {
+      Tooltip.setDefaultFocusDelay(0);
+      Tooltip.setDefaultHoverDelay(0);
+      Tooltip.setDefaultHideDelay(0);
+    });
+
+    let cell;
+
+    beforeEach(() => {
+      cell = getCell(grid, 0);
+    });
+
+    afterEach(async () => {
+      // Wait for cooldown
+      await aTimeout(1);
+    });
+
+    it('should hide the tooltip when starting scrolling', () => {
+      mouseenter(cell);
+      expect(tooltip.opened).to.be.true;
+
+      fire(grid.$.table, 'scroll');
+
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should not hide the tooltip when scrolling using keyboard navigation', async () => {
+      tabKeyDown(document.body);
+      focusin(cell);
+      expect(tooltip.opened).to.be.true;
+
+      await sendKeys({ press: 'ArrowDown' });
+      fire(grid.$.table, 'scroll');
+      await nextFrame();
+
+      expect(tooltip.opened).to.be.true;
+    });
+
+    it('should not show the tooltip on mouseenter while scrolling', async () => {
+      fire(grid.$.table, 'scroll');
+      await nextFrame();
+
+      const cell = getCell(grid, 0);
+      mouseenter(cell);
+
       expect(tooltip.opened).to.be.false;
     });
   });

--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import {
   arrowDown,
   arrowRight,
-  aTimeout,
   escKeyDown,
   fire,
   fixtureSync,
@@ -14,7 +13,7 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/menu-bar';
-import '@vaadin/tooltip';
+import { Tooltip } from '@vaadin/tooltip';
 import { mouseleave } from '@vaadin/tooltip/test/helpers.js';
 
 export function mouseover(target) {
@@ -28,6 +27,12 @@ function getTooltipText() {
 
 describe('menu-bar with tooltip', () => {
   let menuBar, tooltip, buttons;
+
+  before(() => {
+    Tooltip.setDefaultFocusDelay(0);
+    Tooltip.setDefaultHoverDelay(0);
+    Tooltip.setDefaultHideDelay(0);
+  });
 
   beforeEach(async () => {
     menuBar = fixtureSync(`
@@ -262,48 +267,73 @@ describe('menu-bar with tooltip', () => {
   });
 
   describe('delay', () => {
-    afterEach(async () => {
-      // Wait for cooldown timeout.
-      await aTimeout(1);
+    const DEFAULT_DELAY = 500;
+
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({
+        shouldClearNativeTimers: true,
+      });
     });
 
-    it('should use hover delay on menu button mouseover', async () => {
-      tooltip.hoverDelay = 1;
+    afterEach(() => {
+      // Wait for cooldown
+      clock.tick(DEFAULT_DELAY);
+      clock.restore();
+    });
+
+    it('should use hover delay on menu button mouseover', () => {
+      tooltip.hoverDelay = 100;
+
       mouseover(buttons[0]);
       expect(tooltip.opened).to.be.false;
-      await aTimeout(1);
+
+      clock.tick(100);
       expect(tooltip.opened).to.be.true;
     });
 
-    it('should use hide delay on menu button mouseleave', async () => {
-      tooltip.hideDelay = 1;
+    it('should use hide delay on menu button mouseleave', () => {
+      tooltip.hideDelay = 100;
+
       mouseover(buttons[0]);
+      clock.tick(DEFAULT_DELAY);
+
       mouseleave(menuBar);
       expect(tooltip.opened).to.be.true;
-      await aTimeout(1);
+
+      clock.tick(100);
       expect(tooltip.opened).to.be.false;
     });
 
     it('should not use hide delay on menu button mousedown', () => {
-      tooltip.hideDelay = 1;
+      tooltip.hideDelay = 100;
+
       mouseover(buttons[0]);
+      clock.tick(DEFAULT_DELAY);
+
       mousedown(buttons[0]);
       expect(tooltip.opened).to.be.false;
     });
 
-    it('should use focus delay on menu button keyboard focus', async () => {
-      tooltip.focusDelay = 1;
+    it('should use focus delay on menu button keyboard focus', () => {
+      tooltip.focusDelay = 100;
+
       tabKeyDown(document.body);
       focusin(buttons[0]);
       expect(tooltip.opened).to.be.false;
-      await aTimeout(1);
+
+      clock.tick(100);
       expect(tooltip.opened).to.be.true;
     });
 
     it('should not use hide delay on menu button Esc', () => {
-      tooltip.hideDelay = 1;
+      tooltip.hideDelay = 100;
+
       tabKeyDown(document.body);
       focusin(buttons[0]);
+      clock.tick(DEFAULT_DELAY);
+
       escKeyDown(buttons[0]);
       expect(tooltip.opened).to.be.false;
     });

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -11,7 +11,7 @@ import { isKeyboardActive } from '@vaadin/component-base/src/focus-utils.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
-const DEFAULT_DELAY = 0;
+const DEFAULT_DELAY = 500;
 
 let defaultFocusDelay = DEFAULT_DELAY;
 let defaultHoverDelay = DEFAULT_DELAY;

--- a/packages/tooltip/test/tooltip-offset.test.js
+++ b/packages/tooltip/test/tooltip-offset.test.js
@@ -1,9 +1,15 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import '../src/vaadin-tooltip.js';
+import { Tooltip } from '../src/vaadin-tooltip.js';
 
 describe('offset', () => {
   let tooltip, target, overlay;
+
+  before(() => {
+    Tooltip.setDefaultFocusDelay(0);
+    Tooltip.setDefaultHoverDelay(0);
+    Tooltip.setDefaultHideDelay(0);
+  });
 
   beforeEach(() => {
     tooltip = fixtureSync('<vaadin-tooltip text="tooltip"></vaadin-tooltip>');

--- a/packages/tooltip/test/tooltip-position.test.js
+++ b/packages/tooltip/test/tooltip-position.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import '../src/vaadin-tooltip.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { Tooltip } from '../src/vaadin-tooltip.js';
 
 registerStyles(
   'vaadin-tooltip-overlay',
@@ -15,6 +15,12 @@ registerStyles(
 
 describe('position', () => {
   let tooltip, target, overlay;
+
+  before(() => {
+    Tooltip.setDefaultFocusDelay(0);
+    Tooltip.setDefaultHoverDelay(0);
+    Tooltip.setDefaultHideDelay(0);
+  });
 
   beforeEach(() => {
     tooltip = fixtureSync('<vaadin-tooltip text="tooltip"></vaadin-tooltip>');

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -12,10 +12,16 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
-import '../vaadin-tooltip.js';
+import { Tooltip } from '../vaadin-tooltip.js';
 import { mouseenter, mouseleave, waitForIntersectionObserver } from './helpers.js';
 
 describe('vaadin-tooltip', () => {
+  before(() => {
+    Tooltip.setDefaultFocusDelay(0);
+    Tooltip.setDefaultHoverDelay(0);
+    Tooltip.setDefaultHideDelay(0);
+  });
+
   let tooltip, overlay;
 
   beforeEach(() => {

--- a/packages/tooltip/test/visual/lumo/tooltip.test.js
+++ b/packages/tooltip/test/visual/lumo/tooltip.test.js
@@ -3,9 +3,16 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/vaadin-lumo-styles/test/autoload.js';
 import '../../not-animated-styles.js';
 import '../../../theme/lumo/vaadin-tooltip.js';
+import { Tooltip } from '../../../src/vaadin-tooltip.js';
 
 describe('tooltip', () => {
   let div, target, element;
+
+  before(() => {
+    Tooltip.setDefaultFocusDelay(0);
+    Tooltip.setDefaultHoverDelay(0);
+    Tooltip.setDefaultHideDelay(0);
+  });
 
   beforeEach(() => {
     element = fixtureSync('<vaadin-tooltip text="tooltip"></vaadin-tooltip>');

--- a/packages/tooltip/test/visual/material/tooltip.test.js
+++ b/packages/tooltip/test/visual/material/tooltip.test.js
@@ -3,9 +3,16 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../not-animated-styles.js';
 import '../../../theme/material/vaadin-tooltip.js';
 import { colorDark } from '@vaadin/vaadin-material-styles/color.js';
+import { Tooltip } from '../../../src/vaadin-tooltip.js';
 
 describe('tooltip', () => {
   let div, target, element;
+
+  before(() => {
+    Tooltip.setDefaultFocusDelay(0);
+    Tooltip.setDefaultHoverDelay(0);
+    Tooltip.setDefaultHideDelay(0);
+  });
 
   beforeEach(() => {
     element = fixtureSync('<vaadin-tooltip text="tooltip"></vaadin-tooltip>');


### PR DESCRIPTION
## Description

1. Changed default delay from `0` that was in the original implementation to `500` as [discussed](https://github.com/orgs/vaadin/discussions/3196#discussioncomment-3422422),
2. Updated tests for `vaadin-tooltip` and integration tests for the components supporting it.

## Type of change

- Behavior altering fix

## Note

See also internal [Slack discussion](https://vaadin.slack.com/archives/C3TGRP4HY/p1671700930626079?thread_ts=1671694071.536389&cid=C3TGRP4HY) where this was raised.