### PR TITLE
test: extract common context-menu test helpers

### DIFF
--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -22,7 +22,7 @@ export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') 
 }
 
 export function getMenuItems(menu) {
-  return menu.$.overlay.querySelectorAll('[aria-haspopup]');
+  return [...menu.$.overlay.querySelectorAll('[aria-haspopup]')];
 }
 
 export function getSubMenu(menu) {

--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -1,11 +1,30 @@
-import { oneEvent } from '@vaadin/testing-helpers';
+import { fire, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 
 export async function openSubMenus(menu) {
   await oneEvent(menu.$.overlay, 'vaadin-overlay-open');
   const itemElement = menu.$.overlay.querySelector('[aria-haspopup="true"]');
   if (itemElement) {
     itemElement.dispatchEvent(new CustomEvent('mouseover', { bubbles: true, composed: true }));
-    const subMenu = menu.$.overlay.querySelector('vaadin-context-menu');
+    const subMenu = getSubMenu(menu);
     await openSubMenus(subMenu);
   }
+}
+
+export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') {
+  const menu = target.closest('vaadin-context-menu');
+  if (menu) {
+    menu.__openListenerActive = true;
+  }
+  const { right, bottom } = target.getBoundingClientRect();
+  fire(target, event, { x: right, y: bottom });
+  await nextFrame();
+}
+
+export function getMenuItems(menu) {
+  return menu.$.overlay.querySelectorAll('[aria-haspopup]');
+}
+
+export function getSubMenu(menu) {
+  return menu.$.overlay.querySelector('vaadin-context-menu');
 }


### PR DESCRIPTION
## Description

Extracted several context-menu test helpers into `helpers.js` in order to reuse them later in:

- `items.test.js`
- `items-theme.test.js`
- `items-class.test.js`

## Type of change

- [x] Internal
