### PR TITLE
refactor!: improve logic for setting overlay dimensions

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -142,6 +142,57 @@ class ConfirmDialogDialog extends Dialog {
       ></vaadin-confirm-dialog-overlay>
     `;
   }
+
+  static get properties() {
+    return {
+      /**
+       * Height to be set on the overlay content.
+       */
+      contentHeight: {
+        type: String,
+      },
+
+      /**
+       * Width to be set on the overlay content.
+       */
+      contentWidth: {
+        type: String,
+      },
+
+      /** @private */
+      _overlayElement: {
+        type: Object,
+      },
+    };
+  }
+
+  static get observers() {
+    return [
+      '__updateContentHeight(contentHeight, _overlayElement)',
+      '__updateContentWidth(contentWidth, _overlayElement)',
+    ];
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._overlayElement = this.$.overlay;
+  }
+
+  /** @private */
+  __updateContentHeight(height, overlay) {
+    if (overlay) {
+      overlay.style.setProperty('--_vaadin-confirm-dialog-content-height', height);
+    }
+  }
+
+  /** @private */
+  __updateContentWidth(width, overlay) {
+    if (overlay) {
+      overlay.style.setProperty('--_vaadin-confirm-dialog-content-width', width);
+    }
+  }
 }
 
 customElements.define(ConfirmDialogDialog.is, ConfirmDialogDialog);

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -80,6 +80,8 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
         theme$="[[_theme]]"
         no-close-on-outside-click
         no-close-on-esc="[[noCloseOnEsc]]"
+        content-height="[[_contentHeight]]"
+        content-width="[[_contentWidth]]"
       ></vaadin-confirm-dialog-dialog>
 
       <div hidden>
@@ -263,6 +265,22 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
       _rejectButton: {
         type: Object,
       },
+
+      /**
+       * Height to be set on the overlay content.
+       * @protected
+       */
+      _contentHeight: {
+        type: String,
+      },
+
+      /**
+       * Width to be set on the overlay content.
+       * @protected
+       */
+      _contentWidth: {
+        type: String,
+      },
     };
   }
 
@@ -296,12 +314,6 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
     this._overlayElement.addEventListener('vaadin-overlay-escape-press', this._escPressed.bind(this));
     this._overlayElement.addEventListener('vaadin-overlay-open', () => this.__onDialogOpened());
     this._overlayElement.addEventListener('vaadin-confirm-dialog-close', () => this.__onDialogClosed());
-
-    if (this._dimensions) {
-      Object.keys(this._dimensions).forEach((name) => {
-        this._setDimension(name, this._dimensions[name]);
-      });
-    }
 
     this._headerController = new SlotController(this, 'header', 'h3', {
       initializer: (node) => {
@@ -455,31 +467,6 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
   /** @private */
   _getAriaLabel(header) {
     return header || 'confirmation';
-  }
-
-  /** @private */
-  _setWidth(width) {
-    this._setDimensionIfAttached('width', width);
-  }
-
-  /** @private */
-  _setHeight(height) {
-    this._setDimensionIfAttached('height', height);
-  }
-
-  /** @private */
-  _setDimensionIfAttached(name, value) {
-    if (this._overlayElement) {
-      this._setDimension(name, value);
-    } else {
-      this._dimensions ||= {};
-      this._dimensions[name] = value;
-    }
-  }
-
-  /** @private */
-  _setDimension(name, value) {
-    this._overlayElement.style.setProperty(`--_vaadin-confirm-dialog-content-${name}`, value);
   }
 
   /**

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -467,26 +467,22 @@ describe('vaadin-confirm-dialog', () => {
   });
 
   describe('set width and height', () => {
-    let confirm, overlay, spy;
+    let confirm, overlay;
 
     describe('default', () => {
       beforeEach(async () => {
         confirm = fixtureSync('<vaadin-confirm-dialog opened>Confirmation message</vaadin-confirm-dialog>');
         overlay = confirm.$.dialog.$.overlay;
         await oneEvent(overlay, 'vaadin-overlay-open');
-        spy = sinon.spy(confirm, '_setDimension');
       });
 
       it('should update width after opening the dialog', () => {
-        confirm._setWidth('300px');
-        expect(spy.calledWith('width', '300px')).to.be.true;
+        confirm._contentWidth = '300px';
         expect(getComputedStyle(overlay.$.overlay).width).to.be.equal('300px');
       });
 
       it('should update height after opening the dialog', () => {
-        confirm._setHeight('500px');
-        expect(spy.calledWith('height', '500px')).to.be.true;
-        expect(spy.calledWith('height', '500px')).to.be.true;
+        confirm._contentHeight = '500px';
         expect(getComputedStyle(overlay.$.overlay).height).to.equal('500px');
       });
     });
@@ -495,7 +491,6 @@ describe('vaadin-confirm-dialog', () => {
       beforeEach(() => {
         confirm = document.createElement('vaadin-confirm-dialog');
         confirm.message = 'Message';
-        spy = sinon.spy(confirm, '_setDimension');
       });
 
       afterEach(() => {
@@ -503,22 +498,20 @@ describe('vaadin-confirm-dialog', () => {
       });
 
       it('should update width after opening the dialog', async () => {
-        confirm._setWidth('200px');
+        confirm._contentWidth = '200px';
         document.body.appendChild(confirm);
         overlay = confirm.$.dialog.$.overlay;
         confirm.opened = true;
         await oneEvent(overlay, 'vaadin-overlay-open');
-        expect(spy.calledWith('width', '200px')).to.be.true;
         expect(getComputedStyle(overlay.$.overlay).width).to.be.equal('200px');
       });
 
       it('should update height after opening the dialog', async () => {
-        confirm._setHeight('500px');
+        confirm._contentHeight = '500px';
         document.body.appendChild(confirm);
         overlay = confirm.$.dialog.$.overlay;
         confirm.opened = true;
         await oneEvent(overlay, 'vaadin-overlay-open');
-        expect(spy.calledWith('height', '500px')).to.be.true;
         expect(getComputedStyle(overlay.$.overlay).height).to.equal('500px');
       });
     });


### PR DESCRIPTION
## Description

Closes #430

Changed the logic needed by the Flow counterpart to set [width](https://github.com/vaadin/flow-components/blob/e729f10c3c7c451862110a6dae5a0afb94031727/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java#L125) and [height](https://github.com/vaadin/flow-components/blob/e729f10c3c7c451862110a6dae5a0afb94031727/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java#L148).
Replaced private methods with properties (marked as protected for now).

We could consider making these properties private in a separate PR.

## Type of change

- Refactor