### PR TITLE
fix: Register Lumo global styles before other styles

### DIFF
--- a/packages/vaadin-lumo-styles/badge-global.js
+++ b/packages/vaadin-lumo-styles/badge-global.js
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { badge } from './badge.js';
+import { addLumoGlobalStyles } from './global.js';
+
+addLumoGlobalStyles('badge', badge);

--- a/packages/vaadin-lumo-styles/color-global.js
+++ b/packages/vaadin-lumo-styles/color-global.js
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { color } from './color.js';
+import { addLumoGlobalStyles } from './global.js';
+
+addLumoGlobalStyles('color', color);

--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -81,7 +81,7 @@ const colorBase = css`
   }
 `;
 
-addLumoGlobalStyles('color-base', colorBase);
+addLumoGlobalStyles('color-props', colorBase);
 
 const color = css`
   [theme~='dark'] {

--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -5,6 +5,7 @@
  */
 import './version.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { addLumoGlobalStyles } from './global.js';
 
 const colorBase = css`
   :host {
@@ -80,9 +81,7 @@ const colorBase = css`
   }
 `;
 
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${colorBase.toString().replace(':host', 'html')}</style>`;
-document.head.appendChild($tpl.content);
+addLumoGlobalStyles('color-base', colorBase);
 
 const color = css`
   [theme~='dark'] {

--- a/packages/vaadin-lumo-styles/global.js
+++ b/packages/vaadin-lumo-styles/global.js
@@ -8,17 +8,5 @@ export const addLumoGlobalStyles = (id, ...styles) => {
     .join('\n')
     .replace(':host', 'html');
 
-  // Add the first tag before the first existing <style> so that Lumo provides defaults and does not override application styles. Add the rest of the styles after the existing "lumo-" style.
-  const lastExistingLumoTag = Array.from(document.querySelectorAll(`head > style[id^='${prefix}']`)).pop();
-  if (!lastExistingLumoTag || !lastExistingLumoTag.nextElementSibling) {
-    const firstNonLumoStyleOrLinkTag = document.querySelector('head > style') || document.querySelector('head > link');
-    if (firstNonLumoStyleOrLinkTag) {
-      document.head.insertBefore(styleTag, firstNonLumoStyleOrLinkTag);
-    } else {
-      // No style or link tags present
-      document.head.append(styleTag);
-    }
-  } else {
-    lastExistingLumoTag.parentElement.insertBefore(styleTag, lastExistingLumoTag.nextElementSibling);
-  }
+  document.head.insertAdjacentElement('afterbegin', styleTag);
 };

--- a/packages/vaadin-lumo-styles/global.js
+++ b/packages/vaadin-lumo-styles/global.js
@@ -1,0 +1,24 @@
+const prefix = 'lumo-';
+
+export const addLumoGlobalStyles = (id, ...styles) => {
+  const styleTag = document.createElement('style');
+  styleTag.id = `${prefix}${id}`;
+  styleTag.textContent = styles
+    .map((style) => style.toString())
+    .join('\n')
+    .replace(':host', 'html');
+
+  // Add the first tag before the first existing <style> so that Lumo provides defaults and does not override application styles. Add the rest of the styles after the existing "lumo-" style.
+  const lastExistingLumoTag = Array.from(document.querySelectorAll(`head > style[id^='${prefix}']`)).pop();
+  if (!lastExistingLumoTag || !lastExistingLumoTag.nextElementSibling) {
+    const firstNonLumoStyleOrLinkTag = document.querySelector('head > style') || document.querySelector('head > link');
+    if (firstNonLumoStyleOrLinkTag) {
+      document.head.insertBefore(styleTag, firstNonLumoStyleOrLinkTag);
+    } else {
+      // No style or link tags present
+      document.head.append(styleTag);
+    }
+  } else {
+    lastExistingLumoTag.parentElement.insertBefore(styleTag, lastExistingLumoTag.nextElementSibling);
+  }
+};

--- a/packages/vaadin-lumo-styles/sizing.js
+++ b/packages/vaadin-lumo-styles/sizing.js
@@ -5,6 +5,7 @@
  */
 import './version.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { addLumoGlobalStyles } from './global.js';
 
 const sizing = css`
   :host {
@@ -23,8 +24,6 @@ const sizing = css`
   }
 `;
 
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${sizing.toString().replace(':host', 'html')}</style>`;
-document.head.appendChild($tpl.content);
+addLumoGlobalStyles('sizing', sizing);
 
 export { sizing };

--- a/packages/vaadin-lumo-styles/sizing.js
+++ b/packages/vaadin-lumo-styles/sizing.js
@@ -24,6 +24,6 @@ const sizing = css`
   }
 `;
 
-addLumoGlobalStyles('sizing', sizing);
+addLumoGlobalStyles('sizing-props', sizing);
 
 export { sizing };

--- a/packages/vaadin-lumo-styles/spacing.js
+++ b/packages/vaadin-lumo-styles/spacing.js
@@ -32,6 +32,6 @@ const spacing = css`
   }
 `;
 
-addLumoGlobalStyles('spacing', spacing);
+addLumoGlobalStyles('spacing-props', spacing);
 
 export { spacing };

--- a/packages/vaadin-lumo-styles/spacing.js
+++ b/packages/vaadin-lumo-styles/spacing.js
@@ -5,6 +5,7 @@
  */
 import './version.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { addLumoGlobalStyles } from './global.js';
 
 const spacing = css`
   :host {
@@ -31,8 +32,6 @@ const spacing = css`
   }
 `;
 
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${spacing.toString().replace(':host', 'html')}</style>`;
-document.head.appendChild($tpl.content);
+addLumoGlobalStyles('spacing', spacing);
 
 export { spacing };

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -37,6 +37,6 @@ const globals = css`
   }
 `;
 
-addLumoGlobalStyles('style', style);
+addLumoGlobalStyles('style-props', style);
 
 export { globals, style };

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -5,6 +5,7 @@
  */
 import './version.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { addLumoGlobalStyles } from './global.js';
 
 const style = css`
   :host {
@@ -36,8 +37,6 @@ const globals = css`
   }
 `;
 
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${style.toString().replace(':host', 'html')}$</style>`;
-document.head.appendChild($tpl.content);
+addLumoGlobalStyles('style', style);
 
 export { globals, style };

--- a/packages/vaadin-lumo-styles/test/visual/badge.test.js
+++ b/packages/vaadin-lumo-styles/test/visual/badge.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../badge-all.js';
+import '../../badge-global.js';
 
 describe('badge', () => {
   it('flex-shrink', async () => {

--- a/packages/vaadin-lumo-styles/test/visual/badge.test.js
+++ b/packages/vaadin-lumo-styles/test/visual/badge.test.js
@@ -1,10 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import { badge } from '../../badge.js';
-
-const badgeStyle = document.createElement('style');
-badgeStyle.textContent = badge.cssText;
-document.head.appendChild(badgeStyle);
+import '../../badge-all.js';
 
 describe('badge', () => {
   it('flex-shrink', async () => {

--- a/packages/vaadin-lumo-styles/typography-global.js
+++ b/packages/vaadin-lumo-styles/typography-global.js
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { addLumoGlobalStyles } from './global.js';
+import { typography } from './typography.js';
+
+addLumoGlobalStyles('typography', typography);

--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -5,6 +5,7 @@
  */
 import './version.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { addLumoGlobalStyles } from './global.js';
 
 const font = css`
   :host {
@@ -123,9 +124,6 @@ const typography = css`
 `;
 
 registerStyles('', typography, { moduleId: 'lumo-typography' });
-
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${font.toString().replace(':host', 'html')}</style>`;
-document.head.appendChild($tpl.content);
+addLumoGlobalStyles('font', font);
 
 export { font, typography };

--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -124,6 +124,6 @@ const typography = css`
 `;
 
 registerStyles('', typography, { moduleId: 'lumo-typography' });
-addLumoGlobalStyles('font', font);
+addLumoGlobalStyles('typography-props', font);
 
 export { font, typography };

--- a/packages/vaadin-lumo-styles/user-colors.js
+++ b/packages/vaadin-lumo-styles/user-colors.js
@@ -29,5 +29,5 @@ const userColors = css`
   }
 `;
 
-addLumoGlobalStyles('user-colors', userColors);
+addLumoGlobalStyles('user-color-props', userColors);
 export { userColors };

--- a/packages/vaadin-lumo-styles/user-colors.js
+++ b/packages/vaadin-lumo-styles/user-colors.js
@@ -5,6 +5,7 @@
  */
 import './version.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { addLumoGlobalStyles } from './global.js';
 
 const userColors = css`
   :host {
@@ -28,8 +29,5 @@ const userColors = css`
   }
 `;
 
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<style>${userColors.toString().replace(':host', 'html')}</style>`;
-document.head.appendChild($tpl.content);
-
+addLumoGlobalStyles('user-colors', userColors);
 export { userColors };

--- a/packages/vaadin-lumo-styles/utility-global.js
+++ b/packages/vaadin-lumo-styles/utility-global.js
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { addLumoGlobalStyles } from './global.js';
+import { utility } from './utility.js';
+
+addLumoGlobalStyles('utility', utility);


### PR DESCRIPTION
## Description

This ensures the styles do not override any application styles

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
