### PR TITLE
refactor: replace user icon with corresponding Unicode entity

### DIFF
--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -111,7 +111,7 @@ class Avatar extends FocusMixin(ElementMixin(ThemableMixin(ControllerMixin(Polym
         preserveAspectRatio="xMidYMid meet"
         aria-hidden="true"
       >
-        <text dy=".35em" text-anchor="middle"></text>
+        <text dy=".35em" text-anchor="middle">&#xea01;</text>
       </svg>
       <svg
         part="abbr"


### PR DESCRIPTION
## Description

Part of #5453

Changed to use the [original approach](https://github.com/vaadin/vaadin-avatar/blob/63a6c7855be3c1f79ec9a1552577c1303829d46f/src/vaadin-avatar.html#L73) that was there before Polymer 3 conversion.

## Type of change

- Refactor