### PR TITLE
chore: allow windows developers to work with this repo without hassle

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+max_line_length = 120
+
+[*.md]
+max_line_length = off

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# For more detail why this file is necessary for seamless cooperation of *nix and windows developers, please read the following:
+# https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+
+# Set the default behavior for text files, in case people don't have core.autocrlf set.
+# Handle line endings automatically for files detected as text and leave all files detected as binary untouched.
+* text=auto
+
+# The above will handle all files NOT found below.
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.js    text
+*.ts    text
+*.yml   text
+*.html  text
+*.json  text
+*.md    text
+*.css   text
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.png   binary
+*.jpg   binary

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ packages/icons/test/visual/screenshots/failed
 # VSCode user configuration folders
 .vscode
 
+# IntelliJ project files
+.idea
+
 # Generated web-types JSON files
 web-types.json
 web-types.lit.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "trailingComma": "all",
   "tabWidth": 2,
   "singleQuote": true,
-  "htmlWhitespaceSensitivity": "strict"
+  "htmlWhitespaceSensitivity": "strict",
+  "endOfLine": "auto"
 }

--- a/scripts/buildWebtypes.js
+++ b/scripts/buildWebtypes.js
@@ -33,7 +33,8 @@ const additionalAttributes = [
  * Get packages using lerna, excluding blacklisted packages
  */
 function getRelevantPackages() {
-  const output = execSync('./node_modules/.bin/lerna ls --json --loglevel silent');
+  const pathToLerna = path.normalize('./node_modules/.bin/lerna');
+  const output = execSync(`${pathToLerna} ls --json --loglevel silent`);
   const allPackages = JSON.parse(output.toString()).map((project) => project.name.replace('@vaadin/', ''));
   return allPackages.filter((pkg) => !blacklistedPackages.some((blacklistedPackage) => pkg.match(blacklistedPackage)));
 }

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -48,7 +48,8 @@ const isLockfileChanged = () => {
  * Get packages changed since main.
  */
 const getChangedPackages = () => {
-  const output = execSync('./node_modules/.bin/lerna la --since origin/main --json --loglevel silent');
+  const pathToLerna = path.normalize('./node_modules/.bin/lerna');
+  const output = execSync(`${pathToLerna} la --since origin/main --json --loglevel silent`);
   return JSON.parse(output.toString()).map((project) => project.name.replace('@vaadin/', ''));
 };
 
@@ -192,7 +193,7 @@ const getTestRunnerHtml = (theme) => (testFramework) =>
         /* Force development mode for element-mixin */
         localStorage.setItem('vaadin.developmentmode.force', true);
       </script>
-      <script type="module" src="${testFramework}"></script>
+      <script type='module' src='${testFramework}'></script>
     </body>
   </html>
 `;


### PR DESCRIPTION
## Description
- The default value of [`endOfLine` check](https://prettier.io/docs/en/options.html#end-of-line) in Prettier changed from `auto` to `LF` in version 2.0.0.  This is very inconvenient for Windows developers. Because when you install `git` on Winwows, you'll automatically have `core.autocrlf` set to `true`, which will basically change all `LF` line endings to `CRLF` line endings when you clone the repository. Git then ensures that `CRLF` is converted back to `LF` on commit. However, because you have `CRLF` locally, Prettier checks fail. The solution to this is to **not** enforce line endings by Prettier, but actually, let `git` handle it automatically.
  -  I've set Prettier 'endOfLine' to `auto` again, so Prettier ignores it
  - Introduced `.gitattributes` file, which enables git to handle `CRLF` to `LF` conversion for Windows developers automatically, regadless of their local settings. Topic is explained [here](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings?platform=windows).
- Introduced very basic .editorconfig - basically to remove the need to manually set the line length to 120 in editors which respect .editorconfig (for example Intellij Idea does and .editorconfig by default overrides any settings made by the developer)
- Additionally fix of some *.js scripts so they are runnable also on Windows machines
- Also added `.idea` directory to .gitingore so IntelliJ Idea project files are ignored when you work with the repository in Idea

## Type of change

[x] Chore
