### PR TITLE
refactor: simplify details and accordion toggle logic

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -80,7 +80,7 @@ class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolymerElement
           text-align: inherit;
         }
       </style>
-      <button id="button" part="content" disabled$="[[disabled]]">
+      <button id="button" part="content" disabled$="[[disabled]]" aria-expanded$="[[__updateAriaExpanded(opened)]]">
         <span part="toggle" aria-hidden="true"></span>
         <slot></slot>
       </button>
@@ -120,6 +120,11 @@ class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolymerElement
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'heading');
     }
+  }
+
+  /** @private */
+  __updateAriaExpanded(opened) {
+    return opened ? 'true' : 'false';
   }
 }
 

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './vaadin-accordion-heading.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
@@ -121,11 +120,6 @@ class AccordionPanel extends DetailsMixin(
     this._tooltipController.setPosition('bottom-start');
 
     this._initContent();
-
-    // Wait for heading element render to complete
-    afterNextRender(this, () => {
-      this._toggleElement = this.focusElement.$.button;
-    });
   }
 
   /**

--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -151,7 +151,7 @@ class Accordion extends KeyboardDirectionMixin(ThemableMixin(ElementMixin(Polyme
    * @override
    */
   get focused() {
-    return (this._getItems() || []).find((item) => isElementFocused(item._toggleElement));
+    return (this._getItems() || []).find((item) => isElementFocused(item.focusElement));
   }
 
   /**
@@ -195,9 +195,7 @@ class Accordion extends KeyboardDirectionMixin(ThemableMixin(ElementMixin(Polyme
    */
   _onKeyDown(event) {
     // Only check keyboard events on details toggle buttons
-    const target = event.composedPath()[0];
-
-    if (!this.items.some((item) => item._toggleElement === target)) {
+    if (!this.items.some((item) => item.focusElement === event.target)) {
       return;
     }
 

--- a/packages/accordion/test/accordion.test.js
+++ b/packages/accordion/test/accordion.test.js
@@ -15,7 +15,7 @@ describe('vaadin-accordion', () => {
   let accordion, heading;
 
   function getHeading(idx) {
-    return accordion.items[idx]._toggleElement;
+    return accordion.items[idx].focusElement;
   }
 
   beforeEach(async () => {

--- a/packages/details/src/vaadin-details-mixin.d.ts
+++ b/packages/details/src/vaadin-details-mixin.d.ts
@@ -20,9 +20,4 @@ export declare class DetailsMixinClass {
    * List of elements passed to the details default slot.
    */
   protected _contentElements: HTMLElement[];
-
-  /**
-   * An element used to toggle the content visibility.
-   */
-  protected _toggleElement: HTMLElement;
 }

--- a/packages/details/src/vaadin-details-mixin.js
+++ b/packages/details/src/vaadin-details-mixin.js
@@ -33,28 +33,30 @@ export const DetailsMixin = (superClass) =>
         _contentElements: {
           type: Array,
         },
-
-        /**
-         * An element used to toggle the content visibility.
-         *
-         * @type {!HTMLElement | undefined}
-         * @protected
-         */
-        _toggleElement: {
-          type: Object,
-          observer: '_toggleElementChanged',
-        },
       };
     }
 
     static get observers() {
-      return ['_openedOrToggleChanged(opened, _toggleElement)', '_openedOrContentChanged(opened, _contentElements)'];
+      return ['_openedOrContentChanged(opened, _contentElements)'];
     }
 
     constructor() {
       super();
 
       this._contentController = new ContentController(this);
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      // Only handle click and not keydown, because `vaadin-details-summary` uses `ButtonMixin`
+      // that already covers this logic, and `vaadin-accordion-heading` uses native `<button>`.
+      this.addEventListener('click', (event) => {
+        if (event.target === this.focusElement) {
+          this.opened = !this.opened;
+        }
+      });
     }
 
     /** @private */
@@ -64,28 +66,5 @@ export const DetailsMixin = (superClass) =>
           el.setAttribute('aria-hidden', opened ? 'false' : 'true');
         });
       }
-    }
-
-    /** @private */
-    _openedOrToggleChanged(opened, toggleElement) {
-      if (toggleElement) {
-        toggleElement.setAttribute('aria-expanded', opened ? 'true' : 'false');
-      }
-    }
-
-    /** @private */
-    _toggleElementChanged(toggleElement) {
-      if (toggleElement) {
-        // Only handle click and not keydown, because `vaadin-details-summary` uses `ButtonMixin`
-        // that already covers this logic, and `vaadin-accordion-heading` uses native `<button>`.
-        toggleElement.addEventListener('click', () => {
-          this._toggle();
-        });
-      }
-    }
-
-    /** @private */
-    _toggle() {
-      this.opened = !this.opened;
     }
   };

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -19,7 +19,6 @@ class SummaryController extends SlotController {
     super(host, 'summary', 'vaadin-details-summary', {
       useUniqueId: true,
       initializer: (node, host) => {
-        host._toggleElement = node;
         host._setFocusElement(node);
         host.stateTarget = node;
       },
@@ -109,6 +108,10 @@ class Details extends DetailsMixin(
     return 'vaadin-details';
   }
 
+  static get observers() {
+    return ['__updateAriaExpanded(focusElement, opened)'];
+  }
+
   static get delegateAttrs() {
     return ['theme'];
   }
@@ -131,7 +134,7 @@ class Details extends DetailsMixin(
     this.addController(this._summaryController);
 
     this.addController(this._tooltipController);
-    this._tooltipController.setTarget(this._toggleElement);
+    this._tooltipController.setTarget(this.focusElement);
     this._tooltipController.setPosition('bottom-start');
 
     this._initContent();
@@ -156,12 +159,19 @@ class Details extends DetailsMixin(
       this._contentElements = nodes;
 
       if (nodes[0] && nodes[0].id) {
-        this._toggleElement.setAttribute('aria-controls', nodes[0].id);
+        this.focusElement.setAttribute('aria-controls', nodes[0].id);
       } else {
-        this._toggleElement.removeAttribute('aria-controls');
+        this.focusElement.removeAttribute('aria-controls');
       }
     });
     this.addController(this._contentController);
+  }
+
+  /** @private */
+  __updateAriaExpanded(focusElement, opened) {
+    if (focusElement) {
+      focusElement.setAttribute('aria-expanded', opened ? 'true' : 'false');
+    }
   }
 }
 

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -15,7 +15,7 @@ describe('vaadin-details', () => {
         </div>
       </vaadin-details>
     `);
-    toggle = details._toggleElement;
+    toggle = details.focusElement;
     content = details.shadowRoot.querySelector('[part="content"]');
   });
 


### PR DESCRIPTION
## Description

- Removed usage of `_toggleElement` which is different in case of `vaadin-details` and `vaadin-accordion-panel`;
- Moved logic related to setting `aria-expanded` from `DetailsMixin` to these components that set it differently;
- Removed usage of waiting for Shadow DOM of `vaadin-accordion-heading` inside of `vaadin-accordion-panel`.

## Type of change

- Refactor