### PR TITLE
refactor: enable more ESLint rules, fix related errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,6 @@
   "rules": {
     "@typescript-eslint/class-literal-property-style": "off",
     "@typescript-eslint/consistent-indexed-object-style": "off",
-    "@typescript-eslint/member-ordering": "off",
     "@typescript-eslint/no-dynamic-delete": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-extraneous-class": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,6 @@
     "vaadin/prettier"
   ],
   "rules": {
-    "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/class-literal-property-style": "off",
     "@typescript-eslint/consistent-indexed-object-style": "off",
     "@typescript-eslint/member-ordering": "off",

--- a/packages/component-base/src/async.d.ts
+++ b/packages/component-base/src/async.d.ts
@@ -9,6 +9,7 @@
  */
 
 export interface AsyncInterface {
+  // eslint-disable-next-line @typescript-eslint/ban-types
   run(fn: Function, delay?: number): number;
   cancel(handle: number): void;
 }
@@ -39,6 +40,7 @@ declare namespace timeOut {
    *
    * @returns Handle used for canceling task
    */
+  // eslint-disable-next-line @typescript-eslint/ban-types
   function run(fn: Function, delay?: number): number;
 
   /**
@@ -103,6 +105,7 @@ declare namespace microTask {
    *
    * @returns Handle used for canceling task
    */
+  // eslint-disable-next-line @typescript-eslint/ban-types
   function run(callback?: Function): number;
 
   /**

--- a/packages/component-base/src/polylit-mixin.d.ts
+++ b/packages/component-base/src/polylit-mixin.d.ts
@@ -14,10 +14,10 @@ export declare class PolylitMixinClass {
   /**
    * Reads a value from a path.
    */
-  protected _get(root: Object, path: String): any;
+  protected _get(root: object, path: string): any;
 
   /**
    * Sets a value to a path.
    */
-  protected _set(root: Object, path: String, value: any): void;
+  protected _set(root: object, path: string, value: any): void;
 }

--- a/packages/polymer-legacy-adapter/test/fixtures/mock-component.js
+++ b/packages/polymer-legacy-adapter/test/fixtures/mock-component.js
@@ -5,10 +5,6 @@ export class MockComponent extends HTMLElement {
     this.shadowRoot.innerHTML = `<div id="content"></div>`;
   }
 
-  connectedCallback() {
-    window.Vaadin.templateRendererCallback(this);
-  }
-
   get $() {
     return {
       content: this.shadowRoot.querySelector('#content'),
@@ -22,6 +18,10 @@ export class MockComponent extends HTMLElement {
   set renderer(renderer) {
     this.__renderer = renderer;
     this.render();
+  }
+
+  connectedCallback() {
+    window.Vaadin.templateRendererCallback(this);
   }
 
   render() {

--- a/packages/polymer-legacy-adapter/test/fixtures/mock-list.js
+++ b/packages/polymer-legacy-adapter/test/fixtures/mock-list.js
@@ -7,10 +7,6 @@ export class MockList extends HTMLElement {
     this.shadowRoot.innerHTML = `<div id="items"></div>`;
   }
 
-  connectedCallback() {
-    window.Vaadin.templateRendererCallback?.(this);
-  }
-
   get renderer() {
     return this.__renderer;
   }
@@ -33,6 +29,10 @@ export class MockList extends HTMLElement {
     return {
       items: this.shadowRoot.querySelector('#items'),
     };
+  }
+
+  connectedCallback() {
+    window.Vaadin.templateRendererCallback?.(this);
   }
 
   render() {


### PR DESCRIPTION
## Description

The PR enables and fixes the following rules:

- [x] @typescript-eslint/ban-types
- [x] @typescript-eslint/member-ordering

Part of https://github.com/vaadin/eslint-config-vaadin/issues/35

## Type of change

- [x] Refactor
