### PR TITLE
refactor: extract checkbox styles to reusable css literal

### DIFF
--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -40,7 +40,8 @@
     "@vaadin/field-base": "24.0.0-beta1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-beta1",
     "@vaadin/vaadin-material-styles": "24.0.0-beta1",
-    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1"
+    "@vaadin/vaadin-themable-mixin": "24.0.0-beta1",
+    "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/checkbox/src/vaadin-checkbox-styles.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const checkboxStyles: CSSResult;

--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const checkboxStyles = css`
+  :host {
+    display: inline-block;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  :host([disabled]) {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .vaadin-checkbox-container {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: baseline;
+  }
+
+  [part='checkbox'],
+  ::slotted(input),
+  ::slotted(label) {
+    grid-row: 1;
+  }
+
+  [part='checkbox'],
+  ::slotted(input) {
+    grid-column: 1;
+  }
+
+  [part='checkbox'] {
+    width: var(--vaadin-checkbox-size, 1em);
+    height: var(--vaadin-checkbox-size, 1em);
+  }
+
+  [part='checkbox']::before {
+    display: block;
+    content: '\\202F';
+    line-height: var(--vaadin-checkbox-size, 1em);
+    contain: paint;
+  }
+
+  /* visually hidden */
+  ::slotted(input) {
+    opacity: 0;
+    cursor: inherit;
+    margin: 0;
+    align-self: stretch;
+    -webkit-appearance: none;
+  }
+`;

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -13,7 +13,10 @@ import { CheckedMixin } from '@vaadin/field-base/src/checked-mixin.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { LabelMixin } from '@vaadin/field-base/src/label-mixin.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { checkboxStyles } from './vaadin-checkbox-styles.js';
+
+registerStyles('vaadin-checkbox', checkboxStyles, { moduleId: 'vaadin-checkbox-styles' });
 
 /**
  * `<vaadin-checkbox>` is an input field representing a binary choice.
@@ -65,57 +68,6 @@ class Checkbox extends LabelMixin(
 
   static get template() {
     return html`
-      <style>
-        :host {
-          display: inline-block;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        :host([disabled]) {
-          -webkit-tap-highlight-color: transparent;
-        }
-
-        .vaadin-checkbox-container {
-          display: grid;
-          grid-template-columns: auto 1fr;
-          align-items: baseline;
-        }
-
-        [part='checkbox'],
-        ::slotted(input),
-        ::slotted(label) {
-          grid-row: 1;
-        }
-
-        [part='checkbox'],
-        ::slotted(input) {
-          grid-column: 1;
-        }
-
-        [part='checkbox'] {
-          width: var(--vaadin-checkbox-size, 1em);
-          height: var(--vaadin-checkbox-size, 1em);
-        }
-
-        [part='checkbox']::before {
-          display: block;
-          content: '\\202F';
-          line-height: var(--vaadin-checkbox-size, 1em);
-          contain: paint;
-        }
-
-        /* visually hidden */
-        ::slotted(input) {
-          opacity: 0;
-          cursor: inherit;
-          margin: 0;
-          align-self: stretch;
-          -webkit-appearance: none;
-        }
-      </style>
       <div class="vaadin-checkbox-container">
         <div part="checkbox" aria-hidden="true"></div>
         <slot name="input"></slot>


### PR DESCRIPTION
## Description

Same as #5557 but for `vaadin-checkbox`.

## Type of change

- Refactor