### PR TITLE
refactor: simplify _hasInputValue workaround, improve JSDoc

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -328,6 +328,20 @@ export const DatePickerMixin = (subclass) =>
 
         /** @private */
         _overlayContent: Object,
+
+        /**
+         * In date-picker, unlike other components extending `InputMixin`,
+         * the property indicates true only if the input has been entered by the user.
+         * In the case of programmatic changes, the property is reset to false.
+         * Read more about why this workaround is needed:
+         * https://github.com/vaadin/web-components/issues/5639
+         *
+         * @protected
+         * @override
+         */
+        _hasInputValue: {
+          type: Boolean,
+        },
       };
     }
 
@@ -351,6 +365,30 @@ export const DatePickerMixin = (subclass) =>
       this._boundOnClick = this._onClick.bind(this);
       this._boundOnScroll = this._onScroll.bind(this);
       this._boundOverlayRenderer = this._overlayRenderer.bind(this);
+    }
+
+    /**
+     * @override
+     * @protected
+     */
+    get _inputElementValue() {
+      return super._inputElementValue;
+    }
+
+    /**
+     * The setter is overridden to reset the `_hasInputValue` property
+     * to false when the input element's value is updated programmatically.
+     * In date-picker, `_hasInputValue` is supposed to indicate true only
+     * if the input has been entered by the user.
+     * Read more about why this workaround is needed:
+     * https://github.com/vaadin/web-components/issues/5639
+     *
+     * @override
+     * @protected
+     */
+    set _inputElementValue(value) {
+      super._inputElementValue = value;
+      this._hasInputValue = false;
     }
 
     /**
@@ -908,9 +946,6 @@ export const DatePickerMixin = (subclass) =>
     /** @private */
     _applyInputValue(date) {
       this._inputElementValue = date ? this._getFormattedDate(this.i18n.formatDate, date) : '';
-      // It is no longer input entered by the user,
-      // so reset the `hasInputValue` property.
-      this._hasInputValue = false;
     }
 
     /** @private */
@@ -976,9 +1011,6 @@ export const DatePickerMixin = (subclass) =>
     _onClearButtonClick(event) {
       event.preventDefault();
       this._inputElementValue = '';
-      // It is no longer input entered by the user,
-      // so reset the `hasInputValue` property.
-      this._hasInputValue = false;
       this.value = '';
       this.validate();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -54,10 +54,7 @@ export const InputMixin = dedupingMixin(
           },
 
           /**
-           * Whether the input element has user input.
-           *
-           * Note, the property indicates true only if the input has been entered by the user.
-           * In the case of programmatic changes, the property must be reset to false.
+           * Whether the input element has a non-empty value.
            *
            * @protected
            */


### PR DESCRIPTION
## Description

The PR documents and simplifies the `hasInputValue` workaround in `date-picker` that was introduced in #5625.

Part of #5410 

## Type of change

- [x] Refactor
