### PR TITLE
fix: do not consider label and hidden elements focusable

### DIFF
--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -109,7 +109,7 @@ export const isFocusable = (target) => {
   }
   const focusables = Array.from(
     target.parentNode.querySelectorAll(
-      '[tabindex], button, input, select, textarea, object, iframe, label, a[href], area[href]',
+      '[tabindex], button, input, select, textarea, object, iframe, a[href], area[href]',
     ),
   ).filter((element) => {
     const part = element.getAttribute('part');
@@ -117,5 +117,5 @@ export const isFocusable = (target) => {
   });
 
   const isFocusableElement = focusables.includes(target);
-  return !target.disabled && isFocusableElement;
+  return !target.disabled && isFocusableElement && getComputedStyle(target).visibility !== 'hidden';
 };

--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -117,5 +117,7 @@ export const isFocusable = (target) => {
   });
 
   const isFocusableElement = focusables.includes(target);
-  return !target.disabled && isFocusableElement && getComputedStyle(target).visibility !== 'hidden';
+  return (
+    !target.disabled && isFocusableElement && target.offsetParent && getComputedStyle(target).visibility !== 'hidden'
+  );
 };

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1614,6 +1614,9 @@ describe('keyboard navigation', () => {
           <label for="disabled-input">Label</label>
           <input id="disabled-input" disabled style="width: 20px">
           <input style="visibility: hidden; width: 20px;">
+          <div hidden>
+            <input>
+          </div>
           <input id="focusable" style="width: 20px">
         </div>
       `);

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -20,6 +20,7 @@ import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
 import '../vaadin-grid-column-group.js';
 import '../vaadin-grid-selection-column.js';
+import { isElementFocused } from '@vaadin/component-base/src/focus-utils.js';
 import {
   flushGrid,
   getCell,
@@ -1604,6 +1605,27 @@ describe('keyboard navigation', () => {
 
       expect(spy.callCount).to.equal(1);
       spy.restore();
+    });
+
+    it('should focus the first actually focusable element when entering interaction mode', () => {
+      const content = getCellContent(getRowCell(0, 1));
+      const contentElements = fixtureSync(`
+        <div>
+          <label for="disabled-input">Label</label>
+          <input id="disabled-input" disabled style="width: 20px">
+          <input style="visibility: hidden; width: 20px;">
+          <input id="focusable" style="width: 20px">
+        </div>
+      `);
+      content.textContent = '';
+      content.append(...contentElements.childNodes);
+      const focusable = content.querySelector('#focusable');
+
+      right(); // Focus the cell with input.
+
+      enter();
+
+      expect(isElementFocused(focusable)).to.be.true;
     });
 
     it('should exit interaction mode from focused single-line input with enter', () => {


### PR DESCRIPTION
## Description

When entering from cell navigation mode to interaction mode (by pressing enter), `<vaadin-grid>` Web Component tries to automatically focus the first element (within the cell) it considers focusable.

https://user-images.githubusercontent.com/1222264/211284364-ed8a3259-e356-49b3-a964-6aede75cb970.mp4

The current logic erroneously considers `<label>` and `<input style="visibility: hidden">` elements as focusable. This PR fixes the issue.

Addresses https://github.com/vaadin/flow-components/pull/4483#discussion_r1064383335

## Type of change

- [x] Bugfix