### PR TITLE
feat: add AriaModalController to handle modal dialogs behavior

### DIFF
--- a/packages/a11y-base/src/aria-modal-controller.d.ts
+++ b/packages/a11y-base/src/aria-modal-controller.d.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { ReactiveController } from 'lit';
+
+/**
+ * A controller for handling modal state on the elements with `dialog` and `alertdialog` role.
+ * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal
+ */
+export class AriaModalController implements ReactiveController {
+  /**
+   * The controller host element.
+   */
+  host: HTMLElement;
+
+  constructor(node: HTMLElement);
+
+  /**
+   * Make the controller host element modal by trapping focus inside it and hiding
+   * other elements from screen readers using `aria-hidden="true"` appropriately.
+   *
+   * The method name is chosen to align with the one provided by native `<dialog>`:
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal
+   */
+  showModal(): void;
+
+  /**
+   * Exit modal state: release focus and remove `aria-hidden` from other elements
+   * unless there are any other underlying elements that are also shown as modal.
+   */
+  close(): void;
+}

--- a/packages/a11y-base/src/aria-modal-controller.js
+++ b/packages/a11y-base/src/aria-modal-controller.js
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { hideOthers } from './aria-hidden.js';
+import { FocusTrapController } from './focus-trap-controller.js';
+
+/**
+ * A controller for handling modal state on the elements with `dialog` and `alertdialog` role.
+ * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal
+ *
+ * Note, the actual `role` and `aria-modal` attributes are supposed to be handled by the
+ * consumer web component. This is done in to ensure the controller only does one thing.
+ */
+export class AriaModalController {
+  constructor(host) {
+    this.host = host;
+  }
+
+  /**
+   * Make the controller host modal by hiding other elements from screen readers
+   * using `aria-hidden` attribute (can be replaced with `inert` in the future).
+   *
+   * The method name is chosen to align with the one provided by native `<dialog>`:
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal
+   */
+  showModal() {
+    this.__showOthers = hideOthers(this.host);
+  }
+
+  /**
+   * Remove `aria-hidden` from other elements unless there are any other
+   * controller hosts on the page activated by using `showModal()` call.
+   */
+  close() {
+    if (this.__showOthers) {
+      this.__showOthers();
+      this.__showOthers = null;
+    }
+  }
+}

--- a/packages/a11y-base/src/aria-modal-controller.js
+++ b/packages/a11y-base/src/aria-modal-controller.js
@@ -14,7 +14,15 @@ import { FocusTrapController } from './focus-trap-controller.js';
  * consumer web component. This is done in to ensure the controller only does one thing.
  */
 export class AriaModalController {
+  /**
+   * @param {HTMLElement} host
+   */
   constructor(host) {
+    /**
+     * The controller host element.
+     *
+     * @type {HTMLElement}
+     */
     this.host = host;
   }
 

--- a/packages/a11y-base/test/aria-modal-controller.test.js
+++ b/packages/a11y-base/test/aria-modal-controller.test.js
@@ -1,0 +1,62 @@
+import { expect } from '@esm-bundle/chai';
+import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { AriaModalController } from '../src/aria-modal-controller.js';
+
+const runTests = (defineHelper, baseMixin) => {
+  let wrapper, elements, modal, controller;
+
+  const tag = defineHelper(
+    'aria-modal',
+    `
+      <input id="input-1" />
+      <input id="input-2" />
+    `,
+    (Base) => class extends baseMixin(Base) {},
+  );
+
+  beforeEach(async () => {
+    wrapper = fixtureSync(`
+      <div>
+        <input id="outer-1" />
+        <${tag}></${tag}>
+        <input id="outer-2" />
+      </div>
+    `);
+    await nextRender();
+    elements = wrapper.children;
+    modal = elements[1];
+    controller = new AriaModalController(modal);
+    modal.addController(controller);
+  });
+
+  describe('aria-hidden', () => {
+    it('should set aria-hidden="true" on other elements when `showModal()` is called', () => {
+      controller.showModal();
+
+      expect(elements[0].getAttribute('aria-hidden')).to.equal('true');
+      expect(elements[1].hasAttribute('aria-hidden')).to.be.false;
+      expect(elements[2].getAttribute('aria-hidden')).to.equal('true');
+    });
+
+    it('should remove aria-hidden="true" from other elements when `close()` is called', () => {
+      controller.showModal();
+
+      controller.close();
+
+      expect(elements[0].hasAttribute('aria-hidden')).to.be.false;
+      expect(elements[1].hasAttribute('aria-hidden')).to.be.false;
+      expect(elements[2].hasAttribute('aria-hidden')).to.be.false;
+    });
+  });
+};
+
+describe('AriaModalController + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('AriaModalController + Lit', () => {
+  runTests(defineLit, PolylitMixin);
+});


### PR DESCRIPTION
## Description

This PR is a version of #5603 adding a new controller that extends `FocusTrapController`.
The name is inspired by [`@react-aria/aria-modal-polyfill`](https://github.com/adobe/react-spectrum/pull/709) and native [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement).

## Type of change

- Internal feature