### PR TITLE
refactor: remove unused imports from AriaModalController

### DIFF
--- a/packages/a11y-base/src/aria-modal-controller.js
+++ b/packages/a11y-base/src/aria-modal-controller.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { hideOthers } from './aria-hidden.js';
-import { FocusTrapController } from './focus-trap-controller.js';
 
 /**
  * A controller for handling modal state on the elements with `dialog` and `alertdialog` role.

--- a/packages/a11y-base/test/aria-modal-controller.test.js
+++ b/packages/a11y-base/test/aria-modal-controller.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { AriaModalController } from '../src/aria-modal-controller.js';


### PR DESCRIPTION
## Description

I missed to remove these leftovers from the original implementation before merging 😕 

## Type of change

- Refactor