### PR TITLE
fix: remove extra bracket from number field CSS selector

### DIFF
--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -205,7 +205,7 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
           direction: rtl;
         }
 
-        ${tag}[dir='rtl']:not([step-buttons-visible]]) input[type="number"]::placeholder {
+        ${tag}[dir='rtl']:not([step-buttons-visible]) input[type="number"]::placeholder {
           text-align: left;
         }
       `,


### PR DESCRIPTION
## Description

Follow-up from #5440 - fixed a typo in the `[step-buttons-visible]` CSS selector.
Note, there is no need to backport this to `23.3` as in #5141 the selector is correct (I fixed it while backporting).

## Type of change

- Bugfix