### PR TITLE
fix!: revalidate number fields after bad input is removed (#5138) (CP: 23.2)

### DIFF
--- a/packages/integer-field/test/validation.test.js
+++ b/packages/integer-field/test/validation.test.js
@@ -108,17 +108,28 @@ describe('validation', () => {
       expect(integerField.invalid).to.be.false;
     });
 
-    it('should be invalid when trying to commit a not valid number', async () => {
+    it('should be invalid when trying to commit an invalid number', async () => {
       await sendKeys({ type: '1--' });
       input.blur();
       expect(integerField.invalid).to.be.true;
     });
 
-    it('should set an empty value when trying to commit a not valid number', async () => {
+    it('should set an empty value when trying to commit an invalid number', async () => {
       integerField.value = '1';
       await sendKeys({ type: '1--' });
       await sendKeys({ type: 'Enter' });
       expect(integerField.value).to.equal('');
+    });
+
+    it('should be valid after removing an invalid number', async () => {
+      await sendKeys({ type: '1--' });
+      input.blur();
+      input.focus();
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      input.blur();
+      expect(integerField.invalid).to.be.false;
     });
   });
 });

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -234,17 +234,19 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
   }
 
   /**
-   * Override a method from `InputConstraintsMixin`
-   * to additionally check for bad user input.
+   * Override the method from `InputConstraintsMixin`
+   * to enforce HTML constraint validation even if
+   * the user didn't add any constraints explicitly:
+   * the field has to be regardless checked for bad input.
    *
    * @override
    */
   checkValidity() {
-    if (this.inputElement && this.inputElement.validity.badInput) {
-      return false;
+    if (this.inputElement) {
+      return this.inputElement.checkValidity();
     }
 
-    return super.checkValidity();
+    return !this.invalid;
   }
 
   /** @private */

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -53,15 +53,6 @@ describe('validation', () => {
       expect(field.checkValidity()).to.equal(input.checkValidity());
     });
 
-    it('should not validate when explicitly set to invalid', () => {
-      field.invalid = true;
-
-      expect(field.value).to.be.empty;
-      expect(field.validate()).to.be.false;
-
-      expect(field.invalid).to.be.true;
-    });
-
     it('should allow setting decimals', () => {
       field.value = 7.6;
       expect(field.value).to.be.equal('7.6');
@@ -151,17 +142,28 @@ describe('validation', () => {
       expect(field.invalid).to.be.false;
     });
 
-    it('should be invalid when trying to commit a not valid number', async () => {
+    it('should be invalid when trying to commit an invalid number', async () => {
       await sendKeys({ type: '1--' });
       input.blur();
       expect(field.invalid).to.be.true;
     });
 
-    it('should set an empty value when trying to commit a not valid number', async () => {
+    it('should set an empty value when trying to commit an invalid number', async () => {
       field.value = '1';
       await sendKeys({ type: '1--' });
       await sendKeys({ type: 'Enter' });
       expect(field.value).to.equal('');
+    });
+
+    it('should be valid after removing an invalid number', async () => {
+      await sendKeys({ type: '1--' });
+      input.blur();
+      input.focus();
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Backspace' });
+      input.blur();
+      expect(field.invalid).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

The PR cherry-picks the following fixes to `23.2`:

- https://github.com/vaadin/web-components/pull/5206

> **Warning**
> This is an altering behavior change. The manually set `invalid` flag can get removed once anything triggers number fields to revalidate, even if the developer didn't add any constraints. However, we still do this change because it is actually a proper fix for the bug.

> **Note**
> No conflicts were reported. I had to perform this cherry-pick manually because I added the target label to the original PR too late.

Fixes https://github.com/vaadin/web-components/issues/5138

## Type of change

- [x] Bugfix
