### PR TITLE
feat: add overlayClass property to vaadin-date-time-picker

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -212,6 +212,17 @@ declare class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(Themabl
    */
   i18n: DateTimePickerI18n;
 
+  /**
+   * A space-delimited list of CSS class names to set on the overlay elements
+   * of the internal components controlled by the `<vaadin-date-time-picker>`:
+   *
+   * - [`<vaadin-date-picker>`](#/elements/vaadin-date-picker#property-overlayClass)
+   * - [`<vaadin-time-picker>`](#/elements/vaadin-time-picker#property-overlayClass)
+   *
+   * @attr {string} overlay-class
+   */
+  overlayClass: string;
+
   addEventListener<K extends keyof DateTimePickerEventMap>(
     type: K,
     listener: (this: DateTimePicker, ev: DateTimePickerEventMap[K]) => void,

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -349,6 +349,19 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
       },
 
       /**
+       * A space-delimited list of CSS class names to set on the overlay elements
+       * of the internal components controlled by the `<vaadin-date-time-picker>`:
+       *
+       * - [`<vaadin-date-picker>`](#/elements/vaadin-date-picker#property-overlayClass)
+       * - [`<vaadin-time-picker>`](#/elements/vaadin-time-picker#property-overlayClass)
+       *
+       * @attr {string} overlay-class
+       */
+      overlayClass: {
+        type: String,
+      },
+
+      /**
        * The current slotted date picker.
        * @private
        */
@@ -383,6 +396,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
       '__i18nChanged(i18n, __datePicker, __timePicker)',
       '__autoOpenDisabledChanged(autoOpenDisabled, __datePicker, __timePicker)',
       '__themeChanged(_theme, __datePicker, __timePicker)',
+      '__overlayClassChanged(overlayClass, __datePicker, __timePicker)',
       '__pickersChanged(__datePicker, __timePicker)',
     ];
   }
@@ -1015,6 +1029,17 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
         picker.removeAttribute('theme');
       }
     });
+  }
+
+  /** @private */
+  __overlayClassChanged(overlayClass, datePicker, timePicker) {
+    if (!datePicker || !timePicker) {
+      // Both pickers are not ready yet
+      return;
+    }
+
+    datePicker.overlayClass = overlayClass;
+    timePicker.overlayClass = overlayClass;
   }
 
   /** @private */

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -521,6 +521,423 @@ snapshots["vaadin-date-time-picker host error"] =
 `;
 /* end snapshot vaadin-date-time-picker host error */
 
+snapshots["vaadin-date-time-picker host overlay class date-picker"] = 
+`<vaadin-date-picker-overlay
+  class="custom date-time-picker-overlay"
+  dir="ltr"
+  id="overlay"
+  opened=""
+  restore-focus-on-close=""
+  start-aligned=""
+  top-aligned=""
+>
+  <vaadin-date-picker-overlay-content
+    class="animate"
+    desktop=""
+    role="dialog"
+  >
+    <vaadin-button
+      role="button"
+      slot="today-button"
+      tabindex="0"
+      theme="tertiary"
+    >
+      Today
+    </vaadin-button>
+    <vaadin-button
+      role="button"
+      slot="cancel-button"
+      tabindex="0"
+      theme="tertiary"
+    >
+      Cancel
+    </vaadin-button>
+    <vaadin-date-picker-month-scroller slot="months">
+      <div slot="vaadin-infinite-scroller-item-content-12">
+        <vaadin-month-calendar>
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-13">
+        <vaadin-month-calendar>
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-14">
+        <vaadin-month-calendar>
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-15">
+        <vaadin-month-calendar>
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-16">
+        <vaadin-month-calendar>
+        </vaadin-month-calendar>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-17">
+        <vaadin-month-calendar>
+        </vaadin-month-calendar>
+      </div>
+    </vaadin-date-picker-month-scroller>
+    <vaadin-date-picker-year-scroller
+      aria-hidden="true"
+      slot="years"
+    >
+      <div slot="vaadin-infinite-scroller-item-content-18">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-19">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-20">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-21">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-22">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-23">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-24">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-25">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-26">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-27">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-28">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-29">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-30">
+        <vaadin-date-picker-year
+          current=""
+          selected=""
+        >
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-31">
+        <vaadin-date-picker-year selected="">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-32">
+        <vaadin-date-picker-year selected="">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-33">
+        <vaadin-date-picker-year selected="">
+        </vaadin-date-picker-year>
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-34">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-35">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-36">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-37">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-38">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-39">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-40">
+      </div>
+      <div slot="vaadin-infinite-scroller-item-content-41">
+      </div>
+    </vaadin-date-picker-year-scroller>
+  </vaadin-date-picker-overlay-content>
+</vaadin-date-picker-overlay>
+`;
+/* end snapshot vaadin-date-time-picker host overlay class date-picker */
+
+snapshots["vaadin-date-time-picker host overlay class time-picker"] = 
+`<vaadin-time-picker-overlay
+  class="custom date-time-picker-overlay"
+  dir="ltr"
+  id="overlay"
+  no-vertical-overlap=""
+  opened=""
+  start-aligned=""
+  top-aligned=""
+>
+  <vaadin-time-picker-scroller
+    id="vaadin-time-picker-scroller-10"
+    role="listbox"
+  >
+    <vaadin-time-picker-item
+      aria-posinset="1"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-0"
+      role="option"
+      tabindex="-1"
+    >
+      00:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="2"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-1"
+      role="option"
+      tabindex="-1"
+    >
+      01:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="3"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-2"
+      role="option"
+      tabindex="-1"
+    >
+      02:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="4"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-3"
+      role="option"
+      tabindex="-1"
+    >
+      03:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="5"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-4"
+      role="option"
+      tabindex="-1"
+    >
+      04:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="6"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-5"
+      role="option"
+      tabindex="-1"
+    >
+      05:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="7"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-6"
+      role="option"
+      tabindex="-1"
+    >
+      06:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="8"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-7"
+      role="option"
+      tabindex="-1"
+    >
+      07:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="9"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-8"
+      role="option"
+      tabindex="-1"
+    >
+      08:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="10"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-9"
+      role="option"
+      tabindex="-1"
+    >
+      09:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="11"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-10"
+      role="option"
+      tabindex="-1"
+    >
+      10:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="12"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-11"
+      role="option"
+      tabindex="-1"
+    >
+      11:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="13"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-12"
+      role="option"
+      tabindex="-1"
+    >
+      12:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="14"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-13"
+      role="option"
+      tabindex="-1"
+    >
+      13:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="15"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-14"
+      role="option"
+      tabindex="-1"
+    >
+      14:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="16"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-15"
+      role="option"
+      tabindex="-1"
+    >
+      15:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="17"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-16"
+      role="option"
+      tabindex="-1"
+    >
+      16:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="18"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-17"
+      role="option"
+      tabindex="-1"
+    >
+      17:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="19"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-18"
+      role="option"
+      tabindex="-1"
+    >
+      18:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="20"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-19"
+      role="option"
+      tabindex="-1"
+    >
+      19:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="21"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-20"
+      role="option"
+      tabindex="-1"
+    >
+      20:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="22"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-21"
+      role="option"
+      tabindex="-1"
+    >
+      21:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="23"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-22"
+      role="option"
+      tabindex="-1"
+    >
+      22:00
+    </vaadin-time-picker-item>
+    <vaadin-time-picker-item
+      aria-posinset="24"
+      aria-selected="false"
+      aria-setsize="24"
+      dir="ltr"
+      id="vaadin-time-picker-item-23"
+      role="option"
+      tabindex="-1"
+    >
+      23:00
+    </vaadin-time-picker-item>
+  </vaadin-time-picker-scroller>
+</vaadin-time-picker-overlay>
+`;
+/* end snapshot vaadin-date-time-picker host overlay class time-picker */
+
 snapshots["vaadin-date-time-picker shadow default"] = 
 `<div class="vaadin-date-time-picker-container">
   <div part="label">

--- a/packages/date-time-picker/test/dom/date-time-picker.test.js
+++ b/packages/date-time-picker/test/dom/date-time-picker.test.js
@@ -1,14 +1,15 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-date-time-picker.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
 describe('vaadin-date-time-picker', () => {
   let dateTimePicker;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetUniqueId();
     dateTimePicker = fixtureSync('<vaadin-date-time-picker></vaadin-date-time-picker>');
+    await nextRender();
   });
 
   describe('host', () => {
@@ -46,6 +47,31 @@ describe('vaadin-date-time-picker', () => {
       dateTimePicker.invalid = true;
       await aTimeout(0);
       await expect(dateTimePicker).dom.to.equalSnapshot();
+    });
+
+    describe('overlay class', () => {
+      const SNAPSHOT_CONFIG = {
+        // Some inline CSS styles related to the overlay's position
+        // may slightly change depending on the environment, so ignore them.
+        ignoreAttributes: ['style'],
+      };
+
+      beforeEach(() => {
+        dateTimePicker.overlayClass = 'custom date-time-picker-overlay';
+      });
+
+      it('date-picker', async () => {
+        const datePicker = dateTimePicker.querySelector('[slot="date-picker"]');
+        datePicker.opened = true;
+        await nextRender();
+        await expect(datePicker.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+      });
+
+      it('time-picker', async () => {
+        const timePicker = dateTimePicker.querySelector('[slot="time-picker"]');
+        timePicker.opened = true;
+        await expect(timePicker.$.comboBox.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+      });
     });
   });
 

--- a/packages/date-time-picker/test/typings/date-time-picker.types.ts
+++ b/packages/date-time-picker/test/typings/date-time-picker.types.ts
@@ -49,5 +49,6 @@ assertType<number | null | undefined>(picker.step);
 assertType<boolean | null | undefined>(picker.showWeekNumbers);
 assertType<boolean | null | undefined>(picker.autoOpenDisabled);
 assertType<boolean | null | undefined>(picker.autofocus);
+assertType<string>(picker.overlayClass);
 assertType<() => boolean>(picker.validate);
 assertType<() => boolean>(picker.checkValidity);


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/3593

Based on #5207

## Type of change

- Feature

## Note

As the date-time-picker doesn't have own overlay, I decided not to use `OverlayClassMixin` in this case.
Instead, the property is defined separately with an appropriate JSDoc and propagated to pickers.