### PR TITLE
refactor: extract text-area styles to reusable css literal

### DIFF
--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -41,7 +41,8 @@
     "@vaadin/input-container": "24.0.0-beta1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-beta1",
     "@vaadin/vaadin-material-styles": "24.0.0-beta1",
-    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1"
+    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1",
+    "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/text-area/src/vaadin-text-area-styles.d.ts
+++ b/packages/text-area/src/vaadin-text-area-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const textAreaStyles: CSSResult;

--- a/packages/text-area/src/vaadin-text-area-styles.js
+++ b/packages/text-area/src/vaadin-text-area-styles.js
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const textAreaStyles = css`
+  :host {
+    animation: 1ms vaadin-text-area-appear;
+  }
+
+  .vaadin-text-area-container {
+    flex: auto;
+  }
+
+  /* The label, helper text and the error message should neither grow nor shrink. */
+  [part='label'],
+  [part='helper-text'],
+  [part='error-message'] {
+    flex: none;
+  }
+
+  [part='input-field'] {
+    flex: auto;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  ::slotted(textarea) {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    flex: auto;
+    overflow: hidden;
+    width: 100%;
+    height: 100%;
+    outline: none;
+    resize: none;
+    margin: 0;
+    padding: 0 0.25em;
+    border: 0;
+    border-radius: 0;
+    min-width: 0;
+    font: inherit;
+    font-size: 1em;
+    line-height: normal;
+    color: inherit;
+    background-color: transparent;
+    /* Disable default invalid style in Firefox */
+    box-shadow: none;
+  }
+
+  /* Override styles from <vaadin-input-container> */
+  [part='input-field'] ::slotted(textarea) {
+    align-self: stretch;
+    white-space: pre-wrap;
+  }
+
+  [part='input-field'] ::slotted(:not(textarea)) {
+    align-self: flex-start;
+  }
+
+  /* Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=1739079 */
+  :host([disabled]) ::slotted(textarea) {
+    user-select: none;
+  }
+
+  @keyframes vaadin-text-area-appear {
+    to {
+      opacity: 1;
+    }
+  }
+`;

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -10,8 +10,9 @@ import { TooltipController } from '@vaadin/component-base/src/tooltip-controller
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TextAreaMixin } from './vaadin-text-area-mixin.js';
+import { textAreaStyles } from './vaadin-text-area-styles.js';
 
-registerStyles('vaadin-text-area', inputFieldShared, { moduleId: 'vaadin-text-area-styles' });
+registerStyles('vaadin-text-area', [inputFieldShared, textAreaStyles], { moduleId: 'vaadin-text-area-styles' });
 
 /**
  * `<vaadin-text-area>` is a web component for multi-line text input.
@@ -65,73 +66,6 @@ export class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolymerEl
 
   static get template() {
     return html`
-      <style>
-        :host {
-          animation: 1ms vaadin-text-area-appear;
-        }
-
-        .vaadin-text-area-container {
-          flex: auto;
-        }
-
-        /* The label, helper text and the error message should neither grow nor shrink. */
-        [part='label'],
-        [part='helper-text'],
-        [part='error-message'] {
-          flex: none;
-        }
-
-        [part='input-field'] {
-          flex: auto;
-          overflow: auto;
-          -webkit-overflow-scrolling: touch;
-        }
-
-        ::slotted(textarea) {
-          -webkit-appearance: none;
-          -moz-appearance: none;
-          flex: auto;
-          overflow: hidden;
-          width: 100%;
-          height: 100%;
-          outline: none;
-          resize: none;
-          margin: 0;
-          padding: 0 0.25em;
-          border: 0;
-          border-radius: 0;
-          min-width: 0;
-          font: inherit;
-          font-size: 1em;
-          line-height: normal;
-          color: inherit;
-          background-color: transparent;
-          /* Disable default invalid style in Firefox */
-          box-shadow: none;
-        }
-
-        /* Override styles from <vaadin-input-container> */
-        [part='input-field'] ::slotted(textarea) {
-          align-self: stretch;
-          white-space: pre-wrap;
-        }
-
-        [part='input-field'] ::slotted(:not(textarea)) {
-          align-self: flex-start;
-        }
-
-        /* Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=1739079 */
-        :host([disabled]) ::slotted(textarea) {
-          user-select: none;
-        }
-
-        @keyframes vaadin-text-area-appear {
-          to {
-            opacity: 1;
-          }
-        }
-      </style>
-
       <div class="vaadin-text-area-container">
         <div part="label">
           <slot name="label"></slot>


### PR DESCRIPTION
## Description

Moved styles from the component's template to `css` literal that could be also used by the Lit version.

## Type of change

- Refactor