### PR TITLE
docs: use fetch in combo-box dataProvider example

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -148,21 +148,17 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  * needs to be set manually. The total number of items can be returned
  * in the second argument of the data provider callback:__
  *
- * ```javascript
- * comboBox.dataProvider = function(params, callback) {
- *   var url = 'https://api.example/data' +
- *       '?page=' + params.page +        // the requested page index
- *       '&per_page=' + params.pageSize; // number of items on the page
- *   var xhr = new XMLHttpRequest();
- *   xhr.onload = function() {
- *     var response = JSON.parse(xhr.responseText);
- *     callback(
- *       response.employees, // requested page of items
- *       response.totalSize  // total number of items
- *     );
- *   };
- *   xhr.open('GET', url, true);
- *   xhr.send();
+ * ```js
+ * comboBox.dataProvider = async (params, callback) => {
+ *   const API = 'https://demo.vaadin.com/demo-data/1.0/filtered-countries';
+ *   const { filter, page, pageSize } = params;
+ *   const index = page * pageSize;
+ *
+ *   const res = await fetch(`${API}?index=${index}&count=${pageSize}&filter=${filter}`);
+ *   if (res.ok) {
+ *     const { result, size } = await res.json();
+ *     callback(result, size);
+ *   }
  * };
  * ```
  *

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -80,21 +80,17 @@ registerStyles('vaadin-combo-box', inputFieldShared, { moduleId: 'vaadin-combo-b
  * needs to be set manually. The total number of items can be returned
  * in the second argument of the data provider callback:__
  *
- * ```javascript
- * comboBox.dataProvider = function(params, callback) {
- *   var url = 'https://api.example/data' +
- *       '?page=' + params.page +        // the requested page index
- *       '&per_page=' + params.pageSize; // number of items on the page
- *   var xhr = new XMLHttpRequest();
- *   xhr.onload = function() {
- *     var response = JSON.parse(xhr.responseText);
- *     callback(
- *       response.employees, // requested page of items
- *       response.totalSize  // total number of items
- *     );
- *   };
- *   xhr.open('GET', url, true);
- *   xhr.send();
+ * ```js
+ * comboBox.dataProvider = async (params, callback) => {
+ *   const API = 'https://demo.vaadin.com/demo-data/1.0/filtered-countries';
+ *   const { filter, page, pageSize } = params;
+ *   const index = page * pageSize;
+ *
+ *   const res = await fetch(`${API}?index=${index}&count=${pageSize}&filter=${filter}`);
+ *   if (res.ok) {
+ *     const { result, size } = await res.json();
+ *     callback(result, size);
+ *   }
  * };
  * ```
  *


### PR DESCRIPTION
## Description

Updated the code example in `vaadin-combo-box` JSDoc to use example from the dev page with `fetch`.

This fixes the VS Code syntax highlighting which for some reason is broken with the current example:

![Screenshot 2023-01-04 at 12 21 53](https://user-images.githubusercontent.com/10589913/210535816-48f9694f-269f-4df8-8d20-82023de4b451.png)

Also refactored the code snippet to ensure it's fully visible in the API docs without scrolling horizontally:

![Screenshot 2023-01-04 at 12 27 28](https://user-images.githubusercontent.com/10589913/210536129-70e3d146-ccb1-4b70-a698-e68b15330432.png)

## Type of change

- Documentation