### PR TITLE
fix: add missing direct npm dependencies to package.json (#5596) (CP: 24.0)

### DIFF
--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -40,6 +40,8 @@
     "@vaadin/button": "24.0.0-rc1",
     "@vaadin/component-base": "24.0.0-rc1",
     "@vaadin/context-menu": "24.0.0-rc1",
+    "@vaadin/item": "24.0.0-rc1",
+    "@vaadin/list-box": "24.0.0-rc1",
     "@vaadin/overlay": "24.0.0-rc1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-rc1",
     "@vaadin/vaadin-material-styles": "24.0.0-rc1",

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -41,6 +41,7 @@
     "@vaadin/component-base": "24.0.0-rc1",
     "@vaadin/field-base": "24.0.0-rc1",
     "@vaadin/input-container": "24.0.0-rc1",
+    "@vaadin/item": "24.0.0-rc1",
     "@vaadin/lit-renderer": "24.0.0-rc1",
     "@vaadin/overlay": "24.0.0-rc1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-rc1",

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -40,6 +40,7 @@
     "@vaadin/component-base": "24.0.0-rc1",
     "@vaadin/field-base": "24.0.0-rc1",
     "@vaadin/input-container": "24.0.0-rc1",
+    "@vaadin/item": "24.0.0-rc1",
     "@vaadin/overlay": "24.0.0-rc1",
     "@vaadin/vaadin-lumo-styles": "24.0.0-rc1",
     "@vaadin/vaadin-material-styles": "24.0.0-rc1",


### PR DESCRIPTION
## Description

Manual cherry-pick of #5596 to `24.0` with adding remaining dependencies on `@vaadin/item` and `@vaadin/list-box`.

## Type of change

- Cherry-pick