### PR TITLE
fix: use correct selector for highlight-read-only-cells theme

### DIFF
--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
@@ -39,7 +39,8 @@ registerStyles(
 
     /* Indicate read-only cells */
 
-    :host([theme~='highlight-read-only-cells']) [part~='body-cell']:not([part~='editable-cell']) {
+    /* prettier-ignore */
+    :host([theme~='highlight-read-only-cells']) [tabindex]:not([part~='editable-cell']):not([part~='header-cell']):not([part~='footer-cell']) {
       background-image: repeating-linear-gradient(
         135deg,
         transparent,


### PR DESCRIPTION
## Description

Fixes #5395

Changed to use `[tabindex]` attribute which applies to focusable elements in shadow DOM.
These are either cells or buttons depending on whether Mac OS is used, see #4260

## Type of change

- Bugfix