### PR TITLE
fix: check dialog readyness before accessing overlay

### DIFF
--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -619,7 +619,9 @@ class Dialog extends ThemePropertyMixin(ElementMixin(DialogDraggableMixin(Dialog
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
   requestContentUpdate() {
-    this.$.overlay.requestContentUpdate();
+    if (this.$) {
+      this.$.overlay.requestContentUpdate();
+    }
   }
 
   /** @private */

--- a/packages/dialog/test/renderer.test.js
+++ b/packages/dialog/test/renderer.test.js
@@ -35,6 +35,12 @@ describe('vaadin-dialog renderer', () => {
       expect(dialog.renderer.calledTwice).to.be.true;
     });
 
+    it('should not throw when requesting content update for an unupgraded dialog', () => {
+      const dialog = document.createElement('vaadin-dialog');
+
+      expect(() => dialog.requestContentUpdate()).not.to.throw();
+    });
+
     it('should clear the content when removing the renderer', () => {
       dialog.renderer = (root) => {
         root.innerHTML = 'foo';


### PR DESCRIPTION
## Description

`<vaadin-dialog>` currently throws when `requestContentUpdate()` is called before the element is fully initialized.

## Type of change

- Bugfix