### PR TITLE
docs: improve JSDoc for checkbox stylable parts and states

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -41,20 +41,20 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEve
  * The following shadow DOM parts are available for styling:
  *
  * Part name   | Description
- * ------------|----------------
- * `checkbox`  | The wrapper element that contains slotted `<input type="checkbox">`
+ * ------------|-------------
+ * `checkbox`  | The element representing a stylable custom checkbox.
  *
  * The following state attributes are available for styling:
  *
- * Attribute       | Description | Part name
- * ----------------|-------------|--------------
- * `active`        | Set when the checkbox is pressed down, either with mouse, touch or the keyboard. | `:host`
- * `disabled`      | Set when the checkbox is disabled. | `:host`
- * `focus-ring`    | Set when the checkbox is focused using the keyboard. | `:host`
- * `focused`       | Set when the checkbox is focused. | `:host`
- * `indeterminate` | Set when the checkbox is in the indeterminate state. | `:host`
- * `checked`       | Set when the checkbox is checked. | `:host`
- * `has-label`     | Set when the checkbox has a label. | `:host`
+ * Attribute       | Description
+ * ----------------|-------------
+ * `active`        | Set when the checkbox is activated with mouse, touch or the keyboard.
+ * `checked`       | Set when the checkbox is checked.
+ * `disabled`      | Set when the checkbox is disabled.
+ * `focus-ring`    | Set when the checkbox is focused using the keyboard.
+ * `focused`       | Set when the checkbox is focused.
+ * `indeterminate` | Set when the checkbox is in the indeterminate state.
+ * `has-label`     | Set when the checkbox has a label.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -30,20 +30,20 @@ registerStyles('vaadin-checkbox', checkboxStyles, { moduleId: 'vaadin-checkbox-s
  * The following shadow DOM parts are available for styling:
  *
  * Part name   | Description
- * ------------|----------------
- * `checkbox`  | The wrapper element that contains slotted <input type="checkbox">.
+ * ------------|-------------
+ * `checkbox`  | The element representing a stylable custom checkbox.
  *
  * The following state attributes are available for styling:
  *
- * Attribute       | Description | Part name
- * ----------------|-------------|--------------
- * `active`        | Set when the checkbox is pressed down, either with mouse, touch or the keyboard. | `:host`
- * `disabled`      | Set when the checkbox is disabled. | `:host`
- * `focus-ring`    | Set when the checkbox is focused using the keyboard. | `:host`
- * `focused`       | Set when the checkbox is focused. | `:host`
- * `indeterminate` | Set when the checkbox is in the indeterminate state. | `:host`
- * `checked`       | Set when the checkbox is checked. | `:host`
- * `has-label`     | Set when the checkbox has a label. | `:host`
+ * Attribute       | Description
+ * ----------------|-------------
+ * `active`        | Set when the checkbox is activated with mouse, touch or the keyboard.
+ * `checked`       | Set when the checkbox is checked.
+ * `disabled`      | Set when the checkbox is disabled.
+ * `focus-ring`    | Set when the checkbox is focused using the keyboard.
+ * `focused`       | Set when the checkbox is focused.
+ * `indeterminate` | Set when the checkbox is in the indeterminate state.
+ * `has-label`     | Set when the checkbox has a label.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/custom-theme/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Rephrased confusing note regarding `::part(checkbox)`. Also, simplified the state attributes table.

## Type of change

- Documentation