### PR TITLE
docs: remove non-ASCII characters from JSDoc and comments

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading.d.ts
+++ b/packages/accordion/src/vaadin-accordion-heading.d.ts
@@ -13,7 +13,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `vaadin-accordion-heading` is the element for the headings in the accordion.
  * As recommended by the WAI ARIA Best Practices, each heading needs to wrap a
  * `<button>`. This element puts that button in the Shadow DOM, as it is more
- * convenient to use and doesn’t make styling of the heading more problematic.
+ * convenient to use and doesn't make styling of the heading more problematic.
  *
  * The WAI ARIA Best Practices also recommend setting `aria-level` depending
  * on what level the headings are. It is hard to determine the level of a heading

--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -14,7 +14,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `vaadin-accordion-heading` is the element for the headings in the accordion.
  * As recommended by the WAI ARIA Best Practices, each heading needs to wrap a
  * `<button>`. This element puts that button in the Shadow DOM, as it is more
- * convenient to use and doesn’t make styling of the heading more problematic.
+ * convenient to use and doesn't make styling of the heading more problematic.
  *
  * The WAI ARIA Best Practices also recommend setting `aria-level` depending
  * on what level the headings are. It is hard to determine the level of a heading

--- a/packages/accordion/src/vaadin-accordion.d.ts
+++ b/packages/accordion/src/vaadin-accordion.d.ts
@@ -27,7 +27,7 @@ export interface AccordionCustomEventMap {
 export type AccordionEventMap = AccordionCustomEventMap & HTMLElementEventMap;
 
 /**
- * `<vaadin-accordion>` is a Web Component implementing accordion widget —
+ * `<vaadin-accordion>` is a Web Component implementing accordion widget:
  * a vertically stacked set of expandable panels. The component should be
  * used as a wrapper for two or more `<vaadin-accordion-panel>` components.
  *

--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -12,7 +12,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { AccordionPanel } from './vaadin-accordion-panel.js';
 
 /**
- * `<vaadin-accordion>` is a Web Component implementing accordion widget —
+ * `<vaadin-accordion>` is a Web Component implementing accordion widget:
  * a vertically stacked set of expandable panels. The component should be
  * used as a wrapper for two or more `<vaadin-accordion-panel>` components.
  *

--- a/packages/charts/src/vaadin-chart-series.d.ts
+++ b/packages/charts/src/vaadin-chart-series.d.ts
@@ -131,7 +131,7 @@ declare class ChartSeries extends HTMLElement {
   markers: ChartSeriesMarkers | null | undefined;
 
   /**
-   * Used to connect the series to an axis; if multiple series have the same “unit”, they will share axis.
+   * Used to connect the series to an axis; if multiple series have the same `unit`, they will share axis.
    * Displayed as a title for the axis.
    * If no unit is defined, then series will be connected to the first axis.
    */

--- a/packages/charts/src/vaadin-chart-series.js
+++ b/packages/charts/src/vaadin-chart-series.js
@@ -137,7 +137,7 @@ class ChartSeries extends PolymerElement {
       },
 
       /**
-       * Used to connect the series to an axis; if multiple series have the same “unit”, they will share axis.
+       * Used to connect the series to an axis; if multiple series have the same `unit`, they will share axis.
        * Displayed as a title for the axis.
        * If no unit is defined, then series will be connected to the first axis.
        */

--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -38,10 +38,11 @@ export interface CheckboxGroupEventMap extends HTMLElementEventMap, CheckboxGrou
  * `<vaadin-checkbox-group>` is a web component that allows the user to choose several items from a group of binary choices.
  *
  * ```html
- * <vaadin-checkbox-group label="Preferred language of contact:">
- *   <vaadin-checkbox value="en" label="English"></vaadin-checkbox>
- *   <vaadin-checkbox value="fr" label="Français"></vaadin-checkbox>
- *   <vaadin-checkbox value="de" label="Deutsch"></vaadin-checkbox>
+ * <vaadin-checkbox-group label="Export data">
+ *   <vaadin-checkbox value="0" label="Order ID"></vaadin-checkbox>
+ *   <vaadin-checkbox value="1" label="Product name"></vaadin-checkbox>
+ *   <vaadin-checkbox value="2" label="Customer"></vaadin-checkbox>
+ *   <vaadin-checkbox value="3" label="Status"></vaadin-checkbox>
  * </vaadin-checkbox-group>
  * ```
  *

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -17,10 +17,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `<vaadin-checkbox-group>` is a web component that allows the user to choose several items from a group of binary choices.
  *
  * ```html
- * <vaadin-checkbox-group label="Preferred language of contact:">
- *   <vaadin-checkbox value="en" label="English"></vaadin-checkbox>
- *   <vaadin-checkbox value="fr" label="Français"></vaadin-checkbox>
- *   <vaadin-checkbox value="de" label="Deutsch"></vaadin-checkbox>
+ * <vaadin-checkbox-group label="Export data">
+ *   <vaadin-checkbox value="0" label="Order ID"></vaadin-checkbox>
+ *   <vaadin-checkbox value="1" label="Product name"></vaadin-checkbox>
+ *   <vaadin-checkbox value="2" label="Customer"></vaadin-checkbox>
+ *   <vaadin-checkbox value="3" label="Status"></vaadin-checkbox>
  * </vaadin-checkbox-group>
  * ```
  *

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -79,7 +79,7 @@ export declare class ComboBoxMixinClass<TItem> {
   /**
    * The `String` value for the selected item of the combo box.
    *
-   * When there’s no item selected, the value is an empty string.
+   * When there is no item selected, the value is an empty string.
    *
    * Use `selectedItem` property to get the raw selected item from
    * the `items` array.

--- a/packages/component-base/src/focus-mixin.js
+++ b/packages/component-base/src/focus-mixin.js
@@ -39,7 +39,7 @@ export const FocusMixin = dedupingMixin(
         // In super.ready() other 'focusin' and 'focusout' listeners might be
         // added, so we call it after our own ones to ensure they execute first.
         // Issue to watch out: when incorrect, <vaadin-combo-box> refocuses the
-        // input field on iOS after “Done” is pressed.
+        // input field on iOS after "Done" is pressed.
         super.ready();
       }
 

--- a/packages/component-base/src/focus-utils.js
+++ b/packages/component-base/src/focus-utils.js
@@ -251,8 +251,8 @@ function collectFocusableNodes(node, result) {
 export function getFocusableElements(element) {
   const focusableElements = [];
   const needsSortByTabIndex = collectFocusableNodes(element, focusableElements);
-  // If there is at least one element with tabindex > 0, we need to sort
-  // the final array by tabindex.≈
+  // If there is at least one element with tabindex > 0,
+  // we need to sort the final array by tabindex.
   if (needsSortByTabIndex) {
     return sortElementsByTabIndex(focusableElements);
   }

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -121,7 +121,7 @@ export interface ContextMenuEventMap extends HTMLElementEventMap, ContextMenuCus
  * in the next renderer call and will be provided with the `root` argument.
  * On first call it will be empty.
  *
- * ### “vaadin-contextmenu” Gesture Event
+ * ### `vaadin-contextmenu` Gesture Event
  *
  * `vaadin-contextmenu` is a gesture event (a custom event),
  * which is dispatched after either `contextmenu` or long touch events.

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -94,7 +94,7 @@ import { ItemsMixin } from './vaadin-contextmenu-items-mixin.js';
  * in the next renderer call and will be provided with the `root` argument.
  * On first call it will be empty.
  *
- * ### “vaadin-contextmenu” Gesture Event
+ * ### `vaadin-contextmenu` Gesture Event
  *
  * `vaadin-contextmenu` is a gesture event (a custom event),
  * which is dispatched after either `contextmenu` or long touch events.

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -248,7 +248,7 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
   /** @protected */
   ready() {
     // Here we create and attach a style element that we use for validating
-    // CSS values in `responsiveSteps`. We can’t add this to the `<template>`,
+    // CSS values in `responsiveSteps`. We can't add this to the `<template>`,
     // because Polymer will throw it away. We need to create this before
     // `super.ready()`, because `super.ready()` invokes property observers,
     // and the observer for `responsiveSteps` does CSS value validation.
@@ -329,7 +329,7 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
   /** @private */
   _isValidCSSLength(value) {
     // Let us choose a CSS property for validating CSS <length> values:
-    // - `border-spacing` accepts `<length> | inherit`, it’s the best! But
+    // - `border-spacing` accepts `<length> | inherit`, it's the best! But
     //   it does not disallow invalid values at all in MSIE :-(
     // - `letter-spacing` and `word-spacing` accept
     //   `<length> | normal | inherit`, and disallows everything else, like
@@ -424,7 +424,7 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
     // Sometimes converting units is not possible, e.g, when element is
     // not connected. Then the `selectedStep` stays `undefined`.
     if (selectedStep) {
-      // Apply the chosen responsive step’s properties
+      // Apply the chosen responsive step's properties
       this._columnCount = selectedStep.columns;
       this._labelsOnTop = selectedStep.labelsPosition === 'top';
     }
@@ -481,7 +481,7 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
         child.style.width = `calc(${childRatio * 99.9}% - ${1 - childRatio} * ${columnSpacing})`;
 
         if (col + colspan > this._columnCount) {
-          // Too big to fit on this row, let’s wrap it
+          // Too big to fit on this row, let's wrap it
           col = 0;
         }
 

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -130,22 +130,22 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
       this._updateFlexAndWidth();
     }
 
-    // Don’t unfreeze the frozen group because of a non-frozen child
+    // Don't unfreeze the frozen group because of a non-frozen child
     if (path === 'frozen' && !this.frozen) {
       this.frozen = value;
     }
 
-    // Don’t unfreeze the frozen group because of a non-frozen child
+    // Don't unfreeze the frozen group because of a non-frozen child
     if (path === 'lastFrozen' && !this._lastFrozen) {
       this._lastFrozen = value;
     }
 
-    // Don’t unfreeze the frozen group because of a non-frozen child
+    // Don't unfreeze the frozen group because of a non-frozen child
     if (path === 'frozenToEnd' && !this.frozenToEnd) {
       this.frozenToEnd = value;
     }
 
-    // Don’t unfreeze the frozen group because of a non-frozen child
+    // Don't unfreeze the frozen group because of a non-frozen child
     if (path === 'firstFrozenToEnd' && !this._firstFrozenToEnd) {
       this._firstFrozenToEnd = value;
     }
@@ -279,7 +279,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
       return;
     }
 
-    // Don’t propagate the default `false` value.
+    // Don't propagate the default `false` value.
     if (frozen !== false) {
       this.__scheduleAutoFreezeWarning(rootColumns, 'frozen');
 
@@ -295,7 +295,7 @@ class GridColumnGroup extends ColumnBaseMixin(PolymerElement) {
       return;
     }
 
-    // Don’t propagate the default `false` value.
+    // Don't propagate the default `false` value.
     if (frozenToEnd !== false) {
       this.__scheduleAutoFreezeWarning(rootColumns, 'frozenToEnd');
 

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -156,7 +156,7 @@ export const ColumnReorderingMixin = (superClass) =>
     /** @private */
     _onTrack(e) {
       if (!this._draggedColumn) {
-        // Reordering didn’t start. Skip this event.
+        // Reordering didn't start. Skip this event.
         return;
       }
 
@@ -196,7 +196,7 @@ export const ColumnReorderingMixin = (superClass) =>
     /** @private */
     _onTrackEnd() {
       if (!this._draggedColumn) {
-        // Reordering didn’t start. Skip this event.
+        // Reordering didn't start. Skip this event.
         return;
       }
 

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -459,10 +459,10 @@ export const DataProviderMixin = (superClass) =>
     _checkSize() {
       if (this.size === undefined && this._effectiveSize === 0) {
         console.warn(
-          'The <vaadin-grid> needs the total number of items' +
-            ' in order to display rows. Set the total number of items' +
-            ' to the `size` property, or provide the total number of items' +
-            ' in the second argument of the `dataProvider`’s `callback` call.',
+          'The <vaadin-grid> needs the total number of items in' +
+            ' order to display rows, which you can specify either by setting' +
+            ' the `size` property, or by providing it to the second argument' +
+            ' of the `dataProvider` function `callback` call.',
         );
       }
     }

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -120,7 +120,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       this.addEventListener('focusout', this._onFocusOut);
 
       // When focus goes from cell to another cell, focusin/focusout events do
-      // not escape the grid’s shadowRoot, thus listening inside the shadowRoot.
+      // not escape the grid's shadowRoot, thus listening inside the shadowRoot.
       this.$.table.addEventListener('focusin', this._onContentFocusIn.bind(this));
 
       this.addEventListener('mousedown', () => {
@@ -243,7 +243,7 @@ export const KeyboardNavigationMixin = (superClass) =>
 
       this._detectInteracting(e);
       if (this.interacting && keyGroup !== 'Interaction') {
-        // When in the interacting mode, only the “Interaction” keys are handled.
+        // When in the interacting mode, only the "Interaction" keys are handled.
         keyGroup = undefined;
       }
 
@@ -526,7 +526,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       const activeRowGroup = activeRow.parentNode;
       const currentRowIndex = this.__getIndexInGroup(activeRow, this._focusedItemIndex);
 
-      // _focusedColumnOrder is memoized — this is to ensure predictable
+      // _focusedColumnOrder is memoized - this is to ensure predictable
       // navigation when entering and leaving detail and column group cells.
       if (this._focusedColumnOrder === undefined) {
         if (isCurrentCellRowDetails) {
@@ -545,7 +545,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       } else {
         // Focusing a regular cell on the destination row
 
-        // Find orderedColumnIndex — the index of order closest matching the
+        // Find orderedColumnIndex - the index of order closest matching the
         // original _focusedColumnOrder in the sorted array of orders
         // of the visible columns on the destination row.
         const dstRowIndex = this.__getIndexInGroup(dstRow, this._focusedItemIndex);

--- a/packages/grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.js
@@ -91,7 +91,7 @@ export const RowDetailsMixin = (superClass) =>
 
     /** @private */
     _detailsOpenedItemsChanged(changeRecord, rowDetailsRenderer) {
-      // Skip to avoid duplicate work of both “.splices” and “.length” updates.
+      // Skip to avoid duplicate work of both `.splices` and `.length` updates.
       if (changeRecord.path === 'detailsOpenedItems.length' || !changeRecord.value) {
         return;
       }

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -262,9 +262,8 @@ export interface GridEventMap<TItem> extends HTMLElementEventMap, GridCustomEven
  * The `<vaadin-grid>` calls this function lazily, only when it needs more data
  * to be displayed.
  *
- * See the [`dataProvider`](#/elements/vaadin-grid#property-dataProvider) in
- * the API reference below for the detailed data provider arguments description,
- * and the “Assigning Data” page in the demos.
+ * See the [`dataProvider`](#/elements/vaadin-grid#property-dataProvider) property
+ * documentation for the detailed data provider arguments description.
  *
  * __Note that expanding the tree grid's item will trigger a call to the `dataProvider`.__
  *

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -134,9 +134,8 @@ import { StylingMixin } from './vaadin-grid-styling-mixin.js';
  * The `<vaadin-grid>` calls this function lazily, only when it needs more data
  * to be displayed.
  *
- * See the [`dataProvider`](#/elements/vaadin-grid#property-dataProvider) in
- * the API reference below for the detailed data provider arguments description,
- * and the “Assigning Data” page in the demos.
+ * See the [`dataProvider`](#/elements/vaadin-grid#property-dataProvider) property
+ * documentation for the detailed data provider arguments description.
  *
  * __Note that expanding the tree grid's item will trigger a call to the `dataProvider`.__
  *
@@ -777,7 +776,7 @@ class Grid extends ElementMixin(
       if (isChrome) {
         // Chrome bug: focusing before mouseup prevents text selection, see http://crbug.com/771903
         const mouseUpListener = (event) => {
-          // If focus is on element within the cell content — respect it, do not change
+          // If focus is on element within the cell content - respect it, do not change
           const contentContainsFocusedElement = cellContent.contains(this.getRootNode().activeElement);
           // Only focus if mouse is released on cell content itself
           const mouseUpWithinCell = event.composedPath().includes(cellContent);

--- a/packages/overlay/src/vaadin-overlay.d.ts
+++ b/packages/overlay/src/vaadin-overlay.d.ts
@@ -152,7 +152,7 @@ declare class Overlay extends ThemableMixin(DirMixin(ControllerMixin(HTMLElement
 
   /**
    * When true the overlay won't disable the main content, showing
-   * it doesn’t change the functionality of the user interface.
+   * it doesn't change the functionality of the user interface.
    */
   modeless: boolean;
 

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -203,7 +203,7 @@ class Overlay extends ThemableMixin(DirMixin(ControllerMixin(PolymerElement))) {
 
       /**
        * When true the overlay won't disable the main content, showing
-       * it doesn’t change the functionality of the user interface.
+       * it doesn't change the functionality of the user interface.
        * @type {boolean}
        */
       modeless: {

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -216,10 +216,8 @@ declare class Select extends OverlayClassMixin(
   renderer: SelectRenderer | undefined;
 
   /**
-   * It stores the the `value` property of the selected item, providing the
-   * value for iron-form.
-   * When there’s an item selected, it's the value of that item, otherwise
-   * it's an empty string.
+   * The `value` property of the selected item, or an empty string
+   * if no item is selected.
    * On change or initialization, the component finds the item which matches the
    * value and displays it.
    * If no value is provided to the component, it selects the first item without

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -247,10 +247,8 @@ class Select extends OverlayClassMixin(
       renderer: Function,
 
       /**
-       * It stores the the `value` property of the selected item, providing the
-       * value for iron-form.
-       * When there’s an item selected, it's the value of that item, otherwise
-       * it's an empty string.
+       * The `value` property of the selected item, or an empty string
+       * if no item is selected.
        * On change or initialization, the component finds the item which matches the
        * value and displays it.
        * If no value is provided to the component, it selects the first item without

--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
@@ -16,7 +16,7 @@ export declare class ThemePropertyMixinClass {
    *
    * Enables the component implementation to propagate the `theme`
    * attribute value to the sub-components in Shadow DOM by binding
-   * the sub-component’s "theme" attribute to the `theme` property of
+   * the sub-component's "theme" attribute to the `theme` property of
    * the host.
    *
    * **NOTE:** Extending the mixin only provides the property for binding,

--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
@@ -16,7 +16,7 @@ export const ThemePropertyMixin = (superClass) =>
          *
          * Enables the component implementation to propagate the `theme`
          * attribute value to the sub-components in Shadow DOM by binding
-         * the sub-component’s "theme" attribute to the `theme` property of
+         * the sub-component's "theme" attribute to the `theme` property of
          * the host.
          *
          * **NOTE:** Extending the mixin only provides the property for binding,

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -9,7 +9,7 @@ const { visualRegressionPlugin } = require('@web/test-runner-visual-regression/p
 
 const HIDDEN_WARNINGS = [
   '<vaadin-crud> Unable to autoconfigure form because the data structure is unknown. Either specify `include` or ensure at least one item is available beforehand.',
-  'The <vaadin-grid> needs the total number of items in order to display rows. Set the total number of items to the `size` property, or provide the total number of items in the second argument of the `dataProvider`’s `callback` call.',
+  'The <vaadin-grid> needs the total number of items in order to display rows, which you can specify either by setting the `size` property, or by providing it to the second argument of the `dataProvider` function `callback` call.',
   /^WARNING: Since Vaadin .* is deprecated.*/u,
   /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/u,
 ];


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/pull/5439#issuecomment-1416832060

Note: this PR only changes JS comments, there are still other UTF-8 entities in CSS to handle separately.

## Type of change

- Documentation