### PR TITLE
fix: allow undefined in activeItem and corresponding event [skip ci]

### DIFF
--- a/packages/grid-pro/test/typings/grid-pro.types.ts
+++ b/packages/grid-pro/test/typings/grid-pro.types.ts
@@ -46,7 +46,7 @@ narrowedGrid.addEventListener('item-property-changed', (event) => {
 
 narrowedGrid.addEventListener('active-item-changed', (event) => {
   assertType<GridActiveItemChangedEvent<TestGridItem>>(event);
-  assertType<TestGridItem>(event.detail.value);
+  assertType<TestGridItem | null | undefined>(event.detail.value);
 });
 
 narrowedGrid.addEventListener('cell-activate', (event) => {

--- a/packages/grid/src/vaadin-grid-active-item-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.d.ts
@@ -14,7 +14,7 @@ export declare class ActiveItemMixinClass<TItem> {
    * The item user has last interacted with. Turns to `null` after user deactivates
    * the item by re-interacting with the currently active item.
    */
-  activeItem: TItem | null;
+  activeItem: TItem | null | undefined;
 }
 
 export declare function isFocusable(target: Element): boolean;

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -68,7 +68,7 @@ export interface GridItemModel<TItem> {
 /**
  * Fired when the `activeItem` property changes.
  */
-export type GridActiveItemChangedEvent<TItem> = CustomEvent<{ value: TItem }>;
+export type GridActiveItemChangedEvent<TItem> = CustomEvent<{ value: TItem | null | undefined }>;
 
 /**
  * Fired when the cell is activated with click or keyboard.

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -88,7 +88,7 @@ assertType<DragAndDropMixinClass<TestGridItem>>(narrowedGrid);
 
 narrowedGrid.addEventListener('active-item-changed', (event) => {
   assertType<GridActiveItemChangedEvent<TestGridItem>>(event);
-  assertType<TestGridItem>(event.detail.value);
+  assertType<TestGridItem | null | undefined>(event.detail.value);
 });
 
 narrowedGrid.addEventListener('cell-activate', (event) => {
@@ -165,7 +165,7 @@ assertType<string | null | undefined>(narrowedGrid.itemIdPath);
 assertType<string>(narrowedGrid.itemHasChildrenPath);
 
 assertType<TestGridItem[] | null | undefined>(narrowedGrid.items);
-assertType<TestGridItem | null>(narrowedGrid.activeItem);
+assertType<TestGridItem | null | undefined>(narrowedGrid.activeItem);
 assertType<boolean>(narrowedGrid.columnReorderingAllowed);
 
 assertType<TestGridItem[]>(narrowedGrid.selectedItems);


### PR DESCRIPTION
## Description

Fixes #5387

Updated `activeItem` typings to support both `null` and `undefined` as our components set both:

https://github.com/vaadin/web-components/blob/7420679a2609ab464d2ea42300aa98846276cfea/packages/crud/src/vaadin-crud.js#L1136

https://github.com/vaadin/web-components/blob/7420679a2609ab464d2ea42300aa98846276cfea/packages/grid/src/vaadin-grid-active-item-mixin.js#L42

Also, updated the type for `active-item-changed` event detail object accordingly, as reported in the issue.

## Type of change

- Bugfix