### PR TITLE
fix!: do not adjust values that are out of allowed range

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -546,8 +546,6 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     const maxTimeObj = this.__validateTime(this.__parseISO(max || MAX_ALLOWED_TIME));
     const maxSec = this.__getSec(maxTimeObj);
 
-    this.__adjustValue(minSec, maxSec, minTimeObj, maxTimeObj);
-
     this.__dropdownItems = this.__generateDropdownList(minSec, maxSec, step);
 
     if (step !== this.__oldStep) {
@@ -583,22 +581,6 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     }
 
     return generatedList;
-  }
-
-  /** @private */
-  __adjustValue(minSec, maxSec, minTimeObj, maxTimeObj) {
-    // Do not change the value if it is empty
-    if (!this.__memoValue) {
-      return;
-    }
-
-    const valSec = this.__getSec(this.__memoValue);
-
-    if (valSec < minSec) {
-      this.__updateValue(minTimeObj);
-    } else if (valSec > maxSec) {
-      this.__updateValue(maxTimeObj);
-    }
   }
 
   /**

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -432,28 +432,28 @@ describe('time-picker', () => {
       expect(timePicker.max).to.be.equal('19:00');
     });
 
-    it('should not allow setting a value lower than min property value', () => {
+    it('should not change value if lower than min property value', () => {
       timePicker.value = '02:00';
       timePicker.min = '10:00';
-      expect(timePicker.value).to.be.equal('10:00');
+      expect(timePicker.value).to.be.equal('02:00');
     });
 
-    it('should not allow setting a value higher than max property value', () => {
+    it('should not change value if higher than max property value', () => {
       timePicker.value = '12:00';
       timePicker.max = '10:00';
-      expect(timePicker.value).to.be.equal('10:00');
+      expect(timePicker.value).to.be.equal('12:00');
     });
 
-    it('should not allow setting a value lower than min value via attribute', () => {
+    it('should not change value if lower than min value via attribute', () => {
       timePicker.setAttribute('value', '02:00');
       timePicker.setAttribute('min', '10:00');
-      expect(timePicker.value).to.be.equal('10:00');
+      expect(timePicker.value).to.be.equal('02:00');
     });
 
-    it('should not allow setting a value higher than max value via attribute', () => {
+    it('should not change value if higher than max value via attribute', () => {
       timePicker.setAttribute('value', '19:00');
       timePicker.setAttribute('max', '16:00');
-      expect(timePicker.value).to.be.equal('16:00');
+      expect(timePicker.value).to.be.equal('19:00');
     });
 
     it('setting min should not change an empty value', () => {

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -432,25 +432,25 @@ describe('time-picker', () => {
       expect(timePicker.max).to.be.equal('19:00');
     });
 
-    it('should not change value if lower than min property value', () => {
+    it('should not adjust value lower than min set using property', () => {
       timePicker.value = '02:00';
       timePicker.min = '10:00';
       expect(timePicker.value).to.be.equal('02:00');
     });
 
-    it('should not change value if higher than max property value', () => {
+    it('should not adjust value higher than max set using property', () => {
       timePicker.value = '12:00';
       timePicker.max = '10:00';
       expect(timePicker.value).to.be.equal('12:00');
     });
 
-    it('should not change value if lower than min value via attribute', () => {
+    it('should not adjust value lower than min set using attribute', () => {
       timePicker.setAttribute('value', '02:00');
       timePicker.setAttribute('min', '10:00');
       expect(timePicker.value).to.be.equal('02:00');
     });
 
-    it('should not change value if higher than max value via attribute', () => {
+    it('should not adjust value higher than max set using attribute', () => {
       timePicker.setAttribute('value', '19:00');
       timePicker.setAttribute('max', '16:00');
       expect(timePicker.value).to.be.equal('19:00');

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -432,30 +432,6 @@ describe('time-picker', () => {
       expect(timePicker.max).to.be.equal('19:00');
     });
 
-    it('should not adjust value lower than min set using property', () => {
-      timePicker.value = '02:00';
-      timePicker.min = '10:00';
-      expect(timePicker.value).to.be.equal('02:00');
-    });
-
-    it('should not adjust value higher than max set using property', () => {
-      timePicker.value = '12:00';
-      timePicker.max = '10:00';
-      expect(timePicker.value).to.be.equal('12:00');
-    });
-
-    it('should not adjust value lower than min set using attribute', () => {
-      timePicker.setAttribute('value', '02:00');
-      timePicker.setAttribute('min', '10:00');
-      expect(timePicker.value).to.be.equal('02:00');
-    });
-
-    it('should not adjust value higher than max set using attribute', () => {
-      timePicker.setAttribute('value', '19:00');
-      timePicker.setAttribute('max', '16:00');
-      expect(timePicker.value).to.be.equal('19:00');
-    });
-
     it('setting min should not change an empty value', () => {
       timePicker.min = '10:00';
       expect(timePicker.value).to.be.equal('');


### PR DESCRIPTION
## Description

For `time-picker`, a value that that was out of range was updated to conform to min and max constraints. In order to align this behaviour with `date-picker`, this PR makes sure that the value is not updated even if it is invalid.

This is a breaking change.

Fixes #4182 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.