### PR TITLE
experiment: add Lit based version of vaadin-button

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-button.d.ts",
+    "!src/vaadin-lit-button.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/button/src/vaadin-button-mixin.js
+++ b/packages/button/src/vaadin-button-mixin.js
@@ -26,7 +26,9 @@ export const ButtonMixin = (superClass) =>
          * @protected
          */
         tabindex: {
+          type: Number,
           value: 0,
+          reflectToAttribute: true,
         },
       };
     }

--- a/packages/button/src/vaadin-lit-button.d.ts
+++ b/packages/button/src/vaadin-lit-button.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ButtonMixin } from './vaadin-button-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-button>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
+
+export { Button };

--- a/packages/button/src/vaadin-lit-button.js
+++ b/packages/button/src/vaadin-lit-button.js
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { buttonStyles, buttonTemplate } from './vaadin-button-base.js';
+import { ButtonMixin } from './vaadin-button-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-button>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-button';
+  }
+
+  static get styles() {
+    return buttonStyles;
+  }
+
+  /** @protected */
+  render() {
+    return buttonTemplate(html);
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+  }
+}
+
+customElements.define(Button.is, Button);
+
+export { Button };

--- a/packages/button/test/button-lit.test.js
+++ b/packages/button/test/button-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-button.js';
+import './button.common.js';

--- a/packages/button/test/button-polymer.test.js
+++ b/packages/button/test/button-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-button.js';
+import './button.common.js';

--- a/packages/button/test/button.common.js
+++ b/packages/button/test/button.common.js
@@ -1,8 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../vaadin-button.js';
 
 describe('vaadin-button', () => {
   let button;
@@ -69,6 +68,7 @@ describe('vaadin-button', () => {
         const spy = sinon.spy();
         button.addEventListener('click', spy);
         button.disabled = true;
+        await nextFrame();
 
         await sendKeys({ down: key });
 


### PR DESCRIPTION
## Description

1. Created a version of `vaadin-buttond` web component using `LitElement` base class,
2. Updated existing unit tests to cover both Polymer and Lit based versions of component,
3. Modified `"files"` entry in `package.json` to **NOT** publish new component to `npm`.

## Type of change

- Experiment

## Disclaimer

This PR can be considered a PoC. It's extracted from #5301 after some refactorings.
Even if we agree to merge it, that doesn't necessarily mean further Lit related work.