### PR TITLE
refactor: move item and list-box extensions to separate files

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-item.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu-item.d.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Item } from '@vaadin/item/src/vaadin-item.js';
+
+/**
+ * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
+ *
+ * @protected
+ */
+declare class ContextMenuItem extends Item {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-context-menu-item': ContextMenuItem;
+  }
+}

--- a/packages/context-menu/src/vaadin-context-menu-item.js
+++ b/packages/context-menu/src/vaadin-context-menu-item.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Item } from '@vaadin/item/src/vaadin-item.js';
+
+/**
+ * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
+ *
+ * @extends Item
+ * @protected
+ */
+class ContextMenuItem extends Item {
+  static get is() {
+    return 'vaadin-context-menu-item';
+  }
+}
+
+customElements.define(ContextMenuItem.is, ContextMenuItem);

--- a/packages/context-menu/src/vaadin-context-menu-list-box.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu-list-box.d.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
+
+/**
+ * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
+ *
+ * @protected
+ */
+declare class ContextMenuListBox extends ListBox {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-context-menu-list-box': ContextMenuListBox;
+  }
+}

--- a/packages/context-menu/src/vaadin-context-menu-list-box.js
+++ b/packages/context-menu/src/vaadin-context-menu-list-box.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
+
+/**
+ * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
+ *
+ * @extends ListBox
+ * @protected
+ */
+class ContextMenuListBox extends ListBox {
+  static get is() {
+    return 'vaadin-context-menu-list-box';
+  }
+}
+
+customElements.define(ContextMenuListBox.is, ContextMenuListBox);

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import './vaadin-context-menu-item.js';
+import './vaadin-context-menu-list-box.js';
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export interface ContextMenuItem {

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -4,8 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
-import { Item } from '@vaadin/item/src/vaadin-item.js';
-import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
 
 export interface ContextMenuItem {
   text?: string;
@@ -15,27 +13,6 @@ export interface ContextMenuItem {
   theme?: string[] | string;
   children?: ContextMenuItem[];
 }
-
-/**
- * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
- *
- * @protected
- */
-declare class ContextMenuItemElement extends Item {}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'vaadin-context-menu-item': ContextMenuItemElement;
-    'vaadin-context-menu-list-box': ContextMenuListBox;
-  }
-}
-
-/**
- * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
- *
- * @protected
- */
-declare class ContextMenuListBox extends ListBox {}
 
 export declare function ItemsMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<ItemsMixinClass> & T;
 

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -3,37 +3,10 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import './vaadin-context-menu-item.js';
+import './vaadin-context-menu-list-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { Item } from '@vaadin/item/src/vaadin-item.js';
-import { ListBox } from '@vaadin/list-box/src/vaadin-list-box.js';
-
-/**
- * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
- *
- * @extends Item
- * @protected
- */
-class ContextMenuItemElement extends Item {
-  static get is() {
-    return 'vaadin-context-menu-item';
-  }
-}
-
-customElements.define(ContextMenuItemElement.is, ContextMenuItemElement);
-
-/**
- * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
- *
- * @extends ListBox
- * @protected
- */
-class ContextMenuListBox extends ListBox {
-  static get is() {
-    return 'vaadin-context-menu-list-box';
-  }
-}
-
-customElements.define(ContextMenuListBox.is, ContextMenuListBox);
 
 /**
  * @polymerMixin


### PR DESCRIPTION
## Description

Pre-requisite for #3010

Moved the components used by `vaadin-context-menu` to separate files, like it's done e.g. in `vaadin-select` package.

## Type of change

- Refactor