### PR TITLE
test: add missing TS definitions tests to vaadin-button

### DIFF
--- a/packages/button/test/typings/button.types.ts
+++ b/packages/button/test/typings/button.types.ts
@@ -1,0 +1,27 @@
+import '../../vaadin-button.js';
+import type { ActiveMixinClass } from '@vaadin/component-base/src/active-mixin.js';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { TabindexMixinClass } from '@vaadin/component-base/src/tabindex-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const assertType = <TExpected>(value: TExpected) => value;
+
+const button = document.createElement('vaadin-button');
+
+// Properties
+assertType<boolean>(button.autofocus);
+assertType<boolean>(button.disabled);
+
+// Mixins
+assertType<ActiveMixinClass>(button);
+assertType<ControllerMixinClass>(button);
+assertType<DisabledMixinClass>(button);
+assertType<ElementMixinClass>(button);
+assertType<FocusMixinClass>(button);
+assertType<KeyboardMixinClass>(button);
+assertType<TabindexMixinClass>(button);
+assertType<ThemableMixinClass>(button);


### PR DESCRIPTION
## Description

We missed to add tests to the `button` package because it didn't have any event types. Let's add them now.

## Type of change

- Tests