### PR TITLE
refactor: enable more ESLint rules, fix related errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,6 @@
     "@typescript-eslint/no-dynamic-delete": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-extraneous-class": "off",
-    "@typescript-eslint/no-invalid-this": "off",
     "@typescript-eslint/no-invalid-void-type": "off",
     "@typescript-eslint/no-shadow": "off",
     "@typescript-eslint/no-unused-expressions": "off",

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -58,7 +58,7 @@ export function deepMerge(target, source) {
 }
 
 ['exportChart', 'exportChartLocal', 'getSVG'].forEach((methodName) => {
-  /* eslint-disable no-invalid-this, prefer-arrow-callback */
+  /* eslint-disable @typescript-eslint/no-invalid-this, prefer-arrow-callback */
   Highcharts.wrap(Highcharts.Chart.prototype, methodName, function (proceed, ...args) {
     Highcharts.fireEvent(this, 'beforeExport');
     const result = proceed.apply(this, args);

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -164,10 +164,7 @@ describe('lazy loading', () => {
         });
       });
 
-      // eslint-disable-next-line prefer-arrow-callback
-      describe('when open', function () {
-        // eslint-disable-next-line @typescript-eslint/no-invalid-this
-        this.timeout(15000);
+      describe('when open', () => {
         beforeEach(() => {
           comboBox.inputElement.focus();
           comboBox.opened = true;

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -166,7 +166,7 @@ describe('lazy loading', () => {
 
       // eslint-disable-next-line prefer-arrow-callback
       describe('when open', function () {
-        // eslint-disable-next-line no-invalid-this
+        // eslint-disable-next-line @typescript-eslint/no-invalid-this
         this.timeout(15000);
         beforeEach(() => {
           comboBox.inputElement.focus();


### PR DESCRIPTION
## Description

The PR enables and fixes the following rules:

- [x] @typescript-eslint/no-invalid-this

Part of https://github.com/vaadin/eslint-config-vaadin/issues/35

## Type of change

- [x] Refactor
