### PR TITLE
chore: Avoid utf-8 characters in code

### DIFF
--- a/packages/button/theme/lumo/vaadin-button-styles.js
+++ b/packages/button/theme/lumo/vaadin-button-styles.js
@@ -28,7 +28,7 @@ const button = css`
     flex-shrink: 0;
   }
 
-  /* Set only for the internal parts so we don’t affect the host vertical alignment */
+  /* Set only for the internal parts so we don't affect the host vertical alignment */
   [part='label'],
   [part='prefix'],
   [part='suffix'] {


### PR DESCRIPTION
Using utf-8 characters provide no benefit but can break file serving when you have encoding issues in your setup