### PR TITLE
docs: add missing JSDoc annotation for the submit event

### DIFF
--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -219,6 +219,12 @@ class MessageInput extends ElementMixin(ThemableMixin(ControllerMixin(PolymerEle
     }
     this._textArea.focus();
   }
+
+  /**
+   * Fired when a new message is submitted with `<vaadin-message-input>`, either
+   * by clicking the "send" button, or pressing the Enter key.
+   * @event submit
+   */
 }
 
 customElements.define(MessageInput.is, MessageInput);


### PR DESCRIPTION
## Description

Fixes #5258

Added `@event` to make sure this event is picked up by `polymer-analyzer` and ends up in `web-types.json`.

## Type of change

- Documentation