### PR TITLE
refactor: extract progress-bar styles to reusable css literal

### DIFF
--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -41,7 +41,8 @@
     "@vaadin/component-base": "24.0.0-beta1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-beta1",
     "@vaadin/vaadin-material-styles": "24.0.0-beta1",
-    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1"
+    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1",
+    "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/progress-bar/src/vaadin-progress-bar-styles.d.ts
+++ b/packages/progress-bar/src/vaadin-progress-bar-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const progressBarStyles: CSSResult;

--- a/packages/progress-bar/src/vaadin-progress-bar-styles.js
+++ b/packages/progress-bar/src/vaadin-progress-bar-styles.js
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const progressBarStyles = css`
+  :host {
+    display: block;
+    width: 100%; /* prevent collapsing inside non-stretching column flex */
+    height: 8px;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  [part='bar'] {
+    height: 100%;
+  }
+
+  [part='value'] {
+    height: 100%;
+    transform-origin: 0 50%;
+    transform: scaleX(var(--vaadin-progress-value));
+  }
+
+  :host([dir='rtl']) [part='value'] {
+    transform-origin: 100% 50%;
+  }
+`;

--- a/packages/progress-bar/src/vaadin-progress-bar.js
+++ b/packages/progress-bar/src/vaadin-progress-bar.js
@@ -5,8 +5,11 @@
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { progressBarStyles } from './vaadin-progress-bar-styles.js';
 import { ProgressMixin } from './vaadin-progress-mixin.js';
+
+registerStyles('vaadin-progress-bar', progressBarStyles, { moduleId: 'vaadin-progress-bar-styles' });
 
 /**
  * `<vaadin-progress-bar>` is a Web Component for progress bars.
@@ -45,44 +48,16 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  * @mixes ElementMixin
  */
 class ProgressBar extends ElementMixin(ThemableMixin(ProgressMixin(PolymerElement))) {
+  static get is() {
+    return 'vaadin-progress-bar';
+  }
+
   static get template() {
     return html`
-      <style>
-        :host {
-          display: block;
-          width: 100%; /* prevent collapsing inside non-stretching column flex */
-          height: 8px;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        [part='bar'] {
-          height: 100%;
-        }
-
-        [part='value'] {
-          height: 100%;
-          transform-origin: 0 50%;
-          transform: scaleX(var(--vaadin-progress-value));
-        }
-
-        /* RTL specific styles */
-
-        :host([dir='rtl']) [part='value'] {
-          transform-origin: 100% 50%;
-        }
-      </style>
-
       <div part="bar">
         <div part="value"></div>
       </div>
     `;
-  }
-
-  static get is() {
-    return 'vaadin-progress-bar';
   }
 }
 


### PR DESCRIPTION
## Description

Same as #5544 but for `vaadin-progress-bar`.

## Type of change

- Refactor