### PR TITLE
test: update selection tests to not use templates

### DIFF
--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -113,7 +113,7 @@ describe('selection', () => {
     });
   });
 
-  describe(`renderer cells`, () => {
+  describe('renderer cells', () => {
     beforeEach(() => {
       grid = fixtureSync(`
         <vaadin-grid style="width: 200px; height: 200px;" size="10">


### PR DESCRIPTION
## Description

Remove the use of `<template>` in the `<vaadin-grid>` `selection.test.js` tests.

## Type of change

Tests