### PR TITLE
experiment: add Lit based version of vaadin-email-field

### DIFF
--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-email-field.d.ts",
+    "!src/vaadin-lit-email-field.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/email-field/src/vaadin-lit-email-field.d.ts
+++ b/packages/email-field/src/vaadin-lit-email-field.d.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { TextField } from '@vaadin/text-field/src/vaadin-lit-text-field.js';
+
+/**
+ * LitElement based version of `<vaadin-email-field>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+declare class EmailField extends TextField {}
+
+export { EmailField };

--- a/packages/email-field/src/vaadin-lit-email-field.js
+++ b/packages/email-field/src/vaadin-lit-email-field.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { TextField } from '@vaadin/text-field/src/vaadin-lit-text-field.js';
+import { emailFieldStyles } from './vaadin-email-field-styles.js';
+
+/**
+ * LitElement based version of `<vaadin-email-field>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+export class EmailField extends TextField {
+  static get is() {
+    return 'vaadin-email-field';
+  }
+
+  static get styles() {
+    return [...super.styles, emailFieldStyles];
+  }
+
+  constructor() {
+    super();
+    this._setType('email');
+    this.pattern = '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-]{2,}$';
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    if (this.inputElement) {
+      this.inputElement.autocapitalize = 'off';
+    }
+  }
+}
+
+customElements.define('vaadin-email-field', EmailField);

--- a/packages/email-field/test/email-field-lit.test.js
+++ b/packages/email-field/test/email-field-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-email-field.js';
+import './email-field.common.js';

--- a/packages/email-field/test/email-field-polymer.test.js
+++ b/packages/email-field/test/email-field-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-email-field.js';
+import './email-field.common.js';

--- a/packages/email-field/test/email-field.common.js
+++ b/packages/email-field/test/email-field.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../src/vaadin-email-field.js';
 
 const validAddresses = [
   'email@example.com',


### PR DESCRIPTION
## Description

1. Created a version of `vaadin-email-field` web component using `LitElement` base class,
2. Updated existing unit tests to cover both Polymer and Lit based versions of component,
3. Modified `"files"` entry in `package.json` to **NOT** publish new component to `npm`.

## Type of change

- Experiment

## Disclaimer

This PR can be considered a PoC. It's extracted from #5301 after some refactorings.
Even if we agree to merge it, that doesn't necessarily mean further Lit related work.