### PR TITLE
test: update overlay unit tests to use renderer

### DIFF
--- a/integration/tests/overlay-template.test.js
+++ b/integration/tests/overlay-template.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import '../vaadin-overlay.js';
+import '@vaadin/overlay/vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 customElements.define(

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/polymer-legacy-adapter": "24.0.0-alpha7",
     "@vaadin/testing-helpers": "^0.3.2",
     "lit": "^2.0.0",
     "sinon": "^13.0.2"

--- a/packages/overlay/test/helpers.js
+++ b/packages/overlay/test/helpers.js
@@ -1,4 +1,16 @@
-import { nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+
+export function createOverlay(text) {
+  const overlay = fixtureSync('<vaadin-overlay></vaadin-overlay');
+  overlay.renderer = (root) => {
+    if (!root.firstChild) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      root.appendChild(div);
+    }
+  };
+  return overlay;
+}
 
 export function open(overlay) {
   return new Promise((resolve) => {

--- a/packages/overlay/test/multiple.test.js
+++ b/packages/overlay/test/multiple.test.js
@@ -1,36 +1,19 @@
 import { expect } from '@esm-bundle/chai';
 import { click, escKeyDown, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-overlay.js';
+import { createOverlay } from './helpers.js';
 
 describe('multiple overlays', () => {
   describe('modal', () => {
     let parent, overlay1, overlay2, overlay3;
 
     beforeEach(() => {
-      parent = fixtureSync(`
-        <div id="parent">
-          <vaadin-overlay>
-            <template>
-              overlay 1
-            </template>
-          </vaadin-overlay>
-          <vaadin-overlay>
-            <template>
-              overlay 2
-            </template>
-          </vaadin-overlay>
-          <vaadin-overlay>
-            <template>
-              overlay 3
-            </template>
-          </vaadin-overlay>
-        </div>
-      `);
-      overlay1 = parent.children[0];
-      overlay2 = parent.children[1];
-      overlay3 = parent.children[2];
+      parent = fixtureSync('<div></div>');
+      overlay1 = createOverlay('overlay 1');
+      overlay2 = createOverlay('overlay 2');
+      overlay3 = createOverlay('overlay 3');
+      parent.append(overlay1, overlay2, overlay3);
     });
 
     afterEach(() => {
@@ -163,22 +146,26 @@ describe('multiple overlays', () => {
     beforeEach(() => {
       parent = fixtureSync(`
         <div id="parent">
-          <vaadin-overlay modeless>
-            <template>
-              overlay 1
-              <input />
-            </template>
-          </vaadin-overlay>
-          <vaadin-overlay modeless>
-            <template>
-              overlay 2
-              <input />
-            </template>
-          </vaadin-overlay>
+          <vaadin-overlay modeless></vaadin-overlay>
+          <vaadin-overlay modeless></vaadin-overlay>
         </div>
       `);
       modeless1 = parent.children[0];
+      modeless1.renderer = (root) => {
+        if (!root.firstChild) {
+          root.textContent = 'overlay 1';
+          const input = document.createElement('input');
+          root.appendChild(input);
+        }
+      };
       modeless2 = parent.children[1];
+      modeless2.renderer = (root) => {
+        if (!root.firstChild) {
+          root.textContent = 'overlay 2';
+          const input = document.createElement('input');
+          root.appendChild(input);
+        }
+      };
     });
 
     afterEach(() => {

--- a/packages/overlay/test/overlay.test.js
+++ b/packages/overlay/test/overlay.test.js
@@ -10,24 +10,29 @@ import {
   oneEvent,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { createOverlay } from './helpers.js';
 
 customElements.define(
   'overlay-wrapper',
   class extends PolymerElement {
     static get template() {
-      return html`
-        <vaadin-overlay id="overlay" opened="[[opened]]">
-          <template> overlay content </template>
-        </vaadin-overlay>
-      `;
+      return html`<vaadin-overlay id="overlay" opened="[[opened]]" renderer="[[renderer]]"></vaadin-overlay>`;
     }
 
     static get properties() {
       return {
         opened: Boolean,
+
+        renderer: {
+          type: Object,
+          value: () => {
+            return (root) => {
+              root.textContent = 'overlay content';
+            };
+          },
+        },
       };
     }
   },
@@ -38,16 +43,11 @@ describe('vaadin-overlay', () => {
     let parent, overlay;
 
     beforeEach(async () => {
-      parent = fixtureSync(`
-        <div id="parent">
-          <vaadin-overlay>
-            <template>
-              overlay-content
-            </template>
-          </vaadin-overlay>
-        </div>
-      `);
-      overlay = parent.children[0];
+      parent = document.createElement('div');
+      overlay = fixtureSync('<vaadin-overlay></vaadin-overlay>', parent);
+      overlay.renderer = (root) => {
+        root.textContent = 'overlay content';
+      };
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
     });
@@ -71,13 +71,7 @@ describe('vaadin-overlay', () => {
     let overlay;
 
     beforeEach(async () => {
-      overlay = fixtureSync(`
-        <vaadin-overlay>
-          <template>
-            overlay-content
-          </template>
-        </vaadin-overlay>
-      `);
+      overlay = createOverlay('overlay content');
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
     });
@@ -110,13 +104,7 @@ describe('vaadin-overlay', () => {
     let overlay, backdrop;
 
     beforeEach(async () => {
-      overlay = fixtureSync(`
-        <vaadin-overlay>
-          <template>
-            overlay-content
-          </template>
-        </vaadin-overlay>
-      `);
+      overlay = createOverlay('overlay content');
       backdrop = overlay.$.backdrop;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
@@ -151,13 +139,7 @@ describe('vaadin-overlay', () => {
     let overlay;
 
     beforeEach(async () => {
-      overlay = fixtureSync(`
-        <vaadin-overlay>
-          <template>
-            overlay-content
-          </template>
-        </vaadin-overlay>
-      `);
+      overlay = createOverlay('overlay content');
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
     });
@@ -203,16 +185,11 @@ describe('vaadin-overlay', () => {
     let parent, overlay, overlayPart, backdrop;
 
     beforeEach(async () => {
-      parent = fixtureSync(`
-        <div id="parent">
-          <vaadin-overlay>
-            <template>
-              <div>overlay-content</div>
-            </template>
-          </vaadin-overlay>
-        </div>
-      `);
-      overlay = parent.children[0];
+      parent = document.createElement('div');
+      overlay = fixtureSync('<vaadin-overlay></vaadin-overlay>', parent);
+      overlay.renderer = (root) => {
+        root.textContent = 'overlay content';
+      };
       overlayPart = overlay.$.overlay;
       backdrop = overlay.$.backdrop;
       overlay.opened = true;
@@ -410,13 +387,7 @@ describe('vaadin-overlay', () => {
     let overlay, overlayPart;
 
     beforeEach(async () => {
-      overlay = fixtureSync(`
-        <vaadin-overlay>
-          <template>
-            <div>overlay-content</div>
-          </template>
-        </vaadin-overlay>
-      `);
+      overlay = createOverlay('overlay content');
       overlayPart = overlay.$.overlay;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
@@ -510,13 +481,7 @@ describe('vaadin-overlay', () => {
     let overlay;
 
     beforeEach(async () => {
-      overlay = fixtureSync(`
-        <vaadin-overlay>
-          <template>
-            overlay-content
-          </template>
-        </vaadin-overlay>
-      `);
+      overlay = createOverlay('overlay content');
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
     });

--- a/packages/overlay/test/position-mixin-listeners.test.js
+++ b/packages/overlay/test/position-mixin-listeners.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import { Overlay } from '../src/vaadin-overlay.js';
 import { PositionMixin } from '../src/vaadin-overlay-position-mixin.js';
 
@@ -10,6 +9,7 @@ class PositionedOverlay extends PositionMixin(Overlay) {
     return 'vaadin-positioned-overlay';
   }
 }
+
 customElements.define(PositionedOverlay.is, PositionedOverlay);
 
 class ScrollableWrapper extends HTMLElement {
@@ -44,15 +44,20 @@ describe('position mixin listeners', () => {
         <div id="target" style="position: fixed; top: 100px; left: 100px; width: 20px; height: 20px; border: 1px solid">
           target
         </div>
-        <vaadin-positioned-overlay id="overlay">
-          <template>
-            <div id="overlay-child" style="width: 50px; height: 50px;"></div>
-          </template>
-        </vaadin-positioned-overlay>
+        <vaadin-positioned-overlay id="overlay"></vaadin-positioned-overlay>
       </scrollable-wrapper>
     `);
     target = wrapper.querySelector('#target');
     overlay = wrapper.querySelector('#overlay');
+    overlay.renderer = (root) => {
+      if (!root.firstChild) {
+        const div = document.createElement('div');
+        div.id = 'overlay-child';
+        div.style.width = '50px';
+        div.style.height = '50px';
+        root.appendChild(div);
+      }
+    };
     updatePositionSpy = sinon.spy(overlay, '_updatePosition');
   });
 

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import { css } from 'lit';
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
 import { Overlay } from '../src/vaadin-overlay.js';
@@ -55,24 +54,30 @@ describe('position mixin', () => {
     );
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     const parent = fixtureSync(`
       <div id="parent">
         <div id="target" style="position: fixed; top: 100px; left: 100px; width: 20px; height: 20px; border: 1px solid">
           target
         </div>
-        <vaadin-positioned-overlay id="overlay">
-          <template>
-            <div id="overlay-child" style="width: 50px; height: 50px;"></div>
-          </template>
-        </vaadin-positioned-overlay>
+        <vaadin-positioned-overlay id="overlay"></vaadin-positioned-overlay>
       </div>
     `);
     target = parent.querySelector('#target');
     overlay = parent.querySelector('#overlay');
+    overlay.renderer = (root) => {
+      if (!root.firstChild) {
+        const div = document.createElement('div');
+        div.id = 'overlay-child';
+        div.style.width = '50px';
+        div.style.height = '50px';
+        root.appendChild(div);
+      }
+    };
     overlayContent = overlay.$.overlay;
     overlay.positionTarget = target;
     overlay.opened = true;
+    await oneEvent(overlay, 'vaadin-overlay-open');
   });
 
   afterEach(() => {

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../src/vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { close, open } from './helpers.js';
@@ -10,13 +9,24 @@ customElements.define(
   class extends PolymerElement {
     static get template() {
       return html`
-        <vaadin-overlay id="overlay">
-          <template>
-            <input id="focusable" />
-          </template>
-        </vaadin-overlay>
+        <vaadin-overlay id="overlay" renderer="[[renderer]]"></vaadin-overlay>
         <input id="focusable" />
       `;
+    }
+
+    static get properties() {
+      return {
+        renderer: {
+          type: Object,
+          value: () => {
+            return (root) => {
+              if (!root.firstChild) {
+                root.appendChild(document.createElement('input'));
+              }
+            };
+          },
+        },
+      };
     }
   },
 );
@@ -37,7 +47,6 @@ describe('restore focus', () => {
     wrapper = fixtureSync('<overlay-field-wrapper></overlay-field-wrapper>');
     overlay = wrapper.$.overlay;
     focusable = wrapper.$.focusable;
-    window.focus();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Description

1. Moved `vaadin-overlay` tests for using `<template>` to the `integration` package, as for other components.
2. Updated remaining tests to use `renderer` and removed `@vaadin/polymer-legacy-adapter` dev dependency.

## Type of change

- Tests