### PR TITLE
test: ensure _hasInputValue is reset on clear button interaction

### DIFF
--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -3,12 +3,13 @@ import {
   defineLit,
   definePolymer,
   escKeyDown,
+  fire,
   fixtureSync,
   keyboardEventFor,
-  keyDownOn,
   nextFrame,
   nextRender,
 } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -40,116 +41,158 @@ const runTests = (defineHelper, baseMixin) => {
       },
   );
 
-  let element, input, button;
+  let element, input, clearButton;
 
-  beforeEach(async () => {
-    element = fixtureSync(`<${tag} value="foo"></${tag}>`);
-    await nextRender();
-    input = element.querySelector('[slot=input]');
-    button = element.clearElement;
+  describe('basic', () => {
+    beforeEach(async () => {
+      element = fixtureSync(`<${tag} value="foo"></${tag}>`);
+      await nextRender();
+      input = element.querySelector('[slot=input]');
+      clearButton = element.clearElement;
+    });
+
+    it('should clear the field value on clear button click', async () => {
+      clearButton.click();
+      await nextFrame();
+      expect(element.value).to.equal('');
+    });
+
+    it('should clear the input value on clear button click', async () => {
+      clearButton.click();
+      await nextFrame();
+      expect(input.value).to.equal('');
+    });
+
+    it('should focus the input on clear button click', () => {
+      const spy = sinon.spy(input, 'focus');
+      clearButton.click();
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should dispatch input event on clear button click', () => {
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      clearButton.click();
+      expect(spy.calledOnce).to.be.true;
+      const event = spy.firstCall.args[0];
+      expect(event.bubbles).to.be.true;
+      expect(event.composed).to.be.true;
+    });
+
+    it('should dispatch change event on clear button click', () => {
+      const spy = sinon.spy();
+      element.addEventListener('change', spy);
+      clearButton.click();
+      expect(spy.calledOnce).to.be.true;
+      const event = spy.firstCall.args[0];
+      expect(event.bubbles).to.be.true;
+      expect(event.composed).to.be.false;
+    });
+
+    it('should call preventDefault on the button click event', () => {
+      const event = new CustomEvent('click', { cancelable: true });
+      clearButton.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should reflect clearButtonVisible property to attribute', async () => {
+      element.clearButtonVisible = true;
+      await nextFrame();
+      expect(element.hasAttribute('clear-button-visible')).to.be.true;
+
+      element.clearButtonVisible = false;
+      await nextFrame();
+      expect(element.hasAttribute('clear-button-visible')).to.be.false;
+    });
+
+    it('should clear value on Esc when clearButtonVisible is true', async () => {
+      element.clearButtonVisible = true;
+      escKeyDown(clearButton);
+      await nextFrame();
+      expect(input.value).to.equal('');
+    });
+
+    it('should not clear value on Esc when clearButtonVisible is false', () => {
+      escKeyDown(clearButton);
+      expect(input.value).to.equal('foo');
+    });
+
+    it('should dispatch input event when clearing value on Esc', () => {
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      element.clearButtonVisible = true;
+      escKeyDown(clearButton);
+      expect(spy.calledOnce).to.be.true;
+      const event = spy.firstCall.args[0];
+      expect(event.bubbles).to.be.true;
+      expect(event.composed).to.be.true;
+    });
+
+    it('should dispatch change event when clearing value on Esc', () => {
+      const spy = sinon.spy();
+      input.addEventListener('change', spy);
+      element.clearButtonVisible = true;
+      escKeyDown(clearButton);
+      expect(spy.calledOnce).to.be.true;
+      const event = spy.firstCall.args[0];
+      expect(event.bubbles).to.be.true;
+      expect(event.composed).to.be.false;
+    });
+
+    it('should call stopPropagation() on Esc when clearButtonVisible is true', () => {
+      element.clearButtonVisible = true;
+      const event = keyboardEventFor('keydown', 27, [], 'Escape');
+      const spy = sinon.spy(event, 'stopPropagation');
+      clearButton.dispatchEvent(event);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should not call stopPropagation() on Esc when clearButtonVisible is false', () => {
+      const event = keyboardEventFor('keydown', 27, [], 'Escape');
+      const spy = sinon.spy(event, 'stopPropagation');
+      clearButton.dispatchEvent(event);
+      expect(spy.called).to.be.false;
+    });
   });
 
-  it('should clear the field value on clear button click', async () => {
-    button.click();
-    await nextFrame();
-    expect(element.value).to.equal('');
-  });
+  describe('has-input-value-changed event', () => {
+    let hasInputValueChangedSpy, valueChangedSpy;
 
-  it('should clear the input value on clear button click', async () => {
-    button.click();
-    await nextFrame();
-    expect(input.value).to.equal('');
-  });
+    beforeEach(async () => {
+      hasInputValueChangedSpy = sinon.spy();
+      valueChangedSpy = sinon.spy();
+      element = fixtureSync(`<${tag} clear-button-visible></${tag}>`);
+      element.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+      element.addEventListener('value-changed', valueChangedSpy);
+      await nextRender();
+      input = element.querySelector('[slot=input]');
+      clearButton = element.clearElement;
+    });
 
-  it('should focus the input on clear button click', () => {
-    const spy = sinon.spy(input, 'focus');
-    button.click();
-    expect(spy.calledOnce).to.be.true;
-  });
+    describe('with user input', () => {
+      beforeEach(async () => {
+        input.value = 'foo';
+        fire(input, 'input');
+        await nextFrame();
+        hasInputValueChangedSpy.resetHistory();
+        valueChangedSpy.resetHistory();
+      });
 
-  it('should dispatch input event on clear button click', () => {
-    const spy = sinon.spy();
-    input.addEventListener('input', spy);
-    button.click();
-    expect(spy.calledOnce).to.be.true;
-    const event = spy.firstCall.args[0];
-    expect(event.bubbles).to.be.true;
-    expect(event.composed).to.be.true;
-  });
+      it('should fire the event on clear button click', async () => {
+        clearButton.click();
+        await nextFrame();
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+      });
 
-  it('should dispatch change event on clear button click', () => {
-    const spy = sinon.spy();
-    element.addEventListener('change', spy);
-    button.click();
-    expect(spy.calledOnce).to.be.true;
-    const event = spy.firstCall.args[0];
-    expect(event.bubbles).to.be.true;
-    expect(event.composed).to.be.false;
-  });
-
-  it('should call preventDefault on the button click event', () => {
-    const event = new CustomEvent('click', { cancelable: true });
-    button.dispatchEvent(event);
-    expect(event.defaultPrevented).to.be.true;
-  });
-
-  it('should reflect clearButtonVisible property to attribute', async () => {
-    element.clearButtonVisible = true;
-    await nextFrame();
-    expect(element.hasAttribute('clear-button-visible')).to.be.true;
-
-    element.clearButtonVisible = false;
-    await nextFrame();
-    expect(element.hasAttribute('clear-button-visible')).to.be.false;
-  });
-
-  it('should clear value on Esc when clearButtonVisible is true', async () => {
-    element.clearButtonVisible = true;
-    escKeyDown(button);
-    await nextFrame();
-    expect(input.value).to.equal('');
-  });
-
-  it('should not clear value on Esc when clearButtonVisible is false', () => {
-    escKeyDown(button);
-    expect(input.value).to.equal('foo');
-  });
-
-  it('should dispatch input event when clearing value on Esc', () => {
-    const spy = sinon.spy();
-    input.addEventListener('input', spy);
-    element.clearButtonVisible = true;
-    escKeyDown(button);
-    expect(spy.calledOnce).to.be.true;
-    const event = spy.firstCall.args[0];
-    expect(event.bubbles).to.be.true;
-    expect(event.composed).to.be.true;
-  });
-
-  it('should dispatch change event when clearing value on Esc', () => {
-    const spy = sinon.spy();
-    input.addEventListener('change', spy);
-    element.clearButtonVisible = true;
-    escKeyDown(button);
-    expect(spy.calledOnce).to.be.true;
-    const event = spy.firstCall.args[0];
-    expect(event.bubbles).to.be.true;
-    expect(event.composed).to.be.false;
-  });
-
-  it('should call stopPropagation() on Esc when clearButtonVisible is true', () => {
-    element.clearButtonVisible = true;
-    const event = keyboardEventFor('keydown', 27, [], 'Escape');
-    const spy = sinon.spy(event, 'stopPropagation');
-    button.dispatchEvent(event);
-    expect(spy.called).to.be.true;
-  });
-
-  it('should not call stopPropagation() on Esc when clearButtonVisible is false', () => {
-    const event = keyboardEventFor('keydown', 27, [], 'Escape');
-    const spy = sinon.spy(event, 'stopPropagation');
-    button.dispatchEvent(event);
-    expect(spy.called).to.be.false;
+      it('should fire the event on Esc', async () => {
+        input.focus();
+        await sendKeys({ press: 'Escape' });
+        await nextFrame();
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+      });
+    });
   });
 };
 


### PR DESCRIPTION
## Description

The PR adds tests ensuring _hasInputValue is reset when clearing the value either by clicking on the clear button or by pressing <kbd>Esc</kbd> in the input element.

Fixes #5410 

## Type of change

- [x] Internal
