### PR TITLE
chore: update minimally supported Safari version to 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ The components below are licensed under [Vaadin Commercial License and Service T
 
 - Chrome (evergreen)
 - Firefox (evergreen)
-- Safari 14.1 or newer
+- Safari 15 or newer
 - Edge (Chromium, evergreen)
 
 **Mobile:**
 
 - Chrome (evergreen) for Android (4.4 or newer)
-- Safari for iOS (14.5 or newer)
+- Safari for iOS (15 or newer)
 
 ## Documentation
 


### PR DESCRIPTION
## Description

Since Vaadin 24, support for Safari 14 is dropped. All iOS devices can be upgraded from Safari 14 to 15.

This enables us to use certain modern features in our web components and themes, especially:

- [Shadow root `delegatesFocus`](https://caniuse.com/mdn-api_shadowroot_delegatesfocus) API which we already use in [`vaadin-accordion`](https://github.com/vaadin/web-components/blob/e1d75d23b4e783575caef2c35fa89bd7f8a73a86/packages/accordion/src/vaadin-accordion-heading.js#L109) in V24,
- [CSS Logical Properties](https://caniuse.com/css-logical-props) - including shorthands and logical border radius properties.
## Type of change

- Internal change