### PR TITLE
refactor: reduce grid updateColumnTree call count

### DIFF
--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -5,7 +5,7 @@
  */
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { animationFrame, microTask } from '@vaadin/component-base/src/async.js';
+import { animationFrame } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { ColumnBaseMixin } from './vaadin-grid-column.js';
 import { updateColumnOrders } from './vaadin-grid-helpers.js';
@@ -377,12 +377,10 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
         this._updateVisibleChildColumns(this._childColumns);
         this._preventHiddenSynchronization = false;
 
-        // Update the column tree with microtask timing to avoid shady style scope issues
-        microTask.run(() => {
-          if (this._grid && this._grid._updateColumnTree) {
-            this._grid._updateColumnTree();
-          }
-        });
+        // Update the column tree
+        if (this._grid && this._grid._debounceUpdateColumnTree) {
+          this._grid._debounceUpdateColumnTree();
+        }
       }
     });
     this._observer.flush();

--- a/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -92,7 +92,7 @@ export const DynamicColumnsMixin = (superClass) =>
 
     /** @protected */
     _debounceUpdateColumnTree() {
-      this.__debouncerUpdateColumnTree = Debouncer.debounce(this.__debouncerUpdateColumnTree, microTask, () =>
+      this.__updateColumnTreeDebouncer = Debouncer.debounce(this.__updateColumnTreeDebouncer, microTask, () =>
         this._updateColumnTree(),
       );
     }

--- a/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -5,7 +5,7 @@
  */
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { timeOut } from '@vaadin/component-base/src/async.js';
+import { microTask, timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { updateCellState } from './vaadin-grid-helpers.js';
 
@@ -91,6 +91,13 @@ export const DynamicColumnsMixin = (superClass) =>
     }
 
     /** @protected */
+    _debounceUpdateColumnTree() {
+      this.__debouncerUpdateColumnTree = Debouncer.debounce(this.__debouncerUpdateColumnTree, microTask, () =>
+        this._updateColumnTree(),
+      );
+    }
+
+    /** @protected */
     _updateColumnTree() {
       const columnTree = this._getColumnTree();
       if (!arrayEquals(columnTree, this._columnTree)) {
@@ -109,7 +116,7 @@ export const DynamicColumnsMixin = (superClass) =>
 
           this.__removeSorters(this._sorters.filter(filterNotConnected));
           this.__removeFilters(this._filters.filter(filterNotConnected));
-          this._updateColumnTree();
+          this._debounceUpdateColumnTree();
         }
 
         this._debouncerCheckImports = Debouncer.debounce(

--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -329,6 +329,7 @@ describe('column groups', () => {
       });
 
       sinon.spy(grid, '__updateHeaderFooterRowVisibility');
+      sinon.spy(grid, '_updateColumnTree');
       grid.dataProvider = infiniteDataProvider;
       flushGrid(grid);
 
@@ -338,6 +339,10 @@ describe('column groups', () => {
     it('should update header and footer rows visibility once', () => {
       // 6 header and footer rows are created
       expect(grid.__updateHeaderFooterRowVisibility.callCount).to.equal(6);
+    });
+
+    it('should update column tree once', () => {
+      expect(grid._updateColumnTree.callCount).to.equal(1);
     });
 
     it('should have right content in header', () => {

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -4,7 +4,7 @@ export const flushGrid = (grid) => {
   grid._observer.flush();
 
   [
-    grid.__debouncerUpdateColumnTree,
+    grid.__updateColumnTreeDebouncer,
     grid._debounceScrolling,
     grid._debounceOverflow,
     grid._debouncerHiddenChanged,

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -4,6 +4,7 @@ export const flushGrid = (grid) => {
   grid._observer.flush();
 
   [
+    grid.__debouncerUpdateColumnTree,
     grid._debounceScrolling,
     grid._debounceOverflow,
     grid._debouncerHiddenChanged,


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/4565

This PR debounces the `_updateColumnTree` function that got called unnecessarily often when column groups were used.

The change has a 6% impact on the `rendertime` metric in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

## Type of change

Performance enhancement