### PR TITLE
refactor: avoid logical assignment operator to not break API docs

### DIFF
--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -549,12 +549,10 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     deepMerge(options, this.additionalOptions);
 
     if (this.type) {
-      options.chart ||= {};
       options.chart.type = this.type;
     }
 
     if (this.polar) {
-      options.chart ||= {};
       options.chart.polar = true;
     }
 
@@ -579,7 +577,6 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (this.categories) {
-      options.xAxis ||= {};
       if (Array.isArray(options.xAxis)) {
         // Set categories on first X axis
         options.xAxis[0].categories = this.categories;
@@ -589,7 +586,6 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (isFinite(this.categoryMin)) {
-      options.xAxis ||= {};
       if (Array.isArray(options.xAxis)) {
         // Set category-min on first X axis
         options.xAxis[0].min = this.categoryMin;
@@ -599,7 +595,6 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (isFinite(this.categoryMax)) {
-      options.xAxis ||= {};
       if (Array.isArray(options.xAxis)) {
         // Set category-max on first x axis
         options.xAxis[0].max = this.categoryMax;
@@ -615,13 +610,13 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (this.emptyText) {
-      options.lang ||= {};
+      if (!options.lang) {
+        options.lang = {};
+      }
       options.lang.noData = this.emptyText;
     }
 
     if (this.categoryPosition) {
-      options.chart ||= {};
-
       options.chart.inverted = this.__shouldInvert();
 
       if (Array.isArray(options.xAxis)) {
@@ -634,14 +629,16 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
     }
 
     if (this.stacking) {
-      options.plotOptions ||= {};
-      options.plotOptions.series ||= {};
+      if (!options.plotOptions) {
+        options.plotOptions = {};
+      }
+      if (!options.plotOptions.series) {
+        options.plotOptions.series = {};
+      }
       options.plotOptions.series.stacking = this.stacking;
     }
 
     if (this.chart3d) {
-      options.chart ||= {};
-
       options.chart.options3d = { ...this._baseChart3d, ...options.chart.options3d };
     }
 
@@ -1372,7 +1369,9 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
     path = path.split('.');
     return path.reduce((obj, key) => {
-      obj[key] ||= {};
+      if (!obj[key]) {
+        obj[key] = {};
+      }
       return obj[key];
     }, object);
   }

--- a/packages/component-base/src/element-mixin.js
+++ b/packages/component-base/src/element-mixin.js
@@ -15,14 +15,20 @@ import { DirMixin } from './dir-mixin.js';
 // for buttons that are based on `[role=button]` e.g vaadin-button.
 setCancelSyntheticClickEvents(false);
 
-window.Vaadin ||= {};
+if (!window.Vaadin) {
+  window.Vaadin = {};
+}
 
 /**
  * Array of Vaadin custom element classes that have been finalized.
  */
-window.Vaadin.registrations ||= [];
+if (!window.Vaadin.registrations) {
+  window.Vaadin.registrations = [];
+}
 
-window.Vaadin.developmentModeCallback ||= {};
+if (!window.Vaadin.developmentModeCallback) {
+  window.Vaadin.developmentModeCallback = {};
+}
 
 window.Vaadin.developmentModeCallback['vaadin-usage-statistics'] = function () {
   usageStatistics();

--- a/packages/component-base/src/iron-list-core.js
+++ b/packages/component-base/src/iron-list-core.js
@@ -491,9 +491,12 @@ export const ironList = {
       this._physicalIndexForKey = {};
       this._firstVisibleIndexVal = null;
       this._lastVisibleIndexVal = null;
-      this._physicalCount ||= 0;
-      this._physicalItems ||= [];
-      this._physicalSizes ||= [];
+      if (!this._physicalItems) {
+        this._physicalItems = [];
+      }
+      if (!this._physicalSizes) {
+        this._physicalSizes = [];
+      }
       this._physicalStart = 0;
       if (this._scrollTop > this._scrollOffset) {
         this._resetScrollPosition(0);
@@ -740,7 +743,9 @@ export const ironList = {
   },
 
   _debounce(name, cb, asyncModule) {
-    this._debouncers ||= {};
+    if (!this._debouncers) {
+      this._debouncers = {};
+    }
     this._debouncers[name] = Debouncer.debounce(this._debouncers[name], asyncModule, cb.bind(this));
     enqueueDebouncer(this._debouncers[name]);
   },

--- a/packages/component-base/src/iron-list-core.js
+++ b/packages/component-base/src/iron-list-core.js
@@ -638,16 +638,21 @@ export const ironList = {
    * @param {boolean=} forceUpdate If true, updates the height no matter what.
    */
   _updateScrollerSize(forceUpdate) {
-    this._estScrollHeight =
+    const estScrollHeight =
       this._physicalBottom +
       Math.max(this._virtualCount - this._physicalCount - this._virtualStart, 0) * this._physicalAverage;
 
-    forceUpdate ||= this._scrollHeight === 0;
-    forceUpdate ||= this._scrollPosition >= this._estScrollHeight - this._physicalSize;
+    this._estScrollHeight = estScrollHeight;
+
     // Amortize height adjustment, so it won't trigger large repaints too often.
-    if (forceUpdate || Math.abs(this._estScrollHeight - this._scrollHeight) >= this._viewportHeight) {
-      this.$.items.style.height = `${this._estScrollHeight}px`;
-      this._scrollHeight = this._estScrollHeight;
+    if (
+      forceUpdate ||
+      this._scrollHeight === 0 ||
+      this._scrollPosition >= estScrollHeight - this._physicalSize ||
+      Math.abs(estScrollHeight - this._scrollHeight) >= this._viewportHeight
+    ) {
+      this.$.items.style.height = `${estScrollHeight}px`;
+      this._scrollHeight = estScrollHeight;
     }
   },
 

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -10,7 +10,9 @@ const caseMap = {};
 const CAMEL_TO_DASH = /([A-Z])/gu;
 
 function camelToDash(camel) {
-  caseMap[camel] ||= camel.replace(CAMEL_TO_DASH, '-$1').toLowerCase();
+  if (!caseMap[camel]) {
+    caseMap[camel] = camel.replace(CAMEL_TO_DASH, '-$1').toLowerCase();
+  }
   return caseMap[camel];
 }
 
@@ -169,7 +171,10 @@ const PolylitMixinImplementation = (superclass) => {
     firstUpdated() {
       super.firstUpdated();
 
-      this.$ ||= {};
+      if (!this.$) {
+        this.$ = {};
+      }
+
       this.shadowRoot.querySelectorAll('[id]').forEach((node) => {
         this.$[node.id] = node;
       });

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -376,7 +376,9 @@ export class IronListAdapter {
       deltaY *= this._scrollPageHeight;
     }
 
-    this._deltaYAcc ||= 0;
+    if (!this._deltaYAcc) {
+      this._deltaYAcc = 0;
+    }
 
     if (this._wheelAnimationFrame) {
       // Accumulate wheel delta while a frame is being processed

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -644,7 +644,10 @@ class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(Po
     const initialPosition = this._monthScroller.position;
 
     const smoothScroll = (timestamp) => {
-      start ||= timestamp;
+      if (!start) {
+        start = timestamp;
+      }
+
       const currentTime = timestamp - start;
 
       if (currentTime < this.scrollDuration) {

--- a/packages/date-picker/test/common.js
+++ b/packages/date-picker/test/common.js
@@ -106,9 +106,8 @@ export function monthsEqual(date1, date2) {
   return date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth();
 }
 
-export function getFirstVisibleItem(scroller, bufferOffset) {
+export function getFirstVisibleItem(scroller, bufferOffset = 0) {
   const children = [];
-  bufferOffset ||= 0;
 
   scroller._buffers.forEach((buffer) => {
     [...buffer.children].forEach((slot) => {

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -468,8 +468,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   }
 
   /** @private */
-  __syncI18n(target, source, props) {
-    props ||= Object.keys(source.i18n);
+  __syncI18n(target, source, props = Object.keys(source.i18n)) {
     props.forEach((prop) => {
       // eslint-disable-next-line no-prototype-builtins
       if (source.i18n && source.i18n.hasOwnProperty(prop)) {

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -130,24 +130,24 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
       this._updateFlexAndWidth();
     }
 
-    if (path === 'frozen') {
-      // Don’t unfreeze the frozen group because of a non-frozen child
-      this.frozen ||= value;
+    // Don’t unfreeze the frozen group because of a non-frozen child
+    if (path === 'frozen' && !this.frozen) {
+      this.frozen = value;
     }
 
-    if (path === 'lastFrozen') {
-      // Don’t unfreeze the frozen group because of a non-frozen child
-      this._lastFrozen ||= value;
+    // Don’t unfreeze the frozen group because of a non-frozen child
+    if (path === 'lastFrozen' && !this._lastFrozen) {
+      this._lastFrozen = value;
     }
 
-    if (path === 'frozenToEnd') {
-      // Don’t unfreeze the frozen group because of a non-frozen child
-      this.frozenToEnd ||= value;
+    // Don’t unfreeze the frozen group because of a non-frozen child
+    if (path === 'frozenToEnd' && !this.frozenToEnd) {
+      this.frozenToEnd = value;
     }
 
-    if (path === 'firstFrozenToEnd') {
-      // Don’t unfreeze the frozen group because of a non-frozen child
-      this._firstFrozenToEnd ||= value;
+    // Don’t unfreeze the frozen group because of a non-frozen child
+    if (path === 'firstFrozenToEnd' && !this._firstFrozenToEnd) {
+      this._firstFrozenToEnd = value;
     }
   }
 

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -224,9 +224,7 @@ export const ColumnReorderingMixin = (superClass) =>
      * @return {HTMLElement | undefined}
      * @protected
      */
-    _cellFromPoint(x, y) {
-      x ||= 0;
-      y ||= 0;
+    _cellFromPoint(x = 0, y = 0) {
       if (!this._draggedColumn) {
         this.$.scroller.toggleAttribute('no-content-pointer-events', true);
       }

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -824,7 +824,9 @@ class Grid extends ElementMixin(
 
         if (section === 'body') {
           // Body
-          column._cells ||= [];
+          if (!column._cells) {
+            column._cells = [];
+          }
           cell = column._cells.find((cell) => cell._vacant);
           if (!cell) {
             cell = this._createCell('td', column);
@@ -835,7 +837,9 @@ class Grid extends ElementMixin(
 
           if (index === cols.length - 1 && this.rowDetailsRenderer) {
             // Add details cell as last cell to body rows
-            this._detailsCells ||= [];
+            if (!this._detailsCells) {
+              this._detailsCells = [];
+            }
             const detailsCell = this._detailsCells.find((cell) => cell._vacant) || this._createCell('td');
             if (this._detailsCells.indexOf(detailsCell) === -1) {
               this._detailsCells.push(detailsCell);
@@ -861,7 +865,9 @@ class Grid extends ElementMixin(
             row.appendChild(cell);
             column[`_${section}Cell`] = cell;
           } else {
-            column._emptyCells ||= [];
+            if (!column._emptyCells) {
+              column._emptyCells = [];
+            }
             cell = column._emptyCells.find((cell) => cell._vacant) || this._createCell(tagName);
             cell._column = column;
             row.appendChild(cell);

--- a/packages/icon/src/vaadin-iconset.js
+++ b/packages/icon/src/vaadin-iconset.js
@@ -81,7 +81,9 @@ class Iconset extends ElementMixin(PolymerElement) {
   applyIcon(name) {
     // Create the icon map on-demand, since the iconset itself has no discrete
     // signal to know when it's children are fully parsed
-    this._icons ||= this.__createIconMap();
+    if (!this._icons) {
+      this._icons = this.__createIconMap();
+    }
     const icon = this._icons[this.__getIconId(name)];
     return {
       svg: cloneSvgNode(icon),

--- a/packages/polymer-legacy-adapter/src/style-modules.js
+++ b/packages/polymer-legacy-adapter/src/style-modules.js
@@ -107,7 +107,10 @@ function getAllThemes() {
   });
 }
 
-window.Vaadin ||= {};
+if (!window.Vaadin) {
+  window.Vaadin = {};
+}
+
 window.Vaadin.styleModules = {
   getAllThemes,
   registerStyles,

--- a/packages/polymer-legacy-adapter/src/style-modules.js
+++ b/packages/polymer-legacy-adapter/src/style-modules.js
@@ -97,7 +97,9 @@ function getAllThemes() {
     /** @type {DomModuleWithCachedStyles} */
     const module = modules[moduleId];
     const themeFor = module.getAttribute('theme-for');
-    module.__allStyles ||= getModuleStyles(module).concat(module.__partialStyles || []);
+    if (!module.__allStyles) {
+      module.__allStyles = getModuleStyles(module).concat(module.__partialStyles || []);
+    }
 
     return {
       themeFor,

--- a/packages/polymer-legacy-adapter/src/template-renderer.js
+++ b/packages/polymer-legacy-adapter/src/template-renderer.js
@@ -123,7 +123,10 @@ function observeTemplates(component) {
 /**
  * Public API
  */
-window.Vaadin ||= {};
+if (!window.Vaadin) {
+  window.Vaadin = {};
+}
+
 window.Vaadin.templateRendererCallback = (component) => {
   processTemplates(component);
   observeTemplates(component);

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -243,7 +243,9 @@ class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableM
       const panel = panels.find((panel) => panel.getAttribute('tab') === tabItem.id);
       if (panel) {
         panel.role = 'tabpanel';
-        panel.id ||= `tabsheet-panel-${generateUniqueId()}`;
+        if (!panel.id) {
+          panel.id = `tabsheet-panel-${generateUniqueId()}`;
+        }
         panel.setAttribute('aria-labelledby', tabItem.id);
 
         tabItem.setAttribute('aria-controls', panel.id);

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -560,7 +560,9 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     const generatedList = [];
 
     // Default step in overlay items is 1 hour
-    step ||= 3600;
+    if (!step) {
+      step = 3600;
+    }
 
     let time = -step + minSec;
     while (time + step >= minSec && time + step <= maxSec) {

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -679,11 +679,10 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
    *
    * @param {!UploadFile | !Array<!UploadFile>=} files - Files being uploaded. Defaults to all outstanding files
    */
-  uploadFiles(files) {
+  uploadFiles(files = this.files) {
     if (files && !Array.isArray(files)) {
       files = [files];
     }
-    files ||= this.files;
     files = files.filter((file) => !file.complete);
     Array.prototype.forEach.call(files, this._uploadFile.bind(this));
   }


### PR DESCRIPTION
## Description

This PR fixes a regression from #5133 that caused API docs to contain internal Polymer properties and methods:

- alpha6: https://cdn.vaadin.com/vaadin-web-components/24.0.0-alpha6/
- alpha7: https://cdn.vaadin.com/vaadin-web-components/24.0.0-alpha7/

The problem seems to be caused by the fact that `polymer-analyzer` fails to parse JS using `||=` syntax.
So it uses `ElementMixin` from Polymer instead of the `ElementMixin` from `@vaadin/component-base`.

## Type of change

- Documentation