### PR TITLE
test: add missing dialog snapshots and types tests

### DIFF
--- a/packages/dialog/test/dom/__snapshots__/dialog.test.snap.js
+++ b/packages/dialog/test/dom/__snapshots__/dialog.test.snap.js
@@ -1,0 +1,43 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-dialog overlay"] = 
+`<vaadin-dialog-overlay
+  focus-trap=""
+  id="overlay"
+  opened=""
+  role="dialog"
+  with-backdrop=""
+>
+  content
+</vaadin-dialog-overlay>
+`;
+/* end snapshot vaadin-dialog overlay */
+
+snapshots["vaadin-dialog overlay modeless"] = 
+`<vaadin-dialog-overlay
+  focus-trap=""
+  id="overlay"
+  modeless=""
+  opened=""
+  role="dialog"
+>
+  content
+</vaadin-dialog-overlay>
+`;
+/* end snapshot vaadin-dialog overlay modeless */
+
+snapshots["vaadin-dialog overlay theme"] = 
+`<vaadin-dialog-overlay
+  focus-trap=""
+  id="overlay"
+  opened=""
+  role="dialog"
+  theme="custom"
+  with-backdrop=""
+>
+  content
+</vaadin-dialog-overlay>
+`;
+/* end snapshot vaadin-dialog overlay theme */
+

--- a/packages/dialog/test/dom/dialog.test.js
+++ b/packages/dialog/test/dom/dialog.test.js
@@ -1,0 +1,38 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import '../../src/vaadin-dialog.js';
+
+describe('vaadin-dialog', () => {
+  let dialog, overlay;
+
+  const SNAPSHOT_CONFIG = {
+    // Some inline CSS styles related to the overlay's position
+    // may slightly change depending on the environment, so ignore them.
+    ignoreAttributes: ['style'],
+  };
+
+  beforeEach(async () => {
+    dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+    await nextRender();
+    overlay = dialog.$.overlay;
+    dialog.renderer = (root) => {
+      root.textContent = 'content';
+    };
+    dialog.opened = true;
+    await oneEvent(overlay, 'vaadin-overlay-open');
+  });
+
+  it('overlay', async () => {
+    await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+
+  it('overlay modeless', async () => {
+    dialog.modeless = true;
+    await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+
+  it('overlay theme', async () => {
+    dialog.setAttribute('theme', 'custom');
+    await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});

--- a/packages/dialog/test/typings/dialog.types.ts
+++ b/packages/dialog/test/typings/dialog.types.ts
@@ -1,6 +1,8 @@
 import '../../vaadin-dialog.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import type { DialogDraggableMixinClass } from '../../src/vaadin-dialog-draggable-mixin.js';
+import type { DialogResizableMixinClass } from '../../src/vaadin-dialog-resizable-mixin.js';
 import type {
   Dialog,
   DialogOpenedChangedEvent,
@@ -16,6 +18,8 @@ const dialog = document.createElement('vaadin-dialog');
 // Mixins
 assertType<ElementMixinClass>(dialog);
 assertType<ThemePropertyMixinClass>(dialog);
+assertType<DialogDraggableMixinClass>(dialog);
+assertType<DialogResizableMixinClass>(dialog);
 
 // Events
 dialog.addEventListener('opened-changed', (event) => {

--- a/packages/dialog/test/typings/dialog.types.ts
+++ b/packages/dialog/test/typings/dialog.types.ts
@@ -1,4 +1,6 @@
 import '../../vaadin-dialog.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type {
   Dialog,
   DialogOpenedChangedEvent,
@@ -11,6 +13,11 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 
 const dialog = document.createElement('vaadin-dialog');
 
+// Mixins
+assertType<ElementMixinClass>(dialog);
+assertType<ThemePropertyMixinClass>(dialog);
+
+// Events
 dialog.addEventListener('opened-changed', (event) => {
   assertType<DialogOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
@@ -22,6 +29,12 @@ dialog.addEventListener('resize', (event) => {
 });
 
 // Properties
+assertType<boolean>(dialog.opened);
+assertType<boolean>(dialog.modeless);
+assertType<boolean>(dialog.draggable);
+assertType<boolean>(dialog.resizable);
+assertType<boolean>(dialog.noCloseOnEsc);
+assertType<boolean>(dialog.noCloseOnOutsideClick);
 assertType<string | null | undefined>(dialog.headerTitle);
 assertType<DialogRenderer | null | undefined>(dialog.renderer);
 assertType<DialogRenderer | null | undefined>(dialog.headerRenderer);


### PR DESCRIPTION
## Description

Added missing snapshot tests to `vaadin-dialog` for testing overlay DOM. Also extended typings tests.
This is done in preparation for adding `OverlayClassMixin` which will be also covered by these tests.

## Type of change

- Tests