### PR TITLE
refactor: avoid unnecessary re-renders on virtualizer size change

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -269,7 +269,8 @@ export class IronListAdapter {
       requestAnimationFrame(() => this._resizeHandler());
     }
 
-    // Schedule and flush a resize handler
+    // Schedule and flush a resize handler. This will cause a
+    // re-render for the elements.
     this._resizeHandler();
     flush();
   }

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -249,41 +249,26 @@ export class IronListAdapter {
       this._debouncers._increasePoolIfNeeded.cancel();
     }
 
-    // Prevent element update while the scroll position is being restored
-    this.__preventElementUpdates = true;
-
-    // Record the scroll position before changing the size
-    let fvi; // First visible index
-    let fviOffsetBefore; // Scroll offset of the first visible index
-    if (size > 0) {
-      fvi = this.adjustedFirstVisibleIndex;
-      fviOffsetBefore = this.__getIndexScrollOffset(fvi);
-    }
-
     // Change the size
     this.__size = size;
 
-    this._itemsChanged({
-      path: 'items',
-    });
-    flush();
-
-    // Try to restore the scroll position if the new size is larger than 0
-    if (size > 0) {
-      fvi = Math.min(fvi, size - 1);
-      this.scrollToIndex(fvi);
-
-      const fviOffsetAfter = this.__getIndexScrollOffset(fvi);
-      if (fviOffsetBefore !== undefined && fviOffsetAfter !== undefined) {
-        this._scrollTop += fviOffsetBefore - fviOffsetAfter;
-      }
+    if (!this._physicalItems) {
+      // Not initialized yet
+      this._itemsChanged({
+        path: 'items',
+      });
+      this.__preventElementUpdates = true;
+      flush();
+      this.__preventElementUpdates = false;
+    } else {
+      // Already initialized, just update _virtualCount
+      this._virtualCount = this.items.length;
     }
 
     if (!this.elementsContainer.children.length) {
       requestAnimationFrame(() => this._resizeHandler());
     }
 
-    this.__preventElementUpdates = false;
     // Schedule and flush a resize handler
     this._resizeHandler();
     flush();

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -201,6 +201,25 @@ describe('virtualizer', () => {
     expect(updateElement.called).to.be.false;
   });
 
+  it('should not request item updates on size increase when scrolled', async () => {
+    const updateElement = sinon.spy((el, index) => {
+      el.textContent = `item-${index}`;
+    });
+    init({ size: 100, updateElement });
+
+    // Scroll halfway down the list
+    virtualizer.scrollToIndex(50);
+    // Manually scroll down a bit
+    scrollTarget.scrollTop += 100;
+    await nextFrame();
+
+    // Increase the size so it shouldn't affect the current viewport items
+    updateElement.resetHistory();
+    virtualizer.size = 200;
+
+    expect(updateElement.called).to.be.false;
+  });
+
   it('should request a different set of items on size decrease', () => {
     const updateElement = sinon.spy((el, index) => {
       el.textContent = `item-${index}`;


### PR DESCRIPTION
## Description

Changing the virtualizer's `size` should never cause element updates if the size change doesn't affect any visible elements. There's actually a [test case](https://github.com/vaadin/web-components/blob/3224d4e1760babd894391ce6ce7e6f08ed467669/packages/component-base/test/virtualizer.test.js#L187) for it also, but it failed to catch the case where the user might have scrolled the virtualizer manually before the size change.

The current size change implementation always [invokes](https://github.com/vaadin/web-components/blob/3224d4e1760babd894391ce6ce7e6f08ed467669/packages/component-base/src/virtualizer-iron-list-adapter.js#L266-L268) the `_itemsChanged` in `iron-list-core`, which in turn would reset the scroll position to 0. To mitigate this, there is a mechanism, based on `scrollToIndex`, to [restore the scroll position](https://github.com/vaadin/web-components/blob/3224d4e1760babd894391ce6ce7e6f08ed467669/packages/component-base/src/virtualizer-iron-list-adapter.js#L273-L279) after the size change back to what it was before.

Due to this workaround, the virtualizer ended up in seemingly the same scroll position, but sometimes having items in the viewport represented by different DOM elements than before the size change so an update was necessary to have the element content up-to-date.

After some investigation, it turns out we only need to use the `_itemsChanged` API once on init, and any following size change can be handled just by updating the `_virtualCount` property directly. Since the scroll position is at 0 initially and updating `_virtualCount` doesn't lose the scroll position, we can remove the workaround for restoring the scroll position altogether.

## Type of change

Performance enhancement