### PR TITLE
refactor: set aria-hidden attribute when trapping focus

### DIFF
--- a/packages/a11y-base/src/aria-hidden.d.ts
+++ b/packages/a11y-base/src/aria-hidden.d.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright (c) 2017 Anton Korzunov
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @fileoverview
+ *
+ * This module includes JS code copied from the `aria-hidden` package:
+ * https://github.com/theKashey/aria-hidden/blob/master/src/index.ts
+ */
+
+export declare type Undo = () => void;
+
+/**
+ * Marks everything except given node(or nodes) as aria-hidden
+ */
+export declare const hideOthers: (
+  originalTarget: Element | Element[],
+  parentNode?: HTMLElement,
+  markerName?: string,
+) => Undo;
+
+/**
+ * Marks everything except given node(or nodes) as inert
+ */
+export declare const inertOthers: (
+  originalTarget: Element | Element[],
+  parentNode?: HTMLElement,
+  markerName?: string,
+) => Undo;
+
+/**
+ * Returns true if the current browser support `inert` attribute.
+ */
+export declare const supportsInert: boolean;
+
+/**
+ * Automatic function to "suppress" DOM elements - _hide_ or _inert_ in the best possible way.
+ */
+export declare const suppressOthers: (
+  originalTarget: Element | Element[],
+  parentNode?: HTMLElement,
+  markerName?: string,
+) => Undo;

--- a/packages/a11y-base/src/aria-hidden.js
+++ b/packages/a11y-base/src/aria-hidden.js
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright (c) 2017 Anton Korzunov
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @fileoverview
+ *
+ * This module includes JS code copied from the `aria-hidden` package:
+ * https://github.com/theKashey/aria-hidden/blob/master/src/index.ts
+ */
+
+/** @type {WeakMap<Element, number>} */
+let counterMap = new WeakMap();
+
+/** @type {WeakMap<Element, boolean>} */
+let uncontrolledNodes = new WeakMap();
+
+/** @type {Record<string, WeakMap<Element, number>>} */
+let markerMap = {};
+
+/** @type {number} */
+let lockCount = 0;
+
+/**
+ * @param {Element | Shadow} node
+ * @return {Element | null}
+ */
+const unwrapHost = (node) => node.host || unwrapHost(node.parentNode);
+
+/**
+ * @param {HTMLEle} parent
+ * @param {Element[]} targets
+ * @return {Element}
+ */
+const correctTargets = (parent, targets) =>
+  targets
+    .map((target) => {
+      if (parent.contains(target)) {
+        return target;
+      }
+
+      const correctedTarget = unwrapHost(target);
+
+      if (correctedTarget && parent.contains(correctedTarget)) {
+        return correctedTarget;
+      }
+
+      console.error('aria-hidden', target, 'in not contained inside', parent, '. Doing nothing');
+
+      return null;
+    })
+    .filter((x) => Boolean(x));
+
+/**
+ * Marks everything except given node(or nodes) as aria-hidden
+ * @param {Element | Element[]} originalTarget - elements to keep on the page
+ * @param {HTMLElement} [parentNode] - top element, defaults to document.body
+ * @param {String} [markerName] - a special attribute to mark every node
+ * @param {String} [controlAttribute] - html Attribute to control
+ * @return {Function}
+ */
+const applyAttributeToOthers = (originalTarget, parentNode, markerName, controlAttribute) => {
+  const targets = correctTargets(parentNode, Array.isArray(originalTarget) ? originalTarget : [originalTarget]);
+
+  if (!markerMap[markerName]) {
+    markerMap[markerName] = new WeakMap();
+  }
+
+  const markerCounter = markerMap[markerName];
+
+  /** @type {Element[]} */
+  const hiddenNodes = [];
+
+  /** @type {Set<Node>} */
+  const elementsToKeep = new Set();
+
+  /** @type {Set<Node>} */
+  const elementsToStop = new Set(targets);
+
+  /**
+   * @param {?Node} el
+   */
+  const keep = (el) => {
+    if (!el || elementsToKeep.has(el)) {
+      return;
+    }
+
+    elementsToKeep.add(el);
+    keep(el.parentNode);
+  };
+
+  targets.forEach(keep);
+
+  /**
+   * @param {?Node} el
+   */
+  const deep = (parent) => {
+    if (!parent || elementsToStop.has(parent)) {
+      return;
+    }
+
+    [...parent.children].forEach((node) => {
+      // Skip elements that don't need to be hidden
+      if (['template', 'script', 'style'].includes(node.localName)) {
+        return;
+      }
+
+      if (elementsToKeep.has(node)) {
+        deep(node);
+      } else {
+        const attr = node.getAttribute(controlAttribute);
+        const alreadyHidden = attr !== null && attr !== 'false';
+        const counterValue = (counterMap.get(node) || 0) + 1;
+        const markerValue = (markerCounter.get(node) || 0) + 1;
+
+        counterMap.set(node, counterValue);
+        markerCounter.set(node, markerValue);
+        hiddenNodes.push(node);
+
+        if (counterValue === 1 && alreadyHidden) {
+          uncontrolledNodes.set(node, true);
+        }
+
+        if (markerValue === 1) {
+          node.setAttribute(markerName, 'true');
+        }
+
+        if (!alreadyHidden) {
+          node.setAttribute(controlAttribute, 'true');
+        }
+      }
+    });
+  };
+
+  deep(parentNode);
+
+  elementsToKeep.clear();
+
+  lockCount += 1;
+
+  return () => {
+    hiddenNodes.forEach((node) => {
+      const counterValue = counterMap.get(node) - 1;
+      const markerValue = markerCounter.get(node) - 1;
+
+      counterMap.set(node, counterValue);
+      markerCounter.set(node, markerValue);
+
+      if (!counterValue) {
+        if (uncontrolledNodes.has(node)) {
+          uncontrolledNodes.delete(node);
+        } else {
+          node.removeAttribute(controlAttribute);
+        }
+      }
+
+      if (!markerValue) {
+        node.removeAttribute(markerName);
+      }
+    });
+
+    lockCount -= 1;
+
+    if (!lockCount) {
+      // clear
+      counterMap = new WeakMap();
+      counterMap = new WeakMap();
+      uncontrolledNodes = new WeakMap();
+      markerMap = {};
+    }
+  };
+};
+
+/**
+ * Marks everything except given node(or nodes) as aria-hidden
+ * @param {Element | Element[]} originalTarget - elements to keep on the page
+ * @param {HTMLElement} [parentNode] - top element, defaults to document.body
+ * @param {String} [markerName] - a special attribute to mark every node
+ * @return {Function} undo command
+ */
+export const hideOthers = (originalTarget, parentNode = document.body, markerName = 'data-aria-hidden') => {
+  const targets = Array.from(Array.isArray(originalTarget) ? originalTarget : [originalTarget]);
+
+  // We should not hide ariaLive elements - https://github.com/theKashey/aria-hidden/issues/10
+  targets.push(...Array.from(parentNode.querySelectorAll('[aria-live]')));
+
+  return applyAttributeToOthers(targets, parentNode, markerName, 'aria-hidden');
+};
+
+/**
+ * Marks everything except given node(or nodes) as inert
+ * @param {Element | Element[]} originalTarget - elements to keep on the page
+ * @param {HTMLElement} [parentNode] - top element, defaults to document.body
+ * @param {String} [markerName] - a special attribute to mark every node
+ * @return {Function} undo command
+ */
+export const inertOthers = (originalTarget, parentNode = document.body, markerName = 'data-inert-ed') => {
+  return applyAttributeToOthers(originalTarget, parentNode, markerName, 'inert');
+};
+
+/**
+ * @return if current browser supports inert
+ */
+export const supportsInert = 'inert' in HTMLElement.prototype;
+
+/**
+ * Automatic function to "suppress" DOM elements - _hide_ or _inert_ in the best possible way
+ * @param {Element | Element[]} originalTarget - elements to keep on the page
+ * @param {HTMLElement} [parentNode] - top element, defaults to document.body
+ * @param {String} [markerName] - a special attribute to mark every node
+ * @return {Function} undo command
+ */
+export const suppressOthers = (originalTarget, parentNode, markerName) =>
+  (supportsInert ? inertOthers : hideOthers)(originalTarget, parentNode, markerName);

--- a/packages/a11y-base/src/focus-trap-controller.js
+++ b/packages/a11y-base/src/focus-trap-controller.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { hideOthers } from './aria-hidden.js';
 import { getFocusableElements, isElementFocused } from './focus-utils.js';
 
 const instances = [];
@@ -84,6 +85,8 @@ export class FocusTrapController {
       throw new Error('The trap node should have at least one focusable descendant or be focusable itself.');
     }
 
+    this.__showOthers = hideOthers(trapNode);
+
     instances.push(this);
 
     if (this.__focusedElementIndex === -1) {
@@ -97,6 +100,11 @@ export class FocusTrapController {
    */
   releaseFocus() {
     this.__trapNode = null;
+
+    if (this.__showOthers) {
+      this.__showOthers();
+      this.__showOthers = null;
+    }
 
     instances.pop();
   }

--- a/packages/a11y-base/test/aria-hidden.test.js
+++ b/packages/a11y-base/test/aria-hidden.test.js
@@ -1,0 +1,212 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { hideOthers, inertOthers } from '../src/aria-hidden.js';
+
+describe('aria-hidden', () => {
+  let parent, target1, target2, sibling, hidden1, hidden2;
+
+  const callbacks = new Set();
+
+  function clear(callback) {
+    callbacks.delete(callback);
+    callback();
+  }
+
+  [
+    { name: 'hideOthers', attr: 'aria-hidden', hideFunc: hideOthers },
+    { name: 'inertOthers', attr: 'inert', hideFunc: inertOthers },
+  ].forEach(({ name, attr, hideFunc }) => {
+    describe(name, () => {
+      beforeEach(async () => {
+        parent = fixtureSync(`
+          <div>
+            <div id="sibling">hide me 1</div>
+            <div id="target1">not me 2</div>
+            <div>
+              <div id="target2">not me 3</div>
+            </div>
+            <div id="hidden1" aria-hidden="true">I am already hidden! 4</div>
+            <div id="hidden2" aria-hidden>I am hidden in a wrong way 5</div>
+          </div>
+        `);
+        sibling = parent.querySelector('#sibling');
+        target1 = parent.querySelector('#target1');
+        target2 = parent.querySelector('#target2');
+        hidden1 = parent.querySelector('#hidden1');
+        hidden2 = parent.querySelector('#hidden2');
+        await nextRender();
+      });
+
+      afterEach(() => {
+        callbacks.forEach(clear);
+      });
+
+      it(`should set ${attr} on other nodes when passing a single target`, () => {
+        const unhide = hideFunc(target1, parent);
+
+        callbacks.add(unhide);
+
+        // Target node is not hidden
+        expect(target1.hasAttribute(attr)).to.be.false;
+
+        // Leaf element isn't hidden
+        expect(target2.hasAttribute(attr)).to.be.false;
+
+        // Parent element is hidden
+        expect(target2.parentNode.getAttribute(attr)).to.equal('true');
+
+        // Sibling element is hidden
+        expect(sibling.getAttribute(attr)).to.equal('true');
+      });
+
+      it(`should remove ${attr} from other nodes when passing a single target`, () => {
+        const unhide = hideFunc(target1, parent);
+
+        unhide();
+
+        // Elements are no longer hidden
+        expect(target2.parentNode.hasAttribute(attr)).to.be.false;
+        expect(sibling.hasAttribute(attr)).to.be.false;
+
+        // Hidden elements are still hidden
+        expect(hidden1.getAttribute(attr)).to.equal(attr === 'inert' ? null : 'true');
+        expect(hidden2.getAttribute(attr)).to.equal(attr === 'inert' ? null : '');
+
+        // Marker attributes are removed
+        expect(hidden1.hasAttribute(`data-${attr}`)).to.be.false;
+        expect(hidden2.hasAttribute(`data-${attr}`)).to.be.false;
+      });
+
+      it(`should set ${attr} on other nodes when passing multiple targets`, () => {
+        const unhide = hideFunc([target1, target2], parent);
+        callbacks.add(unhide);
+
+        // First target node is not hidden
+        expect(target1.hasAttribute(attr)).to.be.false;
+
+        // Second target node is not hidden
+        expect(target2.hasAttribute(attr)).to.be.false;
+
+        // Parent node is not hidden either
+        expect(target2.parentNode.hasAttribute(attr)).to.be.false;
+
+        // Sibling element is hidden
+        expect(sibling.getAttribute(attr)).to.equal('true');
+      });
+
+      it(`should remove ${attr} from other nodes when passing multiple targets`, () => {
+        const unhide = hideFunc([target1, target2], parent);
+        unhide();
+
+        // Sibling element is no longer hidden
+        expect(sibling.hasAttribute(attr)).to.be.false;
+
+        // Hidden elements are still hidden
+        expect(hidden1.getAttribute(attr)).to.equal(attr === 'inert' ? null : 'true');
+        expect(hidden2.getAttribute(attr)).to.equal(attr === 'inert' ? null : '');
+      });
+
+      it(`should set ${attr} correctly when calling on two different targets`, () => {
+        const unhide1 = hideFunc(target1, parent);
+        callbacks.add(unhide1);
+
+        // Everything but the target node is hidden
+        expect(target1.hasAttribute(attr)).to.be.false;
+        expect(target2.parentNode.getAttribute(attr)).to.equal('true');
+        expect(sibling.getAttribute(attr)).to.equal('true');
+
+        const unhide2 = hideFunc(target2, parent);
+        callbacks.add(unhide2);
+
+        // And now the first target is also hidden
+        expect(target1.getAttribute(attr)).to.equal('true');
+        expect(target2.parentNode.getAttribute(attr)).to.equal('true');
+        expect(sibling.getAttribute(attr)).to.equal('true');
+      });
+
+      it(`should remove ${attr} correctly when calling on two different targets`, () => {
+        const unhide1 = hideFunc(target1, parent);
+        const unhide2 = hideFunc(target2, parent);
+
+        unhide1();
+        unhide2();
+
+        // All the elements are no longer hidden
+        expect(target1.hasAttribute(attr)).to.be.false;
+        expect(target2.parentNode.hasAttribute(attr)).to.be.false;
+        expect(sibling.hasAttribute(attr)).to.be.false;
+      });
+
+      it(`should set different attribute markers when using setting ${attr}`, () => {
+        const unhide1 = hideFunc(target1, parent, 'marker1');
+        callbacks.add(unhide1);
+
+        // First marker attribute is set
+        expect(sibling.getAttribute('marker1')).to.equal('true');
+
+        const unhide2 = hideFunc(target2, parent, 'marker2');
+        callbacks.add(unhide2);
+
+        // Both marker attributes are set
+        expect(sibling.getAttribute('marker1')).to.equal('true');
+        expect(sibling.getAttribute('marker2')).to.equal('true');
+      });
+
+      it(`should remove all the attribute markers when using removing ${attr}`, () => {
+        const unhide1 = hideFunc(target1, parent, 'marker1');
+        const unhide2 = hideFunc(target2, parent, 'marker2');
+
+        unhide1();
+        unhide2();
+
+        // Both marker attributes are removed
+        expect(sibling.hasAttribute('marker1')).to.be.false;
+        expect(sibling.hasAttribute('marker2')).to.be.false;
+      });
+
+      describe(`${attr} with shadow DOM`, () => {
+        let nested;
+
+        beforeEach(() => {
+          const root = sibling.attachShadow({ mode: 'open' });
+          nested = document.createElement('span');
+          root.appendChild(nested);
+        });
+
+        it(`should set ${attr} attribute on elements except the one in shadow DOM`, () => {
+          const unhide = hideFunc(nested, parent);
+          callbacks.add(unhide);
+
+          // All the elements are hidden
+          expect(target1.getAttribute(attr)).to.equal('true');
+          expect(target2.parentNode.getAttribute(attr)).to.equal('true');
+
+          // Shadow root host isn't hidden
+          expect(sibling.hasAttribute(attr)).to.be.false;
+        });
+
+        it(`should set ${attr} attribute on elements except the one in shadow DOM`, () => {
+          const unhide = hideFunc(nested, parent);
+          callbacks.add(unhide);
+
+          // All the elements are hidden
+          expect(target1.getAttribute(attr)).to.equal('true');
+          expect(target2.parentNode.getAttribute(attr)).to.equal('true');
+
+          // Shadow root host isn't hidden
+          expect(sibling.hasAttribute(attr)).to.be.false;
+        });
+
+        it(`should remove ${attr} attribute from elements outside the shadow DOM`, () => {
+          const unhide = hideFunc(nested, parent);
+
+          unhide();
+
+          // Elements are no longer hidden
+          expect(target1.hasAttribute(attr)).to.be.false;
+          expect(target2.parentNode.hasAttribute(attr)).to.be.false;
+        });
+      });
+    });
+  });
+});

--- a/packages/a11y-base/test/dom/__snapshots__/aria-hidden.test.snap.js
+++ b/packages/a11y-base/test/dom/__snapshots__/aria-hidden.test.snap.js
@@ -1,0 +1,365 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["aria-hidden hide single target"] = 
+`<div>
+  <div id="parent">
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+    >
+      hide me 1
+    </div>
+    <div id="target1">
+      not me 2
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+    >
+      <div id="target2">
+        not me 3
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      id="outside1"
+    >
+      hide me 4
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      id="hidden1"
+    >
+      I am already hidden! 5
+    </div>
+    <div
+      aria-hidden=""
+      data-aria-hidden="true"
+      id="hidden2"
+    >
+      I am hidden in a wrong way 6
+    </div>
+    <div aria-live="polite">
+      not-hidden life
+    </div>
+    <div aria-live="off">
+      hidden life
+    </div>
+  </div>
+  <div>
+    don't touch me 6
+  </div>
+</div>
+`;
+/* end snapshot aria-hidden hide single target */
+
+snapshots["aria-hidden hide multiple targets"] = 
+`<div>
+  <div id="parent">
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+    >
+      hide me 1
+    </div>
+    <div id="target1">
+      not me 2
+    </div>
+    <div>
+      <div id="target2">
+        not me 3
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      id="outside1"
+    >
+      hide me 4
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      id="hidden1"
+    >
+      I am already hidden! 5
+    </div>
+    <div
+      aria-hidden=""
+      data-aria-hidden="true"
+      id="hidden2"
+    >
+      I am hidden in a wrong way 6
+    </div>
+    <div aria-live="polite">
+      not-hidden life
+    </div>
+    <div aria-live="off">
+      hidden life
+    </div>
+  </div>
+  <div>
+    don't touch me 6
+  </div>
+</div>
+`;
+/* end snapshot aria-hidden hide multiple targets */
+
+snapshots["aria-hidden hide multiple calls"] = 
+`<div>
+  <div id="parent">
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+    >
+      hide me 1
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      id="target1"
+    >
+      not me 2
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+    >
+      <div id="target2">
+        not me 3
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      id="outside1"
+    >
+      hide me 4
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      id="hidden1"
+    >
+      I am already hidden! 5
+    </div>
+    <div
+      aria-hidden=""
+      data-aria-hidden="true"
+      id="hidden2"
+    >
+      I am hidden in a wrong way 6
+    </div>
+    <div aria-live="polite">
+      not-hidden life
+    </div>
+    <div aria-live="off">
+      hidden life
+    </div>
+  </div>
+  <div>
+    don't touch me 6
+  </div>
+</div>
+`;
+/* end snapshot aria-hidden hide multiple calls */
+
+snapshots["aria-hidden inert single target"] = 
+`<div>
+  <div id="parent">
+    <div
+      data-inert-ed="true"
+      inert="true"
+    >
+      hide me 1
+    </div>
+    <div id="target1">
+      not me 2
+    </div>
+    <div
+      data-inert-ed="true"
+      inert="true"
+    >
+      <div id="target2">
+        not me 3
+      </div>
+    </div>
+    <div
+      data-inert-ed="true"
+      id="outside1"
+      inert="true"
+    >
+      hide me 4
+    </div>
+    <div
+      aria-hidden="true"
+      data-inert-ed="true"
+      id="hidden1"
+      inert="true"
+    >
+      I am already hidden! 5
+    </div>
+    <div
+      aria-hidden=""
+      data-inert-ed="true"
+      id="hidden2"
+      inert="true"
+    >
+      I am hidden in a wrong way 6
+    </div>
+    <div
+      aria-live="polite"
+      data-inert-ed="true"
+      inert="true"
+    >
+      not-hidden life
+    </div>
+    <div
+      aria-live="off"
+      data-inert-ed="true"
+      inert="true"
+    >
+      hidden life
+    </div>
+  </div>
+  <div>
+    don't touch me 6
+  </div>
+</div>
+`;
+/* end snapshot aria-hidden inert single target */
+
+snapshots["aria-hidden inert multiple targets"] = 
+`<div>
+  <div id="parent">
+    <div
+      data-inert-ed="true"
+      inert="true"
+    >
+      hide me 1
+    </div>
+    <div id="target1">
+      not me 2
+    </div>
+    <div>
+      <div id="target2">
+        not me 3
+      </div>
+    </div>
+    <div
+      data-inert-ed="true"
+      id="outside1"
+      inert="true"
+    >
+      hide me 4
+    </div>
+    <div
+      aria-hidden="true"
+      data-inert-ed="true"
+      id="hidden1"
+      inert="true"
+    >
+      I am already hidden! 5
+    </div>
+    <div
+      aria-hidden=""
+      data-inert-ed="true"
+      id="hidden2"
+      inert="true"
+    >
+      I am hidden in a wrong way 6
+    </div>
+    <div
+      aria-live="polite"
+      data-inert-ed="true"
+      inert="true"
+    >
+      not-hidden life
+    </div>
+    <div
+      aria-live="off"
+      data-inert-ed="true"
+      inert="true"
+    >
+      hidden life
+    </div>
+  </div>
+  <div>
+    don't touch me 6
+  </div>
+</div>
+`;
+/* end snapshot aria-hidden inert multiple targets */
+
+snapshots["aria-hidden inert multiple calls"] = 
+`<div>
+  <div id="parent">
+    <div
+      data-inert-ed="true"
+      inert="true"
+    >
+      hide me 1
+    </div>
+    <div
+      data-inert-ed="true"
+      id="target1"
+      inert="true"
+    >
+      not me 2
+    </div>
+    <div
+      data-inert-ed="true"
+      inert="true"
+    >
+      <div id="target2">
+        not me 3
+      </div>
+    </div>
+    <div
+      data-inert-ed="true"
+      id="outside1"
+      inert="true"
+    >
+      hide me 4
+    </div>
+    <div
+      aria-hidden="true"
+      data-inert-ed="true"
+      id="hidden1"
+      inert="true"
+    >
+      I am already hidden! 5
+    </div>
+    <div
+      aria-hidden=""
+      data-inert-ed="true"
+      id="hidden2"
+      inert="true"
+    >
+      I am hidden in a wrong way 6
+    </div>
+    <div
+      aria-live="polite"
+      data-inert-ed="true"
+      inert="true"
+    >
+      not-hidden life
+    </div>
+    <div
+      aria-live="off"
+      data-inert-ed="true"
+      inert="true"
+    >
+      hidden life
+    </div>
+  </div>
+  <div>
+    don't touch me 6
+  </div>
+</div>
+`;
+/* end snapshot aria-hidden inert multiple calls */
+

--- a/packages/a11y-base/test/dom/aria-hidden.test.js
+++ b/packages/a11y-base/test/dom/aria-hidden.test.js
@@ -1,0 +1,82 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { hideOthers, inertOthers } from '../../src/aria-hidden.js';
+
+describe('aria-hidden', () => {
+  let wrapper, parent, target1, target2;
+
+  let teardown = [];
+
+  beforeEach(async () => {
+    wrapper = fixtureSync(`
+      <div>
+        <div id="parent">
+          <div>hide me 1</div>
+          <div id="target1">not me 2</div>
+          <div>
+            <div id="target2">not me 3</div>
+          </div>
+          <div id="outside1">hide me 4</div>
+          <svg>
+            <text>svg</text>
+          </svg>
+          <div id="hidden1" aria-hidden="true">I am already hidden! 5</div>
+          <div id="hidden2" aria-hidden>I am hidden in a wrong way 6</div>
+          <div aria-live="polite">not-hidden life</div>
+          <div aria-live="off">hidden life</div>
+        </div>
+        <div>don't touch me 6</div>
+      </div>
+    `);
+    parent = wrapper.children[0];
+    target1 = wrapper.querySelector('#target1');
+    target2 = wrapper.querySelector('#target2');
+    await nextRender();
+  });
+
+  afterEach(() => {
+    teardown.forEach((callback) => {
+      callback();
+    });
+
+    teardown = [];
+  });
+
+  it('hide single target', async () => {
+    const unhide = hideOthers(target1, parent);
+    teardown.push(unhide);
+    await expect(wrapper).dom.to.equalSnapshot();
+  });
+
+  it('hide multiple targets', async () => {
+    const unhide = hideOthers([target1, target2], parent);
+    teardown.push(unhide);
+    await expect(wrapper).dom.to.equalSnapshot();
+  });
+
+  it('hide multiple calls', async () => {
+    const unhide1 = hideOthers(target1, parent);
+    const unhide2 = hideOthers(target2, parent);
+    teardown.push(unhide1, unhide2);
+    await expect(wrapper).dom.to.equalSnapshot();
+  });
+
+  it('inert single target', async () => {
+    const unhide = inertOthers(target1, parent);
+    teardown.push(unhide);
+    await expect(wrapper).dom.to.equalSnapshot();
+  });
+
+  it('inert multiple targets', async () => {
+    const unhide = inertOthers([target1, target2], parent);
+    teardown.push(unhide);
+    await expect(wrapper).dom.to.equalSnapshot();
+  });
+
+  it('inert multiple calls', async () => {
+    const unhide1 = inertOthers(target1, parent);
+    const unhide2 = inertOthers(target2, parent);
+    teardown.push(unhide1, unhide2);
+    await expect(wrapper).dom.to.equalSnapshot();
+  });
+});

--- a/packages/a11y-base/test/focus-trap-controller.test.js
+++ b/packages/a11y-base/test/focus-trap-controller.test.js
@@ -65,7 +65,7 @@ async function shiftTab() {
 }
 
 describe('focus-trap-controller', () => {
-  let element, controller, trap;
+  let element, controller, trap, outside1, outside2;
 
   describe('trapFocus', () => {
     beforeEach(() => {
@@ -73,7 +73,9 @@ describe('focus-trap-controller', () => {
       controller = new FocusTrapController(element);
       element.addController(controller);
       trap = element.querySelector('#trap');
-      element.querySelector('#outside-input-1').focus();
+      outside1 = element.querySelector('#outside-input-1');
+      outside2 = element.querySelector('#outside-input-2');
+      outside1.focus();
     });
 
     it('should set focus on the first focusable element in the default tab order', () => {
@@ -100,6 +102,12 @@ describe('focus-trap-controller', () => {
       input.focus();
       controller.trapFocus(trap);
       expect(document.activeElement).to.equal(input);
+    });
+
+    it('should set aria-hidden attribute on elements outside the trap node', () => {
+      controller.trapFocus(trap);
+      expect(outside1.getAttribute('aria-hidden')).to.equal('true');
+      expect(outside2.getAttribute('aria-hidden')).to.equal('true');
     });
 
     describe('no focusable elements', () => {
@@ -131,6 +139,8 @@ describe('focus-trap-controller', () => {
   });
 
   describe('releaseFocus', () => {
+    let outside1, outside2;
+
     beforeEach(() => {
       element = fixtureSync(`<focus-trap-element></focus-trap-element>`);
       controller = new FocusTrapController(element);
@@ -140,6 +150,17 @@ describe('focus-trap-controller', () => {
 
     it('should not throw when no trap node', () => {
       expect(() => controller.releaseFocus(trap)).not.to.throw(Error);
+    });
+
+    it('should remove aria-hidden attribute when releasing focus', () => {
+      outside1 = element.querySelector('#outside-input-1');
+      outside2 = element.querySelector('#outside-input-2');
+
+      controller.trapFocus(trap);
+      controller.releaseFocus(trap);
+
+      expect(outside1.hasAttribute('aria-hidden')).to.be.false;
+      expect(outside2.hasAttribute('aria-hidden')).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

Based on #5598

## Type of change

- Internal feature / a11y enhancement

## Note

- This enhancement alone might not be enough for `vaadin-dialog` - see [`aria-modal`](https://github.com/adobe/react-spectrum/blob/70e4c442eb0c764ab32c3fc2d03d9c456e6e5bfd/packages/%40react-aria/aria-modal-polyfill/src/index.ts) polyfill used by [React Aria](https://react-spectrum.adobe.com/react-aria/useModalOverlay.html).
- For now, only `aria-hidden="true"` is used, but not `inert`. We need to check screen reader support for `inert`.