### PR TITLE
test: disable animations in tabs and tabsheet visual tests

### DIFF
--- a/packages/tabs/test/visual/lumo/tabs.test.js
+++ b/packages/tabs/test/visual/lumo/tabs.test.js
@@ -1,6 +1,7 @@
 import { nextFrame } from '@vaadin/testing-helpers';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../not-animated-styles.js';
 import '../../../theme/lumo/vaadin-tabs.js';
 
 describe('tabs', () => {

--- a/packages/tabs/test/visual/material/tabs.test.js
+++ b/packages/tabs/test/visual/material/tabs.test.js
@@ -1,6 +1,7 @@
 import { nextFrame } from '@vaadin/testing-helpers';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../not-animated-styles.js';
 import '../../../theme/material/vaadin-tabs.js';
 
 describe('tabs', () => {

--- a/packages/tabs/test/visual/not-animated-styles.js
+++ b/packages/tabs/test/visual/not-animated-styles.js
@@ -1,0 +1,12 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-tab',
+  css`
+    :host,
+    :host::before,
+    :host::after {
+      transition: none !important;
+    }
+  `,
+);

--- a/packages/tabsheet/test/visual/lumo/tabsheet.test.js
+++ b/packages/tabsheet/test/visual/lumo/tabsheet.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '@vaadin/tabs/test/visual/not-animated-styles.js';
 import '../../../theme/lumo/vaadin-tabsheet.js';
 
 describe('tabsheet', () => {
@@ -27,13 +28,13 @@ describe('tabsheet', () => {
             <vaadin-tabsheet>
               <div slot="prefix">Prefix</div>
               <div slot="suffix">Suffix</div>
-      
+
               <vaadin-tabs slot="tabs">
                 <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
                 <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
                 <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
               </vaadin-tabs>
-      
+
               <div tab="tab-1">
                 Odio quis mi. Aliquam massa pede, pharetra quis, tincidunt quis, fringilla at, mauris. Vestibulum a massa.
                 Vestibulum luctus odio ut quam. Maecenas congue convallis diam. Cras urna arcu, vestibulum vitae, blandit ut,

--- a/packages/tabsheet/test/visual/material/tabsheet.test.js
+++ b/packages/tabsheet/test/visual/material/tabsheet.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '@vaadin/tabs/test/visual/not-animated-styles.js';
 import '../../../theme/material/vaadin-tabsheet.js';
 
 describe('tabsheet', () => {
@@ -27,13 +28,13 @@ describe('tabsheet', () => {
             <vaadin-tabsheet>
               <div slot="prefix">Prefix</div>
               <div slot="suffix">Suffix</div>
-      
+
               <vaadin-tabs slot="tabs">
                 <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
                 <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
                 <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
               </vaadin-tabs>
-      
+
               <div tab="tab-1">
                 Odio quis mi. Aliquam massa pede, pharetra quis, tincidunt quis, fringilla at, mauris. Vestibulum a massa.
                 Vestibulum luctus odio ut quam. Maecenas congue convallis diam. Cras urna arcu, vestibulum vitae, blandit ut,


### PR DESCRIPTION
## Description

Some visual tests for `vaadin-tabs` started to fail after recent upgrade to Chrome 108, which apparently loads faster:

```
packages/tabs/test/visual/lumo/tabs.test.js:

 ❌ tabs > scroll > horizontal > rtl > selected
      Error: Visual diff failed. New screenshot is 0.09% different.
      See diff for details: /home/runner/work/web-components/web-components/packages/tabs/test/visual/lumo/screenshots/tabs/failed/rtl-horizontal-scroll-diff.png
        at async o.<anonymous> (packages/tabs/test/visual/lumo/tabs.test.js:170:15)

 ❌ tabs > scroll > vertical > ltr > selected
      Error: Visual diff failed. New screenshot is 0.17% different.
      See diff for details: /home/runner/work/web-components/web-components/packages/tabs/test/visual/lumo/screenshots/tabs/failed/ltr-vertical-scroll-diff.png
        at async o.<anonymous> (packages/tabs/test/visual/lumo/tabs.test.js:170:15)

 ❌ tabs > scroll > vertical > rtl > selected
      Error: Visual diff failed. New screenshot is 0.18% different.
      See diff for details: /home/runner/work/web-components/web-components/packages/tabs/test/visual/lumo/screenshots/tabs/failed/rtl-vertical-scroll-diff.png
        at async o.<anonymous> (packages/tabs/test/visual/lumo/tabs.test.js:170:15)
```

Updated visual tests for `@vaadin/tabs` and `@vaadin/tabsheet` packages to enforce `transition: none`.
See also https://github.com/vaadin/web-components/pull/3696 where the same fix for done for `vaadin-menu-bar-button` visual tests.

## Type of change

- Tests