### PR TITLE
refactor: rename __clear() to _onClearAction()

### DIFF
--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -149,7 +149,7 @@ export const InputControlMixin = (superclass) =>
     _onClearButtonClick(event) {
       event.preventDefault();
       this.inputElement.focus();
-      this.__onClearOriginatedFromUser();
+      this._onClearAction();
     }
 
     /**
@@ -179,7 +179,7 @@ export const InputControlMixin = (superclass) =>
 
       if (this.clearButtonVisible && !!this.value) {
         event.stopPropagation();
-        this.__onClearOriginatedFromUser();
+        this._onClearAction();
       }
     }
 
@@ -207,8 +207,8 @@ export const InputControlMixin = (superclass) =>
       );
     }
 
-    /** @private */
-    __onClearOriginatedFromUser() {
+    /** @protected */
+    _onClearAction() {
       this.clear();
       this.inputElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
       this.inputElement.dispatchEvent(new Event('change', { bubbles: true }));

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -149,7 +149,7 @@ export const InputControlMixin = (superclass) =>
     _onClearButtonClick(event) {
       event.preventDefault();
       this.inputElement.focus();
-      this.__clear();
+      this.__onClearOriginatedFromUser();
     }
 
     /**
@@ -179,7 +179,7 @@ export const InputControlMixin = (superclass) =>
 
       if (this.clearButtonVisible && !!this.value) {
         event.stopPropagation();
-        this.__clear();
+        this.__onClearOriginatedFromUser();
       }
     }
 
@@ -208,7 +208,7 @@ export const InputControlMixin = (superclass) =>
     }
 
     /** @private */
-    __clear() {
+    __onClearOriginatedFromUser() {
       this.clear();
       this.inputElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
       this.inputElement.dispatchEvent(new Event('change', { bubbles: true }));


### PR DESCRIPTION
## Description

The current `InputFieldMixin.__clear()` method is easy to confuse with `InputMixin.clear()` and vice versa. The difference is that the `__clear()` method calls `clear()` but also dispatches input and change events. I believe it is better to name it something like `_onClearAction()` and make it protected so we can re-use it later in other components as well.

## Type of change

- [x] Refactor
