### PR TITLE
refactor: enable more ESLint rules, fix related errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,6 @@
     "@typescript-eslint/no-invalid-void-type": "off",
     "@typescript-eslint/no-shadow": "off",
     "@typescript-eslint/no-unused-expressions": "off",
-    "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/prefer-optional-chain": "off",
     "no-only-tests/no-only-tests": "error",
     "simple-import-sort/imports": [

--- a/packages/component-base/custom_typings/vaadin-usage-statistics.d.ts
+++ b/packages/component-base/custom_typings/vaadin-usage-statistics.d.ts
@@ -1,5 +1,5 @@
 declare module '@vaadin/vaadin-usage-statistics/vaadin-usage-statistics.js' {
-  export { usageStatistics };
-
   function usageStatistics(): void;
+
+  export { usageStatistics };
 }

--- a/packages/component-base/src/async.js
+++ b/packages/component-base/src/async.js
@@ -27,7 +27,6 @@ const microtaskCallbacks = [];
 let microtaskNodeContent = 0;
 let microtaskScheduled = false;
 const microtaskNode = document.createTextNode('');
-new window.MutationObserver(microtaskFlush).observe(microtaskNode, { characterData: true });
 
 function microtaskFlush() {
   microtaskScheduled = false;
@@ -47,6 +46,8 @@ function microtaskFlush() {
   microtaskCallbacks.splice(0, len);
   microtaskLastHandle += len;
 }
+
+new window.MutationObserver(microtaskFlush).observe(microtaskNode, { characterData: true });
 
 /**
  * Async interface wrapper around `setTimeout`.

--- a/packages/component-base/src/debounce.js
+++ b/packages/component-base/src/debounce.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+const debouncerQueue = new Set();
+
 /**
  * @summary Collapse multiple callbacks into one invocation after a timer.
  */
@@ -132,8 +134,6 @@ export class Debouncer {
     return this._timer != null;
   }
 }
-
-let debouncerQueue = new Set();
 
 /**
  * Adds a `Debouncer` to a list of globally flushable tasks.

--- a/packages/component-base/src/dir-mixin.js
+++ b/packages/component-base/src/dir-mixin.js
@@ -9,16 +9,6 @@
  */
 const directionSubscribers = [];
 
-function directionUpdater() {
-  const documentDir = getDocumentDir();
-  directionSubscribers.forEach((element) => {
-    alignDirs(element, documentDir);
-  });
-}
-
-const directionObserver = new MutationObserver(directionUpdater);
-directionObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['dir'] });
-
 function alignDirs(element, documentDir, elementDir = element.getAttribute('dir')) {
   if (documentDir) {
     element.setAttribute('dir', documentDir);
@@ -30,6 +20,16 @@ function alignDirs(element, documentDir, elementDir = element.getAttribute('dir'
 function getDocumentDir() {
   return document.documentElement.getAttribute('dir');
 }
+
+function directionUpdater() {
+  const documentDir = getDocumentDir();
+  directionSubscribers.forEach((element) => {
+    alignDirs(element, documentDir);
+  });
+}
+
+const directionObserver = new MutationObserver(directionUpdater);
+directionObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['dir'] });
 
 /**
  * A mixin to handle `dir` attribute based on the one set on the `<html>` element.

--- a/packages/component-base/src/gestures.d.ts
+++ b/packages/component-base/src/gestures.d.ts
@@ -8,8 +8,6 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
-export { deepTargetFind };
-
 /**
  * Finds the element rendered on the screen at the provided coordinates.
  *
@@ -20,8 +18,7 @@ export { deepTargetFind };
  * found at the screen position given.
  */
 declare function deepTargetFind(x: number, y: number): Element | null;
-
-export { addListener };
+export { deepTargetFind };
 
 /**
  * Adds an event listener to a node for the given gesture type.
@@ -29,8 +26,7 @@ export { addListener };
  * @returns Returns true if a gesture event listener was added.
  */
 declare function addListener(node: EventTarget, evType: string, handler: (p0: Event) => void): boolean;
-
-export { removeListener };
+export { addListener };
 
 /**
  * Removes an event listener from a node for the given gesture type.
@@ -38,16 +34,14 @@ export { removeListener };
  * @returns Returns true if a gesture event listener was removed.
  */
 declare function removeListener(node: EventTarget, evType: string, handler: (p0: Event) => void): boolean;
-
-export { register };
+export { removeListener };
 
 /**
  * Registers a new gesture event recognizer for adding new custom
  * gesture event types.
  */
 declare function register(recog: GestureRecognizer): void;
-
-export { setTouchAction };
+export { register };
 
 /**
  * Sets scrolling direction on node.
@@ -56,13 +50,13 @@ export { setTouchAction };
  * adding event listeners.
  */
 declare function setTouchAction(node: EventTarget, value: string): void;
-
-export { prevent };
+export { setTouchAction };
 
 /**
  * Prevents the dispatch and default action of the given event name.
  */
 declare function prevent(evName: string): void;
+export { prevent };
 
 export interface GestureRecognizer {
   reset(): void;

--- a/packages/component-base/src/gestures.js
+++ b/packages/component-base/src/gestures.js
@@ -8,6 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
 /**
  * @fileoverview
  *

--- a/packages/component-base/test/dir-mixin.test.js
+++ b/packages/component-base/test/dir-mixin.test.js
@@ -108,6 +108,15 @@ const runTests = (baseClass) => {
       await nextFrame();
     });
 
+    // Toggle document dir attribute value
+    function setDir(direction) {
+      if (direction) {
+        document.documentElement.setAttribute('dir', direction);
+      } else {
+        document.documentElement.removeAttribute('dir');
+      }
+    }
+
     // Check that for each `documentDirections` value set, `element` dir
     // attribute value equals to the corresponding `elementDirections` value.
     async function expectDirections(documentDirections, elementDirections) {
@@ -115,15 +124,6 @@ const runTests = (baseClass) => {
         setDir(documentDirections[index]);
         await Promise.resolve();
         expect(element.getAttribute('dir')).to.equal(elementDirections[index]);
-      }
-    }
-
-    // Toggle document dir attribute value
-    function setDir(direction) {
-      if (direction) {
-        document.documentElement.setAttribute('dir', direction);
-      } else {
-        document.documentElement.removeAttribute('dir');
       }
     }
 

--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -1,16 +1,6 @@
 import { fire, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 
-export async function openSubMenus(menu) {
-  await oneEvent(menu.$.overlay, 'vaadin-overlay-open');
-  const itemElement = menu.$.overlay.querySelector('[aria-haspopup="true"]');
-  if (itemElement) {
-    itemElement.dispatchEvent(new CustomEvent('mouseover', { bubbles: true, composed: true }));
-    const subMenu = getSubMenu(menu);
-    await openSubMenus(subMenu);
-  }
-}
-
 export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') {
   const menu = target.closest('vaadin-context-menu');
   if (menu) {
@@ -27,4 +17,14 @@ export function getMenuItems(menu) {
 
 export function getSubMenu(menu) {
   return menu.$.overlay.querySelector('vaadin-context-menu');
+}
+
+export async function openSubMenus(menu) {
+  await oneEvent(menu.$.overlay, 'vaadin-overlay-open');
+  const itemElement = menu.$.overlay.querySelector('[aria-haspopup="true"]');
+  if (itemElement) {
+    itemElement.dispatchEvent(new CustomEvent('mouseover', { bubbles: true, composed: true }));
+    const subMenu = getSubMenu(menu);
+    await openSubMenus(subMenu);
+  }
 }

--- a/packages/crud/test/helpers.js
+++ b/packages/crud/test/helpers.js
@@ -12,6 +12,12 @@ export const getCellContent = (cell) => {
   return cell ? cell.querySelector('slot').assignedNodes()[0] : null;
 };
 
+export const getContainerCell = (container, row, col) => {
+  const rows = getRows(container);
+  const cells = getRowCells(rows[row]);
+  return cells[col];
+};
+
 export const getContainerCellContent = (container, row, col) => {
   return getCellContent(getContainerCell(container, row, col));
 };
@@ -24,10 +30,4 @@ export const getHeaderCellContent = (grid, row, col) => {
 export const getBodyCellContent = (grid, row, col) => {
   const container = grid.$.items;
   return getContainerCellContent(container, row, col);
-};
-
-export const getContainerCell = (container, row, col) => {
-  const rows = getRows(container);
-  const cells = getRowCells(rows[row]);
-  return cells[col];
 };

--- a/packages/date-picker/src/vaadin-date-picker-helper.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-helper.d.ts
@@ -4,7 +4,6 @@
  * @returns Week number
  */
 declare function getISOWeekNumber(Date: Date): number;
-export { getISOWeekNumber };
 
 /**
  * Check if two dates are equal.
@@ -12,7 +11,6 @@ export { getISOWeekNumber };
  * @returns True if the given date objects refer to the same date
  */
 declare function dateEquals(date1: Date | null, date2: Date | null): boolean;
-export { dateEquals };
 
 /**
  * Check if the given date is in the range of allowed dates.
@@ -20,7 +18,6 @@ export { dateEquals };
  * @returns True if the date is in the range
  */
 declare function dateAllowed(date: Date, min: Date | null, max: Date | null): boolean;
-export { dateAllowed };
 
 /**
  * Get closest date from array of dates.
@@ -28,27 +25,23 @@ export { dateAllowed };
  * @returns Closest date
  */
 declare function getClosestDate(date: Date, dates: Date[]): Date;
-export { getClosestDate };
 
 /**
  * Extracts the basic component parts of a date (day, month and year)
  * to the expected format.
  */
 declare function extractDateParts(date: Date): { day: number; month: number; year: number };
-export { extractDateParts };
 
 /**
  * Get difference in months between today and given months value.
  */
 declare function dateAfterXMonths(months: number): number;
-export { dateAfterXMonths };
 
 /**
  * Calculate the year of the date based on the provided reference date
  * Gets a two-digit year and returns a full year.
  */
 declare function getAdjustedYear(referenceDate: Date, year: number, month?: number, day?: number): Date;
-export { getAdjustedYear };
 
 /**
  * Parse date string of one of the following date formats:
@@ -56,4 +49,14 @@ export { getAdjustedYear };
  * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
  */
 declare function parseDate(str: string): Date;
-export { parseDate };
+
+export {
+  getISOWeekNumber,
+  dateEquals,
+  dateAllowed,
+  getClosestDate,
+  extractDateParts,
+  dateAfterXMonths,
+  getAdjustedYear,
+  parseDate,
+};

--- a/packages/date-picker/src/vaadin-date-picker-helper.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-helper.d.ts
@@ -1,13 +1,10 @@
-export { getISOWeekNumber };
-
 /**
  * Get ISO 8601 week number for the given date.
  *
  * @returns Week number
  */
 declare function getISOWeekNumber(Date: Date): number;
-
-export { dateEquals };
+export { getISOWeekNumber };
 
 /**
  * Check if two dates are equal.
@@ -15,8 +12,7 @@ export { dateEquals };
  * @returns True if the given date objects refer to the same date
  */
 declare function dateEquals(date1: Date | null, date2: Date | null): boolean;
-
-export { dateAllowed };
+export { dateEquals };
 
 /**
  * Check if the given date is in the range of allowed dates.
@@ -24,8 +20,7 @@ export { dateAllowed };
  * @returns True if the date is in the range
  */
 declare function dateAllowed(date: Date, min: Date | null, max: Date | null): boolean;
-
-export { getClosestDate };
+export { dateAllowed };
 
 /**
  * Get closest date from array of dates.
@@ -33,20 +28,19 @@ export { getClosestDate };
  * @returns Closest date
  */
 declare function getClosestDate(date: Date, dates: Date[]): Date;
-
-export { extractDateParts };
+export { getClosestDate };
 
 /**
  * Extracts the basic component parts of a date (day, month and year)
  * to the expected format.
  */
 declare function extractDateParts(date: Date): { day: number; month: number; year: number };
+export { extractDateParts };
 
 /**
  * Get difference in months between today and given months value.
  */
 declare function dateAfterXMonths(months: number): number;
-
 export { dateAfterXMonths };
 
 /**
@@ -54,7 +48,6 @@ export { dateAfterXMonths };
  * Gets a two-digit year and returns a full year.
  */
 declare function getAdjustedYear(referenceDate: Date, year: number, month?: number, day?: number): Date;
-
 export { getAdjustedYear };
 
 /**
@@ -63,5 +56,4 @@ export { getAdjustedYear };
  * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
  */
 declare function parseDate(str: string): Date;
-
 export { parseDate };

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -43,11 +43,6 @@ export function getDefaultI18n() {
   };
 }
 
-export async function open(datepicker) {
-  datepicker.open();
-  await waitForOverlayRender();
-}
-
 export async function waitForOverlayRender() {
   // First, wait for vaadin-overlay-open event
   await nextRender();
@@ -57,6 +52,11 @@ export async function waitForOverlayRender() {
 
   // Force dom-repeat to render table elements
   flush();
+}
+
+export async function open(datepicker) {
+  datepicker.open();
+  await waitForOverlayRender();
 }
 
 export function close(datepicker) {

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -432,6 +432,38 @@ describe('keyboard', () => {
   describe('default parser', () => {
     const today = new Date();
 
+    async function checkMonthAndDayOffset(monthOffsetToAdd, dayOffsetToAdd, expectedYearOffset) {
+      input.value = '';
+      const referenceDate = new Date(datepicker.i18n.referenceDate);
+      const yearToTest = referenceDate.getFullYear() + 50;
+      await sendKeys({
+        type: `${referenceDate.getMonth() + 1 + monthOffsetToAdd}/${referenceDate.getDate() + dayOffsetToAdd}/${
+          yearToTest % 100
+        }`,
+      });
+      const result = focusedDate();
+      expect(result.getFullYear()).to.equal(yearToTest + expectedYearOffset);
+    }
+
+    async function checkYearOffset(offsetToAdd, expectedOffset) {
+      input.value = '';
+      const referenceDateYear = datepicker.i18n.referenceDate
+        ? new Date(datepicker.i18n.referenceDate).getFullYear()
+        : today.getFullYear();
+      const yearToTest = referenceDateYear + offsetToAdd;
+      await sendKeys({ type: `6/20/${String(yearToTest).slice(2, 4)}` });
+      const result = focusedDate();
+      expect(result.getFullYear()).to.equal(yearToTest + expectedOffset);
+    }
+
+    async function checkYearOffsets() {
+      await checkYearOffset(0, 0);
+      await checkYearOffset(-49, 0);
+      await checkYearOffset(49, 0);
+      await checkYearOffset(-51, 100);
+      await checkYearOffset(51, -100);
+    }
+
     it('should parse a single digit', async () => {
       await sendKeys({ type: '20' });
       const result = focusedDate();
@@ -531,38 +563,6 @@ describe('keyboard', () => {
       await checkMonthAndDayOffset(-1, 0, 0);
       await checkMonthAndDayOffset(1, 0, -100);
     });
-
-    async function checkMonthAndDayOffset(monthOffsetToAdd, dayOffsetToAdd, expectedYearOffset) {
-      input.value = '';
-      const referenceDate = new Date(datepicker.i18n.referenceDate);
-      const yearToTest = referenceDate.getFullYear() + 50;
-      await sendKeys({
-        type: `${referenceDate.getMonth() + 1 + monthOffsetToAdd}/${referenceDate.getDate() + dayOffsetToAdd}/${
-          yearToTest % 100
-        }`,
-      });
-      const result = focusedDate();
-      expect(result.getFullYear()).to.equal(yearToTest + expectedYearOffset);
-    }
-
-    async function checkYearOffsets() {
-      await checkYearOffset(0, 0);
-      await checkYearOffset(-49, 0);
-      await checkYearOffset(49, 0);
-      await checkYearOffset(-51, 100);
-      await checkYearOffset(51, -100);
-    }
-
-    async function checkYearOffset(offsetToAdd, expectedOffset) {
-      input.value = '';
-      const referenceDateYear = datepicker.i18n.referenceDate
-        ? new Date(datepicker.i18n.referenceDate).getFullYear()
-        : today.getFullYear();
-      const yearToTest = referenceDateYear + offsetToAdd;
-      await sendKeys({ type: `6/20/${String(yearToTest).slice(2, 4)}` });
-      const result = focusedDate();
-      expect(result.getFullYear()).to.equal(yearToTest + expectedOffset);
-    }
   });
 
   describe('change event', () => {

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -189,13 +189,13 @@ describe('validation', () => {
       datePicker.min = '2016-01-01';
       datePicker.max = '2016-12-31';
 
+      const invalidChangedSpy = sinon.spy();
+      datePicker.addEventListener('invalid-changed', invalidChangedSpy);
       datePicker.addEventListener('value-changed', () => {
         expect(invalidChangedSpy.calledOnce).to.be.true;
         done();
       });
 
-      const invalidChangedSpy = sinon.spy();
-      datePicker.addEventListener('invalid-changed', invalidChangedSpy);
       datePicker.open();
       datePicker._overlayContent._selectDate(new Date('2017-01-01')); // Invalid
     });

--- a/packages/grid-pro/test/helpers.js
+++ b/packages/grid-pro/test/helpers.js
@@ -95,14 +95,14 @@ export const getCellContent = (cell) => {
   return cell ? cell.querySelector('slot').assignedNodes()[0] : null;
 };
 
-export const getContainerCellContent = (container, row, col) => {
-  return getCellContent(getContainerCell(container, row, col));
-};
-
 export const getContainerCell = (container, row, col) => {
   const rows = getRows(container);
   const cells = getRowCells(rows[row]);
   return cells[col];
+};
+
+export const getContainerCellContent = (container, row, col) => {
+  return getCellContent(getContainerCell(container, row, col));
 };
 
 export const getCellEditor = (cell) => {

--- a/packages/grid/src/array-data-provider.js
+++ b/packages/grid/src/array-data-provider.js
@@ -39,30 +39,6 @@ function checkPaths(arrayToCheck, action, items) {
 }
 
 /**
- * Sorts the given array of items based on the sorting rules and returns the result.
- *
- * @param {Array<any>} items
- * @param {Array<GridSorterDefinition>} items
- * @return {Array<any>}
- */
-function multiSort(items, sortOrders) {
-  return items.sort((a, b) => {
-    return sortOrders
-      .map((sortOrder) => {
-        if (sortOrder.direction === 'asc') {
-          return compare(get(sortOrder.path, a), get(sortOrder.path, b));
-        } else if (sortOrder.direction === 'desc') {
-          return compare(get(sortOrder.path, b), get(sortOrder.path, a));
-        }
-        return 0;
-      })
-      .reduce((p, n) => {
-        return p !== 0 ? p : n;
-      }, 0);
-  });
-}
-
-/**
  * @param {unknown} value
  * @return {string}
  */
@@ -91,6 +67,30 @@ function compare(a, b) {
     return 1;
   }
   return 0;
+}
+
+/**
+ * Sorts the given array of items based on the sorting rules and returns the result.
+ *
+ * @param {Array<any>} items
+ * @param {Array<GridSorterDefinition>} items
+ * @return {Array<any>}
+ */
+function multiSort(items, sortOrders) {
+  return items.sort((a, b) => {
+    return sortOrders
+      .map((sortOrder) => {
+        if (sortOrder.direction === 'asc') {
+          return compare(get(sortOrder.path, a), get(sortOrder.path, b));
+        } else if (sortOrder.direction === 'desc') {
+          return compare(get(sortOrder.path, b), get(sortOrder.path, a));
+        }
+        return 0;
+      })
+      .reduce((p, n) => {
+        return p !== 0 ? p : n;
+      }, 0);
+  });
 }
 
 /**

--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -5,6 +5,30 @@
  */
 
 /**
+ * @param {!Element} target
+ * @return {boolean}
+ * @protected
+ */
+export const isFocusable = (target) => {
+  if (!target.parentNode) {
+    return false;
+  }
+  const focusables = Array.from(
+    target.parentNode.querySelectorAll(
+      '[tabindex], button, input, select, textarea, object, iframe, a[href], area[href]',
+    ),
+  ).filter((element) => {
+    const part = element.getAttribute('part');
+    return !(part && part.includes('body-cell'));
+  });
+
+  const isFocusableElement = focusables.includes(target);
+  return (
+    !target.disabled && isFocusableElement && target.offsetParent && getComputedStyle(target).visibility !== 'hidden'
+  );
+};
+
+/**
  * @polymerMixin
  */
 export const ActiveItemMixin = (superClass) =>
@@ -97,27 +121,3 @@ export const ActiveItemMixin = (superClass) =>
      * @event cell-activate
      */
   };
-
-/**
- * @param {!Element} target
- * @return {boolean}
- * @protected
- */
-export const isFocusable = (target) => {
-  if (!target.parentNode) {
-    return false;
-  }
-  const focusables = Array.from(
-    target.parentNode.querySelectorAll(
-      '[tabindex], button, input, select, textarea, object, iframe, a[href], area[href]',
-    ),
-  ).filter((element) => {
-    const part = element.getAttribute('part');
-    return !(part && part.includes('body-cell'));
-  });
-
-  const isFocusableElement = focusables.includes(target);
-  return (
-    !target.disabled && isFocusableElement && target.offsetParent && getComputedStyle(target).visibility !== 'hidden'
-  );
-};

--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -144,20 +144,20 @@ afterEach(() => {
 describe('column groups', () => {
   let grid, header, body, footer, headerRows, footerRows, bodyRows;
 
-  function getFooterCellContent(row, col) {
-    return getCellContent(getFooterCell(row, col)).textContent.trim();
-  }
-
-  function getHeaderCellContent(row, col) {
-    return getCellContent(getHeaderCell(row, col)).textContent.trim();
-  }
-
   function getHeaderCell(row, col) {
     return getRowCells(headerRows[row])[col];
   }
 
   function getFooterCell(row, col) {
     return getRowCells(footerRows[row])[col];
+  }
+
+  function getFooterCellContent(row, col) {
+    return getCellContent(getFooterCell(row, col)).textContent.trim();
+  }
+
+  function getHeaderCellContent(row, col) {
+    return getCellContent(getHeaderCell(row, col)).textContent.trim();
   }
 
   function getBodyCellContent(row, col) {

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -131,6 +131,16 @@ export const getCellContent = (cell) => {
   return cell ? cell.querySelector('slot').assignedNodes()[0] : null;
 };
 
+export const getContainerCell = (container, row, col) => {
+  const rows = getRows(container);
+  const cells = getRowCells(rows[row]);
+  return cells[col];
+};
+
+export const getContainerCellContent = (container, row, col) => {
+  return getCellContent(getContainerCell(container, row, col));
+};
+
 export const getHeaderCellContent = (grid, row, col) => {
   const container = grid.$.header;
   return getContainerCellContent(container, row, col);
@@ -141,14 +151,18 @@ export const getBodyCellContent = (grid, row, col) => {
   return getContainerCellContent(container, row, col);
 };
 
-export const getContainerCellContent = (container, row, col) => {
-  return getCellContent(getContainerCell(container, row, col));
-};
-
-export const getContainerCell = (container, row, col) => {
-  const rows = getRows(container);
-  const cells = getRowCells(rows[row]);
-  return cells[col];
+export const fire = (type, detail, options) => {
+  options ||= {};
+  detail = detail === null || detail === undefined ? {} : detail;
+  const event = new Event(type, {
+    bubbles: options.bubbles === undefined ? true : options.bubbles,
+    cancelable: Boolean(options.cancelable),
+    composed: options.composed === undefined ? true : options.composed,
+  });
+  event.detail = detail;
+  const node = options.node || window;
+  node.dispatchEvent(event);
+  return event;
 };
 
 export const dragStart = (source) => {
@@ -225,20 +239,6 @@ export const makeSoloTouchEvent = (type, xy, node) => {
   Object.entries(touchEventInit).forEach(([key, value]) => {
     event[key] = value;
   });
-  node.dispatchEvent(event);
-  return event;
-};
-
-export const fire = (type, detail, options) => {
-  options ||= {};
-  detail = detail === null || detail === undefined ? {} : detail;
-  const event = new Event(type, {
-    bubbles: options.bubbles === undefined ? true : options.bubbles,
-    cancelable: Boolean(options.cancelable),
-    composed: options.composed === undefined ? true : options.composed,
-  });
-  event.detail = detail;
-  const node = options.node || window;
   node.dispatchEvent(event);
   return event;
 };

--- a/packages/grid/test/keyboard-navigation-row-focus.test.js
+++ b/packages/grid/test/keyboard-navigation-row-focus.test.js
@@ -13,6 +13,14 @@ import { flushGrid, getCellContent } from './helpers.js';
 
 let grid, header, footer, body;
 
+function getRowCell(rowIndex, cellIndex) {
+  return grid.$.items.children[rowIndex].children[cellIndex];
+}
+
+function getRowFirstCell(rowIndex) {
+  return getRowCell(rowIndex, 0);
+}
+
 function clickItem(rowIndex) {
   return getCellContent(getRowFirstCell(rowIndex)).click();
 }
@@ -27,14 +35,6 @@ function isRowExpanded(rowIndex) {
 
 function openRowDetails(rowIndex) {
   return grid.openItemDetails(grid.$.items.children[rowIndex]._item);
-}
-
-function getRowCell(rowIndex, cellIndex) {
-  return grid.$.items.children[rowIndex].children[cellIndex];
-}
-
-function getRowFirstCell(rowIndex) {
-  return getRowCell(rowIndex, 0);
 }
 
 function tab(target) {

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -35,20 +35,20 @@ import {
 
 let grid, focusable, scroller, header, footer, body;
 
-function clickItem(rowIndex) {
-  return getCellContent(getRowFirstCell(rowIndex)).click();
-}
-
-function focusItem(rowIndex) {
-  return getRowFirstCell(rowIndex).focus();
-}
-
 function getRowCell(rowIndex, cellIndex) {
   return grid.$.items.children[rowIndex].children[cellIndex];
 }
 
 function getRowFirstCell(rowIndex) {
   return getRowCell(rowIndex, 0);
+}
+
+function clickItem(rowIndex) {
+  return getCellContent(getRowFirstCell(rowIndex)).click();
+}
+
+function focusItem(rowIndex) {
+  return getRowFirstCell(rowIndex).focus();
 }
 
 function getCellInput(rowIndex, colIndex) {

--- a/packages/grid/test/light-dom-observing.test.js
+++ b/packages/grid/test/light-dom-observing.test.js
@@ -48,6 +48,17 @@ class GridWrapper extends PolymerElement {
 
 customElements.define('grid-wrapper', GridWrapper);
 
+function attributeRenderer(attributeName) {
+  return (root, column, model) => {
+    const attributeValue = column.getAttribute(attributeName) || attributeName;
+    if (model) {
+      root.textContent = `${attributeValue} ${model.item.value}`;
+    } else {
+      root.textContent = attributeValue;
+    }
+  };
+}
+
 function createColumn() {
   const column = document.createElement('vaadin-grid-column');
   column.header = 'some header';
@@ -87,17 +98,6 @@ function expectNumberOfColumns(grid, number) {
 
 function getFooterCellContent(grid, row, column) {
   return getContainerCellContent(grid.$.footer, row, column);
-}
-
-function attributeRenderer(attributeName) {
-  return (root, column, model) => {
-    const attributeValue = column.getAttribute(attributeName) || attributeName;
-    if (model) {
-      root.textContent = `${attributeValue} ${model.item.value}`;
-    } else {
-      root.textContent = attributeValue;
-    }
-  };
 }
 
 describe('light dom observing', () => {

--- a/packages/grid/test/styling.test.js
+++ b/packages/grid/test/styling.test.js
@@ -20,45 +20,6 @@ describe('styling', () => {
     firstCell = getContainerCell(grid.$.items, 0, 0);
   });
 
-  describe('cell class name generator', () => {
-    let initialCellClasses;
-
-    beforeEach(() => {
-      initialCellClasses = Array.from(firstCell.classList);
-    });
-
-    const assertClassList = (expectedClasses, row = 0, col = 0) => {
-      const cell = getContainerCell(grid.$.items, row, col);
-      expect(Array.from(cell.classList)).to.deep.equal(initialCellClasses.concat(expectedClasses));
-    };
-
-    runStylingTest('classes', 'cellClassNameGenerator', 'generateCellClassNames', assertClassList);
-  });
-
-  describe('cell part name generator', () => {
-    let initialCellPart;
-
-    beforeEach(() => {
-      initialCellPart = firstCell.getAttribute('part');
-    });
-
-    const assertPartNames = (expectedParts, row = 0, col = 0) => {
-      const cell = getContainerCell(grid.$.items, row, col);
-      const actualPart = cell.getAttribute('part');
-      const customParts = expectedParts.length ? ` ${expectedParts.join(' ')}` : '';
-
-      if (row === 0 && col === 0) {
-        expect(actualPart).to.equal(`${initialCellPart}${customParts}`);
-      } else {
-        expectedParts.forEach((partName) => {
-          expect(actualPart).to.contain(partName);
-        });
-      }
-    };
-
-    runStylingTest('parts', 'cellPartNameGenerator', 'generateCellPartNames', assertPartNames);
-  });
-
   function runStylingTest(entries, generatorFn, requestFn, assertCallback) {
     it(`should add ${entries} for cells`, () => {
       grid[generatorFn] = () => 'foo';
@@ -198,4 +159,43 @@ describe('styling', () => {
       });
     });
   }
+
+  describe('cell class name generator', () => {
+    let initialCellClasses;
+
+    beforeEach(() => {
+      initialCellClasses = Array.from(firstCell.classList);
+    });
+
+    const assertClassList = (expectedClasses, row = 0, col = 0) => {
+      const cell = getContainerCell(grid.$.items, row, col);
+      expect(Array.from(cell.classList)).to.deep.equal(initialCellClasses.concat(expectedClasses));
+    };
+
+    runStylingTest('classes', 'cellClassNameGenerator', 'generateCellClassNames', assertClassList);
+  });
+
+  describe('cell part name generator', () => {
+    let initialCellPart;
+
+    beforeEach(() => {
+      initialCellPart = firstCell.getAttribute('part');
+    });
+
+    const assertPartNames = (expectedParts, row = 0, col = 0) => {
+      const cell = getContainerCell(grid.$.items, row, col);
+      const actualPart = cell.getAttribute('part');
+      const customParts = expectedParts.length ? ` ${expectedParts.join(' ')}` : '';
+
+      if (row === 0 && col === 0) {
+        expect(actualPart).to.equal(`${initialCellPart}${customParts}`);
+      } else {
+        expectedParts.forEach((partName) => {
+          expect(actualPart).to.contain(partName);
+        });
+      }
+    };
+
+    runStylingTest('parts', 'cellPartNameGenerator', 'generateCellPartNames', assertPartNames);
+  });
 });

--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -5,14 +5,13 @@ import '../vaadin-rich-text-editor.js';
 
 describe('accessibility', () => {
   'use strict';
+  let rte, content, buttons, announcer, editor;
 
   const flushFormatAnnouncer = () => {
     rte.__debounceAnnounceFormatting?.flush();
   };
 
   const flushValueDebouncer = () => rte.__debounceSetValue && rte.__debounceSetValue.flush();
-
-  let rte, content, buttons, announcer, editor;
 
   beforeEach(() => {
     rte = fixtureSync('<vaadin-rich-text-editor></vaadin-rich-text-editor>');

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -6,10 +6,9 @@ import { createImage } from './helpers.js';
 
 describe('rich text editor', () => {
   'use strict';
+  let rte, editor;
 
   const flushValueDebouncer = () => rte.__debounceSetValue && rte.__debounceSetValue.flush();
-
-  let rte, editor;
 
   const getButton = (fmt) => rte.shadowRoot.querySelector(`[part~="toolbar-button-${fmt}"]`);
 

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -24,6 +24,40 @@ export { css, unsafeCSS };
 const themeRegistry = [];
 
 /**
+ * Check if the custom element type has themes applied.
+ * @param {Function} elementClass
+ * @returns {boolean}
+ */
+function classHasThemes(elementClass) {
+  return elementClass && Object.prototype.hasOwnProperty.call(elementClass, '__themes');
+}
+
+/**
+ * Check if the custom element type has themes applied.
+ * @param {string} tagName
+ * @returns {boolean}
+ */
+function hasThemes(tagName) {
+  return classHasThemes(customElements.get(tagName));
+}
+
+/**
+ * Flattens the styles into a single array of styles.
+ * @param {CSSResultGroup} styles
+ * @param {CSSResult[]} result
+ * @returns {CSSResult[]}
+ */
+function flattenStyles(styles = []) {
+  return [styles].flat(Infinity).filter((style) => {
+    if (style instanceof CSSResult) {
+      return true;
+    }
+    console.warn('An item in styles is not of type CSSResult. Use `unsafeCSS` or `css`.');
+    return false;
+  });
+}
+
+/**
  * Registers CSS styles for a component type. Make sure to register the styles before
  * the first instance of a component of the type is attached to DOM.
  *
@@ -98,22 +132,6 @@ function getIncludePriority(moduleName = '') {
 }
 
 /**
- * Flattens the styles into a single array of styles.
- * @param {CSSResultGroup} styles
- * @param {CSSResult[]} result
- * @returns {CSSResult[]}
- */
-function flattenStyles(styles = []) {
-  return [styles].flat(Infinity).filter((style) => {
-    if (style instanceof CSSResult) {
-      return true;
-    }
-    console.warn('An item in styles is not of type CSSResult. Use `unsafeCSS` or `css`.');
-    return false;
-  });
-}
-
-/**
  * Gets an array of CSSResults matching the include property of the theme.
  * @param {Theme} theme
  * @returns {CSSResult[]}
@@ -171,24 +189,6 @@ function getThemes(tagName) {
   }
   // No theme modules found, return the default module if it exists
   return getAllThemes().filter((theme) => theme.moduleId === defaultModuleName);
-}
-
-/**
- * Check if the custom element type has themes applied.
- * @param {string} tagName
- * @returns {boolean}
- */
-function hasThemes(tagName) {
-  return classHasThemes(customElements.get(tagName));
-}
-
-/**
- * Check if the custom element type has themes applied.
- * @param {Function} elementClass
- * @returns {boolean}
- */
-function classHasThemes(elementClass) {
-  return elementClass && Object.prototype.hasOwnProperty.call(elementClass, '__themes');
 }
 
 /**

--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -214,36 +214,6 @@ function logCommit(c) {
   console.log(log);
 }
 
-// Log a set of commits, and group by types
-function logCommitsByType(commits) {
-  if (!commits[0]) {
-    return;
-  }
-  const byType = {};
-  commits.forEach((commit) => {
-    const type = commit.bfp ? 'bfp' : commit.breaking ? 'break' : commit.type;
-    byType[type] = [...(byType[type] || []), commit];
-  });
-
-  Object.keys(keyName).forEach((k) => {
-    if (byType[k]) {
-      console.log(`\n#### ${keyName[k]}`);
-
-      if (compact) {
-        byType[k].forEach((c) => logCommit(c));
-      } else {
-        logCommitsByComponent(byType[k].filter((c) => c.components.length));
-
-        const other = byType[k].filter((c) => !c.components.length);
-        if (other.length) {
-          console.log('- Other');
-          other.forEach((c) => logCommit(c));
-        }
-      }
-    }
-  });
-}
-
 function logCommitsByComponent(commits) {
   const byComponent = {};
   commits.forEach((commit) => {
@@ -276,6 +246,36 @@ function logCommitsByComponent(commits) {
       });
       console.log(log.replace(/^\s*[\r\n]/gmu, ''));
     });
+}
+
+// Log a set of commits, and group by types
+function logCommitsByType(commits) {
+  if (!commits[0]) {
+    return;
+  }
+  const byType = {};
+  commits.forEach((commit) => {
+    const type = commit.bfp ? 'bfp' : commit.breaking ? 'break' : commit.type;
+    byType[type] = [...(byType[type] || []), commit];
+  });
+
+  Object.keys(keyName).forEach((k) => {
+    if (byType[k]) {
+      console.log(`\n#### ${keyName[k]}`);
+
+      if (compact) {
+        byType[k].forEach((c) => logCommit(c));
+      } else {
+        logCommitsByComponent(byType[k].filter((c) => c.components.length));
+
+        const other = byType[k].filter((c) => !c.components.length);
+        if (other.length) {
+          console.log('- Other');
+          other.forEach((c) => logCommit(c));
+        }
+      }
+    }
+  });
 }
 
 // Output the release notes for the set of commits


### PR DESCRIPTION
## Description

The PR enables and fixes the following rules:

- [x] @typescript-eslint/no-use-before-define

Part of https://github.com/vaadin/eslint-config-vaadin/issues/35

## Type of change

- [x] Refactor
