### PR TITLE
refactor!: update avatar-group to use custom menu and item

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group-menu-item.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu-item.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2020 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ItemMixin } from '@vaadin/item/src/vaadin-item-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
+ */
+declare class AvatarGroupMenuItem extends ItemMixin(DirMixin(ThemableMixin(HTMLElement))) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-avatar-group-menu-item': AvatarGroupMenuItem;
+  }
+}
+
+export { AvatarGroupMenuItem };

--- a/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright (c) 2020 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ItemMixin } from '@vaadin/item/src/vaadin-item-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
+ *
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes ItemMixin
+ * @mixes ThemableMixin
+ * @protected
+ */
+class AvatarGroupMenuItem extends ItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
+  static get is() {
+    return 'vaadin-avatar-group-menu-item';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: inline-block;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+      </style>
+      <span part="checkmark" aria-hidden="true"></span>
+      <div part="content">
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.setAttribute('role', 'menuitem');
+  }
+}
+
+customElements.define(AvatarGroupMenuItem.is, AvatarGroupMenuItem);
+
+export { AvatarGroupMenuItem };

--- a/packages/avatar-group/src/vaadin-avatar-group-menu.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu.d.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright (c) 2020 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ListMixin } from '@vaadin/component-base/src/list-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
+ */
+declare class AvatarGroupMenu extends ListMixin(DirMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-avatar-group-menu': AvatarGroupMenu;
+  }
+}
+
+export { AvatarGroupMenu };

--- a/packages/avatar-group/src/vaadin-avatar-group-menu.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu.js
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright (c) 2020 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ListMixin } from '@vaadin/component-base/src/list-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
+ *
+ * @extends HTMLElement
+ * @mixes ControllerMixin
+ * @mixes DirMixin
+ * @mixes ListMixin
+ * @mixes ThemableMixin
+ * @protected
+ */
+class AvatarGroupMenu extends ListMixin(ThemableMixin(DirMixin(ControllerMixin(PolymerElement)))) {
+  static get is() {
+    return 'vaadin-avatar-group-menu';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        :host {
+          display: flex;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+
+        [part='items'] {
+          height: 100%;
+          width: 100%;
+          overflow-y: auto;
+          -webkit-overflow-scrolling: touch;
+        }
+      </style>
+      <div part="items">
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  static get properties() {
+    return {
+      // We don't need to define this property since super default is vertical,
+      // but we don't want it to be modified, or be shown in the API docs.
+      /** @private */
+      orientation: {
+        readOnly: true,
+      },
+    };
+  }
+
+  /**
+   * @return {!HTMLElement}
+   * @protected
+   * @override
+   */
+  get _scrollerElement() {
+    return this.shadowRoot.querySelector('[part="items"]');
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.setAttribute('role', 'menu');
+  }
+}
+
+customElements.define(AvatarGroupMenu.is, AvatarGroupMenu);
+
+export { AvatarGroupMenu };

--- a/packages/avatar-group/src/vaadin-avatar-group.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group.d.ts
@@ -65,6 +65,8 @@ export interface AvatarGroupItem {
  * components are themable:
  *
  * - `<vaadin-avatar-group-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
+ * - `<vaadin-avatar-group-menu>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
+ * - `<vaadin-avatar-group-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  */
 declare class AvatarGroup extends ResizeMixin(
   OverlayClassMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))),

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -4,8 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/avatar/src/vaadin-avatar.js';
-import '@vaadin/item/src/vaadin-item.js';
-import '@vaadin/list-box/src/vaadin-list-box.js';
+import './vaadin-avatar-group-menu.js';
+import './vaadin-avatar-group-menu-item.js';
 import './vaadin-avatar-group-overlay.js';
 import { calculateSplices } from '@polymer/polymer/lib/utils/array-splice.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
@@ -58,6 +58,8 @@ const MINIMUM_DISPLAYED_AVATARS = 2;
  * components are themable:
  *
  * - `<vaadin-avatar-group-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
+ * - `<vaadin-avatar-group-menu>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
+ * - `<vaadin-avatar-group-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  *
  * @extends HTMLElement
  * @mixes ControllerMixin
@@ -284,7 +286,7 @@ class AvatarGroup extends ResizeMixin(OverlayClassMixin(ElementMixin(ThemableMix
 
     this._overflowController = new SlotController(this, 'overflow', 'vaadin-avatar', {
       initializer: (overflow) => {
-        overflow.setAttribute('aria-haspopup', 'listbox');
+        overflow.setAttribute('aria-haspopup', 'menu');
         overflow.setAttribute('aria-expanded', 'false');
         overflow.addEventListener('click', (e) => this._onOverflowClick(e));
         overflow.addEventListener('keydown', (e) => this._onOverflowKeyDown(e));
@@ -327,28 +329,27 @@ class AvatarGroup extends ResizeMixin(OverlayClassMixin(ElementMixin(ThemableMix
    * @private
    */
   __overlayRenderer(root) {
-    let listBox = root.firstElementChild;
-    if (!listBox) {
-      listBox = document.createElement('vaadin-list-box');
-      listBox.addEventListener('keydown', (event) => this._onListKeyDown(event));
-      root.appendChild(listBox);
+    let menu = root.firstElementChild;
+    if (!menu) {
+      menu = document.createElement('vaadin-avatar-group-menu');
+      menu.addEventListener('keydown', (event) => this._onListKeyDown(event));
+      root.appendChild(menu);
     }
 
-    listBox.textContent = '';
+    menu.textContent = '';
 
     if (!this._overflowItems) {
       return;
     }
 
     this._overflowItems.forEach((item) => {
-      listBox.appendChild(this.__createItemElement(item));
+      menu.appendChild(this.__createItemElement(item));
     });
   }
 
   /** @private */
   __createItemElement(item) {
-    const itemElement = document.createElement('vaadin-item');
-    itemElement.setAttribute('theme', 'avatar-group-item');
+    const itemElement = document.createElement('vaadin-avatar-group-menu-item');
 
     const avatar = document.createElement('vaadin-avatar');
     itemElement.appendChild(avatar);
@@ -594,8 +595,7 @@ class AvatarGroup extends ResizeMixin(OverlayClassMixin(ElementMixin(ThemableMix
   __openedChanged(opened, wasOpened) {
     if (opened) {
       if (!this._menuElement) {
-        this._menuElement = this.$.overlay.querySelector('vaadin-list-box');
-        this._menuElement.setAttribute('role', 'listbox');
+        this._menuElement = this.$.overlay.querySelector('vaadin-avatar-group-menu');
       }
 
       this._openedWithFocusRing = this._overflow.hasAttribute('focus-ring');

--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -6,7 +6,7 @@ snapshots["vaadin-avatar-group default"] =
   <vaadin-avatar
     abbr="+NaN"
     aria-expanded="false"
-    aria-haspopup="listbox"
+    aria-haspopup="menu"
     hidden=""
     role="button"
     slot="overflow"
@@ -43,7 +43,7 @@ snapshots["vaadin-avatar-group items"] =
   <vaadin-avatar
     abbr="+2"
     aria-expanded="false"
-    aria-haspopup="listbox"
+    aria-haspopup="menu"
     hidden=""
     role="button"
     slot="overflow"
@@ -85,7 +85,7 @@ snapshots["vaadin-avatar-group theme"] =
   <vaadin-avatar
     abbr="+2"
     aria-expanded="false"
-    aria-haspopup="listbox"
+    aria-haspopup="menu"
     hidden=""
     role="button"
     slot="overflow"
@@ -124,7 +124,7 @@ snapshots["vaadin-avatar-group opened default"] =
   <vaadin-avatar
     abbr="+2"
     aria-expanded="false"
-    aria-haspopup="listbox"
+    aria-haspopup="menu"
     focused=""
     role="button"
     slot="overflow"
@@ -145,15 +145,14 @@ snapshots["vaadin-avatar-group opened overlay"] =
   start-aligned=""
   top-aligned=""
 >
-  <vaadin-list-box
+  <vaadin-avatar-group-menu
     aria-orientation="vertical"
-    role="listbox"
+    role="menu"
   >
-    <vaadin-item
+    <vaadin-avatar-group-menu-item
       aria-selected="false"
-      role="option"
+      role="menuitem"
       tabindex="0"
-      theme="avatar-group-item"
     >
       <vaadin-avatar
         abbr="MP"
@@ -164,12 +163,11 @@ snapshots["vaadin-avatar-group opened overlay"] =
       >
       </vaadin-avatar>
       Mno Pqr
-    </vaadin-item>
-    <vaadin-item
+    </vaadin-avatar-group-menu-item>
+    <vaadin-avatar-group-menu-item
       aria-selected="false"
-      role="option"
+      role="menuitem"
       tabindex="-1"
-      theme="avatar-group-item"
     >
       <vaadin-avatar
         abbr="SV"
@@ -180,8 +178,8 @@ snapshots["vaadin-avatar-group opened overlay"] =
       >
       </vaadin-avatar>
       Stu Vwx
-    </vaadin-item>
-  </vaadin-list-box>
+    </vaadin-avatar-group-menu-item>
+  </vaadin-avatar-group-menu>
 </vaadin-avatar-group-overlay>
 `;
 /* end snapshot vaadin-avatar-group opened overlay */
@@ -195,15 +193,14 @@ snapshots["vaadin-avatar-group opened overlay class"] =
   start-aligned=""
   top-aligned=""
 >
-  <vaadin-list-box
+  <vaadin-avatar-group-menu
     aria-orientation="vertical"
-    role="listbox"
+    role="menu"
   >
-    <vaadin-item
+    <vaadin-avatar-group-menu-item
       aria-selected="false"
-      role="option"
+      role="menuitem"
       tabindex="0"
-      theme="avatar-group-item"
     >
       <vaadin-avatar
         abbr="MP"
@@ -214,12 +211,11 @@ snapshots["vaadin-avatar-group opened overlay class"] =
       >
       </vaadin-avatar>
       Mno Pqr
-    </vaadin-item>
-    <vaadin-item
+    </vaadin-avatar-group-menu-item>
+    <vaadin-avatar-group-menu-item
       aria-selected="false"
-      role="option"
+      role="menuitem"
       tabindex="-1"
-      theme="avatar-group-item"
     >
       <vaadin-avatar
         abbr="SV"
@@ -230,8 +226,8 @@ snapshots["vaadin-avatar-group opened overlay class"] =
       >
       </vaadin-avatar>
       Stu Vwx
-    </vaadin-item>
-  </vaadin-list-box>
+    </vaadin-avatar-group-menu-item>
+  </vaadin-avatar-group-menu>
 </vaadin-avatar-group-overlay>
 `;
 /* end snapshot vaadin-avatar-group opened overlay class */

--- a/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js
+++ b/packages/avatar-group/theme/lumo/vaadin-avatar-group-styles.js
@@ -1,6 +1,8 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
+import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
+import { listBox } from '@vaadin/list-box/theme/lumo/vaadin-list-box-styles.js';
 import { menuOverlayCore } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
 import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -54,31 +56,29 @@ registerStyles('vaadin-avatar-group-overlay', [overlay, menuOverlayCore, avatarG
   moduleId: 'lumo-avatar-group-overlay',
 });
 
+registerStyles('vaadin-avatar-group-menu', listBox, { moduleId: 'lumo-avatar-group-menu' });
+
 registerStyles(
-  'vaadin-item',
-  css`
-    :host([theme='avatar-group-item']) {
-      padding: var(--lumo-space-xs);
-      padding-inline-end: var(--lumo-space-m);
-    }
+  'vaadin-avatar-group-menu-item',
+  [
+    item,
+    css`
+      :host {
+        padding: var(--lumo-space-xs);
+        padding-inline-end: var(--lumo-space-m);
+      }
 
-    :host([theme='avatar-group-item']) [part='content'] {
-      display: flex;
-      align-items: center;
-    }
+      [part='content'] {
+        display: flex;
+        align-items: center;
+      }
 
-    :host([theme='avatar-group-item']) ::slotted(vaadin-avatar) {
-      width: var(--lumo-size-xs);
-      height: var(--lumo-size-xs);
-    }
-
-    :host([theme='avatar-group-item']:not([dir='rtl'])) ::slotted(vaadin-avatar) {
-      margin-right: var(--lumo-space-s);
-    }
-
-    :host([theme='avatar-group-item'][dir='rtl']) ::slotted(vaadin-avatar) {
-      margin-left: var(--lumo-space-s);
-    }
-  `,
-  { moduleId: 'lumo-avatar-group-item' },
+      [part='content'] ::slotted(vaadin-avatar) {
+        width: var(--lumo-size-xs);
+        height: var(--lumo-size-xs);
+        margin-inline-end: var(--lumo-space-s);
+      }
+    `,
+  ],
+  { moduleId: 'lumo-avatar-group-menu-item' },
 );

--- a/packages/avatar-group/theme/lumo/vaadin-avatar-group.js
+++ b/packages/avatar-group/theme/lumo/vaadin-avatar-group.js
@@ -1,6 +1,4 @@
 import '@vaadin/avatar/theme/lumo/vaadin-avatar.js';
-import '@vaadin/item/theme/lumo/vaadin-item.js';
-import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
 import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-avatar-group-styles.js';
 import '../../src/vaadin-avatar-group.js';

--- a/packages/avatar-group/theme/material/vaadin-avatar-group-styles.js
+++ b/packages/avatar-group/theme/material/vaadin-avatar-group-styles.js
@@ -1,4 +1,6 @@
 import '@vaadin/vaadin-material-styles/color.js';
+import { item } from '@vaadin/item/theme/material/vaadin-item-styles.js';
+import { listBox } from '@vaadin/list-box/theme/material/vaadin-list-box-styles.js';
 import { menuOverlay } from '@vaadin/vaadin-material-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -46,30 +48,31 @@ registerStyles('vaadin-avatar-group-overlay', [menuOverlay, avatarGroupOverlay],
   moduleId: 'material-avatar-group-overlay',
 });
 
+registerStyles('vaadin-avatar-group-menu', listBox, { moduleId: 'material-avatar-group-menu' });
+
 registerStyles(
-  'vaadin-item',
-  css`
-    :host([theme='avatar-group-item']) {
-      padding: 8px;
-      padding-inline-end: 24px;
-    }
+  'vaadin-avatar-group-menu-item',
+  [
+    item,
+    css`
+      :host {
+        padding: 8px;
+        padding-inline-end: 24px;
+      }
 
-    :host([theme='avatar-group-item']) [part='content'] {
-      display: flex;
-      align-items: center;
-    }
+      [part='content'] {
+        display: flex;
+        align-items: center;
+      }
 
-    :host([theme='avatar-group-item']) [part='checkmark']::before {
-      display: none;
-    }
+      [part='checkmark']::before {
+        display: none;
+      }
 
-    :host([theme='avatar-group-item']:not([dir='rtl'])) ::slotted(vaadin-avatar) {
-      margin-right: 8px;
-    }
-
-    :host([theme='avatar-group-item'][dir='rtl']) ::slotted(vaadin-avatar) {
-      margin-left: 8px;
-    }
-  `,
-  { moduleId: 'material-avatar-group-item' },
+      [part='content'] ::slotted(vaadin-avatar) {
+        margin-inline-end: 8px;
+      }
+    `,
+  ],
+  { moduleId: 'material-avatar-group-menu-item' },
 );

--- a/packages/avatar-group/theme/material/vaadin-avatar-group.js
+++ b/packages/avatar-group/theme/material/vaadin-avatar-group.js
@@ -1,6 +1,4 @@
 import '@vaadin/avatar/theme/material/vaadin-avatar.js';
-import '@vaadin/item/theme/material/vaadin-item.js';
-import '@vaadin/list-box/theme/material/vaadin-list-box.js';
 import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-avatar-group-styles.js';
 import '../../src/vaadin-avatar-group.js';


### PR DESCRIPTION
## Description

Part of #5358

This change is basically same as the following PRs, but for `vaadin-avatar-group`:

- https://github.com/vaadin/web-components/pull/5339
- https://github.com/vaadin/web-components/pull/5354

## Type of change

- Breaking change

## Overview

Apart from not using list-box and item extensions, the main change is related to ARIA roles.
The `role="listbox"` was chosen just as a result of copying the code from `vaadin-select`.

However, actually the [Menu Button](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/) pattern is a better fit in this case - see [example](https://www.w3.org/WAI/ARIA/apg/example-index/menu-button/menu-button-actions.html).
I thought now would be the perfect time to make this relatively small behavior altering change.

### Before (23.3)

- `<vaaadin-avatar-group-list-box role="listbox">`
- `<vaadin-item theme="vaadin-avatar-group-item" role="option">`

![Screenshot 2023-01-26 at 22 52 03](https://user-images.githubusercontent.com/10589913/214947999-c121025d-014f-4c83-859e-e749229f5acc.png)

### After (24.0)

- `<vaaadin-avatar-group-menu role="menu">`
- `<vaadin-avatar-group-menu-item role="menuitem">`

![Screenshot 2023-01-26 at 22 51 25](https://user-images.githubusercontent.com/10589913/214947972-6c003769-3014-42fb-ba44-8a4f53eacccd.png)

## Note

The `vaadin-avatar-group` already a had [breaking change](https://github.com/vaadin/web-components/pull/3905) related to moving list-box to light DOM in V24 alpha1.
Back then I thought that using plain `vaadin-list-box` was a good idea, but I didn't consider ARIA semantics.