### PR TITLE
fix: do not update the whole row when removing grid-pro editor

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
@@ -246,8 +246,7 @@ class GridProEditColumn extends GridColumn {
       cell._focusButton.setAttribute('role', 'button');
     }
 
-    const row = cell.parentElement;
-    this._grid._updateItem(row, row._item);
+    this.__renderCellsContent(cell._renderer, [cell]);
   }
 
   /** @private */


### PR DESCRIPTION
## Description

This PR makes grid-pro run the column renderer on `_removeEditor(cell, _model)` only for the given cell instead of for all the cells on the same row.

Fixes https://github.com/vaadin/flow-components/issues/4562

Why the issue above occurred with the previous implementation:

When entering edit mode for a cell while another cell editor was open...
1. To clear the old editor, `renderer` was run for each cell on the same row where the editor was, even the new edit cell
2. An `editModeRenderer` was run for the new edit cell

A `ComponentRenderer` was used as the `renderer` in phase 1 for the new edit cell which should be fine. However, the updated implementation of `ComponentRenderer` uses Lit's `until` directive, which renders asynchronously once the given promise resolves. By the time that happened, phase 2 had already taken place, and the cell content had been replaced with the new editor -> an error got thrown within lit-html.

## Type of change

Bugfix