### PR TITLE
test: update button unit tests, wait for fixture render

### DIFF
--- a/packages/button/test/button.test.js
+++ b/packages/button/test/button.test.js
@@ -1,18 +1,18 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-button.js';
 
 describe('vaadin-button', () => {
-  let element;
+  let button;
 
   describe('custom element definition', () => {
     let tagName;
 
     beforeEach(() => {
-      element = fixtureSync('<vaadin-button></vaadin-button>');
-      tagName = element.tagName.toLowerCase();
+      button = fixtureSync('<vaadin-button></vaadin-button>');
+      tagName = button.tagName.toLowerCase();
     });
 
     it('should be defined in custom element registry', () => {
@@ -26,36 +26,39 @@ describe('vaadin-button', () => {
 
   describe('role', () => {
     describe('default', () => {
-      beforeEach(() => {
-        element = fixtureSync('<vaadin-button>Press me</vaadin-button>');
+      beforeEach(async () => {
+        button = fixtureSync('<vaadin-button>Press me</vaadin-button>');
+        await nextRender();
       });
 
       it('should set role attribute to button by default', () => {
-        expect(element.getAttribute('role')).to.equal('button');
+        expect(button.getAttribute('role')).to.equal('button');
       });
     });
 
     describe('custom', () => {
-      beforeEach(() => {
-        element = fixtureSync('<vaadin-button role="menuitem">Press me</vaadin-button>');
+      beforeEach(async () => {
+        button = fixtureSync('<vaadin-button role="menuitem">Press me</vaadin-button>');
+        await nextRender();
       });
 
       it('should not override custom role attribute', () => {
-        expect(element.getAttribute('role')).to.equal('menuitem');
+        expect(button.getAttribute('role')).to.equal('menuitem');
       });
     });
   });
 
   describe('keyboard', () => {
-    beforeEach(() => {
-      element = fixtureSync('<vaadin-button>Press me</vaadin-button>');
-      element.focus();
+    beforeEach(async () => {
+      button = fixtureSync('<vaadin-button>Press me</vaadin-button>');
+      await nextRender();
+      button.focus();
     });
 
     ['Enter', 'Space'].forEach((key) => {
       it(`should fire click event on ${key}`, async () => {
         const spy = sinon.spy();
-        element.addEventListener('click', spy);
+        button.addEventListener('click', spy);
 
         await sendKeys({ down: key });
 
@@ -64,33 +67,33 @@ describe('vaadin-button', () => {
 
       it(`should not fire click event on ${key} when disabled`, async () => {
         const spy = sinon.spy();
-        element.addEventListener('click', spy);
-        element.disabled = true;
+        button.addEventListener('click', spy);
+        button.disabled = true;
 
         await sendKeys({ down: key });
 
         expect(spy.called).to.be.false;
       });
 
-      it(`should prevent default behaviour for keydown event on ${key}`, async () => {
+      it(`should prevent default behavior for keydown event on ${key}`, async () => {
         const spy = sinon.spy();
-        element.addEventListener('keydown', spy);
+        button.addEventListener('keydown', spy);
 
         await sendKeys({ down: key });
 
-        const event = spy.args[0][0];
+        const event = spy.firstCall.args[0];
         expect(event).to.be.an.instanceOf(KeyboardEvent);
         expect(event.defaultPrevented).to.be.true;
       });
     });
 
-    it('should not prevent default behaviour for keydown event on non-activation key', async () => {
+    it('should not prevent default behavior for keydown event on non-activation key', async () => {
       const spy = sinon.spy();
-      element.addEventListener('keydown', spy);
+      button.addEventListener('keydown', spy);
 
       await sendKeys({ down: 'ArrowDown' });
 
-      const event = spy.args[0][0];
+      const event = spy.firstCall.args[0];
       expect(event).to.be.an.instanceOf(KeyboardEvent);
       expect(event.defaultPrevented).to.be.false;
     });


### PR DESCRIPTION
## Description

- Updated `vaadin-button` unit tests to use `button` variable name instead of the `element`;
- Added `nextRender()` for easier debugging and to reduce changes during Lit conversion;
- Changed tests for keyboard events to use `spy.firstCall` for getting an event reference.

## Type of change

- Tests