### PR TITLE
refactor: move input value getters and setters to InputMixin (#5586) (CP: 24.0)

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -118,10 +118,15 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
   }
 
   /**
-   * @return {string}
+   * Override this getter from `InputMixin` to allow using
+   * an arbitrary property name instead of `value`
+   * for accessing the input element's value.
+   *
    * @protected
+   * @override
+   * @return {string}
    */
-  get _propertyForValue() {
+  get _inputElementValueProperty() {
     return dashToCamelCase(this.attrForValue);
   }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -132,10 +132,6 @@ export declare class ComboBoxMixinClass<TItem> {
    */
   itemIdPath: string | null | undefined;
 
-  protected readonly _propertyForValue: string;
-
-  protected _inputElementValue: string | undefined;
-
   /**
    * Tag name prefix used by scroller and items.
    */

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -281,32 +281,6 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /**
-     * @return {string}
-     * @protected
-     */
-    get _propertyForValue() {
-      return 'value';
-    }
-
-    /**
-     * @return {string | undefined}
-     * @protected
-     */
-    get _inputElementValue() {
-      return this.inputElement ? this.inputElement[this._propertyForValue] : undefined;
-    }
-
-    /**
-     * @param {string} value
-     * @protected
-     */
-    set _inputElementValue(value) {
-      if (this.inputElement) {
-        this.inputElement[this._propertyForValue] = value;
-      }
-    }
-
-    /**
      * Override method inherited from `InputMixin`
      * to customize the input element.
      * @protected

--- a/packages/combo-box/test/selecting-items.test.js
+++ b/packages/combo-box/test/selecting-items.test.js
@@ -351,7 +351,7 @@ describe('selecting a custom value', () => {
 
     expect(comboBox.value).to.eql('foobar');
     expect(comboBox.selectedItem).to.be.null;
-    expect(comboBox._inputElementValue).to.eql('foobar');
+    expect(comboBox.inputElement.value).to.eql('foobar');
     expect(comboBox.hasAttribute('has-value')).to.be.true;
   });
 

--- a/packages/date-picker/src/vaadin-date-picker-light.js
+++ b/packages/date-picker/src/vaadin-date-picker-light.js
@@ -96,15 +96,16 @@ class DatePickerLight extends ThemableMixin(DatePickerMixin(ValidateMixin(Polyme
     };
   }
 
-  /** @return {string | undefined} */
-  get _inputValue() {
-    return this.inputElement && this.inputElement[dashToCamelCase(this.attrForValue)];
-  }
-
-  set _inputValue(value) {
-    if (this.inputElement) {
-      this.inputElement[dashToCamelCase(this.attrForValue)] = value;
-    }
+  /**
+   * This method from InputMixin is overridden to make
+   * the input element value property customizable.
+   *
+   * @protected
+   * @override
+   * @return {string}
+   */
+  get _inputElementValueProperty() {
+    return dashToCamelCase(this.attrForValue);
   }
 
   /** @protected */

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -372,18 +372,6 @@ export const DatePickerMixin = (subclass) =>
       return null;
     }
 
-    /** @protected */
-    get _inputValue() {
-      return this.inputElement ? this.inputElement.value : undefined;
-    }
-
-    /** @protected */
-    set _inputValue(value) {
-      if (this.inputElement) {
-        this.inputElement.value = value;
-      }
-    }
-
     /**
      * Override an event listener from `DelegateFocusMixin`
      * @protected
@@ -410,7 +398,7 @@ export const DatePickerMixin = (subclass) =>
 
         this.validate();
 
-        if (this._inputValue === '' && this.value !== '') {
+        if (this._inputElementValue === '' && this.value !== '') {
           this.value = '';
         }
       }
@@ -537,9 +525,10 @@ export const DatePickerMixin = (subclass) =>
      * @return {boolean} True if the value is valid
      */
     checkValidity() {
+      const inputValue = this._inputElementValue;
       const inputValid =
-        !this._inputValue ||
-        (!!this._selectedDate && this._inputValue === this._getFormattedDate(this.i18n.formatDate, this._selectedDate));
+        !inputValue ||
+        (!!this._selectedDate && inputValue === this._getFormattedDate(this.i18n.formatDate, this._selectedDate));
       const minMaxValid = !this._selectedDate || dateAllowed(this._selectedDate, this._minDate, this._maxDate);
 
       let inputValidity = true;
@@ -845,7 +834,7 @@ export const DatePickerMixin = (subclass) =>
       // Select the parsed input or focused date
       this._ignoreFocusedDateChange = true;
       if (this.i18n.parseDate) {
-        const inputValue = this._inputValue || '';
+        const inputValue = this._inputElementValue || '';
         const parsedDate = this._getParsedDate(inputValue);
 
         if (this._isValidDate(parsedDate)) {
@@ -900,12 +889,12 @@ export const DatePickerMixin = (subclass) =>
     /** @private */
     _focusAndSelect() {
       this._focus();
-      this._setSelectionRange(0, this._inputValue.length);
+      this._setSelectionRange(0, this._inputElementValue.length);
     }
 
     /** @private */
     _applyInputValue(date) {
-      this._inputValue = date ? this._getFormattedDate(this.i18n.formatDate, date) : '';
+      this._inputElementValue = date ? this._getFormattedDate(this.i18n.formatDate, date) : '';
     }
 
     /** @private */
@@ -933,7 +922,7 @@ export const DatePickerMixin = (subclass) =>
     _onChange(event) {
       // For change event on the native <input> blur, after the input is cleared,
       // we schedule change event to be dispatched on date-picker blur.
-      if (this._inputValue === '') {
+      if (this._inputElementValue === '') {
         this.__dispatchChange = true;
       }
 
@@ -971,7 +960,7 @@ export const DatePickerMixin = (subclass) =>
     _onClearButtonClick(event) {
       event.preventDefault();
       this.value = '';
-      this._inputValue = '';
+      this._inputElementValue = '';
       this.validate();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
     }
@@ -1085,7 +1074,7 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /** @private */
-    _getParsedDate(inputValue = this._inputValue) {
+    _getParsedDate(inputValue = this._inputElementValue) {
       const dateObject = this.i18n.parseDate && this.i18n.parseDate(inputValue);
       const parsedDate = dateObject && parseDate(`${dateObject.year}-${dateObject.month + 1}-${dateObject.day}`);
       return parsedDate;
@@ -1109,7 +1098,7 @@ export const DatePickerMixin = (subclass) =>
 
     /** @private */
     _userInputValueChanged() {
-      if (this._inputValue) {
+      if (this._inputElementValue) {
         const parsedDate = this._getParsedDate();
 
         if (this._isValidDate(parsedDate)) {

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -179,7 +179,7 @@ describe('validation', () => {
       setInputValue(datePicker, 'foo');
 
       datePicker.addEventListener('value-changed', () => {
-        expect(datePicker._inputValue).to.equal('foo');
+        expect(datePicker.inputElement.value).to.equal('foo');
         done();
       });
       datePicker.close();

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -35,6 +35,18 @@ export declare class InputMixinClass {
   protected readonly _hasValue: boolean;
 
   /**
+   * A property for accessing the input element's value.
+   *
+   * Override this getter if the property is different from the default `value` one.
+   */
+  protected readonly _inputElementValueProperty: string;
+
+  /**
+   * The input element's value.
+   */
+  protected _inputElementValue: string | undefined;
+
+  /**
    * Clear the value of the field.
    */
   clear(): void;

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -87,6 +87,39 @@ export const InputMixin = dedupingMixin(
       }
 
       /**
+       * A property for accessing the input element's value.
+       *
+       * Override this getter if the property is different from the default `value` one.
+       *
+       * @protected
+       * @return {string}
+       */
+      get _inputElementValueProperty() {
+        return 'value';
+      }
+
+      /**
+       * The input element's value.
+       *
+       * @protected
+       * @return {string}
+       */
+      get _inputElementValue() {
+        return this.inputElement ? this.inputElement[this._inputElementValueProperty] : undefined;
+      }
+
+      /**
+       * The input element's value.
+       *
+       * @protected
+       */
+      set _inputElementValue(value) {
+        if (this.inputElement) {
+          this.inputElement[this._inputElementValueProperty] = value;
+        }
+      }
+
+      /**
        * Clear the value of the field.
        */
       clear() {
@@ -96,9 +129,7 @@ export const InputMixin = dedupingMixin(
 
         // Clear the input immediately without waiting for the observer.
         // Otherwise, when using Lit, the old value would be restored.
-        if (this.inputElement) {
-          this.inputElement.value = '';
-        }
+        this._inputElementValue = '';
       }
 
       /**
@@ -138,11 +169,7 @@ export const InputMixin = dedupingMixin(
           return;
         }
 
-        if (value != null) {
-          this.inputElement.value = value;
-        } else {
-          this.inputElement.value = '';
-        }
+        this._inputElementValue = value != null ? value : '';
       }
 
       /**


### PR DESCRIPTION
The PR cherry-picks the following improvement to `24.0`:

- https://github.com/vaadin/web-components/pull/5586

Part of https://github.com/vaadin/web-components/issues/5410
