### PR TITLE
fix: do not throw on requestContentUpdate before attach

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -369,6 +369,8 @@ class ContextMenu extends ControllerMixin(ElementMixin(ThemePropertyMixin(ItemsM
   ready() {
     super.ready();
 
+    this._overlayElement = this.$.overlay;
+
     this.addController(
       new MediaQueryController(this._wideMediaQuery, (matches) => {
         this._wide = matches;
@@ -480,7 +482,11 @@ class ContextMenu extends ControllerMixin(ElementMixin(ThemePropertyMixin(ItemsM
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
   requestContentUpdate() {
-    this.$.overlay.requestContentUpdate();
+    if (!this._overlayElement || !this.renderer) {
+      return;
+    }
+
+    this._overlayElement.requestContentUpdate();
   }
 
   /** @private */

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -414,6 +414,12 @@ describe('items', () => {
       }).to.throw(Error);
     });
 
+    it('should not call requestContentUpdate', () => {
+      const spy = sinon.spy(rootMenu.$.overlay, 'requestContentUpdate');
+      rootMenu.requestContentUpdate();
+      expect(spy.called).to.be.false;
+    });
+
     it('should not remove the component attributes', () => {
       rootMenu.close();
       const button = document.createElement('button');

--- a/packages/context-menu/test/renderer.test.js
+++ b/packages/context-menu/test/renderer.test.js
@@ -108,4 +108,9 @@ describe('renderer', () => {
 
     expect(menu.$.overlay.textContent.trim()).to.equal('');
   });
+
+  it('should not throw if requestContentUpdate() called before adding to DOM', () => {
+    const contextMenu = document.createElement('vaadin-context-menu');
+    expect(() => contextMenu.requestContentUpdate()).not.to.throw(Error);
+  });
 });


### PR DESCRIPTION
## Description

Updated `requestContentUpdate()` method in `vaadin-context-menu` to apply missing checks that should be there.
Here are relevant conditions that we have in other components, namely `vaadin-notification` and `vaadin-select`:

https://github.com/vaadin/web-components/blob/3c55d6117bb7d378c45098c68516f5ba1efeaf95/packages/notification/src/vaadin-notification.js#L400-L403

https://github.com/vaadin/web-components/blob/3c55d6117bb7d378c45098c68516f5ba1efeaf95/packages/select/src/vaadin-select.js#L369-L372

## Type of change

- Bugfix