### PR TITLE
fix: Inflate functions inside arrays

### DIFF
--- a/packages/charts/src/helpers.js
+++ b/packages/charts/src/helpers.js
@@ -1,9 +1,7 @@
 export function inflateFunctions(config) {
   if (
     // Check if param is a primitive/null/undefined value
-    !(config instanceof Object) ||
-    // Check if param is a plain object (not an array or HC object)
-    config.constructor !== Object
+    !(config instanceof Object)
   ) {
     return;
   }
@@ -17,7 +15,7 @@ export function inflateFunctions(config) {
         config[attr.substr(4)] = eval(`(function(){${targetProperty}})`);
       }
       delete config[attr];
-    } else if (targetProperty instanceof Object) {
+    } else {
       inflateFunctions(targetProperty);
     }
   });

--- a/packages/charts/test/private-api.test.js
+++ b/packages/charts/test/private-api.test.js
@@ -21,6 +21,14 @@ describe('vaadin-chart private API', () => {
       expect(config.tooltip).to.not.have.property('_fn_formatter');
     });
 
+    it('should inflate function body strings inside arrays', () => {
+      // eslint-disable-next-line camelcase
+      const config = [{ tooltip: { _fn_formatter: 'return "awesome chart"' } }];
+      inflateFunctions(config);
+      expect(config[0].tooltip.formatter).to.be.a('function');
+      expect(config[0].tooltip).to.not.have.property('_fn_formatter');
+    });
+
     it('should inflate empty function strings', () => {
       // eslint-disable-next-line camelcase
       const config = { tooltip: { _fn_formatter: '' } };


### PR DESCRIPTION
## Description

Some chart config objects (e.g. series tooltips) are inside arrays. Functions in those objects should also be inflated.

Fixes vaadin/flow-components#4709

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.
