### PR TITLE
fix: aria id reference should be set after remove/restore are called

### DIFF
--- a/packages/a11y-base/src/aria-id-reference.js
+++ b/packages/a11y-base/src/aria-id-reference.js
@@ -71,7 +71,14 @@ export function restoreGeneratedAriaIDReference(target, attr) {
   if (!target || !attr) {
     return;
   }
-  addValueToAttribute(target, attr, serializeAttributeValue(getAttrMap(attr).get(target)));
+  const attributeMap = getAttrMap(attr);
+  const values = attributeMap.get(target);
+  if (!values || values.size === 0) {
+    target.removeAttribute(attr);
+  } else {
+    addValueToAttribute(target, attr, serializeAttributeValue(values));
+  }
+  attributeMap.delete(target);
 }
 
 /**

--- a/packages/a11y-base/test/aria-id-reference.test.js
+++ b/packages/a11y-base/test/aria-id-reference.test.js
@@ -111,4 +111,19 @@ describe('aria-id-reference', () => {
     restoreGeneratedAriaIDReference(element, attribute);
     expect(element.getAttribute(attribute)).to.be.equal('id-0');
   });
+
+  it(`should be able to set generated ${attribute} after remove/restore are called`, () => {
+    removeAriaIDReference(element, attribute);
+    restoreGeneratedAriaIDReference(element, attribute);
+    setAriaIDReference(element, attribute, { newId: 'id-0', oldId: null, fromUser: false });
+
+    expect(element.getAttribute(attribute)).to.be.equal('id-0');
+  });
+
+  it(`should not add empty ${attribute} if no value was stored`, () => {
+    removeAriaIDReference(element, attribute);
+    restoreGeneratedAriaIDReference(element, attribute);
+
+    expect(element.getAttribute(attribute)).to.be.null;
+  });
 });


### PR DESCRIPTION
## Description

Fix an issue where calling `removeAriaIDReference` followed by `restoreGeneratedAriaIDReference` would prevent any generated ID reference from being set because the presence of `Set` on the targets map makes `setAriaIDReference` assume that the user is still controlling the attribute.

The map entry should be deleted after `restoreGeneratedAriaIDReference` is called to fix this issue.

## Type of change

- [X] Bugfix
- [ ] Feature
