### PR TITLE
fix: make grid with all rows visible respect max height

### DIFF
--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -15,7 +15,8 @@ registerStyles(
     }
 
     :host {
-      display: block;
+      display: flex;
+      flex-direction: column;
       animation: 1ms vaadin-grid-appear;
       height: 400px;
       flex: 1 1 auto;
@@ -32,7 +33,9 @@ registerStyles(
     }
 
     #scroller {
-      display: block;
+      display: flex;
+      flex-direction: column;
+      min-height: 100%;
       transform: translateY(0);
       width: auto;
       height: auto;


### PR DESCRIPTION
## Description

This change makes a `<vaadin-grid>` with `allRowsVisible` enabled to respect CSS `max-height`.

Fixes https://github.com/vaadin/web-components/issues/2150

https://user-images.githubusercontent.com/1222264/215733339-bded13bb-94ab-487c-9d1f-8a5c2eed83a1.mp4

## Type of change

Bugfix