### PR TITLE
refactor: move component properties defaults to themes

### DIFF
--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -22,7 +22,6 @@ registerStyles(
       user-select: none;
       cursor: default;
       outline: none;
-      --vaadin-checkbox-size: calc(var(--lumo-size-m) / 2);
     }
 
     :host([has-label]) ::slotted(label) {

--- a/packages/checkbox/theme/material/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/material/vaadin-checkbox-styles.js
@@ -1,4 +1,5 @@
 import '@vaadin/vaadin-material-styles/color.js';
+import '@vaadin/vaadin-material-styles/style.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
@@ -12,7 +13,6 @@ registerStyles(
       user-select: none;
       outline: none;
       -webkit-tap-highlight-color: transparent;
-      --vaadin-checkbox-size: 16px;
     }
 
     :host([has-label]) ::slotted(label) {

--- a/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
@@ -21,7 +21,6 @@ registerStyles(
       user-select: none;
       cursor: default;
       outline: none;
-      --vaadin-radio-button-size: calc(var(--lumo-size-m) / 2);
     }
 
     :host([has-label]) ::slotted(label) {

--- a/packages/radio-group/theme/material/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/material/vaadin-radio-button-styles.js
@@ -1,4 +1,5 @@
 import '@vaadin/vaadin-material-styles/color.js';
+import '@vaadin/vaadin-material-styles/style.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
@@ -11,7 +12,6 @@ registerStyles(
       user-select: none;
       outline: none;
       -webkit-tap-highlight-color: transparent;
-      --vaadin-radio-button-size: 16px;
     }
 
     :host([has-label]) ::slotted(label) {

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -25,8 +25,18 @@ const style = css`
   }
 `;
 
+/**
+ * Default values for component-specific custom properties.
+ */
+const globals = css`
+  html {
+    --vaadin-checkbox-size: calc(var(--lumo-size-m) / 2);
+    --vaadin-radio-button-size: calc(var(--lumo-size-m) / 2);
+  }
+`;
+
 const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${style.toString().replace(':host', 'html')}</style>`;
+$tpl.innerHTML = `<style>${style.toString().replace(':host', 'html')}${globals.toString()}</style>`;
 document.head.appendChild($tpl.content);
 
-export { style };
+export { globals, style };

--- a/packages/vaadin-material-styles/style.d.ts
+++ b/packages/vaadin-material-styles/style.d.ts
@@ -1,5 +1,3 @@
 import type { CSSResult } from 'lit';
 
 export const globals: CSSResult;
-
-export const style: CSSResult;

--- a/packages/vaadin-material-styles/style.js
+++ b/packages/vaadin-material-styles/style.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import './version.js';
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * Default values for component-specific custom properties.
+ */
+const globals = css`
+  html {
+    --vaadin-checkbox-size: 16px;
+    --vaadin-radio-button-size: 16px;
+  }
+`;
+
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<style>${globals.toString()}</style>`;
+document.head.appendChild($tpl.content);
+
+export { globals };


### PR DESCRIPTION
## Description

Follow-up to #5288. 

As discussed internally, defaults for component specific custom CSS properties should be placed in themes.
This is needed in order to make it possible for users to override them globally, or on the separate element.

## Type of change

- Refactor