### PR TITLE
refactor: update map styles to use Unicode entities for icons

### DIFF
--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -258,7 +258,7 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
         }
 
         .ol-zoom-out:empty::before {
-          content: var(--vaadin-map-icon-zoom-out, '–');
+          content: var(--vaadin-map-icon-zoom-out, '\\2013');
         }
 
         .ol-attribution {
@@ -274,11 +274,11 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
         }
 
         .ol-attribution button span:empty::before {
-          content: var(--vaadin-map-icon-attribution-collapse, '▸');
+          content: var(--vaadin-map-icon-attribution-collapse, '\\25B8');
         }
 
         .ol-attribution.ol-collapsed button span:empty::before {
-          content: var(--vaadin-map-icon-attribution-expand, 'ℹ');
+          content: var(--vaadin-map-icon-attribution-expand, '\\2139');
         }
 
         .ol-attribution ul {
@@ -304,7 +304,7 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
         }
 
         .ol-compass:empty::before {
-          content: var(--vaadin-map-icon-compass, '↑');
+          content: var(--vaadin-map-icon-compass, '\\2191');
         }
 
         .ol-full-screen {
@@ -312,11 +312,11 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
         }
 
         .ol-full-screen button:empty::before {
-          content: var(--vaadin-map-icon-fullscreen, '⤢');
+          content: var(--vaadin-map-icon-fullscreen, '\\2922');
         }
 
         .ol-full-screen .ol-full-screen-true:empty::before {
-          content: var(--vaadin-map-icon-close, '×');
+          content: var(--vaadin-map-icon-close, '\\00D7');
         }
 
         .ol-overviewmap {
@@ -326,11 +326,11 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
         }
 
         .ol-overviewmap button span:empty::before {
-          content: var(--vaadin-map-icon-overview-map-collapse, '▾');
+          content: var(--vaadin-map-icon-overview-map-collapse, '\\25BE');
         }
 
         .ol-overviewmap.ol-collapsed button span:empty::before {
-          content: var(--vaadin-map-icon-overview-map-expand, '▴');
+          content: var(--vaadin-map-icon-overview-map-expand, '\\25B4');
         }
 
         .ol-overviewmap-map {


### PR DESCRIPTION
## Description

Part of #5453

The following icons are used:

- https://www.compart.com/en/unicode/U+2013
- https://www.compart.com/en/unicode/U+25B8
- https://www.compart.com/en/unicode/U+2139
- https://www.compart.com/en/unicode/U+2191
- https://www.compart.com/en/unicode/U+2922
- https://www.compart.com/en/unicode/U+00D7
- https://www.compart.com/en/unicode/U+25BE
- https://www.compart.com/en/unicode/U+25B4

## Type of change

- Refactor