### PR TITLE
fix: make sure item positions are correct after virtualizer size update

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -164,6 +164,7 @@ export class IronListAdapter {
 
       // Manually schedule the resize handler to make sure the placeholder padding is
       // cleared in case the resize observer never triggers.
+      // NOTE: _resizeHandler is already debounced in iron-list-core.
       requestAnimationFrame(() => this._resizeHandler());
     } else {
       // Add element height to the queue
@@ -229,9 +230,7 @@ export class IronListAdapter {
       }
     }
 
-    if (!this.elementsContainer.children.length) {
-      requestAnimationFrame(() => this._resizeHandler());
-    }
+    requestAnimationFrame(() => this._resizeHandler());
 
     this.__preventElementUpdates = false;
     // Schedule and flush a resize handler

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -90,4 +90,29 @@ describe('virtualizer - item height', () => {
     // The padding should have been be cleared and the item should have its original height.
     expect(firstItem.offsetHeight).to.equal(firstItemHeight);
   });
+
+  it('should restore item positions after size change', async () => {
+    fixtureSync(`
+      <style>
+        .container[loading] > div {
+          min-height: 100px;
+        }
+      </style>
+    `);
+
+    // Wait for the content to update (and resize observer to fire)
+    await aTimeout(200);
+
+    elementsContainer.toggleAttribute('loading', true);
+    virtualizer.size += 1;
+    elementsContainer.toggleAttribute('loading', false);
+
+    // Wait for the content to update
+    await aTimeout(200);
+
+    const firstItem = elementsContainer.querySelector(`#item-0`);
+    const secondItem = elementsContainer.querySelector(`#item-1`);
+    // Expect the first item bottom to be the same as the second item top
+    expect(firstItem.getBoundingClientRect().bottom).to.equal(secondItem.getBoundingClientRect().top);
+  });
 });


### PR DESCRIPTION
## Description

Fixes the issue described [here](https://github.com/vaadin/flow-components/blob/3d6f2efb297d4b618275cbeeb2ab54e171dc9fe5/vaadin-renderer-flow-parent/vaadin-renderer-flow/src/main/resources/META-INF/resources/frontend/flow-component-renderer.js#L25-L32).
This fix enables us to update the said `getNode` API to not rely on the `until` directive and return the node as such, which in turn fixes https://github.com/vaadin/flow-components/issues/4562

## Type of change

Bugfix