### PR TITLE
feat: add overlayClass property to vaadin-multi-select-combo-box

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -255,6 +255,13 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
   loading: boolean;
 
   /**
+   * A space-delimited list of CSS class names to set on the overlay element.
+   *
+   * @attr {string} overlay-class
+   */
+  overlayClass: string;
+
+  /**
    * True if the dropdown is open, false otherwise.
    */
   opened: boolean;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -154,6 +154,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           readonly="[[readonly]]"
           auto-open-disabled="[[autoOpenDisabled]]"
           allow-custom-value="[[allowCustomValue]]"
+          overlay-class="[[overlayClass]]"
           data-provider="[[dataProvider]]"
           filter="{{filter}}"
           last-filter="{{_lastFilter}}"
@@ -303,6 +304,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
         type: Boolean,
         value: false,
         reflectToAttribute: true,
+      },
+
+      /**
+       * A space-delimited list of CSS class names to set on the overlay element.
+       *
+       * @attr {string} overlay-class
+       */
+      overlayClass: {
+        type: String,
       },
 
       /**

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -384,6 +384,22 @@ snapshots["vaadin-multi-select-combo-box host opened overlay"] =
 `;
 /* end snapshot vaadin-multi-select-combo-box host opened overlay */
 
+snapshots["vaadin-multi-select-combo-box host opened overlay class"] = 
+`<vaadin-multi-select-combo-box-overlay
+  class="custom multi-select-combo-box-overlay"
+  id="overlay"
+  no-vertical-overlap=""
+>
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+  >
+  </vaadin-multi-select-combo-box-scroller>
+</vaadin-multi-select-combo-box-overlay>
+`;
+/* end snapshot vaadin-multi-select-combo-box host opened overlay class */
+
 snapshots["vaadin-multi-select-combo-box shadow default"] = 
 `<div class="vaadin-multi-select-combo-box-container">
   <div part="label">

--- a/packages/multi-select-combo-box/test/dom/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/dom/multi-select-combo-box.test.js
@@ -74,6 +74,11 @@ describe('vaadin-multi-select-combo-box', () => {
       it('overlay', async () => {
         await expect(comboBox.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
       });
+
+      it('overlay class', async () => {
+        multiSelectComboBox.overlayClass = 'custom multi-select-combo-box-overlay';
+        await expect(comboBox.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+      });
     });
   });
 

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -90,6 +90,7 @@ assertType<string | null | undefined>(narrowedComboBox.helperText);
 assertType<boolean>(narrowedComboBox.readonly);
 assertType<string | null | undefined>(narrowedComboBox.label);
 assertType<boolean>(narrowedComboBox.required);
+assertType<string>(narrowedComboBox.overlayClass);
 
 // Mixins
 assertType<ControllerMixinClass>(narrowedComboBox);


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/3593

Based on #5207

## Type of change

- Feature

## Note

As the overlay in placed in a nested shadow root, I decided not to use `OverlayClassMixin` in this case.
Instead, the property is defined separately with an appropriate JSDoc and propagated to combo-box.