### PR TITLE
chore: update release notes script to list experiments

### DIFF
--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -22,6 +22,7 @@ const keyName = {
   feat: ':rocket:　New Features',
   fix: ':bug:　Bug Fixes',
   refactor: ':nail_care:　Polish',
+  experiment: ':construction:　Experiments',
   docs: ':memo:　Documentation',
   test: ':microscope:　Tests',
   chore: ':house:　Internal',


### PR DESCRIPTION
## Description

This change is needed to list our recently merged Lit experiments as a separate category in the release notes.

## Type of change

- Internal change

## Output example

#### :construction:　Experiments
- `number-field`
  - [⧉](https://github.com/vaadin/web-components/commit/2bfe689) Add Lit based version of vaadin-number-field ([#5541](https://github.com/vaadin/web-components/pull/5541))
- `text-area`
  - [⧉](https://github.com/vaadin/web-components/commit/dc920c1) Add Lit based version of vaadin-text-area ([#5539](https://github.com/vaadin/web-components/pull/5539))
- `text-field`
  - [⧉](https://github.com/vaadin/web-components/commit/f8e274a) Add Lit based version of vaadin-text-field ([#5538](https://github.com/vaadin/web-components/pull/5538))