### PR TITLE
experiment: add LitElement based version of vaadin-text-area

### DIFF
--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-text-area.d.ts",
+    "!src/vaadin-lit-text-area.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/text-area/src/vaadin-lit-text-area.d.ts
+++ b/packages/text-area/src/vaadin-lit-text-area.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { TextAreaMixin } from './vaadin-text-area-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-text-area>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+declare class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {}
+
+export { TextArea };

--- a/packages/text-area/src/vaadin-lit-text-area.js
+++ b/packages/text-area/src/vaadin-lit-text-area.js
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '@vaadin/input-container/src/vaadin-input-container.js';
+import { html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { TextAreaMixin } from './vaadin-text-area-mixin.js';
+import { textAreaStyles } from './vaadin-text-area-styles.js';
+
+/**
+ * LitElement based version of `<vaadin-text-area>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+export class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-text-area';
+  }
+
+  static get styles() {
+    return [inputFieldShared, textAreaStyles];
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div class="vaadin-text-area-container">
+        <div part="label">
+          <slot name="label"></slot>
+          <span part="required-indicator" aria-hidden="true"></span>
+        </div>
+
+        <vaadin-input-container
+          part="input-field"
+          .readonly="${this.readonly}"
+          .disabled="${this.disabled}"
+          .invalid="${this.invalid}"
+          theme="${this._theme}"
+          @scroll="${this._onScroll}"
+        >
+          <slot name="prefix" slot="prefix"></slot>
+          <slot name="textarea"></slot>
+          <slot name="suffix" slot="suffix"></slot>
+          <div id="clearButton" part="clear-button" slot="suffix" aria-hidden="true"></div>
+        </vaadin-input-container>
+
+        <div part="helper-text">
+          <slot name="helper"></slot>
+        </div>
+
+        <div part="error-message">
+          <slot name="error-message"></slot>
+        </div>
+      </div>
+
+      <slot name="tooltip"></slot>
+    `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this._tooltipController.setPosition('top');
+    this.addController(this._tooltipController);
+  }
+}
+
+customElements.define(TextArea.is, TextArea);

--- a/packages/text-area/test/text-area-lit.test.js
+++ b/packages/text-area/test/text-area-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-text-area.js';
+import './text-area.common.js';

--- a/packages/text-area/test/text-area-polymer.test.js
+++ b/packages/text-area/test/text-area-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-text-area.js';
+import './text-area.common.js';

--- a/packages/text-area/test/text-area.common.js
+++ b/packages/text-area/test/text-area.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../src/vaadin-text-area.js';
 
 describe('text-area', () => {
   let textArea;

--- a/packages/text-area/test/validation-lit.test.js
+++ b/packages/text-area/test/validation-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-text-area.js';
+import './validation.common.js';

--- a/packages/text-area/test/validation-polymer.test.js
+++ b/packages/text-area/test/validation-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-text-area.js';
+import './validation.common.js';

--- a/packages/text-area/test/validation.common.js
+++ b/packages/text-area/test/validation.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../src/vaadin-text-area.js';
 
 describe('validation', () => {
   let textArea, validateSpy;


### PR DESCRIPTION
## Description

1. Created a version of `vaadin-text-area` web component using `LitElement` base class,
2. Updated existing unit tests to cover both Polymer and Lit based versions of component,
3. Modified `"files"` entry in `package.json` to **NOT** publish new component to `npm`.

## Type of change

- Experiment

## Disclaimer

This PR can be considered a PoC. It's extracted from #5301 after some refactorings.
Even if we agree to merge it, that doesn't necessarily mean further Lit related work.