### PR TITLE
docs: export item and list-box types for context-menu

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-item.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu-item.d.ts
@@ -9,8 +9,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
- *
- * @protected
  */
 declare class ContextMenuItem extends ItemMixin(DirMixin(ThemableMixin(HTMLElement))) {}
 
@@ -19,3 +17,5 @@ declare global {
     'vaadin-context-menu-item': ContextMenuItem;
   }
 }
+
+export { ContextMenuItem };

--- a/packages/context-menu/src/vaadin-context-menu-list-box.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu-list-box.d.ts
@@ -10,8 +10,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
- *
- * @protected
  */
 declare class ContextMenuListBox extends ListMixin(DirMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {}
 
@@ -20,3 +18,5 @@ declare global {
     'vaadin-context-menu-list-box': ContextMenuListBox;
   }
 }
+
+export { ContextMenuListBox };


### PR DESCRIPTION
## Description

Somehow I missed to export new classes from TS definitions (so that they can be used by user's TS code).
Other components like `vaadin-select-item` have these. Let's also add them to context-menu elements.

## Type of change

- Documentation