### PR TITLE
refactor!: update menu-bar to use vaadin-menu-bar-overlay

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -37,7 +37,7 @@ registerStyles(
  * @extends Overlay
  * @protected
  */
-class ContextMenuOverlay extends PositionMixin(Overlay) {
+export class ContextMenuOverlay extends PositionMixin(Overlay) {
   static get is() {
     return 'vaadin-context-menu-overlay';
   }

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -48,4 +48,9 @@ export declare class ItemsMixinClass {
    * ```
    */
   items: ContextMenuItem[] | undefined;
+
+  /**
+   * Tag name prefix used by overlay, list-box and items.
+   */
+  protected readonly _tagNamePrefix: string;
 }

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -71,6 +71,15 @@ export const ItemsMixin = (superClass) =>
       };
     }
 
+    /**
+     * Tag name prefix used by overlay, list-box and items.
+     * @protected
+     * @return {string}
+     */
+    get _tagNamePrefix() {
+      return 'vaadin-context-menu';
+    }
+
     /** @protected */
     ready() {
       super.ready();
@@ -78,7 +87,7 @@ export const ItemsMixin = (superClass) =>
       // Overlay's outside click listener doesn't work with modeless
       // overlays (submenus) so we need additional logic for it
       this.__itemsOutsideClickListener = (e) => {
-        if (!e.composedPath().some((el) => el.localName === 'vaadin-context-menu-overlay')) {
+        if (!e.composedPath().some((el) => el.localName === `${this._tagNamePrefix}-overlay`)) {
           this.dispatchEvent(new CustomEvent('items-outside-click'));
         }
       };

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ContextMenuOverlay } from '@vaadin/context-menu/src/vaadin-context-menu-overlay.js';
+
+/**
+ * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
+ *
+ * @extends ContextMenuOverlay
+ * @private
+ */
+class MenuBarOverlay extends ContextMenuOverlay {
+  static get is() {
+    return 'vaadin-menu-bar-overlay';
+  }
+}
+
+customElements.define(MenuBarOverlay.is, MenuBarOverlay);

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2019 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import './vaadin-menu-bar-overlay.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { ContextMenu } from '@vaadin/context-menu/src/vaadin-context-menu.js';
 
 /**
@@ -16,10 +18,45 @@ class MenuBarSubmenu extends ContextMenu {
     return 'vaadin-menu-bar-submenu';
   }
 
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: block;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+      </style>
+
+      <slot id="slot"></slot>
+
+      <vaadin-menu-bar-overlay
+        id="overlay"
+        on-opened-changed="_onOverlayOpened"
+        on-vaadin-overlay-open="_onVaadinOverlayOpen"
+        with-backdrop="[[_phone]]"
+        phone$="[[_phone]]"
+        model="[[_context]]"
+        theme$="[[_theme]]"
+      ></vaadin-menu-bar-overlay>
+    `;
+  }
+
   constructor() {
     super();
 
     this.openOn = 'opensubmenu';
+  }
+
+  /**
+   * Tag name prefix used by overlay, list-box and items.
+   * @protected
+   * @return {string}
+   */
+  get _tagNamePrefix() {
+    return 'vaadin-menu-bar';
   }
 
   /**

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -103,7 +103,7 @@ export interface MenuBarEventMap extends HTMLElementEventMap, MenuBarCustomEvent
  * - `<vaadin-menu-bar-button>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-button).
  * - `<vaadin-context-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  * - `<vaadin-context-menu-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
- * - `<vaadin-context-menu-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
+ * - `<vaadin-menu-bar-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  *
  * @fires {CustomEvent} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  */

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -54,7 +54,7 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  * - `<vaadin-menu-bar-button>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-button).
  * - `<vaadin-context-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  * - `<vaadin-context-menu-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
- * - `<vaadin-context-menu-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
+ * - `<vaadin-menu-bar-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  *
  * @fires {CustomEvent<boolean>} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  *

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -56,7 +56,7 @@ snapshots["menu-bar basic"] =
 /* end snapshot menu-bar basic */
 
 snapshots["menu-bar overlay"] = 
-`<vaadin-context-menu-overlay
+`<vaadin-menu-bar-overlay
   dir="ltr"
   id="overlay"
   opened=""
@@ -87,12 +87,12 @@ snapshots["menu-bar overlay"] =
   </vaadin-context-menu-list-box>
   <vaadin-menu-bar-submenu hidden="">
   </vaadin-menu-bar-submenu>
-</vaadin-context-menu-overlay>
+</vaadin-menu-bar-overlay>
 `;
 /* end snapshot menu-bar overlay */
 
 snapshots["menu-bar overlay class"] = 
-`<vaadin-context-menu-overlay
+`<vaadin-menu-bar-overlay
   class="custom menu-bar-overlay"
   dir="ltr"
   id="overlay"
@@ -124,7 +124,7 @@ snapshots["menu-bar overlay class"] =
   </vaadin-context-menu-list-box>
   <vaadin-menu-bar-submenu hidden="">
   </vaadin-menu-bar-submenu>
-</vaadin-context-menu-overlay>
+</vaadin-menu-bar-overlay>
 `;
 /* end snapshot menu-bar overlay class */
 

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-overlay-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-overlay-styles.js
@@ -1,7 +1,7 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-context-menu-overlay',
+  'vaadin-menu-bar-overlay',
   css`
     :host(:first-of-type) {
       padding-top: var(--lumo-space-xs);

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-overlay-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-overlay-styles.js
@@ -1,7 +1,7 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-context-menu-overlay',
+  'vaadin-menu-bar-overlay',
   css`
     :host(:first-of-type) {
       padding-top: 5px;


### PR DESCRIPTION
## Description

Part of #3010

Updated `vaadin-menu-bar` to use `_tagNamePrefix` for the overlay. It will be also used for items, see #5339
This is also what we do e.g. with `vaadin-time-picker-overlay` that extends `vaadin-combo-box-overlay`.

## Type of change

- Refactor