### PR TITLE
refactor: use HTML entity for the menu-bar overflow button

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -123,7 +123,7 @@ export const MenuBarMixin = (superClass) =>
 
           const dots = document.createElement('div');
           dots.setAttribute('aria-hidden', 'true');
-          dots.textContent = '···';
+          dots.innerHTML = '&centerdot;'.repeat(3);
           btn.appendChild(dots);
 
           this._overflow = btn;


### PR DESCRIPTION
## Description

Part of #5453

The `vaadin-menu-bar` uses [middle dot](https://www.compart.com/en/unicode/U+00B7) to render "ellipsis". Updated to use HTML entity for it.

## Type of change

- Refactor