### PR TITLE
fix: inflate functions in arrays

### DIFF
--- a/packages/charts/src/helpers.js
+++ b/packages/charts/src/helpers.js
@@ -1,11 +1,13 @@
 export function inflateFunctions(config) {
+  if (Array.isArray(config)) {
+    config.forEach(inflateFunctions);
+    return;
+  }
   if (
-    // Check if param is an array
-    !Array.isArray(config) &&
     // Check if param is a primitive/null/undefined value
-    (!(config instanceof Object) ||
-      // Check if param is a plain object (not a HC object)
-      config.constructor !== Object)
+    !(config instanceof Object) ||
+    // Check if param is a plain object (not a HC object)
+    config.constructor !== Object
   ) {
     return;
   }

--- a/packages/charts/src/helpers.js
+++ b/packages/charts/src/helpers.js
@@ -1,9 +1,11 @@
 export function inflateFunctions(config) {
   if (
+    // Check if param is an array
+    !Array.isArray(config) &&
     // Check if param is a primitive/null/undefined value
-    !(config instanceof Object) ||
-    // Check if param is a plain object (not an array or HC object)
-    config.constructor !== Object
+    (!(config instanceof Object) ||
+      // Check if param is a plain object (not a HC object)
+      config.constructor !== Object)
   ) {
     return;
   }

--- a/packages/charts/test/private-api.test.js
+++ b/packages/charts/test/private-api.test.js
@@ -29,6 +29,16 @@ describe('vaadin-chart private API', () => {
       expect(config.tooltip).to.not.have.property('_fn_formatter');
     });
 
+    it('should inflate function strings in array', () => {
+      const exportFunction = 'function () {this.exportChart();}';
+      // eslint-disable-next-line camelcase
+      const config = { exporting: { buttons: { contextButton: { menuItems: [{ _fn_onclick: exportFunction }] } } } };
+      inflateFunctions(config);
+      const exportButton = config.exporting.buttons.contextButton.menuItems[0];
+      expect(exportButton.onclick.toString()).to.be.equal(exportFunction);
+      expect(exportButton).to.not.have.property('_fn_onclick');
+    });
+
     it('should not try to inflate if a non-object value is passed', () => {
       // Check for no errors being thrown
       inflateFunctions(null);


### PR DESCRIPTION
## Description

The `inflateFunctions` function currently does not handle functions in arrays, which causes the export buttons to break. 
This is a regression introduced by a previous [fix](https://github.com/vaadin/web-components/pull/5080). This PR updates the logic so that the objects inside arrays are also fed into the function again. 

Fixes #[4696](https://github.com/vaadin/flow-components/issues/4696)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
