### PR TITLE
refactor: add internal protected method for outside click

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -68,11 +68,17 @@ export class ComboBoxOverlay extends PositionMixin(Overlay) {
     content.parentNode.insertBefore(loader, content);
   }
 
-  _outsideClickListener(event) {
+  /**
+   * Override method inherited from `Overlay`
+   * to not close on position target click.
+   *
+   * @param {Event} _event
+   * @return {boolean}
+   * @protected
+   */
+  _shouldCloseOnOutsideClick(event) {
     const eventPath = event.composedPath();
-    if (!eventPath.includes(this.positionTarget) && !eventPath.includes(this)) {
-      this.close();
-    }
+    return !eventPath.includes(this.positionTarget) && !eventPath.includes(this);
   }
 
   _setOverlayWidth(positionTarget, opened) {

--- a/packages/overlay/src/vaadin-overlay.d.ts
+++ b/packages/overlay/src/vaadin-overlay.d.ts
@@ -204,6 +204,12 @@ declare class Overlay extends ThemableMixin(DirMixin(ControllerMixin(HTMLElement
     listener: (this: Overlay, ev: OverlayEventMap[K]) => void,
     options?: EventListenerOptions | boolean,
   ): void;
+
+  /**
+   * Whether to close the overlay on outside click or not.
+   * Override this method to customize the closing logic.
+   */
+  protected _shouldCloseOnOutsideClick(event: Event): boolean;
 }
 
 declare global {

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -412,9 +412,21 @@ class Overlay extends ThemableMixin(DirMixin(ControllerMixin(PolymerElement))) {
   }
 
   /**
-   * We need to listen on 'click' / 'tap' event and capture it and close the overlay before
-   * propagating the event to the listener in the button. Otherwise, if the clicked button would call
-   * open(), this would happen: https://www.youtube.com/watch?v=Z86V_ICUCD4
+   * Whether to close the overlay on outside click or not.
+   * Override this method to customize the closing logic.
+   *
+   * @param {Event} _event
+   * @return {boolean}
+   * @protected
+   */
+  _shouldCloseOnOutsideClick(_event) {
+    return this._last;
+  }
+
+  /**
+   * Outside click listener used in capture phase to close the overlay before
+   * propagating the event to the listener on the element that triggered it.
+   * Otherwise, calling `open()` would result in closing and re-opening.
    *
    * @event vaadin-overlay-outside-click
    * fired before the `vaadin-overlay` will be closed on outside click. If canceled the closing of the overlay is canceled as well.
@@ -427,7 +439,8 @@ class Overlay extends ThemableMixin(DirMixin(ControllerMixin(PolymerElement))) {
       this._mouseUpInside = false;
       return;
     }
-    if (!this._last) {
+
+    if (!this._shouldCloseOnOutsideClick(event)) {
       return;
     }
 


### PR DESCRIPTION
## Description

Related to #5393 - this is an alternative approach to avoid overriding the event listener and to keep it private.

## Type of change

- Refactor / internal feature