### PR TITLE
fix: reset item attributes when teleporting from the sub-menu (#5610) (CP: 23.3)

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -101,11 +101,20 @@ export const ButtonsMixin = (superClass) =>
         // Teleport item component back from "overflow" sub-menu
         const item = btn.item && btn.item.component;
         if (item instanceof HTMLElement && item.classList.contains('vaadin-menu-item')) {
-          btn.appendChild(item);
-          item.classList.remove('vaadin-menu-item');
+          this.__restoreItem(btn, item);
         }
       }
       this.__updateOverflow([]);
+    }
+
+    /** @private */
+    __restoreItem(button, item) {
+      button.appendChild(item);
+      item.removeAttribute('role');
+      item.removeAttribute('aria-expanded');
+      item.removeAttribute('aria-haspopup');
+      item.removeAttribute('tabindex');
+      item.classList.remove('vaadin-menu-item');
     }
 
     /** @private */

--- a/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-buttons-mixin.js
@@ -110,11 +110,10 @@ export const ButtonsMixin = (superClass) =>
     /** @private */
     __restoreItem(button, item) {
       button.appendChild(item);
-      item.removeAttribute('role');
       item.removeAttribute('aria-expanded');
       item.removeAttribute('aria-haspopup');
       item.removeAttribute('tabindex');
-      item.classList.remove('vaadin-menu-item');
+      item.removeAttribute('class');
     }
 
     /** @private */

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -739,7 +739,7 @@ describe('item components', () => {
       await onceResized(menu);
       const item = buttons[2].firstChild;
       expect(item).to.equal(buttons[2].item.component);
-      expect(item.getAttribute('role')).to.not.equal('menuitem');
+      expect(item.classList.contains('vaadin-menu-item')).to.be.false;
     });
 
     it('should restore menu bar item attribute state when moved from sub-menu back to menu bar', async () => {

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -664,6 +664,7 @@ describe('item components', () => {
       { component: makeComponent('3') },
       { text: 'Item 4 text', component: makeComponent('4') },
       { text: 'Item 5', component: document.createElement('vaadin-context-menu-item') },
+      { component: makeComponent('6'), children: [{ text: 'SubItem6.1' }, { text: 'SubItem6.2' }] },
     ];
     await nextRender(menu);
     buttons = menu._buttons;
@@ -699,25 +700,6 @@ describe('item components', () => {
     expect(buttons[4].item.component.textContent).to.equal('Item 5');
   });
 
-  it('should teleport the same component to overflow sub-menu and back', async () => {
-    menu.style.width = '250px';
-    await onceResized(menu);
-    await nextFrame();
-    const subMenu = menu._subMenu;
-    overflow.click();
-    await nextRender(subMenu);
-    const listBox = subMenu.$.overlay.querySelector('vaadin-context-menu-list-box');
-    expect(listBox.items[0]).to.equal(buttons[2].item.component);
-    expect(listBox.items[0].firstChild).to.equal(menu.items[2].component);
-    expect(listBox.items[0].firstChild.localName).to.equal('div');
-    subMenu.close();
-    menu.style.width = 'auto';
-    await onceResized(menu);
-    const item = buttons[2].firstChild;
-    expect(item).to.equal(buttons[2].item.component);
-    expect(item.classList.contains('vaadin-menu-item')).to.be.false;
-  });
-
   it('should close the overflow sub-menu on resize', async () => {
     menu.style.width = '150px';
     await onceResized(menu);
@@ -734,6 +716,42 @@ describe('item components', () => {
     const style = getComputedStyle(item);
     expect(style.position).to.equal('relative');
     expect(Number(style.zIndex)).to.equal(1);
+  });
+
+  describe('overflow', () => {
+    let subMenu;
+
+    beforeEach(async () => {
+      menu.style.width = '250px';
+      await onceResized(menu);
+      subMenu = menu._subMenu;
+    });
+
+    it('should teleport the same component to overflow sub-menu and back', async () => {
+      overflow.click();
+      await nextRender(subMenu);
+      const listBox = subMenu.$.overlay.querySelector('vaadin-context-menu-list-box');
+      expect(listBox.items[0]).to.equal(buttons[2].item.component);
+      expect(listBox.items[0].firstChild).to.equal(menu.items[2].component);
+      expect(listBox.items[0].firstChild.localName).to.equal('div');
+      subMenu.close();
+      menu.style.width = 'auto';
+      await onceResized(menu);
+      const item = buttons[2].firstChild;
+      expect(item).to.equal(buttons[2].item.component);
+      expect(item.getAttribute('role')).to.not.equal('menuitem');
+    });
+
+    it('should restore menu bar item attribute state when moved from sub-menu back to menu bar', async () => {
+      const item = buttons[5].firstChild;
+      const itemAttributes = item.getAttributeNames();
+      overflow.click();
+      await nextRender(subMenu);
+      subMenu.close();
+      menu.style.width = 'auto';
+      await onceResized(menu);
+      expect(item.getAttributeNames()).to.have.members(itemAttributes);
+    });
   });
 });
 


### PR DESCRIPTION
## Description

Manual cherry-pick of #5610 to `23.3` branch.

There was a conflict due to `vaadin-menu-bar-list-box` tag name and merging two mixins into a single one in 24.0.

## Type of change

- Cherry-pick