### PR TITLE
refactor!: remove vaadin-icon import from vaadin-iconset.js

### DIFF
--- a/packages/icons/gulpfile.cjs
+++ b/packages/icons/gulpfile.cjs
@@ -42,7 +42,6 @@ gulp.task('icons', () => {
           // Enclose all icons in a vaadin-iconset
           return `${createCopyright()}
 import '@vaadin/icon/vaadin-iconset.js';
-import '@vaadin/icon/vaadin-icon.js';
 
 const template = document.createElement('template');
 

--- a/packages/icons/test/visual/vaadin-iconset.test.js
+++ b/packages/icons/test/visual/vaadin-iconset.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../vaadin-iconset.js';
+import '../../vaadin-icons.js';
 
 describe('vaadin-iconset', () => {
   let wrapper;

--- a/packages/icons/vaadin-iconset.js
+++ b/packages/icons/vaadin-iconset.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/icon/vaadin-iconset.js';
-import '@vaadin/icon/vaadin-icon.js';
 
 const template = document.createElement('template');
 


### PR DESCRIPTION
## Description

Extracted from #5334.

This is technically a breaking change - for example, I had to update visual tests to use a different import.
In fact, this line shoudn't be there: the `vaadin-iconset` does not require importing `vaadin-icon`.

For anyone who wants to import both, there is still `vaadin-icons.js` entrypoint that does it.
Ideally, we would remove that entrypoint altogether, but we missed to deprecate it in V23 😕 

Also, this is how Lumo iconset is organized. So let's consider changing it here for consistency.

## Type of change

 Refactor