### PR TITLE
test: wait for animation frame to fix flaky ResizeMixin tests (#5347) (CP: 23.2)

### DIFF
--- a/packages/component-base/test/resize-mixin.test.js
+++ b/packages/component-base/test/resize-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ResizeMixin } from '../src/resize-mixin.js';
@@ -97,9 +97,12 @@ describe('resize-mixin', () => {
       describe('multiple children', () => {
         let sibling, spy1, spy2;
 
-        beforeEach(() => {
+        beforeEach(async () => {
           sibling = element.cloneNode(true);
           parent.appendChild(sibling);
+
+          await nextFrame();
+          await nextFrame();
 
           spy1 = sinon.spy(element, '_onResize');
           spy2 = sinon.spy(sibling, '_onResize');


### PR DESCRIPTION
## Description

Cherry-pick of #5347 to `23.2` branch - let's see if tests still fail in Chrome with this change.

## Type of change

- Tests