### PR TITLE
refactor: reset style property when setting empty value

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -181,16 +181,27 @@ class ConfirmDialogDialog extends Dialog {
   }
 
   /** @private */
+  __updateDimension(overlay, dimension, value) {
+    const prop = `--_vaadin-confirm-dialog-content-${dimension}`;
+
+    if (value) {
+      overlay.style.setProperty(prop, value);
+    } else {
+      overlay.style.removeProperty(prop);
+    }
+  }
+
+  /** @private */
   __updateContentHeight(height, overlay) {
     if (overlay) {
-      overlay.style.setProperty('--_vaadin-confirm-dialog-content-height', height);
+      this.__updateDimension(overlay, 'height', height);
     }
   }
 
   /** @private */
   __updateContentWidth(width, overlay) {
     if (overlay) {
-      overlay.style.setProperty('--_vaadin-confirm-dialog-content-width', width);
+      this.__updateDimension(overlay, 'width', width);
     }
   }
 }

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -469,6 +469,13 @@ describe('vaadin-confirm-dialog', () => {
   describe('set width and height', () => {
     let confirm, overlay;
 
+    function getStyleValue(element) {
+      return element
+        .getAttribute('style')
+        .split(':')
+        .map((str) => str.trim().replace(';', ''));
+    }
+
     describe('default', () => {
       beforeEach(async () => {
         confirm = fixtureSync('<vaadin-confirm-dialog opened>Confirmation message</vaadin-confirm-dialog>');
@@ -484,6 +491,26 @@ describe('vaadin-confirm-dialog', () => {
       it('should update height after opening the dialog', () => {
         confirm._contentHeight = '500px';
         expect(getComputedStyle(overlay.$.overlay).height).to.equal('500px');
+      });
+
+      it('should reset style after setting width to null', () => {
+        const prop = '--_vaadin-confirm-dialog-content-width';
+
+        confirm._contentWidth = '500px';
+        expect(getStyleValue(overlay)).to.eql([prop, '500px']);
+
+        confirm._contentWidth = null;
+        expect(overlay.getAttribute('style')).to.be.not.ok;
+      });
+
+      it('should reset style after setting height to null', () => {
+        const prop = '--_vaadin-confirm-dialog-content-height';
+
+        confirm._contentHeight = '500px';
+        expect(getStyleValue(overlay)).to.eql([prop, '500px']);
+
+        confirm._contentHeight = null;
+        expect(overlay.getAttribute('style')).to.be.not.ok;
       });
     });
 


### PR DESCRIPTION
## Description

Follow-up to #5187. The logic added in that PR causes the following CSS properties to be set by default:

```
--_vaadin-confirm-dialog-content-height: undefined;
--_vaadin-confirm-dialog-content-width: undefined;
```

While it works as these values are ignored by CSS, let's fix this to avoid setting such falsy values.    

## Type of change

- Refactor