### PR TITLE
fix: contain layout in checkbox and radio button (Lumo)

### DIFF
--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -23,6 +23,7 @@ registerStyles(
       cursor: default;
       outline: none;
       --vaadin-checkbox-size: calc(var(--lumo-size-m) / 2);
+      contain: layout;
     }
 
     :host([has-label]) ::slotted(label) {

--- a/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
@@ -22,6 +22,7 @@ registerStyles(
       cursor: default;
       outline: none;
       --vaadin-radio-button-size: calc(var(--lumo-size-m) / 2);
+      contain: layout;
     }
 
     :host([has-label]) ::slotted(label) {


### PR DESCRIPTION
These changes should fix the issue described in https://github.com/vaadin/web-components/issues/3570#issuecomment-1078847305

> I have discovered another problem. Under certain conditions like in this test dialog, a scrollbar is displayed especially in Firefox. In Chrome, the scrollbar only comes when an error message is displayed.
>
> The reason seems to be the transform: scale(1.4); in ::before of `[part="checkbox"]. If I take that out, it fits. No idea what the whole ::before is there for.

Though, it might be, that after the recent alignment changes, this particular case no longer happens, with the default styles, as the checkbox/radio part is now slightly higher than before.