### PR TITLE
docs: remove not needed JSDoc annotations from types

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-overlay.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.d.ts
@@ -8,8 +8,6 @@ import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
 
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
- *
- * @protected
  */
 declare class ContextMenuOverlay extends MenuOverlayMixin(Overlay) {}
 

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.d.ts
@@ -8,8 +8,6 @@ import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
 
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
- *
- * @protected
  */
 declare class MenuBarOverlay extends MenuOverlayMixin(Overlay) {}
 

--- a/packages/select/src/vaadin-select-item.d.ts
+++ b/packages/select/src/vaadin-select-item.d.ts
@@ -9,8 +9,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
- *
- * @protected
  */
 declare class SelectItem extends ItemMixin(DirMixin(ThemableMixin(HTMLElement))) {}
 

--- a/packages/select/src/vaadin-select-list-box.d.ts
+++ b/packages/select/src/vaadin-select-list-box.d.ts
@@ -10,8 +10,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
- *
- * @protected
  */
 declare class SelectListBox extends ListMixin(DirMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {}
 


### PR DESCRIPTION
## Description

These JSDoc annotations don't make any sense in `.d.ts` files and they seem to be a copy-paste from `.js` files.
We still need them in actual JS classes though, in order to hide corresponding elements from the API docs.

## Type of change

- Documentation