### PR TITLE
test: disable animation in notification visual tests

### DIFF
--- a/packages/notification/test/not-animated-styles.js
+++ b/packages/notification/test/not-animated-styles.js
@@ -1,0 +1,11 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-notification-card',
+  css`
+    :host([opening]),
+    :host([closing]) {
+      animation: none !important;
+    }
+  `,
+);

--- a/packages/notification/test/visual/lumo/notification.test.js
+++ b/packages/notification/test/visual/lumo/notification.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../../not-animated-styles.js';
 import '../../../theme/lumo/vaadin-notification.js';
 
 describe('notification', () => {

--- a/packages/notification/test/visual/material/notification.test.js
+++ b/packages/notification/test/visual/material/notification.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../../not-animated-styles.js';
 import '../../../theme/material/vaadin-notification.js';
 
 describe('notification', () => {


### PR DESCRIPTION
## Description

Looks like #5253 introduced some flakiness to `vaadin-notification` visual tests. 
This PR disables animations that have a risk of causing this flakiness.

## Type of change

- Tests