### PR TITLE
fix: allow propagating enter key event after selecting value

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -782,7 +782,11 @@ export const ComboBoxMixin = (subclass) =>
       // Do not commit value when custom values are disallowed and input value is not a valid option
       // also stop propagation of the event, otherwise the user could submit a form while the input
       // still contains an invalid value
-      if (!this.allowCustomValue && this._inputElementValue !== '' && this._focusedIndex < 0) {
+      const hasInvalidOption =
+        this._focusedIndex < 0 &&
+        this._inputElementValue !== '' &&
+        this._getItemLabel(this.selectedItem) !== this._inputElementValue;
+      if (!this.allowCustomValue && hasInvalidOption) {
         // Do not submit the surrounding form.
         e.preventDefault();
         // Do not trigger global listeners

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -213,6 +213,43 @@ describe('keyboard', () => {
         expect(keydownSpy.called).to.be.false;
       });
 
+      it('should propagate keyboard enter event after entering an unknown option when custom values are allowed', () => {
+        comboBox.allowCustomValue = true;
+        setInputValue(comboBox, 'foobar');
+        enterKeyDown(input);
+
+        const keydownSpy = sinon.spy();
+        document.addEventListener('keydown', keydownSpy);
+        enterKeyDown(input);
+        expect(keydownSpy.called).to.be.true;
+      });
+
+      it('should propagate keyboard enter event if filtered items are cleared after selecting a valid option', () => {
+        setInputValue(comboBox, 'foo');
+        enterKeyDown(input);
+        // Simulate user or data provider mixin resetting filtered items after closing overlay
+        comboBox.filteredItems = [];
+        expect(comboBox._focusedIndex).to.equal(-1);
+
+        const keydownSpy = sinon.spy();
+        document.addEventListener('keydown', keydownSpy);
+        enterKeyDown(input);
+        expect(keydownSpy.called).to.be.true;
+      });
+
+      it('should propagate keyboard enter event after clearing the value', () => {
+        setInputValue(comboBox, 'foo');
+        enterKeyDown(input);
+
+        setInputValue(comboBox, '');
+        enterKeyDown(input);
+
+        const keydownSpy = sinon.spy();
+        document.addEventListener('keydown', keydownSpy);
+        enterKeyDown(input);
+        expect(keydownSpy.called).to.be.true;
+      });
+
       it('should not close the overlay with enter when custom values are not allowed', () => {
         setInputValue(comboBox, 'foobar');
 

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -164,6 +164,13 @@ describe('keyboard', () => {
   });
 
   describe('selecting items', () => {
+    const verifyEnterKeyPropagation = (allowPropagation) => {
+      const enterEvent = keyboardEventFor('keydown', 13, [], 'Enter');
+      const stopPropagationSpy = sinon.spy(enterEvent, 'stopPropagation');
+      input.dispatchEvent(enterEvent);
+      expect(stopPropagationSpy.called).to.equal(!allowPropagation);
+    };
+
     describe('auto-open', () => {
       beforeEach(async () => {
         comboBox.value = 'bar';
@@ -199,18 +206,13 @@ describe('keyboard', () => {
       });
 
       it('should stop propagation of the keyboard enter event when dropdown is opened', () => {
-        const keydownSpy = sinon.spy();
-        document.addEventListener('keydown', keydownSpy);
-        enterKeyDown(input);
-        expect(keydownSpy.called).to.be.false;
+        verifyEnterKeyPropagation(false);
       });
 
       it('should stop propagation of the keyboard enter event when input value is invalid', () => {
         setInputValue(comboBox, 'foobar');
-        const keydownSpy = sinon.spy();
-        document.addEventListener('keydown', keydownSpy);
-        enterKeyDown(input);
-        expect(keydownSpy.called).to.be.false;
+
+        verifyEnterKeyPropagation(false);
       });
 
       it('should propagate keyboard enter event after entering an unknown option when custom values are allowed', () => {
@@ -218,23 +220,17 @@ describe('keyboard', () => {
         setInputValue(comboBox, 'foobar');
         enterKeyDown(input);
 
-        const keydownSpy = sinon.spy();
-        document.addEventListener('keydown', keydownSpy);
-        enterKeyDown(input);
-        expect(keydownSpy.called).to.be.true;
+        verifyEnterKeyPropagation(true);
       });
 
-      it('should propagate keyboard enter event if filtered items are cleared after selecting a valid option', () => {
+      it('should propagate keyboard enter event if filtered items are cleared after selecting a predefined option', () => {
         setInputValue(comboBox, 'foo');
         enterKeyDown(input);
         // Simulate user or data provider mixin resetting filtered items after closing overlay
         comboBox.filteredItems = [];
         expect(comboBox._focusedIndex).to.equal(-1);
 
-        const keydownSpy = sinon.spy();
-        document.addEventListener('keydown', keydownSpy);
-        enterKeyDown(input);
-        expect(keydownSpy.called).to.be.true;
+        verifyEnterKeyPropagation(true);
       });
 
       it('should propagate keyboard enter event after clearing the value', () => {
@@ -244,10 +240,7 @@ describe('keyboard', () => {
         setInputValue(comboBox, '');
         enterKeyDown(input);
 
-        const keydownSpy = sinon.spy();
-        document.addEventListener('keydown', keydownSpy);
-        enterKeyDown(input);
-        expect(keydownSpy.called).to.be.true;
+        verifyEnterKeyPropagation(true);
       });
 
       it('should not close the overlay with enter when custom values are not allowed', () => {
@@ -436,37 +429,39 @@ describe('keyboard', () => {
 
       it('should stop propagation of the keyboard enter event when input value is invalid', () => {
         setInputValue(comboBox, 'foobar');
-        const keydownSpy = sinon.spy();
-        document.addEventListener('keydown', keydownSpy);
-        enterKeyDown(input);
-        expect(keydownSpy.called).to.be.false;
+
+        verifyEnterKeyPropagation(false);
       });
 
-      it('should not stop propagation of the keyboard enter event when input has a predefined option', () => {
+      it('should propagate the keyboard enter event when input has a predefined option', () => {
         setInputValue(comboBox, 'foo');
         expect(comboBox.opened).to.be.false;
-        const keydownSpy = sinon.spy();
-        document.addEventListener('keydown', keydownSpy);
-        enterKeyDown(input);
-        expect(keydownSpy.called).to.be.true;
+
+        verifyEnterKeyPropagation(true);
       });
 
-      it('should not stop propagation of the keyboard enter event when input has a custom value', () => {
+      it('should propagate keyboard enter event if filtered items are cleared after selecting a predefined option', () => {
+        setInputValue(comboBox, 'foo');
+        enterKeyDown(input);
+        // Simulate user or data provider mixin resetting filtered items after closing overlay
+        comboBox.filteredItems = [];
+        expect(comboBox._focusedIndex).to.equal(-1);
+
+        verifyEnterKeyPropagation(true);
+      });
+
+      it('should propagate the keyboard enter event when input has a custom value', () => {
         comboBox.allowCustomValue = true;
         setInputValue(comboBox, 'foobar');
-        const keydownSpy = sinon.spy();
-        document.addEventListener('keydown', keydownSpy);
-        enterKeyDown(input);
-        expect(keydownSpy.called).to.be.true;
+
+        verifyEnterKeyPropagation(true);
       });
 
-      it('should not stop propagation of the keyboard enter event when input is empty', () => {
+      it('should propagate the keyboard enter event when input is empty', () => {
         comboBox.allowCustomValue = true;
         setInputValue(comboBox, '');
-        const keydownSpy = sinon.spy();
-        document.addEventListener('keydown', keydownSpy);
-        enterKeyDown(input);
-        expect(keydownSpy.called).to.be.true;
+
+        verifyEnterKeyPropagation(true);
       });
     });
   });


### PR DESCRIPTION
## Description

Fixes propagation of enter keydown events after filtered items have been reset.

Fixes https://github.com/vaadin/flow-components/issues/3727

## Type of change

- Bugfix
