### PR TITLE
test: cleanup and simplify overlay focus trap tests

### DIFF
--- a/integration/tests/overlay-focus-trap.test.js
+++ b/integration/tests/overlay-focus-trap.test.js
@@ -42,11 +42,11 @@ describe('focus-trap', () => {
     it('should properly detect focusable elements inside the content', () => {
       expect(focusableElements.length).to.equal(6);
       expect(focusableElements[0]).to.equal(overlay.$.overlay);
-      expect(focusableElements[1]).to.eql(overlay.querySelector('vaadin-text-field').focusElement);
-      expect(focusableElements[2]).to.eql(overlay.querySelector('#radioButton1').focusElement);
-      expect(focusableElements[3]).to.eql(overlay.querySelector('#radioButton2').focusElement);
-      expect(focusableElements[4]).to.eql(overlay.querySelector('#radioButton3').focusElement);
-      expect(focusableElements[5]).to.eql(overlay.querySelector('vaadin-button'));
+      expect(focusableElements[1]).to.equal(overlay.querySelector('vaadin-text-field').focusElement);
+      expect(focusableElements[2]).to.equal(overlay.querySelector('#radioButton1').focusElement);
+      expect(focusableElements[3]).to.equal(overlay.querySelector('#radioButton2').focusElement);
+      expect(focusableElements[4]).to.equal(overlay.querySelector('#radioButton3').focusElement);
+      expect(focusableElements[5]).to.equal(overlay.querySelector('vaadin-button'));
     });
 
     it('should focus focusable elements inside the content when focusTrap = true', async () => {
@@ -59,16 +59,16 @@ describe('focus-trap', () => {
         expect(focusedIndex).to.equal(i);
         tabKeyDown(focusableElements[focusedIndex]);
       }
-      expect(getFocusedElementIndex()).to.eql(0);
+      expect(getFocusedElementIndex()).to.equal(0);
 
       // Shift + Tab
       tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
       for (let i = focusableElements.length - 1; i >= 0; i--) {
         const focusedIndex = getFocusedElementIndex();
-        expect(focusedIndex).to.eql(i);
+        expect(focusedIndex).to.equal(i);
         tabKeyDown(focusableElements[focusedIndex], ['shift']);
       }
-      expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);
+      expect(getFocusedElementIndex()).to.equal(focusableElements.length - 1);
     });
   });
 
@@ -92,10 +92,10 @@ describe('focus-trap', () => {
     });
 
     it('should properly detect multiple focusable elements inside shadow DOM', () => {
-      expect(focusableElements.length).to.eql(4);
+      expect(focusableElements.length).to.equal(4);
       const div = overlay.querySelector('div');
       expect(focusableElements[1]).to.equal(div.shadowRoot.querySelector('input'));
-      expect(focusableElements[2]).to.eql(div.shadowRoot.querySelector('button'));
+      expect(focusableElements[2]).to.equal(div.shadowRoot.querySelector('button'));
     });
 
     it('should not focus the overlay part if the content is already focused', async () => {
@@ -103,7 +103,7 @@ describe('focus-trap', () => {
       // Needs to happen after opened and before focus-trap loop is executed
       focusableElements[1].focus();
       await oneEvent(overlay, 'vaadin-overlay-open');
-      expect(getFocusedElementIndex()).not.to.eql(0);
+      expect(getFocusedElementIndex()).not.to.equal(0);
     });
 
     it('should focus first element with tabIndex=1', async () => {
@@ -112,7 +112,7 @@ describe('focus-trap', () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
       const idx = getFocusedElementIndex();
-      expect(focusableElements[idx].tabIndex).to.eql(1);
+      expect(focusableElements[idx].tabIndex).to.equal(1);
     });
 
     it('should focus focusable elements in shadow DOM on Tab and Shift Tab', async () => {
@@ -125,16 +125,16 @@ describe('focus-trap', () => {
         expect(focusedIndex).to.equal(i);
         tabKeyDown(focusableElements[focusedIndex]);
       }
-      expect(getFocusedElementIndex()).to.eql(0);
+      expect(getFocusedElementIndex()).to.equal(0);
 
       // Shift + Tab
       tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
       for (let i = focusableElements.length - 1; i >= 0; i--) {
         const focusedIndex = getFocusedElementIndex();
-        expect(focusedIndex).to.eql(i);
+        expect(focusedIndex).to.equal(i);
         tabKeyDown(focusableElements[focusedIndex], ['shift']);
       }
-      expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);
+      expect(getFocusedElementIndex()).to.equal(focusableElements.length - 1);
     });
   });
 });

--- a/integration/tests/overlay-focus-trap.test.js
+++ b/integration/tests/overlay-focus-trap.test.js
@@ -41,7 +41,7 @@ describe('focus-trap', () => {
 
     it('should properly detect focusable elements inside the content', () => {
       expect(focusableElements.length).to.equal(6);
-      expect(focusableElements[0]).to.eql(overlay.$.overlay);
+      expect(focusableElements[0]).to.equal(overlay.$.overlay);
       expect(focusableElements[1]).to.eql(overlay.querySelector('vaadin-text-field').focusElement);
       expect(focusableElements[2]).to.eql(overlay.querySelector('#radioButton1').focusElement);
       expect(focusableElements[3]).to.eql(overlay.querySelector('#radioButton2').focusElement);
@@ -94,7 +94,7 @@ describe('focus-trap', () => {
     it('should properly detect multiple focusable elements inside shadow DOM', () => {
       expect(focusableElements.length).to.eql(4);
       const div = overlay.querySelector('div');
-      expect(focusableElements[1]).to.eql(div.shadowRoot.querySelector('input'));
+      expect(focusableElements[1]).to.equal(div.shadowRoot.querySelector('input'));
       expect(focusableElements[2]).to.eql(div.shadowRoot.querySelector('button'));
     });
 

--- a/integration/tests/overlay-focus-trap.test.js
+++ b/integration/tests/overlay-focus-trap.test.js
@@ -1,0 +1,140 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
+import '@vaadin/button/vaadin-button.js';
+import '@vaadin/overlay/vaadin-overlay.js';
+import '@vaadin/radio-group/vaadin-radio-group.js';
+import '@vaadin/text-field/vaadin-text-field.js';
+import { getFocusableElements, isElementFocused } from '@vaadin/component-base/src/focus-utils.js';
+
+describe('focus-trap', () => {
+  let overlay, focusableElements;
+
+  function getFocusedElementIndex() {
+    return focusableElements.findIndex(isElementFocused);
+  }
+
+  describe('elements in light DOM', () => {
+    beforeEach(async () => {
+      overlay = fixtureSync('<vaadin-overlay focus-trap></vaadin-overlay>');
+      await nextRender();
+      overlay.renderer = (root) => {
+        if (!root.firstChild) {
+          root.innerHTML = `
+            <vaadin-text-field></vaadin-text-field>
+            <vaadin-radio-group>
+              <vaadin-radio-button id="radioButton1" label="Button 1"></vaadin-radio-button>
+              <vaadin-radio-button id="radioButton2" label="Button 2"></vaadin-radio-button>
+              <vaadin-radio-button id="radioButton3" label="Button 3"></vaadin-radio-button>
+            </vaadin-radio-group>
+            <vaadin-button>tabindex 0</vaadin-button>
+          `;
+        }
+      };
+      overlay.requestContentUpdate();
+      focusableElements = getFocusableElements(overlay.$.overlay);
+    });
+
+    afterEach(() => {
+      overlay.opened = false;
+    });
+
+    it('should properly detect focusable elements inside the content', () => {
+      expect(focusableElements.length).to.equal(6);
+      expect(focusableElements[0]).to.eql(overlay.$.overlay);
+      expect(focusableElements[1]).to.eql(overlay.querySelector('vaadin-text-field').focusElement);
+      expect(focusableElements[2]).to.eql(overlay.querySelector('#radioButton1').focusElement);
+      expect(focusableElements[3]).to.eql(overlay.querySelector('#radioButton2').focusElement);
+      expect(focusableElements[4]).to.eql(overlay.querySelector('#radioButton3').focusElement);
+      expect(focusableElements[5]).to.eql(overlay.querySelector('vaadin-button'));
+    });
+
+    it('should focus focusable elements inside the content when focusTrap = true', async () => {
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      // Tab
+      for (let i = 0; i < focusableElements.length; i++) {
+        const focusedIndex = getFocusedElementIndex();
+        expect(focusedIndex).to.equal(i);
+        tabKeyDown(focusableElements[focusedIndex]);
+      }
+      expect(getFocusedElementIndex()).to.eql(0);
+
+      // Shift + Tab
+      tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
+      for (let i = focusableElements.length - 1; i >= 0; i--) {
+        const focusedIndex = getFocusedElementIndex();
+        expect(focusedIndex).to.eql(i);
+        tabKeyDown(focusableElements[focusedIndex], ['shift']);
+      }
+      expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);
+    });
+  });
+
+  describe('elements in shadow DOM', () => {
+    beforeEach(async () => {
+      overlay = fixtureSync('<vaadin-overlay focus-trap></vaadin-overlay>');
+      await nextRender();
+      overlay.renderer = (root) => {
+        if (!root.firstChild) {
+          const div = document.createElement('div');
+          div.attachShadow({ mode: 'open' });
+          div.shadowRoot.appendChild(document.createElement('vaadin-text-field'));
+          div.shadowRoot.appendChild(document.createElement('button'));
+          root.appendChild(div);
+
+          root.appendChild(document.createElement('input'));
+        }
+      };
+      overlay.requestContentUpdate();
+      focusableElements = getFocusableElements(overlay.$.overlay);
+    });
+
+    it('should properly detect multiple focusable elements inside shadow DOM', () => {
+      expect(focusableElements.length).to.eql(4);
+      const div = overlay.querySelector('div');
+      expect(focusableElements[1]).to.eql(div.shadowRoot.querySelector('input'));
+      expect(focusableElements[2]).to.eql(div.shadowRoot.querySelector('button'));
+    });
+
+    it('should not focus the overlay part if the content is already focused', async () => {
+      overlay.opened = true;
+      // Needs to happen after opened and before focus-trap loop is executed
+      focusableElements[1].focus();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      expect(getFocusedElementIndex()).not.to.eql(0);
+    });
+
+    it('should focus first element with tabIndex=1', async () => {
+      // It's an arguable behavior, probably overlay should be focused instead
+      focusableElements[1].tabIndex = 1;
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      const idx = getFocusedElementIndex();
+      expect(focusableElements[idx].tabIndex).to.eql(1);
+    });
+
+    it('should focus focusable elements in shadow DOM on Tab and Shift Tab', async () => {
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      // Tab
+      for (let i = 0; i < focusableElements.length; i++) {
+        const focusedIndex = getFocusedElementIndex();
+        expect(focusedIndex).to.equal(i);
+        tabKeyDown(focusableElements[focusedIndex]);
+      }
+      expect(getFocusedElementIndex()).to.eql(0);
+
+      // Shift + Tab
+      tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
+      for (let i = focusableElements.length - 1; i >= 0; i--) {
+        const focusedIndex = getFocusedElementIndex();
+        expect(focusedIndex).to.eql(i);
+        tabKeyDown(focusableElements[focusedIndex], ['shift']);
+      }
+      expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);
+    });
+  });
+});

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -43,11 +43,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/button": "24.0.0-alpha7",
     "@vaadin/polymer-legacy-adapter": "24.0.0-alpha7",
-    "@vaadin/radio-group": "24.0.0-alpha7",
     "@vaadin/testing-helpers": "^0.3.2",
-    "@vaadin/text-field": "24.0.0-alpha7",
     "lit": "^2.0.0",
     "sinon": "^13.0.2"
   }

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -1,159 +1,69 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
-import '@vaadin/button/vaadin-button.js';
-import '@vaadin/text-field/vaadin-text-field.js';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import '@vaadin/radio-group/vaadin-radio-group.js';
-import '@vaadin/radio-group/vaadin-radio-button.js';
 import '../vaadin-overlay.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { getFocusableElements, isElementFocused } from '@vaadin/component-base/src/focus-utils.js';
 
-const shadowTemplate = document.createElement('template');
-shadowTemplate.innerHTML = `
-  <input type="text" id="text">
-  <vaadin-text-field></vaadin-text-field>
-`;
-
-customElements.define(
-  'container-with-shadow',
-  class extends HTMLElement {
-    constructor() {
-      super();
-
-      this.attachShadow({ mode: 'open' });
-      this.shadowRoot.appendChild(document.importNode(shadowTemplate.content, true));
-    }
-  },
-);
-
-customElements.define(
-  'overlay-components-wrapper',
-  class extends PolymerElement {
-    static get template() {
-      return html`
-        <vaadin-overlay id="defaultOverlay" focus-trap>
-          <template>
-            overlay-content
-            <button>tabindex 0</button>
-            <button tabindex="-1">tabindex -1</button>
-            <select tabindex="2">
-              <option>tabindex 2</option>
-            </select>
-            <vaadin-text-field></vaadin-text-field>
-            <textarea tabindex="1">tabindex 1</textarea>
-            <input type="text" id="text" value="tabindex 0" />
-            <vaadin-radio-group>
-              <vaadin-radio-button id="radioButton1" label="Button 1"></vaadin-radio-button>
-              <vaadin-radio-button id="radioButton2" label="Button 2"></vaadin-radio-button>
-              <vaadin-radio-button id="radioButton3" label="Button 3"></vaadin-radio-button>
-            </vaadin-radio-group>
-            <vaadin-button>tabindex 0</vaadin-button>
-          </template>
-        </vaadin-overlay>
-        <vaadin-overlay id="shadowOverlay" focus-trap>
-          <template>
-            <container-with-shadow></container-with-shadow>
-            <input type="text" id="text" />
-          </template>
-        </vaadin-overlay>
-        <vaadin-overlay id="emptyOverlay" focus-trap>
-          <template></template>
-        </vaadin-overlay>
-      `;
-    }
-  },
-);
-
-customElements.define(
-  'nested-overlay-wrapper',
-  class extends PolymerElement {
-    static get template() {
-      return html`
-        <vaadin-overlay id="outer" focus-trap>
-          <template>
-            <button>Button</button>
-            <vaadin-overlay id="nested">
-              <template>Inner content</template>
-            </vaadin-overlay>
-          </template>
-        </vaadin-overlay>
-      `;
-    }
-  },
-);
-
 describe('focus-trap', () => {
-  let overlay, parent, overlayPart, focusableElements;
+  let overlay, overlayPart, focusableElements;
 
   function getFocusedElementIndex() {
     return focusableElements.findIndex(isElementFocused);
   }
 
-  describe('in a component scope', () => {
+  describe('focusable elements', () => {
     beforeEach(async () => {
-      parent = fixtureSync('<overlay-components-wrapper></overlay-components-wrapper>');
+      overlay = fixtureSync('<vaadin-overlay focus-trap></vaadin-overlay>');
       await nextRender();
-      overlay = parent.$.defaultOverlay;
-      overlay.requestContentUpdate();
       overlayPart = overlay.$.overlay;
-      focusableElements = getFocusableElements(overlay.$.overlay);
-      window.focus();
+      overlay.renderer = (root) => {
+        if (!root.firstChild) {
+          root.innerHTML = `
+            <button>tabindex 0</button>
+            <button tabindex="-1">tabindex -1</button>
+            <select tabindex="2">
+              <option>tabindex 2</option>
+            </select>
+            <textarea tabindex="1">tabindex 1</textarea>
+            <input type="text" id="text" value="tabindex 0" />
+          `;
+        }
+      };
+      overlay.requestContentUpdate();
+      focusableElements = getFocusableElements(overlayPart);
     });
 
     afterEach(() => {
       overlay.opened = false;
     });
 
-    it('should not focus the overlay when focusTrap = false', async () => {
-      overlay.focusTrap = false;
-      overlay.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-      expect(getFocusedElementIndex()).to.be.eql(-1);
-    });
-
     it('should properly detect focusable elements inside the content', () => {
-      expect(focusableElements.length).to.equal(10);
+      expect(focusableElements.length).to.equal(5);
       expect(focusableElements[0]).to.eql(overlay.querySelector('textarea'));
       expect(focusableElements[1]).to.eql(overlay.querySelector('select'));
-      expect(focusableElements[2]).to.eql(overlay.$.overlay);
+      expect(focusableElements[2]).to.eql(overlayPart);
       expect(focusableElements[3]).to.eql(overlay.querySelector('button'));
-      expect(focusableElements[4]).to.eql(overlay.querySelector('vaadin-text-field').focusElement);
-      expect(focusableElements[5]).to.eql(overlay.querySelector('#text'));
-      expect(focusableElements[6]).to.eql(overlay.querySelector('#radioButton1').focusElement);
-      expect(focusableElements[7]).to.eql(overlay.querySelector('#radioButton2').focusElement);
-      expect(focusableElements[8]).to.eql(overlay.querySelector('#radioButton3').focusElement);
-      expect(focusableElements[9]).to.eql(overlay.querySelector('vaadin-button'));
+      expect(focusableElements[4]).to.eql(overlay.querySelector('input'));
     });
 
     it('should focus focusable elements inside the content when focusTrap = true', async () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
 
-      // TAB
+      // Tab
       for (let i = 0; i < focusableElements.length; i++) {
-        // Emulating control-state-mixin moving focus
-        if (focusableElements.filter(isElementFocused).length > 1) {
-          i += 1;
-        }
-
         const focusedIndex = getFocusedElementIndex();
         expect(focusedIndex).to.equal(i);
         tabKeyDown(focusableElements[focusedIndex]);
       }
       expect(getFocusedElementIndex()).to.eql(0);
 
-      // SHIFT+TAB
+      // Shift + Tab
       tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
+
       for (let i = focusableElements.length - 1; i >= 0; i--) {
-        expect(getFocusedElementIndex()).to.eql(i);
-
-        // Emulating control-state-mixin moving focus
-        if (focusableElements.filter(isElementFocused).length > 1) {
-          i -= 1;
-        }
-
-        tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
+        const focusedIndex = getFocusedElementIndex();
+        expect(focusedIndex).to.eql(i);
+        tabKeyDown(focusableElements[focusedIndex], ['shift']);
       }
       expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);
     });
@@ -161,7 +71,6 @@ describe('focus-trap', () => {
     it('should update focus sequence when focusing a random element', async () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      expect(getFocusedElementIndex()).to.eql(0);
 
       tabKeyDown(document.body);
       expect(getFocusedElementIndex()).to.eql(1);
@@ -170,313 +79,28 @@ describe('focus-trap', () => {
       tabKeyDown(document.body);
       expect(getFocusedElementIndex()).to.eql(1);
     });
-
-    it('should not throw using Shift Tab on elements with shadow root', async () => {
-      overlay.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-
-      const button = overlay.querySelector('vaadin-button');
-      button.focus();
-      button.blur();
-
-      tabKeyDown(document.body, ['shift']);
-    });
-
-    describe('shadow content', () => {
-      beforeEach(() => {
-        overlay = parent.$.shadowOverlay;
-        overlay.requestContentUpdate();
-        focusableElements = getFocusableElements(overlay.$.overlay);
-      });
-
-      it('should properly detect multiple focusables in web component shadowRoots', () => {
-        expect(focusableElements.length).to.eql(4);
-        expect(focusableElements[1]).to.eql(
-          overlay.querySelector('container-with-shadow').shadowRoot.getElementById('text'),
-        );
-      });
-
-      it('should focus the overlay part on open', async () => {
-        overlay.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        expect(getFocusedElementIndex()).to.eql(0);
-      });
-
-      it('should not focus the overlay part if the content is already focused', async () => {
-        overlay.opened = true;
-        // Needs to happen after opened and before focus-trap loop is executed
-        focusableElements[1].focus();
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        expect(getFocusedElementIndex()).not.to.eql(0);
-      });
-
-      it('should focus first element with tabIndex=1', async () => {
-        // It's an arguable behaviour, probably overlay should be focused instead
-        focusableElements[1].tabIndex = 1;
-        overlay.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        const idx = getFocusedElementIndex();
-        expect(focusableElements[idx].tabIndex).to.eql(1);
-      });
-
-      it('`_cycleTab` should visit elements inside shadow content on keyboard `tab` actions', async () => {
-        overlay.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-
-        // TAB
-        for (let i = 0; i < focusableElements.length; i++) {
-          // Emulating control-state-mixin moving focus
-          if (focusableElements.filter(isElementFocused).length > 1) {
-            i += 1;
-          }
-
-          const focusedIndex = getFocusedElementIndex();
-          expect(focusedIndex).to.equal(i);
-          tabKeyDown(focusableElements[focusedIndex]);
-        }
-        expect(getFocusedElementIndex()).to.eql(0);
-
-        // SHIFT+TAB
-        tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
-        for (let i = focusableElements.length - 1; i >= 0; i--) {
-          expect(getFocusedElementIndex()).to.eql(i);
-
-          // Emulating control-state-mixin moving focus
-          if (focusableElements.filter(isElementFocused).length > 1) {
-            i -= 1;
-          }
-
-          tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
-        }
-        expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);
-      });
-    });
-
-    describe('empty content', () => {
-      beforeEach(() => {
-        overlay = parent.$.emptyOverlay;
-        overlayPart = overlay.$.overlay;
-        focusableElements = getFocusableElements(overlay.$.overlay);
-      });
-
-      it('should focus the overlayPart when focusTrap = true', async () => {
-        overlay.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        expect(focusableElements[0]).to.be.eql(overlayPart);
-        expect(getFocusedElementIndex()).to.eql(0);
-      });
-    });
   });
 
-  describe('in the global scope', () => {
+  describe('empty', () => {
     beforeEach(async () => {
-      parent = fixtureSync(`
-        <div>
-          <vaadin-overlay focus-trap>
-            <template>
-              overlay-content
-              <button>tabindex 0</button>
-              <button tabindex="-1">tabindex -1</button>
-              <select tabindex="2"><option>tabindex 2</option></select>
-              <vaadin-text-field></vaadin-text-field>
-              <textarea tabindex="1">tabindex 1</textarea>
-              <input type="text" id="text" value="tabindex 0">
-              <vaadin-radio-group>
-                <vaadin-radio-button id="radioButton1" label="Button 1"></vaadin-radio-button>
-                <vaadin-radio-button id="radioButton2" label="Button 2"></vaadin-radio-button>
-                <vaadin-radio-button id="radioButton3" label="Button 3"></vaadin-radio-button>
-              </vaadin-radio-group>
-              <vaadin-button>tabindex 0</vaadin-button>
-            </template>
-          </vaadin-overlay>
-        </div>
-      `);
+      overlay = fixtureSync('<vaadin-overlay focus-trap></vaadin-overlay>');
       await nextRender();
-      overlay = parent.firstElementChild;
       overlayPart = overlay.$.overlay;
-      overlay.requestContentUpdate();
-      focusableElements = getFocusableElements(overlay.$.overlay);
-      window.focus();
+      focusableElements = getFocusableElements(overlayPart);
     });
 
-    afterEach(() => {
-      overlay.opened = false;
+    it('should focus the overlay part when focusTrap = true', async () => {
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      expect(focusableElements[0]).to.be.eql(overlayPart);
+      expect(getFocusedElementIndex()).to.eql(0);
     });
 
-    it('should not focus the overlay when focusTrap = false', async () => {
+    it('should not focus the overlay part when focusTrap = false', async () => {
       overlay.focusTrap = false;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
       expect(getFocusedElementIndex()).to.be.eql(-1);
-    });
-
-    it('should properly detect focusable elements inside the content', () => {
-      expect(focusableElements.length).to.equal(10);
-      expect(focusableElements[0]).to.eql(overlay.querySelector('textarea'));
-      expect(focusableElements[1]).to.eql(overlay.querySelector('select'));
-      expect(focusableElements[2]).to.eql(overlay.$.overlay);
-      expect(focusableElements[3]).to.eql(overlay.querySelector('button'));
-      expect(focusableElements[4]).to.eql(overlay.querySelector('vaadin-text-field').focusElement);
-      expect(focusableElements[5]).to.eql(overlay.querySelector('#text'));
-      expect(focusableElements[6]).to.eql(overlay.querySelector('#radioButton1').focusElement);
-      expect(focusableElements[7]).to.eql(overlay.querySelector('#radioButton2').focusElement);
-      expect(focusableElements[8]).to.eql(overlay.querySelector('#radioButton3').focusElement);
-      expect(focusableElements[9]).to.eql(overlay.querySelector('vaadin-button'));
-    });
-
-    it('should focus focusable elements inside the content when focusTrap = true', async () => {
-      overlay.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-
-      // TAB
-      for (let i = 0; i < focusableElements.length; i++) {
-        // Emulating control-state-mixin moving focus
-        if (focusableElements.filter(isElementFocused).length > 1) {
-          i += 1;
-        }
-
-        expect(getFocusedElementIndex()).to.eql(i);
-        tabKeyDown(focusableElements[getFocusedElementIndex()]);
-      }
-      expect(getFocusedElementIndex()).to.eql(0);
-
-      // SHIFT+TAB
-      tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
-      for (let i = focusableElements.length - 1; i >= 0; i--) {
-        expect(getFocusedElementIndex()).to.eql(i);
-
-        // Emulating control-state-mixin moving focus
-        if (focusableElements.filter(isElementFocused).length > 1) {
-          i -= 1;
-        }
-
-        tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
-      }
-      expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);
-    });
-
-    it('should update focus sequence when focusing a random element', async () => {
-      overlay.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-      expect(getFocusedElementIndex()).to.eql(0);
-
-      tabKeyDown(document.body);
-      expect(getFocusedElementIndex()).to.eql(1);
-
-      focusableElements[0].focus();
-      tabKeyDown(document.body);
-      expect(getFocusedElementIndex()).to.eql(1);
-    });
-
-    it('should not throw using Shift Tab on elements with shadow root', async () => {
-      overlay.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-
-      const button = overlay.querySelector('vaadin-button');
-      button.focus();
-      button.blur();
-
-      tabKeyDown(document.body, ['shift']);
-    });
-
-    describe('shadow content', () => {
-      beforeEach(() => {
-        overlay = fixtureSync(`
-          <vaadin-overlay focus-trap>
-            <template>
-              <container-with-shadow></container-with-shadow>
-              <svg></svg>
-              <input type="text" id="text">
-            </template>
-          </vaadin-overlay>
-        `);
-        overlay.requestContentUpdate();
-        focusableElements = getFocusableElements(overlay.$.overlay);
-      });
-
-      it('should properly detect multiple focusables in web component shadowRoots', () => {
-        expect(focusableElements.length).to.eql(4);
-        expect(focusableElements[1]).to.eql(
-          overlay.querySelector('container-with-shadow').shadowRoot.getElementById('text'),
-        );
-      });
-
-      it('should focus the overlay part on open', async () => {
-        overlay.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        expect(getFocusedElementIndex()).to.eql(0);
-      });
-
-      it('should not focus the overlay part if the content is already focused', async () => {
-        overlay.opened = true;
-        // Needs to happen after opened and before focus-trap loop is executed
-        focusableElements[1].focus();
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        expect(getFocusedElementIndex()).not.to.eql(0);
-      });
-
-      it('should focus first element with tabIndex=1', async () => {
-        // It's an arguable behaviour, probably overlay should be focused instead
-        focusableElements[1].tabIndex = 1;
-        overlay.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        const idx = getFocusedElementIndex();
-        expect(focusableElements[idx].tabIndex).to.eql(1);
-      });
-
-      it('`_cycleTab` should visit elements inside shadow content on keyboard `tab` actions', async () => {
-        overlay.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-
-        // TAB
-        for (let i = 0; i < focusableElements.length; i++) {
-          // Emulating control-state-mixin moving focus
-          if (focusableElements.filter(isElementFocused).length > 1) {
-            i += 1;
-          }
-
-          expect(getFocusedElementIndex()).to.eql(i);
-          tabKeyDown(focusableElements[getFocusedElementIndex()]);
-        }
-        expect(getFocusedElementIndex()).to.eql(0);
-
-        // SHIFT+TAB
-        tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
-        for (let i = focusableElements.length - 1; i >= 0; i--) {
-          expect(getFocusedElementIndex()).to.eql(i);
-
-          // Emulating control-state-mixin moving focus
-          if (focusableElements.filter(isElementFocused).length > 1) {
-            i -= 1;
-          }
-
-          tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
-        }
-        expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);
-      });
-    });
-
-    describe('empty content', () => {
-      beforeEach(() => {
-        parent = fixtureSync(`
-          <div>
-            <vaadin-overlay focus-trap>
-              <template>
-              </template>
-            </vaadin-overlay>
-          </div>
-        `);
-        overlay = parent.firstElementChild;
-        overlayPart = overlay.$.overlay;
-        focusableElements = getFocusableElements(overlay.$.overlay);
-      });
-
-      it('should focus the overlayPart when focusTrap = true', async () => {
-        overlay.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        expect(focusableElements[0]).to.be.eql(overlayPart);
-        expect(getFocusedElementIndex()).to.eql(0);
-      });
     });
   });
 
@@ -484,12 +108,26 @@ describe('focus-trap', () => {
     let nested;
 
     beforeEach(async () => {
-      parent = fixtureSync('<nested-overlay-wrapper></nested-overlay-wrapper>');
-      overlay = parent.$.outer;
+      overlay = fixtureSync('<vaadin-overlay focus-trap></vaadin-overlay>');
+      await nextRender();
+      overlay.renderer = (root) => {
+        if (!root.firstChild) {
+          const button = document.createElement('button');
+          button.textContent = 'Button';
+          root.appendChild(button);
+
+          const nested = document.createElement('vaadin-overlay');
+          nested.renderer = (root) => {
+            root.textContent = 'Inner content';
+          };
+          root.appendChild(nested);
+        }
+      };
       overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
       focusableElements = getFocusableElements(overlay.$.overlay);
       await nextRender();
-      nested = overlay.querySelector('#nested');
+      nested = overlay.querySelector('vaadin-overlay');
     });
 
     afterEach(() => {

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -100,7 +100,7 @@ describe('focus-trap', () => {
       overlay.focusTrap = false;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      expect(getFocusedElementIndex()).to.be.eql(-1);
+      expect(getFocusedElementIndex()).to.equal(-1);
     });
   });
 

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -38,7 +38,7 @@ describe('focus-trap', () => {
 
     it('should properly detect focusable elements inside the content', () => {
       expect(focusableElements.length).to.equal(5);
-      expect(focusableElements[0]).to.eql(overlay.querySelector('textarea'));
+      expect(focusableElements[0]).to.equal(overlay.querySelector('textarea'));
       expect(focusableElements[1]).to.eql(overlay.querySelector('select'));
       expect(focusableElements[2]).to.eql(overlayPart);
       expect(focusableElements[3]).to.eql(overlay.querySelector('button'));
@@ -62,7 +62,7 @@ describe('focus-trap', () => {
 
       for (let i = focusableElements.length - 1; i >= 0; i--) {
         const focusedIndex = getFocusedElementIndex();
-        expect(focusedIndex).to.eql(i);
+        expect(focusedIndex).to.equal(i);
         tabKeyDown(focusableElements[focusedIndex], ['shift']);
       }
       expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -39,10 +39,10 @@ describe('focus-trap', () => {
     it('should properly detect focusable elements inside the content', () => {
       expect(focusableElements.length).to.equal(5);
       expect(focusableElements[0]).to.equal(overlay.querySelector('textarea'));
-      expect(focusableElements[1]).to.eql(overlay.querySelector('select'));
-      expect(focusableElements[2]).to.eql(overlayPart);
-      expect(focusableElements[3]).to.eql(overlay.querySelector('button'));
-      expect(focusableElements[4]).to.eql(overlay.querySelector('input'));
+      expect(focusableElements[1]).to.equal(overlay.querySelector('select'));
+      expect(focusableElements[2]).to.equal(overlayPart);
+      expect(focusableElements[3]).to.equal(overlay.querySelector('button'));
+      expect(focusableElements[4]).to.equal(overlay.querySelector('input'));
     });
 
     it('should focus focusable elements inside the content when focusTrap = true', async () => {
@@ -55,7 +55,7 @@ describe('focus-trap', () => {
         expect(focusedIndex).to.equal(i);
         tabKeyDown(focusableElements[focusedIndex]);
       }
-      expect(getFocusedElementIndex()).to.eql(0);
+      expect(getFocusedElementIndex()).to.equal(0);
 
       // Shift + Tab
       tabKeyDown(focusableElements[getFocusedElementIndex()], ['shift']);
@@ -65,7 +65,7 @@ describe('focus-trap', () => {
         expect(focusedIndex).to.equal(i);
         tabKeyDown(focusableElements[focusedIndex], ['shift']);
       }
-      expect(getFocusedElementIndex()).to.eql(focusableElements.length - 1);
+      expect(getFocusedElementIndex()).to.equal(focusableElements.length - 1);
     });
 
     it('should update focus sequence when focusing a random element', async () => {
@@ -73,11 +73,11 @@ describe('focus-trap', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
 
       tabKeyDown(document.body);
-      expect(getFocusedElementIndex()).to.eql(1);
+      expect(getFocusedElementIndex()).to.equal(1);
 
       focusableElements[0].focus();
       tabKeyDown(document.body);
-      expect(getFocusedElementIndex()).to.eql(1);
+      expect(getFocusedElementIndex()).to.equal(1);
     });
   });
 
@@ -92,8 +92,8 @@ describe('focus-trap', () => {
     it('should focus the overlay part when focusTrap = true', async () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      expect(focusableElements[0]).to.be.eql(overlayPart);
-      expect(getFocusedElementIndex()).to.eql(0);
+      expect(focusableElements[0]).to.equal(overlayPart);
+      expect(getFocusedElementIndex()).to.equal(0);
     });
 
     it('should not focus the overlay part when focusTrap = false', async () => {

--- a/packages/overlay/test/overlay.test.js
+++ b/packages/overlay/test/overlay.test.js
@@ -11,7 +11,6 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import '@vaadin/text-field/vaadin-text-field.js';
 import '../vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import '@vaadin/text-field/vaadin-text-field.js';
 import '../src/vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { close, open } from './helpers.js';
@@ -13,7 +12,7 @@ customElements.define(
       return html`
         <vaadin-overlay id="overlay">
           <template>
-            <vaadin-text-field id="focusable"></vaadin-text-field>
+            <input id="focusable" />
           </template>
         </vaadin-overlay>
         <input id="focusable" />


### PR DESCRIPTION
## Description

Some updates to `vaadin-overlay` tests intended to get rid of duplicate tests and to speed up the builds:

1. Split `focus-trap.test.js` in two suites, the one with Vaadin components is moved to `integration` package;
2. Removed duplicate suites added in https://github.com/vaadin/vaadin-overlay/pull/76/commits/a2c4a1dad4043d3d1f9d005d54e4962e74c667c4 - related "scope" logic is [removed](https://github.com/vaadin/web-components/pull/4753) in V24;
3. Updated other test suites in the `overlay` package to use `input` instead of the `vaadin-text-field` element;
4. Replaced `<template>` and extra custom elements with `renderer` and `div` with a shadow root, respectively.

## Type of change

- Tests