### PR TITLE
refactor: remove no longer used protected property

### DIFF
--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -114,19 +114,6 @@ class AccordionPanel extends DetailsMixin(
     `;
   }
 
-  static get properties() {
-    return {
-      /**
-       * A content element.
-       *
-       * @protected
-       */
-      _collapsible: {
-        type: Object,
-      },
-    };
-  }
-
   static get delegateAttrs() {
     return ['theme'];
   }


### PR DESCRIPTION
## Description

The `_collapsible` property usage was removed in #5109 but the property itself is still there. Let's remove it.

## Type of change

- Refactor