### PR TITLE
feat: add overlayClass property to vaadin-confirm-dialog

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -148,6 +148,14 @@ declare class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMi
    */
   cancelTheme: string;
 
+  /**
+   * A space-delimited list of CSS class names
+   * to set on the underlying overlay element.
+   *
+   * @attr {string} overlay-class
+   */
+  overlayClass: string;
+
   addEventListener<K extends keyof ConfirmDialogEventMap>(
     type: K,
     listener: (this: ConfirmDialog, ev: ConfirmDialogEventMap[K]) => void,

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -76,6 +76,7 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
       <vaadin-confirm-dialog-dialog
         id="dialog"
         opened="{{opened}}"
+        overlay-class="[[overlayClass]]"
         aria-label="[[_getAriaLabel(header)]]"
         theme$="[[_theme]]"
         no-close-on-outside-click
@@ -223,6 +224,16 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
       cancelTheme: {
         type: String,
         value: 'tertiary',
+      },
+
+      /**
+       * A space-delimited list of CSS class names
+       * to set on the underlying overlay element.
+       *
+       * @attr {string} overlay-class
+       */
+      overlayClass: {
+        type: String,
       },
 
       /**

--- a/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
+++ b/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
@@ -80,3 +80,43 @@ snapshots["vaadin-confirm-dialog overlay theme"] =
 `;
 /* end snapshot vaadin-confirm-dialog overlay theme */
 
+snapshots["vaadin-confirm-dialog overlay class"] = 
+`<vaadin-confirm-dialog-overlay
+  aria-label="Unsaved changes"
+  class="confirm-dialog-overlay custom"
+  focus-trap=""
+  has-footer=""
+  has-header=""
+  id="overlay"
+  opened=""
+  role="dialog"
+  with-backdrop=""
+>
+  <h3 slot="header">
+    Unsaved changes
+  </h3>
+  Do you want to save or discard the changes?
+  <vaadin-button
+    hidden=""
+    slot="cancel-button"
+    theme="tertiary"
+  >
+    Cancel
+  </vaadin-button>
+  <vaadin-button
+    slot="confirm-button"
+    theme="primary"
+  >
+    Confirm
+  </vaadin-button>
+  <vaadin-button
+    hidden=""
+    slot="reject-button"
+    theme="error tertiary"
+  >
+    Reject
+  </vaadin-button>
+</vaadin-confirm-dialog-overlay>
+`;
+/* end snapshot vaadin-confirm-dialog overlay class */
+

--- a/packages/confirm-dialog/test/dom/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/dom/confirm-dialog.test.js
@@ -31,4 +31,9 @@ describe('vaadin-confirm-dialog', () => {
     dialog.setAttribute('theme', 'custom');
     await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
+
+  it('overlay class', async () => {
+    dialog.overlayClass = 'confirm-dialog-overlay custom';
+    await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
 });

--- a/packages/confirm-dialog/test/typings/confirm-dialog.types.ts
+++ b/packages/confirm-dialog/test/typings/confirm-dialog.types.ts
@@ -24,6 +24,7 @@ assertType<string>(dialog.cancelText);
 assertType<string>(dialog.cancelTheme);
 assertType<string>(dialog.rejectText);
 assertType<string>(dialog.rejectTheme);
+assertType<string>(dialog.overlayClass);
 
 // Events
 dialog.addEventListener('opened-changed', (event) => {


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/3593
Related to https://github.com/vaadin/web-components/issues/5121

Based on #5207

## Type of change

- Feature

## Note

As the overlay in placed in a nested shadow root, I decided not to use `OverlayClassMixin` in this case.
Instead, the property is defined separately with an appropriate JSDoc and propagated to the dialog.