### PR TITLE
refactor: remove no longer needed Safari 13 workaround

### DIFF
--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -321,7 +321,6 @@ export class DialogOverlay extends Overlay {
     if (overlay.style.position !== 'absolute') {
       overlay.style.position = 'absolute';
       this.setAttribute('has-bounds-set', '');
-      this.__forceSafariReflow();
     }
 
     Object.keys(parsedBounds).forEach((arg) => {
@@ -345,22 +344,6 @@ export class DialogOverlay extends Overlay {
     const width = overlayBounds.width;
     const height = overlayBounds.height;
     return { top, left, width, height };
-  }
-
-  /**
-   * Safari 13 renders overflowing elements incorrectly.
-   * This forces it to recalculate height.
-   * @private
-   */
-  __forceSafariReflow() {
-    const scrollPosition = this.$.resizerContainer.scrollTop;
-    const overlay = this.$.overlay;
-    overlay.style.display = 'block';
-
-    requestAnimationFrame(() => {
-      overlay.style.display = '';
-      this.$.resizerContainer.scrollTop = scrollPosition;
-    });
   }
 
   /** @private */


### PR DESCRIPTION
## Description

Removed the workaround for Safari 13 as the problem was fixed later, and we support Safari 15+ in Vaadin 24.

Here is the original bug: https://github.com/vaadin/vaadin-dialog-flow/issues/207#issuecomment-662386853

Related PRs in `vaadin-dialog` web component from 2020:

- https://github.com/vaadin/vaadin-dialog/pull/182
- https://github.com/vaadin/vaadin-dialog/pull/186

## Type of change

- Refactor

## Note

Can be tested with the following HTML snippet in the dialog dev page:

```html
<vaadin-dialog modeless resizable opened>
  <template>
    <vaadin-text-area value="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.      ">
    </vaadin-text-area>
  </template>
</vaadin-dialog>

<script type="module">
  import './common.js';
  import '@vaadin/polymer-legacy-adapter/template-renderer.js';
  import '@vaadin/dialog';
  import '@vaadin/text-area';
</script>
```