### PR TITLE
refactor: use _getVisibleRows() when iterating visible rows

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -5,7 +5,7 @@
  */
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
-import { getBodyRowCells, iterateChildren, updateCellsPart, updateState } from './vaadin-grid-helpers.js';
+import { getBodyRowCells, updateCellsPart, updateState } from './vaadin-grid-helpers.js';
 
 /**
  * @private

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -425,12 +425,10 @@ export const DataProviderMixin = (superClass) =>
           this._debouncerApplyCachedData = Debouncer.debounce(this._debouncerApplyCachedData, timeOut.after(0), () => {
             this._setLoading(false);
 
-            iterateChildren(this.$.items, (row) => {
-              if (!row.hidden) {
-                const cachedItem = this._cache.getItemForIndex(row.index);
-                if (cachedItem) {
-                  this._getItem(row.index, row);
-                }
+            this._getVisibleRows().forEach((row) => {
+              const cachedItem = this._cache.getItemForIndex(row.index);
+              if (cachedItem) {
+                this._getItem(row.index, row);
               }
             });
 


### PR DESCRIPTION
## Description

The PR slightly simplifies the grid data provider mixin by making it use `_getVisibleRows()` instead of `iterateChildren()`.

## Type of change

- [x] Refactor
