### PR TITLE
docs: add missing menu-bar item and list-box typings

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-item.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-item.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ItemMixin } from '@vaadin/item/src/vaadin-item-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
+ */
+declare class MenuBarItem extends ItemMixin(DirMixin(ThemableMixin(HTMLElement))) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-menu-bar-item': MenuBarItem;
+  }
+}
+
+export { MenuBarItem };

--- a/packages/menu-bar/src/vaadin-menu-bar-list-box.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-list-box.d.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ListMixin } from '@vaadin/component-base/src/list-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
+ */
+declare class MenuBarListBox extends ListMixin(DirMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-menu-bar-list-box': MenuBarListBox;
+  }
+}
+
+export { MenuBarListBox };

--- a/packages/menu-bar/test/typings/menu-bar.types.ts
+++ b/packages/menu-bar/test/typings/menu-bar.types.ts
@@ -1,16 +1,22 @@
 import '../../vaadin-menu-bar.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { ListMixinClass } from '@vaadin/component-base/src/list-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+import type { ItemMixinClass } from '@vaadin/item/src/vaadin-item-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { MenuBarItem } from '../../src/vaadin-menu-bar-item.js';
+import type { MenuBarListBox } from '../../src/vaadin-menu-bar-list-box.js';
 import type { MenuBarMixinClass } from '../../src/vaadin-menu-bar-mixin.js';
-import type { MenuBarItem, MenuBarItemSelectedEvent } from '../../vaadin-menu-bar.js';
+import type { MenuBarItem as MenuItem, MenuBarItemSelectedEvent } from '../../vaadin-menu-bar.js';
 
 const menu = document.createElement('vaadin-menu-bar');
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 assertType<boolean | null | undefined>(menu.openOnHover);
-assertType<MenuBarItem[]>(menu.items);
+assertType<MenuItem[]>(menu.items);
 assertType<string>(menu.overlayClass);
 
 assertType<ResizeMixinClass>(menu);
@@ -20,7 +26,7 @@ assertType<MenuBarMixinClass>(menu);
 
 menu.addEventListener('item-selected', (event) => {
   assertType<MenuBarItemSelectedEvent>(event);
-  assertType<MenuBarItem>(event.detail.value);
+  assertType<MenuItem>(event.detail.value);
 });
 
 const menuItem = menu.items[0];
@@ -29,5 +35,21 @@ assertType<string | undefined>(menuItem.tooltip);
 assertType<string | undefined>(menuItem.text);
 assertType<boolean | undefined>(menuItem.disabled);
 assertType<string[] | string | undefined>(menuItem.theme);
-assertType<MenuBarItem[] | undefined>(menuItem.children);
+assertType<MenuItem[] | undefined>(menuItem.children);
 assertType<HTMLElement | string | undefined>(menuItem.component);
+
+// Item
+const item = document.createElement('vaadin-menu-bar-item');
+
+assertType<MenuBarItem>(item);
+assertType<ItemMixinClass>(item);
+assertType<DirMixinClass>(item);
+assertType<ThemableMixinClass>(item);
+
+// List-box
+const listBox = document.createElement('vaadin-menu-bar-list-box');
+
+assertType<MenuBarListBox>(listBox);
+assertType<DirMixinClass>(listBox);
+assertType<ListMixinClass>(listBox);
+assertType<ThemableMixinClass>(listBox);


### PR DESCRIPTION
## Description

As we now provide TS definitions for item / list-box elements in other components, let's add them here also.

## Type of change

- Documentation