### PR TITLE
fix: reset _hasInputValue on programmatic value clear

### DIFF
--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -57,7 +57,7 @@ export const InputMixin = dedupingMixin(
            * Whether the input element has user input.
            *
            * Note, the property indicates true only if the input has been entered by the user.
-           * In the case of programmatic changes, the property is expected to be set to false.
+           * In the case of programmatic changes, the property must be reset to false.
            *
            * @protected
            */

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -54,7 +54,11 @@ export const InputMixin = dedupingMixin(
           },
 
           /**
-           * When true, the input element has a non-empty value entered by the user.
+           * Whether the input element has user input.
+           *
+           * Note, the property indicates true only if the input has been entered by the user.
+           * In the case of programmatic changes, the property is expected to be set to false.
+           *
            * @protected
            */
           _hasInputValue: {
@@ -119,6 +123,8 @@ export const InputMixin = dedupingMixin(
        * Clear the value of the field.
        */
       clear() {
+        this._hasInputValue = false;
+
         this.value = '';
 
         // Clear the input immediately without waiting for the observer.

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -201,7 +201,7 @@ const runTests = (defineHelper, baseMixin) => {
       await nextFrame();
     });
 
-    describe('the field has no input', () => {
+    describe('empty field', () => {
       it('should fire the event once when entering input', async () => {
         input.value = 'foo';
         fire(input, 'input');

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -217,7 +217,7 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
 
-    describe('the field has input', () => {
+    describe('user-originated input', () => {
       beforeEach(async () => {
         input.value = 'foo';
         fire(input, 'input');

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -178,7 +178,7 @@ const runTests = (defineHelper, baseMixin) => {
   });
 
   describe('has-input-value-changed event', () => {
-    let tag, hasInputValueChangedSpy;
+    let tag, hasInputValueChangedSpy, valueChangedSpy;
 
     before(() => {
       tag = defineHelper(
@@ -190,8 +190,10 @@ const runTests = (defineHelper, baseMixin) => {
 
     beforeEach(async () => {
       hasInputValueChangedSpy = sinon.spy();
+      valueChangedSpy = sinon.spy();
       element = fixtureSync(`<${tag}></${tag}>`);
       element.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+      element.addEventListener('value-changed', valueChangedSpy);
       await nextRender();
       input = document.createElement('input');
       element.appendChild(input);
@@ -199,29 +201,52 @@ const runTests = (defineHelper, baseMixin) => {
       await nextFrame();
     });
 
-    it('should fire the event on input value presence change', async () => {
-      input.value = 'foo';
-      fire(input, 'input');
-      await nextFrame();
-      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+    describe('the field has no input', () => {
+      it('should fire the event once when entering input', async () => {
+        input.value = 'foo';
+        fire(input, 'input');
+        await nextFrame();
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+      });
 
-      hasInputValueChangedSpy.resetHistory();
-      input.value = '';
-      fire(input, 'input');
-      await nextFrame();
-      expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+      it('should not fire the event on programmatic clear', async () => {
+        element.clear();
+        await nextFrame();
+        expect(hasInputValueChangedSpy.called).to.be.false;
+      });
     });
 
-    it('should not fire the event on input if input value presence has not changed', async () => {
-      input.value = 'foo';
-      fire(input, 'input');
-      await nextFrame();
-      hasInputValueChangedSpy.resetHistory();
+    describe('the field has input', () => {
+      beforeEach(async () => {
+        input.value = 'foo';
+        fire(input, 'input');
+        await nextFrame();
+        hasInputValueChangedSpy.resetHistory();
+        valueChangedSpy.resetHistory();
+      });
 
-      input.value = 'foobar';
-      fire(input, 'input');
-      await nextFrame();
-      expect(hasInputValueChangedSpy.called).to.be.false;
+      it('should not fire the event when modifying input', async () => {
+        input.value = 'foobar';
+        fire(input, 'input');
+        await nextFrame();
+        expect(hasInputValueChangedSpy.called).to.be.false;
+      });
+
+      it('should fire the event once when removing input', async () => {
+        input.value = '';
+        fire(input, 'input');
+        await nextFrame();
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+      });
+
+      it('should fire the event once on programmatic clear', async () => {
+        element.clear();
+        await nextFrame();
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+      });
     });
   });
 };

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -201,7 +201,7 @@ const runTests = (defineHelper, baseMixin) => {
       await nextFrame();
     });
 
-    describe('empty field', () => {
+    describe('without user input', () => {
       it('should fire the event once when entering input', async () => {
         input.value = 'foo';
         fire(input, 'input');
@@ -217,7 +217,7 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
 
-    describe('user-originated input', () => {
+    describe('with user input', () => {
       beforeEach(async () => {
         input.value = 'foo';
         fire(input, 'input');


### PR DESCRIPTION
## Description

The PR resets `_hasInputValue` to false on programmatic value clear so that Flow won't treat the empty value as bad input. It also mentions in the JSDoc that `_hasInputValue` only indicates true if the input has been entered by the *user*. Ideally, given the way the property works, it should be renamed to `_hasUserInput` but we decided not to change that in the scope of this issue.

> **Note**
>  There will be more PRs like this one. They will cover other cases where the input value can be changed programmatically.

Part of https://github.com/vaadin/web-components/issues/5410

## Type of change

- [x] Bugfix
