### PR TITLE
fix: set aria-selected on selected item, not the focused one

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -306,19 +306,20 @@ export class ComboBoxScroller extends PolymerElement {
   __updateElement(el, index) {
     const item = this.items[index];
     const focusedIndex = this.focusedIndex;
+    const selected = this.__isItemSelected(item, this.selectedItem, this.itemIdPath);
 
     el.setProperties({
       item,
       index,
       label: this.getItemLabel(item),
-      selected: this.__isItemSelected(item, this.selectedItem, this.itemIdPath),
+      selected,
       renderer: this.renderer,
       focused: this.__isItemFocused(focusedIndex, index),
     });
 
     el.id = `${this.__hostTagName}-item-${index}`;
     el.setAttribute('role', this.__getAriaRole(index));
-    el.setAttribute('aria-selected', this.__getAriaSelected(focusedIndex, index));
+    el.setAttribute('aria-selected', selected.toString());
     el.setAttribute('aria-posinset', index + 1);
     el.setAttribute('aria-setsize', this.items.length);
 

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -232,17 +232,12 @@ export class ComboBoxScroller extends PolymerElement {
   }
 
   /** @private */
-  __getAriaSelected(focusedIndex, itemIndex) {
-    return this.__isItemFocused(focusedIndex, itemIndex).toString();
-  }
-
-  /** @private */
   __isItemFocused(focusedIndex, itemIndex) {
     return !this.loading && focusedIndex === itemIndex;
   }
 
-  /** @private */
-  __isItemSelected(item, selectedItem, itemIdPath) {
+  /** @protected */
+  _isItemSelected(item, selectedItem, itemIdPath) {
     if (item instanceof ComboBoxPlaceholder) {
       return false;
     } else if (itemIdPath && item !== undefined && selectedItem !== undefined) {
@@ -306,7 +301,7 @@ export class ComboBoxScroller extends PolymerElement {
   __updateElement(el, index) {
     const item = this.items[index];
     const focusedIndex = this.focusedIndex;
-    const selected = this.__isItemSelected(item, this.selectedItem, this.itemIdPath);
+    const selected = this._isItemSelected(item, this.selectedItem, this.itemIdPath);
 
     el.setProperties({
       item,

--- a/packages/combo-box/test/aria.test.js
+++ b/packages/combo-box/test/aria.test.js
@@ -43,11 +43,12 @@ describe('ARIA', () => {
       expect(input.getAttribute('aria-activedescendant')).to.equal(items[1].id);
     });
 
-    it('should set aria-selected on item elements depending on the focused item', () => {
-      arrowDownKeyDown(input); // Move focus to the 1st item.
+    it('should set aria-selected on item elements depending on the selected item', () => {
+      comboBox.value = 'foo';
       expect(items[0].getAttribute('aria-selected')).to.equal('true');
       expect(items[1].getAttribute('aria-selected')).to.equal('false');
-      arrowDownKeyDown(input); // Move focus to the 2nd item.
+
+      comboBox.value = 'bar';
       expect(items[0].getAttribute('aria-selected')).to.equal('false');
       expect(items[1].getAttribute('aria-selected')).to.equal('true');
     });

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
@@ -24,14 +24,11 @@ class MultiSelectComboBoxScroller extends ComboBoxScroller {
     this.setAttribute('aria-multiselectable', 'true');
   }
 
-  /** @private */
-  __getAriaSelected(_focusedIndex, itemIndex) {
-    const item = this.items[itemIndex];
-    return this.__isItemSelected(item, null, this.itemIdPath).toString();
-  }
-
-  /** @private */
-  __isItemSelected(item, _selectedItem, itemIdPath) {
+  /**
+   * @protected
+   * @override
+   */
+  _isItemSelected(item, _selectedItem, itemIdPath) {
     if (item instanceof ComboBoxPlaceholder) {
       return false;
     }

--- a/packages/time-picker/test/aria.test.js
+++ b/packages/time-picker/test/aria.test.js
@@ -41,11 +41,12 @@ describe('ARIA', () => {
       expect(input.getAttribute('aria-activedescendant')).to.equal(items[1].id);
     });
 
-    it('should set aria-selected on item elements depending on the focused item', () => {
-      arrowDownKeyDown(input); // Move focus to the 1st item.
+    it('should set aria-selected on item elements depending on the selected item', () => {
+      timePicker.value = '00:00';
       expect(items[0].getAttribute('aria-selected')).to.equal('true');
       expect(items[1].getAttribute('aria-selected')).to.equal('false');
-      arrowDownKeyDown(input); // Move focus to the 2nd item.
+
+      timePicker.value = '01:00';
       expect(items[0].getAttribute('aria-selected')).to.equal('false');
       expect(items[1].getAttribute('aria-selected')).to.equal('true');
     });


### PR DESCRIPTION
## Description

Fixes #720

This PR fixes an issue found by @vursen while looking into the `vaadin-list-box` fix for `aria-selected` state.

For some historical reasons, we originally tried to announce focused item change by updating this attribute.
At least in VoiceOver this causes duplicate announcements: both the input text and item are announced.

Now when the `<input>` element is placed in light DOM and linked with the overlay, let's fix this logic.

## Type of change

- Bugfix

## Testing

### VoiceOver + Chrome

Both selected and not selected states are announced 🎉 

<img width="464" alt="vo-not-selected" src="https://user-images.githubusercontent.com/10589913/214867213-35824d76-043e-43e1-bab5-561c5906ee05.png">

<img width="418" alt="vo-selected" src="https://user-images.githubusercontent.com/10589913/214867238-4ef4cbeb-a172-44bb-889e-d9eb063ccea1.png">

Note, VoiceOver + Safari has known issues that don't seem to be affected by this PR: #2748

### JAWS + Edge

Selected item is not announced. This problem also exists on master, I think it's because of focus not moving to the item.
This seems to be the same as #163 - we can't really do anything about it, without changing how combo-box works 😕 

<img width="393" alt="jaws" src="https://user-images.githubusercontent.com/10589913/214864139-ec9d8a72-bdb6-46e0-b183-151a8ed4c67d.png">

### NVDA + Edge

Selected item is not announced, instead items that are not selected get announced. So it seems to work as expected 😎  

<img width="434" alt="nvda" src="https://user-images.githubusercontent.com/10589913/214866302-d6a09974-03e0-4b57-810c-fd645a9d4847.png">

