### PR TITLE
refactor: avoid an unnecessary content update on grid init

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -539,9 +539,15 @@ class Grid extends ElementMixin(
       const cell = this.shadowRoot.activeElement;
       const cellCoordinates = this.__getBodyCellCoordinates(cell);
 
+      const previousSize = virtualizer.size || 0;
       virtualizer.size = effectiveSize;
-      virtualizer.update();
-      virtualizer.flush();
+
+      // Request an update for the previous last row to have the "last" state removed
+      virtualizer.update(previousSize - 1, previousSize - 1);
+      if (effectiveSize < previousSize) {
+        // Size was decreased, so the new last row requires an explicit update
+        virtualizer.update(effectiveSize - 1, effectiveSize - 1);
+      }
 
       // If the focused cell's parent row got hidden by the size change, focus the corresponding new cell
       if (cellCoordinates && cell.parentElement.hidden) {


### PR DESCRIPTION
## Description

There's currently a [call to `virtualizer.update()` in Grid](https://github.com/vaadin/web-components/blob/5bdf21ca061e9b2dd0ff30451ec68e638c359c47/packages/grid/src/vaadin-grid.js#L543) which takes place whenever the effective size changes. This call causes duplicate row updates/renderer invocations when the grid is rendered the first time and it gets an initial effective size assigned:

<img width="462" alt="Screenshot 2022-12-26 at 18 08 05" src="https://user-images.githubusercontent.com/1222264/209566726-44b3cfce-8636-40ee-be69-132d3ce2cc16.png">

This PR changes the logic only to request a content update on effective size change for rows that actually require it:

<img width="455" alt="Screenshot 2022-12-26 at 18 08 18" src="https://user-images.githubusercontent.com/1222264/209567224-6e7ac4af-887d-46fa-8a66-b3e0c4e5dee9.png">

## Type of change

Performance enhancement