### PR TITLE
refactor: use unique ID in scroller, add snapshot tests

### DIFF
--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -8,6 +8,7 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { isFirefox } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
 /**
  * @extends HTMLElement
@@ -329,8 +330,7 @@ export class InfiniteScroller extends PolymerElement {
         itemWrapper.style.height = `${this.itemHeight}px`;
         itemWrapper.instance = {};
 
-        const contentId = (InfiniteScroller._contentIndex = InfiniteScroller._contentIndex + 1 || 0);
-        const slotName = `vaadin-infinite-scroller-item-content-${contentId}`;
+        const slotName = `vaadin-infinite-scroller-item-content-${generateUniqueId()}`;
 
         const slot = document.createElement('slot');
         slot.setAttribute('name', slotName);

--- a/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
@@ -286,6 +286,350 @@ snapshots["vaadin-date-picker host value"] =
 `;
 /* end snapshot vaadin-date-picker host value */
 
+snapshots["vaadin-date-picker host opened overlay"] = 
+`<vaadin-date-picker-overlay
+  dir="ltr"
+  id="overlay"
+  opened=""
+  restore-focus-on-close=""
+  start-aligned=""
+  top-aligned=""
+>
+  <vaadin-date-picker-overlay-content
+    class="animate"
+    desktop=""
+    role="dialog"
+  >
+    <vaadin-button
+      role="button"
+      slot="today-button"
+      tabindex="0"
+      theme="tertiary"
+    >
+      Today
+    </vaadin-button>
+    <vaadin-button
+      role="button"
+      slot="cancel-button"
+      tabindex="0"
+      theme="tertiary"
+    >
+      Cancel
+    </vaadin-button>
+    <vaadin-date-picker-month-scroller slot="months">
+      <div slot="vaadin-infinite-scroller-item-content-4">
+        <vaadin-month-calendar aria-hidden="true">
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-5">
+        <vaadin-month-calendar aria-hidden="true">
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-6">
+        <vaadin-month-calendar aria-hidden="true">
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-7">
+        <vaadin-month-calendar>
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-8">
+        <vaadin-month-calendar aria-hidden="true">
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-9">
+        <vaadin-month-calendar aria-hidden="true">
+        </vaadin-month-calendar>
+      </div>
+    </vaadin-date-picker-month-scroller>
+    <vaadin-date-picker-year-scroller
+      aria-hidden="true"
+      slot="years"
+    >
+      <div slot="vaadin-infinite-scroller-item-content-10">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-11">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-12">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-13">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-14">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-15">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-16">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-17">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-18">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-19">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-20">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-21">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-22">
+        <vaadin-date-picker-year current="">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-23">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-24">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-25">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-26">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-27">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-28">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-29">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-30">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-31">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-32">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-33">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+    </vaadin-date-picker-year-scroller>
+  </vaadin-date-picker-overlay-content>
+</vaadin-date-picker-overlay>
+`;
+/* end snapshot vaadin-date-picker host opened overlay */
+
+snapshots["vaadin-date-picker host opened overlay theme"] = 
+`<vaadin-date-picker-overlay
+  dir="ltr"
+  id="overlay"
+  opened=""
+  restore-focus-on-close=""
+  start-aligned=""
+  theme="custom"
+  top-aligned=""
+>
+  <vaadin-date-picker-overlay-content
+    class="animate"
+    desktop=""
+    role="dialog"
+    theme="custom"
+  >
+    <vaadin-button
+      role="button"
+      slot="today-button"
+      tabindex="0"
+      theme="tertiary"
+    >
+      Today
+    </vaadin-button>
+    <vaadin-button
+      role="button"
+      slot="cancel-button"
+      tabindex="0"
+      theme="tertiary"
+    >
+      Cancel
+    </vaadin-button>
+    <vaadin-date-picker-month-scroller slot="months">
+      <div slot="vaadin-infinite-scroller-item-content-4">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          theme="custom"
+        >
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-5">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          theme="custom"
+        >
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-6">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          theme="custom"
+        >
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-7">
+        <vaadin-month-calendar theme="custom">
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-8">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          theme="custom"
+        >
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-9">
+        <vaadin-month-calendar
+          aria-hidden="true"
+          theme="custom"
+        >
+        </vaadin-month-calendar>
+      </div>
+    </vaadin-date-picker-month-scroller>
+    <vaadin-date-picker-year-scroller
+      aria-hidden="true"
+      slot="years"
+    >
+      <div slot="vaadin-infinite-scroller-item-content-10">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-11">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-12">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-13">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-14">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-15">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-16">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-17">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-18">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-19">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-20">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-21">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-22">
+        <vaadin-date-picker-year
+          current=""
+          theme="custom"
+        >
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-23">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-24">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-25">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-26">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-27">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-28">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-29">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-30">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-31">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-32">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-33">
+        <vaadin-date-picker-year theme="custom">
+        </vaadin-date-picker-year>
+      </div>
+    </vaadin-date-picker-year-scroller>
+  </vaadin-date-picker-overlay-content>
+</vaadin-date-picker-overlay>
+`;
+/* end snapshot vaadin-date-picker host opened overlay theme */
+
 snapshots["vaadin-date-picker shadow default"] = 
 `<div class="vaadin-date-picker-container">
   <div part="label">

--- a/packages/date-picker/test/dom/date-picker.test.js
+++ b/packages/date-picker/test/dom/date-picker.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-date-picker.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
+import { open } from '../common.js';
 
 describe('vaadin-date-picker', () => {
   let datePicker;
@@ -61,6 +62,27 @@ describe('vaadin-date-picker', () => {
     it('value', async () => {
       datePicker.value = '2000-02-01';
       await expect(datePicker).dom.to.equalSnapshot();
+    });
+
+    describe('opened', () => {
+      const SNAPSHOT_CONFIG = {
+        // Some inline CSS styles related to the overlay's position
+        // may slightly change depending on the environment, so ignore them.
+        ignoreAttributes: ['style'],
+      };
+
+      beforeEach(async () => {
+        await open(datePicker);
+      });
+
+      it('overlay', async () => {
+        await expect(datePicker.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+      });
+
+      it('overlay theme', async () => {
+        datePicker.setAttribute('theme', 'custom');
+        await expect(datePicker.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+      });
     });
   });
 


### PR DESCRIPTION
## Description

- Updated the infinite scroller used by `vaadin-date-picker` to generate unique ID using our helpers,
- Added basic and `theme` attribute propagation snapshot tests for `vaadin-date-picker-overlay`.

## Type of change

- Refactor + Tests

## Note

This is a pre-requisite for adding `overlayClass` as I'm going to cover it with a snapshot test too.