### PR TITLE
refactor: set aria-hidden attribute on the radio part

### DIFF
--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -118,7 +118,7 @@ class RadioButton extends LabelMixin(
         }
       </style>
       <div class="vaadin-radio-button-container">
-        <div part="radio"></div>
+        <div part="radio" aria-hidden="true"></div>
         <slot name="input"></slot>
         <slot name="label"></slot>
       </div>

--- a/packages/radio-group/test/dom/__snapshots__/radio-button.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-button.test.snap.js
@@ -53,7 +53,10 @@ snapshots["vaadin-radio-button host disabled"] =
 
 snapshots["vaadin-radio-button shadow default"] = 
 `<div class="vaadin-radio-button-container">
-  <div part="radio">
+  <div
+    aria-hidden="true"
+    part="radio"
+  >
   </div>
   <slot name="input">
   </slot>


### PR DESCRIPTION
## Description

Same as #5322 but for `vaadin-radio-button` which also has `::before` pseudo-element that we don't need to announce.

## Type of change

- Refactor