### PR TITLE
feat: add helpers for setting ID references to aria- attributes

### DIFF
--- a/packages/a11y-base/src/aria-id-reference.d.ts
+++ b/packages/a11y-base/src/aria-id-reference.d.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Removes the current `aria-describedby` attribute value on the given element.
+ */
+export function removeAriaDescribedBy(target: HTMLElement): void;
+
+/**
+ * Restore the generated `aria-describedby` attribute value on the given element.
+ */
+export function restoreGeneratedAriaDescribedBy(target: HTMLElement): void;
+
+/**
+ * Update `aria-describedby` attribute value on the given element.
+ */
+export declare function setAriaDescribedBy(
+  target: HTMLElement,
+  newId: string,
+  oldId?: string,
+  fromUser?: boolean,
+): void;
+
+/**
+ * Removes the current `aria-labelledby` attribute value on the given element.
+ */
+export function removeAriaLabelledBy(target: HTMLElement): void;
+
+/**
+ * Restore the generated `aria-labelledby` attribute value on the given element.
+ */
+export function restoreGeneratedAriaLabellledBy(target: HTMLElement): void;
+
+/**
+ * Update `aria-labelledby` attribute value on the given element.
+ */
+export declare function setAriaLabelledBy(target: HTMLElement, newId: string, oldId?: string, fromUser?: boolean): void;

--- a/packages/a11y-base/src/aria-id-reference.d.ts
+++ b/packages/a11y-base/src/aria-id-reference.d.ts
@@ -11,7 +11,7 @@ export type AriaIDReferenceConfig = {
 };
 
 /**
- * Sets a new ID reference for a {@link target} element and an ARIA {@link attr | attribute}.
+ * Sets a new ID reference for a target element and an ARIA attribute.
  *
  * @param config.newId
  *  The new ARIA ID reference to set. If `null`, the attribute is removed,
@@ -30,12 +30,12 @@ export type AriaIDReferenceConfig = {
 export function setAriaIDReference(target: HTMLElement, attr: string, config: AriaIDReferenceConfig): void;
 
 /**
- * Removes the {@link attr | attribute} value of the given {@link target} element.
+ * Removes the attribute value of the given target element.
  * It also stores the current value, if no stored values are present.
  */
 export function removeAriaIDReference(target: HTMLElement, attr: string): void;
 
 /**
- * Restores the generated values of the {@link attr | attribute} to the given {@link target} element.
+ * Restores the generated values of the attribute to the given target element.
  */
 export function restoreGeneratedAriaIDReference(target: HTMLElement, attr: string): void;

--- a/packages/a11y-base/src/aria-id-reference.d.ts
+++ b/packages/a11y-base/src/aria-id-reference.d.ts
@@ -32,7 +32,7 @@ export function removeAriaLabelledBy(target: HTMLElement): void;
 /**
  * Restore the generated `aria-labelledby` attribute value on the given element.
  */
-export function restoreGeneratedAriaLabellledBy(target: HTMLElement): void;
+export function restoreGeneratedAriaLabelledBy(target: HTMLElement): void;
 
 /**
  * Update `aria-labelledby` attribute value on the given element.

--- a/packages/a11y-base/src/aria-id-reference.d.ts
+++ b/packages/a11y-base/src/aria-id-reference.d.ts
@@ -4,37 +4,38 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * Removes the current `aria-describedby` attribute value on the given element.
- */
-export function removeAriaDescribedBy(target: HTMLElement): void;
+export type AriaIDReferenceConfig = {
+  newId: string | null;
+  oldId: string | null;
+  fromUser: boolean | null;
+};
 
 /**
- * Restore the generated `aria-describedby` attribute value on the given element.
+ * Sets a new ID reference for a {@link target} element and an ARIA {@link attr | attribute}.
+ *
+ * @param config.newId
+ *  The new ARIA ID reference to set. If `null`, the attribute is removed,
+ *  and `config.fromUser` is `true`, any stored values are restored. If there
+ *  are stored values and `config.fromUser` is `false`, then `config.newId`
+ *  is added to the stored values set.
+ * @param config.oldId
+ *  The ARIA ID reference to be removed from the attribute. If there are stored
+ *  values and `config.fromUser` is `false`, then `config.oldId` is removed from
+ *  the stored values set.
+ * @param config.fromUser
+ *  Indicates whether the function is called by the user or internally.
+ *  When `config.fromUser` is called with `true` for the first time,
+ *  the function will clear and store the attribute value for the given element.
  */
-export function restoreGeneratedAriaDescribedBy(target: HTMLElement): void;
+export function setAriaIDReference(target: HTMLElement, attr: string, config: AriaIDReferenceConfig): void;
 
 /**
- * Update `aria-describedby` attribute value on the given element.
+ * Removes the {@link attr | attribute} value of the given {@link target} element.
+ * It also stores the current value, if no stored values are present.
  */
-export declare function setAriaDescribedBy(
-  target: HTMLElement,
-  newId: string,
-  oldId?: string,
-  fromUser?: boolean,
-): void;
+export function removeAriaIDReference(target: HTMLElement, attr: string): void;
 
 /**
- * Removes the current `aria-labelledby` attribute value on the given element.
+ * Restores the generated values of the {@link attr | attribute} to the given {@link target} element.
  */
-export function removeAriaLabelledBy(target: HTMLElement): void;
-
-/**
- * Restore the generated `aria-labelledby` attribute value on the given element.
- */
-export function restoreGeneratedAriaLabelledBy(target: HTMLElement): void;
-
-/**
- * Update `aria-labelledby` attribute value on the given element.
- */
-export declare function setAriaLabelledBy(target: HTMLElement, newId: string, oldId?: string, fromUser?: boolean): void;
+export function restoreGeneratedAriaIDReference(target: HTMLElement, attr: string): void;

--- a/packages/a11y-base/src/aria-id-reference.js
+++ b/packages/a11y-base/src/aria-id-reference.js
@@ -54,6 +54,9 @@ function storeAriaIDReference(target, attr) {
     return;
   }
   const attributeMap = getAttrMap(attr);
+  if (attributeMap.has(target)) {
+    return;
+  }
   const values = deserializeAttributeValue(target.getAttribute(attr));
   attributeMap.set(target, new Set(values));
 }
@@ -64,17 +67,39 @@ function storeAriaIDReference(target, attr) {
  * @param {HTMLElement} target
  * @param {string} attr
  */
-function restoreGeneratedAriaIDReference(target, attr) {
+export function restoreGeneratedAriaIDReference(target, attr) {
   if (!target || !attr) {
     return;
   }
   addValueToAttribute(target, attr, serializeAttributeValue(getAttrMap(attr).get(target)));
 }
 
-function setAriaIDReference(target, attr, newId, oldId, fromUser = false) {
-  if (!target) {
+/**
+ * Sets a new ID reference for a target element and an ARIA attribute.
+ *
+ * @typedef {Object} AriaIdReferenceConfig
+ * @property {string | null | undefined} newId
+ * @property {string | null | undefined} oldId
+ * @property {boolean | null | undefined} fromUser
+ * @param {HTMLElement} target
+ * @param {string} attr
+ * @param {AriaIdReferenceConfig | null | undefined} config
+ * @param config.newId The new ARIA ID reference to set. If `null`, the attribute is removed,
+ * and `config.fromUser` is true, any stored values are restored. If there are stored values
+ * and `config.fromUser` is `false`, then `config.newId` is added to the stored values set.
+ * @param config.oldId The ARIA ID reference to be removed from the attribute. If there are
+ * stored values and `config.fromUser` is `false`, then `config.oldId` is removed from the
+ * stored values set.
+ * @param config.fromUser Indicates whether the function is called by the user or internally.
+ * When `config.fromUser` is called with `true` for the first time, the function will clear
+ * and stores the attribute value for the given element.
+ */
+export function setAriaIDReference(target, attr, config = { newId: null, oldId: null, fromUser: false }) {
+  if (!target || !attr) {
     return;
   }
+
+  const { newId, oldId, fromUser } = config;
 
   const attributeMap = getAttrMap(attr);
   const storedValues = attributeMap.get(target);
@@ -99,7 +124,6 @@ function setAriaIDReference(target, attr, newId, oldId, fromUser = false) {
       attributeMap.delete(target);
     }
 
-    // TODO update comment
     // If it's from user, then clear the attribute value before setting newId
     cleanAriaIDReference(target, attr);
   }
@@ -113,63 +137,13 @@ function setAriaIDReference(target, attr, newId, oldId, fromUser = false) {
 }
 
 /**
- * Restore the generated `aria-describedby` attribute value on the given element.
+ * Removes the {@link attr | attribute} value of the given {@link target} element.
+ * It also stores the current value, if no stored values are present.
  *
  * @param {HTMLElement} target
+ * @param {string} attr
  */
-export function restoreGeneratedAriaDescribedBy(target) {
-  restoreGeneratedAriaIDReference(target, 'aria-describedby');
-}
-
-/**
- * Removes the current `aria-describedby` attribute value on the given element.
- *
- * @param {HTMLElement} target
- */
-export function removeAriaDescribedBy(target) {
-  const attr = 'aria-describedby';
+export function removeAriaIDReference(target, attr) {
   storeAriaIDReference(target, attr);
   cleanAriaIDReference(target, attr);
-}
-
-/**
- * Update `aria-describedby` attribute value on the given element.
- *
- * @param {HTMLElement} target
- * @param {string} newId
- * @param {string} oldId
- */
-export function setAriaDescribedBy(target, newId, oldId, fromUser) {
-  setAriaIDReference(target, 'aria-describedby', newId, oldId, fromUser);
-}
-
-/**
- * Restore the generated `aria-labelledby` attribute value on the given element.
- *
- * @param {HTMLElement} target
- */
-export function restoreGeneratedAriaLabelledBy(target) {
-  restoreGeneratedAriaIDReference(target, 'aria-labelledby');
-}
-
-/**
- * Removes the current `aria-labelledby` attribute value on the given element.
- *
- * @param {HTMLElement} target
- */
-export function removeAriaLabelledBy(target) {
-  const attr = 'aria-labelledby';
-  storeAriaIDReference(target, attr);
-  cleanAriaIDReference(target, attr);
-}
-
-/**
- * Update `aria-labelledby` attribute value on the given element.
- *
- * @param {HTMLElement} target
- * @param {string} newId
- * @param {string} oldId
- */
-export function setAriaLabelledBy(target, newId, oldId, fromUser) {
-  setAriaIDReference(target, 'aria-labelledby', newId, oldId, fromUser);
 }

--- a/packages/a11y-base/src/aria-id-reference.js
+++ b/packages/a11y-base/src/aria-id-reference.js
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import {
+  addValueToAttribute,
+  deserializeAttributeValue,
+  removeValueFromAttribute,
+  serializeAttributeValue,
+} from '@vaadin/component-base/src/dom-utils.js';
+
+const attributeToTargets = new Map();
+
+/**
+ * Gets or creates a Set with the stored values for each element controlled by this helper
+ *
+ * @param {string} attr the attribute name used as key in the map
+ *
+ * @returns {WeakMap<HTMLElement, Set<string>} a weak map with the stored values for the elements being controlled by the helper
+ */
+function getAttrMap(attr) {
+  if (!attributeToTargets.has(attr)) {
+    attributeToTargets.set(attr, new WeakMap());
+  }
+  return attributeToTargets.get(attr);
+}
+
+/**
+ * Cleans the values set on the attribute to the given element.
+ * It also stores the current values in the map, if `storeValue` is `true`.
+ *
+ * @param {HTMLElement} target
+ * @param {string} attr the attribute to be cleared
+ * @param {boolean} storeValue whether or not the current value of the attribute should be stored on the map
+ * @returns
+ */
+function cleanAriaIDReference(target, attr) {
+  if (!target) {
+    return;
+  }
+
+  target.removeAttribute(attr);
+}
+
+/**
+ * Storing values of the accessible attributes in a Set inside of the WeakMap.
+ *
+ * @param {HTMLElement} target
+ * @param {string} attr the attribute to be stored
+ */
+function storeAriaIDReference(target, attr) {
+  if (!target || !attr) {
+    return;
+  }
+  const attributeMap = getAttrMap(attr);
+  const values = deserializeAttributeValue(target.getAttribute(attr));
+  attributeMap.set(target, new Set(values));
+}
+
+/**
+ * Restores the generated values of the attribute to the given element.
+ *
+ * @param {HTMLElement} target
+ * @param {string} attr
+ */
+function restoreGeneratedAriaIDReference(target, attr) {
+  if (!target || !attr) {
+    return;
+  }
+  addValueToAttribute(target, attr, serializeAttributeValue(getAttrMap(attr).get(target)));
+}
+
+function setAriaIDReference(target, attr, newId, oldId, fromUser = false) {
+  if (!target) {
+    return;
+  }
+
+  const attributeMap = getAttrMap(attr);
+  const storedValues = attributeMap.get(target);
+
+  if (!fromUser && !!storedValues) {
+    // If there's any stored values, it means the attribute is being handled by the user
+    // Replace the "oldId" with "newId" on the stored values set and leave
+    storedValues.delete(oldId);
+    storedValues.add(newId);
+    return;
+  }
+
+  if (fromUser) {
+    if (!storedValues) {
+      // If it's called from user and there's no stored values for the attribute,
+      // then store the current value
+      storeAriaIDReference(target, attr);
+    } else if (!newId) {
+      // If called from user with newId == null, it means the attribute will no longer
+      // be in control of the user and the stored values should be restored
+      // Removing the entry on the map for this target
+      attributeMap.delete(target);
+    }
+
+    // TODO update comment
+    // If it's from user, then clear the attribute value before setting newId
+    cleanAriaIDReference(target, attr);
+  }
+
+  removeValueFromAttribute(target, attr, oldId);
+
+  const attributeValue = !newId ? serializeAttributeValue(storedValues) : newId;
+  if (attributeValue) {
+    addValueToAttribute(target, attr, attributeValue);
+  }
+}
+
+/**
+ * Restore the generated `aria-describedby` attribute value on the given element.
+ *
+ * @param {HTMLElement} target
+ */
+export function restoreGeneratedAriaDescribedBy(target) {
+  restoreGeneratedAriaIDReference(target, 'aria-describedby');
+}
+
+/**
+ * Removes the current `aria-describedby` attribute value on the given element.
+ *
+ * @param {HTMLElement} target
+ */
+export function removeAriaDescribedBy(target) {
+  const attr = 'aria-describedby';
+  storeAriaIDReference(target, attr);
+  cleanAriaIDReference(target, attr);
+}
+
+/**
+ * Update `aria-describedby` attribute value on the given element.
+ *
+ * @param {HTMLElement} target
+ * @param {string} newId
+ * @param {string} oldId
+ */
+export function setAriaDescribedBy(target, newId, oldId, fromUser) {
+  setAriaIDReference(target, 'aria-describedby', newId, oldId, fromUser);
+}
+
+/**
+ * Restore the generated `aria-labelledby` attribute value on the given element.
+ *
+ * @param {HTMLElement} target
+ */
+export function restoreGeneratedAriaLabelledBy(target) {
+  restoreGeneratedAriaIDReference(target, 'aria-labelledby');
+}
+
+/**
+ * Removes the current `aria-labelledby` attribute value on the given element.
+ *
+ * @param {HTMLElement} target
+ */
+export function removeAriaLabelledBy(target) {
+  const attr = 'aria-labelledby';
+  storeAriaIDReference(target, attr);
+  cleanAriaIDReference(target, attr);
+}
+
+/**
+ * Update `aria-labelledby` attribute value on the given element.
+ *
+ * @param {HTMLElement} target
+ * @param {string} newId
+ * @param {string} oldId
+ */
+export function setAriaLabelledBy(target, newId, oldId, fromUser) {
+  setAriaIDReference(target, 'aria-labelledby', newId, oldId, fromUser);
+}

--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -97,7 +97,7 @@ export class FieldAriaController {
    * @private
    */
   __setLabelIdToAriaAttribute(labelId, oldLabelId) {
-    setAriaIDReference(this.__target, 'aria-labelledby', { newId: labelId, oldId: oldLabelId, fromUser: false });
+    setAriaIDReference(this.__target, 'aria-labelledby', { newId: labelId, oldId: oldLabelId });
   }
 
   /**

--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
+import { setAriaDescribedBy, setAriaLabelledBy } from '@vaadin/a11y-base/src/aria-id-reference.js';
 
 /**
  * A controller for managing ARIA attributes for a field element:
@@ -97,7 +97,7 @@ export class FieldAriaController {
    * @private
    */
   __setLabelIdToAriaAttribute(labelId, oldLabelId) {
-    this.__setAriaAttributeId('aria-labelledby', labelId, oldLabelId);
+    setAriaLabelledBy(this.__target, labelId, oldLabelId);
   }
 
   /**
@@ -108,11 +108,8 @@ export class FieldAriaController {
   __setErrorIdToAriaAttribute(errorId, oldErrorId) {
     // For groups, add all IDs to aria-labelledby rather than aria-describedby -
     // that should guarantee that it's announced when the group is entered.
-    if (this.__isGroupField) {
-      this.__setAriaAttributeId('aria-labelledby', errorId, oldErrorId);
-    } else {
-      this.__setAriaAttributeId('aria-describedby', errorId, oldErrorId);
-    }
+    const setAriaCallback = this.__isGroupField ? setAriaLabelledBy : setAriaDescribedBy;
+    setAriaCallback(this.__target, errorId, oldErrorId);
   }
 
   /**
@@ -123,11 +120,8 @@ export class FieldAriaController {
   __setHelperIdToAriaAttribute(helperId, oldHelperId) {
     // For groups, add all IDs to aria-labelledby rather than aria-describedby -
     // that should guarantee that it's announced when the group is entered.
-    if (this.__isGroupField) {
-      this.__setAriaAttributeId('aria-labelledby', helperId, oldHelperId);
-    } else {
-      this.__setAriaAttributeId('aria-describedby', helperId, oldHelperId);
-    }
+    const setAriaCallback = this.__isGroupField ? setAriaLabelledBy : setAriaDescribedBy;
+    setAriaCallback(this.__target, helperId, oldHelperId);
   }
 
   /**
@@ -148,25 +142,6 @@ export class FieldAriaController {
       this.__target.setAttribute('aria-required', 'true');
     } else {
       this.__target.removeAttribute('aria-required');
-    }
-  }
-
-  /**
-   * @param {string | null | undefined} newId
-   * @param {string | null | undefined} oldId
-   * @private
-   */
-  __setAriaAttributeId(attr, newId, oldId) {
-    if (!this.__target) {
-      return;
-    }
-
-    if (oldId) {
-      removeValueFromAttribute(this.__target, attr, oldId);
-    }
-
-    if (newId) {
-      addValueToAttribute(this.__target, attr, newId);
     }
   }
 }

--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { setAriaDescribedBy, setAriaLabelledBy } from '@vaadin/a11y-base/src/aria-id-reference.js';
+import { setAriaIDReference } from '@vaadin/a11y-base/src/aria-id-reference.js';
 
 /**
  * A controller for managing ARIA attributes for a field element:
@@ -97,7 +97,7 @@ export class FieldAriaController {
    * @private
    */
   __setLabelIdToAriaAttribute(labelId, oldLabelId) {
-    setAriaLabelledBy(this.__target, labelId, oldLabelId);
+    setAriaIDReference(this.__target, 'aria-labelledby', { newId: labelId, oldId: oldLabelId, fromUser: false });
   }
 
   /**
@@ -108,8 +108,8 @@ export class FieldAriaController {
   __setErrorIdToAriaAttribute(errorId, oldErrorId) {
     // For groups, add all IDs to aria-labelledby rather than aria-describedby -
     // that should guarantee that it's announced when the group is entered.
-    const setAriaCallback = this.__isGroupField ? setAriaLabelledBy : setAriaDescribedBy;
-    setAriaCallback(this.__target, errorId, oldErrorId);
+    const ariaAttribute = this.__isGroupField ? 'aria-labelledby' : 'aria-describedby';
+    setAriaIDReference(this.__target, ariaAttribute, { newId: errorId, oldId: oldErrorId, fromUser: false });
   }
 
   /**
@@ -120,8 +120,8 @@ export class FieldAriaController {
   __setHelperIdToAriaAttribute(helperId, oldHelperId) {
     // For groups, add all IDs to aria-labelledby rather than aria-describedby -
     // that should guarantee that it's announced when the group is entered.
-    const setAriaCallback = this.__isGroupField ? setAriaLabelledBy : setAriaDescribedBy;
-    setAriaCallback(this.__target, helperId, oldHelperId);
+    const ariaAttribute = this.__isGroupField ? 'aria-labelledby' : 'aria-describedby';
+    setAriaIDReference(this.__target, ariaAttribute, { newId: helperId, oldId: oldHelperId, fromUser: false });
   }
 
   /**

--- a/packages/a11y-base/test/aria-id-reference.test.js
+++ b/packages/a11y-base/test/aria-id-reference.test.js
@@ -1,11 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import {
-  removeAriaDescribedBy,
-  removeAriaLabelledBy,
-  restoreGeneratedAriaDescribedBy,
-  restoreGeneratedAriaLabelledBy,
-  setAriaDescribedBy,
-  setAriaLabelledBy,
+  removeAriaIDReference,
+  restoreGeneratedAriaIDReference,
+  setAriaIDReference,
 } from '../src/aria-id-reference.js';
 
 describe('aria-id-reference', () => {
@@ -15,104 +12,103 @@ describe('aria-id-reference', () => {
     element = document.createElement('span');
   });
 
-  function runTestsForAttribute(attribute) {
-    describe(attribute, () => {
-      const setAriaIDReference = attribute === 'aria-labelledby' ? setAriaLabelledBy : setAriaDescribedBy;
-      const removeAriaIdReference = attribute === 'aria-labelledby' ? removeAriaLabelledBy : removeAriaDescribedBy;
-      const restoreGeneratedAriaIdReference =
-        attribute === 'aria-labelledby' ? restoreGeneratedAriaLabelledBy : restoreGeneratedAriaDescribedBy;
+  const attribute = 'aria-labelledby';
 
-      it(`should not set ${attribute} if setAriaLabelledBy is called with 'null'`, () => {
-        setAriaIDReference(element, null, null, false);
-        expect(element.hasAttribute(attribute)).to.be.false;
-      });
+  it(`should not set ${attribute} if setAriaLabelledBy is called with 'null'`, () => {
+    setAriaIDReference(element, attribute, { newId: null, oldId: null, fromUser: false });
+    expect(element.hasAttribute(attribute)).to.be.false;
+  });
 
-      it(`should set ${attribute} to element`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        expect(element.getAttribute(attribute)).to.equal('id-0');
-      });
+  it(`should set ${attribute} to element`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    expect(element.getAttribute(attribute)).to.equal('id-0');
+  });
 
-      it(`should replace previous ${attribute} set`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        setAriaIDReference(element, 'id-1', 'id-0', false);
-        expect(element.getAttribute(attribute)).to.equal('id-1');
-      });
+  it(`should replace previous ${attribute} set`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'id-1', oldId: 'id-0', fromUser: false });
+    expect(element.getAttribute(attribute)).to.equal('id-1');
+  });
 
-      it(`should be possible to append ${attribute} value`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        setAriaIDReference(element, 'id-1', null, false);
+  it(`should be possible to append ${attribute} value`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'id-1', oldId: null, fromUser: false });
 
-        expect(element.getAttribute(attribute)).to.contain('id-0');
-        expect(element.getAttribute(attribute)).to.contain('id-1');
-      });
+    expect(element.getAttribute(attribute)).to.contain('id-0');
+    expect(element.getAttribute(attribute)).to.contain('id-1');
+  });
 
-      it(`should be able to clear ${attribute}`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        setAriaIDReference(element, 'id-1', null, false);
+  it(`should be able to clear ${attribute}`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'id-1', oldId: null, fromUser: false });
 
-        removeAriaIdReference(element);
+    removeAriaIDReference(element, attribute);
 
-        expect(element.hasAttribute(attribute)).to.be.false;
-      });
+    expect(element.hasAttribute(attribute)).to.be.false;
+  });
 
-      it(`should be able to replace generated ${attribute} with a custom value`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        setAriaIDReference(element, 'custom-id', null, true);
+  it(`should be able to replace generated ${attribute} with a custom value`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'custom-id', oldId: null, fromUser: true });
 
-        expect(element.getAttribute(attribute)).to.equal('custom-id');
-      });
+    expect(element.getAttribute(attribute)).to.equal('custom-id');
+  });
 
-      it(`should be able to restore generated ${attribute} value after a custom value is set`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        setAriaIDReference(element, 'id-1', null, false);
-        setAriaIDReference(element, 'custom-id', null, true);
-        setAriaIDReference(element, null, 'custom-id', true);
+  it(`should be able to restore generated ${attribute} value after a custom value is set`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'id-1', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'custom-id', oldId: null, fromUser: true });
+    setAriaIDReference(element, attribute, { newId: null, oldId: 'custom-id', fromUser: true });
 
-        expect(element.getAttribute(attribute)).to.contain('id-0');
-        expect(element.getAttribute(attribute)).to.contain('id-1');
-        expect(element.getAttribute(attribute)).to.not.contain('custom-id');
-      });
+    expect(element.getAttribute(attribute)).to.contain('id-0');
+    expect(element.getAttribute(attribute)).to.contain('id-1');
+    expect(element.getAttribute(attribute)).to.not.contain('custom-id');
+  });
 
-      it(`should be able to change user generated ${attribute}`, () => {
-        setAriaIDReference(element, 'custom-id-0', null, true);
-        setAriaIDReference(element, 'custom-id-1', 'custom-id-0', true);
+  it(`should be able to change user generated ${attribute}`, () => {
+    setAriaIDReference(element, attribute, { newId: 'custom-id-0', oldId: null, fromUser: true });
+    setAriaIDReference(element, attribute, { newId: 'custom-id-1', oldId: 'custom-id-0', fromUser: true });
 
-        expect(element.getAttribute(attribute)).to.equal('custom-id-1');
-      });
+    expect(element.getAttribute(attribute)).to.equal('custom-id-1');
+  });
 
-      it(`should be able to clear and restore genereated ${attribute} value`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        removeAriaIdReference(element);
-        restoreGeneratedAriaIdReference(element);
+  it(`should be able to clear and restore genereated ${attribute} value`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    removeAriaIDReference(element, attribute);
+    restoreGeneratedAriaIDReference(element, attribute);
 
-        expect(element.getAttribute(attribute)).to.equal('id-0');
-      });
+    expect(element.getAttribute(attribute)).to.equal('id-0');
+  });
 
-      it(`should not set ${attribute} when generated ${attribute} is updated`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        setAriaIDReference(element, 'custom-id-1', null, true);
+  it(`should not set ${attribute} when generated ${attribute} is updated`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'custom-id-1', oldId: null, fromUser: true });
 
-        setAriaIDReference(element, 'id-1', 'id-0', false);
-        expect(element.getAttribute(attribute)).to.equal('custom-id-1');
-      });
+    setAriaIDReference(element, attribute, { newId: 'id-1', oldId: 'id-0', fromUser: false });
+    expect(element.getAttribute(attribute)).to.equal('custom-id-1');
+  });
 
-      it(`should keep ${attribute} value if newId == oldId`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        setAriaIDReference(element, 'id-0', 'id-0', false);
+  it(`should keep ${attribute} value if newId == oldId`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: 'id-0', fromUser: false });
 
-        expect(element.getAttribute(attribute)).to.equal('id-0');
-      });
+    expect(element.getAttribute(attribute)).to.equal('id-0');
+  });
 
-      it(`should restore ${attribute} correctly when user value is the same as the previous one`, () => {
-        setAriaIDReference(element, 'id-0', null, false);
-        setAriaIDReference(element, 'id-0', null, true);
-        setAriaIDReference(element, null, null, true);
+  it(`should restore ${attribute} correctly when user value is the same as the previous one`, () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: true });
+    setAriaIDReference(element, attribute, { newId: null, oldId: null, fromUser: true });
 
-        expect(element.getAttribute(attribute)).to.be.equal('id-0');
-      });
-    });
-  }
+    expect(element.getAttribute(attribute)).to.be.equal('id-0');
+  });
 
-  runTestsForAttribute('aria-describedby');
-  runTestsForAttribute('aria-labelledby');
+  it('should restore generated value if removeAriaIDReference is called after custom value had been set', () => {
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+    setAriaIDReference(element, attribute, { newId: 'custom-id-0', oldId: null, fromUser: true });
+
+    removeAriaIDReference(element, attribute);
+    restoreGeneratedAriaIDReference(element, attribute);
+    expect(element.getAttribute(attribute)).to.be.equal('id-0');
+  });
 });

--- a/packages/a11y-base/test/aria-id-reference.test.js
+++ b/packages/a11y-base/test/aria-id-reference.test.js
@@ -1,0 +1,118 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  removeAriaDescribedBy,
+  removeAriaLabelledBy,
+  restoreGeneratedAriaDescribedBy,
+  restoreGeneratedAriaLabelledBy,
+  setAriaDescribedBy,
+  setAriaLabelledBy,
+} from '../src/aria-id-reference.js';
+
+describe('aria-id-reference', () => {
+  let element;
+
+  beforeEach(() => {
+    element = document.createElement('span');
+  });
+
+  function runTestsForAttribute(attribute) {
+    describe(attribute, () => {
+      const setAriaIDReference = attribute === 'aria-labelledby' ? setAriaLabelledBy : setAriaDescribedBy;
+      const removeAriaIdReference = attribute === 'aria-labelledby' ? removeAriaLabelledBy : removeAriaDescribedBy;
+      const restoreGeneratedAriaIdReference =
+        attribute === 'aria-labelledby' ? restoreGeneratedAriaLabelledBy : restoreGeneratedAriaDescribedBy;
+
+      it(`should not set ${attribute} if setAriaLabelledBy is called with 'null'`, () => {
+        setAriaIDReference(element, null, null, false);
+        expect(element.hasAttribute(attribute)).to.be.false;
+      });
+
+      it(`should set ${attribute} to element`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        expect(element.getAttribute(attribute)).to.equal('id-0');
+      });
+
+      it(`should replace previous ${attribute} set`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        setAriaIDReference(element, 'id-1', 'id-0', false);
+        expect(element.getAttribute(attribute)).to.equal('id-1');
+      });
+
+      it(`should be possible to append ${attribute} value`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        setAriaIDReference(element, 'id-1', null, false);
+
+        expect(element.getAttribute(attribute)).to.contain('id-0');
+        expect(element.getAttribute(attribute)).to.contain('id-1');
+      });
+
+      it(`should be able to clear ${attribute}`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        setAriaIDReference(element, 'id-1', null, false);
+
+        removeAriaIdReference(element);
+
+        expect(element.hasAttribute(attribute)).to.be.false;
+      });
+
+      it(`should be able to replace generated ${attribute} with a custom value`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        setAriaIDReference(element, 'custom-id', null, true);
+
+        expect(element.getAttribute(attribute)).to.equal('custom-id');
+      });
+
+      it(`should be able to restore generated ${attribute} value after a custom value is set`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        setAriaIDReference(element, 'id-1', null, false);
+        setAriaIDReference(element, 'custom-id', null, true);
+        setAriaIDReference(element, null, 'custom-id', true);
+
+        expect(element.getAttribute(attribute)).to.contain('id-0');
+        expect(element.getAttribute(attribute)).to.contain('id-1');
+        expect(element.getAttribute(attribute)).to.not.contain('custom-id');
+      });
+
+      it(`should be able to change user generated ${attribute}`, () => {
+        setAriaIDReference(element, 'custom-id-0', null, true);
+        setAriaIDReference(element, 'custom-id-1', 'custom-id-0', true);
+
+        expect(element.getAttribute(attribute)).to.equal('custom-id-1');
+      });
+
+      it(`should be able to clear and restore genereated ${attribute} value`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        removeAriaIdReference(element);
+        restoreGeneratedAriaIdReference(element);
+
+        expect(element.getAttribute(attribute)).to.equal('id-0');
+      });
+
+      it(`should not set ${attribute} when generated ${attribute} is updated`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        setAriaIDReference(element, 'custom-id-1', null, true);
+
+        setAriaIDReference(element, 'id-1', 'id-0', false);
+        expect(element.getAttribute(attribute)).to.equal('custom-id-1');
+      });
+
+      it(`should keep ${attribute} value if newId == oldId`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        setAriaIDReference(element, 'id-0', 'id-0', false);
+
+        expect(element.getAttribute(attribute)).to.equal('id-0');
+      });
+
+      it(`should restore ${attribute} correctly when user value is the same as the previous one`, () => {
+        setAriaIDReference(element, 'id-0', null, false);
+        setAriaIDReference(element, 'id-0', null, true);
+        setAriaIDReference(element, null, null, true);
+
+        expect(element.getAttribute(attribute)).to.be.equal('id-0');
+      });
+    });
+  }
+
+  runTestsForAttribute('aria-describedby');
+  runTestsForAttribute('aria-labelledby');
+});

--- a/packages/component-base/src/dom-utils.d.ts
+++ b/packages/component-base/src/dom-utils.d.ts
@@ -14,6 +14,16 @@
 export function getAncestorRootNodes(node: Node): Node[];
 
 /**
+ * Takes a string with values separated by space and returns a set the values
+ */
+export function deserializeAttributeValue(value: string): Set<string>;
+
+/**
+ * Takes a set of string values and returns a string with values separated by space
+ */
+export function serializeAttributeValue(values: Set<string>): string;
+
+/**
  * Adds a value to an attribute containing space-delimited values.
  */
 export function addValueToAttribute(element: HTMLElement, attr: string, value: string): void;

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -41,10 +41,12 @@ export function getAncestorRootNodes(node) {
 }
 
 /**
+ * Takes a string with values separated by space and returns a set the values
+ *
  * @param {string} value
  * @return {Set<string>}
  */
-function deserializeAttributeValue(value) {
+export function deserializeAttributeValue(value) {
   if (!value) {
     return new Set();
   }
@@ -53,10 +55,15 @@ function deserializeAttributeValue(value) {
 }
 
 /**
+ * Takes a set of string values and returns a string with values separated by space
+ *
  * @param {Set<string>} values
  * @return {string}
  */
-function serializeAttributeValue(values) {
+export function serializeAttributeValue(values) {
+  if (!values) {
+    return '';
+  }
   return [...values].join(' ');
 }
 

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -61,10 +61,7 @@ export function deserializeAttributeValue(value) {
  * @return {string}
  */
 export function serializeAttributeValue(values) {
-  if (!values) {
-    return '';
-  }
-  return [...values].join(' ');
+  return values ? [...values].join(' ') : '';
 }
 
 /**


### PR DESCRIPTION
## Description

Continuation of #5622

These helpers allow custom or generated ID references to be used for `aria-labelledby` and `aria-describedby`. This is needed to make it possible to set custom values to `aria-label`, `aria-labelledby`, and `aria-describedy`.

There are 3 helper functions created:

- The `setAriaIDReference ` functions take a 4th optional parameter `fromUser`, which is used to tell apart if the ID reference is being set from the default behavior (for instance, `aria-labellebdy` set when the `label` attribute changes) or from the user of the component to change the default value to a custom one.
- The `removeAriaIDReference` functions store the current attribute value and remove it. The main usage is for removing `aria-labelledby` to let setting `aria-label`, without losing the previous value. _Probably `removeAriaDescribedBy` existence can be discussed._
- The `restoreGeneratedAriaIDReference` functions, which set back the current stored values for that element to the corresponding attribute and delete the cached values.


Part of https://github.com/vaadin/flow-components/issues/4708


## Type of change

- [ ] Bugfix
- [X] Feature