### PR TITLE
fix: add missing direct npm dependencies to package.json (CP: 24.0)

### DIFF
--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -40,6 +40,7 @@
     "@vaadin/button": "24.0.0-rc1",
     "@vaadin/component-base": "24.0.0-rc1",
     "@vaadin/context-menu": "24.0.0-rc1",
+    "@vaadin/overlay": "24.0.0-rc1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-rc1",
     "@vaadin/vaadin-material-styles": "24.0.0-rc1",
     "@vaadin/vaadin-themable-mixin": "24.0.0-rc1"

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -42,6 +42,7 @@
     "@vaadin/field-base": "24.0.0-rc1",
     "@vaadin/input-container": "24.0.0-rc1",
     "@vaadin/lit-renderer": "24.0.0-rc1",
+    "@vaadin/overlay": "24.0.0-rc1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-rc1",
     "@vaadin/vaadin-material-styles": "24.0.0-rc1",
     "@vaadin/vaadin-themable-mixin": "24.0.0-rc1"

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -43,7 +43,8 @@
     "@vaadin/input-container": "24.0.0-rc1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-rc1",
     "@vaadin/vaadin-material-styles": "24.0.0-rc1",
-    "@vaadin/vaadin-themable-mixin": "24.0.0-rc1"
+    "@vaadin/vaadin-themable-mixin": "24.0.0-rc1",
+    "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -40,6 +40,7 @@
     "@vaadin/component-base": "24.0.0-rc1",
     "@vaadin/field-base": "24.0.0-rc1",
     "@vaadin/input-container": "24.0.0-rc1",
+    "@vaadin/overlay": "24.0.0-rc1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-rc1",
     "@vaadin/vaadin-material-styles": "24.0.0-rc1",
     "@vaadin/vaadin-themable-mixin": "24.0.0-rc1"

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -41,7 +41,8 @@
     "@vaadin/progress-bar": "24.0.0-rc1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-rc1",
     "@vaadin/vaadin-material-styles": "24.0.0-rc1",
-    "@vaadin/vaadin-themable-mixin": "24.0.0-rc1"
+    "@vaadin/vaadin-themable-mixin": "24.0.0-rc1",
+    "lit": "^2.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",


### PR DESCRIPTION
## Description

Manual cherry-pick of #5594 to `24.0` branch to make web components `pnpm` compatible.

## Type of change

- Bugfix