### PR TITLE
experiment: add Lit based version of vaadin-checkbox

### DIFF
--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-checkbox.d.ts",
+    "!src/vaadin-lit-checkbox.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/checkbox/src/vaadin-lit-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-lit-checkbox.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-checkbox>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+declare class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
+
+export { Checkbox };

--- a/packages/checkbox/src/vaadin-lit-checkbox.js
+++ b/packages/checkbox/src/vaadin-lit-checkbox.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
+import { checkboxStyles } from './vaadin-checkbox-styles.js';
+
+/**
+ * LitElement based version of `<vaadin-checkbox>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-checkbox';
+  }
+
+  static get styles() {
+    return checkboxStyles;
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div class="vaadin-checkbox-container">
+        <div part="checkbox" aria-hidden="true"></div>
+        <slot name="input"></slot>
+        <slot name="label"></slot>
+      </div>
+      <slot name="tooltip"></slot>
+    `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+  }
+}
+
+customElements.define(Checkbox.is, Checkbox);

--- a/packages/checkbox/test/checkbox-lit.test.js
+++ b/packages/checkbox/test/checkbox-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-checkbox.js';
+import './checkbox.common.js';

--- a/packages/checkbox/test/checkbox-polymer.test.js
+++ b/packages/checkbox/test/checkbox-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-checkbox.js';
+import './checkbox.common.js';

--- a/packages/checkbox/test/checkbox.common.js
+++ b/packages/checkbox/test/checkbox.common.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, mousedown, mouseup, nextFrame } from '@vaadin/testing-helpers';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../vaadin-checkbox.js';
 
 describe('checkbox', () => {
   let checkbox, input, label, link;
@@ -64,8 +63,9 @@ describe('checkbox', () => {
       expect(checkbox.checked).to.be.false;
     });
 
-    it('should not toggle checked property on click when disabled', () => {
+    it('should not toggle checked property on click when disabled', async () => {
       checkbox.disabled = true;
+      await nextFrame();
       checkbox.click();
       expect(checkbox.checked).to.be.false;
     });
@@ -81,6 +81,7 @@ describe('checkbox', () => {
     it('should be checked on Space press when initially checked is false and indeterminate is true', async () => {
       checkbox.checked = false;
       checkbox.indeterminate = true;
+      await nextFrame();
 
       // Focus on the input
       await sendKeys({ press: 'Tab' });
@@ -94,6 +95,7 @@ describe('checkbox', () => {
     it('should not be checked on Space press when initially checked is true and indeterminate is true', async () => {
       checkbox.checked = true;
       checkbox.indeterminate = true;
+      await nextFrame();
 
       // Focus on the input
       await sendKeys({ press: 'Tab' });
@@ -104,18 +106,22 @@ describe('checkbox', () => {
       expect(checkbox.indeterminate).to.be.false;
     });
 
-    it('should be checked on click when initially checked is false and indeterminate is true', () => {
+    it('should be checked on click when initially checked is false and indeterminate is true', async () => {
       checkbox.checked = false;
       checkbox.indeterminate = true;
+      await nextFrame();
+
       checkbox.click();
 
       expect(checkbox.checked).to.be.true;
       expect(checkbox.indeterminate).to.be.false;
     });
 
-    it('should not be checked on click when initially checked is true and indeterminate is true', () => {
+    it('should not be checked on click when initially checked is true and indeterminate is true', async () => {
       checkbox.checked = true;
       checkbox.indeterminate = true;
+      await nextFrame();
+
       checkbox.click();
 
       expect(checkbox.checked).to.be.false;
@@ -215,16 +221,19 @@ describe('checkbox', () => {
   });
 
   describe('indeterminate property', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       checkbox = fixtureSync(`<vaadin-checkbox></vaadin-checkbox>`);
+      await nextFrame();
       input = checkbox.inputElement;
     });
 
-    it('should delegate the property to the input', () => {
+    it('should delegate the property to the input', async () => {
       checkbox.indeterminate = true;
+      await nextFrame();
       expect(input.indeterminate).to.be.true;
 
       checkbox.indeterminate = false;
+      await nextFrame();
       expect(input.indeterminate).to.be.false;
     });
   });


### PR DESCRIPTION
## Description

Depends on #5557

1. Created a version of `vaadin-checkbox` web component using `LitElement` base class,
2. Updated existing unit tests to cover both Polymer and Lit based versions of component,
3. Modified `"files"` entry in `package.json` to **NOT** publish new component to `npm`.

## Type of change

- Experiment

## Disclaimer

This PR can be considered a PoC. It's extracted from #5301 after some refactorings.
Even if we agree to merge it, that doesn't necessarily mean further Lit related work.