### PR TITLE
fix: make extension patterns match the end of the file name

### DIFF
--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -879,13 +879,10 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       );
       return;
     }
-
     // Escape regex operators common to mime types
     let escapedAccept = this.accept.replace(/[+.]/gu, '\\$&');
-
     // Make extension patterns match the end of the file name
     escapedAccept = escapedAccept.replace(/\\\.[^,]*($|(?=,))/gu, (extension) => `.*${extension}$`);
-
     // Create accept regex that can match comma separated patterns, star (*) wildcards
     const re = new RegExp(`^(${escapedAccept.replace(/[, ]+/gu, '|').replace(/\/\*/gu, '/.*')})$`, 'iu');
     if (this.accept && !(re.test(file.type) || re.test(file.name))) {

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -879,12 +879,16 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       );
       return;
     }
-    const fileExt = file.name.match(/\.[^.]*$|$/u)[0];
+
     // Escape regex operators common to mime types
-    const escapedAccept = this.accept.replace(/[+.]/gu, '\\$&');
+    let escapedAccept = this.accept.replace(/[+.]/gu, '\\$&');
+
+    // Make extension patterns match the end of the file name
+    escapedAccept = escapedAccept.replace(/(^|(?<=[ ,]))\\\.[^ ,]*($|(?=[ ,]))/gu, (extension) => `.*${extension}$`);
+
     // Create accept regex that can match comma separated patterns, star (*) wildcards
     const re = new RegExp(`^(${escapedAccept.replace(/[, ]+/gu, '|').replace(/\/\*/gu, '/.*')})$`, 'iu');
-    if (this.accept && !(re.test(file.type) || re.test(fileExt))) {
+    if (this.accept && !(re.test(file.type) || re.test(file.name))) {
       this.dispatchEvent(
         new CustomEvent('file-reject', {
           detail: { file, error: this.i18n.error.incorrectFileType },

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -899,7 +899,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
   }
 
   /** @private */
-  _getAcceptRegex() {
+  get __acceptRegexp() {
     if (!this.accept) {
       return;
     }

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -495,7 +495,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
   /** @private */
   get __acceptRegexp() {
     if (!this.accept) {
-      return undefined;
+      return null;
     }
     const processedTokens = this.accept.split(',').map((token) => {
       let processedToken = token.trim();

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -884,7 +884,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
     let escapedAccept = this.accept.replace(/[+.]/gu, '\\$&');
 
     // Make extension patterns match the end of the file name
-    escapedAccept = escapedAccept.replace(/(^|(?<=[ ,]))\\\.[^ ,]*($|(?=[ ,]))/gu, (extension) => `.*${extension}$`);
+    escapedAccept = escapedAccept.replace(/\\\.[^,]*($|(?=,))/gu, (extension) => `.*${extension}$`);
 
     // Create accept regex that can match comma separated patterns, star (*) wildcards
     const re = new RegExp(`^(${escapedAccept.replace(/[, ]+/gu, '|').replace(/\/\*/gu, '/.*')})$`, 'iu');

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -880,11 +880,11 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       return;
     }
     // Escape regex operators common to mime types
-    let escapedAccept = this.accept.replace(/[+.]/gu, '\\$&');
+    const escapedAccept = this.accept.replace(/[+.]/gu, '\\$&');
     // Make extension patterns match the end of the file name
-    escapedAccept = escapedAccept.replace(/\\\.[^,]*($|(?=,))/gu, (extension) => `.*${extension}$`);
+    const acceptWithUpdatedExtensions = escapedAccept.replace(/\\\.[^,]*($|(?=,))/gu, (extension) => `.*${extension}$`);
     // Create accept regex that can match comma separated patterns, star (*) wildcards
-    const re = new RegExp(`^(${escapedAccept.replace(/[, ]+/gu, '|').replace(/\/\*/gu, '/.*')})$`, 'iu');
+    const re = new RegExp(`^(${acceptWithUpdatedExtensions.replace(/[, ]+/gu, '|').replace(/\/\*/gu, '/.*')})$`, 'iu');
     if (this.accept && !(re.test(file.type) || re.test(file.name))) {
       this.dispatchEvent(
         new CustomEvent('file-reject', {

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -492,6 +492,26 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
     ];
   }
 
+  /** @private */
+  get __acceptRegexp() {
+    if (!this.accept) {
+      return undefined;
+    }
+    const processedTokens = this.accept.split(',').map((token) => {
+      let processedToken = token.trim();
+      // Escape regex operators common to mime types
+      processedToken = processedToken.replace(/[+.]/gu, '\\$&');
+      // Make extension patterns match the end of the file name
+      if (processedToken.startsWith('\\.')) {
+        processedToken = `.*${processedToken}$`;
+      }
+      // Handle star (*) wildcards
+      return processedToken.replace(/\/\*/gu, '/.*');
+    });
+    // Create accept regex
+    return new RegExp(`^(${processedTokens.join('|')})$`, 'iu');
+  }
+
   /** @protected */
   ready() {
     super.ready();
@@ -879,7 +899,7 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
       );
       return;
     }
-    const re = this._getAcceptRegex();
+    const re = this.__acceptRegexp;
     if (re && !(re.test(file.type) || re.test(file.name))) {
       this.dispatchEvent(
         new CustomEvent('file-reject', {
@@ -896,26 +916,6 @@ class Upload extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElement))
     if (!this.noAuto) {
       this._uploadFile(file);
     }
-  }
-
-  /** @private */
-  get __acceptRegexp() {
-    if (!this.accept) {
-      return;
-    }
-    const processedAccept = this.accept.split(',').map((token) => {
-      let processedToken = token.trim();
-      // Escape regex operators common to mime types
-      processedToken = processedToken.replace(/[+.]/gu, '\\$&');
-      // Make extension patterns match the end of the file name
-      if (processedToken.startsWith('\\.')) {
-        processedToken = `.*${processedToken}$`;
-      }
-      // Handle star (*) wildcards
-      return processedToken.replace(/\/\*/gu, '/.*');
-    });
-    // Create accept regex
-    return new RegExp(`^(${processedAccept.join('|')})$`, 'iu');
   }
 
   /**

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -194,7 +194,7 @@ describe('adding files', () => {
       upload.accept = 'image/*,.bar.baz,video/*';
       file.name = 'foo.bar.baz';
       upload._addFiles([file]);
-      expect(upload.files.length).to.equal(1);
+      expect(upload.files).to.have.lengthOf(1);
     });
 
     it('should allow files with correct mime type', () => {

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -191,8 +191,8 @@ describe('adding files', () => {
     });
 
     it('should allow files with extensions containing multiple dots', () => {
-      upload.accept = 'image/*,.hello.world,video/*';
-      file.name = 'bar.hello.world';
+      upload.accept = 'image/*,.bar.baz,video/*';
+      file.name = 'foo.bar.baz';
       upload._addFiles([file]);
       expect(upload.files.length).to.equal(1);
     });

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -190,6 +190,13 @@ describe('adding files', () => {
       expect(upload.files.length).to.equal(1);
     });
 
+    it('should allow files with extensions containing multiple dots', () => {
+      upload.accept = 'image/*,.hello.world,video/*';
+      file.name = 'bar.hello.world';
+      upload._addFiles([file]);
+      expect(upload.files.length).to.equal(1);
+    });
+
     it('should allow files with correct mime type', () => {
       upload.accept = 'application/x-octet-stream';
       upload._addFiles([file]);

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -197,6 +197,13 @@ describe('adding files', () => {
       expect(upload.files).to.have.lengthOf(1);
     });
 
+    it('should reject files that have partial extension match', () => {
+      upload.accept = 'image/*,.bar.baz,video/*';
+      file.name = 'foo.baz';
+      upload._addFiles([file]);
+      expect(upload.files).to.have.lengthOf(0);
+    });
+
     it('should allow files with correct mime type', () => {
       upload.accept = 'application/x-octet-stream';
       upload._addFiles([file]);


### PR DESCRIPTION
## Description

Currently, the extensions that contain multiple dots (like .tar.gz) are rejected by `Upload` even if the extension is provided through they should be accepted. This PR changes the way the matchers work. The current approach is extracting an extension from a file name and searching for exact matches. With the changes, it will be checked whether the file name ends with one of the provided extensions.

Fixes #[4777](https://github.com/vaadin/flow-components/issues/4777)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.