### PR TITLE
fix: propagate autocapitalize attribute in Chrome

### DIFF
--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -46,6 +46,7 @@ export const InputFieldMixin = (superclass) =>
          */
         autocapitalize: {
           type: String,
+          reflectToAttribute: true,
         },
       };
     }

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -69,6 +69,56 @@ const runTests = (baseClass) => {
     });
   });
 
+  describe('attributes', () => {
+    describe('autocomplete', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag} autocomplete="on"></${tag}>`);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should set autocomplete property on the host element', () => {
+        expect(element.autocomplete).to.equal('on');
+      });
+
+      it('should propagate autocomplete attribute to the input', () => {
+        expect(input.autocomplete).to.equal('on');
+      });
+    });
+
+    describe('autocorrect', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag} autocorrect="on"></${tag}>`);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should set autocorrect property on the host element', () => {
+        expect(element.autocorrect).to.equal('on');
+      });
+
+      it('should propagate autocorrect attribute to the input', () => {
+        expect(input.getAttribute('autocorrect')).to.equal('on');
+      });
+    });
+
+    describe('autocapitalize', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag} autocapitalize="characters"></${tag}>`);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should set autocapitalize property on the host element', () => {
+        expect(element.autocapitalize).to.equal('characters');
+      });
+
+      it('should propagate autocapitalize attribute to the input', () => {
+        expect(input.getAttribute('autocapitalize')).to.equal('characters');
+      });
+    });
+  });
+
   describe('initial validation', () => {
     let validateSpy;
 

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -25,6 +25,7 @@ snapshots["vaadin-login-form host default"] =
       >
         <input
           aria-labelledby="label-vaadin-text-field-0"
+          autocapitalize="none"
           autocomplete="username"
           autocorrect="off"
           id="input-vaadin-text-field-6"
@@ -132,6 +133,7 @@ snapshots["vaadin-login-form host i18n"] =
       >
         <input
           aria-labelledby="label-vaadin-text-field-0"
+          autocapitalize="none"
           autocomplete="username"
           autocorrect="off"
           id="input-vaadin-text-field-6"
@@ -239,6 +241,7 @@ snapshots["vaadin-login-form host noForgotPassword"] =
       >
         <input
           aria-labelledby="label-vaadin-text-field-0"
+          autocapitalize="none"
           autocomplete="username"
           autocorrect="off"
           id="input-vaadin-text-field-6"

--- a/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
@@ -34,6 +34,7 @@ snapshots["vaadin-login-overlay host default"] =
         >
           <input
             aria-labelledby="label-vaadin-text-field-0"
+            autocapitalize="none"
             autocomplete="username"
             autocorrect="off"
             id="input-vaadin-text-field-6"
@@ -151,6 +152,7 @@ snapshots["vaadin-login-overlay host i18n"] =
         >
           <input
             aria-labelledby="label-vaadin-text-field-0"
+            autocapitalize="none"
             autocomplete="username"
             autocorrect="off"
             id="input-vaadin-text-field-6"


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/4452

Added `reflectToAttribute: true` to fix a Chrome specific issue where setting `autocapitalize` attribute does not set corresponding property and it remains `undefined` so the delegation observer fails to set it on the `<input>`.

This only affects `autocapitalize` - two other properties work fine, so I didn't add `reflectToAttribute` there.
While I don't really like inconsistency, this is the cleanest fix that I was able to come up with 🤷‍♂️ 

See https://github.com/vaadin/flow-components/issues/4452#issuecomment-1366514219

## Type of change

- Bugfix