### PR TITLE
fix: ignore label clicks in grid cells

### DIFF
--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -65,7 +65,7 @@ export const ActiveItemMixin = (superClass) =>
 
       const activeElement = this.getRootNode().activeElement;
       const cellContentHasFocus = cellContent.contains(activeElement);
-      if (!cellContentHasFocus && !this._isFocusable(e.target)) {
+      if (!cellContentHasFocus && !this._isFocusable(e.target) && !(e.target instanceof HTMLLabelElement)) {
         this.dispatchEvent(
           new CustomEvent('cell-activate', {
             detail: {

--- a/packages/grid/src/vaadin-grid-tree-toggle.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle.js
@@ -192,7 +192,7 @@ class GridTreeToggle extends ThemableMixin(DirMixin(PolymerElement)) {
     if (this.leaf) {
       return;
     }
-    if (isFocusable(e.target)) {
+    if (isFocusable(e.target) || e.target instanceof HTMLLabelElement) {
       return;
     }
 

--- a/packages/grid/test/renderers.test.js
+++ b/packages/grid/test/renderers.test.js
@@ -182,6 +182,22 @@ describe('renderers', () => {
         expect(e.detail.model.index).to.eql(0);
         expect(e.detail.model.item).to.be.ok;
       });
+
+      it('should not fire a `cell-activate` event on focusable element click', () => {
+        column.renderer = (root) => {
+          root.innerHTML = '<input>';
+        };
+        getCell(grid, 0)._content.firstElementChild.click();
+        expect(spy.called).to.be.false;
+      });
+
+      it('should not fire a `cell-activate` event on label click', () => {
+        column.renderer = (root) => {
+          root.innerHTML = '<label for="foo">foo label</label><input id="foo">';
+        };
+        getCell(grid, 0)._content.firstElementChild.click();
+        expect(spy.called).to.be.false;
+      });
     });
   });
 

--- a/packages/grid/test/tree-toggle.test.js
+++ b/packages/grid/test/tree-toggle.test.js
@@ -91,13 +91,21 @@ describe('tree toggle', () => {
     beforeEach(() => {
       toggle = fixtureSync(`
         <vaadin-grid-tree-toggle>
-          <input><div>foo</div>
+          <label for="foo-input">foo label</label>
+          <input id="foo-input">
+          <div>foo</div>
         </vaadin-grid-tree-toggle>
       `);
     });
 
     it('should not toggle on internal focusable click', () => {
       const clickEvent = click(toggle.querySelector('input'));
+      expect(toggle.expanded).to.be.false;
+      expect(clickEvent.defaultPrevented).to.be.false;
+    });
+
+    it('should not toggle on internal label click', () => {
+      const clickEvent = click(toggle.querySelector('label'));
       expect(toggle.expanded).to.be.false;
       expect(clickEvent.defaultPrevented).to.be.false;
     });


### PR DESCRIPTION
## Description

Fixes a regression caused by https://github.com/vaadin/web-components/pull/5263

- Clicking a `<label>` element inside a grid cell shouldn't affect the active item.
- Clicking a `<label>` inside a `<vaadin-grid-tree-toggle>` shouldn't toggle the expanded item

Before:

https://user-images.githubusercontent.com/1222264/211525821-ed3959f0-cc20-4436-9fb7-fa4d78a90be2.mp4

After:

https://user-images.githubusercontent.com/1222264/211525857-42f5a975-49d4-4784-b95c-52b2e7afd2c3.mp4


## Type of change

- Bugfix