### PR TITLE
fix: allow programmatically multi-sorting if multiSortOnShiftClick is enabled

### DIFF
--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -94,7 +94,7 @@ export const SortMixin = (superClass) =>
       const sorter = e.target;
       e.stopPropagation();
       sorter._grid = this;
-      this.__updateSorter(sorter, e.detail.shiftClick);
+      this.__updateSorter(sorter, e.detail.shiftClick, e.detail.fromSorterClick);
       this.__applySorters();
     }
 
@@ -139,14 +139,17 @@ export const SortMixin = (superClass) =>
     }
 
     /** @private */
-    __updateSorter(sorter, shiftClick) {
+    __updateSorter(sorter, shiftClick, fromSorterClick) {
       if (!sorter.direction && this._sorters.indexOf(sorter) === -1) {
         return;
       }
 
       sorter._order = null;
 
-      if ((this.multiSort && !this.multiSortOnShiftClick) || (this.multiSortOnShiftClick && shiftClick)) {
+      if (
+        (this.multiSort && (!this.multiSortOnShiftClick || !fromSorterClick)) ||
+        (this.multiSortOnShiftClick && shiftClick)
+      ) {
         if (this.multiSortPriority === 'append') {
           this.__appendSorter(sorter);
         } else {

--- a/packages/grid/src/vaadin-grid-sorter.d.ts
+++ b/packages/grid/src/vaadin-grid-sorter.d.ts
@@ -11,7 +11,7 @@ export type GridSorterDirection = 'asc' | 'desc' | null;
 /**
  * Fired when the `path` or `direction` property changes.
  */
-export type GridSorterChangedEvent = CustomEvent<{ shiftClick: boolean }>;
+export type GridSorterChangedEvent = CustomEvent<{ shiftClick: boolean; fromSorterClick: boolean }>;
 
 /**
  * Fired when the `direction` property changes.

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -210,11 +210,14 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
 
     this.dispatchEvent(
       new CustomEvent('sorter-changed', {
-        detail: { shiftClick: this._shiftClick },
+        detail: { shiftClick: this._shiftClick, fromSorterClick: this._fromSorterClick },
         bubbles: true,
         composed: true,
       }),
     );
+    // Cleaning up as a programatically sorting can be done after some user interaction
+    this._fromSorterClick = false;
+    this._shiftClick = false;
   }
 
   /** @private */
@@ -237,6 +240,7 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
 
     e.preventDefault();
     this._shiftClick = e.shiftKey;
+    this._fromSorterClick = true;
     if (this.direction === 'asc') {
       this.direction = 'desc';
     } else if (this.direction === 'desc') {

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -153,12 +153,6 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
         type: Boolean,
         observer: '__isConnectedChanged',
       },
-
-      /** @private */
-      _shiftClick: {
-        type: Boolean,
-        value: false,
-      },
     };
   }
 
@@ -210,7 +204,7 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
 
     this.dispatchEvent(
       new CustomEvent('sorter-changed', {
-        detail: { shiftClick: this._shiftClick, fromSorterClick: this._fromSorterClick },
+        detail: { shiftClick: this._shiftClick ?? false, fromSorterClick: this._fromSorterClick ?? false },
         bubbles: true,
         composed: true,
       }),

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -204,7 +204,7 @@ class GridSorter extends ThemableMixin(DirMixin(PolymerElement)) {
 
     this.dispatchEvent(
       new CustomEvent('sorter-changed', {
-        detail: { shiftClick: this._shiftClick ?? false, fromSorterClick: this._fromSorterClick ?? false },
+        detail: { shiftClick: Boolean(this._shiftClick), fromSorterClick: Boolean(this._fromSorterClick) },
         bubbles: true,
         composed: true,
       }),

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -343,7 +343,7 @@ describe('sorting', () => {
         expect(grid._sorters).to.have.lengthOf(2);
       });
 
-      it('should not multi-sort when programmatically sorting after shif-click', () => {
+      it('should not multi-sort when programmatically sorting after shift-click', () => {
         sorterFirst.direction = null;
         sorterLast.direction = null;
         shiftClick(sorterFirst);

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -320,6 +320,16 @@ describe('sorting', () => {
         click(sorterLast);
         expect(grid._sorters).to.be.empty;
       });
+
+      it('should add to sort if multi-sort is enabled and sorting is done programatically', () => {
+        grid.multiSort = true;
+        sorterFirst.direction = 'desc';
+        sorterLast.direction = 'asc';
+        expect(sorterFirst._order).to.equal(1);
+        expect(sorterFirst.direction).to.equal('desc');
+        expect(sorterLast._order).to.equal(0);
+        expect(sorterLast.direction).to.equal('asc');
+      });
     });
 
     describe('array data provider', () => {

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -321,7 +321,7 @@ describe('sorting', () => {
         expect(grid._sorters).to.be.empty;
       });
 
-      it('should add to sort if multi-sort is enabled and sorting is done programatically', () => {
+      it('should add to sorters if multi-sort is enabled and sorting is done programatically', () => {
         grid.multiSort = true;
         sorterFirst.direction = 'desc';
         sorterLast.direction = 'asc';
@@ -329,6 +329,31 @@ describe('sorting', () => {
         expect(sorterFirst.direction).to.equal('desc');
         expect(sorterLast._order).to.equal(0);
         expect(sorterLast.direction).to.equal('asc');
+        expect(grid._sorters).to.have.lengthOf(2);
+      });
+
+      it('programmatically multi-sorting should be possible after user interacts with the sorters when multi-sort enabled', () => {
+        grid.multiSort = true;
+        click(sorterFirst);
+        click(sorterLast);
+        sorterFirst.direction = 'asc';
+
+        expect(sorterFirst.direction).to.equal('asc');
+        expect(sorterLast.direction).to.equal('asc');
+        expect(grid._sorters).to.have.lengthOf(2);
+      });
+
+      it('should not multi-sort when programmatically sorting after shif-click', () => {
+        sorterFirst.direction = null;
+        sorterLast.direction = null;
+        shiftClick(sorterFirst);
+        shiftClick(sorterLast);
+        expect(grid._sorters).to.have.lengthOf(2);
+        sorterFirst.direction = 'desc';
+
+        expect(sorterFirst.direction).to.equal('desc');
+        expect(sorterLast.direction).to.be.null;
+        expect(grid._sorters).to.have.lengthOf(1);
       });
     });
 

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -314,6 +314,7 @@ assertType<GridSorter>(sorter);
 sorter.addEventListener('sorter-changed', (event) => {
   assertType<GridSorterChangedEvent>(event);
   assertType<boolean>(event.detail.shiftClick);
+  assertType<boolean>(event.detail.fromSorterClick);
 });
 
 sorter.addEventListener('direction-changed', (event) => {


### PR DESCRIPTION
## Description

Add a flag in the `sorter-changed` event to allow the sorting mechanism to detect whether the event was triggered by a user interaction with the sorter or something else (eg. changing `sorter.direction`).

Currently, if `multiSortOnShiftClick` was enabled, it wasn't possible to programmatically do a multi-sorting on the grid.

Fixes https://github.com/vaadin/flow-components/issues/4362

## Type of change

- [x] Bugfix
- [ ] Feature
