### PR TITLE
fix: process all intersection observer event entries

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -474,11 +474,8 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
     this.__onOverlayOpen = this.__onOverlayOpen.bind(this);
 
     this.__targetVisibilityObserver = new IntersectionObserver(
-      ([entry]) => {
-        // workaround for #5667
-        if (entry.rootBounds) {
-          this.__onTargetVisibilityChange(entry.isIntersecting);
-        }
+      (entries) => {
+        entries.forEach((entry) => this.__onTargetVisibilityChange(entry.isIntersecting));
       },
       { threshold: 1 },
     );

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -475,7 +475,10 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
 
     this.__targetVisibilityObserver = new IntersectionObserver(
       ([entry]) => {
-        this.__onTargetVisibilityChange(entry.isIntersecting);
+        // workaround for #5667
+        if (entry.rootBounds) {
+          this.__onTargetVisibilityChange(entry.isIntersecting);
+        }
       },
       { threshold: 1 },
     );

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -694,8 +694,8 @@ describe('vaadin-tooltip', () => {
     beforeEach(async () => {
       container = fixtureSync(`
           <div>
-              <div id='first'>First</div>
-              <div id='second'>Second</div>
+              <div id="first">First</div>
+              <div id="second">Second</div>
           </div>
         `);
       target = container.querySelector('#second');

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -119,66 +119,40 @@ describe('vaadin-tooltip', () => {
   describe('target', () => {
     let target;
 
-    describe('basic', () => {
-      beforeEach(() => {
-        target = document.createElement('div');
-        target.textContent = 'Target';
-        document.body.appendChild(target);
-      });
-
-      afterEach(() => {
-        document.body.removeChild(target);
-      });
-
-      it('should set target as overlay positionTarget', () => {
-        tooltip.target = target;
-        expect(overlay.positionTarget).to.eql(target);
-      });
-
-      it('should set aria-describedby on the target element', () => {
-        tooltip.target = target;
-        expect(target.getAttribute('aria-describedby')).to.equal(overlay.id);
-      });
-
-      it('should retain existing aria-describedby attribute', () => {
-        target.setAttribute('aria-describedby', 'foo');
-        tooltip.target = target;
-
-        expect(target.getAttribute('aria-describedby')).to.contain('foo');
-        expect(target.getAttribute('aria-describedby')).to.contain(overlay.id);
-      });
-
-      it('should restore aria-describedby when clearing target', () => {
-        target.setAttribute('aria-describedby', 'foo');
-        tooltip.target = target;
-
-        tooltip.target = null;
-        expect(target.getAttribute('aria-describedby')).to.equal('foo');
-      });
+    beforeEach(() => {
+      target = document.createElement('div');
+      target.textContent = 'Target';
+      document.body.appendChild(target);
     });
 
-    describe('moving', () => {
-      let container;
+    afterEach(() => {
+      document.body.removeChild(target);
+    });
 
-      beforeEach(async () => {
-        container = fixtureSync(`
-          <div>
-              <div id='first'>First</div>
-              <div id='second'>Second</div>
-          </div>
-        `);
-        target = container.querySelector('#second');
-        tooltip.target = target;
-        await nextFrame();
-      });
+    it('should set target as overlay positionTarget', () => {
+      tooltip.target = target;
+      expect(overlay.positionTarget).to.eql(target);
+    });
 
-      it('should still open overlay when target element was moved', async () => {
-        const firstElement = container.querySelector('#first');
-        firstElement.before(target);
-        await waitForIntersectionObserver();
-        mouseenter(target);
-        expect(overlay.opened).to.be.true;
-      });
+    it('should set aria-describedby on the target element', () => {
+      tooltip.target = target;
+      expect(target.getAttribute('aria-describedby')).to.equal(overlay.id);
+    });
+
+    it('should retain existing aria-describedby attribute', () => {
+      target.setAttribute('aria-describedby', 'foo');
+      tooltip.target = target;
+
+      expect(target.getAttribute('aria-describedby')).to.contain('foo');
+      expect(target.getAttribute('aria-describedby')).to.contain(overlay.id);
+    });
+
+    it('should restore aria-describedby when clearing target', () => {
+      target.setAttribute('aria-describedby', 'foo');
+      tooltip.target = target;
+
+      tooltip.target = null;
+      expect(target.getAttribute('aria-describedby')).to.equal('foo');
     });
   });
 
@@ -710,6 +684,30 @@ describe('vaadin-tooltip', () => {
       otherOverlay.opened = true;
       await nextRender();
 
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('moving target', () => {
+    let container, target;
+
+    beforeEach(async () => {
+      container = fixtureSync(`
+          <div>
+              <div id='first'>First</div>
+              <div id='second'>Second</div>
+          </div>
+        `);
+      target = container.querySelector('#second');
+      tooltip.target = target;
+      await nextFrame();
+    });
+
+    it('should still open overlay when target element was moved', async () => {
+      const firstElement = container.querySelector('#first');
+      firstElement.before(target);
+      await waitForIntersectionObserver();
+      mouseenter(target);
       expect(overlay.opened).to.be.true;
     });
   });


### PR DESCRIPTION
## Description

`vaadin-tooltip` uses an `IntersectionObserver` to watch for the target _full_ visibility. If the user scrolls the page in a way that the target of the tooltip is only partially visible (or not visible at all), the tooltip overlay - if previously shown - is automatically hidden too. This helps to prevent a situation when we would show a tooltip for an element which is not visible.

Issue #5667 reported buggy behaviour of this mechanism when rendering tooltips using lit $repeat directive. However, further investigation showed that it's a more general problem, and the buggy behaviour is observed when you are simply _moving_ elements from place to place (which is what $repeat internally does) - but it's buggy only in Chromium based browsers. 

Even though all involved elements always stay in the viewport Chromium-based browsers trigger `IntersectionObserver` with a pair of `IntersectionObserverEntry` instances when you move one of the elements. This does not happen every time, but only in specific situations - e.g. moving the element _before_ some other element in the DOM. Surprisingly, it does not happen when moving in the other direction. Firefox and Safari do not produce any IntersectionObserver events whatsoever.

As I said, Chromium produces two instances of  `IntersectionObserverEntry` and supplies it to the observer callback at once. From the content of the entries, it seems like the first entry is for an act of removing the element from the viewport (with `isIntersecting==false`) and the second entry is for placing it back to the viewport (with `isIntersecting==true`). I've reported this behaviour to [Chromium bug database](https://bugs.chromium.org/p/chromium/issues/detail?id=1425039), because I don't think it's right - it should be clarified the least.

The problem in our code was that the Observer callback was processing always only the _first_ entry from the `IntersectionObserverEntries` list. The code probably assumed, that because we are always observing only a single target, we will always get a single entry in the callback. In the case of buggy behavior, this is not true. Our code processed only the entry where `isIntersecting==false`, making it think that the target element was removed from the viewport and never returned.

I think the reasonable fix here is to always process all the entries which are passed to the `IntersectionObserver` callback. That'll force the tooltip to process also the second entry in the list, where `isIntersecting` is again set to `true`.

Fixes #5667

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
