### PR TITLE
experiment: add Lit based version of vaadin-progress-bar

### DIFF
--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-progress-bar.d.ts",
+    "!src/vaadin-lit-progress-bar.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/progress-bar/src/vaadin-lit-progress-bar.d.ts
+++ b/packages/progress-bar/src/vaadin-lit-progress-bar.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ProgressMixin } from './vaadin-progress-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-progress-bar>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+declare class ProgressBar extends ProgressMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
+
+export { ProgressBar };

--- a/packages/progress-bar/src/vaadin-lit-progress-bar.js
+++ b/packages/progress-bar/src/vaadin-lit-progress-bar.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { progressBarStyles } from './vaadin-progress-bar-base.js';
+import { ProgressMixin } from './vaadin-progress-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-progress-bar>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class ProgressBar extends ProgressMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-progress-bar';
+  }
+
+  static get styles() {
+    return progressBarStyles;
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div part="bar">
+        <div part="value"></div>
+      </div>
+    `;
+  }
+}
+
+customElements.define(ProgressBar.is, ProgressBar);
+
+export { ProgressBar };

--- a/packages/progress-bar/src/vaadin-lit-progress-bar.js
+++ b/packages/progress-bar/src/vaadin-lit-progress-bar.js
@@ -7,7 +7,7 @@ import { html, LitElement } from 'lit';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { progressBarStyles } from './vaadin-progress-bar-base.js';
+import { progressBarStyles } from './vaadin-progress-bar-styles.js';
 import { ProgressMixin } from './vaadin-progress-mixin.js';
 
 /**

--- a/packages/progress-bar/test/progress-bar-lit.test.js
+++ b/packages/progress-bar/test/progress-bar-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-progress-bar.js';
+import './progress-bar.common.js';

--- a/packages/progress-bar/test/progress-bar-polymer.test.js
+++ b/packages/progress-bar/test/progress-bar-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-progress-bar.js';
+import './progress-bar.common.js';

--- a/packages/progress-bar/test/progress-bar.common.js
+++ b/packages/progress-bar/test/progress-bar.common.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import '../src/vaadin-progress-bar.js';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 
 describe('progress bar', () => {
   let progress;
@@ -31,77 +30,90 @@ describe('progress bar', () => {
       value = progress.shadowRoot.querySelector('[part="value"]');
     });
 
-    it('should have proper scale', () => {
+    it('should have proper scale', async () => {
       progress.value = 0.1;
+      await nextFrame();
       expect(value.getBoundingClientRect().width / progress.offsetWidth).to.be.closeTo(0.1, 0.002);
     });
 
-    it('should set progress-value custom variable properly', () => {
+    it('should set progress-value custom variable properly', async () => {
       progress.value = 0.1;
+      await nextFrame();
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.equal('0.1');
     });
 
-    it('should have proper scale with custom min and max', () => {
+    it('should have proper scale with custom min and max', async () => {
       progress.max = 20;
       progress.min = 10;
       progress.value = 15;
+      await nextFrame();
       expect(value.getBoundingClientRect().width / progress.offsetWidth).to.be.closeTo(0.5, 0.002);
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.equal('0.5');
     });
 
-    it('should set normalized value to 1 in case of wrong bounds', () => {
+    it('should set normalized value to 1 in case of wrong bounds', async () => {
       progress.value = 10;
       progress.max = 12;
       progress.min = 13;
+      await nextFrame();
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('1');
     });
 
-    it('should set normalized value to 1 in case of equal bounds', () => {
+    it('should set normalized value to 1 in case of equal bounds', async () => {
       progress.value = 10;
       progress.max = 10;
       progress.min = 10;
+      await nextFrame();
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('1');
     });
 
-    it('should set normalized value to 0 if the value is undefined', () => {
+    it('should set normalized value to 0 if the value is undefined', async () => {
       progress.value = undefined;
+      await nextFrame();
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('0');
     });
 
-    it('should set normalized value to 0.5 if the value is 0 and min is -1', () => {
+    it('should set normalized value to 0.5 if the value is 0 and min is -1', async () => {
       progress.min = -1;
       progress.value = 0;
+      await nextFrame();
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('0.5');
     });
 
-    it('should clamp normalized value between 0 and 1', () => {
+    it('should clamp normalized value between 0 and 1', async () => {
       progress.value = -1;
+      await nextFrame();
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('0');
 
       progress.value = 2;
+      await nextFrame();
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('1');
     });
 
-    it('should set proper aria-valuenow on value change', () => {
+    it('should set proper aria-valuenow on value change', async () => {
       progress.max = 100;
       progress.value = 50;
+      await nextFrame();
       expect(progress.getAttribute('aria-valuenow')).to.equal('50');
     });
 
-    it('should set proper aria-valuemin on min change', () => {
+    it('should set proper aria-valuemin on min change', async () => {
       progress.max = 100;
       progress.min = 10;
+      await nextFrame();
       expect(progress.getAttribute('aria-valuemin')).to.equal('10');
     });
 
-    it('should set proper aria-valuemax on max change', () => {
+    it('should set proper aria-valuemax on max change', async () => {
       progress.max = 100;
       progress.min = 10;
+      await nextFrame();
       expect(progress.getAttribute('aria-valuemax')).to.equal('100');
     });
 
-    it('should set indeterminate attribute', () => {
+    it('should set indeterminate attribute', async () => {
       progress.indeterminate = true;
+      await nextFrame();
       expect(progress.hasAttribute('indeterminate')).to.be.true;
     });
   });


### PR DESCRIPTION
## Description

Depends on #5557

1. Created a version of `vaadin-progress-bar` web component using `LitElement` base class,
2. Updated existing unit tests to cover both Polymer and Lit based versions of component,
3. Modified `"files"` entry in `package.json` to **NOT** publish new component to `npm`.

## Type of change

- Experiment

## Disclaimer

This PR can be considered a PoC. It's extracted from #5301 after some refactorings.
Even if we agree to merge it, that doesn't necessarily mean further Lit related work.