### PR TITLE
refactor: use row parts instead of states in themes

### DIFF
--- a/packages/grid/test/basic.test.js
+++ b/packages/grid/test/basic.test.js
@@ -210,26 +210,26 @@ describe('basic features', () => {
 
   it('should have attribute last on the last body row', () => {
     grid.scrollToIndex(grid.size - 1);
-    const lastRowSlot = grid.shadowRoot.querySelector('[part~="row"][last] slot');
+    const lastRowSlot = grid.shadowRoot.querySelector('[part~="last-row"] slot');
     expect(lastRowSlot.assignedNodes()[0].textContent).to.equal(String(grid.size - 1));
   });
 
   it('should have attribute last on the last body row after resize', () => {
     grid.size = 2;
-    const lastRowSlot = grid.shadowRoot.querySelector('[part~="row"][last] slot');
+    const lastRowSlot = grid.shadowRoot.querySelector('[part~="last-row"] slot');
     expect(lastRowSlot.assignedNodes()[0].textContent).to.equal(String(grid.size - 1));
   });
 
   it('should not have attribute last on the previous last body row after resize', () => {
     grid.size = 2;
     grid.size = 3;
-    expect(grid.shadowRoot.querySelectorAll('[part~="row"][last]').length).to.equal(1);
+    expect(grid.shadowRoot.querySelectorAll('[part~="last-row"]').length).to.equal(1);
   });
 
   it('should not have attribute last on a row when size incresed beyond viewport ', () => {
     grid.size = 2;
     grid.size = 1000;
-    expect(grid.shadowRoot.querySelectorAll('[part~="row"][last]').length).to.equal(0);
+    expect(grid.shadowRoot.querySelectorAll('[part~="last-row"]').length).to.equal(0);
   });
 
   function getFirstCellRenderCount() {

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -309,8 +309,8 @@ registerStyles(
 
     /* Row stripes */
 
-    :host([theme~='row-stripes']) [part~='row'][part~='even-row'] [part~='body-cell'],
-    :host([theme~='row-stripes']) [part~='row'][part~='even-row'] [part~='details-cell'] {
+    :host([theme~='row-stripes']) [part~='even-row'] [part~='body-cell'],
+    :host([theme~='row-stripes']) [part~='even-row'] [part~='details-cell'] {
       background-image: linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
       background-repeat: repeat-x;
     }

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -57,7 +57,7 @@ registerStyles(
     }
 
     /* Hide first body row top border */
-    :host(:not([theme~='no-row-borders'])) [part~='row'][first] [part~='cell']:not([part~='details-cell']) {
+    :host(:not([theme~='no-row-borders'])) [part~='first-row'] [part~='cell']:not([part~='details-cell']) {
       border-top: 0;
       min-height: calc(var(--lumo-size-m) - var(--_lumo-grid-border-width));
     }
@@ -137,7 +137,7 @@ registerStyles(
       margin-top: -1px;
     }
 
-    :host([all-rows-visible]) [part~='row'][last][dragover='below'] [part~='cell']::after {
+    :host([all-rows-visible]) [part~='last-row'][dragover='below'] [part~='cell']::after {
       height: 1px;
     }
 
@@ -309,8 +309,8 @@ registerStyles(
 
     /* Row stripes */
 
-    :host([theme~='row-stripes']) [part~='row']:not([odd]) [part~='body-cell'],
-    :host([theme~='row-stripes']) [part~='row']:not([odd]) [part~='details-cell'] {
+    :host([theme~='row-stripes']) [part~='row']:not([part~='odd-row']) [part~='body-cell'],
+    :host([theme~='row-stripes']) [part~='row']:not([part~='odd-row']) [part~='details-cell'] {
       background-image: linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
       background-repeat: repeat-x;
     }
@@ -342,7 +342,7 @@ registerStyles(
       min-height: var(--lumo-size-s);
     }
 
-    :host([theme~='compact']) [part~='row'][first] [part~='cell']:not([part~='details-cell']) {
+    :host([theme~='compact']) [part~='first-row'] [part~='cell']:not([part~='details-cell']) {
       min-height: calc(var(--lumo-size-s) - var(--_lumo-grid-border-width));
     }
 

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -309,8 +309,8 @@ registerStyles(
 
     /* Row stripes */
 
-    :host([theme~='row-stripes']) [part~='row']:not([part~='odd-row']) [part~='body-cell'],
-    :host([theme~='row-stripes']) [part~='row']:not([part~='odd-row']) [part~='details-cell'] {
+    :host([theme~='row-stripes']) [part~='row'][part~='even-row'] [part~='body-cell'],
+    :host([theme~='row-stripes']) [part~='row'][part~='even-row'] [part~='details-cell'] {
       background-image: linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
       background-repeat: repeat-x;
     }

--- a/packages/grid/theme/material/vaadin-grid-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-styles.js
@@ -191,7 +191,7 @@ registerStyles(
       margin-top: -1px;
     }
 
-    :host([all-rows-visible]) [part~='row'][last][dragover='below'] [part~='cell']::after {
+    :host([all-rows-visible]) [part~='last-row'][dragover='below'] [part~='cell']::after {
       height: 1px;
     }
 


### PR DESCRIPTION
## Description

Updated themes and tests to use grid row parts instead of state attributes like `first`, `last` and `odd`.
Note, some states are still used especially `dragstart` and `dragover` - we might changes these later.

UPD: the reason why I decided to not change `dragover` from attribute to part is because it would mean having to replace single attribute with multiple parts e.g. `dragover-above-row`, `dragover-below-row`, `dragover-on-top-row`.

## Type of change

- Refactor