### PR TITLE
refactor: enable more ESLint rules, fix related errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,6 @@
     "@typescript-eslint/no-shadow": "off",
     "@typescript-eslint/no-unused-expressions": "off",
     "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/prefer-for-of": "off",
     "@typescript-eslint/prefer-optional-chain": "off",
     "no-only-tests/no-only-tests": "error",
     "simple-import-sort/imports": [

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1314,10 +1314,9 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
             if (!this.tempBodyStyle) {
               let effectiveCss = '';
 
-              const shadowStyles = this.shadowRoot.querySelectorAll('style');
-              for (let i = 0; i < shadowStyles.length; i++) {
-                effectiveCss += shadowStyles[i].textContent;
-              }
+              [...this.shadowRoot.querySelectorAll('style')].forEach((style) => {
+                effectiveCss += style.textContent;
+              });
 
               // Strip off host selectors that target individual instances
               effectiveCss = effectiveCss.replace(/:host\(.+?\)/gu, (match) => {

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -311,13 +311,11 @@ export const ComboBoxDataProviderMixin = (superClass) =>
     _flushPendingRequests(size) {
       if (this._pendingRequests) {
         const lastPage = Math.ceil(size / this.pageSize);
-        const pendingRequestsKeys = Object.keys(this._pendingRequests);
-        for (let reqIdx = 0; reqIdx < pendingRequestsKeys.length; reqIdx++) {
-          const page = parseInt(pendingRequestsKeys[reqIdx]);
-          if (page >= lastPage) {
-            this._pendingRequests[page]([], size);
+        Object.entries(this._pendingRequests).forEach(([page, callback]) => {
+          if (parseInt(page) >= lastPage) {
+            callback([], size);
           }
-        }
+        });
       }
     }
   };

--- a/packages/component-base/src/gestures.js
+++ b/packages/component-base/src/gestures.js
@@ -468,9 +468,9 @@ function _remove(node, evType, handler) {
  */
 export function register(recog) {
   recognizers.push(recog);
-  for (let i = 0; i < recog.emits.length; i++) {
-    gestures[recog.emits[i]] = recog;
-  }
+  recog.emits.forEach((emit) => {
+    gestures[emit] = recog;
+  });
 }
 
 /**

--- a/packages/component-base/test/virtualizer-scrolling.test.js
+++ b/packages/component-base/test/virtualizer-scrolling.test.js
@@ -250,8 +250,8 @@ describe('virtualizer - scrollbar scrolling', () => {
 
     // Scroll to start, taking a couple of steps on the way
     const scrollPositions = [115000, 3500, 0];
-    for (let i = 0; i < scrollPositions.length; i++) {
-      scrollTarget.scrollTop = scrollPositions[i];
+    for (const scrollPosition of scrollPositions) {
+      scrollTarget.scrollTop = scrollPosition;
       await nextFrame();
     }
 

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -123,19 +123,15 @@ export function getFirstVisibleItem(scroller, bufferOffset = 0) {
 }
 
 export function getFocusedMonth(overlayContent) {
-  const months = Array.from(overlayContent.querySelectorAll('vaadin-month-calendar'));
+  const months = [...overlayContent.querySelectorAll('vaadin-month-calendar')];
   return months.find((month) => {
-    const focused = month.shadowRoot.querySelector('[part~="focused"]');
-    return !!focused;
+    return !!month.shadowRoot.querySelector('[part~="focused"]');
   });
 }
 
 export function getFocusedCell(overlayContent) {
-  const months = [...overlayContent.querySelectorAll('vaadin-month-calendar')];
-  return months.find((month) => {
-    // Date that is currently focused
-    return month.shadowRoot.querySelector('[part~="focused"]');
-  });
+  const focusedMonth = getFocusedMonth(overlayContent);
+  return focusedMonth.shadowRoot.querySelector('[part~="focused"]');
 }
 
 /**

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -131,20 +131,11 @@ export function getFocusedMonth(overlayContent) {
 }
 
 export function getFocusedCell(overlayContent) {
-  const months = Array.from(overlayContent.querySelectorAll('vaadin-month-calendar'));
-
-  // Date that is currently focused
-  let focusedCell;
-
-  for (let i = 0; i < months.length; i++) {
-    focusedCell = months[i].shadowRoot.querySelector('[part~="focused"]');
-
-    if (focusedCell) {
-      break;
-    }
-  }
-
-  return focusedCell;
+  const months = [...overlayContent.querySelectorAll('vaadin-month-calendar')];
+  return months.find((month) => {
+    // Date that is currently focused
+    return month.shadowRoot.querySelector('[part~="focused"]');
+  });
 }
 
 /**

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -88,13 +88,8 @@ describe('vaadin-month-calendar', () => {
   });
 
   it('should update value on tap', () => {
-    const dateElements = getDateCells(monthCalendar);
-    for (let i = 0; i < dateElements.length; i++) {
-      if (dateElements[i].date.getDate() === 10) {
-        // Tenth of February.
-        tap(dateElements[i]);
-      }
-    }
+    const date10 = getDateCells(monthCalendar).find((dateElement) => dateElement.date.getDate() === 10);
+    tap(date10);
     expect(monthCalendar.selectedDate.getFullYear()).to.equal(2016);
     expect(monthCalendar.selectedDate.getMonth()).to.equal(1);
     expect(monthCalendar.selectedDate.getDate()).to.equal(10);
@@ -137,13 +132,8 @@ describe('vaadin-month-calendar', () => {
   it('should not update value on disabled date tap', async () => {
     monthCalendar.maxDate = new Date('2016-02-09');
     await nextRender();
-    const dateElements = getDateCells(monthCalendar);
-    for (let i = 0; i < dateElements.length; i++) {
-      if (dateElements[i].date.getDate() === 10) {
-        // Tenth of February.
-        tap(dateElements[i]);
-      }
-    }
+    const date10 = getDateCells(monthCalendar).find((dateElement) => dateElement.date.getDate() === 10);
+    tap(date10);
     expect(monthCalendar.selectedDate).to.be.undefined;
   });
 

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -236,9 +236,9 @@ export class UserTags extends PolymerElement {
     const usersToRemove = [];
 
     splices.forEach((splice) => {
-      for (let i = 0; i < splice.removed.length; i++) {
-        usersToRemove.push(splice.removed[i]);
-      }
+      splice.removed.forEach((user) => {
+        usersToRemove.push(user);
+      });
 
       for (let i = splice.addedCount - 1; i >= 0; i--) {
         usersToAdd.push(users[splice.index + i]);
@@ -291,15 +291,17 @@ export class UserTags extends PolymerElement {
 
     // Check if flash queue contains pending tags for removed users
     if (this.__flashQueue.length > 0) {
-      for (let i = 0; i < removedUsers.length; i++) {
+      removedUsers.forEach((user, i) => {
         if (changedTags.removed[i] === null) {
-          for (let j = 0; j < this.__flashQueue.length; j++) {
-            if (this.__flashQueue[j].some((tag) => tag.uid === removedUsers[i].id)) {
-              this.splice('__flashQueue', i, 1);
-            }
-          }
+          return;
         }
-      }
+
+        this.__flashQueue.forEach((tags) => {
+          if (tags.some((tag) => tag.uid === user.id)) {
+            this.splice('__flashQueue', i, 1);
+          }
+        });
+      });
     }
 
     if (this.opened && this.hasFocus) {

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -85,15 +85,15 @@ export const ItemCache = class ItemCache {
    */
   getCacheAndIndex(index) {
     let thisLevelIndex = index;
-    Object.entries(this.itemCaches).forEach(([expandedIndex, subCache]) => {
-      expandedIndex = Number(expandedIndex);
-      if (thisLevelIndex <= expandedIndex) {
+    for (const [index, subCache] of Object.entries(this.itemCaches)) {
+      const numberIndex = Number(index);
+      if (thisLevelIndex <= numberIndex) {
         return { cache: this, scaledIndex: thisLevelIndex };
-      } else if (thisLevelIndex <= expandedIndex + subCache.effectiveSize) {
-        return subCache.getCacheAndIndex(thisLevelIndex - expandedIndex - 1);
+      } else if (thisLevelIndex <= numberIndex + subCache.effectiveSize) {
+        return subCache.getCacheAndIndex(thisLevelIndex - numberIndex - 1);
       }
       thisLevelIndex -= subCache.effectiveSize;
-    });
+    }
     return { cache: this, scaledIndex: thisLevelIndex };
   }
 };

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -85,17 +85,15 @@ export const ItemCache = class ItemCache {
    */
   getCacheAndIndex(index) {
     let thisLevelIndex = index;
-    const keys = Object.keys(this.itemCaches);
-    for (let i = 0; i < keys.length; i++) {
-      const expandedIndex = Number(keys[i]);
-      const subCache = this.itemCaches[expandedIndex];
+    Object.entries(this.itemCaches).forEach(([expandedIndex, subCache]) => {
+      expandedIndex = Number(expandedIndex);
       if (thisLevelIndex <= expandedIndex) {
         return { cache: this, scaledIndex: thisLevelIndex };
       } else if (thisLevelIndex <= expandedIndex + subCache.effectiveSize) {
         return subCache.getCacheAndIndex(thisLevelIndex - expandedIndex - 1);
       }
       thisLevelIndex -= subCache.effectiveSize;
-    }
+    });
     return { cache: this, scaledIndex: thisLevelIndex };
   }
 };

--- a/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -50,13 +50,7 @@ export const DynamicColumnsMixin = (superClass) =>
 
     /** @private */
     _hasColumnGroups(columns) {
-      for (let i = 0; i < columns.length; i++) {
-        if (columns[i].localName === 'vaadin-grid-column-group') {
-          return true;
-        }
-      }
-
-      return false;
+      return columns.some((column) => column.localName === 'vaadin-grid-column-group');
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -272,16 +272,16 @@ export const ScrollMixin = (superClass) =>
       // Position frozen cells
       const x = this.__isRTL ? normalizedScrollLeft + clientWidth - scrollWidth : scrollLeft;
       const transformFrozen = `translate(${x}px, 0)`;
-      for (let i = 0; i < this._frozenCells.length; i++) {
-        this._frozenCells[i].style.transform = transformFrozen;
-      }
+      this._frozenCells.forEach((cell) => {
+        cell.style.transform = transformFrozen;
+      });
 
       // Position cells frozen to end
       const remaining = this.__isRTL ? normalizedScrollLeft : scrollLeft + clientWidth - scrollWidth;
       const transformFrozenToEnd = `translate(${remaining}px, 0)`;
-      for (let i = 0; i < this._frozenToEndCells.length; i++) {
-        this._frozenToEndCells[i].style.transform = transformFrozenToEnd;
-      }
+      this._frozenToEndCells.forEach((cell) => {
+        cell.style.transform = transformFrozenToEnd;
+      });
 
       // Only update the --_grid-horizontal-scroll-position custom property when navigating
       // on row focus mode to avoid performance issues.

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -215,19 +215,18 @@ export const MenuBarMixin = (superClass) =>
 
     /** @private */
     __restoreButtons(buttons) {
-      for (let i = 0; i < buttons.length; i++) {
-        const btn = buttons[i];
-        btn.disabled = (btn.item && btn.item.disabled) || this.disabled;
-        btn.style.visibility = '';
-        btn.style.position = '';
+      buttons.forEach((button) => {
+        button.disabled = (button.item && button.item.disabled) || this.disabled;
+        button.style.visibility = '';
+        button.style.position = '';
 
         // Teleport item component back from "overflow" sub-menu
-        const item = btn.item && btn.item.component;
+        const item = button.item && button.item.component;
         if (item instanceof HTMLElement && item.getAttribute('role') === 'menuitem') {
-          btn.appendChild(item);
+          button.appendChild(item);
           item.removeAttribute('role');
         }
-      }
+      });
       this.__updateOverflow([]);
     }
 

--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -284,11 +284,10 @@ describe('number-field', () => {
       numberField.value = -1;
       numberField.step = 4;
 
-      const correctSteps = [-4, -8, -12, -16, -20];
-      for (let i = 0; i < correctSteps.length; i++) {
+      [-4, -8, -12, -16, -20].forEach((step) => {
         decreaseButton.click();
-        expect(numberField.value).to.be.equal(String(correctSteps[i]));
-      }
+        expect(numberField.value).to.be.equal(String(step));
+      });
     });
 
     it('should increase value to min value on plus button click when value is under min', () => {
@@ -316,11 +315,10 @@ describe('number-field', () => {
       numberField.value = -1;
       numberField.step = 4;
 
-      const correctSteps = [1, 5, 9, 13, 17];
-      for (let i = 0; i < correctSteps.length; i++) {
+      [1, 5, 9, 13, 17].forEach((step) => {
         increaseButton.click();
-        expect(numberField.value).to.be.equal(String(correctSteps[i]));
-      }
+        expect(numberField.value).to.be.equal(String(step));
+      });
     });
 
     it('should correctly increase value on plus button click when step is a decimal number', () => {
@@ -329,11 +327,10 @@ describe('number-field', () => {
       numberField.value = -0.03;
       numberField.step = 0.01;
 
-      const correctSteps = [-0.02, -0.01, 0, 0.01, 0.02];
-      for (let i = 0; i < correctSteps.length; i++) {
+      [-0.02, -0.01, 0, 0.01, 0.02].forEach((step) => {
         increaseButton.click();
-        expect(numberField.value).to.be.equal(String(correctSteps[i]));
-      }
+        expect(numberField.value).to.be.equal(String(step));
+      });
     });
 
     it('should correctly calculate the precision with decimal value', () => {
@@ -359,12 +356,11 @@ describe('number-field', () => {
         ];
         const reset = { step: 1, min: undefined, max: undefined, value: '' };
 
-        for (let i = 0; i < configs.length; i++) {
-          const { props, expectedValue } = configs[i];
+        configs.forEach(({ props, expectedValue }) => {
           Object.assign(numberField, reset, props);
           increaseButton.click();
           expect(numberField.value).to.be.equal(expectedValue);
-        }
+        });
       });
 
       it('should correctly decrease value', () => {
@@ -377,12 +373,11 @@ describe('number-field', () => {
         ];
         const reset = { step: 1, min: undefined, max: undefined, value: '' };
 
-        for (let i = 0; i < configs.length; i++) {
-          const { props, expectedValue } = configs[i];
+        configs.forEach(({ props, expectedValue }) => {
           Object.assign(numberField, reset, props);
           decreaseButton.click();
           expect(numberField.value).to.be.equal(expectedValue);
-        }
+        });
       });
     });
   });

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -99,17 +99,13 @@ customElements.define(
 
 function afterOverlayOpeningFinished(overlay, callback) {
   const observer = new MutationObserver((mutations, observer) => {
-    for (let i = 0; i < mutations.length; i++) {
-      const mutation = mutations[i];
-      if (mutation.attributeName === 'opening') {
-        const target = mutation.target;
-        const hasFinishedOpening = target.hasAttribute('opened') && !target.hasAttribute('opening');
-        if (hasFinishedOpening) {
-          observer.disconnect();
-          afterNextRender(overlay, callback);
-          return;
-        }
-      }
+    const isOverlayOpened = mutations.some(({ target }) => {
+      return target.hasAttribute('opened') && !target.hasAttribute('opening');
+    });
+
+    if (isOverlayOpened) {
+      observer.disconnect();
+      afterNextRender(overlay, callback);
     }
   });
   observer.observe(overlay, { attributes: true, attributeFilter: ['opening'] });
@@ -117,17 +113,13 @@ function afterOverlayOpeningFinished(overlay, callback) {
 
 function afterOverlayClosingFinished(overlay, callback) {
   const observer = new MutationObserver((mutations, observer) => {
-    for (let i = 0; i < mutations.length; i++) {
-      const mutation = mutations[i];
-      if (mutation.attributeName === 'closing') {
-        const target = mutation.target;
-        const hasFinishedClosing = !target.hasAttribute('opened') && !target.hasAttribute('closing');
-        if (hasFinishedClosing) {
-          observer.disconnect();
-          afterNextRender(overlay, callback);
-          return;
-        }
-      }
+    const isOverlayClosed = mutations.some(({ target }) => {
+      return !target.hasAttribute('opened') && !target.hasAttribute('closing');
+    });
+
+    if (isOverlayClosed) {
+      observer.disconnect();
+      afterNextRender(overlay, callback);
     }
   });
   observer.observe(overlay, { attributes: true, attributeFilter: ['closing'] });

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -411,9 +411,9 @@ describe('upload', () => {
       upload.files = files;
       upload.files[1].complete = true;
 
-      for (let i = 0; i < upload.files.length; i++) {
-        expect(upload.files[i].uploading).not.to.be.ok;
-      }
+      upload.files.forEach((file) => {
+        expect(file.uploading).not.to.be.ok;
+      });
       upload.addEventListener('upload-start', (e) => {
         expect(e.detail.xhr).to.be.ok;
         expect(e.detail.file).to.be.ok;
@@ -433,9 +433,9 @@ describe('upload', () => {
       upload.files = files;
       upload.files[2].name = tempFileName;
 
-      for (let i = 0; i < upload.files.length; i++) {
-        expect(upload.files[i].uploading).not.to.be.ok;
-      }
+      upload.files.forEach((file) => {
+        expect(file.uploading).not.to.be.ok;
+      });
       upload.addEventListener('upload-start', (e) => {
         expect(e.detail.xhr).to.be.ok;
         expect(e.detail.file).to.be.ok;


### PR DESCRIPTION
## Description

The PR enables and fixes the following rules:

- [x] @typescript-eslint/prefer-for-of

Part of https://github.com/vaadin/eslint-config-vaadin/issues/35

## Type of change

- [x] Refactor
