### PR TITLE
feat: add helpers for setting ID reference attributes

### DIFF
--- a/packages/a11y-base/src/aria-id-reference.d.ts
+++ b/packages/a11y-base/src/aria-id-reference.d.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Update `aria-describedby` attribute value on the given element.
+ */
+export declare function setAriaDescribedBy(target: HTMLElement, newId: string, oldId?: string): void;
+
+/**
+ * Update `aria-labelledby` attribute value on the given element.
+ */
+export declare function setAriaLabelledBy(target: HTMLElement, newId: string, oldId?: string): void;

--- a/packages/a11y-base/src/aria-id-reference.js
+++ b/packages/a11y-base/src/aria-id-reference.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
+
+function setAriaIDReference(target, attr, newId, oldId) {
+  if (!target) {
+    return;
+  }
+
+  if (oldId) {
+    removeValueFromAttribute(target, attr, oldId);
+  }
+
+  if (newId) {
+    // TODO: indicate that provided attribute value is managed by this helper,
+    // to distinguish user-originated attribute value from the generated one.
+    // Consider using a flag or storing the target in `WeakMap` or `WeakSet`.
+
+    addValueToAttribute(target, attr, newId);
+  }
+}
+
+/**
+ * Update `aria-describedby` attribute value on the given element.
+ *
+ * @param {HTMLElement} target
+ * @param {string} newId
+ * @param {string} oldId
+ */
+export function setAriaDescribedBy(target, newId, oldId) {
+  setAriaIDReference(target, 'aria-describedby', newId, oldId);
+}
+
+/**
+ * Update `aria-labelledby` attribute value on the given element.
+ *
+ * @param {HTMLElement} target
+ * @param {string} newId
+ * @param {string} oldId
+ */
+export function setAriaLabelledBy(target, newId, oldId) {
+  setAriaIDReference(target, 'aria-labelledby', newId, oldId);
+}

--- a/packages/field-base/src/field-aria-controller.js
+++ b/packages/field-base/src/field-aria-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
+import { setAriaDescribedBy, setAriaLabelledBy } from '@vaadin/a11y-base/src/aria-id-reference.js';
 
 /**
  * A controller for managing ARIA attributes for a field element:
@@ -97,7 +97,7 @@ export class FieldAriaController {
    * @private
    */
   __setLabelIdToAriaAttribute(labelId, oldLabelId) {
-    this.__setAriaAttributeId('aria-labelledby', labelId, oldLabelId);
+    setAriaLabelledBy(this.__target, labelId, oldLabelId);
   }
 
   /**
@@ -108,11 +108,8 @@ export class FieldAriaController {
   __setErrorIdToAriaAttribute(errorId, oldErrorId) {
     // For groups, add all IDs to aria-labelledby rather than aria-describedby -
     // that should guarantee that it's announced when the group is entered.
-    if (this.__isGroupField) {
-      this.__setAriaAttributeId('aria-labelledby', errorId, oldErrorId);
-    } else {
-      this.__setAriaAttributeId('aria-describedby', errorId, oldErrorId);
-    }
+    const setAriaCallback = this.__isGroupField ? setAriaLabelledBy : setAriaDescribedBy;
+    setAriaCallback(this.__target, errorId, oldErrorId);
   }
 
   /**
@@ -123,11 +120,8 @@ export class FieldAriaController {
   __setHelperIdToAriaAttribute(helperId, oldHelperId) {
     // For groups, add all IDs to aria-labelledby rather than aria-describedby -
     // that should guarantee that it's announced when the group is entered.
-    if (this.__isGroupField) {
-      this.__setAriaAttributeId('aria-labelledby', helperId, oldHelperId);
-    } else {
-      this.__setAriaAttributeId('aria-describedby', helperId, oldHelperId);
-    }
+    const setAriaCallback = this.__isGroupField ? setAriaLabelledBy : setAriaDescribedBy;
+    setAriaCallback(this.__target, helperId, oldHelperId);
   }
 
   /**
@@ -148,25 +142,6 @@ export class FieldAriaController {
       this.__target.setAttribute('aria-required', 'true');
     } else {
       this.__target.removeAttribute('aria-required');
-    }
-  }
-
-  /**
-   * @param {string | null | undefined} newId
-   * @param {string | null | undefined} oldId
-   * @private
-   */
-  __setAriaAttributeId(attr, newId, oldId) {
-    if (!this.__target) {
-      return;
-    }
-
-    if (oldId) {
-      removeValueFromAttribute(this.__target, attr, oldId);
-    }
-
-    if (newId) {
-      addValueToAttribute(this.__target, attr, newId);
     }
   }
 }


### PR DESCRIPTION
## Description

1. Added helpers for setting `aria-describedby` and `aria-labelledby`,
2. Updated `FieldAriaController` logic to use newly added helpers.

## Type of change

- Internal feature

## TODO

- [ ] Add tests for both functions similar to those in `aria-hidden.test.js`
- [ ] Update other occurrences of setting `aria-labelledby` attribute, too