### PR TITLE
test: add missing typings tests to vaadin-avatar-group

### DIFF
--- a/packages/avatar-group/test/typings/avatar-group.types.ts
+++ b/packages/avatar-group/test/typings/avatar-group.types.ts
@@ -1,0 +1,21 @@
+import '../../vaadin-avatar-group.js';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { AvatarGroupI18n, AvatarGroupItem } from '../../vaadin-avatar-group.js';
+
+const assertType = <TExpected>(value: TExpected) => value;
+
+const group = document.createElement('vaadin-avatar-group');
+
+// Properties
+assertType<AvatarGroupItem[] | undefined>(group.items);
+assertType<number | null | undefined>(group.maxItemsVisible);
+assertType<AvatarGroupI18n>(group.i18n);
+
+// Mixins
+assertType<ControllerMixinClass>(group);
+assertType<ElementMixinClass>(group);
+assertType<ResizeMixinClass>(group);
+assertType<ThemableMixinClass>(group);


### PR DESCRIPTION
## Description

Added missing type definition tests for `avatar-group` package. 
This will be needed when adding `overlayClass` property.

## Type of change

- Tests