### PR TITLE
refactor: simplify logic to change login overlay opened

### DIFF
--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -59,6 +59,8 @@ class LoginOverlay extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement)
         title="[[title]]"
         description="[[description]]"
         theme$="[[_theme]]"
+        on-vaadin-overlay-escape-press="_preventClosingLogin"
+        on-vaadin-overlay-outside-click="_preventClosingLogin"
       >
         <vaadin-login-form
           theme="with-overlay"
@@ -118,22 +120,12 @@ class LoginOverlay extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement)
   }
 
   /** @protected */
-  ready() {
-    super.ready();
-
-    this._preventClosingLogin = this._preventClosingLogin.bind(this);
-  }
-
-  /** @protected */
   connectedCallback() {
     super.connectedCallback();
 
-    this.$.vaadinLoginOverlayWrapper.addEventListener('vaadin-overlay-outside-click', this._preventClosingLogin);
-    this.$.vaadinLoginOverlayWrapper.addEventListener('vaadin-overlay-escape-press', this._preventClosingLogin);
-
     // Restore opened state if overlay was open when disconnecting
     if (this.__restoreOpened) {
-      this.$.vaadinLoginOverlayWrapper.opened = true;
+      this.opened = true;
     }
   }
 
@@ -141,12 +133,9 @@ class LoginOverlay extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement)
   disconnectedCallback() {
     super.disconnectedCallback();
 
-    this.$.vaadinLoginOverlayWrapper.removeEventListener('vaadin-overlay-outside-click', this._preventClosingLogin);
-    this.$.vaadinLoginOverlayWrapper.removeEventListener('vaadin-overlay-escape-press', this._preventClosingLogin);
-
     // Close overlay and memorize opened state
-    this.__restoreOpened = this.$.vaadinLoginOverlayWrapper.opened;
-    this.$.vaadinLoginOverlayWrapper.opened = false;
+    this.__restoreOpened = this.opened;
+    this.opened = false;
   }
 
   /** @private */


### PR DESCRIPTION
## Description

Updated `vaadin-login-overlay` to avoid removing listeners and adding them back, it's actually not needed.
These events are guaranteed to only fire if the overlay is attached and its `_last` getter returns `true`:

https://github.com/vaadin/web-components/blob/120b978fb0e1a1fd0c1ffad2472387cbb58e4e0f/packages/overlay/src/vaadin-overlay.js#L429-L431

https://github.com/vaadin/web-components/blob/120b978fb0e1a1fd0c1ffad2472387cbb58e4e0f/packages/overlay/src/vaadin-overlay.js#L452-L454

Also changed `connectedCallback()` and `disconnectedCallback()` to check `opened` on the host element.

## Type of change

- Refactor