### PR TITLE
feat: add summary property to details and accordion panel

### DIFF
--- a/dev/accordion.html
+++ b/dev/accordion.html
@@ -23,8 +23,7 @@
         <vaadin-accordion-heading slot="summary">Panel 2</vaadin-accordion-heading>
         <div>Panel 2 content</div>
       </vaadin-accordion-panel>
-      <vaadin-accordion-panel>
-        <vaadin-accordion-heading slot="summary">Panel 3</vaadin-accordion-heading>
+      <vaadin-accordion-panel summary="Panel 3">
         <div>Panel 3 content</div>
       </vaadin-accordion-panel>
     </vaadin-accordion>

--- a/dev/details.html
+++ b/dev/details.html
@@ -16,10 +16,16 @@
   </head>
 
   <body>
+    <vaadin-details summary="Expandable Details">
+      <div>Toggle using mouse, Enter and Space keys.</div>
+    </vaadin-details>
+
+    <!--
     <vaadin-details>
       <vaadin-details-summary slot="summary">Expandable Details</vaadin-details-summary>
       <div>Toggle using mouse, Enter and Space keys.</div>
       <vaadin-tooltip slot="tooltip" text="Click to toggle"></vaadin-tooltip>
     </vaadin-details>
+    -->
   </body>
 </html>

--- a/packages/accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/accordion/src/vaadin-accordion-panel.d.ts
@@ -44,6 +44,12 @@ export type AccordionPanelEventMap = AccordionPanelCustomEventMap & HTMLElementE
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
 declare class AccordionPanel extends DetailsMixin(DelegateFocusMixin(DelegateStateMixin(ThemableMixin(HTMLElement)))) {
+  /**
+   * The text to be used as a text for the default summary,
+   * if there is no element assigned to the "summary" slot.
+   */
+  summary: string | null | undefined;
+
   addEventListener<K extends keyof AccordionPanelEventMap>(
     type: K,
     listener: (this: AccordionPanel, ev: AccordionPanelEventMap[K]) => void,

--- a/packages/accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/accordion/src/vaadin-accordion-panel.d.ts
@@ -45,7 +45,7 @@ export type AccordionPanelEventMap = AccordionPanelCustomEventMap & HTMLElementE
  */
 declare class AccordionPanel extends DetailsMixin(DelegateFocusMixin(DelegateStateMixin(ThemableMixin(HTMLElement)))) {
   /**
-   * A text that is displayed in a heading, if no
+   * A text that is displayed in the heading, if no
    * element is assigned to the `summary` slot.
    */
   summary: string | null | undefined;

--- a/packages/accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/accordion/src/vaadin-accordion-panel.d.ts
@@ -45,8 +45,8 @@ export type AccordionPanelEventMap = AccordionPanelCustomEventMap & HTMLElementE
  */
 declare class AccordionPanel extends DetailsMixin(DelegateFocusMixin(DelegateStateMixin(ThemableMixin(HTMLElement)))) {
   /**
-   * The text to be used as a text for the default summary,
-   * if there is no element assigned to the "summary" slot.
+   * A text that is displayed as a summary
+   * if there is no element assigned to the `summary` slot.
    */
   summary: string | null | undefined;
 

--- a/packages/accordion/src/vaadin-accordion-panel.d.ts
+++ b/packages/accordion/src/vaadin-accordion-panel.d.ts
@@ -45,8 +45,8 @@ export type AccordionPanelEventMap = AccordionPanelCustomEventMap & HTMLElementE
  */
 declare class AccordionPanel extends DetailsMixin(DelegateFocusMixin(DelegateStateMixin(ThemableMixin(HTMLElement)))) {
   /**
-   * A text that is displayed as a summary
-   * if there is no element assigned to the `summary` slot.
+   * A text that is displayed in a heading, if no
+   * element is assigned to the `summary` slot.
    */
   summary: string | null | undefined;
 

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -9,15 +9,9 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
 import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
-import { SummarySlotController } from '@vaadin/details/src/summary-controller.js';
+import { SummaryController } from '@vaadin/details/src/summary-controller.js';
 import { DetailsMixin } from '@vaadin/details/src/vaadin-details-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-
-class SummaryController extends SummarySlotController {
-  constructor(host) {
-    super(host, 'vaadin-accordion-heading');
-  }
-}
 
 /**
  * The accordion panel element.
@@ -117,7 +111,7 @@ class AccordionPanel extends DetailsMixin(
   constructor() {
     super();
 
-    this._summaryController = new SummaryController(this);
+    this._summaryController = new SummaryController(this, 'vaadin-accordion-heading');
     this._summaryController.addEventListener('slot-content-changed', (event) => {
       const { node } = event.target;
 

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -97,8 +97,8 @@ class AccordionPanel extends DetailsMixin(
   static get properties() {
     return {
       /**
-       * The text to be used as a text for the default summary,
-       * if there is no element assigned to the "summary" slot.
+       * A text that is displayed in a heading, if no
+       * element is assigned to the `summary` slot.
        */
       summary: {
         type: String,

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -15,12 +15,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 
 class SummaryController extends SummarySlotController {
   constructor(host) {
-    super(host, 'vaadin-accordion-heading', {
-      initializer: (node, host) => {
-        host._setFocusElement(node);
-        host.stateTarget = node;
-      },
-    });
+    super(host, 'vaadin-accordion-heading');
   }
 }
 
@@ -123,7 +118,17 @@ class AccordionPanel extends DetailsMixin(
     super();
 
     this._summaryController = new SummaryController(this);
+    this._summaryController.addEventListener('slot-content-changed', (event) => {
+      const { node } = event.target;
+
+      this._setFocusElement(node);
+      this.stateTarget = node;
+
+      this._tooltipController.setTarget(node);
+    });
+
     this._tooltipController = new TooltipController(this);
+    this._tooltipController.setPosition('bottom-start');
   }
 
   /** @protected */
@@ -131,10 +136,7 @@ class AccordionPanel extends DetailsMixin(
     super.ready();
 
     this.addController(this._summaryController);
-
     this.addController(this._tooltipController);
-    this._tooltipController.setTarget(this.focusElement);
-    this._tooltipController.setPosition('bottom-start');
   }
 
   /**

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -97,7 +97,7 @@ class AccordionPanel extends DetailsMixin(
   static get properties() {
     return {
       /**
-       * A text that is displayed in a heading, if no
+       * A text that is displayed in the heading, if no
        * element is assigned to the `summary` slot.
        */
       summary: {

--- a/packages/accordion/test/accordion-panel.test.js
+++ b/packages/accordion/test/accordion-panel.test.js
@@ -1,0 +1,142 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import '../vaadin-accordion-panel.js';
+
+describe('vaadin-accordion-panel', () => {
+  let panel;
+
+  describe('opened', () => {
+    let contentPart, contentNode;
+
+    beforeEach(async () => {
+      panel = fixtureSync(`
+        <vaadin-accordion-panel>
+          <div>Content</div>
+        </vaadin-accordion-panel>
+      `);
+      await nextRender();
+      contentPart = panel.shadowRoot.querySelector('[part="content"]');
+      contentNode = panel.querySelector('div');
+    });
+
+    it('should set opened to false by default', () => {
+      expect(panel.opened).to.be.false;
+    });
+
+    it('should reflect opened property to attribute', () => {
+      panel.opened = true;
+      expect(panel.hasAttribute('opened')).to.be.true;
+    });
+
+    it('should hide the content when opened is false', () => {
+      expect(getComputedStyle(contentPart).display).to.equal('none');
+    });
+
+    it('should show the content when `opened` is true', () => {
+      panel.opened = true;
+      expect(getComputedStyle(contentPart).display).to.equal('block');
+    });
+
+    it('should set aria-hidden on the slotted element to true by default', () => {
+      expect(contentNode.getAttribute('aria-hidden')).to.equal('true');
+    });
+
+    it('should set aria-hidden on the slotted element to false when opened', () => {
+      panel.opened = true;
+      expect(contentNode.getAttribute('aria-hidden')).to.equal('false');
+    });
+  });
+
+  ['default', 'custom'].forEach((type) => {
+    const fixtures = {
+      default: `
+        <vaadin-accordion-panel summary="Summary">
+          <div>Content</div>
+        </vaadin-accordion-panel>
+      `,
+      custom: `
+        <vaadin-accordion-panel>
+          <vaadin-accordion-heading slot="summary">Summary</vaadin-accordion-heading>
+          <div>Content</div>
+        </vaadin-accordion-panel>
+      `,
+    };
+
+    let summary;
+
+    describe(`${type} summary`, () => {
+      let toggle;
+
+      beforeEach(async () => {
+        panel = fixtureSync(fixtures[type]);
+        await nextRender();
+        summary = panel.querySelector('[slot="summary"]');
+        toggle = summary.shadowRoot.querySelector('button');
+      });
+
+      it(`should update opened on ${type} summary toggle click`, () => {
+        toggle.click();
+        expect(panel.opened).to.be.true;
+
+        toggle.click();
+        expect(panel.opened).to.be.false;
+      });
+
+      it(`should update opened on ${type} summary toggle Enter`, async () => {
+        toggle.focus();
+
+        await sendKeys({ press: 'Enter' });
+        expect(panel.opened).to.be.true;
+
+        await sendKeys({ press: 'Enter' });
+        expect(panel.opened).to.be.false;
+      });
+
+      it(`should update opened on ${type} summary toggle Space`, async () => {
+        toggle.focus();
+
+        await sendKeys({ press: 'Space' });
+        expect(panel.opened).to.be.true;
+
+        await sendKeys({ press: 'Space' });
+        expect(panel.opened).to.be.false;
+      });
+
+      it(`should update opened on ${type} summary toggle Arrow Down`, async () => {
+        toggle.focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(panel.opened).to.be.false;
+      });
+
+      it(`should fire opened-changed event on ${type} summary toggle click`, () => {
+        const spy = sinon.spy();
+        panel.addEventListener('opened-changed', spy);
+        toggle.click();
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it(`should update aria-expanded on ${type} summary toggle click`, () => {
+        toggle.click();
+        expect(toggle.getAttribute('aria-expanded')).to.equal('true');
+
+        toggle.click();
+        expect(toggle.getAttribute('aria-expanded')).to.equal('false');
+      });
+
+      it(`should set aria-controls attribute on ${type} summary`, () => {
+        const idRegex = /^content-vaadin-accordion-panel-\d+$/u;
+        expect(idRegex.test(summary.getAttribute('aria-controls'))).to.be.true;
+      });
+
+      it(`should propagate disabled attribute to ${type} summary`, () => {
+        panel.disabled = true;
+        expect(summary.hasAttribute('disabled')).to.be.true;
+
+        panel.disabled = false;
+        expect(summary.hasAttribute('disabled')).to.be.false;
+      });
+    });
+  });
+});

--- a/packages/accordion/test/accordion-panel.test.js
+++ b/packages/accordion/test/accordion-panel.test.js
@@ -34,7 +34,7 @@ describe('vaadin-accordion-panel', () => {
       expect(getComputedStyle(contentPart).display).to.equal('none');
     });
 
-    it('should show the content when `opened` is true', () => {
+    it('should show the content when opened is true', () => {
       panel.opened = true;
       expect(getComputedStyle(contentPart).display).to.equal('block');
     });

--- a/packages/accordion/test/accordion-panel.test.js
+++ b/packages/accordion/test/accordion-panel.test.js
@@ -64,7 +64,7 @@ describe('vaadin-accordion-panel', () => {
       `,
     };
 
-    let summary;
+    let heading;
 
     describe(`${type} summary`, () => {
       let toggle;
@@ -72,11 +72,11 @@ describe('vaadin-accordion-panel', () => {
       beforeEach(async () => {
         panel = fixtureSync(fixtures[type]);
         await nextRender();
-        summary = panel.querySelector('[slot="summary"]');
-        toggle = summary.shadowRoot.querySelector('button');
+        heading = panel.querySelector('[slot="summary"]');
+        toggle = heading.shadowRoot.querySelector('button');
       });
 
-      it(`should update opened on ${type} summary toggle click`, () => {
+      it(`should toggle opened on ${type} heading button click`, () => {
         toggle.click();
         expect(panel.opened).to.be.true;
 
@@ -84,7 +84,7 @@ describe('vaadin-accordion-panel', () => {
         expect(panel.opened).to.be.false;
       });
 
-      it(`should update opened on ${type} summary toggle Enter`, async () => {
+      it(`should toggle opened on ${type} heading button Enter`, async () => {
         toggle.focus();
 
         await sendKeys({ press: 'Enter' });
@@ -94,7 +94,7 @@ describe('vaadin-accordion-panel', () => {
         expect(panel.opened).to.be.false;
       });
 
-      it(`should update opened on ${type} summary toggle Space`, async () => {
+      it(`should toggle opened on ${type} heading button Space`, async () => {
         toggle.focus();
 
         await sendKeys({ press: 'Space' });
@@ -104,20 +104,20 @@ describe('vaadin-accordion-panel', () => {
         expect(panel.opened).to.be.false;
       });
 
-      it(`should update opened on ${type} summary toggle Arrow Down`, async () => {
+      it(`should not update opened on ${type} heading button Arrow Down`, async () => {
         toggle.focus();
         await sendKeys({ press: 'ArrowDown' });
         expect(panel.opened).to.be.false;
       });
 
-      it(`should fire opened-changed event on ${type} summary toggle click`, () => {
+      it(`should fire opened-changed event on ${type} heading button click`, () => {
         const spy = sinon.spy();
         panel.addEventListener('opened-changed', spy);
         toggle.click();
         expect(spy.calledOnce).to.be.true;
       });
 
-      it(`should update aria-expanded on ${type} summary toggle click`, () => {
+      it(`should update aria-expanded on ${type} heading button click`, () => {
         toggle.click();
         expect(toggle.getAttribute('aria-expanded')).to.equal('true');
 
@@ -125,17 +125,12 @@ describe('vaadin-accordion-panel', () => {
         expect(toggle.getAttribute('aria-expanded')).to.equal('false');
       });
 
-      it(`should set aria-controls attribute on ${type} summary`, () => {
-        const idRegex = /^content-vaadin-accordion-panel-\d+$/u;
-        expect(idRegex.test(summary.getAttribute('aria-controls'))).to.be.true;
-      });
-
-      it(`should propagate disabled attribute to ${type} summary`, () => {
+      it(`should propagate disabled attribute to ${type} heading`, () => {
         panel.disabled = true;
-        expect(summary.hasAttribute('disabled')).to.be.true;
+        expect(heading.hasAttribute('disabled')).to.be.true;
 
         panel.disabled = false;
-        expect(summary.hasAttribute('disabled')).to.be.false;
+        expect(heading.hasAttribute('disabled')).to.be.false;
       });
     });
   });

--- a/packages/details/src/summary-controller.d.ts
+++ b/packages/details/src/summary-controller.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
+
+/**
+ * A controller to manage the summary element.
+ */
+export class SummarySlotController extends SlotChildObserveController {
+  /**
+   * String used for the summary.
+   */
+  protected summary: string | null | undefined;
+
+  /**
+   * Set summary based on corresponding host property.
+   */
+  setSummary(label: string | null | undefined): void;
+}

--- a/packages/details/src/summary-controller.d.ts
+++ b/packages/details/src/summary-controller.d.ts
@@ -8,7 +8,7 @@ import { SlotChildObserveController } from '@vaadin/component-base/src/slot-chil
 /**
  * A controller to manage the summary element.
  */
-export class SummarySlotController extends SlotChildObserveController {
+export class SummarController extends SlotChildObserveController {
   /**
    * String used for the summary.
    */

--- a/packages/details/src/summary-controller.js
+++ b/packages/details/src/summary-controller.js
@@ -8,7 +8,7 @@ import { SlotChildObserveController } from '@vaadin/component-base/src/slot-chil
 /**
  * A controller to manage the summary element.
  */
-export class SummarySlotController extends SlotChildObserveController {
+export class SummaryController extends SlotChildObserveController {
   constructor(host, tagName) {
     super(host, 'summary', tagName);
   }

--- a/packages/details/src/summary-controller.js
+++ b/packages/details/src/summary-controller.js
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
+
+/**
+ * A controller to manage the summary element.
+ */
+export class SummarySlotController extends SlotChildObserveController {
+  constructor(host, tagName, config) {
+    super(host, 'summary', tagName, config);
+  }
+
+  /**
+   * Set summary based on corresponding host property.
+   *
+   * @param {string} summary
+   */
+  setSummary(summary) {
+    this.summary = summary;
+
+    // Restore the default summary, if needed.
+    const summaryNode = this.getSlotChild();
+    if (!summaryNode) {
+      this.restoreDefaultNode();
+    }
+
+    // When default summary is used, update it.
+    if (this.node === this.defaultNode) {
+      this.updateDefaultNode(this.node);
+    }
+  }
+
+  /**
+   * Override method inherited from `SlotChildObserveController`
+   * to restore and observe the default summary element.
+   *
+   * @protected
+   * @override
+   */
+  restoreDefaultNode() {
+    const { summary } = this;
+
+    // Restore the default summary.
+    if (summary && summary.trim() !== '') {
+      const node = this.attachDefaultNode();
+      this.initNode(node);
+    }
+  }
+
+  /**
+   * Override method inherited from `SlotChildObserveController`
+   * to update the default summary element text content.
+   *
+   * @param {Node | undefined} node
+   * @protected
+   * @override
+   */
+  updateDefaultNode(node) {
+    if (node) {
+      node.textContent = this.summary;
+    }
+
+    // Notify the host after update.
+    super.updateDefaultNode(node);
+  }
+}

--- a/packages/details/src/summary-controller.js
+++ b/packages/details/src/summary-controller.js
@@ -9,8 +9,8 @@ import { SlotChildObserveController } from '@vaadin/component-base/src/slot-chil
  * A controller to manage the summary element.
  */
 export class SummarySlotController extends SlotChildObserveController {
-  constructor(host, tagName, config) {
-    super(host, 'summary', tagName, config);
+  constructor(host, tagName) {
+    super(host, 'summary', tagName);
   }
 
   /**
@@ -45,8 +45,7 @@ export class SummarySlotController extends SlotChildObserveController {
 
     // Restore the default summary.
     if (summary && summary.trim() !== '') {
-      const node = this.attachDefaultNode();
-      this.initNode(node);
+      this.attachDefaultNode();
     }
   }
 

--- a/packages/details/src/vaadin-details-mixin.js
+++ b/packages/details/src/vaadin-details-mixin.js
@@ -44,11 +44,20 @@ export const DetailsMixin = (superClass) =>
       super();
 
       this._contentController = new ContentController(this);
+
+      this._contentController.addEventListener('slot-content-changed', (event) => {
+        const content = event.target.nodes || [];
+
+        // Exclude nodes that are no longer connected
+        this._contentElements = content.filter((node) => node.parentNode === this);
+      });
     }
 
     /** @protected */
     ready() {
       super.ready();
+
+      this.addController(this._contentController);
 
       // Only handle click and not keydown, because `vaadin-details-summary` uses `ButtonMixin`
       // that already covers this logic, and `vaadin-accordion-heading` uses native `<button>`.

--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -62,8 +62,8 @@ declare class Details extends DetailsMixin(
   DelegateStateMixin(DelegateFocusMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement))))),
 ) {
   /**
-   * The text to be used as a text for the default summary,
-   * if there is no element assigned to the "summary" slot.
+   * A text that is displayed in a summary, if no
+   * element is assigned to the `summary` slot.
    */
   summary: string | null | undefined;
 

--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -61,6 +61,12 @@ export type DetailsEventMap = DetailsCustomEventMap & HTMLElementEventMap;
 declare class Details extends DetailsMixin(
   DelegateStateMixin(DelegateFocusMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement))))),
 ) {
+  /**
+   * The text to be used as a text for the default summary,
+   * if there is no element assigned to the "summary" slot.
+   */
+  summary: string | null | undefined;
+
   addEventListener<K extends keyof DetailsEventMap>(
     type: K,
     listener: (this: Details, ev: DetailsEventMap[K]) => void,

--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -62,7 +62,7 @@ declare class Details extends DetailsMixin(
   DelegateStateMixin(DelegateFocusMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement))))),
 ) {
   /**
-   * A text that is displayed in a summary, if no
+   * A text that is displayed in the summary, if no
    * element is assigned to the `summary` slot.
    */
   summary: string | null | undefined;

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -110,7 +110,7 @@ class Details extends DetailsMixin(
   static get properties() {
     return {
       /**
-       * A text that is displayed in a summary, if no
+       * A text that is displayed in the summary, if no
        * element is assigned to the `summary` slot.
        */
       summary: {

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -16,12 +16,7 @@ import { DetailsMixin } from './vaadin-details-mixin.js';
 
 class SummaryController extends SummarySlotController {
   constructor(host) {
-    super(host, 'vaadin-details-summary', {
-      initializer: (node, host) => {
-        host._setFocusElement(node);
-        host.stateTarget = node;
-      },
-    });
+    super(host, 'vaadin-details-summary');
   }
 }
 
@@ -136,7 +131,17 @@ class Details extends DetailsMixin(
     super();
 
     this._summaryController = new SummaryController(this);
+    this._summaryController.addEventListener('slot-content-changed', (event) => {
+      const { node } = event.target;
+
+      this._setFocusElement(node);
+      this.stateTarget = node;
+
+      this._tooltipController.setTarget(node);
+    });
+
     this._tooltipController = new TooltipController(this);
+    this._tooltipController.setPosition('bottom-start');
   }
 
   /** @protected */
@@ -144,10 +149,7 @@ class Details extends DetailsMixin(
     super.ready();
 
     this.addController(this._summaryController);
-
     this.addController(this._tooltipController);
-    this._tooltipController.setTarget(this.focusElement);
-    this._tooltipController.setPosition('bottom-start');
   }
 
   /**

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -11,14 +11,8 @@ import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mi
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { SummarySlotController } from './summary-controller.js';
+import { SummaryController } from './summary-controller.js';
 import { DetailsMixin } from './vaadin-details-mixin.js';
-
-class SummaryController extends SummarySlotController {
-  constructor(host) {
-    super(host, 'vaadin-details-summary');
-  }
-}
 
 /**
  * `<vaadin-details>` is a Web Component which the creates an
@@ -130,7 +124,7 @@ class Details extends DetailsMixin(
   constructor() {
     super();
 
-    this._summaryController = new SummaryController(this);
+    this._summaryController = new SummaryController(this, 'vaadin-details-summary');
     this._summaryController.addEventListener('slot-content-changed', (event) => {
       const { node } = event.target;
 

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -110,8 +110,8 @@ class Details extends DetailsMixin(
   static get properties() {
     return {
       /**
-       * The text to be used as a text for the default summary,
-       * if there is no element assigned to the "summary" slot.
+       * A text that is displayed in a summary, if no
+       * element is assigned to the `summary` slot.
        */
       summary: {
         type: String,

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -88,7 +88,7 @@ describe('vaadin-details', () => {
         summary = details.querySelector('[slot="summary"]');
       });
 
-      it(`should update opened on ${type} summary click`, () => {
+      it(`should toggle opened on ${type} summary click`, () => {
         summary.click();
         expect(details.opened).to.be.true;
 
@@ -96,7 +96,7 @@ describe('vaadin-details', () => {
         expect(details.opened).to.be.false;
       });
 
-      it(`should update opened on ${type} summary Enter`, async () => {
+      it(`should toggle opened on ${type} summary Enter`, async () => {
         summary.focus();
 
         await sendKeys({ press: 'Enter' });
@@ -106,7 +106,7 @@ describe('vaadin-details', () => {
         expect(details.opened).to.be.false;
       });
 
-      it(`should update opened on ${type} summary Space`, async () => {
+      it(`should toggle opened on ${type} summary Space`, async () => {
         summary.focus();
 
         await sendKeys({ press: 'Space' });

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -116,7 +116,7 @@ describe('vaadin-details', () => {
         expect(details.opened).to.be.false;
       });
 
-      it(`should update opened on ${type} summary Arrow Down`, async () => {
+      it(`should not update opened on ${type} summary Arrow Down`, async () => {
         summary.focus();
         await sendKeys({ press: 'ArrowDown' });
         expect(details.opened).to.be.false;
@@ -129,7 +129,7 @@ describe('vaadin-details', () => {
         expect(spy.calledOnce).to.be.true;
       });
 
-      it(`should update aria-expanded on ${type} summary click`, () => {
+      it(`should toggle aria-expanded on ${type} summary click`, () => {
         summary.click();
         expect(summary.getAttribute('aria-expanded')).to.equal('true');
 

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -137,11 +137,6 @@ describe('vaadin-details', () => {
         expect(summary.getAttribute('aria-expanded')).to.equal('false');
       });
 
-      it(`should set aria-controls attribute on ${type} summary`, () => {
-        const idRegex = /^content-vaadin-details-\d+$/u;
-        expect(idRegex.test(summary.getAttribute('aria-controls'))).to.be.true;
-      });
-
       it(`should propagate disabled attribute to ${type} summary`, () => {
         details.disabled = true;
         expect(summary.hasAttribute('disabled')).to.be.true;

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -1,28 +1,17 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-details.js';
 
 describe('vaadin-details', () => {
-  let details, toggle, content;
-
-  beforeEach(() => {
-    details = fixtureSync(`
-      <vaadin-details>
-        <vaadin-details-summary slot="summary">Summary</vaadin-details-summary>
-        <div>
-          <input type="text" />
-        </div>
-      </vaadin-details>
-    `);
-    toggle = details.focusElement;
-    content = details.shadowRoot.querySelector('[part="content"]');
-  });
+  let details;
 
   describe('custom element definition', () => {
     let tagName;
 
     beforeEach(() => {
+      details = fixtureSync('<vaadin-details></vaadin-details>');
       tagName = details.tagName.toLowerCase();
     });
 
@@ -35,20 +24,19 @@ describe('vaadin-details', () => {
     });
   });
 
-  describe('summary', () => {
-    it('should have unnamed slot inside the summary element', () => {
-      const slot = toggle.shadowRoot.querySelector('slot');
-      expect(slot).to.be.ok;
-      expect(slot.assignedNodes()[0].textContent).to.equal('Summary');
-    });
-
-    it('should have disabled attribute when disabled is true', () => {
-      details.disabled = true;
-      expect(toggle.hasAttribute('disabled')).to.equal(true);
-    });
-  });
-
   describe('opened', () => {
+    let contentPart, contentNode;
+
+    beforeEach(() => {
+      details = fixtureSync(`
+        <vaadin-details>
+          <div>Content</div>
+        </vaadin-details>
+      `);
+      contentPart = details.shadowRoot.querySelector('[part="content"]');
+      contentNode = details.querySelector('div');
+    });
+
     it('should set opened to false by default', () => {
       expect(details.opened).to.be.false;
     });
@@ -58,78 +46,109 @@ describe('vaadin-details', () => {
       expect(details.hasAttribute('opened')).to.be.true;
     });
 
-    it('should update opened on toggle button click', () => {
-      toggle.click();
-      expect(details.opened).to.be.true;
-
-      toggle.click();
-      expect(details.opened).to.be.false;
-    });
-
-    it('should update opened on toggle button enter', () => {
-      keyDownOn(toggle, 13, [], 'Enter');
-      expect(details.opened).to.be.true;
-
-      keyDownOn(toggle, 13, [], 'Enter');
-      expect(details.opened).to.be.false;
-    });
-
-    it('should update opened on toggle button space', () => {
-      keyDownOn(toggle, 32, [], ' ');
-      expect(details.opened).to.be.true;
-
-      keyDownOn(toggle, 32, [], ' ');
-      expect(details.opened).to.be.false;
-    });
-
-    it('should not update opened on arrow down key', () => {
-      keyDownOn(toggle, 40, [], 'ArrowDown');
-      expect(details.opened).to.be.false;
-    });
-
     it('should hide the content when opened is false', () => {
-      expect(getComputedStyle(content).display).to.equal('none');
+      expect(getComputedStyle(contentPart).display).to.equal('none');
     });
 
     it('should show the content when `opened` is true', () => {
       details.opened = true;
-      expect(getComputedStyle(content).display).to.equal('block');
-    });
-
-    it('should dispatch opened-changed event when opened changes', () => {
-      const spy = sinon.spy();
-      details.addEventListener('opened-changed', spy);
-      toggle.click();
-      expect(spy.calledOnce).to.be.true;
-    });
-  });
-
-  describe('ARIA roles', () => {
-    it('should set role="button" on the toggle button', () => {
-      expect(toggle.getAttribute('role')).to.equal('button');
-    });
-
-    it('should set aria-expanded on toggle button to false by default', () => {
-      expect(toggle.getAttribute('aria-expanded')).to.equal('false');
-    });
-
-    it('should set aria-expanded on toggle button to true when opened', () => {
-      details.opened = true;
-      expect(toggle.getAttribute('aria-expanded')).to.equal('true');
+      expect(getComputedStyle(contentPart).display).to.equal('block');
     });
 
     it('should set aria-hidden on the slotted element to true by default', () => {
-      expect(details.querySelector('div').getAttribute('aria-hidden')).to.equal('true');
+      expect(contentNode.getAttribute('aria-hidden')).to.equal('true');
     });
 
     it('should set aria-hidden on the slotted element to false when opened', () => {
       details.opened = true;
-      expect(details.querySelector('div').getAttribute('aria-hidden')).to.equal('false');
+      expect(contentNode.getAttribute('aria-hidden')).to.equal('false');
     });
+  });
 
-    it('should set aria-controls on toggle button', () => {
-      const idRegex = /^content-vaadin-details-\d+$/u;
-      expect(idRegex.test(toggle.getAttribute('aria-controls'))).to.be.true;
+  ['default', 'custom'].forEach((type) => {
+    const fixtures = {
+      default: `
+        <vaadin-details summary="Summary">
+          <div>Content</div>
+        </vaadin-details>
+      `,
+      custom: `
+        <vaadin-details>
+          <vaadin-details-summary slot="summary">Summary</vaadin-details-summary>
+          <div>Content</div>
+        </vaadin-details>
+      `,
+    };
+
+    let summary;
+
+    describe(`${type} summary`, () => {
+      beforeEach(() => {
+        details = fixtureSync(fixtures[type]);
+        summary = details.querySelector('[slot="summary"]');
+      });
+
+      it(`should update opened on ${type} summary click`, () => {
+        summary.click();
+        expect(details.opened).to.be.true;
+
+        summary.click();
+        expect(details.opened).to.be.false;
+      });
+
+      it(`should update opened on ${type} summary Enter`, async () => {
+        summary.focus();
+
+        await sendKeys({ press: 'Enter' });
+        expect(details.opened).to.be.true;
+
+        await sendKeys({ press: 'Enter' });
+        expect(details.opened).to.be.false;
+      });
+
+      it(`should update opened on ${type} summary Space`, async () => {
+        summary.focus();
+
+        await sendKeys({ press: 'Space' });
+        expect(details.opened).to.be.true;
+
+        await sendKeys({ press: 'Space' });
+        expect(details.opened).to.be.false;
+      });
+
+      it(`should update opened on ${type} summary Arrow Down`, async () => {
+        summary.focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(details.opened).to.be.false;
+      });
+
+      it(`should fire opened-changed event on ${type} summary click`, () => {
+        const spy = sinon.spy();
+        details.addEventListener('opened-changed', spy);
+        summary.click();
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it(`should update aria-expanded on ${type} summary click`, () => {
+        summary.click();
+        expect(summary.getAttribute('aria-expanded')).to.equal('true');
+
+        summary.click();
+        expect(summary.getAttribute('aria-expanded')).to.equal('false');
+      });
+
+      it(`should set aria-controls attribute on ${type} summary`, () => {
+        const idRegex = /^content-vaadin-details-\d+$/u;
+        expect(idRegex.test(summary.getAttribute('aria-controls'))).to.be.true;
+      });
+
+      it(`should propagate disabled attribute to ${type} summary`, () => {
+        details.disabled = true;
+        expect(summary.hasAttribute('disabled')).to.be.true;
+
+        details.disabled = false;
+        expect(summary.hasAttribute('disabled')).to.be.false;
+      });
     });
   });
 
@@ -140,12 +159,10 @@ describe('vaadin-details', () => {
     beforeEach(() => {
       container = fixtureSync(`
         <div>
-          <vaadin-details>
-            <vaadin-details-summary slot="summary">Summary 1</vaadin-details-summary>
+          <vaadin-details summary="Summary 1">
             <div>Content 1</div>
           </vaadin-details>
-          <vaadin-details>
-          <vaadin-details-summary slot="summary">Summary 2</vaadin-details-summary>
+          <vaadin-details summary="Summary 2">
             <div>Content 2</div>
           </vaadin-details>
         </div>

--- a/packages/details/test/dom/__snapshots__/details.test.snap.js
+++ b/packages/details/test/dom/__snapshots__/details.test.snap.js
@@ -6,6 +6,7 @@ snapshots["vaadin-details host default"] =
   <vaadin-details-summary
     aria-controls="content-vaadin-details-0"
     aria-expanded="false"
+    id="summary-vaadin-details-1"
     role="button"
     slot="summary"
     tabindex="0"
@@ -27,6 +28,7 @@ snapshots["vaadin-details host opened"] =
   <vaadin-details-summary
     aria-controls="content-vaadin-details-0"
     aria-expanded="true"
+    id="summary-vaadin-details-1"
     opened=""
     role="button"
     slot="summary"
@@ -51,6 +53,7 @@ snapshots["vaadin-details host disabled"] =
     aria-disabled="true"
     aria-expanded="false"
     disabled=""
+    id="summary-vaadin-details-1"
     role="button"
     slot="summary"
     tabindex="-1"
@@ -72,6 +75,7 @@ snapshots["vaadin-details host theme"] =
   <vaadin-details-summary
     aria-controls="content-vaadin-details-0"
     aria-expanded="false"
+    id="summary-vaadin-details-1"
     role="button"
     slot="summary"
     tabindex="0"


### PR DESCRIPTION
## Description

Fixes #5077

1. Added `summary` property to `vaadin-details` and `vaadin-acordion-panel` components as an alternative to slot,
2. Updated the `DetailsMixin` to add `ContentController` for setting `_contentElements` to reduce code duplication,
3. Simplified the logic for setting content ARIA attributes to use observers (each components uses its own observer),
4. Added missing tests for `vaadin-accordion-panel`, updated some tests to use both `summary` property and slot.

## Type of change

- Feature