### PR TITLE
refactor!: extract shared combo-box overlay logic to mixin

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright (c) 2015 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { PositionMixinClass } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
+
+export declare function ComboBoxOverlayMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<PositionMixinClass> & T;

--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -31,7 +31,7 @@ export const ComboBoxOverlayMixin = (superClass) =>
      * Override method inherited from `Overlay`
      * to not close on position target click.
      *
-     * @param {Event} _event
+     * @param {Event} event
      * @return {boolean}
      * @protected
      */

--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2015 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
+
+/**
+ * @polymerMixin
+ * @mixes PositionMixin
+ */
+export const ComboBoxOverlayMixin = (superClass) =>
+  class ComboBoxOverlayMixin extends PositionMixin(superClass) {
+    static get observers() {
+      return ['_setOverlayWidth(positionTarget, opened)'];
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      const comboBox = this._comboBox;
+
+      const hostDir = comboBox && comboBox.getAttribute('dir');
+      if (hostDir) {
+        this.setAttribute('dir', hostDir);
+      }
+    }
+
+    /**
+     * Override method inherited from `Overlay`
+     * to not close on position target click.
+     *
+     * @param {Event} _event
+     * @return {boolean}
+     * @protected
+     */
+    _shouldCloseOnOutsideClick(event) {
+      const eventPath = event.composedPath();
+      return !eventPath.includes(this.positionTarget) && !eventPath.includes(this);
+    }
+
+    /** @private */
+    _setOverlayWidth(positionTarget, opened) {
+      if (positionTarget && opened) {
+        const propPrefix = this.localName;
+        this.style.setProperty(`--_${propPrefix}-default-width`, `${positionTarget.clientWidth}px`);
+
+        const customWidth = getComputedStyle(this._comboBox).getPropertyValue(`--${propPrefix}-width`);
+
+        if (customWidth === '') {
+          this.style.removeProperty(`--${propPrefix}-width`);
+        } else {
+          this.style.setProperty(`--${propPrefix}-width`, customWidth);
+        }
+
+        this._updatePosition();
+      }
+    }
+  };

--- a/packages/combo-box/src/vaadin-combo-box-overlay.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.d.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2015 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+import { ComboBoxOverlayMixin } from './vaadin-combo-box-overlay-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-combo-box>`. Not intended to be used separately.
+ */
+declare class ComboBoxOverlay extends ComboBoxOverlayMixin(Overlay) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-combo-box-overlay': ComboBoxOverlay;
+  }
+}
+
+export { ComboBoxOverlay };

--- a/packages/combo-box/theme/lumo/vaadin-combo-box-light.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-light.js
@@ -1,3 +1,3 @@
-import './vaadin-combo-box-dropdown-styles.js';
 import './vaadin-combo-box-item-styles.js';
+import './vaadin-combo-box-overlay-styles.js';
 import '../../src/vaadin-combo-box-light.js';

--- a/packages/combo-box/theme/lumo/vaadin-combo-box-overlay-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-overlay-styles.js
@@ -18,8 +18,6 @@ const comboBoxOverlay = css`
     --_vaadin-combo-box-items-container-border-color: transparent;
   }
 
-  /* Loading state */
-
   /* When items are empty, the spinner needs some room */
   :host(:not([closing])) [part~='content'] {
     min-height: calc(2 * var(--lumo-space-s) + var(--lumo-icon-size-s));
@@ -36,7 +34,9 @@ const comboBoxOverlay = css`
   :host([bottom-aligned]) [part~='overlay'] {
     margin-bottom: var(--lumo-space-xs);
   }
+`;
 
+const comboBoxLoader = css`
   [part~='loader'] {
     position: absolute;
     z-index: 1;
@@ -48,8 +48,6 @@ const comboBoxOverlay = css`
     margin-inline-end: 0;
   }
 
-  /* RTL specific styles */
-
   :host([dir='rtl']) [part~='loader'] {
     left: auto;
     margin-left: 0;
@@ -59,6 +57,8 @@ const comboBoxOverlay = css`
   }
 `;
 
-registerStyles('vaadin-combo-box-overlay', [overlay, menuOverlayCore, comboBoxOverlay, loader], {
+registerStyles('vaadin-combo-box-overlay', [overlay, menuOverlayCore, comboBoxOverlay, loader, comboBoxLoader], {
   moduleId: 'lumo-combo-box-overlay',
 });
+
+export { comboBoxLoader, comboBoxOverlay };

--- a/packages/combo-box/theme/lumo/vaadin-combo-box.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box.js
@@ -1,5 +1,5 @@
 import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
-import './vaadin-combo-box-dropdown-styles.js';
 import './vaadin-combo-box-item-styles.js';
+import './vaadin-combo-box-overlay-styles.js';
 import './vaadin-combo-box-styles.js';
 import '../../src/vaadin-combo-box.js';

--- a/packages/combo-box/theme/material/vaadin-combo-box-light.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-light.js
@@ -1,3 +1,3 @@
-import './vaadin-combo-box-dropdown-styles.js';
 import './vaadin-combo-box-item-styles.js';
+import './vaadin-combo-box-overlay-styles.js';
 import '../../src/vaadin-combo-box-light.js';

--- a/packages/combo-box/theme/material/vaadin-combo-box-overlay-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-overlay-styles.js
@@ -21,7 +21,9 @@ const comboBoxOverlay = css`
   [part='content'] {
     padding: 0;
   }
+`;
 
+const comboBoxLoader = css`
   [part~='loader'] {
     position: absolute;
     z-index: 1;
@@ -31,6 +33,8 @@ const comboBoxOverlay = css`
   }
 `;
 
-registerStyles('vaadin-combo-box-overlay', [menuOverlay, comboBoxOverlay, loader], {
+registerStyles('vaadin-combo-box-overlay', [menuOverlay, comboBoxOverlay, loader, comboBoxLoader], {
   moduleId: 'material-combo-box-overlay',
 });
+
+export { comboBoxLoader, comboBoxOverlay };

--- a/packages/combo-box/theme/material/vaadin-combo-box.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box.js
@@ -1,5 +1,5 @@
 import '@vaadin/input-container/theme/material/vaadin-input-container.js';
-import './vaadin-combo-box-dropdown-styles.js';
 import './vaadin-combo-box-item-styles.js';
+import './vaadin-combo-box-overlay-styles.js';
 import './vaadin-combo-box-styles.js';
 import '../../src/vaadin-combo-box.js';

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.d.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ComboBoxOverlayMixin } from '@vaadin/combo-box/src/vaadin-combo-box-overlay-mixin.js';
+import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+
+/**
+ * An element used internally by `<vaadin-multi-select-combo-box>`. Not intended to be used separately.
+ */
+declare class MultiSelectComboBoxOverlay extends ComboBoxOverlayMixin(Overlay) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-multi-select-combo-box-overlay': MultiSelectComboBoxOverlay;
+  }
+}
+
+export { MultiSelectComboBoxOverlay };

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ComboBoxOverlay } from '@vaadin/combo-box/src/vaadin-combo-box-overlay.js';
+import { ComboBoxOverlayMixin } from '@vaadin/combo-box/src/vaadin-combo-box-overlay-mixin.js';
+import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
@@ -15,9 +16,17 @@ registerStyles(
         var(--_vaadin-multi-select-combo-box-overlay-default-width, auto)
       );
     }
+
+    [part='content'] {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
   `,
   { moduleId: 'vaadin-multi-select-combo-box-overlay-styles' },
 );
+
+let memoizedTemplate;
 
 /**
  * An element used internally by `<vaadin-multi-select-combo-box>`. Not intended to be used separately.
@@ -25,9 +34,25 @@ registerStyles(
  * @extends ComboBoxOverlay
  * @private
  */
-class MultiSelectComboBoxOverlay extends ComboBoxOverlay {
+class MultiSelectComboBoxOverlay extends ComboBoxOverlayMixin(Overlay) {
   static get is() {
     return 'vaadin-multi-select-combo-box-overlay';
+  }
+
+  static get template() {
+    if (!memoizedTemplate) {
+      memoizedTemplate = super.template.cloneNode(true);
+
+      const overlay = memoizedTemplate.content.querySelector('[part~="overlay"]');
+      overlay.removeAttribute('tabindex');
+
+      const loader = document.createElement('div');
+      loader.setAttribute('part', 'loader');
+
+      overlay.insertBefore(loader, overlay.firstElementChild);
+    }
+
+    return memoizedTemplate;
   }
 }
 

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -8,8 +8,12 @@ import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import { comboBoxItem } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-item-styles.js';
+import { comboBoxLoader, comboBoxOverlay } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-overlay-styles.js';
 import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
+import { loader } from '@vaadin/vaadin-lumo-styles/mixins/loader.js';
+import { menuOverlayCore } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
+import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const multiSelectComboBoxItem = css`
@@ -24,6 +28,14 @@ const multiSelectComboBoxItem = css`
 registerStyles('vaadin-multi-select-combo-box-item', [item, comboBoxItem, multiSelectComboBoxItem], {
   moduleId: 'lumo-multi-select-combo-box-item',
 });
+
+registerStyles(
+  'vaadin-multi-select-combo-box-overlay',
+  [overlay, menuOverlayCore, comboBoxOverlay, loader, comboBoxLoader],
+  {
+    moduleId: 'lumo-multi-select-combo-box-overlay',
+  },
+);
 
 const multiSelectComboBox = css`
   :host([has-value]) {

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box.js
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/combo-box/theme/lumo/vaadin-combo-box-dropdown-styles.js';
 import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
+import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-multi-select-combo-box-chip-styles.js';
 import './vaadin-multi-select-combo-box-styles.js';
 import '../../src/vaadin-multi-select-combo-box.js';

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -7,8 +7,11 @@ import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import { comboBoxItem } from '@vaadin/combo-box/theme/material/vaadin-combo-box-item-styles.js';
+import { comboBoxLoader, comboBoxOverlay } from '@vaadin/combo-box/theme/material/vaadin-combo-box-overlay-styles.js';
 import { item } from '@vaadin/item/theme/material/vaadin-item-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
+import { loader } from '@vaadin/vaadin-material-styles/mixins/loader.js';
+import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const multiSelectComboBoxItem = css`
@@ -22,6 +25,10 @@ const multiSelectComboBoxItem = css`
 
 registerStyles('vaadin-multi-select-combo-box-item', [item, comboBoxItem, multiSelectComboBoxItem], {
   moduleId: 'material-multi-select-combo-box-item',
+});
+
+registerStyles('vaadin-multi-select-combo-box-overlay', [menuOverlay, comboBoxOverlay, loader, comboBoxLoader], {
+  moduleId: 'material-multi-select-combo-box-overlay',
 });
 
 const multiSelectComboBox = css`

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box.js
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/combo-box/theme/material/vaadin-combo-box-dropdown-styles.js';
 import '@vaadin/input-container/theme/material/vaadin-input-container.js';
+import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-multi-select-combo-box-chip-styles.js';
 import './vaadin-multi-select-combo-box-styles.js';
 import '../../src/vaadin-multi-select-combo-box.js';

--- a/packages/time-picker/src/vaadin-time-picker-overlay.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker-overlay.d.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ComboBoxOverlayMixin } from '@vaadin/combo-box/src/vaadin-combo-box-overlay-mixin.js';
+import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+
+/**
+ * An element used internally by `<vaadin-time-picker>`. Not intended to be used separately.
+ */
+declare class TimePickerOverlay extends ComboBoxOverlayMixin(Overlay) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-time-picker-overlay': TimePickerOverlay;
+  }
+}
+
+export { TimePickerOverlay };

--- a/packages/time-picker/src/vaadin-time-picker-overlay.js
+++ b/packages/time-picker/src/vaadin-time-picker-overlay.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ComboBoxOverlay } from '@vaadin/combo-box/src/vaadin-combo-box-overlay.js';
+import { ComboBoxOverlayMixin } from '@vaadin/combo-box/src/vaadin-combo-box-overlay-mixin.js';
+import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
@@ -12,9 +13,17 @@ registerStyles(
     #overlay {
       width: var(--vaadin-time-picker-overlay-width, var(--_vaadin-time-picker-overlay-default-width, auto));
     }
+
+    [part='content'] {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
   `,
   { moduleId: 'vaadin-time-picker-overlay-styles' },
 );
+
+let memoizedTemplate;
 
 /**
  * An element used internally by `<vaadin-time-picker>`. Not intended to be used separately.
@@ -22,9 +31,18 @@ registerStyles(
  * @extends ComboBoxOverlay
  * @private
  */
-class TimePickerOverlay extends ComboBoxOverlay {
+class TimePickerOverlay extends ComboBoxOverlayMixin(Overlay) {
   static get is() {
     return 'vaadin-time-picker-overlay';
+  }
+
+  static get template() {
+    if (!memoizedTemplate) {
+      memoizedTemplate = super.template.cloneNode(true);
+      memoizedTemplate.content.querySelector('[part~="overlay"]').removeAttribute('tabindex');
+    }
+
+    return memoizedTemplate;
   }
 }
 

--- a/packages/time-picker/theme/lumo/vaadin-time-picker-styles.js
+++ b/packages/time-picker/theme/lumo/vaadin-time-picker-styles.js
@@ -5,12 +5,19 @@
  */
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { comboBoxItem } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-item-styles.js';
+import { comboBoxOverlay } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-overlay-styles.js';
 import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
+import { menuOverlayCore } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
+import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles('vaadin-time-picker-item', [item, comboBoxItem], {
   moduleId: 'lumo-time-picker-item',
+});
+
+registerStyles('vaadin-time-picker-overlay', [overlay, menuOverlayCore, comboBoxOverlay], {
+  moduleId: 'lumo-time-picker-overlay',
 });
 
 const timePicker = css`

--- a/packages/time-picker/theme/lumo/vaadin-time-picker.js
+++ b/packages/time-picker/theme/lumo/vaadin-time-picker.js
@@ -3,8 +3,7 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/combo-box/theme/lumo/vaadin-combo-box-dropdown-styles.js';
-import '@vaadin/combo-box/theme/lumo/vaadin-combo-box-item-styles.js';
 import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
+import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-time-picker-styles.js';
 import '../../src/vaadin-time-picker.js';

--- a/packages/time-picker/theme/material/vaadin-time-picker-styles.js
+++ b/packages/time-picker/theme/material/vaadin-time-picker-styles.js
@@ -5,12 +5,18 @@
  */
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { comboBoxItem } from '@vaadin/combo-box/theme/material/vaadin-combo-box-item-styles.js';
+import { comboBoxOverlay } from '@vaadin/combo-box/theme/material/vaadin-combo-box-overlay-styles.js';
 import { item } from '@vaadin/item/theme/material/vaadin-item-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
+import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles('vaadin-time-picker-item', [item, comboBoxItem], {
   moduleId: 'material-time-picker-item',
+});
+
+registerStyles('vaadin-time-picker-overlay', [menuOverlay, comboBoxOverlay], {
+  moduleId: 'material-time-picker-overlay',
 });
 
 const timePicker = css`

--- a/packages/time-picker/theme/material/vaadin-time-picker.js
+++ b/packages/time-picker/theme/material/vaadin-time-picker.js
@@ -3,8 +3,7 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/combo-box/theme/material/vaadin-combo-box-dropdown-styles.js';
-import '@vaadin/combo-box/theme/material/vaadin-combo-box-item-styles.js';
 import '@vaadin/input-container/theme/material/vaadin-input-container.js';
+import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-time-picker-styles.js';
 import '../../src/vaadin-time-picker.js';


### PR DESCRIPTION
## Description

Related to #5358

Same as #5391 but for the following components:

- `vaadin-combo-box-overlay`
- `vaadin-time-picker-overlay`
- `vaadin-multi-select-combo-box-overlay`

This PR decouples `TimePickerOverlay` and `MultiSelectComboBoxOverlay` by making them use shared mixin.
Also, theme files have been updated to export `css` tagged literals that are used by all of these components.

## Type of change

- Breaking change