### PR TITLE
docs: remove incorrect JSDoc from vaadin-accordion-heading

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading.d.ts
+++ b/packages/accordion/src/vaadin-accordion-heading.d.ts
@@ -39,8 +39,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `disabled`   | Set when the element is disabled.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
- *
- * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
 declare class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(HTMLElement))) {
   /**


### PR DESCRIPTION
## Description

This `@fires` annotation is clearly a copy-paste: in `vaadin-accordion-heading`, the `opened` property does not notify.

## Type of change

- Documentation