### PR TITLE
test: update notification tests to not use templates

### DIFF
--- a/packages/notification/test/animation.test.js
+++ b/packages/notification/test/animation.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -35,12 +34,8 @@ describe('animated notifications', () => {
   beforeEach(async () => {
     wrapper = fixtureSync(`
       <div>
-        <vaadin-notification position="bottom-center">
-          <template>Notification</template>
-        </vaadin-notification>
-        <vaadin-notification position="middle">
-          <template>Notification</template>
-        </vaadin-notification>
+        <vaadin-notification position="bottom-center"></vaadin-notification>
+        <vaadin-notification position="middle"></vaadin-notification>
       </div>
     `);
     notifications = Array.from(wrapper.children);
@@ -51,6 +46,9 @@ describe('animated notifications', () => {
     notifications.forEach((elm) => {
       elm.duration = duration;
       elm.opened = true;
+      elm.renderer = (root) => {
+        root.textContent = 'Notification';
+      };
     });
     await aTimeout(duration);
   });

--- a/packages/notification/test/multiple.test.js
+++ b/packages/notification/test/multiple.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -23,28 +22,34 @@ describe('multiple notification', () => {
   beforeEach(async () => {
     wrapper = fixtureSync(`
       <div>
-        <vaadin-notification opened position="top-stretch"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="top-start"><template>Notification 1</template></vaadin-notification>
-        <vaadin-notification opened position="top-center"><template>Notification 1</template></vaadin-notification>
-        <vaadin-notification opened position="top-end"><template>Notification 1</template></vaadin-notification>
-        <vaadin-notification opened position="middle"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="bottom-start"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="bottom-center"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="bottom-end"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="bottom-stretch"><template>Notification</template></vaadin-notification>
+        <vaadin-notification opened position="top-stretch"></vaadin-notification>
+        <vaadin-notification opened position="top-start" suffix=" 1"></vaadin-notification>
+        <vaadin-notification opened position="top-center" suffix=" 1"></vaadin-notification>
+        <vaadin-notification opened position="top-end" suffix=" 1"></vaadin-notification>
+        <vaadin-notification opened position="middle"></vaadin-notification>
+        <vaadin-notification opened position="bottom-start"></vaadin-notification>
+        <vaadin-notification opened position="bottom-center"></vaadin-notification>
+        <vaadin-notification opened position="bottom-end"></vaadin-notification>
+        <vaadin-notification opened position="bottom-stretch"></vaadin-notification>
 
-        <vaadin-notification opened position="top-stretch"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="top-start"><template>Notification 2</template></vaadin-notification>
-        <vaadin-notification opened position="top-center"><template>Notification 2</template></vaadin-notification>
-        <vaadin-notification opened position="top-end"><template>Notification 2</template></vaadin-notification>
-        <vaadin-notification opened position="middle"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="bottom-start"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="bottom-center"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="bottom-end"><template>Notification</template></vaadin-notification>
-        <vaadin-notification opened position="bottom-stretch"><template>Notification</template></vaadin-notification>
+        <vaadin-notification opened position="top-stretch"></vaadin-notification>
+        <vaadin-notification opened position="top-start" suffix=" 2"></vaadin-notification>
+        <vaadin-notification opened position="top-center" suffix=" 2"></vaadin-notification>
+        <vaadin-notification opened position="top-end" suffix=" 2"></vaadin-notification>
+        <vaadin-notification opened position="middle"></vaadin-notification>
+        <vaadin-notification opened position="bottom-start"></vaadin-notification>
+        <vaadin-notification opened position="bottom-center"></vaadin-notification>
+        <vaadin-notification opened position="bottom-end"></vaadin-notification>
+        <vaadin-notification opened position="bottom-stretch"></vaadin-notification>
       </div>
     `);
     notifications = Array.from(wrapper.children);
+    notifications.forEach((notification) => {
+      notification.renderer = (root) => {
+        root.textContent = `Notification${notification.getAttribute('suffix') || ''}`;
+      };
+    });
+
     container = notifications[0]._container;
     // Object.values is unsupported in old browsers
     regions = Array.from(container.shadowRoot.querySelectorAll('[region]'));

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, isIOS, listenOnce } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
 
 describe('vaadin-notification', () => {
@@ -9,12 +8,12 @@ describe('vaadin-notification', () => {
 
   beforeEach(() => {
     notification = fixtureSync(`
-      <vaadin-notification duration="20">
-        <template>
-          Your work has been <strong>saved</strong>
-        </template>
-      </vaadin-notification>
+      <vaadin-notification duration="20"></vaadin-notification>
     `);
+
+    notification.renderer = (root) => {
+      root.innerHTML = `Your work has been <strong>saved</strong>`;
+    };
 
     // Force sync card attaching and removal instead of waiting for the animation
     sinon.stub(notification, '_animatedAppendNotificationCard').callsFake(() => notification._appendNotificationCard());

--- a/packages/notification/test/renderer.test.js
+++ b/packages/notification/test/renderer.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-notification.js';
 
 describe('renderer', () => {


### PR DESCRIPTION
## Description

Remove the use of `<template>` in the `<vaadin-notification>` tests.

## Type of change

Tests