### PR TITLE
chore: fix the command used to run snapshot tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -154,7 +154,7 @@ yarn update:lumo --group combo-box
 Run snapshot tests that are in `test/dom` folders under components:
 
 ```sh
-yarn test:it
+yarn test:snapshots
 ```
 
 Update snapshots for all components that have corresponding tests:


### PR DESCRIPTION
## Description

Incorrect command to run snapshot tests in Development.MD 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
