### PR TITLE
refactor: extract text-area logic to reusable TextAreaMixin

### DIFF
--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -34,6 +34,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "24.0.0-beta1",
     "@vaadin/field-base": "24.0.0-beta1",

--- a/packages/text-area/src/vaadin-text-area-mixin.d.ts
+++ b/packages/text-area/src/vaadin-text-area-mixin.d.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { DelegateFocusMixinClass } from '@vaadin/component-base/src/delegate-focus-mixin.js';
+import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/component-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/component-base/src/focus-mixin.js';
+import type { KeyboardMixinClass } from '@vaadin/component-base/src/keyboard-mixin.js';
+import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
+import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
+import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
+import type { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
+import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
+import type { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+
+/**
+ * A mixin providing common text area functionality.
+ */
+export declare function TextAreaMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<ControllerMixinClass> &
+  Constructor<DelegateFocusMixinClass> &
+  Constructor<DelegateStateMixinClass> &
+  Constructor<DisabledMixinClass> &
+  Constructor<FieldMixinClass> &
+  Constructor<FocusMixinClass> &
+  Constructor<InputConstraintsMixinClass> &
+  Constructor<InputControlMixinClass> &
+  Constructor<InputFieldMixinClass> &
+  Constructor<InputMixinClass> &
+  Constructor<KeyboardMixinClass> &
+  Constructor<LabelMixinClass> &
+  Constructor<ResizeMixinClass> &
+  Constructor<SlotStylesMixinClass> &
+  Constructor<TextAreaMixinClass> &
+  Constructor<ValidateMixinClass> &
+  T;
+
+export declare class TextAreaMixinClass {
+  /**
+   * Maximum number of characters (in Unicode code points) that the user can enter.
+   */
+  maxlength: number | null | undefined;
+
+  /**
+   * Minimum number of characters (in Unicode code points) that the user can enter.
+   */
+  minlength: number | null | undefined;
+
+  /**
+   * A regular expression that the value is checked against.
+   * The pattern must match the entire value, not just some subset.
+   */
+  pattern: string;
+}

--- a/packages/text-area/src/vaadin-text-area-mixin.js
+++ b/packages/text-area/src/vaadin-text-area-mixin.js
@@ -1,0 +1,207 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
+import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
+import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
+import { TextAreaController } from '@vaadin/field-base/src/text-area-controller.js';
+
+/**
+ * A mixin providing common text area functionality.
+ *
+ * @polymerMixin
+ * @mixes InputFieldMixin
+ * @mixes ResizeMixin
+ */
+export const TextAreaMixin = (superClass) =>
+  class TextAreaMixinClass extends ResizeMixin(InputFieldMixin(superClass)) {
+    static get properties() {
+      return {
+        /**
+         * Maximum number of characters (in Unicode code points) that the user can enter.
+         */
+        maxlength: {
+          type: Number,
+        },
+
+        /**
+         * Minimum number of characters (in Unicode code points) that the user can enter.
+         */
+        minlength: {
+          type: Number,
+        },
+
+        /**
+         * A regular expression that the value is checked against.
+         * The pattern must match the entire value, not just some subset.
+         */
+        pattern: {
+          type: String,
+        },
+      };
+    }
+
+    static get delegateAttrs() {
+      return [...super.delegateAttrs, 'maxlength', 'minlength', 'pattern'];
+    }
+
+    static get constraints() {
+      return [...super.constraints, 'maxlength', 'minlength', 'pattern'];
+    }
+
+    /**
+     * Used by `InputControlMixin` as a reference to the clear button element.
+     * @protected
+     */
+    get clearElement() {
+      return this.$.clearButton;
+    }
+
+    /**
+     * @protected
+     * @override
+     */
+    _onResize() {
+      this.__scrollPositionUpdated();
+    }
+
+    /** @protected */
+    _onScroll() {
+      this.__scrollPositionUpdated();
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.addController(
+        new TextAreaController(this, (input) => {
+          this._setInputElement(input);
+          this._setFocusElement(input);
+          this.stateTarget = input;
+          this.ariaTarget = input;
+        }),
+      );
+      this.addController(new LabelledInputController(this.inputElement, this._labelController));
+
+      this.addEventListener('animationend', this._onAnimationEnd);
+
+      this._inputField = this.shadowRoot.querySelector('[part=input-field]');
+
+      // Wheel scrolling results in async scroll events. Preventing the wheel
+      // event, scrolling manually and then synchronously updating the scroll position CSS variable
+      // allows us to avoid some jumpy behavior that would occur on wheel otherwise.
+      this._inputField.addEventListener('wheel', (e) => {
+        const scrollTopBefore = this._inputField.scrollTop;
+        this._inputField.scrollTop += e.deltaY;
+
+        if (scrollTopBefore !== this._inputField.scrollTop) {
+          e.preventDefault();
+          this.__scrollPositionUpdated();
+        }
+      });
+
+      this._updateHeight();
+      this.__scrollPositionUpdated();
+    }
+
+    /** @private */
+    __scrollPositionUpdated() {
+      this._inputField.style.setProperty('--_text-area-vertical-scroll-position', '0px');
+      this._inputField.style.setProperty('--_text-area-vertical-scroll-position', `${this._inputField.scrollTop}px`);
+    }
+
+    /** @private */
+    _onAnimationEnd(e) {
+      if (e.animationName.indexOf('vaadin-text-area-appear') === 0) {
+        this._updateHeight();
+      }
+    }
+
+    /**
+     * @param {unknown} newVal
+     * @param {unknown} oldVal
+     * @protected
+     * @override
+     */
+    _valueChanged(newVal, oldVal) {
+      super._valueChanged(newVal, oldVal);
+
+      this._updateHeight();
+    }
+
+    /** @private */
+    _updateHeight() {
+      const input = this.inputElement;
+      const inputField = this._inputField;
+
+      if (!input || !inputField) {
+        return;
+      }
+
+      const scrollTop = inputField.scrollTop;
+
+      // Only clear the height when the content shortens to minimize scrollbar flickering.
+      const valueLength = this.value ? this.value.length : 0;
+
+      if (this._oldValueLength >= valueLength) {
+        const inputFieldHeight = getComputedStyle(inputField).height;
+        const inputWidth = getComputedStyle(input).width;
+
+        // Temporarily fix the height of the wrapping input field container to prevent changing the browsers scroll
+        // position while resetting the textareas height. If the textarea had a large height, then removing its height
+        // will reset its height to the default of two rows. That might reduce the height of the page, and the
+        // browser might adjust the scroll position before we can restore the measured height of the textarea.
+        inputField.style.display = 'block';
+        inputField.style.height = inputFieldHeight;
+
+        // Fix the input element width so its scroll height isn't affected by host's disappearing scrollbars
+        input.style.maxWidth = inputWidth;
+
+        // Clear the height of the textarea to allow measuring a reduced scroll height
+        input.style.height = 'auto';
+      }
+      this._oldValueLength = valueLength;
+
+      const inputHeight = input.scrollHeight;
+      if (inputHeight > input.clientHeight) {
+        input.style.height = `${inputHeight}px`;
+      }
+
+      // Restore
+      input.style.removeProperty('max-width');
+      inputField.style.removeProperty('display');
+      inputField.style.removeProperty('height');
+      inputField.scrollTop = scrollTop;
+    }
+
+    /**
+     * Returns true if the current textarea value satisfies all constraints (if any).
+     * @return {boolean}
+     * @override
+     */
+    checkValidity() {
+      if (!super.checkValidity()) {
+        return false;
+      }
+
+      // Native <textarea> does not support pattern attribute, so we have a custom logic
+      // according to WHATWG spec for <input>, with tests inspired by web-platform-tests
+      // https://html.spec.whatwg.org/multipage/input.html#the-pattern-attribute
+
+      if (!this.pattern || !this.inputElement.value) {
+        // Mark as valid if there is no pattern, or the value is empty
+        return true;
+      }
+
+      try {
+        const match = this.inputElement.value.match(this.pattern);
+        return match ? match[0] === match.input : false;
+      } catch (_) {
+        // If the pattern can not be compiled, then report as valid
+        return true;
+      }
+    }
+  };

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -4,10 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
-import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
-import { PatternMixin } from '@vaadin/field-base/src/pattern-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { TextAreaMixin } from './vaadin-text-area-mixin.js';
 
 /**
  * Fired when the user commits a value change.
@@ -85,17 +83,7 @@ export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEve
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
-declare class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableMixin(ElementMixin(HTMLElement))))) {
-  /**
-   * Maximum number of characters (in Unicode code points) that the user can enter.
-   */
-  maxlength: number | null | undefined;
-
-  /**
-   * Minimum number of characters (in Unicode code points) that the user can enter.
-   */
-  minlength: number | null | undefined;
-
+declare class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   addEventListener<K extends keyof TextAreaEventMap>(
     type: K,
     listener: (this: TextArea, ev: TextAreaEventMap[K]) => void,

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -6,14 +6,10 @@
 import '@vaadin/input-container/src/vaadin-input-container.js';
 import { html, PolymerElement } from '@polymer/polymer';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
-import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
-import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
-import { PatternMixin } from '@vaadin/field-base/src/pattern-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
-import { TextAreaController } from '@vaadin/field-base/src/text-area-controller.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { TextAreaMixin } from './vaadin-text-area-mixin.js';
 
 registerStyles('vaadin-text-area', inputFieldShared, { moduleId: 'vaadin-text-area-styles' });
 
@@ -58,13 +54,11 @@ registerStyles('vaadin-text-area', inputFieldShared, { moduleId: 'vaadin-text-ar
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @extends HTMLElement
- * @mixes InputFieldMixin
  * @mixes ElementMixin
- * @mixes PatternMixin
+ * @mixes TextAreaMixin
  * @mixes ThemableMixin
- * @mixes ResizeMixin
  */
-export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableMixin(ElementMixin(PolymerElement))))) {
+export class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-text-area';
   }
@@ -150,7 +144,7 @@ export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableM
           disabled="[[disabled]]"
           invalid="[[invalid]]"
           theme$="[[_theme]]"
-          on-scroll="__scrollPositionUpdated"
+          on-scroll="_onScroll"
         >
           <slot name="prefix" slot="prefix"></slot>
           <slot name="textarea"></slot>
@@ -171,182 +165,13 @@ export class TextArea extends ResizeMixin(PatternMixin(InputFieldMixin(ThemableM
     `;
   }
 
-  static get properties() {
-    return {
-      /**
-       * Maximum number of characters (in Unicode code points) that the user can enter.
-       */
-      maxlength: {
-        type: Number,
-      },
-
-      /**
-       * Minimum number of characters (in Unicode code points) that the user can enter.
-       */
-      minlength: {
-        type: Number,
-      },
-    };
-  }
-
-  static get delegateAttrs() {
-    return [...super.delegateAttrs, 'maxlength', 'minlength'];
-  }
-
-  static get constraints() {
-    return [...super.constraints, 'maxlength', 'minlength'];
-  }
-
-  /**
-   * Used by `InputControlMixin` as a reference to the clear button element.
-   * @protected
-   */
-  get clearElement() {
-    return this.$.clearButton;
-  }
-
-  /**
-   * @protected
-   * @override
-   */
-  _onResize() {
-    this.__scrollPositionUpdated();
-  }
-
   /** @protected */
   ready() {
     super.ready();
 
-    this.addController(
-      new TextAreaController(this, (input) => {
-        this._setInputElement(input);
-        this._setFocusElement(input);
-        this.stateTarget = input;
-        this.ariaTarget = input;
-      }),
-    );
-    this.addController(new LabelledInputController(this.inputElement, this._labelController));
-
     this._tooltipController = new TooltipController(this);
     this._tooltipController.setPosition('top');
     this.addController(this._tooltipController);
-
-    this.addEventListener('animationend', this._onAnimationEnd);
-
-    this._inputField = this.shadowRoot.querySelector('[part=input-field]');
-
-    // Wheel scrolling results in async scroll events. Preventing the wheel
-    // event, scrolling manually and then synchronously updating the scroll position CSS variable
-    // allows us to avoid some jumpy behavior that would occur on wheel otherwise.
-    this._inputField.addEventListener('wheel', (e) => {
-      const scrollTopBefore = this._inputField.scrollTop;
-      this._inputField.scrollTop += e.deltaY;
-
-      if (scrollTopBefore !== this._inputField.scrollTop) {
-        e.preventDefault();
-        this.__scrollPositionUpdated();
-      }
-    });
-
-    this._updateHeight();
-    this.__scrollPositionUpdated();
-  }
-
-  /** @private */
-  __scrollPositionUpdated() {
-    this._inputField.style.setProperty('--_text-area-vertical-scroll-position', '0px');
-    this._inputField.style.setProperty('--_text-area-vertical-scroll-position', `${this._inputField.scrollTop}px`);
-  }
-
-  /** @private */
-  _onAnimationEnd(e) {
-    if (e.animationName.indexOf('vaadin-text-area-appear') === 0) {
-      this._updateHeight();
-    }
-  }
-
-  /**
-   * @param {unknown} newVal
-   * @param {unknown} oldVal
-   * @protected
-   * @override
-   */
-  _valueChanged(newVal, oldVal) {
-    super._valueChanged(newVal, oldVal);
-
-    this._updateHeight();
-  }
-
-  /** @private */
-  _updateHeight() {
-    const input = this.inputElement;
-    const inputField = this._inputField;
-
-    if (!input || !inputField) {
-      return;
-    }
-
-    const scrollTop = inputField.scrollTop;
-
-    // Only clear the height when the content shortens to minimize scrollbar flickering.
-    const valueLength = this.value ? this.value.length : 0;
-
-    if (this._oldValueLength >= valueLength) {
-      const inputFieldHeight = getComputedStyle(inputField).height;
-      const inputWidth = getComputedStyle(input).width;
-
-      // Temporarily fix the height of the wrapping input field container to prevent changing the browsers scroll
-      // position while resetting the textareas height. If the textarea had a large height, then removing its height
-      // will reset its height to the default of two rows. That might reduce the height of the page, and the
-      // browser might adjust the scroll position before we can restore the measured height of the textarea.
-      inputField.style.display = 'block';
-      inputField.style.height = inputFieldHeight;
-
-      // Fix the input element width so its scroll height isn't affected by host's disappearing scrollbars
-      input.style.maxWidth = inputWidth;
-
-      // Clear the height of the textarea to allow measuring a reduced scroll height
-      input.style.height = 'auto';
-    }
-    this._oldValueLength = valueLength;
-
-    const inputHeight = input.scrollHeight;
-    if (inputHeight > input.clientHeight) {
-      input.style.height = `${inputHeight}px`;
-    }
-
-    // Restore
-    input.style.removeProperty('max-width');
-    inputField.style.removeProperty('display');
-    inputField.style.removeProperty('height');
-    inputField.scrollTop = scrollTop;
-  }
-
-  /**
-   * Returns true if the current textarea value satisfies all constraints (if any).
-   * @return {boolean}
-   */
-  checkValidity() {
-    if (!super.checkValidity()) {
-      return false;
-    }
-
-    // Native <textarea> does not support pattern attribute, so we have a custom logic
-    // according to WHATWG spec for <input>, with tests inspired by web-platform-tests
-    // https://html.spec.whatwg.org/multipage/input.html#the-pattern-attribute
-
-    if (!this.pattern || !this.inputElement.value) {
-      // Mark as valid if there is no pattern, or the value is empty
-      return true;
-    }
-
-    try {
-      const match = this.inputElement.value.match(this.pattern);
-      return match ? match[0] === match.input : false;
-    } catch (_) {
-      // If the pattern can not be compiled, then report as valid
-      return true;
-    }
   }
 }
 


### PR DESCRIPTION
## Description

1. Extracted logic into `TexAreaMixin` (we actually had a similar mixin in Vaadin 14, but changed it in Vaadin 22),
2. Removed usage of `PatternMixin` and inlined its logic to keep all the constraints related properties together.

## Type of change

- Refactor