### PR TITLE
test: improve context-menu Lit renderer tests formatting

### DIFF
--- a/packages/context-menu/test/lit-renderer-directives.test.js
+++ b/packages/context-menu/test/lit-renderer-directives.test.js
@@ -3,14 +3,16 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
-import { html, render } from 'lit';
+import { html, nothing, render } from 'lit';
 import { contextMenuRenderer } from '../lit.js';
 
 async function renderContextMenu(container, { content }) {
   render(
-    html`<vaadin-context-menu open-on="click" ${content ? contextMenuRenderer(() => html`${content}`, content) : null}>
-      <button>Target</button>
-    </vaadin-context-menu>`,
+    html`
+      <vaadin-context-menu open-on="click" ${content ? contextMenuRenderer(() => html`${content}`, content) : nothing}>
+        <button>Target</button>
+      </vaadin-context-menu>
+    `,
     container,
   );
   await nextFrame();
@@ -59,9 +61,11 @@ describe('lit renderer directives', () => {
       beforeEach(async () => {
         rendererSpy = sinon.spy();
         render(
-          html`<vaadin-context-menu open-on="click" ${contextMenuRenderer(rendererSpy)}>
-            <button></button>
-          </vaadin-context-menu>`,
+          html`
+            <vaadin-context-menu open-on="click" ${contextMenuRenderer(rendererSpy)}>
+              <button></button>
+            </vaadin-context-menu>
+          `,
           container,
         );
         await nextFrame();


### PR DESCRIPTION
## Description

Updated Lit renderer directive tests to improve HTML literals formatting and get rid of the `lit-analyzer` warning:

```
(parameter) content: any
Type 'DirectiveResult<{ prototype: any; new(_partInfo: ChildPartInfo | AttributePartInfo | ElementPartInfo) => Directive; }> | null' is not a Lit 2 directive'lit-plugin(no-incompatible-type-binding)(2304)
```

## Type of change

- Tests