### PR TITLE
test: update number-field tests to allow async updates

### DIFF
--- a/packages/number-field/test/number-field.test.js
+++ b/packages/number-field/test/number-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDown, arrowUp, fixtureSync } from '@vaadin/testing-helpers';
+import { arrowDown, arrowUp, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-number-field.js';
@@ -7,396 +7,694 @@ import '../src/vaadin-number-field.js';
 describe('number-field', () => {
   let numberField, input, decreaseButton, increaseButton;
 
-  beforeEach(() => {
-    numberField = fixtureSync('<vaadin-number-field></vaadin-number-field>');
-    input = numberField.inputElement;
-    decreaseButton = numberField.shadowRoot.querySelector('[part=decrease-button]');
-    increaseButton = numberField.shadowRoot.querySelector('[part=increase-button]');
-  });
+  describe('custom element definition', () => {
+    let tagName;
 
-  describe('native', () => {
-    it('should set value with correct decimal places regardless of step', () => {
-      numberField.step = 2;
-      numberField.value = 9.99;
-
-      expect(numberField.value).equal('9.99');
+    beforeEach(() => {
+      numberField = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+      tagName = numberField.tagName.toLowerCase();
     });
 
-    it('should increment value to next multiple of step offset by the min', () => {
-      numberField.step = 3;
-      numberField.min = 4;
-      numberField.value = 4;
-
-      increaseButton.click();
-
-      expect(numberField.value).equal('7');
+    it('should be defined in custom element registry', () => {
+      expect(customElements.get(tagName)).to.be.ok;
     });
 
-    it('should increment value on arrow up', () => {
-      numberField.step = 3;
-      arrowUp(input);
-      expect(numberField.value).equal('3');
-    });
-
-    it('should decrement value on arrow down', () => {
-      numberField.step = 3;
-      arrowDown(input);
-      expect(numberField.value).equal('-3');
-    });
-
-    it('should not change value on arrow keys when readonly', () => {
-      numberField.readonly = true;
-      numberField.value = 0;
-
-      arrowUp(input);
-      expect(numberField.value).to.be.equal('0');
-
-      arrowDown(input);
-      expect(numberField.value).to.be.equal('0');
+    it('should have a valid static "is" getter', () => {
+      expect(customElements.get(tagName).is).to.equal(tagName);
     });
   });
 
-  describe('value control buttons', () => {
-    it('should increase value by 1 on plus button click', () => {
-      numberField.value = 0;
-
-      increaseButton.click();
-
-      expect(numberField.value).to.be.equal('1');
+  describe('basic', () => {
+    beforeEach(async () => {
+      numberField = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+      await nextRender();
+      input = numberField.inputElement;
+      decreaseButton = numberField.shadowRoot.querySelector('[part=decrease-button]');
+      increaseButton = numberField.shadowRoot.querySelector('[part=increase-button]');
     });
 
-    it('should dispatch change event on minus button click', () => {
-      const changeSpy = sinon.spy();
-      numberField.addEventListener('change', changeSpy);
+    describe('native', () => {
+      it('should set value with correct decimal places regardless of step', async () => {
+        numberField.step = 2;
+        numberField.value = 9.99;
+        await nextFrame();
 
-      decreaseButton.click();
-      expect(changeSpy.callCount).to.equal(1);
+        expect(numberField.value).equal('9.99');
+      });
+
+      it('should increment value to next multiple of step offset by the min', async () => {
+        numberField.step = 3;
+        numberField.min = 4;
+        numberField.value = 4;
+        await nextFrame();
+
+        increaseButton.click();
+
+        expect(numberField.value).equal('7');
+      });
+
+      it('should increment value on arrow up', async () => {
+        numberField.step = 3;
+        await nextFrame();
+        arrowUp(input);
+        expect(numberField.value).equal('3');
+      });
+
+      it('should decrement value on arrow down', async () => {
+        numberField.step = 3;
+        await nextFrame();
+        arrowDown(input);
+        expect(numberField.value).equal('-3');
+      });
+
+      it('should not change value on arrow keys when readonly', async () => {
+        numberField.readonly = true;
+        numberField.value = 0;
+        await nextFrame();
+
+        arrowUp(input);
+        expect(numberField.value).to.be.equal('0');
+
+        arrowDown(input);
+        expect(numberField.value).to.be.equal('0');
+      });
     });
 
-    it('should dispatch change event on plus button click', () => {
-      const changeSpy = sinon.spy();
-      numberField.addEventListener('change', changeSpy);
+    describe('value control buttons', () => {
+      it('should increase value by 1 on plus button click', async () => {
+        numberField.value = 0;
+        await nextFrame();
 
-      increaseButton.click();
-      expect(changeSpy.callCount).to.equal(1);
-    });
+        increaseButton.click();
 
-    it('should dispatch single value-changed event on minus button click', () => {
-      const spy = sinon.spy();
-      numberField.addEventListener('value-changed', spy);
+        expect(numberField.value).to.be.equal('1');
+      });
 
-      decreaseButton.click();
-      expect(spy.callCount).to.equal(1);
-    });
+      it('should dispatch change event on minus button click', async () => {
+        const changeSpy = sinon.spy();
+        numberField.addEventListener('change', changeSpy);
 
-    it('should dispatch single value-changed event on plus button click', () => {
-      const spy = sinon.spy();
-      numberField.addEventListener('value-changed', spy);
-
-      increaseButton.click();
-      expect(spy.callCount).to.equal(1);
-    });
-
-    it('should not focus input when a button is clicked', () => {
-      const spy = sinon.spy(input, 'focus');
-      increaseButton.click();
-      expect(spy.called).to.be.false;
-    });
-
-    it('should increase value by 0.2 when step is 0.2 on plus button click', () => {
-      numberField.step = 0.2;
-      numberField.value = 0.6;
-
-      increaseButton.click();
-
-      expect(numberField.value).to.be.equal('0.8');
-    });
-
-    it('should adjust value to exact step on plus button click', () => {
-      numberField.step = 0.2;
-      numberField.value = 0.5;
-
-      increaseButton.click();
-
-      expect(numberField.value).to.be.equal('0.6');
-    });
-
-    it('should decrease value by 1 on minus button click', () => {
-      numberField.value = 0;
-
-      decreaseButton.click();
-
-      expect(numberField.value).to.be.equal('-1');
-    });
-
-    it('should decrease value by 0.2 on minus button click', () => {
-      numberField.value = 0;
-      numberField.step = 0.2;
-
-      decreaseButton.click();
-
-      expect(numberField.value).to.be.equal('-0.2');
-    });
-
-    it('should adjust value to exact step on minus button click', () => {
-      numberField.value = 7;
-      numberField.step = 2;
-
-      decreaseButton.click();
-
-      expect(numberField.value).to.be.equal('6');
-    });
-
-    it('should adjust decimals based on the step value when control button is pressed', () => {
-      numberField.value = 1;
-      numberField.step = 0.001;
-
-      increaseButton.click();
-      expect(numberField.value).to.be.equal('1.001');
-    });
-
-    it('should adjust decimals based on the min value when control button is pressed', () => {
-      numberField.value = 1;
-      numberField.step = 0.001;
-      numberField.min = 0.0001;
-
-      increaseButton.click();
-      expect(numberField.value).to.be.equal('1.0001');
-    });
-
-    it('should not increase value on plus button click when max value is reached', () => {
-      numberField.value = 0;
-      numberField.max = 0;
-
-      increaseButton.click();
-
-      expect(numberField.value).to.be.equal('0');
-    });
-
-    it('should not decrease value on minus button click when min value is reached', () => {
-      numberField.value = 0;
-      numberField.min = 0;
-
-      decreaseButton.click();
-
-      expect(numberField.value).to.be.equal('0');
-    });
-
-    it('should not disable buttons if there are no limits set', () => {
-      expect(decreaseButton.hasAttribute('disabled')).to.be.false;
-      expect(increaseButton.hasAttribute('disabled')).to.be.false;
-    });
-
-    it('should disable minus button if min limit is reached', () => {
-      numberField.value = 0;
-      numberField.min = 0;
-      expect(decreaseButton.hasAttribute('disabled')).to.be.true;
-      expect(increaseButton.hasAttribute('disabled')).to.be.false;
-    });
-
-    it('should disable plus button if max limit is reached', () => {
-      numberField.value = 1;
-      numberField.max = 1;
-      expect(decreaseButton.hasAttribute('disabled')).to.be.false;
-      expect(increaseButton.hasAttribute('disabled')).to.be.true;
-    });
-
-    it('should not change value when the field is disabled and controls are clicked', () => {
-      numberField.disabled = true;
-      numberField.value = 0;
-
-      increaseButton.click();
-      expect(numberField.value).to.be.equal('0');
-
-      decreaseButton.click();
-      expect(numberField.value).to.be.equal('0');
-    });
-
-    it('should not change value on minus button click when min limit is reached', () => {
-      numberField.min = -1;
-      numberField.value = 0;
-
-      decreaseButton.click();
-      expect(numberField.value).to.be.equal('-1');
-
-      decreaseButton.click();
-      expect(numberField.value).to.be.equal('-1');
-    });
-
-    it('should not change value on plus button click when max limit is reached', () => {
-      numberField.max = 1;
-      numberField.value = 0;
-
-      increaseButton.click();
-      expect(numberField.value).to.be.equal('1');
-
-      increaseButton.click();
-      expect(numberField.value).to.be.equal('1');
-    });
-
-    it('should not change value on plus button click when max limit will be reached with the next step', () => {
-      numberField.min = -10;
-      numberField.max = 10;
-      numberField.step = 6;
-      numberField.value = 2;
-
-      increaseButton.click();
-      expect(numberField.value).to.be.equal('8');
-
-      increaseButton.click();
-      expect(numberField.value).to.be.equal('8');
-    });
-
-    it('should prevent touchend event on value control buttons', () => {
-      numberField.value = 0;
-      let e = new CustomEvent('touchend', { cancelable: true });
-      increaseButton.dispatchEvent(e);
-      expect(e.defaultPrevented).to.be.true;
-      expect(numberField.value).to.equal('1');
-
-      e = new CustomEvent('touchend', { cancelable: true });
-      decreaseButton.dispatchEvent(e);
-      expect(e.defaultPrevented).to.be.true;
-      expect(numberField.value).to.equal('0');
-    });
-
-    it('should decrease value to max value on minus button click when value is over max', () => {
-      numberField.value = 50;
-      numberField.max = 10;
-
-      decreaseButton.click();
-
-      expect(numberField.value).to.be.equal(String(numberField.max));
-    });
-
-    it('should decrease value to the closest step value on minus button click', () => {
-      numberField.min = -17;
-      numberField.value = -8;
-      numberField.step = 4;
-
-      decreaseButton.click();
-
-      expect(numberField.value).to.be.equal('-9');
-    });
-
-    it('should correctly decrease value on minus button click', () => {
-      numberField.min = -20;
-      numberField.value = -1;
-      numberField.step = 4;
-
-      [-4, -8, -12, -16, -20].forEach((step) => {
         decreaseButton.click();
-        expect(numberField.value).to.be.equal(String(step));
+        await nextFrame();
+
+        expect(changeSpy.callCount).to.equal(1);
       });
-    });
 
-    it('should increase value to min value on plus button click when value is under min', () => {
-      numberField.value = -40;
-      numberField.min = -10;
+      it('should dispatch change event on plus button click', async () => {
+        const changeSpy = sinon.spy();
+        numberField.addEventListener('change', changeSpy);
 
-      increaseButton.click();
-
-      expect(numberField.value).to.be.equal(String(numberField.min));
-    });
-
-    it('should increase value to the closest step value on plus button click', () => {
-      numberField.min = -17;
-      numberField.value = -8;
-      numberField.step = 4;
-
-      increaseButton.click();
-
-      expect(numberField.value).to.be.equal('-5');
-    });
-
-    it('should correctly increase value on plus button click', () => {
-      numberField.min = -3;
-      numberField.max = 18;
-      numberField.value = -1;
-      numberField.step = 4;
-
-      [1, 5, 9, 13, 17].forEach((step) => {
         increaseButton.click();
-        expect(numberField.value).to.be.equal(String(step));
+        await nextFrame();
+
+        expect(changeSpy.callCount).to.equal(1);
       });
-    });
 
-    it('should correctly increase value on plus button click when step is a decimal number', () => {
-      numberField.min = -0.02;
-      numberField.max = 0.02;
-      numberField.value = -0.03;
-      numberField.step = 0.01;
+      it('should dispatch single value-changed event on minus button click', async () => {
+        const spy = sinon.spy();
+        numberField.addEventListener('value-changed', spy);
 
-      [-0.02, -0.01, 0, 0.01, 0.02].forEach((step) => {
+        decreaseButton.click();
+        await nextFrame();
+
+        expect(spy.callCount).to.equal(1);
+      });
+
+      it('should dispatch single value-changed event on plus button click', async () => {
+        const spy = sinon.spy();
+        numberField.addEventListener('value-changed', spy);
+
         increaseButton.click();
-        expect(numberField.value).to.be.equal(String(step));
-      });
-    });
+        await nextFrame();
 
-    it('should correctly calculate the precision with decimal value', () => {
-      numberField.value = 5.1;
-      numberField.step = 0.01;
-
-      increaseButton.click();
-      expect(numberField.value).to.be.equal('5.11');
-    });
-
-    describe('problematic values', () => {
-      it('should correctly increase value', () => {
-        const configs = [
-          { props: { step: 0.001, value: 1.001 }, expectedValue: '1.002' },
-          { props: { step: 0.001, value: 1.003 }, expectedValue: '1.004' },
-          { props: { step: 0.001, value: 1.005 }, expectedValue: '1.006' },
-          { props: { step: 0.001, value: 2.002 }, expectedValue: '2.003' },
-          { props: { step: 0.001, value: 4.004 }, expectedValue: '4.005' },
-          { props: { step: 0.001, value: 8.008 }, expectedValue: '8.009' },
-          { props: { step: 0.01, value: 16.08 }, expectedValue: '16.09' },
-          { props: { step: 0.01, value: 73.1 }, expectedValue: '73.11' },
-          { props: { step: 0.001, value: 1.0131, min: 0.0001 }, expectedValue: '1.0141' },
-        ];
-        const reset = { step: 1, min: undefined, max: undefined, value: '' };
-
-        configs.forEach(({ props, expectedValue }) => {
-          Object.assign(numberField, reset, props);
-          increaseButton.click();
-          expect(numberField.value).to.be.equal(expectedValue);
-        });
+        expect(spy.callCount).to.equal(1);
       });
 
-      it('should correctly decrease value', () => {
-        const configs = [
-          { props: { step: 0.01, value: 72.9 }, expectedValue: '72.89' },
-          { props: { step: 0.001, min: 0.0001, value: 1.0031 }, expectedValue: '1.0021' },
-          { props: { step: 0.001, min: 0.0001, value: 1.0051 }, expectedValue: '1.0041' },
-          { props: { step: 0.001, min: 0.0001, value: 1.0071 }, expectedValue: '1.0061' },
-          { props: { step: 0.001, min: 0.0001, value: 1.0091 }, expectedValue: '1.0081' },
-        ];
-        const reset = { step: 1, min: undefined, max: undefined, value: '' };
+      it('should not focus input when a button is clicked', () => {
+        const spy = sinon.spy(input, 'focus');
+        increaseButton.click();
+        expect(spy.called).to.be.false;
+      });
 
-        configs.forEach(({ props, expectedValue }) => {
-          Object.assign(numberField, reset, props);
+      it('should increase value by 0.2 when step is 0.2 on plus button click', async () => {
+        numberField.step = 0.2;
+        numberField.value = 0.6;
+        await nextFrame();
+
+        increaseButton.click();
+
+        expect(numberField.value).to.be.equal('0.8');
+      });
+
+      it('should adjust value to exact step on plus button click', async () => {
+        numberField.step = 0.2;
+        numberField.value = 0.5;
+        await nextFrame();
+
+        increaseButton.click();
+
+        expect(numberField.value).to.be.equal('0.6');
+      });
+
+      it('should decrease value by 1 on minus button click', async () => {
+        numberField.value = 0;
+        await nextFrame();
+
+        decreaseButton.click();
+
+        expect(numberField.value).to.be.equal('-1');
+      });
+
+      it('should decrease value by 0.2 on minus button click', async () => {
+        numberField.value = 0;
+        numberField.step = 0.2;
+        await nextFrame();
+
+        decreaseButton.click();
+
+        expect(numberField.value).to.be.equal('-0.2');
+      });
+
+      it('should adjust value to exact step on minus button click', async () => {
+        numberField.value = 7;
+        numberField.step = 2;
+        await nextFrame();
+
+        decreaseButton.click();
+
+        expect(numberField.value).to.be.equal('6');
+      });
+
+      it('should adjust decimals based on the step value when control button is pressed', async () => {
+        numberField.value = 1;
+        numberField.step = 0.001;
+        await nextFrame();
+
+        increaseButton.click();
+        expect(numberField.value).to.be.equal('1.001');
+      });
+
+      it('should adjust decimals based on the min value when control button is pressed', async () => {
+        numberField.value = 1;
+        numberField.step = 0.001;
+        numberField.min = 0.0001;
+        await nextFrame();
+
+        increaseButton.click();
+        expect(numberField.value).to.be.equal('1.0001');
+      });
+
+      it('should not increase value on plus button click when max value is reached', async () => {
+        numberField.value = 0;
+        numberField.max = 0;
+        await nextFrame();
+
+        increaseButton.click();
+
+        expect(numberField.value).to.be.equal('0');
+      });
+
+      it('should not decrease value on minus button click when min value is reached', async () => {
+        numberField.value = 0;
+        numberField.min = 0;
+        await nextFrame();
+
+        decreaseButton.click();
+
+        expect(numberField.value).to.be.equal('0');
+      });
+
+      it('should not disable buttons if there are no limits set', () => {
+        expect(decreaseButton.hasAttribute('disabled')).to.be.false;
+        expect(increaseButton.hasAttribute('disabled')).to.be.false;
+      });
+
+      it('should disable minus button if min limit is reached', async () => {
+        numberField.value = 0;
+        numberField.min = 0;
+        await nextFrame();
+        expect(decreaseButton.hasAttribute('disabled')).to.be.true;
+        expect(increaseButton.hasAttribute('disabled')).to.be.false;
+      });
+
+      it('should disable plus button if max limit is reached', async () => {
+        numberField.value = 1;
+        numberField.max = 1;
+        await nextFrame();
+        expect(decreaseButton.hasAttribute('disabled')).to.be.false;
+        expect(increaseButton.hasAttribute('disabled')).to.be.true;
+      });
+
+      it('should not change value when the field is disabled and controls are clicked', async () => {
+        numberField.disabled = true;
+        numberField.value = 0;
+        await nextFrame();
+
+        increaseButton.click();
+        expect(numberField.value).to.be.equal('0');
+
+        decreaseButton.click();
+        expect(numberField.value).to.be.equal('0');
+      });
+
+      it('should not change value on minus button click when min limit is reached', async () => {
+        numberField.min = -1;
+        numberField.value = 0;
+        await nextFrame();
+
+        decreaseButton.click();
+        expect(numberField.value).to.be.equal('-1');
+
+        decreaseButton.click();
+        expect(numberField.value).to.be.equal('-1');
+      });
+
+      it('should not change value on plus button click when max limit is reached', async () => {
+        numberField.max = 1;
+        numberField.value = 0;
+        await nextFrame();
+
+        increaseButton.click();
+        expect(numberField.value).to.be.equal('1');
+
+        increaseButton.click();
+        expect(numberField.value).to.be.equal('1');
+      });
+
+      it('should not change value on plus button click when max limit will be reached with the next step', async () => {
+        numberField.min = -10;
+        numberField.max = 10;
+        numberField.step = 6;
+        numberField.value = 2;
+        await nextFrame();
+
+        increaseButton.click();
+        expect(numberField.value).to.be.equal('8');
+
+        increaseButton.click();
+        expect(numberField.value).to.be.equal('8');
+      });
+
+      it('should prevent touchend event on value control buttons', async () => {
+        numberField.value = 0;
+        await nextFrame();
+
+        let e = new CustomEvent('touchend', { cancelable: true });
+        increaseButton.dispatchEvent(e);
+        expect(e.defaultPrevented).to.be.true;
+        expect(numberField.value).to.equal('1');
+
+        e = new CustomEvent('touchend', { cancelable: true });
+        decreaseButton.dispatchEvent(e);
+        expect(e.defaultPrevented).to.be.true;
+        expect(numberField.value).to.equal('0');
+      });
+
+      it('should decrease value to max value on minus button click when value is over max', async () => {
+        numberField.value = 50;
+        numberField.max = 10;
+        await nextFrame();
+
+        decreaseButton.click();
+
+        expect(numberField.value).to.be.equal(String(numberField.max));
+      });
+
+      it('should decrease value to the closest step value on minus button click', async () => {
+        numberField.min = -17;
+        numberField.value = -8;
+        numberField.step = 4;
+        await nextFrame();
+
+        decreaseButton.click();
+
+        expect(numberField.value).to.be.equal('-9');
+      });
+
+      it('should correctly decrease value on minus button click', async () => {
+        numberField.min = -20;
+        numberField.value = -1;
+        numberField.step = 4;
+        await nextFrame();
+
+        [-4, -8, -12, -16, -20].forEach((step) => {
           decreaseButton.click();
-          expect(numberField.value).to.be.equal(expectedValue);
+          expect(numberField.value).to.be.equal(String(step));
+        });
+      });
+
+      it('should increase value to min value on plus button click when value is under min', async () => {
+        numberField.value = -40;
+        numberField.min = -10;
+        await nextFrame();
+
+        increaseButton.click();
+
+        expect(numberField.value).to.be.equal(String(numberField.min));
+      });
+
+      it('should increase value to the closest step value on plus button click', async () => {
+        numberField.min = -17;
+        numberField.value = -8;
+        numberField.step = 4;
+        await nextFrame();
+
+        increaseButton.click();
+
+        expect(numberField.value).to.be.equal('-5');
+      });
+
+      it('should correctly increase value on plus button click', async () => {
+        numberField.min = -3;
+        numberField.max = 18;
+        numberField.value = -1;
+        numberField.step = 4;
+        await nextFrame();
+
+        [1, 5, 9, 13, 17].forEach((step) => {
+          increaseButton.click();
+          expect(numberField.value).to.be.equal(String(step));
+        });
+      });
+
+      it('should correctly increase value on plus button click when step is a decimal number', async () => {
+        numberField.min = -0.02;
+        numberField.max = 0.02;
+        numberField.value = -0.03;
+        numberField.step = 0.01;
+        await nextFrame();
+
+        [-0.02, -0.01, 0, 0.01, 0.02].forEach((step) => {
+          increaseButton.click();
+          expect(numberField.value).to.be.equal(String(step));
+        });
+      });
+
+      it('should correctly calculate the precision with decimal value', async () => {
+        numberField.value = 5.1;
+        numberField.step = 0.01;
+        await nextFrame();
+
+        increaseButton.click();
+        expect(numberField.value).to.be.equal('5.11');
+      });
+
+      describe('problematic values', () => {
+        it('should correctly increase value', () => {
+          const configs = [
+            { props: { step: 0.001, value: 1.001 }, expectedValue: '1.002' },
+            { props: { step: 0.001, value: 1.003 }, expectedValue: '1.004' },
+            { props: { step: 0.001, value: 1.005 }, expectedValue: '1.006' },
+            { props: { step: 0.001, value: 2.002 }, expectedValue: '2.003' },
+            { props: { step: 0.001, value: 4.004 }, expectedValue: '4.005' },
+            { props: { step: 0.001, value: 8.008 }, expectedValue: '8.009' },
+            { props: { step: 0.01, value: 16.08 }, expectedValue: '16.09' },
+            { props: { step: 0.01, value: 73.1 }, expectedValue: '73.11' },
+            { props: { step: 0.001, value: 1.0131, min: 0.0001 }, expectedValue: '1.0141' },
+          ];
+          const reset = { step: 1, min: undefined, max: undefined, value: '' };
+
+          configs.forEach(({ props, expectedValue }) => {
+            Object.assign(numberField, reset, props);
+            increaseButton.click();
+            expect(numberField.value).to.be.equal(expectedValue);
+          });
+        });
+
+        it('should correctly decrease value', () => {
+          const configs = [
+            { props: { step: 0.01, value: 72.9 }, expectedValue: '72.89' },
+            { props: { step: 0.001, min: 0.0001, value: 1.0031 }, expectedValue: '1.0021' },
+            { props: { step: 0.001, min: 0.0001, value: 1.0051 }, expectedValue: '1.0041' },
+            { props: { step: 0.001, min: 0.0001, value: 1.0071 }, expectedValue: '1.0061' },
+            { props: { step: 0.001, min: 0.0001, value: 1.0091 }, expectedValue: '1.0081' },
+          ];
+          const reset = { step: 1, min: undefined, max: undefined, value: '' };
+
+          configs.forEach(({ props, expectedValue }) => {
+            Object.assign(numberField, reset, props);
+            decreaseButton.click();
+            expect(numberField.value).to.be.equal(expectedValue);
+          });
         });
       });
     });
-  });
 
-  describe('no initial value', () => {
-    describe('min is defined and max is undefined', () => {
-      describe('min is below zero', () => {
-        it('should set value to the first positive step value when min < 0 on plus button click', () => {
-          numberField.min = -19;
+    describe('no initial value', () => {
+      describe('min is defined and max is undefined', () => {
+        describe('min is below zero', () => {
+          it('should set value to the first positive step value when min < 0 on plus button click', async () => {
+            numberField.min = -19;
+            numberField.step = 6;
+            await nextFrame();
+
+            increaseButton.click();
+
+            expect(numberField.value).to.be.equal('5');
+          });
+
+          it('should set value to the first negative step value when min < 0 zero on plus button click', async () => {
+            numberField.min = -19;
+            numberField.step = 6;
+            await nextFrame();
+
+            decreaseButton.click();
+
+            expect(numberField.value).to.be.equal('-1');
+          });
+        });
+
+        describe('min is above zero', () => {
+          it('should set value to min when min > 0 on pus button click', async () => {
+            numberField.min = 19;
+            numberField.step = 6;
+            await nextFrame();
+
+            increaseButton.click();
+
+            expect(numberField.value).to.be.equal('19');
+          });
+
+          it('should set value to min when min > 0 on minus button click', async () => {
+            numberField.min = 19;
+            numberField.step = 6;
+            await nextFrame();
+
+            decreaseButton.click();
+
+            expect(numberField.value).to.be.equal('19');
+          });
+        });
+
+        describe('min equals zero', () => {
+          it('should set value to the first positive step value when min = 0 on plus button click', async () => {
+            numberField.min = 0;
+            numberField.step = 6;
+            await nextFrame();
+
+            increaseButton.click();
+
+            expect(numberField.value).to.be.equal('6');
+          });
+
+          it('should set value to 0 when min = 0 on minus button click', async () => {
+            numberField.min = 0;
+            numberField.step = 6;
+            await nextFrame();
+
+            decreaseButton.click();
+
+            expect(numberField.value).to.be.equal('0');
+          });
+        });
+      });
+
+      describe('max is defined and min is undefined', () => {
+        describe('max is below zero', () => {
+          it('should set value to the closest to the max value when max < 0 on plus button click', async () => {
+            // -19 cannot be equally divided by 6
+            // The closest is -24, cause with the next stepUp it will become -18
+            numberField.max = -19;
+            numberField.step = 6;
+            await nextFrame();
+
+            increaseButton.click();
+
+            expect(numberField.value).to.be.equal('-24');
+
+            // Check with max that can be equally divided
+            numberField.value = '';
+            numberField.max = -18;
+            numberField.step = 6;
+            await nextFrame();
+
+            increaseButton.click();
+
+            expect(numberField.value).to.be.equal('-18');
+          });
+
+          it('should set value to max when max < 0 on minus button click', async () => {
+            numberField.max = -19;
+            numberField.step = 6;
+            await nextFrame();
+
+            decreaseButton.click();
+
+            expect(numberField.value).to.be.equal('-19');
+          });
+        });
+
+        describe('max is above zero', () => {
+          it('should set value to the first positive step value when max > 0 on minus button click', async () => {
+            numberField.max = 19;
+            numberField.step = 6;
+            await nextFrame();
+
+            increaseButton.click();
+
+            expect(numberField.value).to.be.equal('6');
+          });
+
+          it('should set value to the first step negative step value when max > 0 on minus button click', async () => {
+            numberField.max = 19;
+            numberField.step = 6;
+            await nextFrame();
+
+            decreaseButton.click();
+
+            expect(numberField.value).to.be.equal('-6');
+          });
+        });
+
+        describe('max equals zero', () => {
+          it('should set value to 0 when max = 0 on plus button click', async () => {
+            numberField.max = 0;
+            numberField.step = 6;
+            await nextFrame();
+
+            increaseButton.click();
+
+            expect(numberField.value).to.be.equal('0');
+          });
+
+          it('should set value to the first negative step value when max = 0 on minus button click', async () => {
+            numberField.max = 0;
+            numberField.step = 6;
+            await nextFrame();
+
+            decreaseButton.click();
+
+            expect(numberField.value).to.be.equal('-6');
+          });
+        });
+      });
+
+      describe('min and max values are defined', () => {
+        it('should set value to the closest to the max when min < 0 and max < 0 on plus button click', async () => {
+          numberField.min = -20;
+          numberField.max = -3;
           numberField.step = 6;
+          await nextFrame();
+
+          increaseButton.click();
+
+          expect(numberField.value).to.be.equal('-8');
+
+          // Check with max that can be equally divided
+          numberField.value = '';
+          numberField.min = -24;
+          numberField.step = 6;
+          await nextFrame();
+
+          increaseButton.click();
+
+          expect(numberField.value).to.be.equal('-6');
+        });
+
+        it('should set value to 0 when max = 0 and min = 0 on minus button or plus button click', async () => {
+          numberField.min = 0;
+          numberField.max = 0;
+          numberField.step = 6;
+          await nextFrame();
+
+          decreaseButton.click();
+          expect(numberField.value).to.be.equal('0');
+
+          increaseButton.click();
+          expect(numberField.value).to.be.equal('0');
+        });
+
+        it('should set value to min when min > 0 and max > 0 on plus button click', async () => {
+          numberField.min = 3;
+          numberField.max = 19;
+          numberField.step = 6;
+          await nextFrame();
+
+          increaseButton.click();
+
+          expect(numberField.value).to.be.equal('3');
+        });
+
+        it('should set value to min when min > 0 and max < 0 on plus button click', async () => {
+          numberField.min = 19;
+          numberField.max = -3;
+          numberField.step = 6;
+          await nextFrame();
+
+          increaseButton.click();
+
+          expect(numberField.value).to.be.equal('19');
+        });
+
+        it('should set value to the first positive step value when min < 0 and max is > 0 on plus button click', async () => {
+          numberField.min = -19;
+          numberField.max = 19;
+          numberField.step = 6;
+          await nextFrame();
 
           increaseButton.click();
 
           expect(numberField.value).to.be.equal('5');
         });
 
-        it('should set value to the first negative step value when min < 0 zero on plus button click', () => {
+        it('should set value to max when min < 0 and max < 0 on minus button click', async () => {
           numberField.min = -19;
+          numberField.max = -3;
           numberField.step = 6;
+          await nextFrame();
+
+          decreaseButton.click();
+
+          expect(numberField.value).to.be.equal('-3');
+        });
+
+        it('should set value to min when min > 0 and max > 0 on minus button click', async () => {
+          numberField.min = 3;
+          numberField.max = 19;
+          numberField.step = 6;
+          await nextFrame();
+
+          decreaseButton.click();
+
+          expect(numberField.value).to.be.equal('3');
+        });
+
+        it('should set value to max when min > 0 and max < 0 on minus button click', async () => {
+          numberField.min = 19;
+          numberField.max = -3;
+          numberField.step = 6;
+          await nextFrame();
+
+          decreaseButton.click();
+
+          expect(numberField.value).to.be.equal('-3');
+        });
+
+        it('should set value to the first negative step value when min < 0 and max > 0 on minus button click', async () => {
+          numberField.min = -19;
+          numberField.max = 19;
+          numberField.step = 6;
+          await nextFrame();
 
           decreaseButton.click();
 
@@ -404,112 +702,19 @@ describe('number-field', () => {
         });
       });
 
-      describe('min is above zero', () => {
-        it('should set value to min when min > 0 on pus button click', () => {
-          numberField.min = 19;
+      describe('min and max values are undefined', () => {
+        it('should set value to the first positive step value on minus button click', async () => {
           numberField.step = 6;
-
-          increaseButton.click();
-
-          expect(numberField.value).to.be.equal('19');
-        });
-
-        it('should set value to min when min > 0 on minus button click', () => {
-          numberField.min = 19;
-          numberField.step = 6;
-
-          decreaseButton.click();
-
-          expect(numberField.value).to.be.equal('19');
-        });
-      });
-
-      describe('min equals zero', () => {
-        it('should set value to the first positive step value when min = 0 on plus button click', () => {
-          numberField.min = 0;
-          numberField.step = 6;
+          await nextFrame();
 
           increaseButton.click();
 
           expect(numberField.value).to.be.equal('6');
         });
 
-        it('should set value to 0 when min = 0 on minus button click', () => {
-          numberField.min = 0;
+        it('should set value to the first negative step value on minus button click', async () => {
           numberField.step = 6;
-
-          decreaseButton.click();
-
-          expect(numberField.value).to.be.equal('0');
-        });
-      });
-    });
-
-    describe('max is defined and min is undefined', () => {
-      describe('max is below zero', () => {
-        it('should set value to the closest to the max value when max < 0 on plus button click', () => {
-          // -19 cannot be equally divided by 6
-          // The closest is -24, cause with the next stepUp it will become -18
-          numberField.max = -19;
-          numberField.step = 6;
-
-          increaseButton.click();
-
-          expect(numberField.value).to.be.equal('-24');
-
-          // Check with max that can be equally divided
-          numberField.value = '';
-          numberField.max = -18;
-          numberField.step = 6;
-
-          increaseButton.click();
-
-          expect(numberField.value).to.be.equal('-18');
-        });
-
-        it('should set value to max when max < 0 on minus button click', () => {
-          numberField.max = -19;
-          numberField.step = 6;
-
-          decreaseButton.click();
-
-          expect(numberField.value).to.be.equal('-19');
-        });
-      });
-
-      describe('max is above zero', () => {
-        it('should set value to the first positive step value when max > 0 on minus button click', () => {
-          numberField.max = 19;
-          numberField.step = 6;
-
-          increaseButton.click();
-
-          expect(numberField.value).to.be.equal('6');
-        });
-
-        it('should set value to the first step negative step value when max > 0 on minus button click', () => {
-          numberField.max = 19;
-          numberField.step = 6;
-
-          decreaseButton.click();
-
-          expect(numberField.value).to.be.equal('-6');
-        });
-      });
-
-      describe('max equals zero', () => {
-        it('should set value to 0 when max = 0 on plus button click', () => {
-          numberField.max = 0;
-          numberField.step = 6;
-
-          increaseButton.click();
-
-          expect(numberField.value).to.be.equal('0');
-        });
-
-        it('should set value to the first negative step value when max = 0 on minus button click', () => {
-          numberField.max = 0;
-          numberField.step = 6;
+          await nextFrame();
 
           decreaseButton.click();
 
@@ -518,170 +723,50 @@ describe('number-field', () => {
       });
     });
 
-    describe('min and max values are defined', () => {
-      it('should set value to the closest to the max when min < 0 and max < 0 on plus button click', () => {
-        numberField.min = -20;
-        numberField.max = -3;
-        numberField.step = 6;
+    describe('has-input-value-changed event', () => {
+      let hasInputValueChangedSpy;
 
-        increaseButton.click();
-
-        expect(numberField.value).to.be.equal('-8');
-
-        // Check with max that can be equally divided
-        numberField.value = '';
-        numberField.min = -24;
-        numberField.step = 6;
-
-        increaseButton.click();
-
-        expect(numberField.value).to.be.equal('-6');
+      beforeEach(() => {
+        hasInputValueChangedSpy = sinon.spy();
+        numberField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+        input.focus();
       });
 
-      it('should set value to 0 when max = 0 and min = 0 on minus button or plus button click', () => {
-        numberField.min = 0;
-        numberField.max = 0;
-        numberField.step = 6;
+      it('should fire the event when entering and removing a valid number', async () => {
+        await sendKeys({ type: '555' });
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
 
-        decreaseButton.click();
-        expect(numberField.value).to.be.equal('0');
-
-        increaseButton.click();
-        expect(numberField.value).to.be.equal('0');
+        hasInputValueChangedSpy.resetHistory();
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
       });
 
-      it('should set value to min when min > 0 and max > 0 on plus button click', () => {
-        numberField.min = 3;
-        numberField.max = 19;
-        numberField.step = 6;
+      it('should fire the event when entering and removing an invalid number', async () => {
+        await sendKeys({ type: '--5' });
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
 
-        increaseButton.click();
-
-        expect(numberField.value).to.be.equal('3');
-      });
-
-      it('should set value to min when min > 0 and max < 0 on plus button click', () => {
-        numberField.min = 19;
-        numberField.max = -3;
-        numberField.step = 6;
-
-        increaseButton.click();
-
-        expect(numberField.value).to.be.equal('19');
-      });
-
-      it('should set value to the first positive step value when min < 0 and max is > 0 on plus button click', () => {
-        numberField.min = -19;
-        numberField.max = 19;
-        numberField.step = 6;
-
-        increaseButton.click();
-
-        expect(numberField.value).to.be.equal('5');
-      });
-
-      it('should set value to max when min < 0 and max < 0 on minus button click', () => {
-        numberField.min = -19;
-        numberField.max = -3;
-        numberField.step = 6;
-
-        decreaseButton.click();
-
-        expect(numberField.value).to.be.equal('-3');
-      });
-
-      it('should set value to min when min > 0 and max > 0 on minus button click', () => {
-        numberField.min = 3;
-        numberField.max = 19;
-        numberField.step = 6;
-
-        decreaseButton.click();
-
-        expect(numberField.value).to.be.equal('3');
-      });
-
-      it('should set value to max when min > 0 and max < 0 on minus button click', () => {
-        numberField.min = 19;
-        numberField.max = -3;
-        numberField.step = 6;
-
-        decreaseButton.click();
-
-        expect(numberField.value).to.be.equal('-3');
-      });
-
-      it('should set value to the first negative step value when min < 0 and max > 0 on minus button click', () => {
-        numberField.min = -19;
-        numberField.max = 19;
-        numberField.step = 6;
-
-        decreaseButton.click();
-
-        expect(numberField.value).to.be.equal('-1');
-      });
-    });
-
-    describe('min and max values are undefined', () => {
-      it('should set value to the first positive step value on minus button click', () => {
-        numberField.step = 6;
-
-        increaseButton.click();
-
-        expect(numberField.value).to.be.equal('6');
-      });
-
-      it('should set value to the first negative step value on minus button click', () => {
-        numberField.step = 6;
-
-        decreaseButton.click();
-
-        expect(numberField.value).to.be.equal('-6');
+        hasInputValueChangedSpy.resetHistory();
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
       });
     });
   });
 
-  describe('has-input-value-changed event', () => {
-    let hasInputValueChangedSpy;
+  describe('required', () => {
+    let numberField;
 
-    beforeEach(() => {
-      hasInputValueChangedSpy = sinon.spy();
-      numberField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-      input.focus();
+    beforeEach(async () => {
+      numberField = fixtureSync('<vaadin-number-field required></vaadin-number-field>');
+      await nextRender();
     });
 
-    it('should fire the event when entering and removing a valid number', async () => {
-      await sendKeys({ type: '555' });
-      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-
-      hasInputValueChangedSpy.resetHistory();
-      await sendKeys({ press: 'Backspace' });
-      await sendKeys({ press: 'Backspace' });
-      await sendKeys({ press: 'Backspace' });
-      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+    it('should focus on required indicator click', () => {
+      numberField.shadowRoot.querySelector('[part="required-indicator"]').click();
+      expect(numberField.hasAttribute('focused')).to.be.true;
     });
-
-    it('should fire the event when entering and removing an invalid number', async () => {
-      await sendKeys({ type: '--5' });
-      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-
-      hasInputValueChangedSpy.resetHistory();
-      await sendKeys({ press: 'Backspace' });
-      await sendKeys({ press: 'Backspace' });
-      await sendKeys({ press: 'Backspace' });
-      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-    });
-  });
-});
-
-describe('required', () => {
-  let numberField;
-
-  beforeEach(() => {
-    numberField = fixtureSync('<vaadin-number-field required></vaadin-number-field>');
-  });
-
-  it('should focus on required indicator click', () => {
-    numberField.shadowRoot.querySelector('[part="required-indicator"]').click();
-    expect(numberField.hasAttribute('focused')).to.be.true;
   });
 });

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-number-field.js';
@@ -8,8 +8,9 @@ describe('validation', () => {
   let field, input;
 
   describe('basic', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+      await nextRender();
       input = field.inputElement;
     });
 
@@ -19,90 +20,106 @@ describe('validation', () => {
       expect(field.invalid).to.be.false;
     });
 
-    it('should not pass validation when the field is required and has no value', () => {
+    it('should not pass validation when the field is required and has no value', async () => {
       field.required = true;
+      await nextFrame();
       expect(field.checkValidity()).to.be.false;
       expect(field.validate()).to.be.false;
       expect(field.invalid).to.be.true;
     });
 
-    it('should pass validation when the field is required and has a valid value', () => {
+    it('should pass validation when the field is required and has a valid value', async () => {
       field.required = true;
       field.value = '1';
+      await nextFrame();
       expect(field.checkValidity()).to.be.true;
       expect(field.validate()).to.be.true;
       expect(field.invalid).to.be.false;
     });
 
-    it('should be valid with numeric values', () => {
+    it('should be valid with numeric values', async () => {
       field.value = '1';
+      await nextFrame();
       expect(input.value).to.be.equal('1');
       expect(field.validate()).to.be.true;
     });
 
-    it('should prevent setting non-numeric values', () => {
+    it('should prevent setting non-numeric values', async () => {
       field.value = 'foo';
+      await nextFrame();
       expect(field.value).to.be.empty;
       expect(field.validate()).to.be.true;
     });
 
-    it('should align checkValidity with the native input element', () => {
+    it('should align checkValidity with the native input element', async () => {
       field.value = -1;
       field.min = 0;
+      await nextFrame();
 
       expect(field.checkValidity()).to.equal(input.checkValidity());
     });
 
-    it('should allow setting decimals', () => {
+    it('should allow setting decimals', async () => {
       field.value = 7.6;
+      await nextFrame();
       expect(field.value).to.be.equal('7.6');
     });
 
-    it('should not prevent invalid values applied programmatically (step)', () => {
+    it('should not prevent invalid values applied programmatically (step)', async () => {
       field.step = 0.1;
       field.value = 7.686;
+      await nextFrame();
       expect(field.value).to.be.equal('7.686');
     });
 
-    it('should not prevent invalid values applied programmatically (min)', () => {
+    it('should not prevent invalid values applied programmatically (min)', async () => {
       field.min = 2;
       field.value = 1;
+      await nextFrame();
       expect(field.value).to.be.equal('1');
     });
 
-    it('should not prevent invalid values applied programmatically (max)', () => {
+    it('should not prevent invalid values applied programmatically (max)', async () => {
       field.max = 2;
       field.value = 3;
+      await nextFrame();
       expect(field.value).to.be.equal('3');
     });
 
-    it('should validate when setting limits', () => {
+    it('should validate when setting limits', async () => {
       field.min = 2;
       field.max = 4;
+      await nextFrame();
 
       field.value = '';
+      await nextFrame();
       expect(field.validate(), 'empty value is allowed because not required').to.be.true;
 
       field.value = '3';
+      await nextFrame();
       expect(field.validate(), 'valid value should be in the range').to.be.true;
 
       field.value = '1';
+      await nextFrame();
       expect(field.validate(), 'value should not be below min').to.be.false;
 
       field.value = '3';
+      await nextFrame();
       expect(field.validate(), 'invalid status should be reset when setting valid value').to.be.true;
 
       field.value = '5';
+      await nextFrame();
       expect(field.validate(), 'value should not be greater than max').to.be.false;
     });
 
-    it('should dispatch change event after validation', () => {
+    it('should dispatch change event after validation', async () => {
       const validateSpy = sinon.spy(field, 'validate');
       const changeSpy = sinon.spy();
       field.required = true;
       field.addEventListener('change', changeSpy);
-      field.value = '123';
+      input.value = '123';
       input.dispatchEvent(new CustomEvent('change'));
+      await nextFrame();
       expect(validateSpy.calledOnce).to.be.true;
       expect(changeSpy.calledAfter(validateSpy)).to.be.true;
     });
@@ -117,10 +134,13 @@ describe('validation', () => {
       expect(event.detail.valid).to.be.true;
     });
 
-    it('should fire a validated event on validation failure', () => {
+    it('should fire a validated event on validation failure', async () => {
       const validatedSpy = sinon.spy();
       field.addEventListener('validated', validatedSpy);
+
       field.required = true;
+      await nextFrame();
+
       field.validate();
 
       expect(validatedSpy.calledOnce).to.be.true;
@@ -130,8 +150,9 @@ describe('validation', () => {
   });
 
   describe('bad input', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+      await nextRender();
       input = field.inputElement;
       input.focus();
     });
@@ -150,6 +171,7 @@ describe('validation', () => {
 
     it('should set an empty value when trying to commit an invalid number', async () => {
       field.value = '1';
+      await nextFrame();
       await sendKeys({ type: '1--' });
       await sendKeys({ type: 'Enter' });
       expect(field.value).to.equal('');
@@ -228,167 +250,213 @@ describe('validation', () => {
 
   describe('step', () => {
     describe('default', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+        await nextRender();
       });
 
-      it('should not validate by step when only min and max are set', () => {
+      it('should not validate by step when only min and max are set', async () => {
         field.min = 1;
         field.max = 5;
         field.value = 1.5; // Would be invalid by default step=1
+        await nextFrame();
         expect(field.validate()).to.be.true;
       });
     });
 
     describe('values', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
         field.step = 1.5;
+        await nextRender();
       });
 
       [-6, -1.5, 0, 1.5, 4.5].forEach((validValue) => {
-        it(`should validate valid value "${validValue}" by step when defined by user`, () => {
+        it(`should validate valid value "${validValue}" by step when defined by user`, async () => {
           field.value = validValue;
+          await nextFrame();
           expect(field.validate()).to.be.true;
         });
       });
 
       [-3.5, -1, 2, 2.5].forEach((invalidValue) => {
-        it(`should validate invalid value "${invalidValue}" by step when defined by user`, () => {
+        it(`should validate invalid value "${invalidValue}" by step when defined by user`, async () => {
           field.value = invalidValue;
+          await nextFrame();
           expect(field.validate()).to.be.false;
         });
       });
     });
 
     describe('basis', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
         field.min = 1;
         field.step = 1.5;
+        await nextRender();
       });
 
       [1, 2.5, 4, 5.5].forEach((validValue) => {
-        it(`should validate valid value "${validValue}" using min as basis`, () => {
+        it(`should validate valid value "${validValue}" using min as basis`, async () => {
           field.value = validValue;
+          await nextFrame();
           expect(field.validate()).to.be.true;
         });
       });
 
       [1.5, 3, 5].forEach((invalidValue) => {
-        it(`should validate invalid value "${invalidValue}" using min as basis`, () => {
+        it(`should validate invalid value "${invalidValue}" using min as basis`, async () => {
           field.value = invalidValue;
+          await nextFrame();
           expect(field.validate()).to.be.false;
         });
       });
     });
 
     describe('the default step is set initially', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         field = fixtureSync('<vaadin-number-field step="1"></vaadin-number-field>');
+        await nextRender();
       });
 
-      it('should validate by step when default value defined as attribute', () => {
+      it('should validate by step when default value defined as attribute', async () => {
         field.value = 1.5;
+        await nextFrame();
         expect(field.validate()).to.be.false;
+
         field.value = 1;
+        await nextFrame();
         expect(field.validate()).to.be.true;
       });
     });
 
     describe('a custom step is set initially', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         field = fixtureSync('<vaadin-number-field step="1.5"></vaadin-number-field>');
+        await nextRender();
       });
 
-      it('should validate by step when defined as attribute', () => {
+      it('should validate by step when defined as attribute', async () => {
         field.value = 1;
+        await nextFrame();
         expect(field.validate()).to.be.false;
+
         field.value = 1.5;
+        await nextFrame();
         expect(field.validate()).to.be.true;
       });
     });
   });
 
   describe('removing constraints', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+      await nextRender();
     });
 
-    it('should update "invalid" state when "required" is removed', () => {
+    it('should update "invalid" state when "required" is removed', async () => {
       field.required = true;
+      await nextFrame();
+
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.required = false;
+      await nextFrame();
+
       expect(field.invalid).to.be.false;
     });
 
-    it('should update "invalid" state when "min" is removed', () => {
+    it('should update "invalid" state when "min" is removed', async () => {
       field.value = '42';
       field.min = 50;
+      await nextFrame();
+
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.min = '';
+      await nextFrame();
+
       expect(field.invalid).to.be.false;
     });
 
-    it('should update "invalid" state when "max" is removed', () => {
+    it('should update "invalid" state when "max" is removed', async () => {
       field.value = '42';
       field.max = 20;
+      await nextFrame();
+
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.max = '';
+      await nextFrame();
+
       expect(field.invalid).to.be.false;
     });
 
-    it('should update "invalid" state when "step" is removed', () => {
+    it('should update "invalid" state when "step" is removed', async () => {
       field.value = '3';
       field.min = 0;
       field.step = 2;
+      await nextFrame();
+
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.step = null;
+      await nextFrame();
+
       expect(field.invalid).to.be.false;
     });
 
-    it('should not update "invalid" when "step" is removed but the field is still required', () => {
+    it('should not update "invalid" when "step" is removed but the field is still required', async () => {
       field.required = true;
       field.step = 2;
+      await nextFrame();
+
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.step = null;
+      await nextFrame();
+
       expect(field.invalid).to.be.true;
     });
 
-    it('should not set "invalid" to false when "min" is set to 0', () => {
+    it('should not set "invalid" to false when "min" is set to 0', async () => {
       field.value = '-5';
       field.min = -1;
+      await nextFrame();
+
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.min = 0;
+      await nextFrame();
+
       expect(field.invalid).to.be.true;
     });
 
-    it('should not set "invalid" to false when "max" is set to 0', () => {
+    it('should not set "invalid" to false when "max" is set to 0', async () => {
       field.value = '5';
       field.max = 1;
+      await nextFrame();
+
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.max = 0;
+      await nextFrame();
+
       expect(field.invalid).to.be.true;
     });
   });
 
   describe('invalid is set initially', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-number-field invalid></vaadin-number-field>');
+      await nextRender();
     });
 
     it('should not remove "invalid" state when ready', () => {
@@ -397,8 +465,9 @@ describe('validation', () => {
   });
 
   describe('invalid and value are set initially', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-number-field invalid value="123456"></vaadin-number-field>');
+      await nextRender();
     });
 
     it('should not remove "invalid" state when ready', () => {


### PR DESCRIPTION
## Description

1. Added `nextRender()` after calling `fixtureSync()` - this makes tests easier to debug as the element is rendered,
2. Added `nextFrame()` after setting properties - this makes our unit tests forwards-compatible with `LitElement`.

## Type of change

- Tests