### PR TITLE
docs: add private JSDoc annotation to theme classes

### DIFF
--- a/packages/vaadin-lumo-styles/version.js
+++ b/packages/vaadin-lumo-styles/version.js
@@ -3,6 +3,13 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+
+/**
+ * Dummy custom element used for collecting
+ * development time usage statistics.
+ *
+ * @private
+ */
 class Lumo extends HTMLElement {
   static get version() {
     return '24.0.0-alpha8';

--- a/packages/vaadin-material-styles/version.js
+++ b/packages/vaadin-material-styles/version.js
@@ -3,6 +3,13 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+
+/**
+ * Dummy custom element used for collecting
+ * development time usage statistics.
+ *
+ * @private
+ */
 class Material extends HTMLElement {
   static get version() {
     return '24.0.0-alpha8';


### PR DESCRIPTION
## Description

These internal classes should't appear in the API docs, but at least `Lumo` gets listed there, see [24.0.0-alpha8](https://cdn.vaadin.com/vaadin-web-components/24.0.0-alpha8/#/elements/vaadin-lumo-styles) docs.
Added missing JSDoc annotation to clarify the purpose of these elements and exclude them from API.

## Type of change

- Documentation