### PR TITLE
test: update dialog tests to not use templates

### DIFF
--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,31 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { esc, fixtureSync } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-dialog.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-
-customElements.define(
-  'x-dialog',
-  class XDialog extends PolymerElement {
-    static get template() {
-      return html`
-        <vaadin-dialog id="dialog">
-          <template>
-            <span>[[message]]</span>
-            <input value="{{text::input}}" />
-          </template>
-        </vaadin-dialog>
-      `;
-    }
-
-    static get properties() {
-      return {
-        message: String,
-        text: String,
-      };
-    }
-  },
-);
 
 describe('vaadin-dialog', () => {
   describe('custom element definition', () => {
@@ -63,12 +38,13 @@ describe('vaadin-dialog', () => {
 
     beforeEach(() => {
       dialog = fixtureSync(`
-        <vaadin-dialog opened theme="foo">
-          <template>
-            <div>Simple dialog</div>
-          </template>
-        </vaadin-dialog>
+        <vaadin-dialog opened theme="foo"></vaadin-dialog>
       `);
+
+      dialog.renderer = (root) => {
+        root.innerHTML = '<div>Simple dialog</div>';
+      };
+
       overlay = dialog.$.overlay;
       backdrop = overlay.$.backdrop;
     });
@@ -165,14 +141,14 @@ describe('vaadin-dialog', () => {
     });
   });
 
-  describe('without template', () => {
+  describe('without renderer', () => {
     let dialog;
 
     beforeEach(() => {
       dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
     });
 
-    it('should not throw an exception if template is not present', () => {
+    it('should not throw an exception if renderer is not present', () => {
       const openDialog = () => {
         dialog.opened = true;
       };
@@ -183,29 +159,6 @@ describe('vaadin-dialog', () => {
       dialog.opened = true;
       const contentMinWidth = parseFloat(getComputedStyle(dialog.$.overlay.$.content).minWidth);
       expect(contentMinWidth).to.be.gt(0);
-    });
-  });
-
-  describe('data binding', () => {
-    let container, dialog, overlay;
-
-    beforeEach(() => {
-      container = fixtureSync('<x-dialog></x-dialog>');
-      dialog = container.$.dialog;
-      overlay = dialog.$.overlay;
-      dialog.opened = true;
-    });
-
-    it('should bind parent property', () => {
-      container.message = 'foo';
-      expect(overlay.querySelector('span').textContent.trim()).to.equal('foo');
-    });
-
-    it('should support two-way data binding', () => {
-      const input = overlay.querySelector('input');
-      input.value = 'bar';
-      input.dispatchEvent(new CustomEvent('input'));
-      expect(container.text).to.equal('bar');
     });
   });
 });

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -11,9 +11,11 @@ customElements.define(
     constructor() {
       super();
       const root = this.attachShadow({ mode: 'open' });
-      root.innerHTML = `<div class="draggable">
-        <span>draggable</span>
-      </div>`;
+      root.innerHTML = `
+        <div class="draggable">
+          <span>draggable</span>
+        </div>
+      `;
     }
   },
 );

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -1,17 +1,17 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/text-area/vaadin-text-area.js';
 import './not-animated-styles.js';
 import '../src/vaadin-dialog.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 customElements.define(
   'internally-draggable',
-  class extends PolymerElement {
-    static get template() {
-      return html` <div class="draggable">
+  class extends HTMLElement {
+    constructor() {
+      super();
+      const root = this.attachShadow({ mode: 'open' });
+      root.innerHTML = `<div class="draggable">
         <span>draggable</span>
       </div>`;
     }
@@ -51,21 +51,20 @@ describe('helper methods', () => {
   beforeEach(() => {
     wrapper = fixtureSync(`
       <div>
-        <vaadin-dialog modeless draggable opened>
-          <template>
-            <div>Modeless dialog 1</div>
-          </template>
-        </vaadin-dialog>
-        <vaadin-dialog modeless draggable opened>
-          <template>
-            <div>Modeless dialog 2</div>
-          </template>
-        </vaadin-dialog>
+        <vaadin-dialog modeless draggable opened></vaadin-dialog>
+        <vaadin-dialog modeless draggable opened></vaadin-dialog>
       </div>
     `);
     dialogs = wrapper.children;
     dialog1 = dialogs[0];
+    dialog1.renderer = (root) => {
+      root.innerHTML = '<div>Modeless dialog 1</div>';
+    };
+
     dialog2 = dialogs[1];
+    dialog2.renderer = (root) => {
+      root.innerHTML = '<div>Modeless dialog 2</div>';
+    };
     overlay = dialog1.$.overlay;
     overlayPart = overlay.$.overlay;
     container = overlay.$.resizerContainer;
@@ -114,12 +113,11 @@ describe('resizable', () => {
 
   beforeEach(() => {
     dialog = fixtureSync(`
-      <vaadin-dialog resizable opened modeless>
-        <template>
-          <div>Resizable dialog</div>
-        </template>
-      </vaadin-dialog>
+      <vaadin-dialog resizable opened modeless></vaadin-dialog>
     `);
+    dialog.renderer = (root) => {
+      root.innerHTML = '<div>Resizable dialog</div>';
+    };
     overlayPart = dialog.$.overlay.$.overlay;
     bounds = overlayPart.getBoundingClientRect();
     dx = 30;
@@ -347,15 +345,17 @@ describe('draggable', () => {
 
   beforeEach(() => {
     dialog = fixtureSync(`
-      <vaadin-dialog draggable opened modeless>
-        <template>
-          <div>Draggable dialog</div>
-          <div class="draggable">Draggable area</div>
-          <internally-draggable></internally-draggable>
-          <button>OK</button>
-        </template>
-      </vaadin-dialog>
+      <vaadin-dialog draggable opened modeless></vaadin-dialog>
     `);
+    dialog.renderer = (root) => {
+      root.innerHTML = `
+        <div>Draggable dialog</div>
+        <div class="draggable">Draggable area</div>
+        <internally-draggable></internally-draggable>
+        <button>OK</button>
+      `;
+    };
+
     container = dialog.$.overlay.$.resizerContainer;
     content = dialog.$.overlay.$.content;
     button = dialog.$.overlay.querySelector('button');
@@ -596,22 +596,24 @@ describe('touch', () => {
 
   beforeEach(() => {
     resizable = fixtureSync(`
-      <vaadin-dialog resizable opened modeless>
-        <template>
-          <div>Resizable dialog</div>
-        </template>
-      </vaadin-dialog>
+      <vaadin-dialog resizable opened modeless></vaadin-dialog>
     `);
+    resizable.renderer = (root) => {
+      root.innerHTML = `<div>Resizable dialog</div>`;
+    };
+
     draggable = fixtureSync(`
-      <vaadin-dialog draggable opened modeless>
-        <template>
-          <div>Draggable dialog</div>
-          <div class="draggable">Draggable area</div>
-          <internally-draggable></internally-draggable>
-          <button>OK</button>
-        </template>
-      </vaadin-dialog>
+      <vaadin-dialog draggable opened modeless></vaadin-dialog>
     `);
+    draggable.renderer = (root) => {
+      root.innerHTML = `
+        <div>Draggable dialog</div>
+        <div class="draggable">Draggable area</div>
+        <internally-draggable></internally-draggable>
+        <button>OK</button>
+      `;
+    };
+
     resizableOverlay = resizable.$.overlay;
     draggableOverlay = draggable.$.overlay;
     resizableContainer = resizableOverlay.$.resizerContainer;
@@ -699,26 +701,24 @@ describe('touch', () => {
 });
 
 describe('bring to front', () => {
-  let wrapper, dialogs, modalDialog, modelessDialog;
+  let wrapper, modalDialog, modelessDialog;
 
   beforeEach(() => {
     wrapper = fixtureSync(`
       <div>
-        <vaadin-dialog id="modalDialog">
-          <template>
-            MODAL_DIALOG
-          </template>
-        </vaadin-dialog>
-        <vaadin-dialog id="modelessDialog" modeless>
-          <template>
-            MODELESS_DIALOG
-          </template>
-        </vaadin-dialog>
+        <vaadin-dialog id="modalDialog"></vaadin-dialog>
+        <vaadin-dialog id="modelessDialog" modeless></vaadin-dialog>
       </div>
     `);
-    dialogs = wrapper.children;
-    modalDialog = dialogs[0];
-    modelessDialog = dialogs[1];
+    [modalDialog, modelessDialog] = wrapper.children;
+
+    modalDialog.renderer = (root) => {
+      root.textContent = 'MODAL_DIALOG';
+    };
+
+    modelessDialog.renderer = (root) => {
+      root.textContent = 'MODELESS_DIALOG';
+    };
   });
 
   it('modal should not bring to front and close if a modeless dialog is on top', () => {
@@ -748,10 +748,9 @@ describe('overflowing content', () => {
 
   beforeEach(() => {
     dialog = fixtureSync(`
-      <vaadin-dialog resizable opened modeless>
-        <template></template>
-      </vaadin-dialog>
+      <vaadin-dialog resizable opened modeless></vaadin-dialog>
     `);
+
     overlay = dialog.$.overlay;
     overlayPart = overlay.$.overlay;
     container = overlay.$.resizerContainer;


### PR DESCRIPTION
## Description

Remove the use of `<template>` in the `<vaadin-dialog>` tests.

## Type of change

Tests