### PR TITLE
docs: fix details and accordion-panel mixins JSDoc

### DIFF
--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -67,6 +67,13 @@ class ContentController extends SlotObserveController {
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ *
+ * @extends HTMLElement
+ * @mixes ControllerMixin
+ * @mixes DetailsMixin
+ * @mixes DelegateFocusMixin
+ * @mixes DelegateStateMixin
+ * @mixes ThemableMixin
  */
 class AccordionPanel extends DetailsMixin(
   DelegateFocusMixin(DelegateStateMixin(ThemableMixin(ControllerMixin(PolymerElement)))),

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -89,6 +89,7 @@ class ContentController extends SlotObserveController {
  * @mixes DetailsMixin
  * @mixes DelegateFocusMixin
  * @mixes DelegateStateMixin
+ * @mixes ElementMixin
  * @mixes ThemableMixin
  */
 class Details extends DetailsMixin(

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -86,9 +86,9 @@ class ContentController extends SlotObserveController {
  *
  * @extends HTMLElement
  * @mixes ControllerMixin
+ * @mixes DetailsMixin
  * @mixes DelegateFocusMixin
  * @mixes DelegateStateMixin
- * @mixes ElementMixin
  * @mixes ThemableMixin
  */
 class Details extends DetailsMixin(


### PR DESCRIPTION
## Description

This PR improves API documentation for `vaadin-details` and `vaadin-accordion-panel`, see comparison below.

## Type of change

- Documentation

## Comparison

### `<vaadin-details>`

Added missing `DetailsMixin` with `opened` property.

<details>
<summary>Before</summary>

![details-before](https://user-images.githubusercontent.com/10589913/209844123-bb5187e7-4867-48a1-9180-47c4d9b84471.png)

</details>

<details>
<summary>After</summary>

![details-after](https://user-images.githubusercontent.com/10589913/209844187-86bd5ce9-3d90-4e58-90d4-4c15ee39ca18.png)

</details>

### `<vaadin-accordion-panel>`

Added JSDoc for all the mixins - this is needed because `AccordionPanel` no longer extends `Details`.

<details>
<summary>Before</summary>

![accordion-panel-before](https://user-images.githubusercontent.com/10589913/209845694-7084e62b-5896-4ab1-83c5-1e7e07bc385b.png)

</details>

<details>
<summary>After</summary>

![accordion-panel-after](https://user-images.githubusercontent.com/10589913/209845705-8411fc5d-4d5c-4c70-8faa-1281111c329b.png)

</details>