### PR TITLE
refactor: use Unicode entities for forward and back buttons

### DIFF
--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -110,11 +110,11 @@ class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(PolymerEleme
         }
 
         [part='back-button']::after {
-          content: '◀';
+          content: '\\25C0';
         }
 
         [part='forward-button']::after {
-          content: '▶';
+          content: '\\25B6';
         }
 
         :host([orientation='vertical']) [part='back-button'],
@@ -125,11 +125,11 @@ class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(PolymerEleme
         /* RTL specific styles */
 
         :host([dir='rtl']) [part='back-button']::after {
-          content: '▶';
+          content: '\\25B6';
         }
 
         :host([dir='rtl']) [part='forward-button']::after {
-          content: '◀';
+          content: '\\25C0';
         }
       </style>
       <div on-click="_scrollBack" part="back-button" aria-hidden="true"></div>


### PR DESCRIPTION
## Description

Part of #5453

Updated `vaadin-tabs` internal parts to use unicode entities for these icons:

<img width="217" alt="forward-back" src="https://user-images.githubusercontent.com/10589913/216826752-d5595423-9042-4ac1-b462-ecdc303fe403.png">

## Type of change

- Refactor

## Note

Can be tested with the following HTML in the dev page:

```html
<script type="module">
  import '@vaadin/tabs/src/vaadin-tabs.js';
</script>

<vaadin-tabs style="max-width: 100%; width: 200px">
  <vaadin-tab>Analytics</vaadin-tab>
  <vaadin-tab>Customers</vaadin-tab>
  <vaadin-tab>Dashboards</vaadin-tab>
  <vaadin-tab>Documents</vaadin-tab>
  <vaadin-tab>Orders</vaadin-tab>
</vaadin-tabs>
```