### PR TITLE
feat: export context-menu item styles as CSS literals

### DIFF
--- a/packages/context-menu/theme/lumo/vaadin-context-menu-item-styles.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu-item-styles.js
@@ -1,0 +1,45 @@
+import '@vaadin/vaadin-lumo-styles/color.js';
+import '@vaadin/vaadin-lumo-styles/font-icons.js';
+import '@vaadin/vaadin-lumo-styles/sizing.js';
+import '@vaadin/vaadin-lumo-styles/spacing.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const contextMenuItem = css`
+  /* :hover needed to workaround https://github.com/vaadin/web-components/issues/3133 */
+  :host(:hover) {
+    user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+  }
+
+  :host([role='menuitem'][menu-item-checked]) [part='checkmark']::before {
+    opacity: 1;
+  }
+
+  :host([aria-haspopup='true'])::after {
+    font-family: lumo-icons;
+    font-size: var(--lumo-icon-size-xs);
+    content: var(--lumo-icons-angle-right);
+    color: var(--lumo-tertiary-text-color);
+  }
+
+  :host(:not([dir='rtl'])[aria-haspopup='true'])::after {
+    margin-right: calc(var(--lumo-space-m) * -1);
+    padding-left: var(--lumo-space-m);
+  }
+
+  :host([expanded]) {
+    background-color: var(--lumo-primary-color-10pct);
+  }
+
+  /* RTL styles */
+  :host([dir='rtl'][aria-haspopup='true'])::after {
+    content: var(--lumo-icons-angle-left);
+    margin-left: calc(var(--lumo-space-m) * -1);
+    padding-right: var(--lumo-space-m);
+  }
+`;
+
+registerStyles('vaadin-context-menu-item', contextMenuItem, { moduleId: 'lumo-context-menu-item' });
+
+export { contextMenuItem };

--- a/packages/context-menu/theme/lumo/vaadin-context-menu-styles.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu-styles.js
@@ -1,9 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
-import '@vaadin/vaadin-lumo-styles/font-icons.js';
-import '@vaadin/vaadin-lumo-styles/color.js';
-import '@vaadin/vaadin-lumo-styles/sizing.js';
-import '@vaadin/vaadin-lumo-styles/typography.js';
 import { menuOverlay } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -33,43 +29,3 @@ const contextMenuOverlay = css`
 registerStyles('vaadin-context-menu-overlay', [menuOverlay, contextMenuOverlay], {
   moduleId: 'lumo-context-menu-overlay',
 });
-
-registerStyles(
-  'vaadin-context-menu-item',
-  css`
-    /* :hover needed to workaround https://github.com/vaadin/web-components/issues/3133 */
-    :host(:hover) {
-      user-select: none;
-      -ms-user-select: none;
-      -webkit-user-select: none;
-    }
-
-    :host([role='menuitem'][menu-item-checked]) [part='checkmark']::before {
-      opacity: 1;
-    }
-
-    :host([aria-haspopup='true'])::after {
-      font-family: lumo-icons;
-      font-size: var(--lumo-icon-size-xs);
-      content: var(--lumo-icons-angle-right);
-      color: var(--lumo-tertiary-text-color);
-    }
-
-    :host(:not([dir='rtl'])[aria-haspopup='true'])::after {
-      margin-right: calc(var(--lumo-space-m) * -1);
-      padding-left: var(--lumo-space-m);
-    }
-
-    :host([expanded]) {
-      background-color: var(--lumo-primary-color-10pct);
-    }
-
-    /* RTL styles */
-    :host([dir='rtl'][aria-haspopup='true'])::after {
-      content: var(--lumo-icons-angle-left);
-      margin-left: calc(var(--lumo-space-m) * -1);
-      padding-right: var(--lumo-space-m);
-    }
-  `,
-  { moduleId: 'lumo-context-menu-item' },
-);

--- a/packages/context-menu/theme/lumo/vaadin-context-menu.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu.js
@@ -1,3 +1,4 @@
+import './vaadin-context-menu-item-styles.js';
 import './vaadin-context-menu-list-box-styles.js';
 import './vaadin-context-menu-styles.js';
 import '@vaadin/item/theme/lumo/vaadin-item.js';

--- a/packages/context-menu/theme/material/vaadin-context-menu-item-styles.js
+++ b/packages/context-menu/theme/material/vaadin-context-menu-item-styles.js
@@ -1,0 +1,35 @@
+import '@vaadin/vaadin-material-styles/font-icons.js';
+import '@vaadin/vaadin-material-styles/color.js';
+import '@vaadin/vaadin-material-styles/typography.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+const contextMenuItem = css`
+  :host([aria-haspopup='true'])::after {
+    font-family: material-icons;
+    font-size: var(--material-icon-font-size);
+  }
+
+  :host(:not([dir='rtl'])[aria-haspopup='true'])::after {
+    content: var(--material-icons-chevron-right);
+    padding-left: 9px;
+    margin-right: -9px;
+  }
+
+  :host([dir='rtl'][aria-haspopup='true'])::after {
+    content: var(--material-icons-chevron-left);
+    padding-right: 9px;
+    margin-left: -9px;
+  }
+
+  :host([menu-item-checked]) [part='checkmark']::before {
+    content: var(--material-icons-check);
+  }
+
+  :host([expanded]) {
+    background-color: var(--material-secondary-background-color);
+  }
+`;
+
+registerStyles('vaadin-context-menu-item', contextMenuItem, { moduleId: 'material-context-menu-item' });
+
+export { contextMenuItem };

--- a/packages/context-menu/theme/material/vaadin-context-menu-styles.js
+++ b/packages/context-menu/theme/material/vaadin-context-menu-styles.js
@@ -1,6 +1,3 @@
-import '@vaadin/vaadin-material-styles/font-icons.js';
-import '@vaadin/vaadin-material-styles/color.js';
-import '@vaadin/vaadin-material-styles/typography.js';
 import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -14,34 +11,3 @@ const contextMenuOverlay = css`
 registerStyles('vaadin-context-menu-overlay', [menuOverlay, contextMenuOverlay], {
   moduleId: 'material-context-menu-overlay',
 });
-
-registerStyles(
-  'vaadin-context-menu-item',
-  css`
-    :host([aria-haspopup='true'])::after {
-      font-family: material-icons;
-      font-size: var(--material-icon-font-size);
-    }
-
-    :host(:not([dir='rtl'])[aria-haspopup='true'])::after {
-      content: var(--material-icons-chevron-right);
-      padding-left: 9px;
-      margin-right: -9px;
-    }
-
-    :host([dir='rtl'][aria-haspopup='true'])::after {
-      content: var(--material-icons-chevron-left);
-      padding-right: 9px;
-      margin-left: -9px;
-    }
-
-    :host([menu-item-checked]) [part='checkmark']::before {
-      content: var(--material-icons-check);
-    }
-
-    :host([expanded]) {
-      background-color: var(--material-secondary-background-color);
-    }
-  `,
-  { moduleId: 'material-context-menu-item' },
-);

--- a/packages/context-menu/theme/material/vaadin-context-menu.js
+++ b/packages/context-menu/theme/material/vaadin-context-menu.js
@@ -1,3 +1,4 @@
+import './vaadin-context-menu-item-styles.js';
 import './vaadin-context-menu-list-box-styles.js';
 import './vaadin-context-menu-styles.js';
 import '@vaadin/item/theme/material/vaadin-item.js';


### PR DESCRIPTION
## Description

Same as #5359 but for `vaadin-context-menu-item`. 

Pre-requisite for #5354

## Type of change

- Internal feature