### PR TITLE
fix: add missing direct npm dependencies to package.json

### DIFF
--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -41,6 +41,8 @@
     "@vaadin/button": "24.0.0-beta1",
     "@vaadin/component-base": "24.0.0-beta1",
     "@vaadin/context-menu": "24.0.0-beta1",
+    "@vaadin/item": "24.0.0-beta1",
+    "@vaadin/list-box": "24.0.0-beta1",
     "@vaadin/overlay": "24.0.0-beta1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-beta1",
     "@vaadin/vaadin-material-styles": "24.0.0-beta1",

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -42,6 +42,7 @@
     "@vaadin/component-base": "24.0.0-beta1",
     "@vaadin/field-base": "24.0.0-beta1",
     "@vaadin/input-container": "24.0.0-beta1",
+    "@vaadin/item": "24.0.0-beta1",
     "@vaadin/lit-renderer": "24.0.0-beta1",
     "@vaadin/overlay": "24.0.0-beta1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-beta1",

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -40,6 +40,7 @@
     "@vaadin/component-base": "24.0.0-beta1",
     "@vaadin/field-base": "24.0.0-beta1",
     "@vaadin/input-container": "24.0.0-beta1",
+    "@vaadin/item": "24.0.0-beta1",
     "@vaadin/overlay": "24.0.0-beta1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-beta1",
     "@vaadin/vaadin-material-styles": "24.0.0-beta1",


### PR DESCRIPTION
## Description

Follow-up to #5594

Not all the packages were fixed as I missed to see a few errors, especially these:

```
Error while transforming packages/time-picker/theme/lumo/vaadin-time-picker-styles.js: Could not resolve import "@vaadin/item/theme/lumo/vaadin-item-styles.js".
   7 | import { comboBoxItem } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-item-styles.js';
   8 | import { comboBoxOverlay } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-overlay-styles.js';
>  9 | import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
     |                      ^
  10 | import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
  11 | import { menuOverlayCore } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
  12 | import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';

Error while transforming packages/menu-bar/theme/lumo/vaadin-menu-bar-item-styles.js: Could not resolve import "@vaadin/item/theme/lumo/vaadin-item-styles.js".
  2 | import '@vaadin/vaadin-lumo-styles/spacing.js';
  3 | import { contextMenuItem } from '@vaadin/context-menu/theme/lumo/vaadin-context-menu-item-styles.js';
> 4 | import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
    |                      ^
  5 | import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
  6 |
  7 | const menuBarItem = css`

Error while transforming packages/menu-bar/theme/lumo/vaadin-menu-bar-list-box-styles.js: Could not resolve import "@vaadin/list-box/theme/lumo/vaadin-list-box-styles.js".
  1 | import { contextMenuListBox } from '@vaadin/context-menu/theme/lumo/vaadin-context-menu-list-box-styles.js';
> 2 | import { listBox } from '@vaadin/list-box/theme/lumo/vaadin-list-box-styles.js';
    |                         ^
  3 | import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
  4 |
  5 | registerStyles('vaadin-menu-bar-list-box', [listBox, contextMenuListBox], { moduleId: 'lumo-menu-bar-list-box' });

Error while transforming packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js: Could not resolve import "@vaadin/item/theme/lumo/vaadin-item-styles.js".
  10 | import { comboBoxItem } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-item-styles.js';
  11 | import { comboBoxLoader, comboBoxOverlay } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-overlay-styles.js';
> 12 | import { item } from '@vaadin/item/theme/lumo/vaadin-item-styles.js';
     |                      ^
  13 | import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
  14 | import { loader } from '@vaadin/vaadin-lumo-styles/mixins/loader.js';
  15 | import { menuOverlayCore } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
```

## Type of change

- Bugfix