### PR TITLE
test: update text-field tests to allow async property updates

### DIFF
--- a/packages/text-field/test/validation.test.js
+++ b/packages/text-field/test/validation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-text-field.js';
 
@@ -57,13 +57,16 @@ describe('validation', () => {
   });
 
   describe('basic', () => {
-    beforeEach(() => {
+    let validatedSpy;
+
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-text-field></vaadin-text-field>');
+      await nextRender();
+      validatedSpy = sinon.spy();
+      field.addEventListener('validated', validatedSpy);
     });
 
     it('should fire a validated event on validation success', () => {
-      const validatedSpy = sinon.spy();
-      field.addEventListener('validated', validatedSpy);
       field.validate();
 
       expect(validatedSpy.calledOnce).to.be.true;
@@ -71,10 +74,10 @@ describe('validation', () => {
       expect(event.detail.valid).to.be.true;
     });
 
-    it('should fire a validated event on validation failure', () => {
-      const validatedSpy = sinon.spy();
-      field.addEventListener('validated', validatedSpy);
+    it('should fire a validated event on validation failure', async () => {
       field.required = true;
+      await nextFrame();
+
       field.validate();
 
       expect(validatedSpy.calledOnce).to.be.true;
@@ -84,40 +87,49 @@ describe('validation', () => {
   });
 
   describe('required', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-text-field></vaadin-text-field>');
+      await nextRender();
     });
 
-    it('should update "invalid" state when "required" is removed', () => {
+    it('should update "invalid" state when "required" is removed', async () => {
       field.required = true;
+      await nextFrame();
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.required = false;
+      await nextFrame();
       expect(field.invalid).to.be.false;
     });
   });
 
   describe('minlength', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-text-field></vaadin-text-field>');
+      await nextRender();
     });
 
-    it('should not validate the field when minlength is set', () => {
+    it('should not validate the field when minlength is set', async () => {
       field.minlength = 2;
+      await nextFrame();
       expect(field.invalid).to.be.false;
     });
 
-    it('should validate the field when invalid after minlength is changed', () => {
+    it('should validate the field when invalid after minlength is changed', async () => {
       field.invalid = true;
+      await nextFrame();
+
       const spy = sinon.spy(field, 'validate');
       field.minlength = 2;
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it.skip('should update "invalid" state when "minlength" is removed', () => {
+    it.skip('should update "invalid" state when "minlength" is removed', async () => {
       field.minlength = 5;
       field.value = 'foo';
+      await nextFrame();
 
       // There seems to be no way to make minlength/maxlength trigger invalid
       // state in a native input programmatically. It can only become invalid
@@ -133,30 +145,36 @@ describe('validation', () => {
       expect(field.invalid).to.be.true; // Fails here
 
       field.minlength = undefined;
+      await nextFrame();
       expect(field.invalid).to.be.false;
     });
   });
 
   describe('maxlength', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-text-field></vaadin-text-field>');
+      await nextRender();
     });
 
-    it('should not validate the field when maxlength is set', () => {
+    it('should not validate the field when maxlength is set', async () => {
       field.maxlength = 6;
+      await nextFrame();
       expect(field.invalid).to.be.false;
     });
 
-    it('should validate the field when invalid after maxlength is changed', () => {
+    it('should validate the field when invalid after maxlength is changed', async () => {
       field.invalid = true;
+      await nextFrame();
       const spy = sinon.spy(field, 'validate');
       field.maxlength = 2;
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it.skip('should update "invalid" state when "maxlength" is removed', () => {
+    it.skip('should update "invalid" state when "maxlength" is removed', async () => {
       field.maxlength = 3;
       field.value = 'foobar';
+      await nextFrame();
 
       // There seems to be no way to make minlength/maxlength trigger invalid
       // state in a native input programmatically. It can only become invalid
@@ -172,22 +190,27 @@ describe('validation', () => {
       expect(field.invalid).to.be.true; // Fails here
 
       field.maxlength = undefined;
+      await nextFrame();
       expect(field.invalid).to.be.false;
     });
   });
 
   describe('pattern', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-text-field></vaadin-text-field>');
+      await nextRender();
     });
 
-    it('should update "invalid" state when "pattern" is removed', () => {
+    it('should update "invalid" state when "pattern" is removed', async () => {
       field.value = '123foo';
       field.pattern = '\\d+';
+      await nextFrame();
+
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.pattern = '';
+      await nextFrame();
       expect(field.invalid).to.be.false;
     });
   });


### PR DESCRIPTION
## Description

1. Added `nextRender()` after calling `fixtureSync()` - this makes tests easier to debug as the element is rendered,
2. Added `nextFrame()` after setting properties - this makes our unit tests forwards-compatible with `LitElement`.

## Type of change

- Tests