### PR TITLE
feat: add OverlayClassMixin to forward CSS class names

### DIFF
--- a/packages/component-base/src/overlay-class-mixin.d.ts
+++ b/packages/component-base/src/overlay-class-mixin.d.ts
@@ -18,6 +18,10 @@ export declare class OverlayClassMixinClass {
    * A space-delimited list of CSS class names to set on the overlay element.
    * This property does not affect other CSS class names set manually via JS.
    *
+   * Note, if the CSS class name was set with this property, clearing it will
+   * remove it from the overlay, even if the same class name was also added
+   * manually, e.g. by using `classList.add()` in the `renderer` function.
+   *
    * @attr {string} overlay-class
    */
   overlayClass: string;

--- a/packages/component-base/src/overlay-class-mixin.d.ts
+++ b/packages/component-base/src/overlay-class-mixin.d.ts
@@ -15,8 +15,8 @@ export declare function OverlayClassMixin<T extends Constructor<HTMLElement>>(
 
 export declare class OverlayClassMixinClass {
   /**
-   * Space-separated list of CSS class names to be set on the overlay element.
-   * This property does not affect other CSS class names set manually with JS.
+   * A space-delimited list of CSS class names to set on the overlay element.
+   * This property does not affect other CSS class names set manually via JS.
    *
    * @attr {string} overlay-class
    */

--- a/packages/component-base/src/overlay-class-mixin.d.ts
+++ b/packages/component-base/src/overlay-class-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * Copyright (c) 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';

--- a/packages/component-base/src/overlay-class-mixin.d.ts
+++ b/packages/component-base/src/overlay-class-mixin.d.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+/**
+ * A mixin that forwards CSS class names to the internal overlay element
+ * by setting the `overlayClass` property or `overlay-class` attribute.
+ */
+export declare function OverlayClassMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<OverlayClassMixinClass> & T;
+
+export declare class OverlayClassMixinClass {
+  /**
+   * Space-separated list of CSS class names to be set on the overlay element.
+   * This property does not affect other CSS class names set manually with JS.
+   *
+   * @attr {string} overlay-class
+   */
+  overlayClass: string;
+
+  /**
+   * An overlay element on which CSS class names are set.
+   */
+  protected _overlayElement: HTMLElement;
+}

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -58,21 +58,20 @@ export const OverlayClassMixin = (superclass) =>
         this.__initialClasses = [...overlayElement.classList];
       }
 
-      if (this._previousClasses !== undefined) {
+      if (this.__previousClasses !== undefined) {
         // Remove old classes that no longer apply
-        this._previousClasses.forEach((name) => {
-          if (!this.__initialClasses.includes(name)) {
-            overlayElement.classList.remove(name);
-          }
-        });
+        const classesToRemove = [...this.__previousClasses].filter((name) => !this.__initialClasses.includes(name));
+        if (classesToRemove.length > 0) {
+          overlayElement.classList.remove(...classesToRemove);
+        }
       }
 
       // Add new classes based on the overlayClass
-      const classInfo = typeof overlayClass === 'string' ? overlayClass.split(' ') : [];
-      if (classInfo.length > 0) {
-        overlayElement.classList.add(...classInfo);
+      const classesToAdd = typeof overlayClass === 'string' ? overlayClass.split(' ') : [];
+      if (classesToAdd.length > 0) {
+        overlayElement.classList.add(...classesToAdd);
       }
 
-      this._previousClasses = classInfo;
+      this.__previousClasses = classesToAdd;
     }
   };

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -18,6 +18,10 @@ export const OverlayClassMixin = (superclass) =>
          * A space-delimited list of CSS class names to set on the overlay element.
          * This property does not affect other CSS class names set manually via JS.
          *
+         * Note, if the CSS class name was set with this property, clearing it will
+         * remove it from the overlay, even if the same class name was also added
+         * manually, e.g. by using `classList.add()` in the `renderer` function.
+         *
          * @attr {string} overlay-class
          */
         overlayClass: {

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -69,7 +69,9 @@ export const OverlayClassMixin = (superclass) =>
 
       // Add new classes based on the overlayClass
       const classInfo = typeof overlayClass === 'string' ? overlayClass.split(' ') : [];
-      overlayElement.classList.add(...classInfo);
+      if (classInfo.length > 0) {
+        overlayElement.classList.add(...classInfo);
+      }
 
       this._previousClasses = classInfo;
     }

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -69,9 +69,7 @@ export const OverlayClassMixin = (superclass) =>
 
       // Add new classes based on the overlayClass
       const classInfo = typeof overlayClass === 'string' ? overlayClass.split(' ') : [];
-      classInfo.forEach((name) => {
-        overlayElement.classList.add(name);
-      });
+      overlayElement.classList.add(...classInfo);
 
       this._previousClasses = classInfo;
     }

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -54,22 +54,24 @@ export const OverlayClassMixin = (superclass) =>
         return;
       }
 
+      const { classList } = overlayElement;
+
       if (!this.__initialClasses) {
-        this.__initialClasses = [...overlayElement.classList];
+        this.__initialClasses = new Set(classList);
       }
 
-      if (this.__previousClasses !== undefined) {
+      if (Array.isArray(this.__previousClasses)) {
         // Remove old classes that no longer apply
-        const classesToRemove = [...this.__previousClasses].filter((name) => !this.__initialClasses.includes(name));
+        const classesToRemove = this.__previousClasses.filter((name) => !this.__initialClasses.has(name));
         if (classesToRemove.length > 0) {
-          overlayElement.classList.remove(...classesToRemove);
+          classList.remove(...classesToRemove);
         }
       }
 
       // Add new classes based on the overlayClass
       const classesToAdd = typeof overlayClass === 'string' ? overlayClass.split(' ') : [];
       if (classesToAdd.length > 0) {
-        overlayElement.classList.add(...classesToAdd);
+        classList.add(...classesToAdd);
       }
 
       this.__previousClasses = classesToAdd;

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A mixin that forwards CSS class names to the internal overlay element
+ * by setting the `overlayClass` property or `overlay-class` attribute.
+ *
+ * @polymerMixin
+ */
+export const OverlayClassMixin = (superclass) =>
+  class OverlayClassMixinClass extends superclass {
+    static get properties() {
+      return {
+        /**
+         * Space-separated list of CSS class names to be set on the overlay element.
+         * This property does not affect other CSS class names set manually with JS.
+         *
+         * @attr {string} overlay-class
+         */
+        overlayClass: {
+          type: String,
+        },
+
+        /**
+         * An overlay element on which CSS class names are set.
+         *
+         * @protected
+         */
+        _overlayElement: {
+          type: Object,
+        },
+      };
+    }
+
+    static get observers() {
+      return ['__updateOverlayClassNames(overlayClass, _overlayElement)'];
+    }
+
+    /**
+     * @param {HTMLElement} overlay
+     * @param {string[]} classInfo
+     * @private
+     */
+    __applyClassNames(overlay, classInfo) {
+      classInfo.forEach((name) => {
+        if (!this._customClasses.has(name)) {
+          overlay.classList.add(name);
+        }
+      });
+    }
+
+    /**
+     * @param {HTMLElement} overlay
+     * @param {string[]} classInfo
+     * @private
+     */
+    __clearClassNames(overlay, classInfo) {
+      if (this._previousClasses) {
+        this._previousClasses.forEach((name) => {
+          if (!classInfo.includes(name)) {
+            overlay.classList.remove(name);
+            this._previousClasses.delete(name);
+          }
+        });
+      }
+    }
+
+    /**
+     * @param {HTMLElement} overlay
+     * @param {string[]} classInfo
+     * @private
+     */
+    __storeClassNames(overlay, classInfo) {
+      this._previousClasses = new Set();
+
+      this._customClasses = new Set(overlay.className.split(/\s/u).filter((s) => s !== ''));
+
+      classInfo.forEach((name) => {
+        if (!this._customClasses.has(name)) {
+          this._previousClasses.add(name);
+        }
+      });
+    }
+
+    /** @private */
+    __updateOverlayClassNames(overlayClass, overlayElement) {
+      if (overlayElement) {
+        // Overlay is set but overlayClass is not set
+        if (overlayClass === undefined && this.__oldOverlayClass === undefined) {
+          return;
+        }
+
+        const classInfo = typeof overlayClass === 'string' ? overlayClass.split(' ') : [];
+
+        if (this._previousClasses === undefined) {
+          // Remember custom classes on the first run
+          this.__storeClassNames(overlayElement, classInfo);
+        } else {
+          // Remove old classes that no longer apply
+          this.__clearClassNames(overlayElement, classInfo);
+        }
+
+        // Add new classes based on the overlayClass
+        this.__applyClassNames(overlayElement, classInfo);
+
+        this.__oldOverlayClass = overlayClass;
+      }
+    }
+  };

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -76,7 +76,7 @@ export const OverlayClassMixin = (superclass) =>
     __storeClassNames(overlay, classInfo) {
       this._previousClasses = new Set();
 
-      this._customClasses = new Set(overlay.className.split(/\s/u).filter((s) => s !== ''));
+      this._customClasses = new Set(overlay.className.split(' ').filter((s) => s !== ''));
 
       classInfo.forEach((name) => {
         if (!this._customClasses.has(name)) {

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -15,8 +15,8 @@ export const OverlayClassMixin = (superclass) =>
     static get properties() {
       return {
         /**
-         * Space-separated list of CSS class names to be set on the overlay element.
-         * This property does not affect other CSS class names set manually with JS.
+         * A space-delimited list of CSS class names to set on the overlay element.
+         * This property does not affect other CSS class names set manually via JS.
          *
          * @attr {string} overlay-class
          */

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -39,74 +39,36 @@ export const OverlayClassMixin = (superclass) =>
       return ['__updateOverlayClassNames(overlayClass, _overlayElement)'];
     }
 
-    /**
-     * @param {HTMLElement} overlay
-     * @param {string[]} classInfo
-     * @private
-     */
-    __applyClassNames(overlay, classInfo) {
-      classInfo.forEach((name) => {
-        if (!this._customClasses.has(name)) {
-          overlay.classList.add(name);
-        }
-      });
-    }
+    /** @private */
+    __updateOverlayClassNames(overlayClass, overlayElement) {
+      if (!overlayElement) {
+        return;
+      }
 
-    /**
-     * @param {HTMLElement} overlay
-     * @param {string[]} classInfo
-     * @private
-     */
-    __clearClassNames(overlay, classInfo) {
-      if (this._previousClasses) {
+      // Overlay is set but overlayClass is not set
+      if (overlayClass === undefined) {
+        return;
+      }
+
+      if (!this.__initialClasses) {
+        this.__initialClasses = [...overlayElement.classList];
+      }
+
+      if (this._previousClasses !== undefined) {
+        // Remove old classes that no longer apply
         this._previousClasses.forEach((name) => {
-          if (!classInfo.includes(name)) {
-            overlay.classList.remove(name);
-            this._previousClasses.delete(name);
+          if (!this.__initialClasses.includes(name)) {
+            overlayElement.classList.remove(name);
           }
         });
       }
-    }
 
-    /**
-     * @param {HTMLElement} overlay
-     * @param {string[]} classInfo
-     * @private
-     */
-    __storeClassNames(overlay, classInfo) {
-      this._previousClasses = new Set();
-
-      this._customClasses = new Set(overlay.className.split(' ').filter((s) => s !== ''));
-
+      // Add new classes based on the overlayClass
+      const classInfo = typeof overlayClass === 'string' ? overlayClass.split(' ') : [];
       classInfo.forEach((name) => {
-        if (!this._customClasses.has(name)) {
-          this._previousClasses.add(name);
-        }
+        overlayElement.classList.add(name);
       });
-    }
 
-    /** @private */
-    __updateOverlayClassNames(overlayClass, overlayElement) {
-      if (overlayElement) {
-        // Overlay is set but overlayClass is not set
-        if (overlayClass === undefined && this.__oldOverlayClass === undefined) {
-          return;
-        }
-
-        const classInfo = typeof overlayClass === 'string' ? overlayClass.split(' ') : [];
-
-        if (this._previousClasses === undefined) {
-          // Remember custom classes on the first run
-          this.__storeClassNames(overlayElement, classInfo);
-        } else {
-          // Remove old classes that no longer apply
-          this.__clearClassNames(overlayElement, classInfo);
-        }
-
-        // Add new classes based on the overlayClass
-        this.__applyClassNames(overlayElement, classInfo);
-
-        this.__oldOverlayClass = overlayClass;
-      }
+      this._previousClasses = classInfo;
     }
   };

--- a/packages/component-base/test/overlay-class-mixin.test.js
+++ b/packages/component-base/test/overlay-class-mixin.test.js
@@ -1,0 +1,157 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { OverlayClassMixin } from '../src/overlay-class-mixin.js';
+import { define } from './helpers.js';
+
+const runTests = (baseClass) => {
+  const tag = define[baseClass](
+    'overlay-class-mixin',
+    '<slot name="overlay">',
+    (Base) =>
+      class extends OverlayClassMixin(Base) {
+        ready() {
+          super.ready();
+
+          this._overlayElement = this.querySelector('[slot]');
+        }
+      },
+  );
+
+  let element, overlay;
+
+  describe('default', () => {
+    beforeEach(async () => {
+      element = fixtureSync(`
+        <${tag}>
+          <div slot="overlay"></div>
+        </${tag}>
+      `);
+      await nextRender();
+      overlay = element.querySelector('div');
+    });
+
+    it('should forward class names set using property', async () => {
+      element.overlayClass = 'foo bar';
+      await nextFrame();
+
+      expect(overlay.classList.contains('foo')).to.be.true;
+      expect(overlay.classList.contains('bar')).to.be.true;
+    });
+
+    it('should forward class names set using attribute', async () => {
+      element.setAttribute('overlay-class', 'foo bar');
+      await nextFrame();
+
+      expect(overlay.classList.contains('foo')).to.be.true;
+      expect(overlay.classList.contains('bar')).to.be.true;
+    });
+
+    it('should update class names when property changes', async () => {
+      element.overlayClass = 'foo bar';
+      await nextFrame();
+
+      element.overlayClass = 'foo';
+      await nextFrame();
+
+      expect(overlay.classList.contains('foo')).to.be.true;
+      expect(overlay.classList.contains('bar')).to.be.false;
+    });
+
+    it('should update class names when attribute changes', async () => {
+      element.setAttribute('overlay-class', 'foo bar');
+      await nextFrame();
+
+      element.setAttribute('overlay-class', 'foo');
+      await nextFrame();
+
+      expect(overlay.classList.contains('foo')).to.be.true;
+      expect(overlay.classList.contains('bar')).to.be.false;
+    });
+  });
+
+  describe('custom classes', () => {
+    beforeEach(async () => {
+      element = fixtureSync(`
+        <${tag}>
+          <div slot="overlay" class="qux"></div>
+        </${tag}>
+      `);
+      await nextRender();
+      overlay = element.querySelector('div');
+    });
+
+    it('should not override custom static class using property', async () => {
+      element.overlayClass = 'foo bar';
+      await nextFrame();
+
+      expect(overlay.classList.contains('foo')).to.be.true;
+      expect(overlay.classList.contains('bar')).to.be.true;
+      expect(overlay.classList.contains('qux')).to.be.true;
+    });
+
+    it('should not override custom static class using attribute', async () => {
+      element.setAttribute('overlay-class', 'foo bar');
+      await nextFrame();
+
+      expect(overlay.classList.contains('foo')).to.be.true;
+      expect(overlay.classList.contains('bar')).to.be.true;
+      expect(overlay.classList.contains('qux')).to.be.true;
+    });
+
+    it('should not remove custom static class when clearing property', async () => {
+      element.overlayClass = 'baz qux';
+      await nextFrame();
+
+      element.overlayClass = null;
+      await nextFrame();
+
+      expect(overlay.classList.contains('baz')).to.be.false;
+      expect(overlay.classList.contains('qux')).to.be.true;
+    });
+
+    it('should not remove custom static class when removing attribute', async () => {
+      element.setAttribute('overlay-class', 'baz qux');
+      await nextFrame();
+
+      element.removeAttribute('overlay-class');
+      await nextFrame();
+
+      expect(overlay.classList.contains('baz')).to.be.false;
+      expect(overlay.classList.contains('qux')).to.be.true;
+    });
+
+    it('should not remove custom dynamic class when clearing property', async () => {
+      overlay.classList.add('xyz');
+
+      element.overlayClass = 'abc xyz';
+      await nextFrame();
+
+      element.overlayClass = null;
+      await nextFrame();
+
+      expect(overlay.classList.contains('abc')).to.be.false;
+      expect(overlay.classList.contains('xyz')).to.be.true;
+    });
+
+    it('should not remove custom dynamic class when removing attribute', async () => {
+      overlay.classList.add('xyz');
+
+      element.setAttribute('overlay-class', 'abc xyz');
+      await nextFrame();
+
+      element.removeAttribute('overlay-class');
+      await nextFrame();
+
+      expect(overlay.classList.contains('abc')).to.be.false;
+      expect(overlay.classList.contains('xyz')).to.be.true;
+    });
+  });
+};
+
+describe('OverlayClassMixin + Polymer', () => {
+  runTests('polymer');
+});
+
+describe('OverlayClassMixin + Lit', () => {
+  runTests('lit');
+});


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/3593

Related to #5121

## Type of change

- Feature

## Note

- Implementation is largely copied from Lit [`classMap`](https://github.com/lit/lit/blob/main/packages/lit-html/src/directives/class-map.ts) directive;
- Tests are also inspired by the [`classMap`](https://github.com/lit/lit/blob/main/packages/lit-html/src/test/directives/class-map_test.ts) directive unit tests.