### PR TITLE
refactor: remove not needed override in LabelController

### DIFF
--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -70,21 +70,6 @@ export class LabelController extends SlotObserveController {
   }
 
   /**
-   * Override method inherited from `SlotMixin` to observe
-   * the default label node, but not the custom one.
-   *
-   * @param {Node} node
-   * @protected
-   * @override
-   */
-  initNode(node) {
-    if (node === this.defaultNode) {
-      this.updateDefaultNode(node);
-      this.observeNode(node);
-    }
-  }
-
-  /**
    * Override to observe the newly added custom node.
    *
    * @param {Node} node


### PR DESCRIPTION
## Description

Removed the `initNode` override from `LabelController` because it's not needed:

- `updateDefaultNode` is called in `setLabel` after the default `<label>` is created;
- `observeNode` is also triggered from `restoreDefaultNode` called by `setLabel`.

The method was added in the initial version of the controller, but then I refactored it.

## Type of change

- Refactor