### PR TITLE
refactor: extract clear button related logic to ClearButtonMixin

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -11,6 +11,7 @@ import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
@@ -238,6 +239,7 @@ interface ComboBox<TItem = ComboBoxDefaultItem>
     KeyboardMixinClass,
     OverlayClassMixinClass,
     InputMixinClass,
+    ClearButtonMixinClass,
     InputControlMixinClass,
     InputConstraintsMixinClass,
     FocusMixinClass,

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -7,6 +7,7 @@ import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
@@ -142,6 +143,7 @@ assertType<FieldMixinClass>(narrowedComboBox);
 assertType<FocusMixinClass>(narrowedComboBox);
 assertType<InputConstraintsMixinClass>(narrowedComboBox);
 assertType<InputControlMixinClass>(narrowedComboBox);
+assertType<ClearButtonMixinClass>(narrowedComboBox);
 assertType<InputMixinClass>(narrowedComboBox);
 assertType<KeyboardMixinClass>(narrowedComboBox);
 assertType<OverlayClassMixinClass>(narrowedComboBox);

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -6,6 +6,7 @@ import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
@@ -96,6 +97,7 @@ assertType<KeyboardMixinClass>(datePicker);
 assertType<DelegateFocusMixinClass>(datePicker);
 assertType<LabelMixinClass>(datePicker);
 assertType<InputConstraintsMixinClass>(datePicker);
+assertType<ClearButtonMixinClass>(datePicker);
 assertType<InputControlMixinClass>(datePicker);
 assertType<InputMixinClass>(datePicker);
 assertType<ValidateMixinClass>(datePicker);

--- a/packages/field-base/src/clear-button-mixin.d.ts
+++ b/packages/field-base/src/clear-button-mixin.d.ts
@@ -19,7 +19,18 @@ export declare class ClearButtonMixinClass {
   /**
    * Set to true to display the clear icon which clears the input.
    *
+   * It is up to the component to choose where to place the clear icon:
+   * in the Shadow DOM or in the light DOM. In any way, a reference to
+   * the clear icon element should be provided via the `clearElement` getter.
+   *
    * @attr {boolean} clear-button-visible
    */
   clearButtonVisible: boolean;
+
+  /**
+   * Clears the value and dispatches `input` and `change` events
+   * on the input element. This method should be called
+   * when the clear action originates from the user.
+   */
+  protected _onClearAction(): void;
 }

--- a/packages/field-base/src/clear-button-mixin.d.ts
+++ b/packages/field-base/src/clear-button-mixin.d.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { InputMixinClass } from './input-mixin.js';
+
+/**
+ * A mixin that manages the clear button.
+ */
+export declare function ClearButtonMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<ClearButtonMixinClass> & Constructor<InputMixinClass> & Constructor<KeyboardMixinClass> & T;
+
+export declare class ClearButtonMixinClass {
+  /**
+   * Set to true to display the clear icon which clears the input.
+   *
+   * @attr {boolean} clear-button-visible
+   */
+  clearButtonVisible: boolean;
+}

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
+import { InputMixin } from './input-mixin.js';
+
+/**
+ * A mixin that manages the clear button.
+ *
+ * @polymerMixin
+ * @mixes InputMixin
+ * @mixes KeyboardMixin
+ */
+export const ClearButtonMixin = (superclass) =>
+  class ClearButtonMixinClass extends InputMixin(KeyboardMixin(superclass)) {
+    static get properties() {
+      return {
+        /**
+         * Set to true to display the clear icon which clears the input.
+         *
+         * @attr {boolean} clear-button-visible
+         */
+        clearButtonVisible: {
+          type: Boolean,
+          reflectToAttribute: true,
+          value: false,
+        },
+      };
+    }
+
+    /**
+     * Any element extending this mixin is required to implement this getter.
+     * It returns the reference to the clear button element.
+     *
+     * @protected
+     * @return {Element | null | undefined}
+     */
+    get clearElement() {
+      console.warn(`Please implement the 'clearElement' property in <${this.localName}>`);
+      return null;
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      if (this.clearElement) {
+        this.clearElement.addEventListener('click', (event) => this._onClearButtonClick(event));
+      }
+    }
+
+    /**
+     * @param {Event} event
+     * @protected
+     */
+    _onClearButtonClick(event) {
+      event.preventDefault();
+      this.inputElement.focus();
+      this._onClearAction();
+    }
+
+    /**
+     * Override an event listener inherited from `KeydownMixin` to clear on Esc.
+     * Components that extend this mixin can prevent this behavior by overriding
+     * this method without calling `super._onEscape` to provide custom logic.
+     *
+     * @param {KeyboardEvent} event
+     * @protected
+     * @override
+     */
+    _onEscape(event) {
+      super._onEscape(event);
+
+      if (this.clearButtonVisible && !!this.value) {
+        event.stopPropagation();
+        this._onClearAction();
+      }
+    }
+
+    /** @protected */
+    _onClearAction() {
+      this.clear();
+      this.inputElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+      this.inputElement.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  };

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -92,6 +92,8 @@ export const ClearButtonMixin = (superclass) =>
      */
     _onClearAction() {
       this.clear();
+      // Note, according to the HTML spec, the native change event isn't composed
+      // while the input event is composed.
       this.inputElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
       this.inputElement.dispatchEvent(new Event('change', { bubbles: true }));
     }

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -20,6 +20,10 @@ export const ClearButtonMixin = (superclass) =>
         /**
          * Set to true to display the clear icon which clears the input.
          *
+         * It is up to the component to choose where to place the clear icon:
+         * in the Shadow DOM or in the light DOM. In any way, a reference to
+         * the clear icon element should be provided via the `clearElement` getter.
+         *
          * @attr {boolean} clear-button-visible
          */
         clearButtonVisible: {
@@ -79,7 +83,13 @@ export const ClearButtonMixin = (superclass) =>
       }
     }
 
-    /** @protected */
+    /**
+     * Clears the value and dispatches `input` and `change` events
+     * on the input element. This method should be called
+     * when the clear action originates from the user.
+     *
+     * @protected
+     */
     _onClearAction() {
       this.clear();
       this.inputElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));

--- a/packages/field-base/src/input-control-mixin.d.ts
+++ b/packages/field-base/src/input-control-mixin.d.ts
@@ -10,6 +10,7 @@ import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegat
 import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { ClearButtonMixinClass } from './clear-button-mixin.js';
 import type { FieldMixinClass } from './field-mixin.js';
 import type { InputConstraintsMixinClass } from './input-constraints-mixin.js';
 import type { InputMixinClass } from './input-mixin.js';
@@ -22,7 +23,8 @@ import type { ValidateMixinClass } from './validate-mixin.js';
  */
 export declare function InputControlMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<ControllerMixinClass> &
+): Constructor<ClearButtonMixinClass> &
+  Constructor<ControllerMixinClass> &
   Constructor<DelegateFocusMixinClass> &
   Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &
@@ -56,12 +58,6 @@ export declare class InputControlMixinClass {
    * If true, the input text gets fully selected when the field is focused using click or touch / tap.
    */
   autoselect: boolean;
-
-  /**
-   * Set to true to display the clear icon which clears the input.
-   * @attr {boolean} clear-button-visible
-   */
-  clearButtonVisible: boolean;
 
   /**
    * The name of this field.

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -7,6 +7,7 @@ import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { DelegateFocusMixin } from '@vaadin/component-base/src/delegate-focus-mixin.js';
 import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
+import { ClearButtonMixin } from './clear-button-mixin.js';
 import { FieldMixin } from './field-mixin.js';
 import { InputConstraintsMixin } from './input-constraints-mixin.js';
 import { SlotStylesMixin } from './slot-styles-mixin.js';
@@ -19,11 +20,12 @@ import { SlotStylesMixin } from './slot-styles-mixin.js';
  * @mixes FieldMixin
  * @mixes InputConstraintsMixin
  * @mixes KeyboardMixin
+ * @mixes ClearButtonMixin
  * @mixes SlotStylesMixin
  */
 export const InputControlMixin = (superclass) =>
   class InputControlMixinClass extends SlotStylesMixin(
-    DelegateFocusMixin(InputConstraintsMixin(FieldMixin(KeyboardMixin(superclass)))),
+    DelegateFocusMixin(InputConstraintsMixin(FieldMixin(ClearButtonMixin(KeyboardMixin(superclass))))),
   ) {
     static get properties() {
       return {
@@ -49,16 +51,6 @@ export const InputControlMixin = (superclass) =>
          */
         autoselect: {
           type: Boolean,
-          value: false,
-        },
-
-        /**
-         * Set to true to display the clear icon which clears the input.
-         * @attr {boolean} clear-button-visible
-         */
-        clearButtonVisible: {
-          type: Boolean,
-          reflectToAttribute: true,
           value: false,
         },
 
@@ -109,17 +101,6 @@ export const InputControlMixin = (superclass) =>
       this._boundOnBeforeInput = this._onBeforeInput.bind(this);
     }
 
-    /**
-     * Any element extending this mixin is required to implement this getter.
-     * It returns the reference to the clear button element.
-     * @protected
-     * @return {Element | null | undefined}
-     */
-    get clearElement() {
-      console.warn(`Please implement the 'clearElement' property in <${this.localName}>`);
-      return null;
-    }
-
     /** @protected */
     get slotStyles() {
       // Needed for Safari, where ::slotted(...)::placeholder does not work
@@ -133,25 +114,6 @@ export const InputControlMixin = (superclass) =>
       ];
     }
 
-    /** @protected */
-    ready() {
-      super.ready();
-
-      if (this.clearElement) {
-        this.clearElement.addEventListener('click', (e) => this._onClearButtonClick(e));
-      }
-    }
-
-    /**
-     * @param {Event} event
-     * @protected
-     */
-    _onClearButtonClick(event) {
-      event.preventDefault();
-      this.inputElement.focus();
-      this._onClearAction();
-    }
-
     /**
      * Override an event listener from `DelegateFocusMixin`.
      * @param {FocusEvent} event
@@ -163,23 +125,6 @@ export const InputControlMixin = (superclass) =>
 
       if (this.autoselect && this.inputElement) {
         this.inputElement.select();
-      }
-    }
-
-    /**
-     * Override an event listener inherited from `KeydownMixin` to clear on Esc.
-     * Components that extend this mixin can prevent this behavior by overriding
-     * this method without calling `super._onEscape` to provide custom logic.
-     * @param {KeyboardEvent} event
-     * @protected
-     * @override
-     */
-    _onEscape(event) {
-      super._onEscape(event);
-
-      if (this.clearButtonVisible && !!this.value) {
-        event.stopPropagation();
-        this._onClearAction();
       }
     }
 
@@ -205,13 +150,6 @@ export const InputControlMixin = (superclass) =>
           cancelable: event.cancelable,
         }),
       );
-    }
-
-    /** @protected */
-    _onClearAction() {
-      this.clear();
-      this.inputElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
-      this.inputElement.dispatchEvent(new Event('change', { bubbles: true }));
     }
 
     /**

--- a/packages/field-base/src/input-field-mixin.d.ts
+++ b/packages/field-base/src/input-field-mixin.d.ts
@@ -10,6 +10,7 @@ import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegat
 import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { ClearButtonMixinClass } from './clear-button-mixin.js';
 import type { FieldMixinClass } from './field-mixin.js';
 import type { InputConstraintsMixinClass } from './input-constraints-mixin.js';
 import type { InputControlMixinClass } from './input-control-mixin.js';
@@ -23,7 +24,8 @@ import type { ValidateMixinClass } from './validate-mixin.js';
  */
 export declare function InputFieldMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<ControllerMixinClass> &
+): Constructor<ClearButtonMixinClass> &
+  Constructor<ControllerMixinClass> &
   Constructor<DelegateFocusMixinClass> &
   Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -1,0 +1,162 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  defineLit,
+  definePolymer,
+  escKeyDown,
+  fixtureSync,
+  keyboardEventFor,
+  keyDownOn,
+  nextFrame,
+  nextRender,
+} from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ClearButtonMixin } from '../src/clear-button-mixin.js';
+import { InputController } from '../src/input-controller.js';
+
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'clear-button-mixin',
+    `
+      <slot name="input"></slot>
+      <button id="clearButton">Clear</button>
+    `,
+    (Base) =>
+      class extends ClearButtonMixin(baseMixin(Base)) {
+        get clearElement() {
+          return this.$.clearButton;
+        }
+
+        ready() {
+          super.ready();
+
+          this.addController(
+            new InputController(this, (input) => {
+              this._setInputElement(input);
+            }),
+          );
+        }
+      },
+  );
+
+  let element, input, button;
+
+  beforeEach(async () => {
+    element = fixtureSync(`<${tag} value="foo"></${tag}>`);
+    await nextRender();
+    input = element.querySelector('[slot=input]');
+    button = element.clearElement;
+  });
+
+  it('should clear the field value on clear button click', async () => {
+    button.click();
+    await nextFrame();
+    expect(element.value).to.equal('');
+  });
+
+  it('should clear the input value on clear button click', async () => {
+    button.click();
+    await nextFrame();
+    expect(input.value).to.equal('');
+  });
+
+  it('should focus the input on clear button click', () => {
+    const spy = sinon.spy(input, 'focus');
+    button.click();
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should dispatch input event on clear button click', () => {
+    const spy = sinon.spy();
+    input.addEventListener('input', spy);
+    button.click();
+    expect(spy.calledOnce).to.be.true;
+    const event = spy.firstCall.args[0];
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.true;
+  });
+
+  it('should dispatch change event on clear button click', () => {
+    const spy = sinon.spy();
+    element.addEventListener('change', spy);
+    button.click();
+    expect(spy.calledOnce).to.be.true;
+    const event = spy.firstCall.args[0];
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.false;
+  });
+
+  it('should call preventDefault on the button click event', () => {
+    const event = new CustomEvent('click', { cancelable: true });
+    button.dispatchEvent(event);
+    expect(event.defaultPrevented).to.be.true;
+  });
+
+  it('should reflect clearButtonVisible property to attribute', async () => {
+    element.clearButtonVisible = true;
+    await nextFrame();
+    expect(element.hasAttribute('clear-button-visible')).to.be.true;
+
+    element.clearButtonVisible = false;
+    await nextFrame();
+    expect(element.hasAttribute('clear-button-visible')).to.be.false;
+  });
+
+  it('should clear value on Esc when clearButtonVisible is true', async () => {
+    element.clearButtonVisible = true;
+    escKeyDown(button);
+    await nextFrame();
+    expect(input.value).to.equal('');
+  });
+
+  it('should not clear value on Esc when clearButtonVisible is false', () => {
+    escKeyDown(button);
+    expect(input.value).to.equal('foo');
+  });
+
+  it('should dispatch input event when clearing value on Esc', () => {
+    const spy = sinon.spy();
+    input.addEventListener('input', spy);
+    element.clearButtonVisible = true;
+    escKeyDown(button);
+    expect(spy.calledOnce).to.be.true;
+    const event = spy.firstCall.args[0];
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.true;
+  });
+
+  it('should dispatch change event when clearing value on Esc', () => {
+    const spy = sinon.spy();
+    input.addEventListener('change', spy);
+    element.clearButtonVisible = true;
+    escKeyDown(button);
+    expect(spy.calledOnce).to.be.true;
+    const event = spy.firstCall.args[0];
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.false;
+  });
+
+  it('should call stopPropagation() on Esc when clearButtonVisible is true', () => {
+    element.clearButtonVisible = true;
+    const event = keyboardEventFor('keydown', 27, [], 'Escape');
+    const spy = sinon.spy(event, 'stopPropagation');
+    button.dispatchEvent(event);
+    expect(spy.called).to.be.true;
+  });
+
+  it('should not call stopPropagation() on Esc when clearButtonVisible is false', () => {
+    const event = keyboardEventFor('keydown', 27, [], 'Escape');
+    const spy = sinon.spy(event, 'stopPropagation');
+    button.dispatchEvent(event);
+    expect(spy.called).to.be.false;
+  });
+};
+
+describe('ClearButtonMixin + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('ClearButtonMixin + Lit', () => {
+  runTests(defineLit, PolylitMixin);
+});

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -16,6 +16,7 @@ import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
@@ -339,6 +340,7 @@ interface MultiSelectComboBox
     SlotStylesMixinClass,
     LabelMixinClass,
     KeyboardMixinClass,
+    ClearButtonMixinClass,
     Omit<InputMixinClass, 'value'>,
     InputControlMixinClass,
     InputConstraintsMixinClass,

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -10,6 +10,7 @@ import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mix
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
@@ -108,6 +109,7 @@ assertType<FieldMixinClass>(narrowedComboBox);
 assertType<FocusMixinClass>(narrowedComboBox);
 assertType<InputConstraintsMixinClass>(narrowedComboBox);
 assertType<InputControlMixinClass>(narrowedComboBox);
+assertType<ClearButtonMixinClass>(narrowedComboBox);
 assertType<Omit<InputMixinClass, 'value'>>(narrowedComboBox);
 assertType<KeyboardMixinClass>(narrowedComboBox);
 assertType<LabelMixinClass>(narrowedComboBox);

--- a/packages/time-picker/test/typings/time-picker.types.ts
+++ b/packages/time-picker/test/typings/time-picker.types.ts
@@ -6,6 +6,7 @@ import type {
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
 import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
@@ -28,6 +29,7 @@ const timePicker = document.createElement('vaadin-time-picker');
 assertType<ControllerMixinClass>(timePicker);
 assertType<ElementMixinClass>(timePicker);
 assertType<InputControlMixinClass>(timePicker);
+assertType<ClearButtonMixinClass>(timePicker);
 assertType<PatternMixinClass>(timePicker);
 assertType<ValidateMixinClass>(timePicker);
 assertType<ThemableMixinClass>(timePicker);


### PR DESCRIPTION
## Description

The PR extracts the clear button logic from `InputControlMixin` into a `ClearButtonMixin` for the sake of separation of concerns.

> **Note**
> It seems we had such a mixin in the past but we apparently removed it due to a Firefox memory issue. Let's hope we don't run into it again.

## Type of change

- [x] Feature
