### PR TITLE
refactor: extract number-field styles to reusable css literal

### DIFF
--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -41,7 +41,8 @@
     "@vaadin/input-container": "24.0.0-beta1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-beta1",
     "@vaadin/vaadin-material-styles": "24.0.0-beta1",
-    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1"
+    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1",
+    "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/number-field/src/vaadin-number-field-styles.d.ts
+++ b/packages/number-field/src/vaadin-number-field-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const numberFieldStyles: CSSResult;

--- a/packages/number-field/src/vaadin-number-field-styles.js
+++ b/packages/number-field/src/vaadin-number-field-styles.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const numberFieldStyles = css`
+  :host([readonly]) [part$='button'] {
+    pointer-events: none;
+  }
+
+  [part='decrease-button']::before {
+    content: '\\2212';
+  }
+
+  [part='increase-button']::before {
+    content: '+';
+  }
+
+  [part='decrease-button'],
+  [part='increase-button'] {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+  }
+
+  :host([dir='rtl']) [part='input-field'] {
+    direction: ltr;
+  }
+`;

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -10,8 +10,11 @@ import { TooltipController } from '@vaadin/component-base/src/tooltip-controller
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
+import { numberFieldStyles } from './vaadin-number-field-styles.js';
 
-registerStyles('vaadin-number-field', inputFieldShared, { moduleId: 'vaadin-number-field-styles' });
+registerStyles('vaadin-number-field', [inputFieldShared, numberFieldStyles], {
+  moduleId: 'vaadin-number-field-styles',
+});
 
 /**
  * `<vaadin-number-field>` is an input field web component that only accepts numeric input.
@@ -54,31 +57,6 @@ export class NumberField extends NumberFieldMixin(ThemableMixin(ElementMixin(Pol
 
   static get template() {
     return html`
-      <style>
-        :host([readonly]) [part$='button'] {
-          pointer-events: none;
-        }
-
-        [part='decrease-button']::before {
-          content: '\\2212';
-        }
-
-        [part='increase-button']::before {
-          content: '+';
-        }
-
-        [part='decrease-button'],
-        [part='increase-button'] {
-          -webkit-user-select: none;
-          -moz-user-select: none;
-          user-select: none;
-        }
-
-        :host([dir='rtl']) [part='input-field'] {
-          direction: ltr;
-        }
-      </style>
-
       <div class="vaadin-field-container">
         <div part="label">
           <slot name="label"></slot>


### PR DESCRIPTION
## Description

Moved styles from the component's template to `css` literal that could be also used by the Lit version.

## Type of change

- Refactor