### PR TITLE
test: add missing confirm-dialog snapshots and types tests

### DIFF
--- a/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
+++ b/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
@@ -1,0 +1,82 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-confirm-dialog overlay"] = 
+`<vaadin-confirm-dialog-overlay
+  aria-label="Unsaved changes"
+  focus-trap=""
+  has-footer=""
+  has-header=""
+  id="overlay"
+  opened=""
+  role="dialog"
+  with-backdrop=""
+>
+  <h3 slot="header">
+    Unsaved changes
+  </h3>
+  Do you want to save or discard the changes?
+  <vaadin-button
+    hidden=""
+    slot="cancel-button"
+    theme="tertiary"
+  >
+    Cancel
+  </vaadin-button>
+  <vaadin-button
+    slot="confirm-button"
+    theme="primary"
+  >
+    Confirm
+  </vaadin-button>
+  <vaadin-button
+    hidden=""
+    slot="reject-button"
+    theme="error tertiary"
+  >
+    Reject
+  </vaadin-button>
+</vaadin-confirm-dialog-overlay>
+`;
+/* end snapshot vaadin-confirm-dialog overlay */
+
+snapshots["vaadin-confirm-dialog overlay theme"] = 
+`<vaadin-confirm-dialog-overlay
+  aria-label="Unsaved changes"
+  focus-trap=""
+  has-footer=""
+  has-header=""
+  id="overlay"
+  opened=""
+  role="dialog"
+  theme="custom"
+  with-backdrop=""
+>
+  <h3 slot="header">
+    Unsaved changes
+  </h3>
+  Do you want to save or discard the changes?
+  <vaadin-button
+    hidden=""
+    slot="cancel-button"
+    theme="tertiary"
+  >
+    Cancel
+  </vaadin-button>
+  <vaadin-button
+    slot="confirm-button"
+    theme="primary"
+  >
+    Confirm
+  </vaadin-button>
+  <vaadin-button
+    hidden=""
+    slot="reject-button"
+    theme="error tertiary"
+  >
+    Reject
+  </vaadin-button>
+</vaadin-confirm-dialog-overlay>
+`;
+/* end snapshot vaadin-confirm-dialog overlay theme */
+

--- a/packages/confirm-dialog/test/dom/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/dom/confirm-dialog.test.js
@@ -1,0 +1,34 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import '../../src/vaadin-confirm-dialog.js';
+
+describe('vaadin-confirm-dialog', () => {
+  let dialog, overlay;
+
+  const SNAPSHOT_CONFIG = {
+    // Some inline CSS styles related to the overlay's position
+    // may slightly change depending on the environment, so ignore them.
+    ignoreAttributes: ['style'],
+  };
+
+  beforeEach(async () => {
+    dialog = fixtureSync(`
+      <vaadin-confirm-dialog header="Unsaved changes">
+        Do you want to save or discard the changes?
+      </vaadin-confirm-dialog>
+    `);
+    await nextRender();
+    overlay = dialog.$.dialog._overlayElement;
+    dialog.opened = true;
+    await oneEvent(overlay, 'vaadin-overlay-open');
+  });
+
+  it('overlay', async () => {
+    await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+
+  it('overlay theme', async () => {
+    dialog.setAttribute('theme', 'custom');
+    await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});

--- a/packages/confirm-dialog/test/typings/confirm-dialog.types.ts
+++ b/packages/confirm-dialog/test/typings/confirm-dialog.types.ts
@@ -1,10 +1,31 @@
 import '../../vaadin-confirm-dialog.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { ConfirmDialogOpenedChangedEvent } from '../../vaadin-confirm-dialog.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const dialog = document.createElement('vaadin-confirm-dialog');
 
+// Mixins
+assertType<ElementMixinClass>(dialog);
+assertType<ThemePropertyMixinClass>(dialog);
+
+// Properties
+assertType<boolean>(dialog.opened);
+assertType<boolean>(dialog.noCloseOnEsc);
+assertType<boolean>(dialog.cancelButtonVisible);
+assertType<boolean>(dialog.rejectButtonVisible);
+assertType<string>(dialog.header);
+assertType<string | null | undefined>(dialog.message);
+assertType<string>(dialog.confirmText);
+assertType<string>(dialog.confirmTheme);
+assertType<string>(dialog.cancelText);
+assertType<string>(dialog.cancelTheme);
+assertType<string>(dialog.rejectText);
+assertType<string>(dialog.rejectTheme);
+
+// Events
 dialog.addEventListener('opened-changed', (event) => {
   assertType<ConfirmDialogOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);


### PR DESCRIPTION
## Description

Same as #5308 but for `vaadin-confirm-dialog`.

Added missing snapshot tests to `vaadin-confirm-dialog` for testing overlay DOM. Also extended typings tests.
This is done in preparation for adding `OverlayClassMixin` which will be also covered by these tests.

## Type of change

- Tests