### PR TITLE
chore: include _hasInputValue in type declarations

### DIFF
--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -35,6 +35,11 @@ export declare class InputMixinClass {
   protected readonly _hasValue: boolean;
 
   /**
+   * Whether the input element has any non-empty value.
+   */
+  protected _hasInputValue: boolean;
+
+  /**
    * Clear the value of the field.
    */
   clear(): void;

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -54,7 +54,8 @@ export const InputMixin = dedupingMixin(
           },
 
           /**
-           * When true, the input element has a non-empty value entered by the user.
+           * Whether the input element has any non-empty value.
+           *
            * @protected
            */
           _hasInputValue: {


### PR DESCRIPTION
## Description

The PR includes `_hasInputValue` in InputMixin's type declarations for consistency.

Part of #5410 

## Type of change

- [x] Chore
