### PR TITLE
test: rename datepicker to datePicker

### DIFF
--- a/integration/tests/dialog-date-picker.test.js
+++ b/integration/tests/dialog-date-picker.test.js
@@ -8,7 +8,7 @@ import '@vaadin/dialog';
 import { open, waitForScrollToFinish } from '@vaadin/date-picker/test/helpers.js';
 
 describe('date-picker in dialog', () => {
-  let dialog, datepicker;
+  let dialog, datePicker;
 
   beforeEach(async () => {
     dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
@@ -17,11 +17,11 @@ describe('date-picker in dialog', () => {
     };
     dialog.opened = true;
     await nextFrame();
-    datepicker = dialog.$.overlay.querySelector('vaadin-date-picker');
+    datePicker = dialog.$.overlay.querySelector('vaadin-date-picker');
   });
 
   afterEach(async () => {
-    datepicker.opened = false;
+    datePicker.opened = false;
     dialog.opened = false;
     await nextFrame();
   });
@@ -30,10 +30,10 @@ describe('date-picker in dialog', () => {
     let overlayContent;
 
     beforeEach(async () => {
-      datepicker.inputElement.focus();
-      await open(datepicker);
+      datePicker.inputElement.focus();
+      await open(datePicker);
       await nextRender();
-      overlayContent = datepicker._overlayContent;
+      overlayContent = datePicker._overlayContent;
     });
 
     it('should focus the Today button on second Tab when inside a dialog', async () => {
@@ -65,7 +65,7 @@ describe('date-picker in dialog', () => {
       await nextRender();
       await waitForScrollToFinish(overlayContent);
 
-      const spy = sinon.spy(datepicker.inputElement, 'focus');
+      const spy = sinon.spy(datePicker.inputElement, 'focus');
 
       await sendKeys({ down: 'Shift' });
       await sendKeys({ press: 'Tab' });
@@ -77,7 +77,7 @@ describe('date-picker in dialog', () => {
     it('should not close the dialog when closing date-picker on input element Escape', async () => {
       await sendKeys({ press: 'Escape' });
 
-      expect(datepicker.opened).to.be.false;
+      expect(datePicker.opened).to.be.false;
       expect(dialog.opened).to.be.true;
     });
 
@@ -95,7 +95,7 @@ describe('date-picker in dialog', () => {
 
       await sendKeys({ press: 'Escape' });
 
-      expect(datepicker.opened).to.be.false;
+      expect(datePicker.opened).to.be.false;
       expect(dialog.opened).to.be.true;
     });
 
@@ -108,7 +108,7 @@ describe('date-picker in dialog', () => {
 
       await sendKeys({ press: 'Escape' });
 
-      expect(datepicker.opened).to.be.false;
+      expect(datePicker.opened).to.be.false;
       expect(dialog.opened).to.be.true;
     });
 
@@ -120,7 +120,7 @@ describe('date-picker in dialog', () => {
 
       await sendKeys({ press: 'Escape' });
 
-      expect(datepicker.opened).to.be.false;
+      expect(datePicker.opened).to.be.false;
       expect(dialog.opened).to.be.true;
     });
   });
@@ -128,21 +128,21 @@ describe('date-picker in dialog', () => {
   describe('modeless', () => {
     beforeEach(async () => {
       dialog.modeless = true;
-      await open(datepicker);
+      await open(datePicker);
     });
 
     it('should not end up behind the dialog overlay on mousedown', async () => {
-      datepicker.dispatchEvent(new CustomEvent('mousedown', { bubbles: true, composed: true }));
+      datePicker.dispatchEvent(new CustomEvent('mousedown', { bubbles: true, composed: true }));
       await nextFrame();
-      expect(parseFloat(getComputedStyle(datepicker.$.overlay).zIndex)).to.equal(
+      expect(parseFloat(getComputedStyle(datePicker.$.overlay).zIndex)).to.equal(
         parseFloat(getComputedStyle(dialog.$.overlay).zIndex) + 1,
       );
     });
 
     it('should not end up behind the dialog overlay on touchstart', async () => {
-      touchstart(datepicker);
+      touchstart(datePicker);
       await nextFrame();
-      expect(parseFloat(getComputedStyle(datepicker.$.overlay).zIndex)).to.equal(
+      expect(parseFloat(getComputedStyle(datePicker.$.overlay).zIndex)).to.equal(
         parseFloat(getComputedStyle(dialog.$.overlay).zIndex) + 1,
       );
     });

--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -7,11 +7,11 @@ import { parseDate } from '../src/vaadin-date-picker-helper.js';
 import { close, open, touchTap, waitForOverlayRender } from './helpers.js';
 
 describe('basic features', () => {
-  let datepicker, input;
+  let datePicker, input;
 
   beforeEach(() => {
-    datepicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
-    input = datepicker.inputElement;
+    datePicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+    input = datePicker.inputElement;
   });
 
   it('should parse date components with varying number of digits', () => {
@@ -29,49 +29,49 @@ describe('basic features', () => {
   });
 
   it('should have default value', () => {
-    expect(datepicker.value).to.equal('');
+    expect(datePicker.value).to.equal('');
   });
 
   it('should notify value change', () => {
     const spy = sinon.spy();
-    datepicker.addEventListener('value-changed', spy);
-    datepicker.value = '2000-02-01';
+    datePicker.addEventListener('value-changed', spy);
+    datePicker.value = '2000-02-01';
     expect(spy.calledOnce).to.be.true;
   });
 
   it('should keep focused attribute when focus moves to overlay', async () => {
-    datepicker.focus();
+    datePicker.focus();
     await sendKeys({ press: 'ArrowDown' });
     await waitForOverlayRender();
-    expect(datepicker.hasAttribute('focused')).to.be.true;
+    expect(datePicker.hasAttribute('focused')).to.be.true;
   });
 
   it('should have focused attribute when closed and focused', async () => {
-    datepicker.focus();
+    datePicker.focus();
     await sendKeys({ press: 'ArrowDown' });
     await waitForOverlayRender();
     await sendKeys({ press: 'Escape' });
-    expect(datepicker.hasAttribute('focused')).to.be.true;
+    expect(datePicker.hasAttribute('focused')).to.be.true;
   });
 
   it('should notify opened changed on open and close', async () => {
     const spy = sinon.spy();
-    datepicker.addEventListener('opened-changed', spy);
-    await open(datepicker);
+    datePicker.addEventListener('opened-changed', spy);
+    await open(datePicker);
     expect(spy.calledOnce).to.be.true;
-    await close(datepicker);
+    await close(datePicker);
     expect(spy.calledTwice).to.be.true;
   });
 
   it('should set opened to false with close call', async () => {
-    await open(datepicker);
-    await close(datepicker);
-    expect(datepicker.opened).to.be.false;
+    await open(datePicker);
+    await close(datePicker);
+    expect(datePicker.opened).to.be.false;
   });
 
   it('should open on input tap', async () => {
     tap(input);
-    await oneEvent(datepicker.$.overlay, 'vaadin-overlay-open');
+    await oneEvent(datePicker.$.overlay, 'vaadin-overlay-open');
   });
 
   it('should focus the input on touch tap', () => {
@@ -80,106 +80,106 @@ describe('basic features', () => {
   });
 
   it('should open on input container element click', () => {
-    const inputField = datepicker.shadowRoot.querySelector('[part="input-field"]');
+    const inputField = datePicker.shadowRoot.querySelector('[part="input-field"]');
     click(inputField);
-    expect(datepicker.opened).to.be.true;
+    expect(datePicker.opened).to.be.true;
   });
 
   it('should prevent default for the handled click event', () => {
-    const inputField = datepicker.shadowRoot.querySelector('[part="input-field"]');
+    const inputField = datePicker.shadowRoot.querySelector('[part="input-field"]');
     const event = click(inputField);
     expect(event.defaultPrevented).to.be.true;
   });
 
   it('should not prevent default for click when autoOpenDisabled', () => {
-    datepicker.autoOpenDisabled = true;
-    const inputField = datepicker.shadowRoot.querySelector('[part="input-field"]');
+    datePicker.autoOpenDisabled = true;
+    const inputField = datePicker.shadowRoot.querySelector('[part="input-field"]');
     const event = click(inputField);
     expect(event.defaultPrevented).to.be.false;
   });
 
   it('should lead zeros correctly', () => {
-    datepicker.value = '+000300-02-01';
+    datePicker.value = '+000300-02-01';
     expect(input.value).to.equal('2/1/0300');
   });
 
   it('should format display correctly', () => {
-    datepicker.value = '2000-02-01';
+    datePicker.value = '2000-02-01';
     expect(input.value).to.equal('2/1/2000');
-    datepicker.value = '1999-12-31';
+    datePicker.value = '1999-12-31';
     expect(input.value).to.equal('12/31/1999');
   });
 
   it('should format display correctly with sub 100 years', () => {
-    datepicker.value = '+000001-02-01';
+    datePicker.value = '+000001-02-01';
     expect(input.value).to.equal('2/1/0001');
-    datepicker.value = '+000099-02-01';
+    datePicker.value = '+000099-02-01';
     expect(input.value).to.equal('2/1/0099');
   });
 
-  it('should not change datepicker width', async () => {
-    datepicker.style.display = 'inline-block';
+  it('should not change datePicker width', async () => {
+    datePicker.style.display = 'inline-block';
 
-    datepicker.value = '2000-01-01';
-    const width = datepicker.clientWidth;
+    datePicker.value = '2000-01-01';
+    const width = datePicker.clientWidth;
 
-    await open(datepicker);
-    expect(datepicker.clientWidth).to.equal(width);
+    await open(datePicker);
+    expect(datePicker.clientWidth).to.equal(width);
   });
 
   describe('value property formats', () => {
     it('should accept ISO format', () => {
       const date = new Date(0, 1, 3);
 
-      datepicker.value = '0000-02-03';
+      datePicker.value = '0000-02-03';
       date.setFullYear(0);
-      expect(datepicker._selectedDate).to.eql(date);
+      expect(datePicker._selectedDate).to.eql(date);
 
-      datepicker.value = '+010000-02-03';
+      datePicker.value = '+010000-02-03';
       date.setFullYear(10000);
-      expect(datepicker._selectedDate).to.eql(date);
+      expect(datePicker._selectedDate).to.eql(date);
 
-      datepicker.value = '-010000-02-03';
+      datePicker.value = '-010000-02-03';
       date.setFullYear(-10000);
-      expect(datepicker._selectedDate).to.eql(date);
+      expect(datePicker._selectedDate).to.eql(date);
     });
 
     it('should not accept non-ISO formats', () => {
-      datepicker.value = '03/02/01';
-      expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.be.null;
+      datePicker.value = '03/02/01';
+      expect(datePicker.value).to.equal('');
+      expect(datePicker._selectedDate).to.be.null;
 
-      datepicker.value = '2010/02/03';
-      expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.be.null;
+      datePicker.value = '2010/02/03';
+      expect(datePicker.value).to.equal('');
+      expect(datePicker._selectedDate).to.be.null;
 
-      datepicker.value = '03/02/2010';
-      expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.be.null;
+      datePicker.value = '03/02/2010';
+      expect(datePicker.value).to.equal('');
+      expect(datePicker._selectedDate).to.be.null;
 
-      datepicker.value = '3 Feb 2010';
-      expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.be.null;
+      datePicker.value = '3 Feb 2010';
+      expect(datePicker.value).to.equal('');
+      expect(datePicker._selectedDate).to.be.null;
 
-      datepicker.value = 'Feb 3, 2010';
-      expect(datepicker.value).to.equal('');
-      expect(datepicker._selectedDate).to.be.null;
+      datePicker.value = 'Feb 3, 2010';
+      expect(datePicker.value).to.equal('');
+      expect(datePicker._selectedDate).to.be.null;
     });
 
     it('should output ISO format', () => {
       const date = new Date(0, 1, 3);
 
       date.setFullYear(0);
-      datepicker._selectedDate = date;
-      expect(datepicker.value).to.equal('0000-02-03');
+      datePicker._selectedDate = date;
+      expect(datePicker.value).to.equal('0000-02-03');
 
       date.setFullYear(10000);
-      datepicker._selectedDate = new Date(date.getTime());
-      expect(datepicker.value).to.equal('+010000-02-03');
+      datePicker._selectedDate = new Date(date.getTime());
+      expect(datePicker.value).to.equal('+010000-02-03');
 
       date.setFullYear(-10000);
-      datepicker._selectedDate = new Date(date.getTime());
-      expect(datepicker.value).to.equal('-010000-02-03');
+      datePicker._selectedDate = new Date(date.getTime());
+      expect(datePicker.value).to.equal('-010000-02-03');
     });
   });
 
@@ -187,8 +187,8 @@ describe('basic features', () => {
     let overlayContent;
 
     beforeEach(async () => {
-      datepicker.i18n = {
-        ...datepicker.i18n,
+      datePicker.i18n = {
+        ...datePicker.i18n,
         weekdays: ['sunnuntai', 'maanantai', 'tiistai', 'keskiviikko', 'torstai', 'perjantai', 'lauantai'],
         weekdaysShort: ['su', 'ma', 'ti', 'ke', 'to', 'pe', 'la'],
         firstDayOfWeek: 1,
@@ -201,8 +201,8 @@ describe('basic features', () => {
         },
       };
 
-      await open(datepicker);
-      overlayContent = datepicker._overlayContent;
+      await open(datePicker);
+      overlayContent = datePicker._overlayContent;
     });
 
     it('should notify i18n mutation to children', () => {
@@ -213,7 +213,7 @@ describe('basic features', () => {
     });
 
     it('should reflect value in overlay header', () => {
-      datepicker.value = '2000-02-01';
+      datePicker.value = '2000-02-01';
       expect(overlayContent.shadowRoot.querySelector('[part="label"]').textContent.trim()).to.equal('1.2.2000');
     });
 
@@ -225,20 +225,20 @@ describe('basic features', () => {
 
   describe('autoselect', () => {
     it('should set autoselect to false by default', () => {
-      expect(datepicker.autoselect).to.be.false;
+      expect(datePicker.autoselect).to.be.false;
     });
 
     it('should not select content on focus when autoselect is false', () => {
       const spy = sinon.spy(input, 'select');
-      datepicker.value = '2016-07-14';
+      datePicker.value = '2016-07-14';
       input.focus();
       expect(spy.called).to.be.false;
     });
 
     it('should select content on focus when autoselect is true', () => {
       const spy = sinon.spy(input, 'select');
-      datepicker.value = '2016-07-14';
-      datepicker.autoselect = true;
+      datePicker.value = '2016-07-14';
+      datePicker.autoselect = true;
       input.focus();
       expect(spy.calledOnce).to.be.true;
     });
@@ -259,87 +259,87 @@ describe('inside flexbox', () => {
 });
 
 describe('clear button', () => {
-  let datepicker, clearButton;
+  let datePicker, clearButton;
 
   beforeEach(() => {
-    datepicker = fixtureSync('<vaadin-date-picker clear-button-visible></vaadin-date-picker>');
-    clearButton = datepicker.shadowRoot.querySelector('[part="clear-button"]');
+    datePicker = fixtureSync('<vaadin-date-picker clear-button-visible></vaadin-date-picker>');
+    clearButton = datePicker.shadowRoot.querySelector('[part="clear-button"]');
   });
 
   it('should have clearButtonVisible property', () => {
-    expect(datepicker).to.have.property('clearButtonVisible', true);
+    expect(datePicker).to.have.property('clearButtonVisible', true);
   });
 
   it('should clear the value on click', () => {
-    datepicker.value = '2000-02-01';
+    datePicker.value = '2000-02-01';
     click(clearButton);
-    expect(datepicker.value).to.equal('');
+    expect(datePicker.value).to.equal('');
   });
 
   it('should clear the value on touch tap', () => {
-    datepicker.value = '2000-02-01';
+    datePicker.value = '2000-02-01';
     touchTap(clearButton);
-    expect(datepicker.value).to.equal('');
+    expect(datePicker.value).to.equal('');
   });
 
   it('should remove has-value attribute on clear', () => {
-    datepicker.value = '2000-02-01';
+    datePicker.value = '2000-02-01';
     click(clearButton);
-    expect(datepicker.hasAttribute('has-value')).to.be.false;
+    expect(datePicker.hasAttribute('has-value')).to.be.false;
   });
 
   it('should prevent default on clear button click event', () => {
-    datepicker.value = '2000-02-01';
+    datePicker.value = '2000-02-01';
     const event = click(clearButton);
     expect(event.defaultPrevented).to.be.true;
   });
 
   it('should prevent default on Esc when clearing value', () => {
-    datepicker.value = '2000-02-01';
+    datePicker.value = '2000-02-01';
     const event = keyboardEventFor('keydown', 27, [], 'Escape');
-    datepicker.inputElement.dispatchEvent(event);
+    datePicker.inputElement.dispatchEvent(event);
     expect(event.defaultPrevented).to.be.true;
   });
 
   it('should stop propagation on Esc when clearing value', () => {
-    datepicker.value = '2000-02-01';
+    datePicker.value = '2000-02-01';
     const event = keyboardEventFor('keydown', 27, [], 'Escape');
     const spy = sinon.spy(event, 'stopPropagation');
-    datepicker.inputElement.dispatchEvent(event);
+    datePicker.inputElement.dispatchEvent(event);
     expect(spy.calledOnce).to.be.true;
   });
 
   it('should not stop propagation on Esc when no value is set', () => {
     const event = keyboardEventFor('keydown', 27, [], 'Escape');
     const spy = sinon.spy(event, 'stopPropagation');
-    datepicker.inputElement.dispatchEvent(event);
+    datePicker.inputElement.dispatchEvent(event);
     expect(spy.called).to.be.false;
   });
 
   it('should not stop propagation on Esc when clearButtonVisible is false', () => {
-    datepicker.clearButtonVisible = false;
+    datePicker.clearButtonVisible = false;
     const event = keyboardEventFor('keydown', 27, [], 'Escape');
     const spy = sinon.spy(event, 'stopPropagation');
-    datepicker.inputElement.dispatchEvent(event);
+    datePicker.inputElement.dispatchEvent(event);
     expect(spy.called).to.be.false;
   });
 
   it('should not close on clear button click when opened', async () => {
-    await open(datepicker);
-    datepicker.value = '2001-01-01';
+    await open(datePicker);
+    datePicker.value = '2001-01-01';
     click(clearButton);
-    expect(datepicker.opened).to.be.true;
+    expect(datePicker.opened).to.be.true;
   });
 
   it('should not open on clear button click when not opened', () => {
-    datepicker.value = '2001-01-01';
+    datePicker.value = '2001-01-01';
     click(clearButton);
-    expect(datepicker.opened).to.be.not.ok;
+    expect(datePicker.opened).to.be.not.ok;
   });
 });
 
 describe('wrapped', () => {
-  let container, datepicker;
+  let container, datePicker;
 
   beforeEach(() => {
     container = fixtureSync(`
@@ -349,22 +349,22 @@ describe('wrapped', () => {
         </div>
       </div>
     `);
-    datepicker = container.querySelector('vaadin-date-picker');
+    datePicker = container.querySelector('vaadin-date-picker');
   });
 
   it('should match the parent width', () => {
     container.querySelector('div').style.width = '120px';
-    datepicker.style.width = '100%';
-    expect(datepicker.clientWidth).to.equal(120);
+    datePicker.style.width = '100%';
+    expect(datePicker.clientWidth).to.equal(120);
   });
 });
 
 describe('initial value attribute', () => {
-  let datepicker, input;
+  let datePicker, input;
 
   beforeEach(() => {
-    datepicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
-    input = datepicker.inputElement;
+    datePicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
+    input = datePicker.inputElement;
   });
 
   it('should format the input value', () => {
@@ -373,13 +373,13 @@ describe('initial value attribute', () => {
 });
 
 describe('auto open disabled', () => {
-  let datepicker, input, toggleButton;
+  let datePicker, input, toggleButton;
 
   beforeEach(() => {
-    datepicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
-    input = datepicker.inputElement;
-    toggleButton = datepicker.shadowRoot.querySelector('[part="toggle-button"]');
-    datepicker.autoOpenDisabled = true;
+    datePicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
+    input = datePicker.inputElement;
+    toggleButton = datePicker.shadowRoot.querySelector('[part="toggle-button"]');
+    datePicker.autoOpenDisabled = true;
   });
 
   it('should focus the input on touch tap', () => {
@@ -389,44 +389,44 @@ describe('auto open disabled', () => {
 
   it('should not blur the input on open', async () => {
     touchTap(input);
-    await open(datepicker);
+    await open(datePicker);
     expect(document.activeElement).to.equal(input);
   });
 
   it('should not open on input tap', () => {
     tap(input);
-    expect(datepicker.opened).not.to.be.true;
+    expect(datePicker.opened).not.to.be.true;
   });
 
   it('should open on calendar icon tap', async () => {
     tap(toggleButton);
-    await oneEvent(datepicker.$.overlay, 'vaadin-overlay-open');
+    await oneEvent(datePicker.$.overlay, 'vaadin-overlay-open');
   });
 });
 
 describe('ios', () => {
-  let datepicker, input;
+  let datePicker, input;
 
   beforeEach(() => {
-    datepicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
-    input = datepicker.inputElement;
-    datepicker._ios = true;
+    datePicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
+    input = datePicker.inputElement;
+    datePicker._ios = true;
   });
 
   it('should focus the input when closed', () => {
-    datepicker.focus();
+    datePicker.focus();
     expect(document.activeElement).to.equal(input);
   });
 
   it('should blur the input when opened', async () => {
-    datepicker.focus();
-    await open(datepicker);
+    datePicker.focus();
+    await open(datePicker);
     expect(document.activeElement).to.not.equal(input);
   });
 
   describe('auto open disabled', () => {
     beforeEach(() => {
-      datepicker.autoOpenDisabled = true;
+      datePicker.autoOpenDisabled = true;
     });
 
     it('should focus the input on touch tap', () => {
@@ -436,13 +436,13 @@ describe('ios', () => {
 
     it('should blur the input on open', async () => {
       touchTap(input);
-      await open(datepicker);
+      await open(datePicker);
       expect(document.activeElement).to.not.equal(input);
     });
 
     it('should not open on input tap', () => {
       tap(input);
-      expect(datepicker.opened).not.to.be.true;
+      expect(datePicker.opened).not.to.be.true;
     });
   });
 });

--- a/packages/date-picker/test/custom-input.test.js
+++ b/packages/date-picker/test/custom-input.test.js
@@ -6,49 +6,49 @@ import '../vaadin-date-picker-light.js';
 import { open, setInputValue, waitForScrollToFinish } from './helpers.js';
 
 describe('custom input', () => {
-  let datepicker, overlay;
+  let datePicker, overlay;
 
   beforeEach(() => {
-    datepicker = fixtureSync(`
+    datePicker = fixtureSync(`
       <vaadin-date-picker-light attr-for-value="value">
         <input class="input">
       </vaadin-date-picker-light>
     `);
-    overlay = datepicker.$.overlay;
+    overlay = datePicker.$.overlay;
   });
 
   it('should open calendar on tap', () => {
-    tap(datepicker);
+    tap(datePicker);
     expect(overlay.opened).to.be.true;
   });
 
   it('should open calendar on input', () => {
-    setInputValue(datepicker, '1');
+    setInputValue(datePicker, '1');
     expect(overlay.opened).to.be.true;
   });
 
   it('should not open calendar on input when autoOpenDisabled is true', () => {
-    datepicker.autoOpenDisabled = true;
-    setInputValue(datepicker, '1');
+    datePicker.autoOpenDisabled = true;
+    setInputValue(datePicker, '1');
     expect(overlay.opened).not.to.be.true;
   });
 
   it('should close on overlay date tap', async () => {
-    await open(datepicker);
-    const spy = sinon.spy(datepicker, 'close');
-    fire(datepicker._overlayContent, 'date-tap', { date: new Date() });
+    await open(datePicker);
+    const spy = sinon.spy(datePicker, 'close');
+    fire(datePicker._overlayContent, 'date-tap', { date: new Date() });
     expect(spy.called).to.be.true;
   });
 
   it('should show week numbers', async () => {
-    datepicker.showWeekNumbers = true;
-    await open(datepicker);
-    expect(datepicker._overlayContent.showWeekNumbers).to.be.true;
+    datePicker.showWeekNumbers = true;
+    await open(datePicker);
+    expect(datePicker._overlayContent.showWeekNumbers).to.be.true;
   });
 
   describe('theme attribute', () => {
     beforeEach(() => {
-      datepicker.setAttribute('theme', 'foo');
+      datePicker.setAttribute('theme', 'foo');
     });
 
     it('should propagate theme attribute to overlay', () => {
@@ -56,17 +56,17 @@ describe('custom input', () => {
     });
 
     it('should propagate theme attribute to overlay content', async () => {
-      await open(datepicker);
-      expect(datepicker._overlayContent.getAttribute('theme')).to.equal('foo');
+      await open(datePicker);
+      expect(datePicker._overlayContent.getAttribute('theme')).to.equal('foo');
     });
 
     describe('in content', () => {
       beforeEach(async () => {
-        await open(datepicker);
+        await open(datePicker);
       });
 
       it('should propagate theme attribute to month calendar', async () => {
-        const overlayContent = datepicker._overlayContent;
+        const overlayContent = datePicker._overlayContent;
         await waitForScrollToFinish(overlayContent);
         const monthCalendar = overlayContent.querySelector('vaadin-month-calendar');
         expect(monthCalendar.getAttribute('theme')).to.equal('foo');

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -6,23 +6,23 @@ import '../src/vaadin-date-picker.js';
 import { getFocusedCell, monthsEqual, open, outsideClick, waitForOverlayRender } from './helpers.js';
 
 describe('dropdown', () => {
-  let datepicker, input, overlay;
+  let datePicker, input, overlay;
 
   beforeEach(() => {
-    datepicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
-    input = datepicker.inputElement;
-    overlay = datepicker.$.overlay;
+    datePicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+    input = datePicker.inputElement;
+    overlay = datePicker.$.overlay;
   });
 
   it('should update position of the overlay after changing opened property', async () => {
-    datepicker.opened = true;
+    datePicker.opened = true;
     await oneEvent(overlay, 'vaadin-overlay-open');
     expect(input.getBoundingClientRect().bottom).to.be.closeTo(overlay.getBoundingClientRect().top, 0.01);
   });
 
-  it('should detach overlay on datepicker detach', async () => {
-    await open(datepicker);
-    datepicker.parentElement.removeChild(datepicker);
+  it('should detach overlay on datePicker detach', async () => {
+    await open(datePicker);
+    datePicker.parentElement.removeChild(datePicker);
     expect(overlay.parentElement).to.not.be.ok;
   });
 
@@ -30,12 +30,12 @@ describe('dropdown', () => {
     let toggleButton;
 
     beforeEach(() => {
-      toggleButton = datepicker.shadowRoot.querySelector('[part="toggle-button"]');
+      toggleButton = datePicker.shadowRoot.querySelector('[part="toggle-button"]');
     });
 
     it('should open by tapping the calendar icon', () => {
       toggleButton.click();
-      expect(datepicker.opened).to.be.true;
+      expect(datePicker.opened).to.be.true;
       expect(overlay.opened).to.be.true;
     });
 
@@ -44,7 +44,7 @@ describe('dropdown', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
 
       toggleButton.click();
-      expect(datepicker.opened).to.be.false;
+      expect(datePicker.opened).to.be.false;
       expect(overlay.opened).to.be.false;
     });
 
@@ -56,8 +56,8 @@ describe('dropdown', () => {
 
   describe('scroll to date', () => {
     it('should scroll to today by default', async () => {
-      datepicker.open();
-      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
+      datePicker.open();
+      const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -66,10 +66,10 @@ describe('dropdown', () => {
     });
 
     it('should scroll to initial position', async () => {
-      datepicker.initialPosition = '2016-01-01';
+      datePicker.initialPosition = '2016-01-01';
 
-      datepicker.open();
-      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
+      datePicker.open();
+      const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -78,10 +78,10 @@ describe('dropdown', () => {
     });
 
     it('should scroll to selected value', async () => {
-      datepicker.value = '2000-02-01';
+      datePicker.value = '2000-02-01';
 
-      datepicker.open();
-      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
+      datePicker.open();
+      const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -90,40 +90,40 @@ describe('dropdown', () => {
     });
 
     it('should remember the initial position on reopen', async () => {
-      await open(datepicker);
-      const overlayContent = datepicker._overlayContent;
+      await open(datePicker);
+      const overlayContent = datePicker._overlayContent;
       const initialPosition = overlayContent.initialPosition;
 
-      datepicker.close();
+      datePicker.close();
       await nextRender();
 
-      await open(datepicker);
+      await open(datePicker);
       expect(overlayContent.initialPosition).to.be.eql(initialPosition);
     });
 
     it('should scroll to date on reopen', async () => {
-      datepicker.open();
+      datePicker.open();
 
       // We must scroll to initial position on reopen because
       // scrollTop can be reset while the dropdown is closed.
-      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
+      const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
       expect(spy.called).to.be.true;
 
-      datepicker.close();
+      datePicker.close();
       await nextRender();
       spy.resetHistory();
 
-      await open(datepicker);
+      await open(datePicker);
       expect(spy.called).to.be.true;
     });
 
     it('should scroll to min date when today is not allowed', async () => {
-      datepicker.min = '2100-01-01';
+      datePicker.min = '2100-01-01';
 
-      datepicker.open();
-      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
+      datePicker.open();
+      const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -132,10 +132,10 @@ describe('dropdown', () => {
     });
 
     it('should scroll to max date when today is not allowed', async () => {
-      datepicker.max = '2000-01-01';
+      datePicker.max = '2000-01-01';
 
-      datepicker.open();
-      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
+      datePicker.open();
+      const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -144,13 +144,13 @@ describe('dropdown', () => {
     });
 
     it('should scroll to initial position even when not allowed', async () => {
-      datepicker.min = '2016-01-01';
-      datepicker.max = '2016-12-31';
+      datePicker.min = '2016-01-01';
+      datePicker.max = '2016-12-31';
 
-      datepicker.initialPosition = '2015-01-01';
+      datePicker.initialPosition = '2015-01-01';
 
-      datepicker.open();
-      const spy = sinon.spy(datepicker._overlayContent, 'scrollToDate');
+      datePicker.open();
+      const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
 
@@ -162,7 +162,7 @@ describe('dropdown', () => {
   describe('outside click', () => {
     it('should restore focus to the input on outside click', async () => {
       input.focus();
-      await open(datepicker);
+      await open(datePicker);
       outsideClick();
       await aTimeout(0);
       expect(document.activeElement).to.equal(input);
@@ -170,7 +170,7 @@ describe('dropdown', () => {
 
     it('should focus the input on outside click', async () => {
       expect(document.activeElement).to.equal(document.body);
-      await open(datepicker);
+      await open(datePicker);
       outsideClick();
       await aTimeout(0);
       expect(document.activeElement).to.equal(input);
@@ -179,33 +179,33 @@ describe('dropdown', () => {
     it('should restore focus-ring attribute set before opening on outside click', async () => {
       // Focus the input with Tab
       await sendKeys({ press: 'Tab' });
-      await open(datepicker);
+      await open(datePicker);
       outsideClick();
       await aTimeout(0);
-      expect(datepicker.hasAttribute('focus-ring')).to.be.true;
+      expect(datePicker.hasAttribute('focus-ring')).to.be.true;
     });
 
     it('should not remove focus-ring attribute set after opening on outside click', async () => {
-      await open(datepicker);
+      await open(datePicker);
       input.focus();
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
       outsideClick();
       await aTimeout(0);
-      expect(datepicker.hasAttribute('focus-ring')).to.be.true;
+      expect(datePicker.hasAttribute('focus-ring')).to.be.true;
     });
 
     it('should not set focus-ring attribute if it was not set before opening', async () => {
-      await open(datepicker);
+      await open(datePicker);
       outsideClick();
       await aTimeout(0);
-      expect(datepicker.hasAttribute('focus-ring')).to.be.false;
+      expect(datePicker.hasAttribute('focus-ring')).to.be.false;
     });
   });
 
   describe('date tap', () => {
     function dateTap() {
-      const date = getFocusedCell(datepicker._overlayContent);
+      const date = getFocusedCell(datePicker._overlayContent);
       mousedown(date);
       date.focus();
       date.click();
@@ -213,17 +213,17 @@ describe('dropdown', () => {
 
     it('should close the overlay on date tap', async () => {
       input.focus();
-      await open(datepicker);
+      await open(datePicker);
 
       dateTap();
       await aTimeout(0);
 
-      expect(datepicker.opened).to.be.false;
+      expect(datePicker.opened).to.be.false;
     });
 
     it('should restore focus to the input on date tap', async () => {
       input.focus();
-      await open(datepicker);
+      await open(datePicker);
 
       dateTap();
       await aTimeout(0);
@@ -234,43 +234,43 @@ describe('dropdown', () => {
     it('should restore focus-ring attribute set before opening on date tap', async () => {
       // Focus the input with Tab
       await sendKeys({ press: 'Tab' });
-      await open(datepicker);
+      await open(datePicker);
 
       dateTap();
       await aTimeout(0);
 
-      expect(datepicker.hasAttribute('focus-ring')).to.be.true;
+      expect(datePicker.hasAttribute('focus-ring')).to.be.true;
     });
 
     it('should not remove focus-ring attribute after opening on date tap', async () => {
-      await open(datepicker);
+      await open(datePicker);
       // Focus the input with Tab
       await sendKeys({ press: 'Tab' });
 
       dateTap();
       await aTimeout(0);
 
-      expect(datepicker.hasAttribute('focus-ring')).to.be.true;
+      expect(datePicker.hasAttribute('focus-ring')).to.be.true;
     });
   });
 
   describe('virtual keyboard', () => {
     it('should disable virtual keyboard on close', async () => {
-      await open(datepicker);
-      datepicker.close();
+      await open(datePicker);
+      datePicker.close();
       expect(input.inputMode).to.equal('none');
     });
 
     it('should re-enable virtual keyboard on touchstart', async () => {
-      await open(datepicker);
-      datepicker.close();
-      touchstart(datepicker);
+      await open(datePicker);
+      datePicker.close();
+      touchstart(datePicker);
       expect(input.inputMode).to.equal('');
     });
 
     it('should re-enable virtual keyboard on blur', async () => {
-      await open(datepicker);
-      datepicker.close();
+      await open(datePicker);
+      datePicker.close();
       await sendKeys({ press: 'Tab' });
       expect(input.inputMode).to.equal('');
     });

--- a/packages/date-picker/test/fullscreen.test.js
+++ b/packages/date-picker/test/fullscreen.test.js
@@ -6,7 +6,7 @@ import '../src/vaadin-date-picker.js';
 import { getFocusedCell, open, touchTap, waitForOverlayRender } from './helpers.js';
 
 describe('fullscreen mode', () => {
-  let datepicker, input, overlay, width, height;
+  let datePicker, input, overlay, width, height;
 
   before(() => {
     width = window.innerWidth;
@@ -15,9 +15,9 @@ describe('fullscreen mode', () => {
 
   beforeEach(async () => {
     await setViewport({ width: 420, height });
-    datepicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
-    input = datepicker.inputElement;
-    overlay = datepicker.$.overlay;
+    datePicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+    input = datePicker.inputElement;
+    overlay = datePicker.$.overlay;
   });
 
   afterEach(async () => {
@@ -26,13 +26,13 @@ describe('fullscreen mode', () => {
 
   describe('overlay attribute', () => {
     it('should set fullscreen attribute on the overlay when a viewport is small', async () => {
-      await open(datepicker);
+      await open(datePicker);
       expect(overlay.hasAttribute('fullscreen')).to.be.true;
     });
 
     it('should remove fullscreen mode from the the overlay after resizing viewport', async () => {
       await setViewport({ width: 500, height });
-      await open(datepicker);
+      await open(datePicker);
       expect(overlay.hasAttribute('fullscreen')).to.be.false;
     });
   });
@@ -42,7 +42,7 @@ describe('fullscreen mode', () => {
       it('should open overlay on input tap', async () => {
         tap(input);
         await waitForOverlayRender();
-        expect(datepicker.opened).to.be.true;
+        expect(datePicker.opened).to.be.true;
       });
 
       it('should not focus the input on touch tap', async () => {
@@ -60,13 +60,13 @@ describe('fullscreen mode', () => {
 
       it('should blur input element when opening overlay', async () => {
         const spy = sinon.spy(input, 'blur');
-        await open(datepicker);
+        await open(datePicker);
         expect(spy.called).to.be.true;
       });
 
       it('should focus date element when opening overlay', async () => {
-        await open(datepicker);
-        const cell = getFocusedCell(datepicker._overlayContent);
+        await open(datePicker);
+        const cell = getFocusedCell(datePicker._overlayContent);
         expect(cell).to.be.instanceOf(HTMLTableCellElement);
         expect(cell.getAttribute('part')).to.include('today');
       });
@@ -74,12 +74,12 @@ describe('fullscreen mode', () => {
 
     describe('auto open disabled', () => {
       beforeEach(() => {
-        datepicker.autoOpenDisabled = true;
+        datePicker.autoOpenDisabled = true;
       });
 
       it('should not open overlay on input tap', () => {
         tap(input);
-        expect(datepicker.opened).not.to.be.true;
+        expect(datePicker.opened).not.to.be.true;
       });
 
       it('should focus the input on touch tap', () => {
@@ -96,13 +96,13 @@ describe('fullscreen mode', () => {
 
       it('should blur input element when opening overlay', async () => {
         const spy = sinon.spy(input, 'blur');
-        await open(datepicker);
+        await open(datePicker);
         expect(spy.called).to.be.true;
       });
 
       it('should not focus the input when opening overlay', async () => {
         touchTap(input);
-        await open(datepicker);
+        await open(datePicker);
         expect(document.activeElement).to.not.equal(input);
       });
     });
@@ -110,15 +110,15 @@ describe('fullscreen mode', () => {
 
   describe('focused attribute', () => {
     it('should keep focused attribute after opening overlay', async () => {
-      datepicker.focus();
-      await open(datepicker);
-      expect(datepicker.hasAttribute('focused')).to.be.true;
+      datePicker.focus();
+      await open(datePicker);
+      expect(datePicker.hasAttribute('focused')).to.be.true;
     });
 
     it('should remove focused attribute when closing overlay', async () => {
-      await open(datepicker);
+      await open(datePicker);
       await sendKeys({ press: 'Escape' });
-      expect(datepicker.hasAttribute('focused')).to.be.false;
+      expect(datePicker.hasAttribute('focused')).to.be.false;
     });
   });
 
@@ -126,22 +126,22 @@ describe('fullscreen mode', () => {
     let overlayContent;
 
     beforeEach(async () => {
-      await open(datepicker);
-      overlayContent = datepicker._overlayContent;
+      await open(datePicker);
+      overlayContent = datePicker._overlayContent;
     });
 
     it('should close the dropdown on Today button Esc', async () => {
       overlayContent._todayButton.focus();
       await sendKeys({ press: 'Escape' });
 
-      expect(datepicker.opened).to.be.false;
+      expect(datePicker.opened).to.be.false;
     });
 
     it('should close the dropdown on Cancel button Esc', async () => {
       overlayContent.focusCancel();
       await sendKeys({ press: 'Escape' });
 
-      expect(datepicker.opened).to.be.false;
+      expect(datePicker.opened).to.be.false;
     });
 
     it('should move focus to Cancel button on date cell Shift Tab', async () => {

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -54,15 +54,15 @@ export async function waitForOverlayRender() {
   flush();
 }
 
-export async function open(datepicker) {
-  datepicker.open();
+export async function open(datePicker) {
+  datePicker.open();
   await waitForOverlayRender();
 }
 
-export function close(datepicker) {
+export function close(datePicker) {
   return new Promise((resolve) => {
-    listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', resolve);
-    datepicker.close();
+    listenOnce(datePicker.$.overlay, 'vaadin-overlay-close', resolve);
+    datePicker.close();
   });
 }
 

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -8,16 +8,16 @@ import { getAdjustedYear } from '../src/vaadin-date-picker-helper.js';
 import { close, getFocusedCell, idleCallback, open, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
 
 describe('keyboard', () => {
-  let datepicker;
+  let datePicker;
   let input;
 
   function focusedDate() {
-    return datepicker._overlayContent.focusedDate;
+    return datePicker._overlayContent.focusedDate;
   }
 
   beforeEach(() => {
-    datepicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
-    input = datepicker.inputElement;
+    datePicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
+    input = datePicker.inputElement;
     input.focus();
   });
 
@@ -31,7 +31,7 @@ describe('keyboard', () => {
     });
 
     it('should change focused date on user input', async () => {
-      datepicker.value = '2000-01-01';
+      datePicker.value = '2000-01-01';
 
       input.select();
       await sendKeys({ type: '1/30/2000' });
@@ -51,12 +51,12 @@ describe('keyboard', () => {
     it('should select focused date on Enter', async () => {
       await sendKeys({ type: '1/1/2001' });
       await sendKeys({ press: 'Enter' });
-      expect(datepicker.value).to.equal('2001-01-01');
+      expect(datePicker.value).to.equal('2001-01-01');
     });
 
     it('should update focused date on value change', async () => {
-      datepicker.value = '2000-01-01';
-      await open(datepicker);
+      datePicker.value = '2000-01-01';
+      await open(datePicker);
       expect(focusedDate().getMonth()).to.equal(0);
       expect(focusedDate().getDate()).to.equal(1);
       expect(focusedDate().getFullYear()).to.equal(2000);
@@ -65,26 +65,26 @@ describe('keyboard', () => {
     // FIXME: flaky test often failing locally due to scroll animation
     it.skip('should display focused date while overlay focused', async () => {
       await sendKeys({ type: '1/2/2000' });
-      const content = datepicker._overlayContent;
+      const content = datePicker._overlayContent;
       await waitForScrollToFinish(content);
 
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
 
-      await nextRender(datepicker);
+      await nextRender(datePicker);
 
       await sendKeys({ press: 'ArrowDown' });
       expect(input.value).not.to.equal('1/2/2000');
     });
 
     it('should reflect focused date to input', async () => {
-      datepicker.value = '2000-01-01';
-      await open(datepicker);
+      datePicker.value = '2000-01-01';
+      await open(datePicker);
 
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
 
-      await nextRender(datepicker);
+      await nextRender(datePicker);
 
       await sendKeys({ press: 'ArrowDown' });
       expect(input.value).to.equal('1/8/2000');
@@ -93,8 +93,8 @@ describe('keyboard', () => {
 
   describe('no parseDate', () => {
     beforeEach(() => {
-      datepicker.i18n = {
-        ...datepicker.i18n,
+      datePicker.i18n = {
+        ...datePicker.i18n,
         parseDate: null,
       };
     });
@@ -111,9 +111,9 @@ describe('keyboard', () => {
     });
 
     it('should select focused date on close', async () => {
-      await open(datepicker);
-      await close(datepicker);
-      expect(datepicker._selectedDate).to.equal(datepicker._focusedDate);
+      await open(datePicker);
+      await close(datePicker);
+      expect(datePicker._selectedDate).to.equal(datePicker._focusedDate);
     });
   });
 
@@ -121,53 +121,53 @@ describe('keyboard', () => {
     it('should open the overlay on input', async () => {
       await sendKeys({ type: 'j' });
       await waitForOverlayRender();
-      expect(datepicker.opened).to.be.true;
+      expect(datePicker.opened).to.be.true;
     });
 
     it('should open the overlay on Arrow Down', async () => {
       await sendKeys({ press: 'ArrowDown' });
       await waitForOverlayRender();
-      expect(datepicker.opened).to.be.true;
+      expect(datePicker.opened).to.be.true;
     });
 
     it('should open the overlay on Arrow Up', async () => {
       await sendKeys({ press: 'ArrowUp' });
       await waitForOverlayRender();
-      expect(datepicker.opened).to.be.true;
+      expect(datePicker.opened).to.be.true;
     });
 
     it('should open on Arrow Down if autoOpenDisabled is true', async () => {
-      datepicker.autoOpenDisabled = true;
+      datePicker.autoOpenDisabled = true;
       await sendKeys({ press: 'ArrowDown' });
       await waitForOverlayRender();
-      expect(datepicker.opened).to.be.true;
+      expect(datePicker.opened).to.be.true;
     });
 
     it('should open on Arrow Up if autoOpenDisabled is true', async () => {
-      datepicker.autoOpenDisabled = true;
+      datePicker.autoOpenDisabled = true;
       await sendKeys({ press: 'ArrowUp' });
       await waitForOverlayRender();
-      expect(datepicker.opened).to.be.true;
+      expect(datePicker.opened).to.be.true;
     });
 
     it('should not open the overlay on Arrow Right', async () => {
       await sendKeys({ press: 'ArrowRight' });
-      expect(datepicker.opened).to.be.not.ok;
+      expect(datePicker.opened).to.be.not.ok;
     });
 
     it('should not open the overlay on Arrow Left', async () => {
       await sendKeys({ press: 'ArrowLeft' });
-      expect(datepicker.opened).to.be.not.ok;
+      expect(datePicker.opened).to.be.not.ok;
     });
 
     it('should not open the overlay on Enter', async () => {
       await sendKeys({ press: 'Enter' });
-      expect(datepicker.opened).to.be.not.ok;
+      expect(datePicker.opened).to.be.not.ok;
     });
 
     it('should not throw on Enter before opening overlay', () => {
       expect(() => {
-        datepicker.focus();
+        datePicker.focus();
         enter(input);
       }).not.to.throw(Error);
     });
@@ -178,8 +178,8 @@ describe('keyboard', () => {
 
     beforeEach(async () => {
       // Open the overlay
-      await open(datepicker);
-      overlayContent = datepicker._overlayContent;
+      await open(datePicker);
+      overlayContent = datePicker._overlayContent;
       await idleCallback();
     });
 
@@ -187,7 +187,7 @@ describe('keyboard', () => {
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
       await waitForOverlayRender();
-      expect(datepicker.hasAttribute('focused')).to.be.true;
+      expect(datePicker.hasAttribute('focused')).to.be.true;
     });
 
     it('should move focus back to the input on Cancel button tap', async () => {
@@ -262,7 +262,7 @@ describe('keyboard', () => {
     it('should clear selection on close', async () => {
       input.select();
 
-      await close(datepicker);
+      await close(datePicker);
       expect(input.selectionStart).to.equal(input.selectionEnd);
     });
 
@@ -313,27 +313,27 @@ describe('keyboard', () => {
     describe('empty', () => {
       beforeEach(async () => {
         // Open the overlay
-        await open(datepicker);
+        await open(datePicker);
       });
 
       it('should close the overlay when input is focused', async () => {
         await sendKeys({ press: 'Escape' });
-        expect(datepicker.opened).to.be.false;
+        expect(datePicker.opened).to.be.false;
       });
 
       it('should close the overlay when calendar has focus', async () => {
         // Move focus to the calendar
         await sendKeys({ press: 'ArrowDown' });
-        await nextRender(datepicker);
+        await nextRender(datePicker);
 
         await sendKeys({ press: 'Escape' });
-        expect(datepicker.opened).to.be.false;
+        expect(datePicker.opened).to.be.false;
       });
 
       it('should move focus from the calendar back to input', async () => {
         // Move focus to the calendar
         await sendKeys({ press: 'ArrowDown' });
-        await nextRender(datepicker);
+        await nextRender(datePicker);
         expect(document.activeElement).to.not.equal(input);
 
         await sendKeys({ press: 'Escape' });
@@ -342,7 +342,7 @@ describe('keyboard', () => {
 
       it('should revert input value on input Esc when empty', async () => {
         await sendKeys({ type: '1/2/2000' });
-        await nextRender(datepicker);
+        await nextRender(datePicker);
 
         await sendKeys({ press: 'Escape' });
         expect(input.value).to.equal('');
@@ -350,10 +350,10 @@ describe('keyboard', () => {
 
       it('should not change value on input Esc when empty', async () => {
         await sendKeys({ type: '1/2/2000' });
-        await nextRender(datepicker);
+        await nextRender(datePicker);
 
         await sendKeys({ press: 'Escape' });
-        expect(datepicker.value).to.equal('');
+        expect(datePicker.value).to.equal('');
       });
 
       it('should revert input value on calendar Esc when empty', async () => {
@@ -361,7 +361,7 @@ describe('keyboard', () => {
 
         // Move focus to the calendar
         await sendKeys({ press: 'ArrowDown' });
-        await nextRender(datepicker);
+        await nextRender(datePicker);
 
         await sendKeys({ press: 'Escape' });
 
@@ -373,18 +373,18 @@ describe('keyboard', () => {
 
         // Move focus to the calendar
         await sendKeys({ press: 'ArrowDown' });
-        await nextRender(datepicker);
+        await nextRender(datePicker);
 
         await sendKeys({ press: 'Escape' });
 
-        expect(datepicker.value).to.equal('');
+        expect(datePicker.value).to.equal('');
       });
     });
 
     describe('with value', () => {
       beforeEach(async () => {
-        datepicker.value = '2000-01-01';
-        await open(datepicker);
+        datePicker.value = '2000-01-01';
+        await open(datePicker);
         input.select();
       });
 
@@ -400,7 +400,7 @@ describe('keyboard', () => {
         await sendKeys({ type: '1/2/2000' });
 
         await sendKeys({ press: 'Escape' });
-        expect(datepicker.value).to.equal('2000-01-01');
+        expect(datePicker.value).to.equal('2000-01-01');
       });
 
       it('should revert input value on calendar Esc when value is set', async () => {
@@ -409,7 +409,7 @@ describe('keyboard', () => {
 
         // Move focus to the calendar
         await sendKeys({ press: 'ArrowDown' });
-        await nextRender(datepicker);
+        await nextRender(datePicker);
 
         await sendKeys({ press: 'Escape' });
         expect(input.value).to.equal('1/1/2000');
@@ -421,10 +421,10 @@ describe('keyboard', () => {
 
         // Move focus to the calendar
         await sendKeys({ press: 'ArrowDown' });
-        await nextRender(datepicker);
+        await nextRender(datePicker);
 
         await sendKeys({ press: 'Escape' });
-        expect(datepicker.value).to.equal('2000-01-01');
+        expect(datePicker.value).to.equal('2000-01-01');
       });
     });
   });
@@ -434,7 +434,7 @@ describe('keyboard', () => {
 
     async function checkMonthAndDayOffset(monthOffsetToAdd, dayOffsetToAdd, expectedYearOffset) {
       input.value = '';
-      const referenceDate = new Date(datepicker.i18n.referenceDate);
+      const referenceDate = new Date(datePicker.i18n.referenceDate);
       const yearToTest = referenceDate.getFullYear() + 50;
       await sendKeys({
         type: `${referenceDate.getMonth() + 1 + monthOffsetToAdd}/${referenceDate.getDate() + dayOffsetToAdd}/${
@@ -447,8 +447,8 @@ describe('keyboard', () => {
 
     async function checkYearOffset(offsetToAdd, expectedOffset) {
       input.value = '';
-      const referenceDateYear = datepicker.i18n.referenceDate
-        ? new Date(datepicker.i18n.referenceDate).getFullYear()
+      const referenceDateYear = datePicker.i18n.referenceDate
+        ? new Date(datePicker.i18n.referenceDate).getFullYear()
         : today.getFullYear();
       const yearToTest = referenceDateYear + offsetToAdd;
       await sendKeys({ type: `6/20/${String(yearToTest).slice(2, 4)}` });
@@ -501,8 +501,8 @@ describe('keyboard', () => {
     });
 
     it('should parse in base 10', async () => {
-      datepicker.i18n = {
-        ...datepicker.i18n,
+      datePicker.i18n = {
+        ...datePicker.i18n,
         referenceDate: '2022-01-01',
       };
       await sendKeys({ type: '09/09/09' });
@@ -537,24 +537,24 @@ describe('keyboard', () => {
     });
 
     it('should parse short year with a custom reference date later in century', async () => {
-      datepicker.i18n = {
-        ...datepicker.i18n,
+      datePicker.i18n = {
+        ...datePicker.i18n,
         referenceDate: '1999-01-01',
       };
       await checkYearOffsets();
     });
 
     it('should parse short year with a custom reference date earlier in century', async () => {
-      datepicker.i18n = {
-        ...datepicker.i18n,
+      datePicker.i18n = {
+        ...datePicker.i18n,
         referenceDate: '2001-01-01',
       };
       await checkYearOffsets();
     });
 
     it('should parse short year with a custom reference date and ambiguous year difference', async () => {
-      datepicker.i18n = {
-        ...datepicker.i18n,
+      datePicker.i18n = {
+        ...datePicker.i18n,
         referenceDate: '2001-03-15',
       };
       await checkMonthAndDayOffset(0, 0, 0);
@@ -570,7 +570,7 @@ describe('keyboard', () => {
 
     beforeEach(() => {
       spy = sinon.spy();
-      datepicker.addEventListener('change', spy);
+      datePicker.addEventListener('change', spy);
     });
 
     it('should not fire change on focused date change', async () => {
@@ -586,7 +586,7 @@ describe('keyboard', () => {
 
     it('should fire change after value-changed event', async () => {
       const valueChangedSpy = sinon.spy();
-      datepicker.addEventListener('value-changed', valueChangedSpy);
+      datePicker.addEventListener('value-changed', valueChangedSpy);
 
       await sendKeys({ type: '1/2/2000' });
       await sendKeys({ press: 'Enter' });
@@ -597,11 +597,11 @@ describe('keyboard', () => {
 
     it('should fire change on selecting date with Enter', async () => {
       // Open the overlay
-      await open(datepicker);
+      await open(datePicker);
 
       // Move focus to the calendar
       await sendKeys({ press: 'ArrowDown' });
-      await nextRender(datepicker);
+      await nextRender(datePicker);
 
       await sendKeys({ press: 'Enter' });
       expect(spy.calledOnce).to.be.true;
@@ -609,45 +609,45 @@ describe('keyboard', () => {
 
     it('should fire change on selecting date with Space', async () => {
       // Open the overlay
-      await open(datepicker);
+      await open(datePicker);
 
       // Move focus to the calendar
       await sendKeys({ press: 'ArrowDown' });
-      await nextRender(datepicker);
+      await nextRender(datePicker);
 
       await sendKeys({ press: 'Space' });
       expect(spy.calledOnce).to.be.true;
     });
 
     it('should fire change clear button click', () => {
-      datepicker.clearButtonVisible = true;
-      datepicker.value = '2000-01-01';
-      datepicker.$.clearButton.click();
+      datePicker.clearButtonVisible = true;
+      datePicker.value = '2000-01-01';
+      datePicker.$.clearButton.click();
       expect(spy.calledOnce).to.be.true;
     });
 
     it('should not fire change on programmatic value change', () => {
-      datepicker.value = '2000-01-01';
+      datePicker.value = '2000-01-01';
       expect(spy.called).to.be.false;
     });
 
     it('should not fire change on programmatic value change when opened', async () => {
-      await open(datepicker);
-      datepicker.value = '2000-01-01';
-      await close(datepicker);
+      await open(datePicker);
+      datePicker.value = '2000-01-01';
+      await close(datePicker);
       expect(spy.called).to.be.false;
     });
 
     it('should not fire change on programmatic value change when text input changed', async () => {
       await sendKeys({ type: '1/2/2000' });
-      datepicker.value = '2000-01-01';
-      await close(datepicker);
+      datePicker.value = '2000-01-01';
+      await close(datePicker);
       expect(spy.called).to.be.false;
     });
 
     it('should not fire change if the value was not changed', async () => {
-      datepicker.value = '2000-01-01';
-      await open(datepicker);
+      datePicker.value = '2000-01-01';
+      await open(datePicker);
       await sendKeys({ press: 'Enter' });
       expect(spy.called).to.be.false;
     });
@@ -661,65 +661,65 @@ describe('keyboard', () => {
 
   describe('auto open disabled', () => {
     beforeEach(() => {
-      datepicker.autoOpenDisabled = true;
+      datePicker.autoOpenDisabled = true;
     });
 
     it('should not open overlay on input', async () => {
       await sendKeys({ type: 'j' });
-      expect(datepicker.opened).not.to.be.true;
+      expect(datePicker.opened).not.to.be.true;
     });
 
     it('should focus parsed date when opening overlay', async () => {
       await sendKeys({ type: '1/20/2000' });
-      await open(datepicker);
+      await open(datePicker);
       await waitForOverlayRender();
 
       expect(focusedDate().getMonth()).to.equal(0);
       expect(focusedDate().getDate()).to.equal(20);
     });
 
-    it('should set datepicker value on blur', async () => {
+    it('should set datePicker value on blur', async () => {
       await sendKeys({ type: '1/1/2000' });
       await sendKeys({ press: 'Tab' });
-      expect(datepicker.value).to.equal('2000-01-01');
+      expect(datePicker.value).to.equal('2000-01-01');
     });
 
     it('should revert input value on Esc when overlay not initialized', async () => {
       await sendKeys({ type: '1/1/2000' });
       await sendKeys({ press: 'Escape' });
       expect(input.value).to.equal('');
-      expect(datepicker.value).to.equal('');
+      expect(datePicker.value).to.equal('');
     });
 
     it('should revert input value on Esc when overlay has been initialized', async () => {
-      await open(datepicker);
-      await close(datepicker);
+      await open(datePicker);
+      await close(datePicker);
       await sendKeys({ type: '1/1/2000' });
       await sendKeys({ press: 'Escape' });
-      expect(datepicker.value).to.equal('');
+      expect(datePicker.value).to.equal('');
     });
 
     it('should not revert input value on esc after selected value is removed', async () => {
-      await open(datepicker);
+      await open(datePicker);
       await sendKeys({ type: '1/1/2000' });
-      await close(datepicker);
+      await close(datePicker);
       input.value = '';
       await sendKeys({ press: 'Escape' });
-      expect(datepicker.value).to.equal('');
+      expect(datePicker.value).to.equal('');
     });
 
     it('should apply the input value on enter when overlay not initialized', async () => {
       await sendKeys({ type: '1/1/2000' });
       await sendKeys({ press: 'Enter' });
-      expect(datepicker.value).to.equal('2000-01-01');
+      expect(datePicker.value).to.equal('2000-01-01');
     });
 
     it('should apply input value on enter when overlay has been initialized', async () => {
-      await open(datepicker);
-      await close(datepicker);
+      await open(datePicker);
+      await close(datePicker);
       await sendKeys({ type: '1/1/2000' });
       await sendKeys({ press: 'Enter' });
-      expect(datepicker.value).to.equal('2000-01-01');
+      expect(datePicker.value).to.equal('2000-01-01');
     });
   });
 
@@ -728,32 +728,32 @@ describe('keyboard', () => {
     let changeSpy;
 
     beforeEach(() => {
-      validateSpy = sinon.spy(datepicker, 'validate');
+      validateSpy = sinon.spy(datePicker, 'validate');
       changeSpy = sinon.spy();
-      datepicker.addEventListener('change', changeSpy);
+      datePicker.addEventListener('change', changeSpy);
     });
 
     describe('overlay is open and value selected', () => {
       beforeEach(async () => {
-        await open(datepicker);
+        await open(datePicker);
         await sendKeys({ type: '01/02/20' });
-        await nextRender(datepicker);
+        await nextRender(datePicker);
       });
 
       it('should validate without change on Esc', async () => {
         await sendKeys({ press: 'Escape' });
 
         // Wait for overlay to finish closing
-        await nextRender(datepicker);
+        await nextRender(datePicker);
 
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.called).to.be.false;
       });
 
       it('should change after validate on overlay close', (done) => {
-        listenOnce(datepicker.$.overlay, 'vaadin-overlay-close', () => {
+        listenOnce(datePicker.$.overlay, 'vaadin-overlay-close', () => {
           // Wait for overlay to finish closing
-          nextRender(datepicker).then(() => {
+          nextRender(datePicker).then(() => {
             expect(validateSpy.calledOnce).to.be.true;
             expect(changeSpy.calledOnce).to.be.true;
             expect(changeSpy.calledAfter(validateSpy)).to.be.true;
@@ -761,14 +761,14 @@ describe('keyboard', () => {
           });
         });
 
-        datepicker.close();
+        datePicker.close();
       });
 
       it('should change after validate on Enter', async () => {
         await sendKeys({ press: 'Enter' });
 
         // Wait for overlay to finish closing
-        await nextRender(datepicker);
+        await nextRender(datePicker);
 
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.calledOnce).to.be.true;
@@ -778,26 +778,26 @@ describe('keyboard', () => {
 
     describe('overlay is closed, value is set', () => {
       beforeEach(async () => {
-        await open(datepicker);
+        await open(datePicker);
         await sendKeys({ type: '01/02/20' });
-        await close(datepicker);
+        await close(datePicker);
         validateSpy.resetHistory();
         changeSpy.resetHistory();
         // Wait for overlay to finish closing
-        await nextRender(datepicker);
-        datepicker._focus();
+        await nextRender(datePicker);
+        datePicker._focus();
       });
 
       it('should change after validate on clear button click', () => {
-        datepicker.clearButtonVisible = true;
-        datepicker.$.clearButton.click();
+        datePicker.clearButtonVisible = true;
+        datePicker.$.clearButton.click();
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.calledOnce).to.be.true;
         expect(changeSpy.calledAfter(validateSpy)).to.be.true;
       });
 
       it('should change after validate on Esc with clear button', async () => {
-        datepicker.clearButtonVisible = true;
+        datePicker.clearButtonVisible = true;
         await sendKeys({ press: 'Escape' });
         expect(validateSpy.calledOnce).to.be.true;
         expect(changeSpy.calledOnce).to.be.true;
@@ -831,7 +831,7 @@ describe('keyboard', () => {
 
     describe('autoOpenDisabled true', () => {
       beforeEach(() => {
-        datepicker.autoOpenDisabled = true;
+        datePicker.autoOpenDisabled = true;
       });
 
       it('should change after validate on Enter', async () => {
@@ -874,11 +874,11 @@ describe('keyboard', () => {
           await sendKeys({ press: 'Enter' });
           validateSpy.resetHistory();
           changeSpy.resetHistory();
-          datepicker._focusAndSelect();
+          datePicker._focusAndSelect();
         });
 
         it('should change after validate on Esc with clear button', async () => {
-          datepicker.clearButtonVisible = true;
+          datePicker.clearButtonVisible = true;
           await sendKeys({ press: 'Escape' });
           expect(validateSpy.calledOnce).to.be.true;
           expect(changeSpy.calledOnce).to.be.true;

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -15,24 +15,24 @@ import {
 
 describe('keyboard navigation', () => {
   describe('date-picker', () => {
-    let datepicker;
+    let datePicker;
     let input;
 
     describe('default', () => {
       beforeEach(() => {
-        datepicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
-        input = datepicker.inputElement;
+        datePicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
+        input = datePicker.inputElement;
         input.focus();
       });
 
       it('should be focused on today if no value / initial position is set', async () => {
         const today = new Date();
-        await open(datepicker);
+        await open(datePicker);
 
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(datepicker._overlayContent);
+        const cell = getFocusedCell(datePicker._overlayContent);
         expect(cell.date).to.eql(new Date(today.getFullYear(), today.getMonth(), today.getDate()));
       });
 
@@ -48,32 +48,32 @@ describe('keyboard navigation', () => {
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(datepicker._overlayContent);
+        const cell = getFocusedCell(datePicker._overlayContent);
         expect(cell.date).to.eql(new Date(today.getFullYear(), today.getMonth(), today.getDate()));
       });
     });
 
     describe('value', () => {
       beforeEach(() => {
-        datepicker = fixtureSync('<vaadin-date-picker value="2001-01-01"></vaadin-date-picker>');
-        input = datepicker.inputElement;
+        datePicker = fixtureSync('<vaadin-date-picker value="2001-01-01"></vaadin-date-picker>');
+        input = datePicker.inputElement;
         input.focus();
       });
 
       it('should be focused on selected value when overlay is opened', async () => {
-        await open(datepicker);
+        await open(datePicker);
 
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(datepicker._overlayContent);
+        const cell = getFocusedCell(datePicker._overlayContent);
         expect(cell.date).to.eql(new Date(2001, 0, 1));
       });
 
       it('should not lose focused date after deselecting', async () => {
-        await open(datepicker);
+        await open(datePicker);
 
-        const content = datepicker._overlayContent;
+        const content = datePicker._overlayContent;
         const focused = content.focusedDate;
 
         // Move focus to the calendar
@@ -89,18 +89,18 @@ describe('keyboard navigation', () => {
 
     describe('initial position', () => {
       beforeEach(() => {
-        datepicker = fixtureSync('<vaadin-date-picker initial-position="2001-01-01"></vaadin-date-picker>');
-        input = datepicker.inputElement;
+        datePicker = fixtureSync('<vaadin-date-picker initial-position="2001-01-01"></vaadin-date-picker>');
+        input = datePicker.inputElement;
         input.focus();
       });
 
       it('should be focused on initial position when opened', async () => {
-        await open(datepicker);
+        await open(datePicker);
 
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(datepicker._overlayContent);
+        const cell = getFocusedCell(datePicker._overlayContent);
         expect(cell.date).to.eql(new Date(2001, 0, 1));
       });
 
@@ -114,7 +114,7 @@ describe('keyboard navigation', () => {
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        const cell = getFocusedCell(datepicker._overlayContent);
+        const cell = getFocusedCell(datePicker._overlayContent);
         expect(cell.date).to.eql(new Date(2001, 0, 1));
       });
     });

--- a/packages/date-picker/test/theme-propagation.test.js
+++ b/packages/date-picker/test/theme-propagation.test.js
@@ -4,34 +4,34 @@ import '../src/vaadin-date-picker.js';
 import { open, waitForScrollToFinish } from './helpers.js';
 
 describe('theme attribute', () => {
-  let datepicker;
+  let datePicker;
 
   beforeEach(async () => {
-    datepicker = fixtureSync(`<vaadin-date-picker theme="foo"></vaadin-date-picker>`);
+    datePicker = fixtureSync(`<vaadin-date-picker theme="foo"></vaadin-date-picker>`);
     await nextRender();
   });
 
   it('should propagate theme attribute to the input container', () => {
-    const inputField = datepicker.shadowRoot.querySelector('[part="input-field"]');
+    const inputField = datePicker.shadowRoot.querySelector('[part="input-field"]');
     expect(inputField.getAttribute('theme')).to.equal('foo');
   });
 
   it('should propagate theme attribute to overlay', () => {
-    expect(datepicker.$.overlay.getAttribute('theme')).to.equal('foo');
+    expect(datePicker.$.overlay.getAttribute('theme')).to.equal('foo');
   });
 
   it('should propagate theme attribute to overlay content', async () => {
-    await open(datepicker);
-    expect(datepicker._overlayContent.getAttribute('theme')).to.equal('foo');
+    await open(datePicker);
+    expect(datePicker._overlayContent.getAttribute('theme')).to.equal('foo');
   });
 
   describe('in content', () => {
     beforeEach(async () => {
-      await open(datepicker);
+      await open(datePicker);
     });
 
     it('should propagate theme attribute to month calendar', async () => {
-      const overlayContent = datepicker._overlayContent;
+      const overlayContent = datePicker._overlayContent;
       await waitForScrollToFinish(overlayContent);
       const monthCalendar = overlayContent.querySelector('vaadin-month-calendar');
       expect(monthCalendar.getAttribute('theme')).to.equal('foo');

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -6,24 +6,24 @@ import { activateScroller, getDefaultI18n, open } from './helpers.js';
 
 describe('WAI-ARIA', () => {
   describe('date picker', () => {
-    let datepicker, input;
+    let datePicker, input;
 
     beforeEach(() => {
-      datepicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
-      input = datepicker.inputElement;
+      datePicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+      input = datePicker.inputElement;
     });
 
     it('should toggle aria-expanded attribute on open', () => {
-      datepicker.open();
+      datePicker.open();
       expect(input.getAttribute('aria-expanded')).to.equal('true');
-      datepicker.close();
+      datePicker.close();
       expect(input.getAttribute('aria-expanded')).to.equal('false');
     });
 
     it('should set aria-hidden on all calendars except focused one', async () => {
-      await open(datepicker);
-      await nextRender(datepicker);
-      const calendars = datepicker._overlayContent.querySelectorAll('vaadin-month-calendar');
+      await open(datePicker);
+      await nextRender(datePicker);
+      const calendars = datePicker._overlayContent.querySelectorAll('vaadin-month-calendar');
       calendars.forEach((calendar) => {
         const focused = calendar.shadowRoot.querySelector('[part~="focused"]');
         expect(calendar.getAttribute('aria-hidden')).to.equal(focused ? null : 'true');


### PR DESCRIPTION
## Description

Renames `datepicker` to `datePicker` in tests for the sake of consistency.

## Type of change

- [x] Internal