### PR TITLE
test: add a test for scrolling to grid index before unhiding

### DIFF
--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -252,7 +252,7 @@ export const nextResize = (target) => {
 /**
  * Resolves once the function is invoked on the given object.
  */
-function onceInvoked(object, functionName) {
+export function onceInvoked(object, functionName) {
   return new Promise((resolve) => {
     const stub = sinon.stub(object, functionName).callsFake((...args) => {
       stub.restore();

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, listenOnce, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, listenOnce, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
 import {
@@ -160,6 +160,16 @@ describe('scroll to index', () => {
         });
       });
       parent.appendChild(grid);
+    });
+
+    it('should scroll to index after unhiding', async () => {
+      grid.hidden = true;
+      grid.scrollToIndex(100);
+      grid.hidden = false;
+
+      await aTimeout(100);
+      expect(getFirstVisibleItem(grid).index).to.be.above(75);
+      expect(grid.$.table.scrollTop).to.be.above(0);
     });
 
     it('should scroll to index only once', (done) => {

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, listenOnce, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, listenOnce, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
 import {
@@ -9,6 +9,7 @@ import {
   getPhysicalAverage,
   getPhysicalItems,
   infiniteDataProvider,
+  onceInvoked,
 } from './helpers.js';
 
 const createGrid = (height, size) => {
@@ -167,7 +168,7 @@ describe('scroll to index', () => {
       grid.scrollToIndex(100);
       grid.hidden = false;
 
-      await aTimeout(100);
+      await onceInvoked(grid, 'scrollToIndex');
       expect(getFirstVisibleItem(grid).index).to.be.above(75);
       expect(grid.$.table.scrollTop).to.be.above(0);
     });


### PR DESCRIPTION
## Description

Was [working on removing](https://github.com/vaadin/web-components/commit/819ce51355a5e1b041460066c448441312699317) the `"vaadin-grid-appear"` animation and came up with a case where it's actually necessary. Added the missing test case so the animation doesn't get accidentally removed.

## Type of change

Test