### PR TITLE
fix: clear dragover row and cell parts on dragover change

### DIFF
--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { iterateChildren, updateRowStates, updateStringRowStates } from './vaadin-grid-helpers.js';
+import { iterateChildren, updateBooleanRowStates, updateStringRowStates } from './vaadin-grid-helpers.js';
 
 const DropMode = {
   BETWEEN: 'between',
@@ -156,12 +156,12 @@ export const DragAndDropMixin = (superClass) =>
         // Set the default transfer data
         e.dataTransfer.setData('text', this.__formatDefaultTransferData(rows));
 
-        updateRowStates(row, { dragstart: rows.length > 1 ? `${rows.length}` : '' });
+        updateBooleanRowStates(row, { dragstart: rows.length > 1 ? `${rows.length}` : '' });
         this.style.setProperty('--_grid-drag-start-x', `${e.clientX - rowRect.left + 20}px`);
         this.style.setProperty('--_grid-drag-start-y', `${e.clientY - rowRect.top + 10}px`);
 
         requestAnimationFrame(() => {
-          updateRowStates(row, { dragstart: null });
+          updateBooleanRowStates(row, { dragstart: false });
           this.style.setProperty('--_grid-drag-start-x', '');
           this.style.setProperty('--_grid-drag-start-y', '');
         });
@@ -398,7 +398,7 @@ export const DragAndDropMixin = (superClass) =>
         }
       });
 
-      updateRowStates(row, {
+      updateBooleanRowStates(row, {
         'drag-disabled': !!dragDisabled,
         'drop-disabled': !!dropDisabled,
       });

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { iterateChildren, updateRowStates } from './vaadin-grid-helpers.js';
+import { iterateChildren, updateRowStates, updateStringRowStates } from './vaadin-grid-helpers.js';
 
 const DropMode = {
   BETWEEN: 'between',
@@ -255,7 +255,7 @@ export const DragAndDropMixin = (superClass) =>
         } else if (row) {
           this._dragOverItem = row._item;
           if (row.getAttribute('dragover') !== this._dropLocation) {
-            updateRowStates(row, { dragover: this._dropLocation }, true);
+            updateStringRowStates(row, { dragover: this._dropLocation });
           }
         } else {
           this._clearDragStyles();
@@ -310,7 +310,7 @@ export const DragAndDropMixin = (superClass) =>
     _clearDragStyles() {
       this.removeAttribute('dragover');
       iterateChildren(this.$.items, (row) => {
-        updateRowStates(row, { dragover: null }, true);
+        updateStringRowStates(row, { dragover: null });
       });
     }
 

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -87,7 +87,7 @@ export function updateCellsPart(cells, part, value) {
  * @param {!HTMLElement} row
  * @param {Object} states
  */
-export function updateRowStates(row, states) {
+export function updateBooleanRowStates(row, states) {
   const cells = getBodyRowCells(row);
 
   Object.entries(states).forEach(([state, value]) => {
@@ -113,20 +113,20 @@ export function updateStringRowStates(row, states) {
 
   Object.entries(states).forEach(([state, value]) => {
     const prevValue = row.getAttribute(state);
-    const prevRowPart = `${state}-${prevValue}-row`;
-    const rowPart = `${state}-${value}-row`;
 
     // Row state attribute
     updateState(row, state, value);
 
     // remove previous part from row and cells if there was any
     if (prevValue) {
+      const prevRowPart = `${state}-${prevValue}-row`;
       updatePart(row, false, prevRowPart);
       updateCellsPart(cells, `${prevRowPart}-cell`, false);
     }
 
     // set new part to rows and cells if there is a value
     if (value) {
+      const rowPart = `${state}-${value}-row`;
       updatePart(row, value, rowPart);
       updateCellsPart(cells, `${rowPart}-cell`, value);
     }

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -86,22 +86,50 @@ export function updateCellsPart(cells, part, value) {
 /**
  * @param {!HTMLElement} row
  * @param {Object} states
- * @param {boolean} appendValue
  */
-export function updateRowStates(row, states, appendValue) {
+export function updateRowStates(row, states) {
   const cells = getBodyRowCells(row);
 
   Object.entries(states).forEach(([state, value]) => {
     // Row state attribute
     updateState(row, state, value);
 
-    const rowPart = appendValue ? `${state}-${value}-row` : `${state}-row`;
+    const rowPart = `${state}-row`;
 
     // Row part attribute
     updatePart(row, value, rowPart);
 
     // Cells part attribute
     updateCellsPart(cells, `${rowPart}-cell`, value);
+  });
+}
+
+/**
+ * @param {!HTMLElement} row
+ * @param {Object} states
+ */
+export function updateStringRowStates(row, states) {
+  const cells = getBodyRowCells(row);
+
+  Object.entries(states).forEach(([state, value]) => {
+    const prevValue = row.getAttribute(state);
+    const prevRowPart = `${state}-${prevValue}-row`;
+    const rowPart = `${state}-${value}-row`;
+
+    // Row state attribute
+    updateState(row, state, value);
+
+    // remove previous part from row and cells if there was any
+    if (prevValue) {
+      updatePart(row, false, prevRowPart);
+      updateCellsPart(cells, `${prevRowPart}-cell`, false);
+    }
+
+    // set new part to rows and cells if there is a value
+    if (value) {
+      updatePart(row, value, rowPart);
+      updateCellsPart(cells, `${rowPart}-cell`, value);
+    }
   });
 }
 

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -27,7 +27,7 @@ import { DragAndDropMixin } from './vaadin-grid-drag-and-drop-mixin.js';
 import { DynamicColumnsMixin } from './vaadin-grid-dynamic-columns-mixin.js';
 import { EventContextMixin } from './vaadin-grid-event-context-mixin.js';
 import { FilterMixin } from './vaadin-grid-filter-mixin.js';
-import { getBodyRowCells, iterateChildren, updateCellsPart, updateRowStates } from './vaadin-grid-helpers.js';
+import { getBodyRowCells, iterateChildren, updateBooleanRowStates, updateCellsPart } from './vaadin-grid-helpers.js';
 import { KeyboardNavigationMixin } from './vaadin-grid-keyboard-navigation-mixin.js';
 import { RowDetailsMixin } from './vaadin-grid-row-details-mixin.js';
 import { ScrollMixin } from './vaadin-grid-scroll-mixin.js';
@@ -975,7 +975,7 @@ class Grid extends ElementMixin(
 
   /** @private */
   _updateRowOrderParts(row, index = row.index) {
-    updateRowStates(row, {
+    updateBooleanRowStates(row, {
       first: index === 0,
       last: index === this._effectiveSize - 1,
       odd: index % 2 !== 0,
@@ -985,7 +985,7 @@ class Grid extends ElementMixin(
 
   /** @private */
   _updateRowStateParts(row, { expanded, selected, detailsOpened }) {
-    updateRowStates(row, {
+    updateBooleanRowStates(row, {
       expanded,
       selected,
       'details-opened': detailsOpened,

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -579,6 +579,27 @@ describe('drag and drop', () => {
         fireDragOver(row, 'under');
         expect(row.getAttribute('dragover')).to.equal('below');
       });
+
+      it('should clear previous dragover row part attribute on dragover change', () => {
+        grid.dropMode = 'between';
+        const row = grid.$.items.children[0];
+        fireDragOver(row, 'above');
+        fireDragOver(row, 'below');
+        expect(row.getAttribute('part')).to.not.contain('dragover-above-row');
+        expect(row.getAttribute('part')).to.contain('dragover-below-row');
+      });
+
+      it('should clear previous dragover cells part attribute on dragover change', () => {
+        grid.dropMode = 'between';
+        const row = grid.$.items.children[0];
+        fireDragOver(row, 'above');
+        fireDragOver(row, 'below');
+        const cells = getRowBodyCells(row);
+        cells.forEach((cell) => {
+          expect(cell.getAttribute('part')).to.not.contain('dragover-above-row-cell');
+          expect(cell.getAttribute('part')).to.contain('dragover-below-row-cell');
+        });
+      });
     });
 
     describe('dragleave', () => {
@@ -589,7 +610,7 @@ describe('drag and drop', () => {
         expect(spy.called).to.be.false;
       });
 
-      it('should clear the grid drag styles', () => {
+      it('should clear the grid dragover attribute', () => {
         grid.dropMode = 'on-grid';
         fireDragOver();
         expect(grid.hasAttribute('dragover')).to.be.true;
@@ -597,13 +618,36 @@ describe('drag and drop', () => {
         expect(grid.hasAttribute('dragover')).to.be.false;
       });
 
-      it('should clear the row drag styles', () => {
+      it('should clear the row dragover attribute', () => {
         grid.dropMode = 'on-top';
         fireDragOver();
         const row = grid.$.items.children[0];
         expect(row.hasAttribute('dragover')).to.be.true;
         fireDragLeave();
         expect(row.hasAttribute('dragover')).to.be.false;
+      });
+
+      it('should clear the row dragover parts', () => {
+        grid.dropMode = 'on-top';
+        fireDragOver();
+        const row = grid.$.items.children[0];
+        expect(row.getAttribute('part')).to.contain('dragover-');
+        fireDragLeave();
+        expect(row.getAttribute('part')).to.not.contain('dragover-');
+      });
+
+      it('should clear the cells dragover parts', () => {
+        grid.dropMode = 'on-top';
+        fireDragOver();
+        const row = grid.$.items.children[0];
+        const cells = getRowBodyCells(row);
+        cells.forEach((cell) => {
+          expect(cell.getAttribute('part')).to.contain('dragover-');
+        });
+        fireDragLeave();
+        cells.forEach((cell) => {
+          expect(cell.getAttribute('part')).to.not.contain('dragover-');
+        });
       });
     });
 
@@ -663,6 +707,29 @@ describe('drag and drop', () => {
         expect(row.hasAttribute('dragover')).to.be.true;
         fireDrop();
         expect(row.hasAttribute('dragover')).to.be.false;
+      });
+
+      it('should clear the row dragover parts', () => {
+        grid.dropMode = 'on-top';
+        fireDragOver();
+        const row = grid.$.items.children[0];
+        expect(row.getAttribute('part')).to.contain('dragover-');
+        fireDrop();
+        expect(row.getAttribute('part')).to.not.contain('dragover-');
+      });
+
+      it('should clear the cells dragover parts', () => {
+        grid.dropMode = 'on-top';
+        fireDragOver();
+        const row = grid.$.items.children[0];
+        const cells = getRowBodyCells(row);
+        cells.forEach((cell) => {
+          expect(cell.getAttribute('part')).to.contain('dragover-');
+        });
+        fireDrop();
+        cells.forEach((cell) => {
+          expect(cell.getAttribute('part')).to.not.contain('dragover-');
+        });
       });
 
       it('should dispatch a grid specific event', () => {


### PR DESCRIPTION
## Description

When the user is dragging over a grid which is set in `between`, `on-top-or-between` or `on-top` drop mode, then the rows and cells `dragover` attribute is automatically set with an appropriate value (one of `above`, `on-top`, `below`). In addition the `part` attribute is enriched with an appropriate part (`dragover-on-top-row`, `dragover-above-row`, `dragover-below-row` etc.)

The problem before this fix was that as the user was dragging over the row, only the `dragover` attribute was updated correctly, but the `part` attribute was not properly cleared when the dragover value changed. So, for example,  when dragover changed from `above` to `below`, the row had both parts `dragover-above-row`, `dragover-below-row` and not only `dragover-below-row` part. 

The fix introduces another helper function for setting string-based states (such as `dragover`) to the grid rows. The newly introduced function correctly removes the previous part from the row and celss before setting a new one.

The issue with the original updateRowStates function is [also visible here ](https://github.com/vaadin/web-components/issues/5536#issuecomment-1448403218) - this is the case when you want to clear the parts from row on i.e. drop-leave.

Fixes #5536

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
