### PR TITLE
refactor: extract button template and reusable css literal

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -39,7 +39,8 @@
     "@vaadin/component-base": "24.0.0-beta1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-beta1",
     "@vaadin/vaadin-material-styles": "24.0.0-beta1",
-    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1"
+    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1",
+    "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/button/src/vaadin-button-base.d.ts
+++ b/packages/button/src/vaadin-button-base.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult, TemplateResult } from 'lit';
+
+export const styles: CSSResult;
+
+export function template<
+  T extends HTMLTemplateElement | TemplateResult,
+  F extends (strings: TemplateStringsArray, ...values: any[]) => T,
+>(tag: F): T;

--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const buttonStyles = css`
+  :host {
+    display: inline-block;
+    position: relative;
+    outline: none;
+    white-space: nowrap;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  /* Aligns the button with form fields when placed on the same line.
+  Note, to make it work, the form fields should have the same "::before" pseudo-element. */
+  .vaadin-button-container::before {
+    content: '\\2003';
+    display: inline-block;
+    width: 0;
+    max-height: 100%;
+  }
+
+  .vaadin-button-container {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    width: 100%;
+    height: 100%;
+    min-height: inherit;
+    text-shadow: inherit;
+  }
+
+  [part='prefix'],
+  [part='suffix'] {
+    flex: none;
+  }
+
+  [part='label'] {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`;
+
+export const buttonTemplate = (html) => html`
+  <div class="vaadin-button-container">
+    <span part="prefix" aria-hidden="true">
+      <slot name="prefix"></slot>
+    </span>
+    <span part="label">
+      <slot></slot>
+    </span>
+    <span part="suffix" aria-hidden="true">
+      <slot name="suffix"></slot>
+    </span>
+  </div>
+  <slot name="tooltip"></slot>
+`;

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -7,8 +7,11 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { buttonStyles, buttonTemplate } from './vaadin-button-base.js';
 import { ButtonMixin } from './vaadin-button-mixin.js';
+
+registerStyles('vaadin-button', buttonStyles, { moduleId: 'vaadin-button-styles' });
 
 /**
  * `<vaadin-button>` is an accessible and customizable button that allows users to perform actions.
@@ -50,66 +53,7 @@ class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(Poly
   }
 
   static get template() {
-    return html`
-      <style>
-        :host {
-          display: inline-block;
-          position: relative;
-          outline: none;
-          white-space: nowrap;
-          -webkit-user-select: none;
-          -moz-user-select: none;
-          user-select: none;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        /* Aligns the button with form fields when placed on the same line.
-          Note, to make it work, the form fields should have the same "::before" pseudo-element. */
-        .vaadin-button-container::before {
-          content: '\\2003';
-          display: inline-block;
-          width: 0;
-          max-height: 100%;
-        }
-
-        .vaadin-button-container {
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          text-align: center;
-          width: 100%;
-          height: 100%;
-          min-height: inherit;
-          text-shadow: inherit;
-        }
-
-        [part='prefix'],
-        [part='suffix'] {
-          flex: none;
-        }
-
-        [part='label'] {
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-      </style>
-      <div class="vaadin-button-container">
-        <span part="prefix" aria-hidden="true">
-          <slot name="prefix"></slot>
-        </span>
-        <span part="label">
-          <slot></slot>
-        </span>
-        <span part="suffix" aria-hidden="true">
-          <slot name="suffix"></slot>
-        </span>
-      </div>
-      <slot name="tooltip"></slot>
-    `;
+    return buttonTemplate(html);
   }
 
   /** @protected */

--- a/packages/crud/src/vaadin-crud-edit.js
+++ b/packages/crud/src/vaadin-crud-edit.js
@@ -10,6 +10,21 @@
  */
 import { html } from '@polymer/polymer/polymer-element.js';
 import { Button } from '@vaadin/button/src/vaadin-button.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * Use registerStyles instead of the `<style>` tag to make sure
+ * that this CSS will override core styles of `vaadin-button`.
+ */
+registerStyles(
+  'vaadin-crud-edit',
+  css`
+    :host {
+      display: block;
+    }
+  `,
+  { moduleId: 'vaadin-crud-edit-styles' },
+);
 
 /**
  * `<vaadin-crud-edit>` is a helper element for `<vaadin-grid-column>` that provides
@@ -25,11 +40,6 @@ import { Button } from '@vaadin/button/src/vaadin-button.js';
 class CrudEdit extends Button {
   static get template() {
     return html`
-      <style>
-        :host {
-          display: block;
-        }
-      </style>
       <div part="icon"></div>
       <slot name="tooltip"></slot>
     `;


### PR DESCRIPTION
## Description

Refactored `html` and `css` literals to be placed in `vaadin-button-base.js` as prototyped in #5301 

## Type of change

- Refactor