### PR TITLE
refactor: avoid unnecessary render cycles in the data provider callback

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -442,8 +442,7 @@ export const DataProviderMixin = (superClass) =>
             this._debouncerApplyCachedData.flush();
           }
 
-          // TODO: Move this into the debouncer as well
-          // Notify that the data has been received
+          // Notify that new data has been received
           this.__itemsReceived();
         });
       }


### PR DESCRIPTION
## Description

This change improves how a data provider callback is processed in `vaadin-grid-data-provider-mixin`. It makes sure that the cache gets fully updated with all synchronously available data before actually rendering the grid rows. The updated data provider causes significantly fewer row rendering cycles when hierarchical data is applied to the grid.

This will be followed by a related PR to `flow-component`.

## Type of change

Performance enhancement