### PR TITLE
refactor: rename SlotObserveController to clarify its goal

### DIFF
--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -9,12 +9,12 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
 import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
-import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { DetailsMixin } from '@vaadin/details/src/vaadin-details-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-class SummaryController extends SlotObserveController {
+class SummaryController extends SlotChildObserveController {
   constructor(host) {
     super(host, 'summary', 'vaadin-accordion-heading', {
       initializer: (node, host) => {

--- a/packages/component-base/src/slot-child-observe-controller.d.ts
+++ b/packages/component-base/src/slot-child-observe-controller.d.ts
@@ -9,7 +9,7 @@ import { SlotController } from './slot-controller.js';
  * A controller that observes slotted element mutations, especially ID attribute
  * and the text content, and fires an event to notify host element about those.
  */
-export class SlotObserveController extends SlotController {
+export class SlotChildObserveController extends SlotController {
   /**
    * Setup the mutation observer on the node to update ID and notify host.
    * Node doesn't get observed automatically until this method is called.

--- a/packages/component-base/src/slot-child-observe-controller.js
+++ b/packages/component-base/src/slot-child-observe-controller.js
@@ -9,7 +9,7 @@ import { SlotController } from './slot-controller.js';
  * A controller that observes slotted element mutations, especially ID attribute
  * and the text content, and fires an event to notify host element about those.
  */
-export class SlotObserveController extends SlotController {
+export class SlotChildObserveController extends SlotController {
   constructor(host, slot, tagName, config = {}) {
     super(host, slot, tagName, { ...config, useUniqueId: true });
   }

--- a/packages/details/src/content-controller.d.ts
+++ b/packages/details/src/content-controller.d.ts
@@ -3,10 +3,9 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-
-import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 
 /**
  * A controller to manage the default content slot.
  */
-export class ContentController extends SlotObserveController {}
+export class ContentController extends SlotChildObserveController {}

--- a/packages/details/src/content-controller.js
+++ b/packages/details/src/content-controller.js
@@ -3,13 +3,12 @@
  * Copyright (c) 2019 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-
-import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 
 /**
  * A controller to manage the default content slot.
  */
-export class ContentController extends SlotObserveController {
+export class ContentController extends SlotChildObserveController {
   /**
    * Override method from `SlotController` to change
    * the ID prefix for the default slot content.

--- a/packages/field-base/src/error-controller.d.ts
+++ b/packages/field-base/src/error-controller.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 
 /**
  * A controller that manages the error message node content.
  */
-export class ErrorController extends SlotObserveController {
+export class ErrorController extends SlotChildObserveController {
   /**
    * String used for the error message text content.
    */

--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -3,12 +3,12 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 
 /**
  * A controller that manages the error message node content.
  */
-export class ErrorController extends SlotObserveController {
+export class ErrorController extends SlotChildObserveController {
   constructor(host) {
     super(host, 'error-message', 'div');
   }
@@ -79,8 +79,8 @@ export class ErrorController extends SlotObserveController {
   }
 
   /**
-   * Override method inherited from `SlotObserveController`
-   * to restore and the default error message element.
+   * Override method inherited from `SlotChildObserveController`
+   * to restore the default error message element.
    *
    * @protected
    * @override
@@ -90,7 +90,7 @@ export class ErrorController extends SlotObserveController {
   }
 
   /**
-   * Override method inherited from `SlotObserveController`
+   * Override method inherited from `SlotChildObserveController`
    * to update the error message text and hidden state.
    *
    * Note: unlike with other controllers, this method is

--- a/packages/field-base/src/helper-controller.d.ts
+++ b/packages/field-base/src/helper-controller.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 
 /**
  * A controller that manages the helper node content.
  */
-export class HelperController extends SlotObserveController {
+export class HelperController extends SlotChildObserveController {
   /**
    * String used for the helper text.
    */

--- a/packages/field-base/src/helper-controller.js
+++ b/packages/field-base/src/helper-controller.js
@@ -3,12 +3,12 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 
 /**
  * A controller that manages the helper node content.
  */
-export class HelperController extends SlotObserveController {
+export class HelperController extends SlotChildObserveController {
   constructor(host) {
     // Do not provide tag name, as we create helper lazily.
     super(host, 'helper', null);
@@ -35,7 +35,7 @@ export class HelperController extends SlotObserveController {
   }
 
   /**
-   * Override method inherited from `SlotObserveController`
+   * Override method inherited from `SlotChildObserveController`
    * to create the default helper element lazily as needed.
    *
    * @param {Node | undefined} node
@@ -57,7 +57,7 @@ export class HelperController extends SlotObserveController {
   }
 
   /**
-   * Override method inherited from `SlotObserveController`
+   * Override method inherited from `SlotChildObserveController`
    * to update the default helper element text content.
    *
    * @param {Node | undefined} node

--- a/packages/field-base/src/label-controller.d.ts
+++ b/packages/field-base/src/label-controller.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 
 /**
  * A controller to manage the label element.
  */
-export class LabelController extends SlotObserveController {
+export class LabelController extends SlotChildObserveController {
   /**
    * String used for the label.
    */

--- a/packages/field-base/src/label-controller.js
+++ b/packages/field-base/src/label-controller.js
@@ -3,12 +3,12 @@
  * Copyright (c) 2021 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotObserveController } from '@vaadin/component-base/src/slot-observe-controller.js';
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 
 /**
  * A controller to manage the label element.
  */
-export class LabelController extends SlotObserveController {
+export class LabelController extends SlotChildObserveController {
   constructor(host) {
     super(host, 'label', 'label');
   }
@@ -34,7 +34,7 @@ export class LabelController extends SlotObserveController {
   }
 
   /**
-   * Override method inherited from `SlotObserveController`
+   * Override method inherited from `SlotChildObserveController`
    * to restore and observe the default label element.
    *
    * @protected
@@ -53,7 +53,7 @@ export class LabelController extends SlotObserveController {
   }
 
   /**
-   * Override method inherited from `SlotObserveController`
+   * Override method inherited from `SlotChildObserveController`
    * to update the default label element text content.
    *
    * @param {Node | undefined} node


### PR DESCRIPTION
## Description

As discussed with @vursen internally, this controller is named incorrectly: it doesn't observe the `<slot>` element itself (that is actually handled by `SlotController`), but the child node added to it. Renamed it to make this clear.

## Type of change

- Refactor