### PR TITLE
refactor: extract duplicate internal methods to helpers

### DIFF
--- a/packages/crud/src/vaadin-crud-form.js
+++ b/packages/crud/src/vaadin-crud-form.js
@@ -10,6 +10,7 @@
  */
 import '@vaadin/text-field/src/vaadin-text-field.js';
 import { FormLayout } from '@vaadin/form-layout/src/vaadin-form-layout.js';
+import { capitalize } from './vaadin-crud-helpers.js';
 import { IncludedMixin } from './vaadin-crud-include-mixin.js';
 
 /**
@@ -62,7 +63,7 @@ class CrudForm extends IncludedMixin(FormLayout) {
   /** @private */
   __createField(parent, path) {
     const field = document.createElement('vaadin-text-field');
-    field.label = this.__capitalize(path);
+    field.label = capitalize(path);
     field.path = path;
     field.required = true;
     parent.appendChild(field);
@@ -85,29 +86,6 @@ class CrudForm extends IncludedMixin(FormLayout) {
     });
     if (!this._fields.length) {
       this._fields = undefined;
-    }
-  }
-
-  /** @private */
-  __capitalize(path) {
-    return path
-      .toLowerCase()
-      .replace(/([^\w]+)/gu, ' ')
-      .trim()
-      .replace(/^./u, (c) => c.toUpperCase());
-  }
-
-  /** @private */
-  __set(path, val, obj) {
-    if (obj && path) {
-      path
-        .split('.')
-        .slice(0, -1)
-        .reduce((o, p) => {
-          o[p] ||= {};
-          return o[p];
-        }, obj);
-      this.set(path, val, obj);
     }
   }
 }

--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -14,6 +14,7 @@ import '@vaadin/grid/src/vaadin-grid-sorter.js';
 import '@vaadin/grid/src/vaadin-grid-filter.js';
 import './vaadin-crud-edit-column.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
+import { capitalize, getProperty } from './vaadin-crud-helpers.js';
 import { IncludedMixin } from './vaadin-crud-include-mixin.js';
 
 /**
@@ -169,7 +170,7 @@ class CrudGrid extends IncludedMixin(Grid) {
       col = document.createElement('vaadin-grid-column');
       parent.appendChild(col);
       col.renderer = (root, _column, model) => {
-        root.textContent = path ? this.get(path, model.item) : model.item;
+        root.textContent = path ? getProperty(path, model.item) : model.item;
       };
     }
 
@@ -267,33 +268,10 @@ class CrudGrid extends IncludedMixin(Grid) {
   __createGroup(parent, header) {
     const grp = document.createElement('vaadin-grid-column-group');
     if (header) {
-      grp.header = this.__capitalize(header);
+      grp.header = capitalize(header);
     }
     parent.appendChild(grp);
     return grp;
-  }
-
-  /** @private */
-  __capitalize(path) {
-    return path
-      .toLowerCase()
-      .replace(/([^\w]+)/gu, ' ')
-      .trim()
-      .replace(/^./u, (c) => c.toUpperCase());
-  }
-
-  /** @private */
-  __set(path, val, obj) {
-    if (obj && path) {
-      path
-        .split('.')
-        .slice(0, -1)
-        .reduce((o, p) => {
-          o[p] ||= {};
-          return o[p];
-        }, obj);
-      this.set(path, val, obj);
-    }
   }
 }
 

--- a/packages/crud/src/vaadin-crud-helpers.d.ts
+++ b/packages/crud/src/vaadin-crud-helpers.d.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2022 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+
+/**
+ * Convenience utility for capitalizing a string, with
+ * replacing non-alphanumeric characters with spaces.
+ */
+export function capitalize(path: string): string;
+
+/**
+ * Convenience method for reading a value from a path.
+ */
+export function getProperty(path: string, obj: Record<string, unknown>): unknown;
+
+/**
+ * Convenience utility for setting a value to a path.
+ *
+ * Note, if any part in the path is undefined, this
+ * function initializes it with an empty object.
+ */
+export function setProperty(path: string, value: unknown, obj: Record<string, unknown>): void;

--- a/packages/crud/src/vaadin-crud-helpers.js
+++ b/packages/crud/src/vaadin-crud-helpers.js
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2022 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import { get, set } from '@polymer/polymer/lib/utils/path.js';
+
+/**
+ * Convenience utility for capitalizing a string, with
+ * replacing non-alphanumeric characters with spaces.
+ *
+ * @param {string} path
+ * @return {string}
+ */
+export function capitalize(path) {
+  return path
+    .toLowerCase()
+    .replace(/([^\w]+)/gu, ' ')
+    .trim()
+    .replace(/^./u, (c) => c.toUpperCase());
+}
+
+/**
+ * Convenience utility for reading a value from a path.
+ *
+ * @param {string} path
+ * @param {Object} obj
+ * @return {*}
+ */
+export function getProperty(path, obj) {
+  return get(obj, path);
+}
+
+/**
+ * Convenience utility for setting a value to a path.
+ *
+ * Note, if any part in the path is undefined, this
+ * function initializes it with an empty object.
+ *
+ * @param {string} path
+ * @param {*} value
+ * @param {Object} obj
+ */
+export function setProperty(path, value, obj) {
+  if (obj && path) {
+    path
+      .split('.')
+      .slice(0, -1)
+      .reduce((o, p) => {
+        // Create an object
+        if (!o[p]) {
+          o[p] = {};
+        }
+        return o[p];
+      }, obj);
+
+    set(obj, path, value);
+  }
+}

--- a/packages/crud/src/vaadin-crud-include-mixin.js
+++ b/packages/crud/src/vaadin-crud-include-mixin.js
@@ -8,6 +8,7 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
+import { setProperty } from './vaadin-crud-helpers.js';
 
 /**
  * @polymerMixin
@@ -56,7 +57,9 @@ export const IncludedMixin = (superClass) =>
         this.include = include ? include.split(/, */u) : undefined;
       } else if (!this._fields && Array.isArray(include)) {
         const item = {};
-        this.include.forEach((path) => this.__set(path, null, item));
+        this.include.forEach((path) => {
+          setProperty(path, null, item);
+        });
         this._configure(item);
       }
     }

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -22,6 +22,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { getProperty, setProperty } from './vaadin-crud-helpers.js';
 
 /**
  * @private
@@ -1171,7 +1172,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       this._fields.forEach((e) => {
         const path = e.path || e.getAttribute('path');
         if (path) {
-          e.value = this.get(path, item);
+          e.value = getProperty(path, item);
         }
       });
 
@@ -1252,7 +1253,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     this._fields.forEach((e) => {
       const path = e.path || e.getAttribute('path');
       if (path) {
-        this.__set(path, e.value, item);
+        setProperty(path, e.value, item);
       }
     });
     const evt = this.dispatchEvent(new CustomEvent('save', { detail: { item }, cancelable: true }));
@@ -1264,7 +1265,9 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
           this.items.push(item);
         }
       } else {
-        this.editedItem ||= {};
+        if (!this.editedItem) {
+          this.editedItem = {};
+        }
         Object.assign(this.editedItem, item);
       }
       this._grid.clearCache();
@@ -1303,23 +1306,6 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       }
       this._grid.clearCache();
       this.__closeEditor();
-    }
-  }
-
-  /**
-   * Utility method for setting nested values in JSON objects but initializing empty keys unless `Polymer.Base.set`
-   * @private
-   */
-  __set(path, val, obj) {
-    if (obj && path) {
-      path
-        .split('.')
-        .slice(0, -1)
-        .reduce((o, p) => {
-          o[p] ||= {};
-          return o[p];
-        }, obj);
-      this.set(path, val, obj);
     }
   }
 

--- a/packages/crud/test/crud-form.test.js
+++ b/packages/crud/test/crud-form.test.js
@@ -113,9 +113,5 @@ describe('crud form', () => {
       expect(crudForm.querySelectorAll('vaadin-text-field')[1].label).to.be.equal('Name last');
       expect(crudForm.querySelectorAll('vaadin-text-field')[2].label).to.be.equal('Role');
     });
-
-    it('should capitalize correctly', () => {
-      expect(crudForm.__capitalize('-aa.bb cc-dd FF')).to.be.equal('Aa bb cc dd ff');
-    });
   });
 });

--- a/packages/crud/test/crud-grid.test.js
+++ b/packages/crud/test/crud-grid.test.js
@@ -191,10 +191,6 @@ describe('crud grid', () => {
           getBodyCellContent(grid, 0, 3).firstElementChild.click();
         });
 
-        it('should capitalize correctly', () => {
-          expect(grid.__capitalize('aa.bb cc-dd FF')).to.be.equal('Aa bb cc dd ff');
-        });
-
         it('should only render one control in a cell', async () => {
           grid.requestContentUpdate();
           await nextRender(grid);

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -210,14 +210,14 @@ describe('crud', () => {
     });
   });
 
-  describe('utils', () => {
-    it('should be possible to set nested properties to an object', () => {
+  describe('helpers', () => {
+    it('should set nested properties to an object with setProperty', () => {
       const o = {};
       setProperty('a.b.c', 'd', o);
       expect(o.a.b.c).to.be.equal('d');
     });
 
-    it('should be possible to get nested properties from an object', () => {
+    it('should get nested properties from an object with getProperty', () => {
       const o = { a: { b: { c: 'd' } } };
       expect(getProperty('a.b.c', o)).to.be.equal('d');
     });

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, change, fire, fixtureSync, listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '../src/vaadin-crud.js';
+import { capitalize, getProperty, setProperty } from '../src/vaadin-crud-helpers.js';
 import { flushGrid, getBodyCellContent } from './helpers.js';
 
 describe('crud', () => {
@@ -209,20 +210,20 @@ describe('crud', () => {
     });
   });
 
-  describe('objects', () => {
-    beforeEach(() => {
-      crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
-    });
-
+  describe('utils', () => {
     it('should be possible to set nested properties to an object', () => {
       const o = {};
-      crud.__set('a.b.c', 'd', o);
+      setProperty('a.b.c', 'd', o);
       expect(o.a.b.c).to.be.equal('d');
     });
 
-    it('should be possible to get nested properties to an object', () => {
+    it('should be possible to get nested properties from an object', () => {
       const o = { a: { b: { c: 'd' } } };
-      expect(crud.get('a.b.c', o)).to.be.equal('d');
+      expect(getProperty('a.b.c', o)).to.be.equal('d');
+    });
+
+    it('should capitalize string and remove non-letter characters', () => {
+      expect(capitalize('-aa.bb cc-dd FF')).to.be.equal('Aa bb cc dd ff');
     });
   });
 


### PR DESCRIPTION
## Description

Moved some common methods to `vaadin-crud-helpers.js` (file name chosen to align with `vaadin-grid-helpers.js`).
Also updated unit tests to actually use these helpers, rather than calling private methods of components 🙈 

Related to #5184 - some changes in this PR include removal of `||=` syntax to ensure `polymer-analyzer` doesn't fail.

## Type of change

- Refactor