### PR TITLE
refactor: reorganize controllers initialization logic

### DIFF
--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -135,13 +135,30 @@ class AccordionPanel extends DetailsMixin(
     return ['disabled', 'opened'];
   }
 
+  constructor() {
+    super();
+
+    this._summaryController = new SummaryController(this);
+    this._contentController = new ContentController(this);
+    this._tooltipController = new TooltipController(this);
+  }
+
   /** @protected */
   ready() {
     super.ready();
 
-    this._initSummary();
+    this.addController(this._summaryController);
+
+    this.addController(this._tooltipController);
+    this._tooltipController.setTarget(this.focusElement);
+    this._tooltipController.setPosition('bottom-start');
+
     this._initContent();
-    this._initTooltip();
+
+    // Wait for heading element render to complete
+    afterNextRender(this, () => {
+      this._toggleElement = this.focusElement.$.button;
+    });
   }
 
   /**
@@ -156,19 +173,7 @@ class AccordionPanel extends DetailsMixin(
   }
 
   /** @private */
-  _initSummary() {
-    this._summaryController = new SummaryController(this);
-    this.addController(this._summaryController);
-
-    // Wait for heading element render to complete
-    afterNextRender(this, () => {
-      this._toggleElement = this.focusElement.$.button;
-    });
-  }
-
-  /** @private */
   _initContent() {
-    this._contentController = new ContentController(this);
     this._contentController.addEventListener('slot-content-changed', (event) => {
       // Store nodes to toggle `aria-hidden` attribute
       const content = event.target.nodes || [];
@@ -188,15 +193,6 @@ class AccordionPanel extends DetailsMixin(
       }
     });
     this.addController(this._contentController);
-  }
-
-  /** @private */
-  _initTooltip() {
-    this._tooltipController = new TooltipController(this);
-    this.addController(this._tooltipController);
-
-    this._tooltipController.setTarget(this.focusElement);
-    this._tooltipController.setPosition('bottom-start');
   }
 }
 

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -137,13 +137,25 @@ class Details extends DetailsMixin(
     return ['disabled', 'opened'];
   }
 
+  constructor() {
+    super();
+
+    this._summaryController = new SummaryController(this);
+    this._contentController = new ContentController(this);
+    this._tooltipController = new TooltipController(this);
+  }
+
   /** @protected */
   ready() {
     super.ready();
 
-    this._initSummary();
+    this.addController(this._summaryController);
+
+    this.addController(this._tooltipController);
+    this._tooltipController.setTarget(this._toggleElement);
+    this._tooltipController.setPosition('bottom-start');
+
     this._initContent();
-    this._initTooltip();
   }
 
   /**
@@ -158,14 +170,7 @@ class Details extends DetailsMixin(
   }
 
   /** @private */
-  _initSummary() {
-    this._summaryController = new SummaryController(this);
-    this.addController(this._summaryController);
-  }
-
-  /** @private */
   _initContent() {
-    this._contentController = new ContentController(this);
     this._contentController.addEventListener('slot-content-changed', (event) => {
       // Store nodes to toggle `aria-hidden` attribute
       const { nodes } = event.target;
@@ -178,15 +183,6 @@ class Details extends DetailsMixin(
       }
     });
     this.addController(this._contentController);
-  }
-
-  /** @private */
-  _initTooltip() {
-    this._tooltipController = new TooltipController(this);
-    this.addController(this._tooltipController);
-
-    this._tooltipController.setTarget(this._toggleElement);
-    this._tooltipController.setPosition('bottom-start');
   }
 }
 


### PR DESCRIPTION
## Description

Extracted from #5164 to make that PR diff smaller, as this change makes sense on its own:

- Controllers are now created in `constructor` as e.g. in mixins,
- Controllers are added in the correct order in `ready` callback.

## Type of change

- Refactor