### PR TITLE
fix: reset _hasInputValue on programmatic input change (#5625) (CP: 24.0)

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -327,6 +327,20 @@ export const DatePickerMixin = (subclass) =>
 
         /** @private */
         _overlayContent: Object,
+
+        /**
+         * In date-picker, unlike other components extending `InputMixin`,
+         * the property indicates true only if the input has been entered by the user.
+         * In the case of programmatic changes, the property is reset to false.
+         * Read more about why this workaround is needed:
+         * https://github.com/vaadin/web-components/issues/5639
+         *
+         * @protected
+         * @override
+         */
+        _hasInputValue: {
+          type: Boolean,
+        },
       };
     }
 
@@ -350,6 +364,30 @@ export const DatePickerMixin = (subclass) =>
       this._boundOnClick = this._onClick.bind(this);
       this._boundOnScroll = this._onScroll.bind(this);
       this._boundOverlayRenderer = this._overlayRenderer.bind(this);
+    }
+
+    /**
+     * @override
+     * @protected
+     */
+    get _inputElementValue() {
+      return super._inputElementValue;
+    }
+
+    /**
+     * The setter is overridden to reset the `_hasInputValue` property
+     * to false when the input element's value is updated programmatically.
+     * In date-picker, `_hasInputValue` is supposed to indicate true only
+     * if the input has been entered by the user.
+     * Read more about why this workaround is needed:
+     * https://github.com/vaadin/web-components/issues/5639
+     *
+     * @override
+     * @protected
+     */
+    set _inputElementValue(value) {
+      super._inputElementValue = value;
+      this._hasInputValue = false;
     }
 
     /**
@@ -895,9 +933,6 @@ export const DatePickerMixin = (subclass) =>
     /** @private */
     _applyInputValue(date) {
       this._inputElementValue = date ? this._getFormattedDate(this.i18n.formatDate, date) : '';
-      // It is no longer input entered by the user,
-      // so reset the `hasInputValue` property.
-      this._hasInputValue = false;
     }
 
     /** @private */
@@ -963,9 +998,6 @@ export const DatePickerMixin = (subclass) =>
     _onClearButtonClick(event) {
       event.preventDefault();
       this._inputElementValue = '';
-      // It is no longer input entered by the user,
-      // so reset the `hasInputValue` property.
-      this._hasInputValue = false;
       this.value = '';
       this.validate();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -895,6 +895,9 @@ export const DatePickerMixin = (subclass) =>
     /** @private */
     _applyInputValue(date) {
       this._inputElementValue = date ? this._getFormattedDate(this.i18n.formatDate, date) : '';
+      // It is no longer input entered by the user,
+      // so reset the `hasInputValue` property.
+      this._hasInputValue = false;
     }
 
     /** @private */
@@ -959,8 +962,11 @@ export const DatePickerMixin = (subclass) =>
      */
     _onClearButtonClick(event) {
       event.preventDefault();
-      this.value = '';
       this._inputElementValue = '';
+      // It is no longer input entered by the user,
+      // so reset the `hasInputValue` property.
+      this._hasInputValue = false;
+      this.value = '';
       this.validate();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
     }

--- a/packages/date-picker/test/events.test.js
+++ b/packages/date-picker/test/events.test.js
@@ -3,8 +3,8 @@ import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
-import '../vaadin-date-picker.js';
-import { close, open } from './helpers.js';
+import '../src/vaadin-date-picker.js';
+import { close, open, waitForScrollToFinish } from './helpers.js';
 
 describe('events', () => {
   let datePicker;
@@ -103,6 +103,84 @@ describe('events', () => {
       await sendKeys({ type: '1/2/2000' });
       await sendKeys({ press: 'Escape' });
       expect(changeSpy.called).to.be.false;
+    });
+  });
+
+  describe('has-input-value-changed event', () => {
+    let clearButton, hasInputValueChangedSpy, valueChangedSpy;
+
+    beforeEach(async () => {
+      hasInputValueChangedSpy = sinon.spy();
+      valueChangedSpy = sinon.spy();
+      datePicker = fixtureSync('<vaadin-date-picker clear-button-visible></vaadin-date-picker>');
+      clearButton = datePicker.shadowRoot.querySelector('[part=clear-button]');
+      datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+      datePicker.addEventListener('value-changed', valueChangedSpy);
+      datePicker.inputElement.focus();
+    });
+
+    describe('without value', () => {
+      describe('with user input', () => {
+        beforeEach(async () => {
+          await sendKeys({ type: '1/1/2022' });
+          await waitForScrollToFinish(datePicker._overlayContent);
+          hasInputValueChangedSpy.resetHistory();
+        });
+
+        it('should be fired when clearing the user input with Esc', async () => {
+          await sendKeys({ press: 'Escape' });
+          expect(datePicker.inputElement.value).to.be.empty;
+          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        });
+
+        it('should be fired when comitting the user input with Enter', async () => {
+          await sendKeys({ press: 'Enter' });
+          expect(valueChangedSpy.calledOnce).to.be.true;
+          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+        });
+
+        it('should be fired when selecting a date with Space', async () => {
+          // Move focus inside the dropdown to the typed date.
+          await sendKeys({ press: 'ArrowDown' });
+          await waitForScrollToFinish(datePicker._overlayContent);
+          // Select that date.
+          await sendKeys({ press: 'Space' });
+          expect(valueChangedSpy.calledOnce).to.be.true;
+          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+        });
+      });
+    });
+
+    describe('with value', () => {
+      beforeEach(async () => {
+        await sendKeys({ type: '1/1/2022' });
+        await sendKeys({ press: 'Enter' });
+        valueChangedSpy.resetHistory();
+        hasInputValueChangedSpy.resetHistory();
+      });
+
+      describe('with user input', () => {
+        beforeEach(async () => {
+          await sendKeys({ type: 'foo' });
+          hasInputValueChangedSpy.resetHistory();
+        });
+
+        it('should be fired on clear button click', () => {
+          clearButton.click();
+          expect(datePicker.inputElement.value).to.be.empty;
+          expect(valueChangedSpy.calledOnce).to.be.true;
+          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+        });
+
+        it('should be fired when reverting the user input to the value with Esc', async () => {
+          await sendKeys({ press: 'Escape' });
+          expect(datePicker.inputElement.value).to.equal('1/1/2022');
+          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        });
+      });
     });
   });
 });

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -54,10 +54,7 @@ export const InputMixin = dedupingMixin(
           },
 
           /**
-           * Whether the input element has user input.
-           *
-           * Note, the property indicates true only if the input has been entered by the user.
-           * In the case of programmatic changes, the property must be reset to false.
+           * Whether the input element has a non-empty value.
            *
            * @protected
            */


### PR DESCRIPTION
The PR cherry-picks the following fixes to `24.0`:

- #5625
- #5645

Part of https://github.com/vaadin/web-components/issues/5410