### PR TITLE
fix!: set correct role attribute on the list-box and item

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -349,7 +349,6 @@ class AvatarGroup extends ResizeMixin(OverlayClassMixin(ElementMixin(ThemableMix
   __createItemElement(item) {
     const itemElement = document.createElement('vaadin-item');
     itemElement.setAttribute('theme', 'avatar-group-item');
-    itemElement.setAttribute('role', 'option');
 
     const avatar = document.createElement('vaadin-avatar');
     itemElement.appendChild(avatar);

--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -84,6 +84,13 @@ class Item extends ItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
     // eslint-disable-next-line no-unused-expressions
     this.value;
   }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.setAttribute('role', 'option');
+  }
 }
 
 customElements.define(Item.is, Item);

--- a/packages/item/test/dom/__snapshots__/item.test.snap.js
+++ b/packages/item/test/dom/__snapshots__/item.test.snap.js
@@ -1,0 +1,46 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-item host default"] = 
+`<vaadin-item
+  aria-selected="false"
+  role="option"
+>
+</vaadin-item>
+`;
+/* end snapshot vaadin-item host default */
+
+snapshots["vaadin-item host selected"] = 
+`<vaadin-item
+  aria-selected="true"
+  role="option"
+  selected=""
+>
+</vaadin-item>
+`;
+/* end snapshot vaadin-item host selected */
+
+snapshots["vaadin-item host disabled"] = 
+`<vaadin-item
+  aria-disabled="true"
+  aria-selected="false"
+  disabled=""
+  role="option"
+>
+</vaadin-item>
+`;
+/* end snapshot vaadin-item host disabled */
+
+snapshots["vaadin-item shadow default"] = 
+`<span
+  aria-hidden="true"
+  part="checkmark"
+>
+</span>
+<div part="content">
+  <slot>
+  </slot>
+</div>
+`;
+/* end snapshot vaadin-item shadow default */
+

--- a/packages/item/test/dom/item.test.js
+++ b/packages/item/test/dom/item.test.js
@@ -1,0 +1,33 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-item.js';
+
+describe('vaadin-item', () => {
+  let item;
+
+  beforeEach(() => {
+    item = fixtureSync('<vaadin-item></vaadin-item>');
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(item).dom.to.equalSnapshot();
+    });
+
+    it('selected', async () => {
+      item.selected = true;
+      await expect(item).dom.to.equalSnapshot();
+    });
+
+    it('disabled', async () => {
+      item.disabled = true;
+      await expect(item).dom.to.equalSnapshot();
+    });
+  });
+
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(item).shadowDom.to.equalSnapshot();
+    });
+  });
+});

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -107,7 +107,8 @@ class ListBox extends ElementMixin(MultiSelectListMixin(ThemableMixin(Controller
   /** @protected */
   ready() {
     super.ready();
-    this.setAttribute('role', 'list');
+
+    this.setAttribute('role', 'listbox');
 
     setTimeout(this._checkImport.bind(this), 2000);
 

--- a/packages/list-box/src/vaadin-multi-select-list-mixin.js
+++ b/packages/list-box/src/vaadin-multi-select-list-mixin.js
@@ -101,12 +101,18 @@ export const MultiSelectListMixin = (superClass) =>
         this.items.forEach((item) => {
           item.selected = false;
         });
+
+        this.removeAttribute('aria-multiselectable');
       }
 
       // Changing from single to multiple selection, add selected to selectedValues.
-      if (value && !oldValue && this.selected !== undefined) {
-        this.selectedValues = [...this.selectedValues, this.selected];
-        this.selected = undefined;
+      if (value && !oldValue) {
+        this.setAttribute('aria-multiselectable', 'true');
+
+        if (this.selected !== undefined) {
+          this.selectedValues = [...this.selectedValues, this.selected];
+          this.selected = undefined;
+        }
       }
     }
 

--- a/packages/list-box/test/dom/__snapshots__/list-box.test.snap.js
+++ b/packages/list-box/test/dom/__snapshots__/list-box.test.snap.js
@@ -1,0 +1,29 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-list-box host default"] = 
+`<vaadin-list-box role="listbox">
+</vaadin-list-box>
+`;
+/* end snapshot vaadin-list-box host default */
+
+snapshots["vaadin-list-box host multiple"] = 
+`<vaadin-list-box
+  aria-multiselectable="true"
+  multiple=""
+  role="listbox"
+>
+</vaadin-list-box>
+`;
+/* end snapshot vaadin-list-box host multiple */
+
+snapshots["vaadin-list-box shadow default"] = 
+`<div part="items">
+  <slot>
+  </slot>
+</div>
+<slot name="tooltip">
+</slot>
+`;
+/* end snapshot vaadin-list-box shadow default */
+

--- a/packages/list-box/test/dom/list-box.test.js
+++ b/packages/list-box/test/dom/list-box.test.js
@@ -1,0 +1,28 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-list-box.js';
+
+describe('vaadin-list-box', () => {
+  let listBox;
+
+  beforeEach(() => {
+    listBox = fixtureSync('<vaadin-list-box></vaadin-list-box>');
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(listBox).dom.to.equalSnapshot();
+    });
+
+    it('multiple', async () => {
+      listBox.multiple = true;
+      await expect(listBox).dom.to.equalSnapshot();
+    });
+  });
+
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(listBox).shadowDom.to.equalSnapshot();
+    });
+  });
+});

--- a/packages/list-box/test/list-box.test.js
+++ b/packages/list-box/test/list-box.test.js
@@ -18,13 +18,4 @@ describe('vaadin-list-box', () => {
   it('should extend list-mixin', () => {
     expect(listBox._hasVaadinListMixin).to.be.true;
   });
-
-  it('should have an unnamed slot for content', () => {
-    const slot = listBox.shadowRoot.querySelector('slot:not([name])');
-    expect(slot.assignedNodes().length).to.be.equal(5);
-  });
-
-  it('should have role attribute', () => {
-    expect(listBox.getAttribute('role')).to.equal('list');
-  });
 });

--- a/packages/list-box/test/multi-select-list-mixin.test.js
+++ b/packages/list-box/test/multi-select-list-mixin.test.js
@@ -164,4 +164,12 @@ describe('MultiSelectListMixin', () => {
     list.items[3].click();
     expect(list._scrollerElement.scrollTop).to.be.greaterThan(0);
   });
+
+  it('should remove aria-multiselectable when multiple is set back to false', () => {
+    list.multiple = true;
+    expect(list.hasAttribute('aria-multiselectable')).to.be.true;
+
+    list.multiple = false;
+    expect(list.hasAttribute('aria-multiselectable')).to.be.false;
+  });
 });

--- a/packages/list-box/test/multi-select-list-mixin.test.js
+++ b/packages/list-box/test/multi-select-list-mixin.test.js
@@ -165,7 +165,7 @@ describe('MultiSelectListMixin', () => {
     expect(list._scrollerElement.scrollTop).to.be.greaterThan(0);
   });
 
-  it('should remove aria-multiselectable when multiple is set back to false', () => {
+  it('should toggle aria-multiselectable on multiple property change', () => {
     list.multiple = true;
     expect(list.hasAttribute('aria-multiselectable')).to.be.true;
 

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -447,8 +447,6 @@ class Select extends OverlayClassMixin(
         true,
       );
 
-      menuElement.setAttribute('role', 'listbox');
-
       // Store the menu element reference
       this.__lastMenuElement = menuElement;
     }
@@ -458,7 +456,6 @@ class Select extends OverlayClassMixin(
   __initMenuItems(menuElement) {
     if (menuElement.items) {
       this._items = menuElement.items;
-      this._items.forEach((item) => item.setAttribute('role', 'option'));
     }
   }
 
@@ -594,8 +591,7 @@ class Select extends OverlayClassMixin(
     // Store reference to the original item
     labelItem._sourceItem = selected;
 
-    this.__initValueItemElement(labelItem);
-    this.focusElement.appendChild(labelItem);
+    this.__appendValueItemElement(labelItem, this.focusElement);
 
     // Ensure the item gets proper styles
     labelItem.selected = true;
@@ -621,10 +617,13 @@ class Select extends OverlayClassMixin(
 
   /**
    * @param {!HTMLElement} itemElement
+   * @param {!HTMLElement} parent
    * @private
    */
-  __initValueItemElement(itemElement) {
+  __appendValueItemElement(itemElement, parent) {
+    parent.appendChild(itemElement);
     itemElement.removeAttribute('tabindex');
+    itemElement.removeAttribute('aria-selected');
     itemElement.removeAttribute('role');
     itemElement.setAttribute('id', this._itemId);
   }
@@ -646,8 +645,7 @@ class Select extends OverlayClassMixin(
     if (!selected) {
       if (this.placeholder) {
         const item = this.__createItemElement({ label: this.placeholder });
-        this.__initValueItemElement(item);
-        valueButton.appendChild(item);
+        this.__appendValueItemElement(item, valueButton);
         valueButton.setAttribute('placeholder', '');
       }
     } else {

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -76,11 +76,7 @@ snapshots["vaadin-select host placeholder"] =
     slot="value"
     tabindex="0"
   >
-    <vaadin-select-item
-      aria-selected="false"
-      id="value-vaadin-select-3"
-      role="option"
-    >
+    <vaadin-select-item id="value-vaadin-select-3">
       Placeholder
     </vaadin-select-item>
   </vaadin-select-value-button>
@@ -168,9 +164,7 @@ snapshots["vaadin-select host value"] =
     tabindex="0"
   >
     <vaadin-select-item
-      aria-selected="true"
       id="value-vaadin-select-3"
-      role="option"
       selected=""
     >
       Option 1


### PR DESCRIPTION
## Description

Fixes #154
Fixes #5378

1. Changed the default `role` attribute for `vaadin-list-box` element from `list` to `listbox`;
2. Updated the `vaadin-item` to set `role="option"` instead of expecting the list-box to set it;
3. Added missing logic to toggle `aria-multiselectable` attribute to `MultiSelectListMixin`;
4. Updated `vaadin-avatar-group` and `vaadin-select` that use list-box and item accordingly;
5. Fixed `vaadin-select` to remove `role` attribute and `aria-selected` from the cloned item;
6. Added missing snapshot tests for the item and list-box, removed some existing unit tests.

## Type of change

- Behavior altering fix

## Screen readers

### VoiceOver + Chrome

#### Before (broken)

![Screenshot 2023-01-26 at 11 01 17](https://user-images.githubusercontent.com/10589913/214812565-95bd680a-e29c-485d-9fc2-d9c69f893dff.png)

#### After (working)

Two announcements: "not selected" for the item and "selected" for the list-box:

![Screenshot 2023-01-26 at 11 19 36](https://user-images.githubusercontent.com/10589913/214813133-8cef2334-8928-4cd7-90e8-16f34efe63af.png)

### NVDA + Edge

New behavior (after) - didn't check the old one:

![Screenshot 2023-01-26 at 11 11 19](https://user-images.githubusercontent.com/10589913/214812934-9bbc4712-f302-4b94-ab53-7ca8f82b564e.png)

### JAWS + Edge

Nnew behavior (after) - didn't check the old one:

![Screenshot 2023-01-26 at 12 00 10](https://user-images.githubusercontent.com/10589913/214813032-2ff7a707-f076-4099-ac06-c2207654b5cd.png)