### PR TITLE
fix[combo-box]: Correct aria-setsize placement on scroller

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -239,8 +239,6 @@ export class ComboBoxScroller extends PolymerElement {
     if (this.__virtualizer && items) {
       this.__virtualizer.size = items.length;
       this.__virtualizer.flush();
-      // Ensure the total count of items is properly announced.
-      this.setAttribute('aria-setsize', items.length);
       this.requestContentUpdate();
     }
   }
@@ -305,6 +303,7 @@ export class ComboBoxScroller extends PolymerElement {
     el.setAttribute('role', this.__getAriaRole(index));
     el.setAttribute('aria-selected', this.__getAriaSelected(focusedIndex, index));
     el.setAttribute('aria-posinset', index + 1);
+    el.setAttribute('aria-setsize', this.items.length);
 
     if (this.theme) {
       el.setAttribute('theme', this.theme);

--- a/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
+++ b/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
@@ -330,13 +330,13 @@ snapshots["vaadin-combo-box host opened overlay"] =
   top-aligned=""
 >
   <vaadin-combo-box-scroller
-    aria-setsize="2"
     id="vaadin-combo-box-scroller-3"
     role="listbox"
   >
     <vaadin-combo-box-item
       aria-posinset="1"
       aria-selected="false"
+      aria-setsize="2"
       id="vaadin-combo-box-item-0"
       role="option"
       tabindex="-1"
@@ -346,6 +346,7 @@ snapshots["vaadin-combo-box host opened overlay"] =
     <vaadin-combo-box-item
       aria-posinset="2"
       aria-selected="false"
+      aria-setsize="2"
       id="vaadin-combo-box-item-1"
       role="option"
       tabindex="-1"
@@ -368,13 +369,13 @@ snapshots["vaadin-combo-box host opened overlay class"] =
   top-aligned=""
 >
   <vaadin-combo-box-scroller
-    aria-setsize="2"
     id="vaadin-combo-box-scroller-3"
     role="listbox"
   >
     <vaadin-combo-box-item
       aria-posinset="1"
       aria-selected="false"
+      aria-setsize="2"
       id="vaadin-combo-box-item-0"
       role="option"
       tabindex="-1"
@@ -384,6 +385,7 @@ snapshots["vaadin-combo-box host opened overlay class"] =
     <vaadin-combo-box-item
       aria-posinset="2"
       aria-selected="false"
+      aria-setsize="2"
       id="vaadin-combo-box-item-1"
       role="option"
       tabindex="-1"
@@ -406,13 +408,13 @@ snapshots["vaadin-combo-box host opened theme overlay"] =
   top-aligned=""
 >
   <vaadin-combo-box-scroller
-    aria-setsize="2"
     id="vaadin-combo-box-scroller-3"
     role="listbox"
   >
     <vaadin-combo-box-item
       aria-posinset="1"
       aria-selected="false"
+      aria-setsize="2"
       id="vaadin-combo-box-item-0"
       role="option"
       tabindex="-1"
@@ -422,6 +424,7 @@ snapshots["vaadin-combo-box host opened theme overlay"] =
     <vaadin-combo-box-item
       aria-posinset="2"
       aria-selected="false"
+      aria-setsize="2"
       id="vaadin-combo-box-item-1"
       role="option"
       tabindex="-1"
@@ -481,7 +484,6 @@ snapshots["vaadin-combo-box shadow default"] =
   no-vertical-overlap=""
 >
   <vaadin-combo-box-scroller
-    aria-setsize="0"
     id="vaadin-combo-box-scroller-3"
     role="listbox"
   >
@@ -543,7 +545,6 @@ snapshots["vaadin-combo-box shadow disabled"] =
   no-vertical-overlap=""
 >
   <vaadin-combo-box-scroller
-    aria-setsize="0"
     id="vaadin-combo-box-scroller-3"
     role="listbox"
   >
@@ -605,7 +606,6 @@ snapshots["vaadin-combo-box shadow readonly"] =
   no-vertical-overlap=""
 >
   <vaadin-combo-box-scroller
-    aria-setsize="0"
     id="vaadin-combo-box-scroller-3"
     role="listbox"
   >
@@ -667,7 +667,6 @@ snapshots["vaadin-combo-box shadow invalid"] =
   no-vertical-overlap=""
 >
   <vaadin-combo-box-scroller
-    aria-setsize="0"
     id="vaadin-combo-box-scroller-3"
     role="listbox"
   >
@@ -730,7 +729,6 @@ snapshots["vaadin-combo-box shadow theme"] =
   theme="align-right"
 >
   <vaadin-combo-box-scroller
-    aria-setsize="0"
     id="vaadin-combo-box-scroller-3"
     role="listbox"
   >

--- a/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
+++ b/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
@@ -357,13 +357,13 @@ snapshots["vaadin-time-picker host opened overlay"] =
   top-aligned=""
 >
   <vaadin-time-picker-scroller
-    aria-setsize="24"
     id="vaadin-time-picker-scroller-3"
     role="listbox"
   >
     <vaadin-time-picker-item
       aria-posinset="1"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-0"
       role="option"
@@ -374,6 +374,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="2"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-1"
       role="option"
@@ -384,6 +385,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="3"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-2"
       role="option"
@@ -394,6 +396,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="4"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-3"
       role="option"
@@ -404,6 +407,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="5"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-4"
       role="option"
@@ -414,6 +418,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="6"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-5"
       role="option"
@@ -424,6 +429,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="7"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-6"
       role="option"
@@ -434,6 +440,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="8"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-7"
       role="option"
@@ -444,6 +451,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="9"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-8"
       role="option"
@@ -454,6 +462,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="10"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-9"
       role="option"
@@ -464,6 +473,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="11"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-10"
       role="option"
@@ -474,6 +484,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="12"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-11"
       role="option"
@@ -484,6 +495,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="13"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-12"
       role="option"
@@ -494,6 +506,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="14"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-13"
       role="option"
@@ -504,6 +517,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="15"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-14"
       role="option"
@@ -514,6 +528,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="16"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-15"
       role="option"
@@ -524,6 +539,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="17"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-16"
       role="option"
@@ -534,6 +550,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="18"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-17"
       role="option"
@@ -544,6 +561,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="19"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-18"
       role="option"
@@ -554,6 +572,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="20"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-19"
       role="option"
@@ -564,6 +583,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="21"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-20"
       role="option"
@@ -574,6 +594,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="22"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-21"
       role="option"
@@ -584,6 +605,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="23"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-22"
       role="option"
@@ -594,6 +616,7 @@ snapshots["vaadin-time-picker host opened overlay"] =
     <vaadin-time-picker-item
       aria-posinset="24"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-23"
       role="option"
@@ -617,13 +640,13 @@ snapshots["vaadin-time-picker host opened overlay class"] =
   top-aligned=""
 >
   <vaadin-time-picker-scroller
-    aria-setsize="24"
     id="vaadin-time-picker-scroller-3"
     role="listbox"
   >
     <vaadin-time-picker-item
       aria-posinset="1"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-0"
       role="option"
@@ -634,6 +657,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="2"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-1"
       role="option"
@@ -644,6 +668,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="3"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-2"
       role="option"
@@ -654,6 +679,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="4"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-3"
       role="option"
@@ -664,6 +690,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="5"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-4"
       role="option"
@@ -674,6 +701,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="6"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-5"
       role="option"
@@ -684,6 +712,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="7"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-6"
       role="option"
@@ -694,6 +723,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="8"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-7"
       role="option"
@@ -704,6 +734,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="9"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-8"
       role="option"
@@ -714,6 +745,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="10"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-9"
       role="option"
@@ -724,6 +756,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="11"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-10"
       role="option"
@@ -734,6 +767,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="12"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-11"
       role="option"
@@ -744,6 +778,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="13"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-12"
       role="option"
@@ -754,6 +789,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="14"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-13"
       role="option"
@@ -764,6 +800,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="15"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-14"
       role="option"
@@ -774,6 +811,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="16"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-15"
       role="option"
@@ -784,6 +822,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="17"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-16"
       role="option"
@@ -794,6 +833,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="18"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-17"
       role="option"
@@ -804,6 +844,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="19"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-18"
       role="option"
@@ -814,6 +855,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="20"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-19"
       role="option"
@@ -824,6 +866,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="21"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-20"
       role="option"
@@ -834,6 +877,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="22"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-21"
       role="option"
@@ -844,6 +888,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="23"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-22"
       role="option"
@@ -854,6 +899,7 @@ snapshots["vaadin-time-picker host opened overlay class"] =
     <vaadin-time-picker-item
       aria-posinset="24"
       aria-selected="false"
+      aria-setsize="24"
       dir="ltr"
       id="vaadin-time-picker-item-23"
       role="option"


### PR DESCRIPTION
## Description

Currently, `aria-setsize` is set on the container with `role="listbox"`.  This is not correct and instead should be placed on each item along with `aria-posinset`.  In addition, the value for the set size currently used is incorrectly 0 when a `dataProvider` is used.

Fixes #3255 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
