### PR TITLE
refactor: enable more ESLint rules, fix related errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,6 @@
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-extraneous-class": "off",
     "@typescript-eslint/no-invalid-this": "off",
-    "@typescript-eslint/no-invalid-void-type": "off",
     "@typescript-eslint/no-shadow": "off",
     "@typescript-eslint/no-unused-expressions": "off",
     "@typescript-eslint/no-use-before-define": "off",
@@ -82,6 +81,7 @@
         "mocha": true
       },
       "rules": {
+        "@typescript-eslint/no-invalid-void-type": "off",
         "no-await-in-loop": "off",
         "max-classes-per-file": "off",
         "simple-import-sort/imports": [

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -47,9 +47,9 @@ export declare class InputMixinClass {
 
   protected _inputElementChanged(input: HTMLElement, oldInput: HTMLElement): void;
 
-  protected _onChange(event: void): void;
+  protected _onChange(event: Event): void;
 
-  protected _onInput(event: void): void;
+  protected _onInput(event: Event): void;
 
   protected _setInputElement(input: HTMLElement): void;
 


### PR DESCRIPTION
## Description

The PR enables and fixes the following rules:

- [x] @typescript-eslint/no-invalid-void-type

Part of https://github.com/vaadin/eslint-config-vaadin/issues/35

## Type of change

- [x] Refactor
