### PR TITLE
fix: add required vertical space for combo-box overlay

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -52,6 +52,12 @@ export class ComboBoxOverlay extends ComboBoxOverlayMixin(Overlay) {
 
     return memoizedTemplate;
   }
+
+  constructor() {
+    super();
+
+    this.requiredVerticalSpace = 200;
+  }
 }
 
 customElements.define(ComboBoxOverlay.is, ComboBoxOverlay);

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -164,6 +164,22 @@ describe('overlay position', () => {
       expect(overlayPart.getBoundingClientRect().bottom).to.closeTo(inputField.getBoundingClientRect().top, 1);
     });
 
+    it('should be above input when near bottom', async () => {
+      moveComboBox(xCenter, yBottom - 200, 300);
+
+      comboBox.open();
+      await aTimeout(1);
+      expect(overlayPart.getBoundingClientRect().bottom).to.closeTo(inputField.getBoundingClientRect().top, 1);
+    });
+
+    it('should be below input when far from bottom', async () => {
+      moveComboBox(xCenter, yBottom - 220, 300);
+
+      comboBox.open();
+      await aTimeout(1);
+      expect(overlayPart.getBoundingClientRect().top).to.closeTo(inputField.getBoundingClientRect().bottom, 1);
+    });
+
     describe('lazy data provider', () => {
       beforeEach(() => {
         comboBox.items = undefined;

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -26,7 +26,8 @@ describe('overlay position', () => {
         vaadin-combo-box-overlay::part(overlay) {
           margin: 0 !important;
         }
-      </style>`);
+      </style>
+    `);
 
     comboBox = fixtureSync(`<vaadin-combo-box label='comboBox' style='width: 300px;' items='[1]'></vaadin-combo-box>`);
     const comboBoxRect = comboBox.getBoundingClientRect();

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -154,23 +154,6 @@ describe('overlay position', () => {
       expect(overlayPart.getBoundingClientRect().bottom).to.closeTo(inputField.getBoundingClientRect().top, 1);
     });
 
-    it('should be above input when near bottom', async () => {
-      moveComboBox(xCenter, yBottom - 200, 300);
-
-      comboBox.open();
-      await aTimeout(1);
-      expect(overlayPart.getBoundingClientRect().bottom).to.closeTo(inputField.getBoundingClientRect().top, 1);
-    });
-
-    it('should be below input when far from bottom', async () => {
-      moveComboBox(xCenter, yBottom - 220, 300);
-
-      await aTimeout(1);
-      comboBox.open();
-      await aTimeout(1);
-      expect(overlayPart.getBoundingClientRect().top).to.closeTo(inputField.getBoundingClientRect().bottom, 1);
-    });
-
     it('should reposition after filtering', async () => {
       moveComboBox(xCenter, yBottom, 300);
 
@@ -179,6 +162,40 @@ describe('overlay position', () => {
       comboBox.open();
       await aTimeout(0);
       expect(overlayPart.getBoundingClientRect().bottom).to.closeTo(inputField.getBoundingClientRect().top, 1);
+    });
+
+    describe('lazy data provider', () => {
+      beforeEach(() => {
+        comboBox.items = undefined;
+
+        comboBox.dataProvider = (params, callback) => {
+          const index = params.page * params.pageSize;
+          const size = 20;
+          const result = [...Array(size).keys()].map((i) => {
+            return {
+              label: `Item ${index + i}`,
+              value: `item-${index + i}`,
+            };
+          });
+          setTimeout(() => callback(result, size), 100);
+        };
+      });
+
+      it('should be above input when near bottom', async () => {
+        moveComboBox(xCenter, yBottom - 200, 300);
+
+        comboBox.open();
+        await aTimeout(1);
+        expect(overlayPart.getBoundingClientRect().bottom).to.closeTo(inputField.getBoundingClientRect().top, 1);
+      });
+
+      it('should be below input when far from bottom', async () => {
+        moveComboBox(xCenter, yBottom - 220, 300);
+
+        comboBox.open();
+        await aTimeout(1);
+        expect(overlayPart.getBoundingClientRect().top).to.closeTo(inputField.getBoundingClientRect().bottom, 1);
+      });
     });
   });
 

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, isIOS } from '@vaadin/testing-helpers';
-import '../src/vaadin-combo-box.js';
+import '../vaadin-combo-box.js';
+import './not-animated-styles.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { makeItems, setInputValue } from './helpers.js';
 
@@ -33,6 +34,13 @@ describe('overlay position', () => {
   }
 
   beforeEach(async () => {
+    fixtureSync(`
+      <style>
+        vaadin-combo-box-overlay::part(overlay) {
+          margin: 0 !important;
+        }
+      </style>`);
+
     comboBox = fixtureSync(`<vaadin-combo-box label='comboBox' style='width: 300px;' items='[1]'></vaadin-combo-box>`);
     const comboBoxRect = comboBox.getBoundingClientRect();
     comboBox.items = makeItems(20);
@@ -157,6 +165,23 @@ describe('overlay position', () => {
       comboBox.open();
       await aTimeout(1);
       expect(overlayPart.getBoundingClientRect().bottom).to.closeTo(inputField.getBoundingClientRect().top, 1);
+    });
+
+    it('should be above input when near bottom', async () => {
+      moveComboBox(xCenter, yBottom - 200, 300);
+
+      comboBox.open();
+      await aTimeout(1);
+      expect(overlayPart.getBoundingClientRect().bottom).to.closeTo(inputField.getBoundingClientRect().top, 1);
+    });
+
+    it('should be below input when far from bottom', async () => {
+      moveComboBox(xCenter, yBottom - 220, 300);
+
+      await aTimeout(1);
+      comboBox.open();
+      await aTimeout(1);
+      expect(overlayPart.getBoundingClientRect().top).to.closeTo(inputField.getBoundingClientRect().bottom, 1);
     });
 
     it('should reposition after filtering', async () => {

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -2,20 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, isIOS } from '@vaadin/testing-helpers';
 import '../vaadin-combo-box.js';
 import './not-animated-styles.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { makeItems, setInputValue } from './helpers.js';
-
-class XFixed extends PolymerElement {
-  static get template() {
-    return html`
-      <div style="position: fixed;">
-        <slot></slot>
-      </div>
-    `;
-  }
-}
-
-customElements.define('x-fixed', XFixed);
 
 describe('overlay position', () => {
   let comboBox, overlayPart, inputField;

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -188,12 +188,10 @@ describe('overlay position', () => {
         comboBox.dataProvider = (params, callback) => {
           const index = params.page * params.pageSize;
           const size = 20;
-          const result = [...Array(size).keys()].map((i) => {
-            return {
-              label: `Item ${index + i}`,
-              value: `item-${index + i}`,
-            };
-          });
+          const result = [...Array(size).keys()].map((i) => ({
+            label: `Item ${index + i}`,
+            value: `item-${index + i}`,
+          }));
           setTimeout(() => callback(result, size), 100);
         };
       });

--- a/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
@@ -57,8 +57,9 @@ export declare class PositionMixinClass {
 
   /**
    * If the overlay content has no intrinsic height, this property can be used to set
-   * the minimum vertical space required by the overlay. If there is not enough space
-   * available on the primary side, the overlay will be positioned on the opposite side.
+   * the minimum vertical space (in pixels) required by the overlay. Setting a value to
+   * the property effectively disables the content measurement in favor of using this
+   * fixed value for determining the open direction.
    *
    * @attr {number} required-vertical-space
    **/

--- a/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
@@ -54,4 +54,13 @@ export declare class PositionMixinClass {
    * @attr {boolean} no-vertical-overlap
    */
   noVerticalOverlap: boolean;
+
+  /**
+   * If the overlay content has no intrinsic height, this property can be used to set
+   * the minimum vertical space required by the overlay. If there is not enough space
+   * available on the primary side, the overlay will be positioned on the opposite side.
+   *
+   * @attr {number} required-vertical-space
+   **/
+  requiredVerticalSpace: number;
 }

--- a/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
@@ -62,6 +62,6 @@ export declare class PositionMixinClass {
    * fixed value for determining the open direction.
    *
    * @attr {number} required-vertical-space
-   **/
+   */
   requiredVerticalSpace: number;
 }

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -101,7 +101,7 @@ export const PositionMixin = (superClass) =>
          * fixed value for determining the open direction.
          *
          * @attr {number} required-vertical-space
-         **/
+         */
         requiredVerticalSpace: {
           type: Number,
           value: 0,

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -274,11 +274,8 @@ export const PositionMixin = (superClass) =>
     __shouldAlignStartVertically(targetRect) {
       // Using previous size to fix a case where window resize may cause the overlay to be squeezed
       // smaller than its current space before the fit-calculations.
-      const contentHeight = Math.max(
-        this.__oldContentHeight || 0,
-        this.$.overlay.offsetHeight,
-        this.requiredVerticalSpace,
-      );
+      const contentHeight =
+        this.requiredVerticalSpace || Math.max(this.__oldContentHeight || 0, this.$.overlay.offsetHeight);
       this.__oldContentHeight = this.$.overlay.offsetHeight;
 
       const viewportHeight = Math.min(window.innerHeight, document.documentElement.clientHeight);

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -96,8 +96,9 @@ export const PositionMixin = (superClass) =>
 
         /**
          * If the overlay content has no intrinsic height, this property can be used to set
-         * the minimum vertical space required by the overlay. If there is not enough space
-         * available on the primary side, the overlay will be positioned on the opposite side.
+         * the minimum vertical space (in pixels) required by the overlay. Setting a value to
+         * the property effectively disables the content measurement in favor of using this
+         * fixed value for determining the open direction.
          *
          * @attr {number} required-vertical-space
          **/

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -93,12 +93,24 @@ export const PositionMixin = (superClass) =>
           type: Boolean,
           value: false,
         },
+
+        /**
+         * If the overlay content has no intrinsic height, this property can be used to set
+         * the minimum vertical space required by the overlay. If there is not enough space
+         * available on the primary side, the overlay will be positioned on the opposite side.
+         *
+         * @attr {number} required-vertical-space
+         **/
+        requiredVerticalSpace: {
+          type: Number,
+          value: 0,
+        },
       };
     }
 
     static get observers() {
       return [
-        '__positionSettingsChanged(horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap)',
+        '__positionSettingsChanged(horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap, requiredVerticalSpace)',
         '__overlayOpenedChanged(opened, positionTarget)',
       ];
     }
@@ -262,7 +274,11 @@ export const PositionMixin = (superClass) =>
     __shouldAlignStartVertically(targetRect) {
       // Using previous size to fix a case where window resize may cause the overlay to be squeezed
       // smaller than its current space before the fit-calculations.
-      const contentHeight = Math.max(this.__oldContentHeight || 0, this.$.overlay.offsetHeight);
+      const contentHeight = Math.max(
+        this.__oldContentHeight || 0,
+        this.$.overlay.offsetHeight,
+        this.requiredVerticalSpace,
+      );
       this.__oldContentHeight = this.$.overlay.offsetHeight;
 
       const viewportHeight = Math.min(window.innerHeight, document.documentElement.clientHeight);

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -171,6 +171,22 @@ describe('position mixin', () => {
       expectEdgesAligned(TOP, TOP);
     });
 
+    it('should flip when out of required vertical space', () => {
+      overlay.requiredVerticalSpace = 200;
+      target.style.top = `${targetPositionToFlipOverlay - 100}px`;
+      updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
+    });
+
+    it('should flip back when enough required vertical space', () => {
+      overlay.requiredVerticalSpace = 200;
+      target.style.top = `${targetPositionToFlipOverlay - 100}px`;
+      updatePosition();
+      target.style.top = `${targetPositionToFlipOverlay - 200}px`;
+      updatePosition();
+      expectEdgesAligned(TOP, TOP);
+    });
+
     it('should choose the bigger side when it fits neither', () => {
       overlayContent.style.height = `${document.documentElement.clientHeight}px`;
 
@@ -258,6 +274,22 @@ describe('position mixin', () => {
       target.style.top = `${targetPositionToFlipOverlay - 3}px`;
       updatePosition();
       target.style.top = `${targetPositionToFlipOverlay + 3}px`;
+      updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
+    });
+
+    it('should flip when out of required vertical space', () => {
+      overlay.requiredVerticalSpace = 200;
+      target.style.top = `${targetPositionToFlipOverlay + 100}px`;
+      updatePosition();
+      expectEdgesAligned(TOP, TOP);
+    });
+
+    it('should flip back when enough required vertical space', () => {
+      overlay.requiredVerticalSpace = 200;
+      target.style.top = `${targetPositionToFlipOverlay + 100}px`;
+      updatePosition();
+      target.style.top = `${targetPositionToFlipOverlay + 200}px`;
       updatePosition();
       expectEdgesAligned(BOTTOM, BOTTOM);
     });

--- a/packages/overlay/test/typings/overlay.types.ts
+++ b/packages/overlay/test/typings/overlay.types.ts
@@ -66,3 +66,4 @@ assertType<boolean>(customOverlay.noVerticalOverlap);
 assertType<'end' | 'start'>(customOverlay.horizontalAlign);
 assertType<'bottom' | 'top'>(customOverlay.verticalAlign);
 assertType<HTMLElement>(customOverlay.positionTarget);
+assertType<number>(customOverlay.requiredVerticalSpace);


### PR DESCRIPTION
## Description

Since the `<combo-box>` overlay has no intrinsic height, `PositionMixin` had it always aligned below the input field on open.

A new property was added for the `PositionMixin` to cover this case (defining required vertical space for overlays that have no intrinsic height of their own). A default value for the property was assigned to the `<vaadin-combo-box-overlay>` to fix the issue.

Fixes https://github.com/vaadin/flow-components/issues/2820

## Type of change

Bugfix