### PR TITLE
refactor!: make vaadin-select-item not extend vaadin-item

### DIFF
--- a/dev/select.html
+++ b/dev/select.html
@@ -18,17 +18,15 @@
 
     <script>
       const select = document.querySelector('vaadin-select');
-      select.renderer = (root, _, model) => {
-        root.innerHTML = `
-          <vaadin-list-box>
-            <vaadin-item value="xs" disabled>XS (out of stock)</vaadin-item>
-            <vaadin-item value="s">S</vaadin-item>
-            <vaadin-item value="m">M</vaadin-item>
-            <vaadin-item value="l">L</vaadin-item>
-            <vaadin-item value="xl">XL</vaadin-item>
-          </vaadin-list-box>
-        `;
-      };
+      select.items = items = [
+        { label: 'Show all', value: 'all' },
+        { component: 'hr' },
+        { label: 'XS (out of stock)', value: 'xs', disabled: true },
+        { label: 'S', value: 's' },
+        { label: 'M', value: 'm' },
+        { label: 'L', value: 'l' },
+        { label: 'XL', value: 'xl' },
+      ];
     </script>
   </body>
 </html>

--- a/packages/select/src/vaadin-select-item.d.ts
+++ b/packages/select/src/vaadin-select-item.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ItemMixin } from '@vaadin/item/src/vaadin-item-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-select>`. Not intended to be used separately.
+ *
+ * @protected
+ */
+declare class SelectItem extends ItemMixin(DirMixin(ThemableMixin(HTMLElement))) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-select-item': SelectItem;
+  }
+}

--- a/packages/select/src/vaadin-select-item.js
+++ b/packages/select/src/vaadin-select-item.js
@@ -3,18 +3,51 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Item } from '@vaadin/item/src/vaadin-item.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ItemMixin } from '@vaadin/item/src/vaadin-item-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
- * @extends Item
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes ItemMixin
+ * @mixes ThemableMixin
  * @protected
  */
-class SelectItem extends Item {
+class SelectItem extends ItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-select-item';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: inline-block;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+      </style>
+      <span part="checkmark" aria-hidden="true"></span>
+      <div part="content">
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.setAttribute('role', 'option');
   }
 }
 
 customElements.define(SelectItem.is, SelectItem);
+
+export { SelectItem };

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -79,6 +79,7 @@ snapshots["vaadin-select host placeholder"] =
     <vaadin-select-item
       aria-selected="false"
       id="value-vaadin-select-3"
+      role="option"
     >
       Placeholder
     </vaadin-select-item>
@@ -169,6 +170,7 @@ snapshots["vaadin-select host value"] =
     <vaadin-select-item
       aria-selected="true"
       id="value-vaadin-select-3"
+      role="option"
       selected=""
     >
       Option 1

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -1,10 +1,14 @@
 import '../../vaadin-select.js';
+import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+import type { ItemMixinClass } from '@vaadin/item/src/vaadin-item-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { SelectItem } from '../../src/vaadin-select-item.js';
 import type {
   Select,
   SelectChangeEvent,
   SelectInvalidChangedEvent,
-  SelectItem,
+  SelectItem as Item,
   SelectOpenedChangedEvent,
   SelectRenderer,
   SelectValidatedEvent,
@@ -16,7 +20,7 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 const select: Select = document.createElement('vaadin-select');
 
 // Properties
-assertType<SelectItem[] | null | undefined>(select.items);
+assertType<Item[] | null | undefined>(select.items);
 assertType<boolean>(select.opened);
 assertType<SelectRenderer | undefined>(select.renderer);
 assertType<string>(select.value);
@@ -32,7 +36,7 @@ assertType<() => boolean>(select.validate);
 assertType<ValidateMixinClass>(select);
 
 // Item properties
-const item: SelectItem = select.items ? select.items[0] : {};
+const item: Item = select.items ? select.items[0] : {};
 assertType<string | undefined>(item.label);
 assertType<string | undefined>(item.value);
 assertType<boolean | undefined>(item.disabled);
@@ -70,3 +74,11 @@ const renderer: SelectRenderer = (root, owner) => {
 };
 
 select.renderer = renderer;
+
+// Item
+const option = document.createElement('vaadin-select-item');
+
+assertType<SelectItem>(option);
+assertType<ItemMixinClass>(option);
+assertType<DirMixinClass>(option);
+assertType<ThemableMixinClass>(option);

--- a/packages/select/test/visual/lumo/select.test.js
+++ b/packages/select/test/visual/lumo/select.test.js
@@ -14,15 +14,11 @@ describe('select', () => {
     div.style.display = 'inline-block';
     div.style.padding = '10px';
     element = fixtureSync('<vaadin-select></vaadin-select>', div);
-    element.renderer = (root) => {
-      root.innerHTML = `
-        <vaadin-list-box>
-          <vaadin-item>item 1</vaadin-item>
-          <vaadin-item>item 2</vaadin-item>
-          <vaadin-item>item 3</vaadin-item>
-        </vaadin-list-box>
-      `;
-    };
+    element.items = [
+      { label: 'item 1', value: 'value-1' },
+      { label: 'item 2', value: 'value-2' },
+      { label: 'item 3', value: 'value-3' },
+    ];
     await nextFrame();
   });
 

--- a/packages/select/test/visual/lumo/select.test.js
+++ b/packages/select/test/visual/lumo/select.test.js
@@ -38,7 +38,7 @@ describe('select', () => {
   });
 
   it('readonly', async () => {
-    element.value = 'item 1';
+    element.value = 'value-1';
     element.readonly = true;
     await visualDiff(div, 'readonly');
   });
@@ -60,7 +60,7 @@ describe('select', () => {
   });
 
   it('value', async () => {
-    element.value = 'item 1';
+    element.value = 'value-1';
     await visualDiff(div, 'value');
   });
 
@@ -136,19 +136,19 @@ describe('select', () => {
   });
 
   it('align-center', async () => {
-    element.value = 'item 1';
+    element.value = 'value-1';
     element.setAttribute('theme', 'align-center');
     await visualDiff(div, 'align-center');
   });
 
   it('align-right', async () => {
-    element.value = 'item 1';
+    element.value = 'value-1';
     element.setAttribute('theme', 'align-right');
     await visualDiff(div, 'align-right');
   });
 
   it('small', async () => {
-    element.value = 'item 1';
+    element.value = 'value-1';
     element.setAttribute('theme', 'small');
     await visualDiff(div, 'small');
   });
@@ -160,7 +160,7 @@ describe('select', () => {
 
   it('width with value', async () => {
     element.style.width = '80px';
-    element.value = 'item 1';
+    element.value = 'value-1';
     await visualDiff(div, 'width-value');
   });
 

--- a/packages/select/test/visual/material/select.test.js
+++ b/packages/select/test/visual/material/select.test.js
@@ -14,15 +14,11 @@ describe('select', () => {
     div.style.display = 'inline-block';
     div.style.padding = '10px';
     element = fixtureSync('<vaadin-select></vaadin-select>', div);
-    element.renderer = (root) => {
-      root.innerHTML = `
-        <vaadin-list-box>
-          <vaadin-item>item 1</vaadin-item>
-          <vaadin-item>item 2</vaadin-item>
-          <vaadin-item>item 3</vaadin-item>
-        </vaadin-list-box>
-      `;
-    };
+    element.items = [
+      { label: 'item 1', value: 'value-1' },
+      { label: 'item 2', value: 'value-2' },
+      { label: 'item 3', value: 'value-3' },
+    ];
     await nextFrame();
   });
 

--- a/packages/select/test/visual/material/select.test.js
+++ b/packages/select/test/visual/material/select.test.js
@@ -59,7 +59,7 @@ describe('select', () => {
   });
 
   it('value', async () => {
-    element.value = 'item 1';
+    element.value = 'value-1';
     await visualDiff(div, 'value');
   });
 
@@ -123,7 +123,7 @@ describe('select', () => {
 
   it('width with value', async () => {
     element.style.width = '80px';
-    element.value = 'item 1';
+    element.value = 'value-1';
     await visualDiff(div, 'width-value');
   });
 

--- a/packages/select/theme/lumo/vaadin-select-styles.js
+++ b/packages/select/theme/lumo/vaadin-select-styles.js
@@ -6,9 +6,12 @@
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
+import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
 import { menuOverlay } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles('vaadin-select-item', item, { moduleId: 'lumo-select-item' });
 
 const select = css`
   :host(:not([theme*='align'])) ::slotted([slot='value']) {

--- a/packages/select/theme/lumo/vaadin-select.js
+++ b/packages/select/theme/lumo/vaadin-select.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
-import '@vaadin/item/theme/lumo/vaadin-item.js';
 import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
 import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-select-styles.js';

--- a/packages/select/theme/material/vaadin-select-styles.js
+++ b/packages/select/theme/material/vaadin-select-styles.js
@@ -4,9 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/vaadin-material-styles/font-icons.js';
+import { item } from '@vaadin/item/theme/material/vaadin-item-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
 import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles('vaadin-select-item', item, { moduleId: 'material-select-item' });
 
 const select = css`
   :host {

--- a/packages/select/theme/material/vaadin-select.js
+++ b/packages/select/theme/material/vaadin-select.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/input-container/theme/material/vaadin-input-container.js';
-import '@vaadin/item/theme/material/vaadin-item.js';
 import '@vaadin/list-box/theme/material/vaadin-list-box.js';
 import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-select-styles.js';


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/5358

Same as #5366 but for `vaadin-select-item`. Note, I also added TS definitions for consistency.

## Type of change

- Breaking change