### PR TITLE
test: add missing snapshot tests to vaadin-menu-bar

### DIFF
--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -1,0 +1,93 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["menu-bar basic"] = 
+`<vaadin-menu-bar role="menubar">
+  <vaadin-menu-bar-button
+    role="menuitem"
+    tabindex="0"
+  >
+    Home
+  </vaadin-menu-bar-button>
+  <vaadin-menu-bar-button
+    aria-expanded="false"
+    aria-haspopup="true"
+    role="menuitem"
+    tabindex="0"
+  >
+    Reports
+  </vaadin-menu-bar-button>
+  <vaadin-menu-bar-button
+    aria-disabled="true"
+    disabled=""
+    role="menuitem"
+    tabindex="-1"
+  >
+    Dashboard
+  </vaadin-menu-bar-button>
+  <vaadin-menu-bar-button
+    role="menuitem"
+    tabindex="0"
+  >
+    <vaadin-context-menu-item
+      aria-selected="false"
+      theme="menu-bar-item"
+    >
+      <strong>
+        Help
+      </strong>
+    </vaadin-context-menu-item>
+  </vaadin-menu-bar-button>
+  <vaadin-menu-bar-button
+    aria-expanded="false"
+    aria-haspopup="true"
+    aria-label="More options"
+    hidden=""
+    role="menuitem"
+    slot="overflow"
+    tabindex="0"
+  >
+    <div aria-hidden="true">
+      ···
+    </div>
+  </vaadin-menu-bar-button>
+</vaadin-menu-bar>
+`;
+/* end snapshot menu-bar basic */
+
+snapshots["menu-bar overlay"] = 
+`<vaadin-context-menu-overlay
+  dir="ltr"
+  id="overlay"
+  opened=""
+  right-aligned=""
+  start-aligned=""
+  top-aligned=""
+>
+  <vaadin-context-menu-list-box
+    aria-orientation="vertical"
+    role="list"
+  >
+    <vaadin-context-menu-item
+      aria-haspopup="false"
+      aria-selected="false"
+      role="menuitem"
+      tabindex="0"
+    >
+      View Reports
+    </vaadin-context-menu-item>
+    <vaadin-context-menu-item
+      aria-haspopup="false"
+      aria-selected="false"
+      role="menuitem"
+      tabindex="-1"
+    >
+      Generate Report
+    </vaadin-context-menu-item>
+  </vaadin-context-menu-list-box>
+  <vaadin-menu-bar-submenu hidden="">
+  </vaadin-menu-bar-submenu>
+</vaadin-context-menu-overlay>
+`;
+/* end snapshot menu-bar overlay */
+

--- a/packages/menu-bar/test/dom/menu-bar.test.js
+++ b/packages/menu-bar/test/dom/menu-bar.test.js
@@ -1,0 +1,46 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '../../src/vaadin-menu-bar.js';
+import '../not-animated-styles.js';
+
+describe('menu-bar', () => {
+  let menu;
+
+  const SNAPSHOT_CONFIG = {
+    // Some inline CSS styles related to the overlay's position
+    // may slightly change depending on the environment, so ignore them.
+    ignoreAttributes: ['style'],
+  };
+
+  beforeEach(async () => {
+    menu = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
+    menu.items = [
+      { text: 'Home' },
+      {
+        text: 'Reports',
+        children: [{ text: 'View Reports' }, { text: 'Generate Report' }],
+      },
+      { text: 'Dashboard', disabled: true },
+      {
+        component: (() => {
+          const item = document.createElement('vaadin-context-menu-item');
+          const bold = document.createElement('strong');
+          bold.textContent = 'Help';
+          item.appendChild(bold);
+          return item;
+        })(),
+      },
+    ];
+    await nextRender();
+  });
+
+  it('basic', async () => {
+    await expect(menu).dom.to.equalSnapshot();
+  });
+
+  it('overlay', async () => {
+    menu._buttons[1].click();
+    await nextRender();
+    await expect(menu._subMenu.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});


### PR DESCRIPTION
## Description

Added snapshot tests to `vaadin-menu-bar`. This is a pre-requisite for adding `overlayClass` property. 

## Type of change

- Tests