### PR TITLE
feat: add custom CSS properties for field border-radius

### DIFF
--- a/packages/input-container/src/vaadin-input-container.js
+++ b/packages/input-container/src/vaadin-input-container.js
@@ -19,6 +19,22 @@ export class InputContainer extends ThemableMixin(DirMixin(PolymerElement)) {
           display: flex;
           align-items: center;
           flex: 0 1 auto;
+          border-radius:
+            /* See https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius */
+            var(--vaadin-input-container-top-start-radius, var(--__border-radius))
+            var(--vaadin-input-container-top-end-radius, var(--__border-radius))
+            var(--vaadin-input-container-bottom-end-radius, var(--__border-radius))
+            var(--vaadin-input-container-bottom-start-radius, var(--__border-radius));
+          --_border-radius: var(--vaadin-input-container-border-radius, 0px);
+        }
+
+        :host([dir='rtl']) {
+          border-radius:
+            /* Don't use logical props, see https://github.com/vaadin/vaadin-time-picker/issues/145 */
+            var(--vaadin-input-container-top-end-radius, var(--_border-radius))
+            var(--vaadin-input-container-top-start-radius, var(--_border-radius))
+            var(--vaadin-input-container-bottom-start-radius, var(--_border-radius))
+            var(--vaadin-input-container-bottom-end-radius, var(--_border-radius));
         }
 
         :host([hidden]) {

--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -8,14 +8,30 @@ registerStyles(
   'vaadin-input-container',
   css`
     :host {
-      border-radius: var(--lumo-border-radius-m);
       background-color: var(--lumo-contrast-10pct);
-      padding: 0 calc(0.375em + var(--lumo-border-radius-m) / 4 - 1px);
+      padding: 0 calc(0.375em + var(--_input-container-radius) / 4 - 1px);
       font-weight: 500;
       line-height: 1;
       position: relative;
       cursor: text;
       box-sizing: border-box;
+      border-radius:
+        /* See https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius#syntax */
+        var(--vaadin-input-container-top-start-radius, var(--_input-container-radius))
+        var(--vaadin-input-container-top-end-radius, var(--_input-container-radius))
+        var(--vaadin-input-container-bottom-end-radius, var(--_input-container-radius))
+        var(--vaadin-input-container-bottom-start-radius, var(--_input-container-radius));
+      /* Fallback */
+      --_input-container-radius: var(--vaadin-input-container-border-radius, var(--lumo-border-radius-m));
+    }
+
+    :host([dir='rtl']) {
+      border-radius:
+        /* Don't use logical props, see https://github.com/vaadin/vaadin-time-picker/issues/145 */
+        var(--vaadin-input-container-top-end-radius, var(--_input-container-radius))
+        var(--vaadin-input-container-top-start-radius, var(--_input-container-radius))
+        var(--vaadin-input-container-bottom-start-radius, var(--_input-container-radius))
+        var(--vaadin-input-container-bottom-end-radius, var(--_input-container-radius));
     }
 
     /* Used for hover and activation effects */

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -32,6 +32,7 @@ const globals = css`
   html {
     --vaadin-checkbox-size: calc(var(--lumo-size-m) / 2);
     --vaadin-radio-button-size: calc(var(--lumo-size-m) / 2);
+    --vaadin-input-container-border-radius: var(--lumo-border-radius-m);
   }
 `;
 


### PR DESCRIPTION
## Description

Related to #2954

Originally inspired by https://github.com/vaadin/web-components/pull/5251#pullrequestreview-1240365133

These individual properties would enable us to implement the filled Material text field:

![Screenshot 2023-01-09 at 14 03 02](https://user-images.githubusercontent.com/10589913/211303745-e22d8c0a-1a2d-497d-bc9a-143baa7053ac.png)

## Type of change

- Feature