### PR TITLE
test: move template tests to integration

### DIFF
--- a/integration/tests/dialog-template.test.js
+++ b/integration/tests/dialog-template.test.js
@@ -1,0 +1,22 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '@vaadin/polymer-legacy-adapter/template-renderer.js';
+import '@vaadin/dialog';
+
+describe('vaadin-dialog template', () => {
+  let dialog, overlay;
+
+  beforeEach(() => {
+    dialog = fixtureSync(`
+        <vaadin-dialog>
+          <template>foo</template>
+        </vaadin-dialog>
+      `);
+    overlay = dialog.$.overlay;
+  });
+
+  it('should render the template', () => {
+    dialog.opened = true;
+    expect(overlay.textContent).to.equal('foo');
+  });
+});

--- a/integration/tests/dialog-template.test.js
+++ b/integration/tests/dialog-template.test.js
@@ -8,10 +8,10 @@ describe('vaadin-dialog template', () => {
 
   beforeEach(() => {
     dialog = fixtureSync(`
-        <vaadin-dialog>
-          <template>foo</template>
-        </vaadin-dialog>
-      `);
+      <vaadin-dialog>
+        <template>foo</template>
+      </vaadin-dialog>
+    `);
     overlay = dialog.$.overlay;
   });
 

--- a/integration/tests/grid-pro-edit-column-template.test.js
+++ b/integration/tests/grid-pro-edit-column-template.test.js
@@ -2,9 +2,9 @@ import { expect } from '@esm-bundle/chai';
 import { enter, esc, fixtureSync, space } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import '../vaadin-grid-pro.js';
-import '../vaadin-grid-pro-edit-column.js';
-import { createItems, dblclick, flushGrid, getCellEditor, getContainerCell } from './helpers.js';
+import '@vaadin/grid-pro/vaadin-grid-pro.js';
+import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
+import { createItems, dblclick, flushGrid, getCellEditor, getContainerCell } from '@vaadin/grid-pro/test/helpers.js';
 
 describe('edit column template', () => {
   describe('default', () => {

--- a/integration/tests/grid-templates.test.js
+++ b/integration/tests/grid-templates.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-bind.js';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/text-field/vaadin-text-field.js';
-import '../vaadin-grid.js';
+import '@vaadin/grid';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   flushGrid,
@@ -14,7 +14,7 @@ import {
   getContainerCellContent,
   getFirstCell,
   infiniteDataProvider,
-} from './helpers.js';
+} from '@vaadin/grid/test/helpers.js';
 
 class GridWithSlots extends PolymerElement {
   static get template() {

--- a/integration/tests/notification-template.test.js
+++ b/integration/tests/notification-template.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import '../vaadin-notification.js';
+import '@vaadin/notification';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class XNotification extends PolymerElement {

--- a/integration/tests/virtual-list-template.test.js
+++ b/integration/tests/virtual-list-template.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
-import '../vaadin-virtual-list.js';
+import '@vaadin/virtual-list';
 
 describe('template', () => {
   let list;

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/polymer-legacy-adapter": "24.0.0-beta1",
     "@vaadin/testing-helpers": "^0.4.0",
     "@vaadin/text-area": "24.0.0-beta1",
     "lit": "^2.0.0",

--- a/packages/dialog/test/renderer.test.js
+++ b/packages/dialog/test/renderer.test.js
@@ -1,75 +1,54 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-dialog.js';
 
 describe('vaadin-dialog renderer', () => {
-  describe('without template', () => {
-    let dialog, overlay;
+  let dialog, overlay;
 
-    beforeEach(() => {
-      dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
-      overlay = dialog.$.overlay;
-    });
-
-    it('should render the content of renderer function when renderer function provided', () => {
-      dialog.renderer = (root) => {
-        const div = document.createElement('div');
-        div.textContent = 'The content of the dialog';
-        root.appendChild(div);
-      };
-      dialog.opened = true;
-
-      expect(overlay.textContent).to.include('The content of the dialog');
-    });
-
-    it('should run renderers when requesting content update', () => {
-      dialog.renderer = sinon.spy();
-      dialog.opened = true;
-
-      expect(dialog.renderer.calledOnce).to.be.true;
-
-      dialog.requestContentUpdate();
-
-      expect(dialog.renderer.calledTwice).to.be.true;
-    });
-
-    it('should not throw when requesting content update for an unupgraded dialog', () => {
-      const dialog = document.createElement('vaadin-dialog');
-
-      expect(() => dialog.requestContentUpdate()).not.to.throw();
-    });
-
-    it('should clear the content when removing the renderer', () => {
-      dialog.renderer = (root) => {
-        root.innerHTML = 'foo';
-      };
-      dialog.opened = true;
-
-      expect(overlay.textContent).to.equal('foo');
-
-      dialog.renderer = null;
-
-      expect(overlay.textContent).to.equal('');
-    });
+  beforeEach(() => {
+    dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+    overlay = dialog.$.overlay;
   });
 
-  describe('with template', () => {
-    let dialog, overlay;
+  it('should render the content of renderer function when renderer function provided', () => {
+    dialog.renderer = (root) => {
+      const div = document.createElement('div');
+      div.textContent = 'The content of the dialog';
+      root.appendChild(div);
+    };
+    dialog.opened = true;
 
-    beforeEach(() => {
-      dialog = fixtureSync(`
-        <vaadin-dialog>
-          <template>foo</template>
-        </vaadin-dialog>
-      `);
-      overlay = dialog.$.overlay;
-    });
+    expect(overlay.textContent).to.include('The content of the dialog');
+  });
 
-    it('should render the template', () => {
-      dialog.opened = true;
-      expect(overlay.textContent).to.equal('foo');
-    });
+  it('should run renderers when requesting content update', () => {
+    dialog.renderer = sinon.spy();
+    dialog.opened = true;
+
+    expect(dialog.renderer.calledOnce).to.be.true;
+
+    dialog.requestContentUpdate();
+
+    expect(dialog.renderer.calledTwice).to.be.true;
+  });
+
+  it('should not throw when requesting content update for an unupgraded dialog', () => {
+    const dialog = document.createElement('vaadin-dialog');
+
+    expect(() => dialog.requestContentUpdate()).not.to.throw();
+  });
+
+  it('should clear the content when removing the renderer', () => {
+    dialog.renderer = (root) => {
+      root.innerHTML = 'foo';
+    };
+    dialog.opened = true;
+
+    expect(overlay.textContent).to.equal('foo');
+
+    dialog.renderer = null;
+
+    expect(overlay.textContent).to.equal('');
   });
 });

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/polymer-legacy-adapter": "24.0.0-beta1",
     "@vaadin/testing-helpers": "^0.4.0",
     "lit": "^2.0.0",
     "sinon": "^13.0.2"

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -56,7 +56,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/polymer-legacy-adapter": "24.0.0-beta1",
     "@vaadin/testing-helpers": "^0.4.0",
     "lit": "^2.0.0",
     "sinon": "^13.0.2"

--- a/packages/grid/test/visual/lumo/grid.test.js
+++ b/packages/grid/test/visual/lumo/grid.test.js
@@ -1,6 +1,5 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../../../theme/lumo/vaadin-grid.js';
 import '../../../theme/lumo/vaadin-grid-column-group.js';
 import '../../../theme/lumo/vaadin-grid-sorter.js';

--- a/packages/grid/test/visual/material/grid.test.js
+++ b/packages/grid/test/visual/material/grid.test.js
@@ -1,4 +1,3 @@
-import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../../../theme/material/vaadin-grid.js';
 import '../../../theme/material/vaadin-grid-column-group.js';
 import '../../../theme/material/vaadin-grid-sorter.js';

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -48,7 +48,6 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/button": "24.0.0-beta1",
-    "@vaadin/polymer-legacy-adapter": "24.0.0-beta1",
     "@vaadin/testing-helpers": "^0.4.0",
     "sinon": "^13.0.2"
   },

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/polymer-legacy-adapter": "24.0.0-beta1",
     "@vaadin/testing-helpers": "^0.4.0",
     "lit": "^2.0.0",
     "sinon": "^13.0.2"


### PR DESCRIPTION
## Description

- Move the remaining `<template>` API tests from the component packages to `integration`.
- Remove the dependency on `polymer-legacy-adapter` from the component packages

## Type of change

Tests