### PR TITLE
fix: update _hasInputValue on programmatic input change

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-combo-box.js
+++ b/packages/time-picker/src/vaadin-time-picker-combo-box.js
@@ -82,7 +82,7 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
   /**
    * The setter is overridden to ensure the `_hasInputValue` property
    * doesn't wrongly indicate true after the input element's value
-   * is reverted or cleared.
+   * is reverted or cleared programmatically.
    *
    * @override
    * @protected

--- a/packages/time-picker/src/vaadin-time-picker-combo-box.js
+++ b/packages/time-picker/src/vaadin-time-picker-combo-box.js
@@ -81,6 +81,12 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
     // See https://github.com/vaadin/vaadin-time-picker/issues/145
     this.setAttribute('dir', 'ltr');
   }
+
+  /** @override */
+  _onClearAction() {
+    this.dispatchEvent(new CustomEvent('clear-action'));
+    super._onClearAction();
+  }
 }
 
 customElements.define(TimePickerComboBox.is, TimePickerComboBox);

--- a/packages/time-picker/src/vaadin-time-picker-combo-box.js
+++ b/packages/time-picker/src/vaadin-time-picker-combo-box.js
@@ -71,6 +71,27 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
     return this.querySelector('[part="clear-button"]');
   }
 
+  /**
+   * @override
+   * @protected
+   */
+  get _inputElementValue() {
+    return super._inputElementValue;
+  }
+
+  /**
+   * The setter is overridden to ensure the `_hasInputValue` property
+   * doesn't wrongly indicate true after the input element's value
+   * is reverted or cleared.
+   *
+   * @override
+   * @protected
+   */
+  set _inputElementValue(value) {
+    super._inputElementValue = value;
+    this._hasInputValue = value.length > 0;
+  }
+
   /** @protected */
   ready() {
     super.ready();
@@ -80,12 +101,6 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
 
     // See https://github.com/vaadin/vaadin-time-picker/issues/145
     this.setAttribute('dir', 'ltr');
-  }
-
-  /** @override */
-  _onClearAction() {
-    this.dispatchEvent(new CustomEvent('clear-action'));
-    super._onClearAction();
   }
 }
 

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -125,6 +125,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
           position-target="[[_inputContainer]]"
           theme$="[[_theme]]"
           on-change="__onComboBoxChange"
+          on-clear-action="__onComboBoxClearAction"
         >
           <vaadin-input-container
             part="input-field"
@@ -641,6 +642,11 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     this.validate();
 
     this.__dispatchChange();
+  }
+
+  /** @private */
+  __onComboBoxClearAction() {
+    this._hasInputValue = false;
   }
 
   /** @private */

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -125,7 +125,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
           position-target="[[_inputContainer]]"
           theme$="[[_theme]]"
           on-change="__onComboBoxChange"
-          on-clear-action="__onComboBoxClearAction"
+          on-has-input-value-changed="__onComboBoxHasInputValueChanged"
         >
           <vaadin-input-container
             part="input-field"
@@ -644,9 +644,13 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     this.__dispatchChange();
   }
 
-  /** @private */
-  __onComboBoxClearAction() {
-    this._hasInputValue = false;
+  /**
+   * Synchronizes the `_hasInputValue` property with the internal combo-box's one.
+   *
+   * @private
+   */
+  __onComboBoxHasInputValueChanged() {
+    this._hasInputValue = this.$.comboBox._hasInputValue;
   }
 
   /** @private */

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -6,14 +6,13 @@ import './not-animated-styles.js';
 import '../vaadin-time-picker.js';
 
 describe('events', () => {
-  let timePicker, comboBox;
+  let timePicker;
 
   describe('change event', () => {
     let changeSpy, inputElement;
 
     beforeEach(() => {
       timePicker = fixtureSync(`<vaadin-time-picker></vaadin-time-picker>`);
-      comboBox = timePicker.$.comboBox;
       inputElement = timePicker.inputElement;
       changeSpy = sinon.spy();
       timePicker.addEventListener('change', changeSpy);
@@ -94,6 +93,69 @@ describe('events', () => {
       enter(inputElement);
       inputElement.blur();
       expect(changeSpy.callCount).to.equal(1);
+    });
+  });
+
+  describe('has-input-value-changed event', () => {
+    let clearButton, hasInputValueChangedSpy, valueChangedSpy;
+
+    beforeEach(async () => {
+      hasInputValueChangedSpy = sinon.spy();
+      valueChangedSpy = sinon.spy();
+      timePicker = fixtureSync('<vaadin-time-picker clear-button-visible></vaadin-time-picker>');
+      clearButton = timePicker.shadowRoot.querySelector('[part=clear-button]');
+      timePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+      timePicker.addEventListener('value-changed', valueChangedSpy);
+      timePicker.inputElement.focus();
+    });
+
+    describe('without value', () => {
+      it('should be fired when entering user input', async () => {
+        await sendKeys({ type: '12:00' });
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+      });
+
+      // describe('with user input', () => {
+      //   beforeEach(async () => {
+      //     await sendKeys({ type: '12:00' });
+      //     hasInputValueChangedSpy.resetHistory();
+      //   });
+
+      //   it('should be fired when clearing the user input with Esc', async () => {
+      //     // Clear selection in the dropdown.
+      //     await sendKeys({ press: 'Escape' });
+      //     // Clear the user input.
+      //     await sendKeys({ press: 'Escape' });
+      //     expect(timePicker.inputElement.value).to.be.empty;
+      //     expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+      //   });
+      // });
+    });
+
+    describe('with value', () => {
+      beforeEach(async () => {
+        await sendKeys({ type: '10:00' });
+        await sendKeys({ press: 'Enter' });
+        valueChangedSpy.resetHistory();
+        hasInputValueChangedSpy.resetHistory();
+      });
+
+      it('should be fired on clear button click', () => {
+        clearButton.click();
+        expect(timePicker.inputElement.value).to.be.empty;
+        expect(valueChangedSpy.calledOnce).to.be.true;
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+      });
+
+      it('should be fired when clearing the value with Esc', async () => {
+        // Clear the value.
+        await sendKeys({ press: 'Escape' });
+        expect(timePicker.inputElement.value).to.be.empty;
+        expect(valueChangedSpy.calledOnce).to.be.true;
+        expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+      });
     });
   });
 });

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -115,21 +115,40 @@ describe('events', () => {
         expect(hasInputValueChangedSpy.calledOnce).to.be.true;
       });
 
-      // describe('with user input', () => {
-      //   beforeEach(async () => {
-      //     await sendKeys({ type: '12:00' });
-      //     hasInputValueChangedSpy.resetHistory();
-      //   });
+      describe('with user input', () => {
+        beforeEach(async () => {
+          await sendKeys({ type: '12:00' });
+          hasInputValueChangedSpy.resetHistory();
+        });
 
-      //   it('should be fired when clearing the user input with Esc', async () => {
-      //     // Clear selection in the dropdown.
-      //     await sendKeys({ press: 'Escape' });
-      //     // Clear the user input.
-      //     await sendKeys({ press: 'Escape' });
-      //     expect(timePicker.inputElement.value).to.be.empty;
-      //     expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-      //   });
-      // });
+        it('should be fired when clearing the user input with Esc', async () => {
+          // Clear selection in the dropdown.
+          await sendKeys({ press: 'Escape' });
+          // Clear the user input.
+          await sendKeys({ press: 'Escape' });
+          expect(timePicker.inputElement.value).to.be.empty;
+          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        });
+      });
+
+      describe('with bad user input', async () => {
+        beforeEach(async () => {
+          await sendKeys({ type: 'foo' });
+          hasInputValueChangedSpy.resetHistory();
+        });
+
+        it('should be fired when clearing bad user input with Esc', async () => {
+          await sendKeys({ press: 'Escape' });
+          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        });
+
+        it('should be fired when clearing committed bad user input with Esc', async () => {
+          await sendKeys({ press: 'Enter' });
+          hasInputValueChangedSpy.resetHistory();
+          await sendKeys({ press: 'Escape' });
+          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        });
+      });
     });
 
     describe('with value', () => {
@@ -149,7 +168,6 @@ describe('events', () => {
       });
 
       it('should be fired when clearing the value with Esc', async () => {
-        // Clear the value.
         await sendKeys({ press: 'Escape' });
         expect(timePicker.inputElement.value).to.be.empty;
         expect(valueChangedSpy.calledOnce).to.be.true;


### PR DESCRIPTION
## Description

- Synchronized time-picker's `_hasInputValue` property with one of the internal combo-box. 
- Ensured the internal combo-box's `_hasInputValue` gets updated when the input element's value is changed programmatically.

Part of #5410 

## Type of change

- [x] Bugfix
