### PR TITLE
test: update avatar visual tests tooltip delay

### DIFF
--- a/packages/avatar/test/visual/lumo/avatar.test.js
+++ b/packages/avatar/test/visual/lumo/avatar.test.js
@@ -3,7 +3,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/tooltip/test/not-animated-styles.js';
 import '../../../theme/lumo/vaadin-avatar.js';
-import { Tooltip } from '../../../src/vaadin-tooltip.js';
+import { Tooltip } from '@vaadin/tooltip/src/vaadin-tooltip.js';
 
 describe('avatar', () => {
   let div, element;

--- a/packages/avatar/test/visual/lumo/avatar.test.js
+++ b/packages/avatar/test/visual/lumo/avatar.test.js
@@ -3,6 +3,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/tooltip/test/not-animated-styles.js';
 import '../../../theme/lumo/vaadin-avatar.js';
+import { Tooltip } from '../../../src/vaadin-tooltip.js';
 
 describe('avatar', () => {
   let div, element;
@@ -12,6 +13,12 @@ describe('avatar', () => {
     div.style.display = 'inline-block';
     div.style.padding = '10px';
     element = fixtureSync('<vaadin-avatar></vaadin-avatar>', div);
+  });
+
+  before(() => {
+    Tooltip.setDefaultFocusDelay(0);
+    Tooltip.setDefaultHoverDelay(0);
+    Tooltip.setDefaultHideDelay(0);
   });
 
   it('basic', async () => {

--- a/packages/avatar/test/visual/material/avatar.test.js
+++ b/packages/avatar/test/visual/material/avatar.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/material/vaadin-avatar.js';
+import { Tooltip } from '../../../src/vaadin-tooltip.js';
 
 describe('avatar', () => {
   let div, element;
@@ -10,6 +11,12 @@ describe('avatar', () => {
     div.style.display = 'inline-block';
     div.style.padding = '10px';
     element = fixtureSync('<vaadin-avatar></vaadin-avatar>', div);
+  });
+
+  before(() => {
+    Tooltip.setDefaultFocusDelay(0);
+    Tooltip.setDefaultHoverDelay(0);
+    Tooltip.setDefaultHideDelay(0);
   });
 
   it('basic', async () => {

--- a/packages/avatar/test/visual/material/avatar.test.js
+++ b/packages/avatar/test/visual/material/avatar.test.js
@@ -1,7 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../theme/material/vaadin-avatar.js';
-import { Tooltip } from '../../../src/vaadin-tooltip.js';
+import { Tooltip } from '@vaadin/tooltip/src/vaadin-tooltip.js';
 
 describe('avatar', () => {
   let div, element;


### PR DESCRIPTION
Follow-up for https://github.com/vaadin/web-components/pull/5156

There seems to be a failing test case in avatar currently