### PR TITLE
refactor: extract shared menu overlay logic to the mixin

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-overlay.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.d.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
+ *
+ * @protected
+ */
+declare class ContextMenuOverlay extends MenuOverlayMixin(Overlay) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-context-menu-overlay': ContextMenuOverlay;
+  }
+}
+
+export { ContextMenuOverlay };

--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -4,133 +4,22 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
-import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
+import { styles } from './vaadin-menu-overlay-styles.js';
 
-registerStyles(
-  'vaadin-context-menu-overlay',
-  css`
-    :host {
-      align-items: flex-start;
-      justify-content: flex-start;
-    }
-
-    :host([right-aligned]),
-    :host([end-aligned]) {
-      align-items: flex-end;
-    }
-
-    :host([bottom-aligned]) {
-      justify-content: flex-end;
-    }
-
-    [part='overlay'] {
-      background-color: #fff;
-    }
-  `,
-  { moduleId: 'vaadin-context-menu-overlay-styles' },
-);
+registerStyles('vaadin-context-menu-overlay', styles, { moduleId: 'vaadin-context-menu-overlay-styles' });
 
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
  *
  * @extends Overlay
+ * @mixes MenuOverlayMixin
  * @protected
  */
-export class ContextMenuOverlay extends PositionMixin(Overlay) {
+export class ContextMenuOverlay extends MenuOverlayMixin(Overlay) {
   static get is() {
     return 'vaadin-context-menu-overlay';
-  }
-
-  static get properties() {
-    return {
-      /**
-       * @protected
-       */
-      parentOverlay: {
-        type: Object,
-        readOnly: true,
-      },
-    };
-  }
-
-  static get observers() {
-    return ['_themeChanged(_theme)'];
-  }
-
-  ready() {
-    super.ready();
-
-    this.addEventListener('keydown', (e) => {
-      if (!e.defaultPrevented && e.composedPath()[0] === this.$.overlay && [38, 40].indexOf(e.keyCode) > -1) {
-        const child = this.getFirstChild();
-        if (child && Array.isArray(child.items) && child.items.length) {
-          e.preventDefault();
-          if (e.keyCode === 38) {
-            child.items[child.items.length - 1].focus();
-          } else {
-            child.focus();
-          }
-        }
-      }
-    });
-  }
-
-  getFirstChild() {
-    return this.querySelector(':not(style):not(slot)');
-  }
-
-  _themeChanged() {
-    this.close();
-  }
-
-  getBoundaries() {
-    // Measure actual overlay and content sizes
-    const overlayRect = this.getBoundingClientRect();
-    const contentRect = this.$.overlay.getBoundingClientRect();
-
-    // Maximum x and y values are imposed by content size and overlay limits.
-    let yMax = overlayRect.bottom - contentRect.height;
-
-    // Adjust constraints to ensure bottom-aligned applies to sub-menu.
-    const parent = this.parentOverlay;
-    if (parent && parent.hasAttribute('bottom-aligned')) {
-      const parentStyle = getComputedStyle(parent);
-      yMax = yMax - parseFloat(parentStyle.bottom) - parseFloat(parentStyle.height);
-    }
-
-    return {
-      xMax: overlayRect.right - contentRect.width,
-      xMin: overlayRect.left + contentRect.width,
-      yMax,
-    };
-  }
-
-  _updatePosition() {
-    super._updatePosition();
-
-    if (this.positionTarget && this.parentOverlay) {
-      // This overlay is positioned by a parent menu item,
-      // adjust the position by the overlay content paddings
-      const content = this.$.content;
-      const style = getComputedStyle(content);
-
-      // Horizontal adjustment
-      const isLeftAligned = !!this.style.left;
-      if (isLeftAligned) {
-        this.style.left = `${parseFloat(this.style.left) + parseFloat(style.paddingLeft)}px`;
-      } else {
-        this.style.right = `${parseFloat(this.style.right) + parseFloat(style.paddingRight)}px`;
-      }
-
-      // Vertical adjustment
-      const isBottomAligned = !!this.style.bottom;
-      if (isBottomAligned) {
-        this.style.bottom = `${parseFloat(this.style.bottom) - parseFloat(style.paddingBottom)}px`;
-      } else {
-        this.style.top = `${parseFloat(this.style.top) - parseFloat(style.paddingTop)}px`;
-      }
-    }
   }
 }
 

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.d.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { PositionMixinClass } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
+
+export declare function MenuOverlayMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<MenuOverlayMixinClass> & Constructor<PositionMixinClass> & T;
+
+export declare class MenuOverlayMixinClass {
+  protected readonly parentOverlay: HTMLElement | undefined;
+
+  /**
+   * Returns the adjusted boundaries of the overlay.
+   */
+  getBoundaries(): { xMax: number; xMin: number; yMax: number };
+
+  /**
+   * Returns the first element in the overlay content.
+   */
+  getFirstChild(): HTMLElement;
+}

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
+
+/**
+ * @polymerMixin
+ */
+export const MenuOverlayMixin = (superClass) =>
+  class MenuOverlayMixin extends PositionMixin(superClass) {
+    static get properties() {
+      return {
+        /**
+         * @protected
+         */
+        parentOverlay: {
+          type: Object,
+          readOnly: true,
+        },
+      };
+    }
+
+    static get observers() {
+      return ['_themeChanged(_theme)'];
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.addEventListener('keydown', (e) => {
+        if (!e.defaultPrevented && e.composedPath()[0] === this.$.overlay && [38, 40].indexOf(e.keyCode) > -1) {
+          const child = this.getFirstChild();
+          if (child && Array.isArray(child.items) && child.items.length) {
+            e.preventDefault();
+            if (e.keyCode === 38) {
+              child.items[child.items.length - 1].focus();
+            } else {
+              child.focus();
+            }
+          }
+        }
+      });
+    }
+
+    /**
+     * Returns the first element in the overlay content.
+     *
+     * @returns {HTMLElement}
+     */
+    getFirstChild() {
+      return this.querySelector(':not(style):not(slot)');
+    }
+
+    /** @private */
+    _themeChanged() {
+      this.close();
+    }
+
+    /**
+     * Returns the adjusted boundaries of the overlay.
+     *
+     * @returns {object}
+     */
+    getBoundaries() {
+      // Measure actual overlay and content sizes
+      const overlayRect = this.getBoundingClientRect();
+      const contentRect = this.$.overlay.getBoundingClientRect();
+
+      // Maximum x and y values are imposed by content size and overlay limits.
+      let yMax = overlayRect.bottom - contentRect.height;
+
+      // Adjust constraints to ensure bottom-aligned applies to sub-menu.
+      const parent = this.parentOverlay;
+      if (parent && parent.hasAttribute('bottom-aligned')) {
+        const parentStyle = getComputedStyle(parent);
+        yMax = yMax - parseFloat(parentStyle.bottom) - parseFloat(parentStyle.height);
+      }
+
+      return {
+        xMax: overlayRect.right - contentRect.width,
+        xMin: overlayRect.left + contentRect.width,
+        yMax,
+      };
+    }
+
+    /**
+     * @protected
+     * @override
+     */
+    _updatePosition() {
+      super._updatePosition();
+
+      if (this.positionTarget && this.parentOverlay) {
+        // This overlay is positioned by a parent menu item,
+        // adjust the position by the overlay content paddings
+        const content = this.$.content;
+        const style = getComputedStyle(content);
+
+        // Horizontal adjustment
+        const isLeftAligned = !!this.style.left;
+        if (isLeftAligned) {
+          this.style.left = `${parseFloat(this.style.left) + parseFloat(style.paddingLeft)}px`;
+        } else {
+          this.style.right = `${parseFloat(this.style.right) + parseFloat(style.paddingRight)}px`;
+        }
+
+        // Vertical adjustment
+        const isBottomAligned = !!this.style.bottom;
+        if (isBottomAligned) {
+          this.style.bottom = `${parseFloat(this.style.bottom) - parseFloat(style.paddingBottom)}px`;
+        } else {
+          this.style.top = `${parseFloat(this.style.top) - parseFloat(style.paddingTop)}px`;
+        }
+      }
+    }
+  };

--- a/packages/context-menu/src/vaadin-menu-overlay-styles.d.ts
+++ b/packages/context-menu/src/vaadin-menu-overlay-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const styles: CSSResult;

--- a/packages/context-menu/src/vaadin-menu-overlay-styles.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-styles.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const styles = css`
+  :host {
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  :host([right-aligned]),
+  :host([end-aligned]) {
+    align-items: flex-end;
+  }
+
+  :host([bottom-aligned]) {
+    justify-content: flex-end;
+  }
+
+  [part='overlay'] {
+    background-color: #fff;
+  }
+`;

--- a/packages/context-menu/theme/lumo/vaadin-context-menu-overlay-styles.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu-overlay-styles.js
@@ -29,3 +29,5 @@ const contextMenuOverlay = css`
 registerStyles('vaadin-context-menu-overlay', [menuOverlay, contextMenuOverlay], {
   moduleId: 'lumo-context-menu-overlay',
 });
+
+export { contextMenuOverlay };

--- a/packages/context-menu/theme/lumo/vaadin-context-menu.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu.js
@@ -1,5 +1,5 @@
 import './vaadin-context-menu-item-styles.js';
 import './vaadin-context-menu-list-box-styles.js';
-import './vaadin-context-menu-styles.js';
+import './vaadin-context-menu-overlay-styles.js';
 import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import '../../src/vaadin-context-menu.js';

--- a/packages/context-menu/theme/material/vaadin-context-menu-overlay-styles.js
+++ b/packages/context-menu/theme/material/vaadin-context-menu-overlay-styles.js
@@ -11,3 +11,5 @@ const contextMenuOverlay = css`
 registerStyles('vaadin-context-menu-overlay', [menuOverlay, contextMenuOverlay], {
   moduleId: 'material-context-menu-overlay',
 });
+
+export { contextMenuOverlay };

--- a/packages/context-menu/theme/material/vaadin-context-menu.js
+++ b/packages/context-menu/theme/material/vaadin-context-menu.js
@@ -1,5 +1,5 @@
 import './vaadin-context-menu-item-styles.js';
 import './vaadin-context-menu-list-box-styles.js';
-import './vaadin-context-menu-styles.js';
+import './vaadin-context-menu-overlay-styles.js';
 import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import '../../src/vaadin-context-menu.js';

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.d.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { MenuOverlayMixin } from '@vaadin/context-menu/src/vaadin-menu-overlay-mixin.js';
+import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+
+/**
+ * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
+ *
+ * @protected
+ */
+declare class MenuBarOverlay extends MenuOverlayMixin(Overlay) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-menu-bar-overlay': MenuBarOverlay;
+  }
+}
+
+export { MenuBarOverlay };

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -3,15 +3,21 @@
  * Copyright (c) 2019 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ContextMenuOverlay } from '@vaadin/context-menu/src/vaadin-context-menu-overlay.js';
+import { MenuOverlayMixin } from '@vaadin/context-menu/src/vaadin-menu-overlay-mixin.js';
+import { styles } from '@vaadin/context-menu/src/vaadin-menu-overlay-styles.js';
+import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles('vaadin-menu-bar-overlay', styles, { moduleId: 'vaadin-menu-bar-overlay-styles' });
 
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
- * @extends ContextMenuOverlay
+ * @extends Overlay
+ * @mixes MenuOverlayMixin
  * @private
  */
-class MenuBarOverlay extends ContextMenuOverlay {
+class MenuBarOverlay extends MenuOverlayMixin(Overlay) {
   static get is() {
     return 'vaadin-menu-bar-overlay';
   }

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-overlay-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-overlay-styles.js
@@ -1,11 +1,13 @@
+import { contextMenuOverlay } from '@vaadin/context-menu/theme/lumo/vaadin-context-menu-overlay-styles.js';
+import { menuOverlay } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles(
-  'vaadin-menu-bar-overlay',
-  css`
-    :host(:first-of-type) {
-      padding-top: var(--lumo-space-xs);
-    }
-  `,
-  { moduleId: 'lumo-menu-bar-overlay' },
-);
+const menuBarOverlay = css`
+  :host(:first-of-type) {
+    padding-top: var(--lumo-space-xs);
+  }
+`;
+
+registerStyles('vaadin-menu-bar-overlay', [menuOverlay, contextMenuOverlay, menuBarOverlay], {
+  moduleId: 'lumo-menu-bar-overlay',
+});

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar.js
@@ -3,5 +3,5 @@ import './vaadin-menu-bar-item-styles.js';
 import './vaadin-menu-bar-list-box-styles.js';
 import './vaadin-menu-bar-overlay-styles.js';
 import './vaadin-menu-bar-styles.js';
-import '@vaadin/context-menu/theme/lumo/vaadin-context-menu.js';
+import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import '../../src/vaadin-menu-bar.js';

--- a/packages/menu-bar/theme/material/vaadin-menu-bar-overlay-styles.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar-overlay-styles.js
@@ -1,11 +1,13 @@
+import { contextMenuOverlay } from '@vaadin/context-menu/theme/material/vaadin-context-menu-overlay-styles.js';
+import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles(
-  'vaadin-menu-bar-overlay',
-  css`
-    :host(:first-of-type) {
-      padding-top: 5px;
-    }
-  `,
-  { moduleId: 'material-menu-bar-overlay' },
-);
+const menuBarOverlay = css`
+  :host(:first-of-type) {
+    padding-top: 5px;
+  }
+`;
+
+registerStyles('vaadin-menu-bar-overlay', [menuOverlay, contextMenuOverlay, menuBarOverlay], {
+  moduleId: 'material-menu-bar-overlay',
+});

--- a/packages/menu-bar/theme/material/vaadin-menu-bar.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar.js
@@ -3,5 +3,5 @@ import './vaadin-menu-bar-item-styles.js';
 import './vaadin-menu-bar-list-box-styles.js';
 import './vaadin-menu-bar-styles.js';
 import './vaadin-menu-bar-overlay-styles.js';
-import '@vaadin/context-menu/theme/material/vaadin-context-menu.js';
+import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import '../../src/vaadin-menu-bar.js';


### PR DESCRIPTION
## Description

Related to #5358

Follow-up to #5353 where the `vaadin-menu-bar-overlay` was added.

## Type of change

- Refactor