### PR TITLE
refactor: extract vaadin-combo-box-item logic to the mixin

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-item-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-item-mixin.d.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright (c) 2015 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+export type ComboBoxDefaultItem = any;
+
+export interface ComboBoxItemModel<TItem> {
+  index: number;
+  item: TItem;
+  selected: boolean;
+  focused: boolean;
+}
+
+export type ComboBoxItemRenderer<TItem, TOwner> = (
+  root: HTMLElement,
+  owner: TOwner,
+  model: ComboBoxItemModel<TItem>,
+) => void;
+
+export declare function ComboBoxItemMixin<TItem, TOwner, T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<ComboBoxItemMixinClass<TItem, TOwner>> & T;
+
+export declare class ComboBoxItemMixinClass<TItem, TOwner> {
+  /**
+   * The item to render.
+   */
+  index: number;
+
+  /**
+   * The item to render.
+   */
+  item: TItem;
+
+  /**
+   * The text to render in the item.
+   */
+  label: string;
+
+  /**
+   * True when item is selected.
+   */
+  selected: boolean;
+
+  /**
+   * True when item is focused.
+   */
+  focused: boolean;
+
+  /**
+   * Custom function for rendering the item content.
+   */
+  renderer: ComboBoxItemRenderer<TItem, TOwner>;
+
+  /**
+   * Requests an update for the content of the item.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   */
+  requestContentUpdate(): void;
+}

--- a/packages/combo-box/src/vaadin-combo-box-item-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-item-mixin.js
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright (c) 2015 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * @polymerMixin
+ */
+export const ComboBoxItemMixin = (superClass) =>
+  class ComboBoxItemMixinClass extends superClass {
+    static get properties() {
+      return {
+        /**
+         * The index of the item.
+         */
+        index: {
+          type: Number,
+        },
+
+        /**
+         * The item to render.
+         */
+        item: {
+          type: Object,
+        },
+
+        /**
+         * The text to render in the item.
+         */
+        label: {
+          type: String,
+        },
+
+        /**
+         * True when item is selected.
+         */
+        selected: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+        },
+
+        /**
+         * True when item is focused.
+         */
+        focused: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+        },
+
+        /**
+         * Custom function for rendering the item content.
+         */
+        renderer: {
+          type: Function,
+        },
+      };
+    }
+
+    static get observers() {
+      return ['__rendererOrItemChanged(renderer, index, item.*, selected, focused)', '__updateLabel(label, renderer)'];
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      this._comboBox = this.parentNode.comboBox;
+
+      const hostDir = this._comboBox.getAttribute('dir');
+      if (hostDir) {
+        this.setAttribute('dir', hostDir);
+      }
+    }
+
+    /**
+     * Requests an update for the content of the item.
+     * While performing the update, it invokes the renderer passed in the `renderer` property.
+     *
+     * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+     */
+    requestContentUpdate() {
+      if (!this.renderer) {
+        return;
+      }
+
+      const model = {
+        index: this.index,
+        item: this.item,
+        focused: this.focused,
+        selected: this.selected,
+      };
+
+      this.renderer(this, this._comboBox, model);
+    }
+
+    /** @private */
+    __rendererOrItemChanged(renderer, index, item) {
+      if (item === undefined || index === undefined) {
+        return;
+      }
+
+      if (this._oldRenderer !== renderer) {
+        this.innerHTML = '';
+        // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
+        // When clearing the rendered content, this part needs to be manually disposed of.
+        // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
+        delete this._$litPart$;
+      }
+
+      if (renderer) {
+        this._oldRenderer = renderer;
+        this.requestContentUpdate();
+      }
+    }
+
+    /** @private */
+    __updateLabel(label, renderer) {
+      if (renderer) {
+        return;
+      }
+
+      this.textContent = label;
+    }
+  };

--- a/packages/combo-box/src/vaadin-combo-box-item.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-item.d.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright (c) 2015 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ComboBox } from './vaadin-combo-box.js';
+import type { ComboBoxDefaultItem, ComboBoxItemMixinClass } from './vaadin-combo-box-item-mixin.js';
+
+/**
+ * An item element used by the `<vaadin-combo-box>` dropdown.
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name   | Description
+ * ------------|--------------
+ * `checkmark` | The graphical checkmark shown for a selected item
+ * `content`   | The element that wraps the item content
+ *
+ * The following state attributes are exposed for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `selected`   | Set when the item is selected
+ * `focused`    | Set when the item is focused
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
+ */
+declare class ComboBoxItem extends HTMLElement {}
+
+interface ComboBoxItem<TItem = ComboBoxDefaultItem>
+  extends ComboBoxItemMixinClass<TItem, ComboBox>,
+    DirMixinClass,
+    ThemableMixinClass {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-combo-box-item': ComboBoxItem;
+  }
+}
+
+export { ComboBoxItem };

--- a/packages/combo-box/src/vaadin-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-combo-box-item.js
@@ -6,6 +6,7 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ComboBoxItemMixin } from './vaadin-combo-box-item-mixin.js';
 
 /**
  * An item element used by the `<vaadin-combo-box>` dropdown.
@@ -28,11 +29,12 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *
+ * @mixes ComboBoxItemMixin
  * @mixes ThemableMixin
  * @mixes DirMixin
  * @private
  */
-export class ComboBoxItem extends ThemableMixin(DirMixin(PolymerElement)) {
+export class ComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
   static get template() {
     return html`
       <style>
@@ -53,119 +55,6 @@ export class ComboBoxItem extends ThemableMixin(DirMixin(PolymerElement)) {
 
   static get is() {
     return 'vaadin-combo-box-item';
-  }
-
-  static get properties() {
-    return {
-      /**
-       * The index of the item
-       */
-      index: Number,
-
-      /**
-       * The item to render
-       * @type {(String|Object)}
-       */
-      item: Object,
-
-      /**
-       * The text label corresponding to the item
-       */
-      label: String,
-
-      /**
-       * True when item is selected
-       */
-      selected: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true,
-      },
-
-      /**
-       * True when item is focused
-       */
-      focused: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true,
-      },
-
-      /**
-       * Custom function for rendering the content of the `<vaadin-combo-box-item>` propagated from the combo box element.
-       */
-      renderer: Function,
-
-      /**
-       * Saved instance of a custom renderer function.
-       */
-      _oldRenderer: Function,
-    };
-  }
-
-  static get observers() {
-    return ['__rendererOrItemChanged(renderer, index, item.*, selected, focused)', '__updateLabel(label, renderer)'];
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-
-    this._comboBox = this.parentNode.comboBox;
-
-    const hostDir = this._comboBox.getAttribute('dir');
-    if (hostDir) {
-      this.setAttribute('dir', hostDir);
-    }
-  }
-
-  /**
-   * Requests an update for the content of the item.
-   * While performing the update, it invokes the renderer passed in the `renderer` property.
-   *
-   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
-   */
-  requestContentUpdate() {
-    if (!this.renderer) {
-      return;
-    }
-
-    const model = {
-      index: this.index,
-      item: this.item,
-      focused: this.focused,
-      selected: this.selected,
-    };
-
-    this.renderer(this, this._comboBox, model);
-  }
-
-  /** @private */
-  __rendererOrItemChanged(renderer, index, item) {
-    if (item === undefined || index === undefined) {
-      return;
-    }
-
-    if (this._oldRenderer !== renderer) {
-      this.innerHTML = '';
-      // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
-      // When clearing the rendered content, this part needs to be manually disposed of.
-      // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
-      delete this._$litPart$;
-    }
-
-    if (renderer) {
-      this._oldRenderer = renderer;
-      this.requestContentUpdate();
-    }
-  }
-
-  /** @private */
-  __updateLabel(label, renderer) {
-    if (renderer) {
-      return;
-    }
-
-    this.textContent = label;
   }
 }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -9,19 +9,11 @@ import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mix
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import type { ComboBox } from './vaadin-combo-box.js';
+import type { ComboBoxDefaultItem, ComboBoxItemModel, ComboBoxItemRenderer } from './vaadin-combo-box-item-mixin.js';
 
-export type ComboBoxDefaultItem = any;
+export type { ComboBoxDefaultItem, ComboBoxItemModel };
 
-export interface ComboBoxItemModel<TItem> {
-  index: number;
-  item: TItem;
-}
-
-export type ComboBoxRenderer<TItem> = (
-  root: HTMLElement,
-  comboBox: ComboBox<TItem>,
-  model: ComboBoxItemModel<TItem>,
-) => void;
+export type ComboBoxRenderer<TItem> = ComboBoxItemRenderer<TItem, ComboBox<TItem>>;
 
 export declare function ComboBoxMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -1,6 +1,7 @@
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { DelegateFocusMixinClass } from '@vaadin/component-base/src/delegate-focus-mixin.js';
 import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
+import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
 import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
@@ -15,6 +16,8 @@ import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js'
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
 import type { ComboBoxDataProviderMixinClass } from '../../src/vaadin-combo-box-data-provider-mixin';
+import type { ComboBoxItem } from '../../src/vaadin-combo-box-item';
+import type { ComboBoxItemMixinClass, ComboBoxItemRenderer } from '../../src/vaadin-combo-box-item-mixin';
 import type { ComboBoxMixinClass } from '../../src/vaadin-combo-box-mixin';
 import type {
   ComboBox,
@@ -213,3 +216,23 @@ assertType<InputMixinClass>(narrowedComboBoxLight);
 assertType<KeyboardMixinClass>(narrowedComboBoxLight);
 assertType<ThemableMixinClass>(narrowedComboBoxLight);
 assertType<ValidateMixinClass>(narrowedComboBoxLight);
+
+// Item
+const genericItem = document.createElement('vaadin-combo-box-item');
+assertType<ComboBoxItem>(genericItem);
+
+const narrowedItem = genericItem as ComboBoxItem<TestComboBoxItem>;
+
+// Item properties
+assertType<TestComboBoxItem>(narrowedItem.item);
+assertType<number>(narrowedItem.index);
+assertType<string>(narrowedItem.label);
+assertType<boolean>(narrowedItem.focused);
+assertType<boolean>(narrowedItem.selected);
+assertType<ComboBoxItemRenderer<TestComboBoxItem, ComboBox>>(narrowedItem.renderer);
+assertType<() => void>(narrowedItem.requestContentUpdate);
+
+// Item mixins
+assertType<ComboBoxItemMixinClass<TestComboBoxItem, ComboBox>>(narrowedItem);
+assertType<DirMixinClass>(narrowedItem);
+assertType<ThemableMixinClass>(narrowedItem);


### PR DESCRIPTION
## Description

Part of #5358

1. Created `ComboBoxItemMixin` to be used by `vaadin-time-picker-item` and `vaadin-multi-select-combo-box-item`,
2. Added missing type definitions for `vaadin-combo-box-item` element and corresponding tests to the typings folder.

## Type of change

- Refactor