### PR TITLE
test: update not-animated-styles to use new overlay

### DIFF
--- a/packages/menu-bar/test/not-animated-styles.js
+++ b/packages/menu-bar/test/not-animated-styles.js
@@ -1,7 +1,7 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-context-menu-overlay',
+  'vaadin-menu-bar-overlay',
   css`
     :host([opening]),
     :host([closing]),


### PR DESCRIPTION
## Description

Follow-up from #5353 where I forgot to change the tag name in `not-animated-styles` JS module.

## Type of change

- Tests