### PR TITLE
fix: do not check for extending Item when setting ARIA attribute

### DIFF
--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -21,10 +21,7 @@ snapshots["context-menu items"] =
     >
       Menu Item 1
     </vaadin-context-menu-item>
-    <hr
-      aria-haspopup="false"
-      role="separator"
-    >
+    <hr role="separator">
     <vaadin-context-menu-item
       aria-expanded="false"
       aria-haspopup="true"
@@ -111,10 +108,7 @@ snapshots["context-menu items overlay class"] =
     >
       Menu Item 1
     </vaadin-context-menu-item>
-    <hr
-      aria-haspopup="false"
-      role="separator"
-    >
+    <hr role="separator">
     <vaadin-context-menu-item
       aria-expanded="false"
       aria-haspopup="true"

--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -12,7 +12,7 @@ export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') 
 }
 
 export function getMenuItems(menu) {
-  return [...menu.$.overlay.querySelectorAll('[aria-haspopup]')];
+  return [...menu.$.overlay.querySelectorAll('[role="menu"] > :not([role="separator]"')];
 }
 
 export function getSubMenu(menu) {


### PR DESCRIPTION
## Description

As we no longer use extensions of `vaadin-item` in V24, this logic has to be adjusted accordingly.
Also, setting `aria-expanded` attribute only makes sense for elements with `role="menuitem"`.

## Type of change

- Refactor