### PR TITLE
docs: remove incorrect usage of DisabledMixin types

### DIFF
--- a/packages/field-base/src/input-constraints-mixin.d.ts
+++ b/packages/field-base/src/input-constraints-mixin.d.ts
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
-import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import type { DelegateStateMixinClass } from './delegate-state-mixin.js';
 import type { InputMixinClass } from './input-mixin.js';
 import type { ValidateMixinClass } from './validate-mixin.js';
@@ -15,7 +14,6 @@ import type { ValidateMixinClass } from './validate-mixin.js';
 export declare function InputConstraintsMixin<T extends Constructor<HTMLElement>>(
   base: T,
 ): Constructor<DelegateStateMixinClass> &
-  Constructor<DisabledMixinClass> &
   Constructor<InputConstraintsMixinClass> &
   Constructor<InputMixinClass> &
   Constructor<ValidateMixinClass> &

--- a/packages/field-base/src/pattern-mixin.d.ts
+++ b/packages/field-base/src/pattern-mixin.d.ts
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
-import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import type { DelegateStateMixinClass } from './delegate-state-mixin.js';
 import type { InputConstraintsMixinClass } from './input-constraints-mixin.js';
 import type { InputMixinClass } from './input-mixin.js';
@@ -16,7 +15,6 @@ import type { ValidateMixinClass } from './validate-mixin.js';
 export declare function PatternMixin<T extends Constructor<HTMLElement>>(
   base: T,
 ): Constructor<DelegateStateMixinClass> &
-  Constructor<DisabledMixinClass> &
   Constructor<InputConstraintsMixinClass> &
   Constructor<InputMixinClass> &
   Constructor<PatternMixinClass> &


### PR DESCRIPTION
## Description

For some reason, most likely due to copy-paste, `DisabledMixin` is used in typings of mixins that don't apply it internally.
Updated `PatternMixin` and `InputConstraintsMixin` types accordingly. This doesn't affect actual components.

## Type of change

- Documentation