### PR TITLE
fix: propagate autocapitalize attribute in Chrome (#5175) (CP: 23.2)

### DIFF
--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -46,6 +46,7 @@ export const InputFieldMixin = (superclass) =>
          */
         autocapitalize: {
           type: String,
+          reflectToAttribute: true,
         },
       };
     }

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -67,6 +67,56 @@ describe('input-field-mixin', () => {
     });
   });
 
+  describe('attributes', () => {
+    describe('autocomplete', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`<input-field-mixin-element autocomplete="on"></input-field-mixin-element>`);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should set autocomplete property on the host element', () => {
+        expect(element.autocomplete).to.equal('on');
+      });
+
+      it('should propagate autocomplete attribute to the input', () => {
+        expect(input.autocomplete).to.equal('on');
+      });
+    });
+
+    describe('autocorrect', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`<input-field-mixin-element autocorrect="on"></input-field-mixin-element>`);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should set autocorrect property on the host element', () => {
+        expect(element.autocorrect).to.equal('on');
+      });
+
+      it('should propagate autocorrect attribute to the input', () => {
+        expect(input.getAttribute('autocorrect')).to.equal('on');
+      });
+    });
+
+    describe('autocapitalize', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`<input-field-mixin-element autocapitalize="characters"></input-field-mixin-element>`);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should set autocapitalize property on the host element', () => {
+        expect(element.autocapitalize).to.equal('characters');
+      });
+
+      it('should propagate autocapitalize attribute to the input', () => {
+        expect(input.getAttribute('autocapitalize')).to.equal('characters');
+      });
+    });
+  });
+
   describe('initial validation', () => {
     let validateSpy;
 

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -26,6 +26,7 @@ snapshots["vaadin-login-form host default"] =
       >
         <input
           aria-labelledby="label-vaadin-text-field-0"
+          autocapitalize="none"
           autocomplete="username"
           autocorrect="off"
           id="input-vaadin-text-field-6"
@@ -127,6 +128,7 @@ snapshots["vaadin-login-form host i18n"] =
       >
         <input
           aria-labelledby="label-vaadin-text-field-0"
+          autocapitalize="none"
           autocomplete="username"
           autocorrect="off"
           id="input-vaadin-text-field-6"

--- a/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
@@ -38,6 +38,7 @@ snapshots["vaadin-login-overlay host default"] =
         >
           <input
             aria-labelledby="label-vaadin-text-field-0"
+            autocapitalize="none"
             autocomplete="username"
             autocorrect="off"
             id="input-vaadin-text-field-6"
@@ -152,6 +153,7 @@ snapshots["vaadin-login-overlay host i18n"] =
         >
           <input
             aria-labelledby="label-vaadin-text-field-0"
+            autocapitalize="none"
             autocomplete="username"
             autocorrect="off"
             id="input-vaadin-text-field-6"


### PR DESCRIPTION
## Description

Manual cherry-pick of #5175 to `23.2` branch. 
The automated cherry-pick failed because of conflicts was caused by snapshots and lack of Lit tests on this branch.

## Type of change

- Cherry-pick