### PR TITLE
test: add missing avatar-group overlay snapshot tests

### DIFF
--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -99,3 +99,90 @@ snapshots["vaadin-avatar-group theme"] =
 `;
 /* end snapshot vaadin-avatar-group theme */
 
+snapshots["vaadin-avatar-group opened default"] = 
+`<vaadin-avatar-group aria-label="Currently 4 active users">
+  <vaadin-avatar
+    abbr="AD"
+    name="Abc Def"
+    role="button"
+    tabindex="0"
+    with-tooltip=""
+  >
+    <vaadin-tooltip slot="tooltip">
+    </vaadin-tooltip>
+  </vaadin-avatar>
+  <vaadin-avatar
+    abbr="GJ"
+    name="Ghi Jkl"
+    role="button"
+    tabindex="0"
+    with-tooltip=""
+  >
+    <vaadin-tooltip slot="tooltip">
+    </vaadin-tooltip>
+  </vaadin-avatar>
+  <vaadin-avatar
+    abbr="+2"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    focused=""
+    role="button"
+    slot="overflow"
+    tabindex="0"
+  >
+    <vaadin-tooltip slot="tooltip">
+    </vaadin-tooltip>
+  </vaadin-avatar>
+</vaadin-avatar-group>
+`;
+/* end snapshot vaadin-avatar-group opened default */
+
+snapshots["vaadin-avatar-group opened overlay"] = 
+`<vaadin-avatar-group-overlay
+  dir="ltr"
+  id="overlay"
+  no-vertical-overlap=""
+  start-aligned=""
+  top-aligned=""
+>
+  <vaadin-list-box
+    aria-orientation="vertical"
+    role="listbox"
+  >
+    <vaadin-item
+      aria-selected="false"
+      role="option"
+      tabindex="0"
+      theme="avatar-group-item"
+    >
+      <vaadin-avatar
+        abbr="MP"
+        aria-hidden="true"
+        name="Mno Pqr"
+        role="button"
+        tabindex="-1"
+      >
+      </vaadin-avatar>
+      Mno Pqr
+    </vaadin-item>
+    <vaadin-item
+      aria-selected="false"
+      role="option"
+      tabindex="-1"
+      theme="avatar-group-item"
+    >
+      <vaadin-avatar
+        abbr="SV"
+        aria-hidden="true"
+        name="Stu Vwx"
+        role="button"
+        tabindex="-1"
+      >
+      </vaadin-avatar>
+      Stu Vwx
+    </vaadin-item>
+  </vaadin-list-box>
+</vaadin-avatar-group-overlay>
+`;
+/* end snapshot vaadin-avatar-group opened overlay */
+

--- a/packages/avatar-group/test/dom/avatar-group.test.js
+++ b/packages/avatar-group/test/dom/avatar-group.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-avatar-group.js';
 
 describe('vaadin-avatar-group', () => {
@@ -24,5 +24,29 @@ describe('vaadin-avatar-group', () => {
     await nextFrame();
     group.setAttribute('theme', 'small');
     await expect(group).dom.to.equalSnapshot();
+  });
+
+  describe('opened', () => {
+    const SNAPSHOT_CONFIG = {
+      // Some inline CSS styles related to the overlay's position
+      // may slightly change depending on the environment, so ignore them.
+      ignoreAttributes: ['style'],
+    };
+
+    beforeEach(async () => {
+      group.maxItemsVisible = 3;
+      group.items = [{ name: 'Abc Def' }, { name: 'Ghi Jkl' }, { name: 'Mno Pqr' }, { name: 'Stu Vwx' }];
+      await nextRender();
+      group._overflow.click();
+      await nextRender();
+    });
+
+    it('default', async () => {
+      await expect(group).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
+
+    it('overlay', async () => {
+      await expect(group.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
   });
 });


### PR DESCRIPTION
## Description

Added missing overlay snapshot tests for `vaadin-avatar-group`. 
This will be needed when adding `overlayClass` property.

## Type of change

- Tests