### PR TITLE
refactor: extract email-field styles to reusable css literal

### DIFF
--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -39,7 +39,8 @@
     "@vaadin/text-field": "24.0.0-beta1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-beta1",
     "@vaadin/vaadin-material-styles": "24.0.0-beta1",
-    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1"
+    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1",
+    "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/email-field/src/vaadin-email-field-styles.d.ts
+++ b/packages/email-field/src/vaadin-email-field-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const emailFieldStyles: CSSResult;

--- a/packages/email-field/src/vaadin-email-field-styles.js
+++ b/packages/email-field/src/vaadin-email-field-styles.js
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+// See https://github.com/vaadin/vaadin-text-field/issues/466
+export const emailFieldStyles = css`
+  :host([dir='rtl']) [part='input-field'] {
+    direction: ltr;
+  }
+
+  :host([dir='rtl']) [part='input-field'] ::slotted(input)::placeholder {
+    direction: rtl;
+    text-align: left;
+  }
+`;

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -4,23 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { emailFieldStyles } from './vaadin-email-field-styles.js';
 
-// See https://github.com/vaadin/vaadin-text-field/issues/466
-registerStyles(
-  'vaadin-email-field',
-  css`
-    :host([dir='rtl']) [part='input-field'] {
-      direction: ltr;
-    }
-
-    :host([dir='rtl']) [part='input-field'] ::slotted(input)::placeholder {
-      direction: rtl;
-      text-align: left;
-    }
-  `,
-  { moduleId: 'vaadin-email-field-styles' },
-);
+registerStyles('vaadin-email-field', emailFieldStyles, { moduleId: 'vaadin-email-field-styles' });
 
 /**
  * `<vaadin-email-field>` is a Web Component for email field control in forms.


### PR DESCRIPTION
## Description

Moved styles from the component's template to `css` literal that could be also used by the Lit version.

## Type of change

- Refactor