### PR TITLE
refactor!: make time-picker item not extend combo-box item

### DIFF
--- a/packages/combo-box/theme/lumo/vaadin-combo-box-item-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-item-styles.js
@@ -21,3 +21,5 @@ const comboBoxItem = css`
 registerStyles('vaadin-combo-box-item', [item, comboBoxItem], {
   moduleId: 'lumo-combo-box-item',
 });
+
+export { comboBoxItem };

--- a/packages/combo-box/theme/material/vaadin-combo-box-item-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-item-styles.js
@@ -16,3 +16,5 @@ const comboBoxItem = css`
 registerStyles('vaadin-combo-box-item', [item, comboBoxItem], {
   moduleId: 'material-combo-box-item',
 });
+
+export { comboBoxItem };

--- a/packages/time-picker/src/vaadin-time-picker-item.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker-item.d.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { ComboBoxItemMixinClass } from '@vaadin/combo-box/src/vaadin-combo-box-item-mixin.js';
+import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { TimePicker } from './vaadin-time-picker.js';
+
+/**
+ * An item element used by the `<vaadin-time-picker>` dropdown.
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name   | Description
+ * ------------|--------------
+ * `checkmark` | The graphical checkmark shown for a selected item
+ * `content`   | The element that wraps the item content
+ *
+ * The following state attributes are exposed for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `selected`   | Set when the item is selected
+ * `focused`    | Set when the item is focused
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
+ */
+declare class TimePickerItem extends HTMLElement {}
+
+interface TimePickerItem extends ComboBoxItemMixinClass<string, TimePicker>, DirMixinClass, ThemableMixinClass {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-time-picker-item': TimePickerItem;
+  }
+}
+
+export { TimePickerItem };

--- a/packages/time-picker/src/vaadin-time-picker-item.js
+++ b/packages/time-picker/src/vaadin-time-picker-item.js
@@ -3,34 +3,58 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ComboBoxItem } from '@vaadin/combo-box/src/vaadin-combo-box-item.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ComboBoxItemMixin } from '@vaadin/combo-box/src/vaadin-combo-box-item-mixin.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * An element used for items in `<vaadin-time-picker>`.
+ * An item element used by the `<vaadin-time-picker>` dropdown.
  *
  * ### Styling
  *
  * The following shadow DOM parts are available for styling:
  *
- * Part name | Description
- * ----------|-------------
- * `content` | The element that wraps the item content
+ * Part name   | Description
+ * ------------|--------------
+ * `checkmark` | The graphical checkmark shown for a selected item
+ * `content`   | The element that wraps the item content
  *
  * The following state attributes are exposed for styling:
  *
- * Attribute  | Description                   | Part name
- * -----------|-------------------------------|-----------
- * `selected` | Set when the item is selected | :host
- * `focused`  | Set when the item is focused  | :host
+ * Attribute    | Description
+ * -------------|-------------
+ * `selected`   | Set when the item is selected
+ * `focused`    | Set when the item is focused
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *
- * @extends ComboBoxItem
+ * @mixes ComboBoxItemMixin
+ * @mixes ThemableMixin
+ * @mixes DirMixin
  * @private
  */
-class TimePickerItem extends ComboBoxItem {
+export class TimePickerItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-time-picker-item';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: block;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+      </style>
+      <span part="checkmark" aria-hidden="true"></span>
+      <div part="content">
+        <slot></slot>
+      </div>
+    `;
   }
 }
 

--- a/packages/time-picker/test/typings/time-picker.types.ts
+++ b/packages/time-picker/test/typings/time-picker.types.ts
@@ -1,10 +1,16 @@
 import '../../vaadin-time-picker.js';
+import type {
+  ComboBoxItemMixinClass,
+  ComboBoxItemRenderer,
+} from '@vaadin/combo-box/src/vaadin-combo-box-item-mixin.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { TimePickerItem } from '../../src/vaadin-time-picker-item.js';
 import type {
   TimePicker,
   TimePickerChangeEvent,
@@ -60,3 +66,20 @@ timePicker.addEventListener('validated', (event) => {
   assertType<TimePickerValidatedEvent>(event);
   assertType<boolean>(event.detail.valid);
 });
+
+// Item
+const item = document.createElement('vaadin-time-picker-item');
+assertType<TimePickerItem>(item);
+
+// Item properties
+assertType<number>(item.index);
+assertType<string>(item.label);
+assertType<boolean>(item.focused);
+assertType<boolean>(item.selected);
+assertType<ComboBoxItemRenderer<string, TimePicker>>(item.renderer);
+assertType<() => void>(item.requestContentUpdate);
+
+// Item mixins
+assertType<ComboBoxItemMixinClass<string, TimePicker>>(item);
+assertType<DirMixinClass>(item);
+assertType<ThemableMixinClass>(item);

--- a/packages/time-picker/theme/lumo/vaadin-time-picker-styles.js
+++ b/packages/time-picker/theme/lumo/vaadin-time-picker-styles.js
@@ -4,8 +4,14 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
+import { comboBoxItem } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-item-styles.js';
+import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles('vaadin-time-picker-item', [item, comboBoxItem], {
+  moduleId: 'lumo-time-picker-item',
+});
 
 const timePicker = css`
   [part~='toggle-button']::before {

--- a/packages/time-picker/theme/material/vaadin-time-picker-styles.js
+++ b/packages/time-picker/theme/material/vaadin-time-picker-styles.js
@@ -4,8 +4,14 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/vaadin-material-styles/font-icons.js';
+import { comboBoxItem } from '@vaadin/combo-box/theme/material/vaadin-combo-box-item-styles.js';
+import { item } from '@vaadin/item/theme/material/vaadin-item-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles('vaadin-time-picker-item', [item, comboBoxItem], {
+  moduleId: 'material-time-picker-item',
+});
 
 const timePicker = css`
   [part~='toggle-button']::before {


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/5358

Note, I also added missing type definitions for consistency with other item elements.

## Type of change

- Refactor