### PR TITLE
fix: init the DOM observer in ready() instead of constructor()

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -634,11 +634,11 @@ class DateTimePicker extends FieldMixin(
 
   /** @private */
   __i18nChanged(changeRecord) {
-    if (this.__datePicker && this.__datePicker.$) {
+    if (this.__datePicker) {
       this.__datePicker.set(changeRecord.path, changeRecord.value);
     }
 
-    if (this.__timePicker && this.__timePicker.$) {
+    if (this.__timePicker) {
       this.__timePicker.set(changeRecord.path, changeRecord.value);
     }
   }

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -634,11 +634,11 @@ class DateTimePicker extends FieldMixin(
 
   /** @private */
   __i18nChanged(changeRecord) {
-    if (this.__datePicker) {
+    if (this.__datePicker && this.__datePicker.$) {
       this.__datePicker.set(changeRecord.path, changeRecord.value);
     }
 
-    if (this.__timePicker) {
+    if (this.__timePicker && this.__timePicker.$) {
       this.__timePicker.set(changeRecord.path, changeRecord.value);
     }
   }

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -403,10 +403,6 @@ class DateTimePicker extends FieldMixin(
 
     this.__changeEventHandler = this.__changeEventHandler.bind(this);
     this.__valueChangedEventHandler = this.__valueChangedEventHandler.bind(this);
-
-    this._observer = new FlattenedNodesObserver(this, (info) => {
-      this.__onDomChange(info.addedNodes);
-    });
   }
 
   /** @protected */
@@ -415,6 +411,10 @@ class DateTimePicker extends FieldMixin(
 
     this.__datePicker = this._getDirectSlotChild('date-picker');
     this.__timePicker = this._getDirectSlotChild('time-picker');
+
+    this._observer = new FlattenedNodesObserver(this, (info) => {
+      this.__onDomChange(info.addedNodes);
+    });
 
     if (this.autofocus && !this.disabled) {
       window.requestAnimationFrame(() => this.focus());

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -109,7 +109,7 @@ describe('i18n set before added to the DOM', () => {
   });
 
   it('should have the correct i18n', async () => {
-    await nextFrame();
+    await aTimeout(0);
     document.body.appendChild(dateTimePicker);
     expect(datePicker.i18n.cancel).to.equal('CUSTOM');
   });

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-date-time-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
@@ -97,20 +97,20 @@ customElements.define(
   });
 });
 
-describe('i18n set before added to the DOM', () => {
-  let dateTimePicker, datePicker;
+describe('i18n set to child date picker before added to the DOM', () => {
+  let dateTimePicker, slottedDatePicker;
 
   beforeEach(() => {
     dateTimePicker = document.createElement('vaadin-date-time-picker');
-    datePicker = document.createElement('vaadin-date-picker');
-    datePicker.slot = 'date-picker';
-    datePicker.i18n = { ...datePicker.i18n, cancel: 'CUSTOM' };
-    dateTimePicker.appendChild(datePicker);
+    slottedDatePicker = document.createElement('vaadin-date-picker');
+    slottedDatePicker.slot = 'date-picker';
+    slottedDatePicker.i18n = { ...slottedDatePicker.i18n, cancel: 'Peruuta' };
+    dateTimePicker.appendChild(slottedDatePicker);
   });
 
-  it('should have the correct i18n', async () => {
+  it('slotted date picker should have the correct i18n', async () => {
     await aTimeout(0);
     document.body.appendChild(dateTimePicker);
-    expect(datePicker.i18n.cancel).to.equal('CUSTOM');
+    expect(slottedDatePicker.i18n.cancel).to.equal('Peruuta');
   });
 });

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -97,7 +97,25 @@ customElements.define(
   });
 });
 
-describe('i18n set to child date picker before added to the DOM', () => {
+describe('setting i18n on a slotted picker before connected to the DOM', () => {
+     beforeEach(() => {
+         dateTimePicker = document.createElement('vaadin-date-time-picker');
+     });
+     
+     describe('date-picker', () => {
+       beforeEach(() => {
+         slottedDatePicker = document.createElement('vaadin-date-picker');
+         slottedDatePicker.slot = 'date-picker';
+         slottedDatePicker.i18n = { ...slottedDatePicker.i18n, cancel: 'Peruuta' };
+         dateTimePicker.appendChild(slottedDatePicker);
+       });
+       
+       it('should not have i18n overridden', () => {
+         ...
+       });
+     }); 
+  });
+})
   let dateTimePicker, slottedDatePicker;
 
   beforeEach(() => {

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -98,37 +98,24 @@ customElements.define(
 });
 
 describe('setting i18n on a slotted picker before connected to the DOM', () => {
-     beforeEach(() => {
-         dateTimePicker = document.createElement('vaadin-date-time-picker');
-     });
-     
-     describe('date-picker', () => {
-       beforeEach(() => {
-         slottedDatePicker = document.createElement('vaadin-date-picker');
-         slottedDatePicker.slot = 'date-picker';
-         slottedDatePicker.i18n = { ...slottedDatePicker.i18n, cancel: 'Peruuta' };
-         dateTimePicker.appendChild(slottedDatePicker);
-       });
-       
-       it('should not have i18n overridden', () => {
-         ...
-       });
-     }); 
-  });
-})
-  let dateTimePicker, slottedDatePicker;
+  let dateTimePicker, datePicker;
 
   beforeEach(() => {
     dateTimePicker = document.createElement('vaadin-date-time-picker');
-    slottedDatePicker = document.createElement('vaadin-date-picker');
-    slottedDatePicker.slot = 'date-picker';
-    slottedDatePicker.i18n = { ...slottedDatePicker.i18n, cancel: 'Peruuta' };
-    dateTimePicker.appendChild(slottedDatePicker);
   });
 
-  it('slotted date picker should have the correct i18n', async () => {
-    await aTimeout(0);
-    document.body.appendChild(dateTimePicker);
-    expect(slottedDatePicker.i18n.cancel).to.equal('Peruuta');
+  describe('date-picker', () => {
+    beforeEach(() => {
+      datePicker = document.createElement('vaadin-date-picker');
+      datePicker.slot = 'date-picker';
+      datePicker.i18n = { ...datePicker.i18n, cancel: 'Peruuta' };
+      dateTimePicker.appendChild(datePicker);
+    });
+
+    it('should not have i18n overridden', async () => {
+      await aTimeout(0);
+      document.body.appendChild(dateTimePicker);
+      expect(datePicker.i18n.cancel).to.equal('Peruuta');
+    });
   });
 });

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-date-time-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
@@ -94,5 +94,23 @@ customElements.define(
       expect(dateTimePicker.i18n).to.have.property('cancel', 'Peruuta');
       expect(datePicker.i18n).to.have.property('cancel', 'Peruuta');
     });
+  });
+});
+
+describe('i18n set before added to the DOM', () => {
+  let dateTimePicker, datePicker;
+
+  beforeEach(() => {
+    dateTimePicker = document.createElement('vaadin-date-time-picker');
+    datePicker = document.createElement('vaadin-date-picker');
+    datePicker.slot = 'date-picker';
+    datePicker.i18n = { ...datePicker.i18n, cancel: 'CUSTOM' };
+    dateTimePicker.appendChild(datePicker);
+  });
+
+  it.only('should have the correct i18n', async () => {
+    await nextFrame();
+    document.body.appendChild(dateTimePicker);
+    expect(datePicker.i18n.cancel).to.equal('CUSTOM');
   });
 });

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -108,7 +108,7 @@ describe('i18n set before added to the DOM', () => {
     dateTimePicker.appendChild(datePicker);
   });
 
-  it.only('should have the correct i18n', async () => {
+  it('should have the correct i18n', async () => {
     await nextFrame();
     document.body.appendChild(dateTimePicker);
     expect(datePicker.i18n.cancel).to.equal('CUSTOM');


### PR DESCRIPTION
## Description

The related Flow component issue: [4667](https://github.com/vaadin/flow-components/issues/4667)

In v23.3, i18n can be incorrectly updated before the component is ready. This is due to `FlattenedNodesObserver` being flushed prematurely, and the listeners being invoked while the component is not ready. In v24, the slotted components are handled in a different way, therefore this behaviour is not observed. 

This PR moves the observer initialization logic to after when the date picker and time pickers are already set and the component is ready. This way, the initial i18n update will not override the correct i18n.

Related to https://github.com/vaadin/flow-components/pull/4706

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.