### PR TITLE
refactor: remove a unnecessary clear() method override

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -153,20 +153,6 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
-   * Override method from `InputMixin`.
-   *
-   * @protected
-   * @override
-   */
-  clear() {
-    super.clear();
-
-    if (this.inputElement) {
-      this.inputElement.value = '';
-    }
-  }
-
-  /**
    * Override Enter handler to keep overlay open
    * when item is selected or unselected.
    * @param {!Event} event


### PR DESCRIPTION
## Description

The `clear()` method override is unnecessary. The original `InputMixin.clear()` method already clears the input element's value. It is apparently a leftover from some early refactorings.

## Type of change

- [x] Refactor
