### PR TITLE
experiment: add Lit based version of vaadin-number-field

### DIFF
--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-number-field.d.ts",
+    "!src/vaadin-lit-number-field.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/number-field/src/vaadin-lit-number-field.d.ts
+++ b/packages/number-field/src/vaadin-lit-number-field.d.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-number-field>` web component.
+ * Note: this is a prototype not supposed to be used publicly.
+ */
+declare class NumberField extends NumberFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {}
+
+export { NumberField };

--- a/packages/number-field/src/vaadin-lit-number-field.d.ts
+++ b/packages/number-field/src/vaadin-lit-number-field.d.ts
@@ -11,7 +11,12 @@ import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
 
 /**
  * LitElement based version of `<vaadin-number-field>` web component.
- * Note: this is a prototype not supposed to be used publicly.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
  */
 declare class NumberField extends NumberFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {}
 

--- a/packages/number-field/src/vaadin-lit-number-field.js
+++ b/packages/number-field/src/vaadin-lit-number-field.js
@@ -15,7 +15,12 @@ import { numberFieldStyles } from './vaadin-number-field-styles.js';
 
 /**
  * LitElement based version of `<vaadin-number-field>` web component.
- * Note: this is a prototype not supposed to be used publicly.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
  */
 class NumberField extends NumberFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/number-field/src/vaadin-lit-number-field.js
+++ b/packages/number-field/src/vaadin-lit-number-field.js
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '@vaadin/input-container/src/vaadin-input-container.js';
+import { html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
+import { numberFieldStyles } from './vaadin-number-field-styles.js';
+
+/**
+ * LitElement based version of `<vaadin-number-field>` web component.
+ * Note: this is a prototype not supposed to be used publicly.
+ */
+class NumberField extends NumberFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-number-field';
+  }
+
+  static get styles() {
+    return [inputFieldShared, numberFieldStyles];
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div class="vaadin-field-container">
+        <div part="label">
+          <slot name="label"></slot>
+          <span part="required-indicator" aria-hidden="true" @click="${this.focus}"></span>
+        </div>
+
+        <vaadin-input-container
+          part="input-field"
+          .readonly="${this.readonly}"
+          .disabled="${this.disabled}"
+          .invalid="${this.invalid}"
+          theme="${this._theme}"
+        >
+          <div
+            part="decrease-button"
+            ?disabled="${!this._isButtonEnabled(-1, this.value, this.min, this.max, this.step)}"
+            ?hidden="${!this.stepButtonsVisible}"
+            @click="${this._onDecreaseButtonClick}"
+            @touchend="${this._onDecreaseButtonTouchend}"
+            aria-hidden="true"
+            slot="prefix"
+          ></div>
+          <slot name="prefix" slot="prefix"></slot>
+          <slot name="input"></slot>
+          <slot name="suffix" slot="suffix"></slot>
+          <div id="clearButton" part="clear-button" slot="suffix" aria-hidden="true"></div>
+          <div
+            part="increase-button"
+            ?disabled="${!this._isButtonEnabled(1, this.value, this.min, this.max, this.step)}"
+            ?hidden="${!this.stepButtonsVisible}"
+            @click="${this._onIncreaseButtonClick}"
+            @touchend="${this._onIncreaseButtonTouchend}"
+            aria-hidden="true"
+            slot="suffix"
+          ></div>
+        </vaadin-input-container>
+
+        <div part="helper-text">
+          <slot name="helper"></slot>
+        </div>
+
+        <div part="error-message">
+          <slot name="error-message"></slot>
+        </div>
+      </div>
+
+      <slot name="tooltip"></slot>
+    `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+    this._tooltipController.setPosition('top');
+  }
+
+  /**
+   * Override method from `InputConstraintsMixin`
+   * to create observer after the initial update
+   * and preserve invalid state set as attribute.
+   *
+   * @protected
+   * @override
+   */
+  async _createConstraintsObserver() {
+    await this.updateComplete;
+
+    super._createConstraintsObserver();
+  }
+}
+
+customElements.define(NumberField.is, NumberField);
+
+export { NumberField };

--- a/packages/number-field/test/number-field-lit.test.js
+++ b/packages/number-field/test/number-field-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-number-field.js';
+import './number-field.common.js';

--- a/packages/number-field/test/number-field-polymer.test.js
+++ b/packages/number-field/test/number-field-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-number-field.js';
+import './number-field.common.js';

--- a/packages/number-field/test/number-field.common.js
+++ b/packages/number-field/test/number-field.common.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { arrowDown, arrowUp, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../src/vaadin-number-field.js';
 
 describe('number-field', () => {
   let numberField, input, decreaseButton, increaseButton;

--- a/packages/number-field/test/validation-lit.test.js
+++ b/packages/number-field/test/validation-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-number-field.js';
+import './validation.common.js';

--- a/packages/number-field/test/validation-polymer.test.js
+++ b/packages/number-field/test/validation-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-number-field.js';
+import './validation.common.js';

--- a/packages/number-field/test/validation.common.js
+++ b/packages/number-field/test/validation.common.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../src/vaadin-number-field.js';
 
 describe('validation', () => {
   let field, input;


### PR DESCRIPTION
## Description

1. Created a version of `vaadin-number-field` web component using `LitElement` base class,
2. Updated existing unit tests to cover both Polymer and Lit based versions of component,
3. Modified `"files"` entry in `package.json` to **NOT** publish new component to `npm`.

## Type of change

- Experiment

## Disclaimer

This PR can be considered a PoC. It's extracted from #5301 after some refactorings.
Even if we agree to merge it, that doesn't necessarily mean further Lit related work.