### PR TITLE
experiment: add LitElement based version of vaadin-text-field

### DIFF
--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-text-field.d.ts",
+    "!src/vaadin-lit-text-field.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/text-field/src/vaadin-lit-text-field.d.ts
+++ b/packages/text-field/src/vaadin-lit-text-field.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { TextFieldMixin } from './vaadin-text-field-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-text-field>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+declare class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {}
+
+export { TextField };

--- a/packages/text-field/src/vaadin-lit-text-field.js
+++ b/packages/text-field/src/vaadin-lit-text-field.js
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '@vaadin/input-container/src/vaadin-input-container.js';
+import { css, html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { TextFieldMixin } from './vaadin-text-field-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-text-field>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+export class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-text-field';
+  }
+
+  static get styles() {
+    return [
+      inputFieldShared,
+      css`
+        [part='input-field'] {
+          flex-grow: 0;
+        }
+      `,
+    ];
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div class="vaadin-field-container">
+        <div part="label">
+          <slot name="label"></slot>
+          <span part="required-indicator" aria-hidden="true" @click="${this.focus}"></span>
+        </div>
+
+        <vaadin-input-container
+          part="input-field"
+          .readonly="${this.readonly}"
+          .disabled="${this.disabled}"
+          .invalid="${this.invalid}"
+          theme="${this._theme}"
+        >
+          <slot name="prefix" slot="prefix"></slot>
+          <slot name="input"></slot>
+          <slot name="suffix" slot="suffix"></slot>
+          <div id="clearButton" part="clear-button" slot="suffix" aria-hidden="true"></div>
+        </vaadin-input-container>
+
+        <div part="helper-text">
+          <slot name="helper"></slot>
+        </div>
+
+        <div part="error-message">
+          <slot name="error-message"></slot>
+        </div>
+      </div>
+
+      <slot name="tooltip"></slot>
+    `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this._tooltipController.setPosition('top');
+    this.addController(this._tooltipController);
+  }
+}
+
+customElements.define(TextField.is, TextField);

--- a/packages/text-field/test/text-field-lit.test.js
+++ b/packages/text-field/test/text-field-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-text-field.js';
+import './text-field.common.js';

--- a/packages/text-field/test/text-field-polymer.test.js
+++ b/packages/text-field/test/text-field-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-text-field.js';
+import './text-field.common.js';

--- a/packages/text-field/test/text-field.common.js
+++ b/packages/text-field/test/text-field.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../src/vaadin-text-field.js';
 
 describe('text-field', () => {
   let textField, input;
@@ -175,6 +174,7 @@ describe('text-field', () => {
       it('should select content on focus when autoselect is true', async () => {
         textField.value = '123';
         textField.autoselect = true;
+        await nextFrame();
         input.dispatchEvent(new CustomEvent('focus', { bubbles: false }));
         await aTimeout(1);
         expect(input.selectionEnd - input.selectionStart).to.equal(3);

--- a/packages/text-field/test/validation-lit.test.js
+++ b/packages/text-field/test/validation-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-text-field.js';
+import './validation.common.js';

--- a/packages/text-field/test/validation-polymer.test.js
+++ b/packages/text-field/test/validation-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-text-field.js';
+import './validation.common.js';

--- a/packages/text-field/test/validation.common.js
+++ b/packages/text-field/test/validation.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../src/vaadin-text-field.js';
 
 describe('validation', () => {
   let field, validateSpy;


### PR DESCRIPTION
## Description

1. Created a version of `vaadin-text-field` web component using `LitElement` base class,
2. Updated existing unit tests to cover both Polymer and Lit based versions of component,
3. Modified `"files"` entry in `package.json` to **NOT** publish new component to `npm`.

## Type of change

- Experiment

## Disclaimer

This PR can be considered a PoC. It's extracted from #5301 after some refactorings.
Even if we agree to merge it, that doesn't necessarily mean further Lit related work.