### PR TITLE
test: add missing notification snapshots and types tests

### DIFF
--- a/packages/notification/test/dom/__snapshots__/notification.test.snap.js
+++ b/packages/notification/test/dom/__snapshots__/notification.test.snap.js
@@ -1,0 +1,26 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-notification card"] = 
+`<vaadin-notification-card
+  aria-live="polite"
+  role="alert"
+  slot="bottom-start"
+>
+  content
+</vaadin-notification-card>
+`;
+/* end snapshot vaadin-notification card */
+
+snapshots["vaadin-notification card theme"] = 
+`<vaadin-notification-card
+  aria-live="polite"
+  role="alert"
+  slot="bottom-start"
+  theme="custom"
+>
+  content
+</vaadin-notification-card>
+`;
+/* end snapshot vaadin-notification card theme */
+

--- a/packages/notification/test/dom/notification.test.js
+++ b/packages/notification/test/dom/notification.test.js
@@ -1,0 +1,27 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import '../../vaadin-notification.js';
+
+describe('vaadin-notification', () => {
+  let notification, card;
+
+  beforeEach(async () => {
+    notification = fixtureSync('<vaadin-notification></vaadin-notification>');
+    await nextRender();
+    card = notification._card;
+    notification.renderer = (root) => {
+      root.textContent = 'content';
+    };
+    notification.opened = true;
+    await oneEvent(card, 'animationend');
+  });
+
+  it('card', async () => {
+    await expect(card).dom.to.equalSnapshot();
+  });
+
+  it('card theme', async () => {
+    notification.setAttribute('theme', 'custom');
+    await expect(card).dom.to.equalSnapshot();
+  });
+});

--- a/packages/notification/test/typings/notification.types.ts
+++ b/packages/notification/test/typings/notification.types.ts
@@ -1,11 +1,28 @@
 import '../../vaadin-notification.js';
-import type { NotificationOpenedChangedEvent, NotificationRenderer } from '../../vaadin-notification.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import type {
+  NotificationOpenedChangedEvent,
+  NotificationPosition,
+  NotificationRenderer,
+} from '../../vaadin-notification.js';
 import { Notification } from '../../vaadin-notification.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 
 const notification = document.createElement('vaadin-notification');
 
+// Mixins
+assertType<ElementMixinClass>(notification);
+assertType<ThemePropertyMixinClass>(notification);
+
+// Properties
+assertType<number>(notification.duration);
+assertType<boolean>(notification.opened);
+assertType<NotificationPosition>(notification.position);
+assertType<NotificationRenderer | undefined>(notification.renderer);
+
+// Events
 notification.addEventListener('opened-changed', (event) => {
   assertType<NotificationOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);


### PR DESCRIPTION
## Description

Added missing snapshot tests to `vaadin-notification` for testing card DOM. Also extended typings tests.
This is done in preparation for adding `OverlayClassMixin` which will be also covered by these tests.

## Type of change

- Tests