### PR TITLE
refactor: set aria-hidden attribute on the checkbox part

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -117,7 +117,7 @@ class Checkbox extends LabelMixin(
         }
       </style>
       <div class="vaadin-checkbox-container">
-        <div part="checkbox"></div>
+        <div part="checkbox" aria-hidden="true"></div>
         <slot name="input"></slot>
         <slot name="label"></slot>
       </div>

--- a/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
+++ b/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
@@ -45,7 +45,10 @@ snapshots["vaadin-checkbox host disabled"] =
 
 snapshots["vaadin-checkbox shadow default"] = 
 `<div class="vaadin-checkbox-container">
-  <div part="checkbox">
+  <div
+    aria-hidden="true"
+    part="checkbox"
+  >
   </div>
   <slot name="input">
   </slot>


### PR DESCRIPTION
## Description

Added `aria-hidden` attribute to ensure the `::before` pseudo-element is not announced by screen readers.
See https://github.com/vaadin/web-components/pull/5288#discussion_r1068047861 for the discussion around the checkmark icon where this solution was proposed.

## Type of change

- Refactor