### PR TITLE
test: update grid light-dom-observing tests to not use templates

### DIFF
--- a/packages/grid/test/light-dom-observing.test.js
+++ b/packages/grid/test/light-dom-observing.test.js
@@ -1,368 +1,128 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import '@polymer/polymer/lib/elements/dom-bind.js';
-import '@polymer/polymer/lib/elements/dom-repeat.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-column-group.js';
 import '../vaadin-grid-selection-column.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   flushGrid,
-  getCellContent,
+  getBodyCellContent,
+  getContainerCellContent,
   getHeaderCellContent,
-  getRowCells,
   getRows,
   infiniteDataProvider,
   scrollToEnd,
 } from './helpers.js';
-
-class XBooleanToggle extends PolymerElement {
-  static get template() {
-    return html`[[value]]`;
-  }
-
-  static get properties() {
-    return {
-      value: { type: Boolean, notify: true },
-    };
-  }
-}
-
-customElements.define('x-boolean-toggle', XBooleanToggle);
 
 class GridWrapper extends PolymerElement {
   static get template() {
     return html`
       <vaadin-grid id="grid" size="10">
         <slot name="grid"></slot>
-        <vaadin-grid-column-group>
-          <template class="header">wrapper group header</template>
-          <template class="footer">wrapper group footer</template>
+        <vaadin-grid-column-group header="wrapper group header" footerRenderer="[[groupFooterRenderer]]">
           <slot name="group"></slot>
-          <vaadin-grid-column>
-            <template class="header">wrapper column header</template>
-            <template class="footer">wrapper column footer</template>
-            <template>wrapper column body [[item.value]]</template>
-          </vaadin-grid-column>
+
+          <vaadin-grid-column
+            header="wrapper column header"
+            footerRenderer="[[columnFooterRenderer]]"
+            renderer="[[columnRenderer]]"
+          ></vaadin-grid-column>
         </vaadin-grid-column-group>
       </vaadin-grid>
     `;
+  }
+
+  groupFooterRenderer(root) {
+    root.textContent = 'wrapper group footer';
+  }
+
+  columnFooterRenderer(root, _column) {
+    root.textContent = 'wrapper column footer';
+  }
+
+  columnRenderer(root, _column, model) {
+    root.textContent = `wrapper column body${model.item.value}`;
   }
 }
 
 customElements.define('grid-wrapper', GridWrapper);
 
-const createColumn = () => {
+function createColumn() {
   const column = document.createElement('vaadin-grid-column');
-  column.innerHTML = `
-    <template class="header">some header</template>
-    <template class="footer">some footer</template>
-    <template>some body [[item.value]]</template>
-  `;
+  column.header = 'some header';
+  column.footerRenderer = (root) => {
+    root.textContent = 'some footer';
+  };
+  column.renderer = (root, _column, model) => {
+    root.textContent = `some body ${model.item.value}`;
+  };
   return column;
-};
+}
 
-const createGroup = () => {
+function createGroup() {
   const group = document.createElement('vaadin-grid-column-group');
-  group.innerHTML = `
-    <template class="header">some group header</template>
-    <template class="footer">some group footer</template>
-    <vaadin-grid-column>
-      <template class="header">some foo header</template>
-      <template class="footer">some foo footer</template>
-      <template>some foo body [[item.value]]</template>
-    </vaadin-grid-column>
-    <vaadin-grid-column>
-      <template class="header">some bar header</template>
-      <template class="footer">some bar footer</template>
-      <template>some bar body [[item.value]]</template>
-    </vaadin-grid-column>
-  `;
+  group.header = 'some group header';
+  group.footerRenderer = (root) => {
+    root.textContent = 'some group footer';
+  };
+  const column1 = document.createElement('vaadin-grid-column');
+  column1.header = 'some foo header';
+  column1.footerRenderer = (root) => {
+    root.textContent = 'some foo footer';
+  };
+  column1.renderer = (root, _column, model) => {
+    root.textContent = `some foo body ${model.item.value}`;
+  };
+  const column2 = document.createElement('vaadin-grid-column');
+  column2.header = 'some bar header';
+  column2.footerRenderer = (root) => {
+    root.textContent = 'some bar footer';
+  };
+  column2.renderer = (root, _column, model) => {
+    root.textContent = `some bar body ${model.item.value}`;
+  };
+  group.appendChild(column1);
+  group.appendChild(column2);
   return group;
-};
+}
 
-const fixtures = {
-  columns: `
-    <vaadin-grid size="10">
-      <vaadin-grid-column>
-        <template class="header">first header</template>
-        <template class="footer">first footer</template>
-        <template>first body [[item.value]]</template>
-      </vaadin-grid-column>
-      <vaadin-grid-column>
-        <template class="header">second header</template>
-        <template class="footer">second footer</template>
-        <template>second body [[item.value]]</template>
-      </vaadin-grid-column>
-    </vaadin-grid>
-  `,
-  'plain-groups': `
-    <vaadin-grid size="10">
-      <vaadin-grid-column-group>
-        <template class="header">first group header</template>
-        <template class="footer">first group footer</template>
-        <vaadin-grid-column>
-          <template class="header">first foo header</template>
-          <template class="footer">first foo footer</template>
-          <template>first foo body [[item.value]]</template>
-        </vaadin-grid-column>
-        <vaadin-grid-column>
-          <template class="header">first bar header</template>
-          <template class="footer">first bar footer</template>
-          <template>first bar body [[item.value]]</template>
-        </vaadin-grid-column>
-      </vaadin-grid-column-group>
-      <vaadin-grid-column-group>
-        <template class="header">second group header</template>
-        <template class="footer">second group footer</template>
-        <vaadin-grid-column>
-          <template class="header">second foo header</template>
-          <template class="footer">second foo footer</template>
-          <template>second foo body [[item.value]]</template>
-        </vaadin-grid-column>
-        <vaadin-grid-column>
-          <template class="header">second bar header</template>
-          <template class="footer">second bar footer</template>
-          <template>second bar body [[item.value]]</template>
-        </vaadin-grid-column>
-      </vaadin-grid-column-group>
-    </vaadin-grid>
-  `,
-  'nested-groups': `
-    <vaadin-grid size="10">
-      <vaadin-grid-column-group>
-        <template class="header">group header</template>
-        <template class="footer">group footer</template>
-        <vaadin-grid-column-group>
-          <template class="header">first nested group header</template>
-          <template class="footer">first nested group footer</template>
-          <vaadin-grid-column>
-            <template class="header">first foo header</template>
-            <template class="footer">first foo footer</template>
-            <template>first foo body [[item.value]]</template>
-          </vaadin-grid-column>
-          <vaadin-grid-column>
-            <template class="header">first bar header</template>
-            <template class="footer">first bar footer</template>
-            <template>first bar body [[item.value]]</template>
-          </vaadin-grid-column>
-        </vaadin-grid-column-group>
-        <vaadin-grid-column-group>
-          <template class="header">second nested group header</template>
-          <template class="footer">second nested group footer</template>
-          <vaadin-grid-column>
-            <template class="header">second foo header</template>
-            <template class="footer">second foo footer</template>
-            <template>second foo body [[item.value]]</template>
-          </vaadin-grid-column>
-          <vaadin-grid-column>
-            <template class="header">second bar header</template>
-            <template class="footer">second bar footer</template>
-            <template>second bar body [[item.value]]</template>
-          </vaadin-grid-column>
-        </vaadin-grid-column-group>
-      </vaadin-grid-column-group>
-    </vaadin-grid>
-  `,
-  'dom-repeat-columns': `
-    <vaadin-grid id="grid" size="10">
-      <dom-repeat as="column">
-        <template is="dom-repeat" as="column">
-          <vaadin-grid-column>
-            <template class="header">grid repeats column [[column]] header</template>
-            <template class="footer">grid repeats column [[column]] footer</template>
-            <template>grid repeats column [[column]] body [[item.value]]</template>
-          </vaadin-grid-column>
-        </template>
-      </dom-repeat>
-    </vaadin-grid>
-  `,
-  'dom-repeat-columns-in-group': `
-    <vaadin-grid size="10">
-      <vaadin-grid-column-group>
-        <dom-repeat as="column">
-          <template is="dom-repeat" as="column">
-            <vaadin-grid-column>
-              <template class="header">group repeats column [[column]] header</template>
-              <template class="footer">group repeats column [[column]] footer</template>
-              <template>group repeats column [[column]] body [[item.value]]</template>
-            </vaadin-grid-column>
-          </template>
-        </dom-repeat>
-      </vaadin-grid-column-group>
-    </vaadin-grid>
-  `,
-  'dom-repeat-groups': `
-    <vaadin-grid size="10">
-      <dom-repeat as="column">
-        <template is="dom-repeat" as="column">
-          <vaadin-grid-column-group>
-            <vaadin-grid-column>
-              <template class="header">grid repeats group [[column]] header</template>
-              <template class="footer">grid repeats group [[column]] footer</template>
-              <template>grid repeats group [[column]] body [[item.value]]</template>
-            </vaadin-grid-column>
-          </vaadin-grid-column-group>
-        </template>
-      </dom-repeat>
-    </vaadin-grid>
-  `,
-  'dom-repeat-groups-in-group': `
-    <vaadin-grid size="10">
-      <vaadin-grid-column-group>
-        <dom-repeat as="column">
-          <template is="dom-repeat" as="column">
-            <vaadin-grid-column-group>
-              <vaadin-grid-column>
-                <template class="header">group repeats group [[column]] header</template>
-                <template class="footer">group repeats group [[column]] footer</template>
-                <template>group repeats group [[column]] body [[item.value]]</template>
-              </vaadin-grid-column>
-            </vaadin-grid-column-group>
-          </template>
-        </dom-repeat>
-      </vaadin-grid-column-group>
-    </vaadin-grid>
-  `,
-  'dom-repeat-columns-detailed': `
-    <dom-bind>
-      <template>
-        <vaadin-grid id="grid" size="10">
-          <template class="row-details">
-            <div class="details">grid repeats column with detail detail [[item.value]]</div>
-          </template>
-          <vaadin-grid-column frozen width="20px">
-            <template><x-boolean-toggle value="{{detailsOpened}}"></x-boolean-toggle></template>
-            <template class="header">detail toggle</template>
-          </vaadin-grid-column>
-          <dom-repeat as="column">
-            <template is="dom-repeat" as="column">
-              <vaadin-grid-column>
-                <template class="header">grid repeats column with detail [[column]] header</template>
-                <template>grid repeats column with detail [[column]] body [[item.value]]</template>
-              </vaadin-grid-column>
-            </template>
-          </dom-repeat>
-        </vaadin-grid>
-      </template>
-    </dom-bind>
-  `,
-  'effective-children-columns': `
-    <grid-wrapper>
-      <vaadin-grid-column>
-        <template class="header">foo header</template>
-        <template class="footer">foo footer</template>
-        <template>foo body [[item.value]]</template>
-      </vaadin-grid-column>
-      <vaadin-grid-column>
-        <template class="header">bar header</template>
-        <template class="footer">bar footer</template>
-        <template>bar body [[item.value]]</template>
-      </vaadin-grid-column>
-    </grid-wrapper>
-  `,
-  'effective-children-groups': `
-    <grid-wrapper>
-      <vaadin-grid-column-group>
-        <template class="header">first group header</template>
-        <template class="footer">first group footer</template>
-        <vaadin-grid-column>
-          <template class="header">first foo header</template>
-          <template class="footer">first foo footer</template>
-          <template>first foo body [[item.value]]</template>
-        </vaadin-grid-column>
-        <vaadin-grid-column>
-          <template class="header">first bar header</template>
-          <template class="footer">first bar footer</template>
-          <template>first bar body [[item.value]]</template>
-        </vaadin-grid-column>
-      </vaadin-grid-column-group>
-      <vaadin-grid-column-group>
-        <template class="header">second group header</template>
-        <template class="footer">second group footer</template>
-        <vaadin-grid-column>
-          <template class="header">second foo header</template>
-          <template class="footer">second foo footer</template>
-          <template>second foo body [[item.value]]</template>
-        </vaadin-grid-column>
-        <vaadin-grid-column>
-          <template class="header">second bar header</template>
-          <template class="footer">second bar footer</template>
-          <template>second bar body [[item.value]]</template>
-        </vaadin-grid-column>
-      </vaadin-grid-column-group>
-    </grid-wrapper>
-  `,
-};
+function expectNumberOfColumns(grid, number) {
+  const lastLevel = getRows(grid.$.header).length - 1;
+  expect(getRows(grid.$.header)[lastLevel].cells.length).to.be.equal(number);
+  expect(getRows(grid.$.items)[0].cells.length).to.be.equal(number);
+  expect(getRows(grid.$.footer)[0].cells.length).to.be.equal(number);
+}
+
+function getFooterCellContent(grid, row, column) {
+  return getContainerCellContent(grid.$.footer, row, column);
+}
+
+function attributeRenderer(attributeName) {
+  return (root, column, model) => {
+    const attributeValue = column.getAttribute(attributeName) || attributeName;
+    if (model) {
+      root.textContent = `${attributeValue} ${model.item.value}`;
+    } else {
+      root.textContent = attributeValue;
+    }
+  };
+}
 
 describe('light dom observing', () => {
-  let wrapper, grid, header, body, footer, repeater;
-
-  function init(fixtureName, options) {
-    grid = fixtureSync(fixtures[fixtureName]);
-
-    if (grid.$.grid) {
-      // Unwrap the <grid-wrapper>
-      wrapper = grid;
-      grid = grid.$.grid || grid;
-    }
-
-    repeater = grid.querySelector('dom-repeat');
-    if (repeater) {
-      repeater.items = options.columns;
-    }
-
-    // Assign the slot to the <grid-wrapper> children.
-    if (wrapper) {
-      Array.from(wrapper.children).forEach((wrapperChild) =>
-        wrapperChild.setAttribute('slot', options && options.inGroup ? 'group' : 'grid'),
-      );
-    }
-
-    header = grid.$.header;
-    body = grid.$.items;
-    footer = grid.$.footer;
-
-    grid.dataProvider = infiniteDataProvider;
-    flushGrid(grid);
-  }
-
-  function expectFirstColumnHeader(columnName, level) {
-    level ||= 0;
-    expect(getCellContent(getRows(header)[level].cells[0]).textContent).to.contain(`${columnName} header`);
-  }
-
-  function expectFirstColumnFooter(columnName, level) {
-    level ||= 0;
-    const lastLevel = getRows(header).length - 1;
-    expect(getCellContent(getRows(footer)[lastLevel - level].cells[0]).textContent).to.contain(`${columnName} footer`);
-  }
-
-  function expectFirstColumnBody(columnName) {
-    expect(getCellContent(getRows(body)[0].cells[0]).textContent).to.contain(`${columnName} body foo0`);
-    expect(getCellContent(getRows(body)[1].cells[0]).textContent).to.contain(`${columnName} body foo1`);
-    expect(getCellContent(getRows(body)[2].cells[0]).textContent).to.contain(`${columnName} body foo2`);
-  }
-
-  function expectFirstColumn(columnName, level) {
-    expectFirstColumnHeader(columnName, level);
-    expectFirstColumnFooter(columnName, level);
-    expectFirstColumnBody(columnName);
-  }
-
-  function expectNumberOfColumns(number) {
-    const lastLevel = getRows(header).length - 1;
-    expect(getRows(header)[lastLevel].cells.length).to.be.equal(number);
-    expect(getRows(body)[0].cells.length).to.be.equal(number);
-    expect(getRows(footer)[0].cells.length).to.be.equal(number);
-  }
+  let wrapper, grid;
 
   describe('generic operations', () => {
     describe('columns inside grid', () => {
       beforeEach(async () => {
-        init('columns');
+        grid = fixtureSync(`
+          <vaadin-grid size="10">
+            <vaadin-grid-column header="first header"></vaadin-grid-column>
+            <vaadin-grid-column header="second header"></vaadin-grid-column>
+          </vaadin-grid>
+        `);
+        grid.dataProvider = infiniteDataProvider;
+
         flushGrid(grid);
         await nextFrame();
       });
@@ -372,21 +132,24 @@ describe('light dom observing', () => {
         grid.insertBefore(column, grid.firstChild);
         await nextRender();
         flushGrid(grid);
-        expectFirstColumn('some');
+
+        expect(getHeaderCellContent(grid, 0, 0).textContent).to.equal('some header');
+        expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('some body foo0');
+        expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('some footer');
       });
 
       it('should support adding selection column late', async () => {
         const column = document.createElement('vaadin-grid-selection-column');
-        column.innerHTML = `
-          <template class="header">some header</template>
-          <template>some body [[item.value]]</template>
-          <template class="footer">some footer</template>
-        `;
-
+        column.header = 'some header';
+        column.renderer = attributeRenderer('some body');
+        column.footerRenderer = attributeRenderer('some footer');
         grid.insertBefore(column, grid.firstChild);
         await nextRender();
         flushGrid(grid);
-        expectFirstColumn('some');
+
+        expect(getHeaderCellContent(grid, 0, 0).textContent).to.equal('some header');
+        expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('some body foo0');
+        expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('some footer');
       });
 
       it('should support removing late', async () => {
@@ -394,7 +157,7 @@ describe('light dom observing', () => {
         grid.removeChild(column);
         await nextRender();
         flushGrid(grid);
-        expectFirstColumn('second');
+        expect(getHeaderCellContent(grid, 0, 0).textContent).to.equal('second header');
       });
 
       it('should invoke node observer twice when adding columns', async () => {
@@ -458,8 +221,31 @@ describe('light dom observing', () => {
       let firstGroup;
 
       beforeEach(async () => {
-        init('plain-groups');
+        grid = fixtureSync(`
+          <vaadin-grid size="10">
+            <vaadin-grid-column-group header="first group header" footer="first group footer">
+              <vaadin-grid-column header="first foo header" footer="first foo footer" prefix="first foo body"></vaadin-grid-column>
+              <vaadin-grid-column header="first bar header" footer="first bar footer" prefix="first bar body"></vaadin-grid-column>
+            </vaadin-grid-column-group>
+
+            <vaadin-grid-column-group header="second group header" footer="second group footer">
+              <vaadin-grid-column header="second foo header" footer="second foo footer" prefix="second foo body"></vaadin-grid-column>
+              <vaadin-grid-column header="second bar header" footer="second bar footer" prefix="second bar body"></vaadin-grid-column>
+            </vaadin-grid-column-group>
+          </vaadin-grid>
+        `);
         firstGroup = grid.querySelector('vaadin-grid-column-group');
+
+        grid.querySelectorAll('vaadin-grid-column').forEach((column) => {
+          column.renderer = attributeRenderer('prefix');
+          column.footerRenderer = attributeRenderer('footer');
+        });
+
+        grid.querySelectorAll('vaadin-grid-column-group').forEach((group) => {
+          group.footerRenderer = attributeRenderer('footer');
+        });
+
+        grid.dataProvider = infiniteDataProvider;
         await nextFrame();
       });
 
@@ -467,53 +253,78 @@ describe('light dom observing', () => {
         const column = createColumn();
         firstGroup.insertBefore(column, firstGroup.firstChild);
         await nextFrame();
-        expectFirstColumn('some', 1);
+        expect(getHeaderCellContent(grid, 1, 0).textContent).to.equal('some header');
+        expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('some body foo0');
+        expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('some footer');
       });
 
       it('should support removing late', async () => {
         const column = firstGroup.querySelector('vaadin-grid-column');
         firstGroup.removeChild(column);
         await nextFrame();
-        expectFirstColumn('first bar', 1);
-      });
-    });
-
-    describe('groups inside grid', () => {
-      beforeEach(() => {
-        init('plain-groups');
+        expect(getHeaderCellContent(grid, 1, 0).textContent).to.equal('first bar header');
+        expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('first bar body foo0');
+        expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('first bar footer');
       });
 
-      it('should support adding late', async () => {
+      it('should support adding group late', async () => {
         const group = createGroup();
         grid.insertBefore(group, grid.firstChild);
 
         await nextRender();
         flushGrid(grid);
 
-        expectFirstColumnHeader('some group', 0);
-        expectFirstColumnFooter('some group', 0);
-        expectFirstColumn('some foo', 1);
+        expect(getHeaderCellContent(grid, 0, 0).textContent).to.equal('some group header');
+        expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('some foo body foo0');
+        expect(getFooterCellContent(grid, 1, 0).textContent).to.equal('some group footer');
       });
 
-      it('should support removing late', async () => {
+      it('should support removing group late', async () => {
         const group = grid.querySelector('vaadin-grid-column-group');
         grid.removeChild(group);
 
         await nextRender();
         flushGrid(grid);
 
-        expectFirstColumnHeader('second group', 0);
-        expectFirstColumnFooter('second group', 0);
-        expectFirstColumn('second foo', 1);
+        expect(getHeaderCellContent(grid, 0, 0).textContent).to.equal('second group header');
+        expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('second foo body foo0');
+        expect(getFooterCellContent(grid, 1, 0).textContent).to.equal('second group footer');
       });
     });
 
     describe('groups inside group', () => {
       let firstGroup;
 
-      beforeEach(() => {
-        init('nested-groups');
+      beforeEach(async () => {
+        grid = fixtureSync(`
+          <vaadin-grid size="10">
+            <vaadin-grid-column-group header="group header" footer="group footer">
+              <vaadin-grid-column-group header="first nested group header" footer="first nested group footer">
+                <vaadin-grid-column header="first foo header" footer="first foo footer" prefix="first foo body"></vaadin-grid-column>
+                <vaadin-grid-column header="first bar header" footer="first bar footer" prefix="first bar body"></vaadin-grid-column>
+              </vaadin-grid-column-group>
+
+              <vaadin-grid-column-group header="second nested group header" footer="second nested group footer">
+                <vaadin-grid-column header="second foo header" footer="second foo footer" prefix="second foo body"></vaadin-grid-column>
+                <vaadin-grid-column header="second bar header" footer="second bar footer" prefix="second bar body"></vaadin-grid-column>
+              </vaadin-grid-column-group>
+            </vaadin-grid-column-group>
+          </vaadin-grid>
+        `);
+
         firstGroup = grid.querySelector('vaadin-grid-column-group');
+
+        grid.querySelectorAll('vaadin-grid-column').forEach((column) => {
+          column.renderer = attributeRenderer('prefix');
+          column.footerRenderer = attributeRenderer('footer');
+        });
+
+        grid.querySelectorAll('vaadin-grid-column-group').forEach((group) => {
+          group.footerRenderer = attributeRenderer('footer');
+        });
+
+        grid.dataProvider = infiniteDataProvider;
+        await nextFrame();
       });
 
       it('should support adding late', async () => {
@@ -523,9 +334,9 @@ describe('light dom observing', () => {
         await nextRender();
         flushGrid(grid);
 
-        expectFirstColumnHeader('some group', 1);
-        expectFirstColumnFooter('some group', 1);
-        expectFirstColumn('some foo', 2);
+        expect(getHeaderCellContent(grid, 1, 0).textContent).to.equal('some group header');
+        expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('some foo body foo0');
+        expect(getFooterCellContent(grid, 1, 0).textContent).to.equal('some group footer');
       });
 
       it('should support removing late', async () => {
@@ -534,113 +345,9 @@ describe('light dom observing', () => {
 
         await nextRender();
 
-        expectFirstColumnHeader('second nested group', 1);
-        expectFirstColumnFooter('second nested group', 1);
-        expectFirstColumn('second foo', 2);
-      });
-    });
-  });
-
-  function shouldSupportDomRepeat(prefix, columnsLevel) {
-    it('should provide initial state', async () => {
-      repeater.render();
-      await nextFrame();
-      expectFirstColumn(`${prefix} a`, columnsLevel);
-      expectFirstColumn('', columnsLevel);
-      expectNumberOfColumns(3);
-    });
-
-    it('should add columns late', async () => {
-      flushGrid(grid);
-      repeater.unshift('items', 'd');
-      repeater.render();
-      await nextFrame();
-      flushGrid(grid);
-      expectFirstColumn(`${prefix} d`, columnsLevel);
-      expectFirstColumn('', columnsLevel);
-      expectNumberOfColumns(4);
-    });
-
-    it('should remove columns late', async () => {
-      flushGrid(grid);
-      repeater.shift('items');
-      repeater.render();
-      await nextFrame();
-      flushGrid(grid);
-      expectFirstColumn(`${prefix} b`, columnsLevel);
-      expectFirstColumn('', columnsLevel);
-      expectNumberOfColumns(2);
-    });
-
-    it('should remove cell content', async () => {
-      flushGrid(grid);
-      const contentCount = grid.querySelectorAll('vaadin-grid-cell-content').length;
-      repeater.shift('items');
-      repeater.render();
-      flushGrid(grid);
-      await nextFrame();
-      await aTimeout(0);
-      expect(grid.querySelectorAll('vaadin-grid-cell-content').length).to.be.below(contentCount);
-    });
-  }
-
-  describe('dom-repeat', () => {
-    let columns;
-
-    beforeEach(() => {
-      columns = 'a b c'.split(' ');
-    });
-
-    describe('columns inside grid', () => {
-      beforeEach(async () => {
-        init('dom-repeat-columns', { columns });
-        await aTimeout(0);
-      });
-
-      shouldSupportDomRepeat('grid repeats column');
-    });
-
-    describe('columns inside group', () => {
-      beforeEach(async () => {
-        init('dom-repeat-columns-in-group', { columns });
-        await aTimeout(0);
-      });
-
-      shouldSupportDomRepeat('group repeats column', 1);
-    });
-
-    describe('groups inside grid', () => {
-      beforeEach(async () => {
-        init('dom-repeat-groups', { columns });
-        await aTimeout(0);
-      });
-
-      shouldSupportDomRepeat('grid repeats group', 1);
-    });
-
-    describe('groups inside group', () => {
-      beforeEach(async () => {
-        init('dom-repeat-groups-in-group', { columns });
-        await aTimeout(0);
-      });
-
-      shouldSupportDomRepeat('group repeats group', 2);
-    });
-
-    describe('with row detail', () => {
-      beforeEach(() => {
-        init('dom-repeat-columns-detailed', { columns });
-      });
-
-      it('should obey the "detailsOpened" template property', async () => {
-        repeater.render();
-        await nextFrame();
-        const row = getRows(grid.$.items)[0];
-        const cell = getRowCells(row)[0];
-        const toggle = getCellContent(cell).children[0];
-        // Open row details
-        toggle.value = true;
-        expect(grid.detailsOpenedItems).to.contain(row._item);
+        expect(getHeaderCellContent(grid, 1, 0).textContent).to.equal('second nested group header');
+        expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('second foo body foo0');
+        expect(getFooterCellContent(grid, 1, 0).textContent).to.equal('second nested group footer');
       });
     });
   });
@@ -650,13 +357,30 @@ describe('light dom observing', () => {
       describe('children mutations', () => {
         describe('with columns', () => {
           beforeEach(() => {
-            init('effective-children-columns', { inGroup });
+            const slot = inGroup ? 'group' : 'grid';
+            wrapper = fixtureSync(`
+              <grid-wrapper>
+                <vaadin-grid-column slot="${slot}" header="foo header" footer="foo footer" prefix="foo body"></vaadin-grid-column>
+                <vaadin-grid-column slot="${slot}" header="bar header" footer="bar footer" prefix="bar body"></vaadin-grid-column>
+              </grid-wrapper>
+            `);
+
+            wrapper.querySelectorAll('vaadin-grid-column').forEach((column) => {
+              column.renderer = attributeRenderer('prefix');
+              column.footerRenderer = attributeRenderer('footer');
+            });
+
+            grid = wrapper.$.grid;
+
+            grid.dataProvider = infiniteDataProvider;
           });
 
           it('should provide initial state', async () => {
             await nextFrame();
-            expectFirstColumn('foo', 1);
-            expectNumberOfColumns(3);
+            expect(getHeaderCellContent(grid, 1, 0).textContent).to.equal('foo header');
+            expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('foo body foo0');
+            expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('foo footer');
+            expectNumberOfColumns(grid, 3);
           });
 
           it('should support adding late', async () => {
@@ -664,31 +388,64 @@ describe('light dom observing', () => {
             column.setAttribute('slot', inGroup ? 'group' : 'grid');
             wrapper.insertBefore(column, wrapper.firstChild);
             await nextFrame();
-            expectFirstColumn('some', 1);
-            expectNumberOfColumns(4);
+            flushGrid(grid);
+            expect(getHeaderCellContent(grid, 1, 0).textContent).to.equal('some header');
+            expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('some body foo0');
+            expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('some footer');
+            expectNumberOfColumns(grid, 4);
           });
 
           it('should support removing late', async () => {
             const column = wrapper.querySelector('vaadin-grid-column');
             wrapper.removeChild(column);
             await nextFrame();
-            expectFirstColumn('bar', 1);
-            expectNumberOfColumns(2);
+            flushGrid(grid);
+            expect(getHeaderCellContent(grid, 1, 0).textContent).to.equal('bar header');
+            expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('bar body foo0');
+            expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('bar footer');
+            expectNumberOfColumns(grid, 2);
           });
         });
 
         describe('with groups', () => {
-          let firstGroup;
+          beforeEach(async () => {
+            const slot = inGroup ? 'group' : 'grid';
+            wrapper = fixtureSync(`
+              <grid-wrapper>
+                <vaadin-grid-column-group header="first group header" footer="first group footer" slot="${slot}">
+                  <vaadin-grid-column header="first foo header" footer="first foo footer" prefix="first foo body"></vaadin-grid-column>
+                  <vaadin-grid-column header="first bar header" footer="first bar footer" prefix="first bar body"></vaadin-grid-column>
+                </vaadin-grid-column-group>
 
-          beforeEach(() => {
-            init('effective-children-groups', { inGroup });
-            firstGroup = wrapper.querySelector('vaadin-grid-column-group');
+                <vaadin-grid-column-group header="second group header" footer="second group footer" slot="${slot}">
+                  <vaadin-grid-column header="second foo header" footer="second foo footer" prefix="second foo body"></vaadin-grid-column>
+                  <vaadin-grid-column header="second bar header" footer="second bar footer" prefix="second bar body"></vaadin-grid-column>
+                </vaadin-grid-column-group>
+              </grid-wrapper>
+            `);
+
+            wrapper.querySelectorAll('vaadin-grid-column').forEach((column) => {
+              column.renderer = attributeRenderer('prefix');
+              column.footerRenderer = attributeRenderer('footer');
+            });
+
+            wrapper.querySelectorAll('vaadin-grid-column-group').forEach((group) => {
+              group.footerRenderer = attributeRenderer('footer');
+            });
+
+            grid = wrapper.$.grid;
+
+            grid.dataProvider = infiniteDataProvider;
+
+            flushGrid(grid);
+            await nextFrame();
           });
 
           it('should provide initial state', async () => {
-            await nextFrame();
-            expectFirstColumn('first foo', inGroup ? 2 : 1);
-            expectNumberOfColumns(5);
+            expect(getHeaderCellContent(grid, inGroup ? 2 : 1, 0).textContent).to.equal('first foo header');
+            expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('first foo body foo0');
+            expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('first foo footer');
+            expectNumberOfColumns(grid, 5);
           });
 
           it('should support adding late', async () => {
@@ -696,64 +453,77 @@ describe('light dom observing', () => {
             group.setAttribute('slot', inGroup ? 'group' : 'grid');
             wrapper.insertBefore(group, wrapper.firstChild);
             await nextFrame();
-            expectFirstColumn('some foo', inGroup ? 2 : 1);
-            expectNumberOfColumns(7);
+            flushGrid(grid);
+            expect(getHeaderCellContent(grid, inGroup ? 2 : 1, 0).textContent).to.equal('some foo header');
+            expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('some foo body foo0');
+            expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('some foo footer');
+            expectNumberOfColumns(grid, 7);
           });
 
           it('should support removing late', async () => {
+            const firstGroup = wrapper.querySelector('vaadin-grid-column-group');
             wrapper.removeChild(firstGroup);
             await nextFrame();
-            expectFirstColumn('second foo', inGroup ? 2 : 1);
-            expectNumberOfColumns(3);
-          });
-        });
-      });
-
-      describe('nested group mutations', () => {
-        let firstGroup;
-
-        beforeEach(() => {
-          init('effective-children-groups', { inGroup });
-          firstGroup = wrapper.querySelector('vaadin-grid-column-group');
-        });
-
-        describe('with columns', () => {
-          it('should support adding late', async () => {
-            const column = createColumn();
-            firstGroup.insertBefore(column, firstGroup.firstChild);
-            await nextFrame();
-            expectFirstColumn('some', inGroup ? 2 : 1);
-            expectNumberOfColumns(6);
-          });
-
-          it('should support removing late', async () => {
-            const column = firstGroup.querySelector('vaadin-grid-column');
-            firstGroup.removeChild(column);
-            await nextFrame();
-            expectFirstColumn('first bar', inGroup ? 2 : 1);
-            expectNumberOfColumns(4);
-          });
-        });
-
-        describe('with groups', () => {
-          it('should support adding late', async () => {
-            const group = createGroup();
-            firstGroup.insertBefore(group, firstGroup.firstChild);
-            await nextFrame();
-            expectFirstColumn('some foo', inGroup ? 3 : 2);
-            expectNumberOfColumns(7);
-          });
-
-          it('should support removing late', async () => {
-            const group = createGroup();
-            firstGroup.insertBefore(group, firstGroup.firstChild);
-            await nextFrame();
             flushGrid(grid);
-            expectNumberOfColumns(7);
-            firstGroup.removeChild(group);
-            await nextFrame();
-            expectFirstColumn('first foo', inGroup ? 2 : 1);
-            expectNumberOfColumns(5);
+            expect(getHeaderCellContent(grid, inGroup ? 2 : 1, 0).textContent).to.equal('second foo header');
+            expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('second foo body foo0');
+            expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('second foo footer');
+            expectNumberOfColumns(grid, 3);
+          });
+
+          describe('nested group mutations', () => {
+            let firstGroup;
+
+            beforeEach(() => {
+              firstGroup = wrapper.querySelector('vaadin-grid-column-group');
+            });
+
+            describe('with columns', () => {
+              it('should support adding late', async () => {
+                const column = createColumn();
+                firstGroup.insertBefore(column, firstGroup.firstChild);
+                await nextFrame();
+                expect(getHeaderCellContent(grid, inGroup ? 2 : 1, 0).textContent).to.equal('some header');
+                expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('some body foo0');
+                expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('some footer');
+                expectNumberOfColumns(grid, 6);
+              });
+
+              it('should support removing late', async () => {
+                const column = firstGroup.querySelector('vaadin-grid-column');
+                firstGroup.removeChild(column);
+                await nextFrame();
+                expect(getHeaderCellContent(grid, inGroup ? 2 : 1, 0).textContent).to.equal('first bar header');
+                expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('first bar body foo0');
+                expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('first bar footer');
+                expectNumberOfColumns(grid, 4);
+              });
+            });
+
+            describe('with groups', () => {
+              it('should support adding late', async () => {
+                const group = createGroup();
+                firstGroup.insertBefore(group, firstGroup.firstChild);
+                await nextFrame();
+                expect(getHeaderCellContent(grid, inGroup ? 3 : 2, 0).textContent).to.equal('some foo header');
+                expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('some foo body foo0');
+                expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('some foo footer');
+                expectNumberOfColumns(grid, 7);
+              });
+
+              it('should support removing late', async () => {
+                const group = createGroup();
+                firstGroup.insertBefore(group, firstGroup.firstChild);
+                await nextFrame();
+                expectNumberOfColumns(grid, 7);
+                group.remove();
+                await nextFrame();
+                expect(getHeaderCellContent(grid, inGroup ? 2 : 1, 0).textContent).to.equal('first foo header');
+                expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('first foo body foo0');
+                expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('first foo footer');
+                expectNumberOfColumns(grid, 5);
+              });
+            });
           });
         });
       });

--- a/packages/grid/test/light-dom-observing.test.js
+++ b/packages/grid/test/light-dom-observing.test.js
@@ -62,28 +62,19 @@ function createColumn() {
 
 function createGroup() {
   const group = document.createElement('vaadin-grid-column-group');
+  group.innerHTML = `
+    <vaadin-grid-column header="some foo header" footer="some foo footer" prefix="some foo body"></vaadin-grid-column>
+    <vaadin-grid-column header="some bar header" footer="some bar footer" prefix="some bar body"></vaadin-grid-column>
+  `;
   group.header = 'some group header';
   group.footerRenderer = (root) => {
     root.textContent = 'some group footer';
   };
-  const column1 = document.createElement('vaadin-grid-column');
-  column1.header = 'some foo header';
-  column1.footerRenderer = (root) => {
-    root.textContent = 'some foo footer';
-  };
-  column1.renderer = (root, _column, model) => {
-    root.textContent = `some foo body ${model.item.value}`;
-  };
-  const column2 = document.createElement('vaadin-grid-column');
-  column2.header = 'some bar header';
-  column2.footerRenderer = (root) => {
-    root.textContent = 'some bar footer';
-  };
-  column2.renderer = (root, _column, model) => {
-    root.textContent = `some bar body ${model.item.value}`;
-  };
-  group.appendChild(column1);
-  group.appendChild(column2);
+
+  group.querySelectorAll('vaadin-grid-column').forEach((column) => {
+    column.renderer = attributeRenderer('prefix');
+    column.footerRenderer = attributeRenderer('footer');
+  });
   return group;
 }
 


### PR DESCRIPTION
## Description

Remove the use of `<template>` in the `<vaadin-grid>` `light-dom-observing.test.js` tests.

Additionally:
- refactored the old test file to be less unreadable
- removed the tests that were basically testing Polymer `<dom-repeat>` (there are existing cases that test modifications in the column set)

## Type of change

- Tests