### PR TITLE
fix: make extension patterns match the end of the file name (#5652) (CP: 23.3)

### DIFF
--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -251,6 +251,20 @@ describe('file list', () => {
       expect(upload.files.length).to.equal(1);
     });
 
+    it('should allow files with extensions containing multiple dots', () => {
+      upload.accept = 'image/*,.bar.baz,video/*';
+      file.name = 'foo.bar.baz';
+      upload._addFiles([file]);
+      expect(upload.files).to.have.lengthOf(1);
+    });
+
+    it('should reject files that have partial extension match', () => {
+      upload.accept = 'image/*,.bar.baz,video/*';
+      file.name = 'foo.baz';
+      upload._addFiles([file]);
+      expect(upload.files).to.have.lengthOf(0);
+    });
+
     it('should allow files with correct mime type', () => {
       upload.accept = 'application/x-octet-stream';
       upload._addFiles([file]);


### PR DESCRIPTION
## Description

Cherry-pick of [5652](https://github.com/vaadin/web-components/pull/5652) to v23.3.

Fixes #[4777](https://github.com/vaadin/flow-components/issues/4777)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.