### PR TITLE
refactor: add i18n test from v23.3 fix to v24

### DIFF
--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -97,20 +97,25 @@ customElements.define(
   });
 });
 
-describe('i18n set to slotted date picker before it is added to the DOM', () => {
+describe('setting i18n on a slotted picker before connected to the DOM', () => {
   let dateTimePicker, datePicker;
 
   beforeEach(() => {
     dateTimePicker = document.createElement('vaadin-date-time-picker');
-    datePicker = document.createElement('vaadin-date-picker');
-    datePicker.slot = 'date-picker';
-    datePicker.i18n = { ...datePicker.i18n, cancel: 'Peruuta' };
-    dateTimePicker.appendChild(datePicker);
   });
 
-  it('slotted date picker should have the correct i18n', async () => {
-    await aTimeout(0);
-    document.body.appendChild(dateTimePicker);
-    expect(datePicker.i18n).to.have.property('cancel', 'Peruuta');
+  describe('date-picker', () => {
+    beforeEach(() => {
+      datePicker = document.createElement('vaadin-date-picker');
+      datePicker.slot = 'date-picker';
+      datePicker.i18n = { ...datePicker.i18n, cancel: 'Peruuta' };
+      dateTimePicker.appendChild(datePicker);
+    });
+
+    it('should not have i18n overridden', async () => {
+      await aTimeout(0);
+      document.body.appendChild(dateTimePicker);
+      expect(datePicker.i18n.cancel).to.equal('Peruuta');
+    });
   });
 });

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-date-time-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
@@ -94,5 +94,23 @@ customElements.define(
       expect(dateTimePicker.i18n).to.have.property('cancel', 'Peruuta');
       expect(datePicker.i18n).to.have.property('cancel', 'Peruuta');
     });
+  });
+});
+
+describe('i18n set to slotted date picker before it is added to the DOM', () => {
+  let dateTimePicker, datePicker;
+
+  beforeEach(() => {
+    dateTimePicker = document.createElement('vaadin-date-time-picker');
+    datePicker = document.createElement('vaadin-date-picker');
+    datePicker.slot = 'date-picker';
+    datePicker.i18n = { ...datePicker.i18n, cancel: 'Peruuta' };
+    dateTimePicker.appendChild(datePicker);
+  });
+
+  it('slotted date picker should have the correct i18n', async () => {
+    await aTimeout(0);
+    document.body.appendChild(dateTimePicker);
+    expect(datePicker.i18n).to.have.property('cancel', 'Peruuta');
   });
 });


### PR DESCRIPTION
## Description

Add the test from the [v23.3 PR](https://github.com/vaadin/web-components/pull/5604) to v24 as well.

See related [issue](https://github.com/vaadin/flow-components/pull/4706)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.