### PR TITLE
test: update date-picker unit tests to wait for overlay open

### DIFF
--- a/packages/date-picker/test/custom-input.test.js
+++ b/packages/date-picker/test/custom-input.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, tap } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, oneEvent, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker-light.js';
@@ -17,13 +17,15 @@ describe('custom input', () => {
     overlay = datePicker.$.overlay;
   });
 
-  it('should open calendar on tap', () => {
+  it('should open calendar on tap', async () => {
     tap(datePicker);
+    await oneEvent(overlay, 'vaadin-overlay-open');
     expect(overlay.opened).to.be.true;
   });
 
-  it('should open calendar on input', () => {
+  it('should open calendar on input', async () => {
     setInputValue(datePicker, '1');
+    await oneEvent(overlay, 'vaadin-overlay-open');
     expect(overlay.opened).to.be.true;
   });
 

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -33,8 +33,9 @@ describe('dropdown', () => {
       toggleButton = datePicker.shadowRoot.querySelector('[part="toggle-button"]');
     });
 
-    it('should open by tapping the calendar icon', () => {
+    it('should open by tapping the calendar icon', async () => {
       toggleButton.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(datePicker.opened).to.be.true;
       expect(overlay.opened).to.be.true;
     });

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -15,8 +15,9 @@ describe('keyboard', () => {
     return datePicker._overlayContent.focusedDate;
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     datePicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
+    await nextRender();
     input = datePicker.inputElement;
     input.focus();
   });
@@ -50,6 +51,7 @@ describe('keyboard', () => {
 
     it('should select focused date on Enter', async () => {
       await sendKeys({ type: '1/1/2001' });
+      await waitForOverlayRender();
       await sendKeys({ press: 'Enter' });
       expect(datePicker.value).to.equal('2001-01-01');
     });
@@ -466,6 +468,7 @@ describe('keyboard', () => {
 
     it('should parse a single digit', async () => {
       await sendKeys({ type: '20' });
+      await waitForOverlayRender();
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(today.getFullYear());
       expect(result.getMonth()).to.equal(today.getMonth());
@@ -474,6 +477,7 @@ describe('keyboard', () => {
 
     it('should parse two digits', async () => {
       await sendKeys({ type: '6/20' });
+      await waitForOverlayRender();
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(today.getFullYear());
       expect(result.getMonth()).to.equal(5);
@@ -482,6 +486,7 @@ describe('keyboard', () => {
 
     it('should parse three digits', async () => {
       await sendKeys({ type: '6/20/1999' });
+      await waitForOverlayRender();
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(1999);
       expect(result.getMonth()).to.equal(5);
@@ -490,12 +495,14 @@ describe('keyboard', () => {
 
     it('should parse three digits with small year', async () => {
       await sendKeys({ type: '6/20/0099' });
+      await waitForOverlayRender();
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(99);
     });
 
     it('should parse three digits with negative year', async () => {
       await sendKeys({ type: '6/20/-1' });
+      await waitForOverlayRender();
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(-1);
     });
@@ -506,6 +513,7 @@ describe('keyboard', () => {
         referenceDate: '2022-01-01',
       };
       await sendKeys({ type: '09/09/09' });
+      await waitForOverlayRender();
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(2009);
       expect(result.getMonth()).to.equal(8);
@@ -575,11 +583,13 @@ describe('keyboard', () => {
 
     it('should not fire change on focused date change', async () => {
       await sendKeys({ type: '1/2/2000' });
+      await waitForOverlayRender();
       expect(spy.called).to.be.false;
     });
 
     it('should fire change on user text input commit', async () => {
       await sendKeys({ type: '1/2/2000' });
+      await waitForOverlayRender();
       await sendKeys({ press: 'Enter' });
       expect(spy.called).to.be.true;
     });
@@ -589,6 +599,7 @@ describe('keyboard', () => {
       datePicker.addEventListener('value-changed', valueChangedSpy);
 
       await sendKeys({ type: '1/2/2000' });
+      await waitForOverlayRender();
       await sendKeys({ press: 'Enter' });
 
       expect(valueChangedSpy.calledOnce).to.be.true;
@@ -640,6 +651,7 @@ describe('keyboard', () => {
 
     it('should not fire change on programmatic value change when text input changed', async () => {
       await sendKeys({ type: '1/2/2000' });
+      await waitForOverlayRender();
       datePicker.value = '2000-01-01';
       await close(datePicker);
       expect(spy.called).to.be.false;
@@ -654,6 +666,7 @@ describe('keyboard', () => {
 
     it('should not fire change when reverting input with Escape', async () => {
       await sendKeys({ type: '1/2/2000' });
+      await waitForOverlayRender();
       await sendKeys({ press: 'Escape' });
       expect(spy.called).to.be.false;
     });

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { enter, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import { DatePicker } from '../vaadin-date-picker.js';
-import { close, open, setInputValue } from './helpers.js';
+import { close, open, setInputValue, waitForOverlayRender } from './helpers.js';
 
 class DatePicker2016 extends DatePicker {
   checkValidity() {
@@ -12,6 +12,19 @@ class DatePicker2016 extends DatePicker {
 }
 
 customElements.define('vaadin-date-picker-2016', DatePicker2016);
+
+function waitForValueChange(datePicker, callback) {
+  let stub;
+
+  return new Promise((resolve) => {
+    stub = sinon.stub().callsFake((e) => {
+      resolve(stub);
+    });
+
+    datePicker.addEventListener('value-changed', stub);
+    callback();
+  });
+}
 
 describe('validation', () => {
   let datePicker;
@@ -71,8 +84,9 @@ describe('validation', () => {
   describe('basic', () => {
     let validateSpy;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       datePicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+      await nextRender();
       validateSpy = sinon.spy(datePicker, 'validate');
     });
 
@@ -101,10 +115,11 @@ describe('validation', () => {
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should validate on clear button click', () => {
+    it('should validate on clear button click', async () => {
       datePicker.clearButtonVisible = true;
       // Set invalid value.
       setInputValue(datePicker, 'foo');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       validateSpy.resetHistory();
       datePicker.$.clearButton.click();
@@ -156,62 +171,59 @@ describe('validation', () => {
       expect(datePicker.invalid).to.be.false;
     });
 
-    it('should set proper validity by the time the value-changed event is fired', (done) => {
+    it('should set proper validity by the time the value-changed event is fired', async () => {
       // Set invalid value.
       setInputValue(datePicker, 'foo');
+      await waitForOverlayRender();
+
       expect(datePicker.validate()).to.be.false;
 
       validateSpy.resetHistory();
 
-      datePicker.addEventListener('value-changed', () => {
-        expect(validateSpy.callCount).to.equal(1);
-        expect(datePicker.invalid).to.be.false;
-        done();
-      });
-
-      datePicker.open();
       setInputValue(datePicker, '01/01/2000');
-      datePicker.close();
+      const valueChangeSpy = await waitForValueChange(datePicker, () => datePicker.close());
+
+      expect(valueChangeSpy.calledAfter(validateSpy)).to.be.true;
+      expect(validateSpy.callCount).to.equal(1);
+      expect(datePicker.invalid).to.be.false;
     });
 
-    it('should keep invalid input value during value-changed event', (done) => {
+    it('should keep invalid input value when closing overlay', async () => {
       datePicker.value = '2020-01-01';
       setInputValue(datePicker, 'foo');
-
-      datePicker.addEventListener('value-changed', () => {
-        expect(datePicker.inputElement.value).to.equal('foo');
-        done();
-      });
-      datePicker.close();
+      await waitForOverlayRender();
+      await waitForValueChange(datePicker, () => datePicker.close());
+      expect(datePicker.inputElement.value).to.equal('foo');
     });
 
-    it('should change invalid state only once', (done) => {
+    it('should change invalid state only once', async () => {
       datePicker.min = '2016-01-01';
       datePicker.max = '2016-12-31';
 
       const invalidChangedSpy = sinon.spy();
       datePicker.addEventListener('invalid-changed', invalidChangedSpy);
-      datePicker.addEventListener('value-changed', () => {
-        expect(invalidChangedSpy.calledOnce).to.be.true;
-        done();
+
+      await open(datePicker);
+
+      await waitForValueChange(datePicker, () => {
+        datePicker._overlayContent._selectDate(new Date('2017-01-01')); // Invalid
       });
 
-      datePicker.open();
-      datePicker._overlayContent._selectDate(new Date('2017-01-01')); // Invalid
+      expect(invalidChangedSpy.calledOnce).to.be.true;
     });
 
-    it('should reflect correct invalid value on value-changed eventListener', (done) => {
+    it('should reflect correct invalid value on value-changed eventListener', async () => {
       datePicker.min = '2016-01-01';
       datePicker.max = '2016-12-31';
       datePicker.value = '2016-01-01'; // Valid
 
-      datePicker.addEventListener('value-changed', () => {
-        expect(datePicker.invalid).to.be.equal(true);
-        done();
+      await open(datePicker);
+
+      await waitForValueChange(datePicker, () => {
+        datePicker._overlayContent._selectDate(new Date('2017-01-01')); // Invalid
       });
 
-      datePicker.open();
-      datePicker._overlayContent._selectDate(new Date('2017-01-01')); // Invalid
+      expect(datePicker.invalid).to.be.true;
     });
 
     it('should fire a validated event on validation success', () => {
@@ -237,26 +249,33 @@ describe('validation', () => {
   });
 
   describe('input value', () => {
-    beforeEach(() => {
+    let overlay;
+
+    beforeEach(async () => {
       datePicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+      await nextRender();
+      overlay = datePicker.$.overlay;
       datePicker.inputElement.focus();
     });
 
-    it('should be valid when committing a valid date', () => {
+    it('should be valid when committing a valid date', async () => {
       setInputValue(datePicker, '1/1/2022');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.invalid).to.be.false;
     });
 
-    it('should be invalid when trying to commit an invalid date', () => {
+    it('should be invalid when trying to commit an invalid date', async () => {
       setInputValue(datePicker, 'foo');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.invalid).to.be.true;
     });
 
-    it('should set an empty value when trying to commit an invalid date', () => {
+    it('should set an empty value when trying to commit an invalid date', async () => {
       datePicker.value = '2020-01-01';
       setInputValue(datePicker, 'foo');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.value).to.equal('');
       expect(datePicker.inputElement.value).to.equal('foo');

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-date-picker.js';
-import { activateScroller, getDefaultI18n, open } from './helpers.js';
+import { activateScroller, close, getDefaultI18n, open } from './helpers.js';
 
 describe('WAI-ARIA', () => {
   describe('date picker', () => {
@@ -13,10 +13,10 @@ describe('WAI-ARIA', () => {
       input = datePicker.inputElement;
     });
 
-    it('should toggle aria-expanded attribute on open', () => {
-      datePicker.open();
+    it('should toggle aria-expanded attribute on open', async () => {
+      await open(datePicker);
       expect(input.getAttribute('aria-expanded')).to.equal('true');
-      datePicker.close();
+      await close(datePicker);
       expect(input.getAttribute('aria-expanded')).to.equal('false');
     });
 


### PR DESCRIPTION
## Description

This PR aims to ensure that tests opening `vaadin-date-picker-overlay` wait for `vaadin-overlay-open` event.
It's actually a pre-requisite for #4314 as we need to ensure `hideOthers()` isn't called during fixture teardown.

## Type of change

- Tests