### PR TITLE
DO NOT MERGE: first experimental prototype of Lit based versions

### DIFF
--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-details.d.ts",
+    "!src/vaadin-lit-details.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/details/src/lib/details-base.d.ts
+++ b/packages/details/src/lib/details-base.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult, TemplateResult } from 'lit';
+
+export const styles: CSSResult;
+
+export function template<
+  T extends HTMLTemplateElement | TemplateResult,
+  F extends (strings: TemplateStringsArray, ...values: any[]) => T,
+>(tag: F): T;

--- a/packages/details/src/lib/details-base.js
+++ b/packages/details/src/lib/details-base.js
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const styles = css`
+  :host {
+    display: block;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  [part='content'] {
+    display: none;
+  }
+
+  :host([opened]) [part='content'] {
+    display: block;
+  }
+`;
+
+export const template = (html) => html`
+  <slot name="summary"></slot>
+  <div part="content">
+    <slot></slot>
+  </div>
+  <slot name="tooltip"></slot>
+`;

--- a/packages/details/src/vaadin-details-mixin.d.ts
+++ b/packages/details/src/vaadin-details-mixin.d.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { DelegateFocusMixinClass } from '@vaadin/component-base/src/delegate-focus-mixin.js';
+import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
+import type { CollapsibleMixinClass } from './collapsible-mixin.js';
+
+/**
+ * A mixin providing common details functionality.
+ */
+export declare function DetailsMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<CollapsibleMixinClass> &
+  Constructor<DelegateFocusMixinClass> &
+  Constructor<DelegateStateMixinClass> &
+  Constructor<DetailsMixinClass> &
+  T;
+
+export declare class DetailsMixinClass {
+  /**
+   * A text that is displayed in the summary, if no
+   * element is assigned to the `summary` slot.
+   */
+  summary: string | null | undefined;
+}

--- a/packages/details/src/vaadin-details-mixin.js
+++ b/packages/details/src/vaadin-details-mixin.js
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
+import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { CollapsibleMixin } from './collapsible-mixin.js';
+import { SummaryController } from './summary-controller.js';
+
+/**
+ * A mixin providing common details functionality.
+ *
+ * @polymerMixin
+ * @mixes CollapsibleMixin
+ * @mixes DelegateFocusMixin
+ * @mixes DelegateStateMixin
+ */
+export const DetailsMixin = (superClass) =>
+  class DetailsMixin extends CollapsibleMixin(DelegateStateMixin(DelegateFocusMixin(superClass))) {
+    static get properties() {
+      return {
+        /**
+         * A text that is displayed in the summary, if no
+         * element is assigned to the `summary` slot.
+         */
+        summary: {
+          type: String,
+          observer: '_summaryChanged',
+        },
+      };
+    }
+
+    static get observers() {
+      return ['__updateAriaControls(focusElement, _contentElements)', '__updateAriaExpanded(focusElement, opened)'];
+    }
+
+    static get delegateAttrs() {
+      return ['theme'];
+    }
+
+    static get delegateProps() {
+      return ['disabled', 'opened'];
+    }
+
+    constructor() {
+      super();
+
+      this._summaryController = new SummaryController(this, 'vaadin-details-summary');
+      this._summaryController.addEventListener('slot-content-changed', (event) => {
+        const { node } = event.target;
+
+        this._setFocusElement(node);
+        this.stateTarget = node;
+
+        this._tooltipController.setTarget(node);
+      });
+
+      this._tooltipController = new TooltipController(this);
+      this._tooltipController.setPosition('bottom-start');
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.addController(this._summaryController);
+      this.addController(this._tooltipController);
+    }
+
+    /**
+     * Override method inherited from `DisabledMixin`
+     * to not set `aria-disabled` on the host element.
+     *
+     * @protected
+     * @override
+     */
+    _setAriaDisabled() {
+      // The `aria-disabled` is set on the details summary.
+    }
+
+    /** @private */
+    _summaryChanged(summary) {
+      this._summaryController.setSummary(summary);
+    }
+
+    /** @private */
+    __updateAriaControls(summary, contentElements) {
+      if (summary && contentElements) {
+        const node = contentElements[0];
+
+        if (node && node.id) {
+          summary.setAttribute('aria-controls', node.id);
+        } else {
+          summary.removeAttribute('aria-controls');
+        }
+      }
+    }
+
+    /** @private */
+    __updateAriaExpanded(focusElement, opened) {
+      if (focusElement) {
+        focusElement.setAttribute('aria-expanded', opened ? 'true' : 'false');
+      }
+    }
+  };

--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -4,11 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
-import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { CollapsibleMixin } from './collapsible-mixin.js';
+import { DetailsMixin } from './vaadin-details-mixin.js';
 
 /**
  * Fired when the `opened` property changes.
@@ -58,15 +56,7 @@ export type DetailsEventMap = DetailsCustomEventMap & HTMLElementEventMap;
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
-declare class Details extends CollapsibleMixin(
-  DelegateStateMixin(DelegateFocusMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement))))),
-) {
-  /**
-   * A text that is displayed in the summary, if no
-   * element is assigned to the `summary` slot.
-   */
-  summary: string | null | undefined;
-
+declare class Details extends DetailsMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {
   addEventListener<K extends keyof DetailsEventMap>(
     type: K,
     listener: (this: Details, ev: DetailsEventMap[K]) => void,

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -6,13 +6,12 @@
 import './vaadin-details-summary.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
-import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { CollapsibleMixin } from './collapsible-mixin.js';
-import { SummaryController } from './summary-controller.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { styles, template } from './lib/details-base.js';
+import { DetailsMixin } from './vaadin-details-mixin.js';
+
+registerStyles('vaadin-details', styles, { moduleId: 'vaadin-details-styles' });
 
 /**
  * `<vaadin-details>` is a Web Component which the creates an
@@ -52,134 +51,18 @@ import { SummaryController } from './summary-controller.js';
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  *
  * @extends HTMLElement
- * @mixes CollapsibleMixin
  * @mixes ControllerMixin
- * @mixes DelegateFocusMixin
- * @mixes DelegateStateMixin
+ * @mixes DetailsMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class Details extends CollapsibleMixin(
-  DelegateStateMixin(DelegateFocusMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))))),
-) {
+class Details extends DetailsMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement)))) {
   static get template() {
-    return html`
-      <style>
-        :host {
-          display: block;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        [part='content'] {
-          display: none;
-        }
-
-        :host([opened]) [part='content'] {
-          display: block;
-        }
-      </style>
-
-      <slot name="summary"></slot>
-
-      <div part="content">
-        <slot></slot>
-      </div>
-
-      <slot name="tooltip"></slot>
-    `;
+    return template(html);
   }
 
   static get is() {
     return 'vaadin-details';
-  }
-
-  static get properties() {
-    return {
-      /**
-       * A text that is displayed in the summary, if no
-       * element is assigned to the `summary` slot.
-       */
-      summary: {
-        type: String,
-        observer: '_summaryChanged',
-      },
-    };
-  }
-
-  static get observers() {
-    return ['__updateAriaControls(focusElement, _contentElements)', '__updateAriaExpanded(focusElement, opened)'];
-  }
-
-  static get delegateAttrs() {
-    return ['theme'];
-  }
-
-  static get delegateProps() {
-    return ['disabled', 'opened'];
-  }
-
-  constructor() {
-    super();
-
-    this._summaryController = new SummaryController(this, 'vaadin-details-summary');
-    this._summaryController.addEventListener('slot-content-changed', (event) => {
-      const { node } = event.target;
-
-      this._setFocusElement(node);
-      this.stateTarget = node;
-
-      this._tooltipController.setTarget(node);
-    });
-
-    this._tooltipController = new TooltipController(this);
-    this._tooltipController.setPosition('bottom-start');
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this.addController(this._summaryController);
-    this.addController(this._tooltipController);
-  }
-
-  /**
-   * Override method inherited from `DisabledMixin`
-   * to not set `aria-disabled` on the host element.
-   *
-   * @protected
-   * @override
-   */
-  _setAriaDisabled() {
-    // The `aria-disabled` is set on the details summary.
-  }
-
-  /** @private */
-  _summaryChanged(summary) {
-    this._summaryController.setSummary(summary);
-  }
-
-  /** @private */
-  __updateAriaControls(summary, contentElements) {
-    if (summary && contentElements) {
-      const node = contentElements[0];
-
-      if (node && node.id) {
-        summary.setAttribute('aria-controls', node.id);
-      } else {
-        summary.removeAttribute('aria-controls');
-      }
-    }
-  }
-
-  /** @private */
-  __updateAriaExpanded(focusElement, opened) {
-    if (focusElement) {
-      focusElement.setAttribute('aria-expanded', opened ? 'true' : 'false');
-    }
   }
 }
 

--- a/packages/details/src/vaadin-lit-details.d.ts
+++ b/packages/details/src/vaadin-lit-details.d.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { DetailsMixin } from './vaadin-details-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-details>` web component.
+ * Note: this is a prototype not supposed to be used publicly.
+ */
+declare class Details extends DetailsMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
+
+export { Details };

--- a/packages/details/src/vaadin-lit-details.js
+++ b/packages/details/src/vaadin-lit-details.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import './vaadin-details-summary.js';
+import { html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { styles, template } from './lib/details-base.js';
+import { DetailsMixin } from './vaadin-details-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-details>` web component.
+ * Note: this is a prototype not supposed to be used publicly.
+ *
+ * @private
+ */
+class Details extends DetailsMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-details';
+  }
+
+  static get styles() {
+    return styles;
+  }
+
+  /** @protected */
+  render() {
+    return template(html);
+  }
+}
+
+customElements.define(Details.is, Details);
+
+export { Details };

--- a/packages/details/test/details-lit.test.js
+++ b/packages/details/test/details-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-details.js';
+import './details.common.js';

--- a/packages/details/test/details-polymer.test.js
+++ b/packages/details/test/details-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-details.js';
+import './details.common.js';

--- a/packages/details/test/details.common.js
+++ b/packages/details/test/details.common.js
@@ -1,8 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../vaadin-details.js';
 
 describe('vaadin-details', () => {
   let details;
@@ -27,12 +26,13 @@ describe('vaadin-details', () => {
   describe('opened', () => {
     let contentPart, contentNode;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       details = fixtureSync(`
         <vaadin-details>
           <div>Content</div>
         </vaadin-details>
       `);
+      await nextRender();
       contentPart = details.shadowRoot.querySelector('[part="content"]');
       contentNode = details.querySelector('div');
     });
@@ -41,8 +41,9 @@ describe('vaadin-details', () => {
       expect(details.opened).to.be.false;
     });
 
-    it('should reflect opened property to attribute', () => {
+    it('should reflect opened property to attribute', async () => {
       details.opened = true;
+      await nextFrame();
       expect(details.hasAttribute('opened')).to.be.true;
     });
 
@@ -50,8 +51,9 @@ describe('vaadin-details', () => {
       expect(getComputedStyle(contentPart).display).to.equal('none');
     });
 
-    it('should show the content when `opened` is true', () => {
+    it('should show the content when `opened` is true', async () => {
       details.opened = true;
+      await nextFrame();
       expect(getComputedStyle(contentPart).display).to.equal('block');
     });
 
@@ -59,8 +61,9 @@ describe('vaadin-details', () => {
       expect(contentNode.getAttribute('aria-hidden')).to.equal('true');
     });
 
-    it('should set aria-hidden on the slotted element to false when opened', () => {
+    it('should set aria-hidden on the slotted element to false when opened', async () => {
       details.opened = true;
+      await nextFrame();
       expect(contentNode.getAttribute('aria-hidden')).to.equal('false');
     });
   });
@@ -83,16 +86,19 @@ describe('vaadin-details', () => {
     let summary;
 
     describe(`${type} summary`, () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         details = fixtureSync(fixtures[type]);
+        await nextRender();
         summary = details.querySelector('[slot="summary"]');
       });
 
-      it(`should toggle opened on ${type} summary click`, () => {
+      it(`should toggle opened on ${type} summary click`, async () => {
         summary.click();
+        await nextFrame();
         expect(details.opened).to.be.true;
 
         summary.click();
+        await nextFrame();
         expect(details.opened).to.be.false;
       });
 
@@ -122,26 +128,31 @@ describe('vaadin-details', () => {
         expect(details.opened).to.be.false;
       });
 
-      it(`should fire opened-changed event on ${type} summary click`, () => {
+      it(`should fire opened-changed event on ${type} summary click`, async () => {
         const spy = sinon.spy();
         details.addEventListener('opened-changed', spy);
         summary.click();
+        await nextFrame();
         expect(spy.calledOnce).to.be.true;
       });
 
-      it(`should toggle aria-expanded on ${type} summary click`, () => {
+      it(`should toggle aria-expanded on ${type} summary click`, async () => {
         summary.click();
+        await nextFrame();
         expect(summary.getAttribute('aria-expanded')).to.equal('true');
 
         summary.click();
+        await nextFrame();
         expect(summary.getAttribute('aria-expanded')).to.equal('false');
       });
 
-      it(`should propagate disabled attribute to ${type} summary`, () => {
+      it(`should propagate disabled attribute to ${type} summary`, async () => {
         details.disabled = true;
+        await nextFrame();
         expect(summary.hasAttribute('disabled')).to.be.true;
 
         details.disabled = false;
+        await nextFrame();
         expect(summary.hasAttribute('disabled')).to.be.false;
       });
     });
@@ -151,7 +162,7 @@ describe('vaadin-details', () => {
     const idRegex = /^content-vaadin-details-\d+$/u;
     let container, details;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       container = fixtureSync(`
         <div>
           <vaadin-details summary="Summary 1">
@@ -162,6 +173,7 @@ describe('vaadin-details', () => {
           </vaadin-details>
         </div>
       `);
+      await nextRender();
       details = container.querySelectorAll('vaadin-details');
     });
 

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-item.d.ts",
+    "!src/vaadin-lit-item.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/item/src/lib/item-base.d.ts
+++ b/packages/item/src/lib/item-base.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult, TemplateResult } from 'lit';
+
+export const styles: CSSResult;
+
+export function template<
+  T extends HTMLTemplateElement | TemplateResult,
+  F extends (strings: TemplateStringsArray, ...values: any[]) => T,
+>(tag: F): T;

--- a/packages/item/src/lib/item-base.js
+++ b/packages/item/src/lib/item-base.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const styles = css`
+  :host {
+    display: inline-block;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+`;
+
+export const template = (html) => html`
+  <span part="checkmark" aria-hidden="true"></span>
+  <div part="content">
+    <slot></slot>
+  </div>
+`;

--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -5,8 +5,11 @@
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { styles, template } from './lib/item-base.js';
 import { ItemMixin } from './vaadin-item-mixin.js';
+
+registerStyles('vaadin-item', styles, { moduleId: 'vaadin-item-styles' });
 
 /**
  * `<vaadin-item>` is a Web Component providing layout for items in tabs and menus.
@@ -52,26 +55,12 @@ import { ItemMixin } from './vaadin-item-mixin.js';
  * @mixes DirMixin
  */
 class Item extends ItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
-  static get template() {
-    return html`
-      <style>
-        :host {
-          display: inline-block;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-      </style>
-      <span part="checkmark" aria-hidden="true"></span>
-      <div part="content">
-        <slot></slot>
-      </div>
-    `;
-  }
-
   static get is() {
     return 'vaadin-item';
+  }
+
+  static get template() {
+    return template(html);
   }
 
   constructor() {

--- a/packages/item/src/vaadin-lit-item.d.ts
+++ b/packages/item/src/vaadin-lit-item.d.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ItemMixin } from './vaadin-item-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-item>` web component.
+ * Note: this is a prototype not supposed to be used publicly.
+ */
+declare class Item extends ItemMixin(DirMixin(ThemableMixin(LitElement))) {}
+
+export { Item };

--- a/packages/item/src/vaadin-lit-item.js
+++ b/packages/item/src/vaadin-lit-item.js
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { styles, template } from './lib/item-base.js';
+import { ItemMixin } from './vaadin-item-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-item>` web component.
+ * Note: this is a prototype not supposed to be used publicly.
+ *
+ * @private
+ */
+class Item extends ItemMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-item';
+  }
+
+  static get styles() {
+    return styles;
+  }
+
+  /** @protected */
+  render() {
+    return template(html);
+  }
+}
+
+customElements.define(Item.is, Item);
+
+export { Item };

--- a/packages/item/test/item-lit.test.js
+++ b/packages/item/test/item-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-item.js';
+import './item.common.js';

--- a/packages/item/test/item-polymer.test.js
+++ b/packages/item/test/item-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-item.js';
+import './item.common.js';

--- a/packages/item/test/item.common.js
+++ b/packages/item/test/item.common.js
@@ -1,12 +1,12 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-item.js';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 
 describe('vaadin-item', () => {
   let item, tagName;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     item = fixtureSync('<vaadin-item>label</vaadin-item>');
+    await nextRender();
     tagName = item.tagName.toLowerCase();
   });
 

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-radio-button.d.ts",
+    "!src/vaadin-lit-radio-button.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",
@@ -37,6 +39,7 @@
     "polymer"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "24.0.0-beta1",
     "@vaadin/field-base": "24.0.0-beta1",

--- a/packages/radio-group/src/lib/radio-button-base.d.ts
+++ b/packages/radio-group/src/lib/radio-button-base.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult, TemplateResult } from 'lit';
+
+export const styles: CSSResult;
+
+export function template<
+  T extends HTMLTemplateElement | TemplateResult,
+  F extends (strings: TemplateStringsArray, ...values: any[]) => T,
+>(tag: F): T;

--- a/packages/radio-group/src/lib/radio-button-base.js
+++ b/packages/radio-group/src/lib/radio-button-base.js
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const styles = css`
+  :host {
+    display: inline-block;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  :host([disabled]) {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .vaadin-radio-button-container {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: baseline;
+  }
+
+  [part='radio'],
+  ::slotted(input),
+  ::slotted(label) {
+    grid-row: 1;
+  }
+
+  [part='radio'],
+  ::slotted(input) {
+    grid-column: 1;
+  }
+
+  [part='radio'] {
+    width: var(--vaadin-radio-button-size, 1em);
+    height: var(--vaadin-radio-button-size, 1em);
+  }
+
+  [part='radio']::before {
+    display: block;
+    content: '\\202F';
+    line-height: var(--vaadin-radio-button-size, 1em);
+    contain: paint;
+  }
+
+  /* visually hidden */
+  ::slotted(input) {
+    opacity: 0;
+    cursor: inherit;
+    margin: 0;
+    align-self: stretch;
+    -webkit-appearance: none;
+  }
+`;
+
+export const template = (html) => html`
+  <div class="vaadin-radio-button-container">
+    <div part="radio" aria-hidden="true"></div>
+    <slot name="input"></slot>
+    <slot name="label"></slot>
+  </div>
+`;

--- a/packages/radio-group/src/vaadin-lit-radio-button.d.ts
+++ b/packages/radio-group/src/vaadin-lit-radio-button.d.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { RadioButtonMixin } from './vaadin-radio-button-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-radio-button>` web component.
+ * Note: this is a prototype not supposed to be used publicly.
+ */
+declare class RadioButton extends RadioButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
+
+export { RadioButton };

--- a/packages/radio-group/src/vaadin-lit-radio-button.js
+++ b/packages/radio-group/src/vaadin-lit-radio-button.js
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { styles, template } from './lib/radio-button-base.js';
+import { RadioButtonMixin } from './vaadin-radio-button-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-radio-button>` web component.
+ * Note: this is a prototype not supposed to be used publicly.
+ *
+ * @private
+ */
+class RadioButton extends RadioButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-radio-button';
+  }
+
+  static get styles() {
+    return styles;
+  }
+
+  /** @protected */
+  render() {
+    return template(html);
+  }
+}
+
+customElements.define(RadioButton.is, RadioButton);
+
+export { RadioButton };

--- a/packages/radio-group/src/vaadin-radio-button-mixin.d.ts
+++ b/packages/radio-group/src/vaadin-radio-button-mixin.d.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/component-base/src/delegate-focus-mixin.js';
+import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { CheckedMixinClass } from '@vaadin/field-base/src/checked-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+
+/**
+ * A mixin providing common radio button functionality.
+ */
+export declare function RadioButtonMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<ActiveMixinClass> &
+  Constructor<CheckedMixinClass> &
+  Constructor<DelegateFocusMixinClass> &
+  Constructor<DelegateStateMixinClass> &
+  Constructor<DisabledMixinClass> &
+  Constructor<FocusMixinClass> &
+  Constructor<InputMixinClass> &
+  Constructor<KeyboardMixinClass> &
+  Constructor<LabelMixinClass> &
+  T;
+
+export declare class RadioButtonMixinClass {
+  /**
+   * The name of the radio button.
+   */
+  name: string;
+}

--- a/packages/radio-group/src/vaadin-radio-button-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-button-mixin.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
+import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
+import { CheckedMixin } from '@vaadin/field-base/src/checked-mixin.js';
+import { InputController } from '@vaadin/field-base/src/input-controller.js';
+import { LabelMixin } from '@vaadin/field-base/src/label-mixin.js';
+import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
+
+/**
+ * A mixin providing common radio button functionality.
+ *
+ * @polymerMixin
+ * @mixes ActiveMixin
+ * @mixes CheckedMixin
+ * @mixes DelegateFocusMixin
+ * @mixes LabelMixin
+ */
+export const RadioButtonMixin = (superclass) =>
+  class RadioButtonMixinClass extends LabelMixin(CheckedMixin(DelegateFocusMixin(ActiveMixin(superclass)))) {
+    static get properties() {
+      return {
+        /**
+         * The name of the radio button.
+         *
+         * @type {string}
+         */
+        name: {
+          type: String,
+          value: '',
+        },
+      };
+    }
+
+    /** @override */
+    static get delegateAttrs() {
+      return [...super.delegateAttrs, 'name'];
+    }
+
+    constructor() {
+      super();
+
+      this._setType('radio');
+
+      // Set the string "on" as the default value for the radio button following the HTML specification:
+      // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
+      this.value = 'on';
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.addController(
+        new InputController(this, (input) => {
+          this._setInputElement(input);
+          this._setFocusElement(input);
+          this.stateTarget = input;
+          this.ariaTarget = input;
+        }),
+      );
+      this.addController(new LabelledInputController(this.inputElement, this._labelController));
+    }
+  };

--- a/packages/radio-group/src/vaadin-radio-button.d.ts
+++ b/packages/radio-group/src/vaadin-radio-button.d.ts
@@ -3,13 +3,10 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { CheckedMixin } from '@vaadin/field-base/src/checked-mixin.js';
-import { LabelMixin } from '@vaadin/field-base/src/label-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { RadioButtonMixin } from './vaadin-radio-button-mixin.js';
 
 /**
  * Fired when the `checked` property changes.
@@ -57,9 +54,7 @@ export interface RadioButtonEventMap extends HTMLElementEventMap, RadioButtonCus
  *
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  */
-declare class RadioButton extends LabelMixin(
-  CheckedMixin(DelegateFocusMixin(ActiveMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))))),
-) {
+declare class RadioButton extends RadioButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {
   /**
    * The name of the radio button.
    */

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -4,15 +4,13 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ActiveMixin } from '@vaadin/component-base/src/active-mixin.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { CheckedMixin } from '@vaadin/field-base/src/checked-mixin.js';
-import { InputController } from '@vaadin/field-base/src/input-controller.js';
-import { LabelMixin } from '@vaadin/field-base/src/label-mixin.js';
-import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { styles, template } from './lib/radio-button-base.js';
+import { RadioButtonMixin } from './vaadin-radio-button-mixin.js';
+
+registerStyles('vaadin-radio-button', styles, { moduleId: 'vaadin-radio-button-styles' });
 
 /**
  * `<vaadin-radio-button>` is a web component representing a choice in a radio group.
@@ -53,120 +51,15 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @mixes ControllerMixin
  * @mixes ThemableMixin
  * @mixes ElementMixin
- * @mixes ActiveMixin
- * @mixes CheckedMixin
- * @mixes LabelMixin
+ * @mixes RadioButtonMixin
  */
-class RadioButton extends LabelMixin(
-  CheckedMixin(DelegateFocusMixin(ActiveMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement)))))),
-) {
+class RadioButton extends RadioButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-radio-button';
   }
 
   static get template() {
-    return html`
-      <style>
-        :host {
-          display: inline-block;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        :host([disabled]) {
-          -webkit-tap-highlight-color: transparent;
-        }
-
-        .vaadin-radio-button-container {
-          display: grid;
-          grid-template-columns: auto 1fr;
-          align-items: baseline;
-        }
-
-        [part='radio'],
-        ::slotted(input),
-        ::slotted(label) {
-          grid-row: 1;
-        }
-
-        [part='radio'],
-        ::slotted(input) {
-          grid-column: 1;
-        }
-
-        [part='radio'] {
-          width: var(--vaadin-radio-button-size, 1em);
-          height: var(--vaadin-radio-button-size, 1em);
-        }
-
-        [part='radio']::before {
-          display: block;
-          content: '\\202F';
-          line-height: var(--vaadin-radio-button-size, 1em);
-          contain: paint;
-        }
-
-        /* visually hidden */
-        ::slotted(input) {
-          opacity: 0;
-          cursor: inherit;
-          margin: 0;
-          align-self: stretch;
-          -webkit-appearance: none;
-        }
-      </style>
-      <div class="vaadin-radio-button-container">
-        <div part="radio" aria-hidden="true"></div>
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-    `;
-  }
-
-  static get properties() {
-    return {
-      /**
-       * The name of the radio button.
-       *
-       * @type {string}
-       */
-      name: {
-        type: String,
-        value: '',
-      },
-    };
-  }
-
-  /** @override */
-  static get delegateAttrs() {
-    return [...super.delegateAttrs, 'name'];
-  }
-
-  constructor() {
-    super();
-
-    this._setType('radio');
-
-    // Set the string "on" as the default value for the radio button following the HTML specification:
-    // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
-    this.value = 'on';
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this.addController(
-      new InputController(this, (input) => {
-        this._setInputElement(input);
-        this._setFocusElement(input);
-        this.stateTarget = input;
-        this.ariaTarget = input;
-      }),
-    );
-    this.addController(new LabelledInputController(this.inputElement, this._labelController));
+    return template(html);
   }
 }
 

--- a/packages/radio-group/test/radio-button-lit.test.js
+++ b/packages/radio-group/test/radio-button-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-radio-button.js';
+import './radio-button.common.js';

--- a/packages/radio-group/test/radio-button-polymer.test.js
+++ b/packages/radio-group/test/radio-button-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-radio-button.js';
+import './radio-button.common.js';

--- a/packages/radio-group/test/radio-button.common.js
+++ b/packages/radio-group/test/radio-button.common.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, mousedown, mouseup, nextFrame } from '@vaadin/testing-helpers';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../vaadin-radio-button.js';
 
 describe('radio-button', () => {
   let radio, input, label;
@@ -25,8 +24,9 @@ describe('radio-button', () => {
   });
 
   describe('default', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       radio = fixtureSync('<vaadin-radio-button label="Label"></vaadin-radio-button>');
+      await nextFrame();
       label = radio.querySelector('[slot=label]');
     });
 
@@ -44,8 +44,9 @@ describe('radio-button', () => {
   });
 
   describe('native input', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       radio = fixtureSync('<vaadin-radio-button></vaadin-radio-button>');
+      await nextFrame();
       input = radio.querySelector('[slot=input]');
       label = radio.querySelector('[slot=label]');
     });
@@ -110,8 +111,9 @@ describe('radio-button', () => {
   });
 
   describe('disabled attribute', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       radio = fixtureSync('<vaadin-radio-button disabled></vaadin-radio-button>');
+      await nextFrame();
       input = radio.querySelector('[slot=input]');
       label = radio.querySelector('[slot=label]');
     });
@@ -138,8 +140,9 @@ describe('radio-button', () => {
 
   // TODO: A legacy suit. Replace with snapshot tests when possible.
   describe('active attribute', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       radio = fixtureSync('<vaadin-radio-button></vaadin-radio-button>');
+      await nextFrame();
       input = radio.querySelector('[slot=input]');
     });
 
@@ -167,8 +170,9 @@ describe('radio-button', () => {
   describe('change event', () => {
     let spy;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       radio = fixtureSync('<vaadin-radio-button></vaadin-radio-button>');
+      await nextFrame();
       label = radio.querySelector('[slot=label]');
       input = radio.querySelector('[slot=input]');
 
@@ -195,19 +199,22 @@ describe('radio-button', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should not fire on programmatic toggle', () => {
+    it('should not fire on programmatic toggle', async () => {
       radio.checked = true;
+      await nextFrame();
       expect(spy.called).to.be.false;
     });
 
-    it('should not fire on input click when checked', () => {
+    it('should not fire on input click when checked', async () => {
       radio.checked = true;
+      await nextFrame();
       input.click();
       expect(spy.called).to.be.false;
     });
 
-    it('should not fire on label click when checked', () => {
+    it('should not fire on label click when checked', async () => {
       radio.checked = true;
+      await nextFrame();
       label.click();
       expect(spy.called).to.be.false;
     });
@@ -227,23 +234,26 @@ describe('radio-button', () => {
 
   describe('delegation', () => {
     describe('name attribute', () => {
-      beforeEach(() => {
-        radio = fixtureSync(`<vaadin-radio-button name="Name"></vaadin-radio-button>`);
+      beforeEach(async () => {
+        radio = fixtureSync('<vaadin-radio-button name="Name"></vaadin-radio-button>');
+        await nextFrame();
         input = radio.querySelector('[slot=input]');
       });
 
-      it('should delegate name attribute to the input', () => {
+      it('should delegate name attribute to the input', async () => {
         expect(input.getAttribute('name')).to.equal('Name');
 
         radio.removeAttribute('name');
+        await nextFrame();
         expect(input.hasAttribute('name')).to.be.false;
       });
     });
   });
 
   describe('has-label attribute', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       radio = fixtureSync('<vaadin-radio-button></vaadin-radio-button>');
+      await nextFrame();
     });
 
     it('should not set has-label attribute when label content is empty', () => {


### PR DESCRIPTION
## Description

TL;DR: this is not our first step towards moving to Lit - but now it's an attempt to get it done.

> **Warning**
> This PR is a personal initiative, not something currently planned by the team to work on.
> It is intended to be a discussion opener rather than a ready to use implementation.

## Type of change

- Prototype

## Background

There has been a discussion on [Vaadin Discord](https://discord.com/channels/732335336448852018/1058317210277380156) server recently about our plans to remove Polymer in 2023.
This is a very long-lasting idea that I've been trying to pursue since 2018 - which is almost 5 years now:

1. Even before Lit 1.0 was out, I already [started prototyping](https://github.com/web-padawan/lit-components/commit/61a4ba6dca33b46ee4276bd647527182eea2fd54) the `lit-components` project using 0.x in May 2018;
2. One year later, in November 2019, I published [the blog post](https://vaadin.com/blog/next-generation-vaadin-components) at https://vaadin.com outlining some rough plans;
3. That concluded with a [`component-mixins`](https://github.com/vaadin/component-mixins) research project - most of its code is now incorporated to this repo;
4. We released a few incomplete alphas for 7 web components, but realised the complexity of remaining effort.
5. Next step was to remove most of usage of Polymer in Vaadin components - see this list of [issues and PRs](https://github.com/vaadin/web-components/issues?q=label%3Ano-polymer+is%3Aclosed);
6. Another project that took some time was adding [Lit directives](https://github.com/vaadin/web-components/issues/266) for components that support `renderer` function; 
7. Then I created [`PolylitMixin`](https://github.com/web-padawan/polylit) - first, as as personal project. Later we moved it to this repo and improved logic;
8. We also added Lit support for some mixins, namely [`ThemableMixin`](https://github.com/vaadin/web-components/issues/401), [`DirMixin`](https://github.com/vaadin/web-components/pull/3718) and other mixins / controllers;
9. Finally, we added `lit-html` usage to [`vaadin-upload`](https://github.com/vaadin/web-components/pull/4870), [`vaadin-avatar-group`](https://github.com/vaadin/web-components/pull/4869) and [`vaadin-message-list`](https://github.com/vaadin/web-components/pull/4868).

That said, we still don't have any web component that `extends LitElement` and people are disappointed about it.
This PR proposes one possible solution for moving forward with Lit support without exposing it publicly (yet).

## Proposal

1. For each component, extract logic into a mixin. Existing examples: `ButtonMixin`, `ItemMixin`, `ProgressMixin` etc.
2. Move component core styles from `<style>` tag inside the template to a `css` tagged literal from the `lit` package;
3. Add new base classes for Lit versions e.g `src/vaadin-lit-button.js` using the same `vaadin-button` tag name;
4. Update existing classes to use new mixins / styles, while keeping all the JSDoc comments / TS definitions untouched; 
5. Update unit tests to cover **both** original base classes (Polymer-based) and new experimental classes (Lit-based);
6. Exclude new files like  `src/vaadin-lit-button.js` from `"files"` in `package.json` to  **NOT** publish them to npm.

## Components

Currently, this PR covers the following web components as an illustration of the suggested approach:

- `vaadin-details`
- `vaadin-item`
- `vaadin-radio-button`

I'm planning to gradually update this PR with adding more simple components, and rebase as necessary.
This is going to be my main focus for "Community Friday" at Vaadin (every two weeks including today).

Some complex components are not supposed to be covered by this PR:

- `vaadin-date-picker` is only partially converted to Lit - see the [WIP branch](https://github.com/vaadin/web-components/compare/proto/date-picker-lit) with two updated components;
- `vaadin-grid`, `vaadin-grid-pro` and `vaadin-crud` were converted by @tomivirkki in [this branch](https://github.com/vaadin/web-components/tree/lit-grid).

## Next Steps

We are going to have a meeting to clarify our plans related to web components Lit conversion in early February.
So we'll discuss this within a team and decide what to do next. Then we will hopefully share more updates.

## 10.02 Update

The following experiments have been merged to `main` and `24.0` branches and this PR is now updated:

- https://github.com/vaadin/web-components/pull/5538
- https://github.com/vaadin/web-components/pull/5539
- https://github.com/vaadin/web-components/pull/5541
- https://github.com/vaadin/web-components/pull/5549
- https://github.com/vaadin/web-components/pull/5551
- https://github.com/vaadin/web-components/pull/5558
- https://github.com/vaadin/web-components/pull/5567