### PR TITLE
fix: propagate autocapitalize attribute in Chrome (#5175) (CP: 22.0)

### DIFF
--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -46,6 +46,7 @@ export const InputFieldMixin = (superclass) =>
          */
         autocapitalize: {
           type: String,
+          reflectToAttribute: true,
         },
 
         /**

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -71,6 +71,53 @@ describe('input-field-mixin', () => {
     });
   });
 
+  describe('attributes', () => {
+    describe('autocomplete', () => {
+      beforeEach(() => {
+        element = fixtureSync(`<input-field-mixin-element autocomplete="on"></input-field-mixin-element>`);
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should set autocomplete property on the host element', () => {
+        expect(element.autocomplete).to.equal('on');
+      });
+
+      it('should propagate autocomplete attribute to the input', () => {
+        expect(input.autocomplete).to.equal('on');
+      });
+    });
+
+    describe('autocorrect', () => {
+      beforeEach(() => {
+        element = fixtureSync(`<input-field-mixin-element autocorrect="on"></input-field-mixin-element>`);
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should set autocorrect property on the host element', () => {
+        expect(element.autocorrect).to.equal('on');
+      });
+
+      it('should propagate autocorrect attribute to the input', () => {
+        expect(input.getAttribute('autocorrect')).to.equal('on');
+      });
+    });
+
+    describe('autocapitalize', () => {
+      beforeEach(() => {
+        element = fixtureSync(`<input-field-mixin-element autocapitalize="characters"></input-field-mixin-element>`);
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should set autocapitalize property on the host element', () => {
+        expect(element.autocapitalize).to.equal('characters');
+      });
+
+      it('should propagate autocapitalize attribute to the input', () => {
+        expect(input.getAttribute('autocapitalize')).to.equal('characters');
+      });
+    });
+  });
+
   describe('validation', () => {
     beforeEach(() => {
       element = fixtureSync('<input-field-mixin-element></input-field-mixin-element>');


### PR DESCRIPTION
## Description

Manual cherry-pick of #5175 to `22.0` branch. 
The automated cherry-pick failed because of conflicts lack of Lit tests on this branch, as well as login snapshots.

## Type of change

- Cherry-pick