### PR TITLE
fix: open detail when summary child components clicked

### DIFF
--- a/packages/accordion/test/accordion.test.js
+++ b/packages/accordion/test/accordion.test.js
@@ -32,7 +32,7 @@ describe('vaadin-accordion', () => {
           <div>Content 2</div>
         </vaadin-accordion-panel>
         <vaadin-accordion-panel>
-          <vaadin-accordion-heading slot="summary">Panel 3</vaadin-accordion-heading>
+          <vaadin-accordion-heading slot="summary"><div>Panel 3</div></vaadin-accordion-heading>
           <div>Content 3</div>
         </vaadin-accordion-panel>
       </vaadin-accordion>
@@ -137,6 +137,11 @@ describe('vaadin-accordion', () => {
       accordion.addEventListener('opened-changed', spy);
       getHeading(1).click();
       expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should open panel when component in summary is clicked', () => {
+      getHeading(2).firstChild.click();
+      expect(accordion.items[2].opened).to.be.true;
     });
   });
 

--- a/packages/details/src/collapsible-mixin.js
+++ b/packages/details/src/collapsible-mixin.js
@@ -64,10 +64,15 @@ export const CollapsibleMixin = (superClass) =>
       // Only handle click and not keydown, because `vaadin-details-summary` uses `ButtonMixin`
       // that already covers this logic, and `vaadin-accordion-heading` uses native `<button>`.
       this.addEventListener('click', (event) => {
-        if (event.target === this.focusElement) {
+        if (this._isChildOfFocusElement(event.target)) {
           this.opened = !this.opened;
         }
       });
+    }
+
+    /** @private */
+    _isChildOfFocusElement(node) {
+      return this.focusElement && this.focusElement.contains(node);
     }
 
     /** @private */

--- a/packages/details/src/collapsible-mixin.js
+++ b/packages/details/src/collapsible-mixin.js
@@ -63,16 +63,13 @@ export const CollapsibleMixin = (superClass) =>
 
       // Only handle click and not keydown, because `vaadin-details-summary` uses `ButtonMixin`
       // that already covers this logic, and `vaadin-accordion-heading` uses native `<button>`.
-      this.addEventListener('click', (event) => {
-        if (this._isChildOfFocusElement(event.target)) {
+      this.addEventListener('click', ({ target }) => {
+        const summary = this.focusElement;
+
+        if (summary && (target === summary || summary.contains(target))) {
           this.opened = !this.opened;
         }
       });
-    }
-
-    /** @private */
-    _isChildOfFocusElement(node) {
-      return this.focusElement && this.focusElement.contains(node);
     }
 
     /** @private */

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -63,9 +63,15 @@ describe('vaadin-details', () => {
       details.opened = true;
       expect(contentNode.getAttribute('aria-hidden')).to.equal('false');
     });
+
+    it('should not close when a content is clicked', () => {
+      details.opened = true;
+      contentNode.click();
+      expect(details.opened).to.be.true;
+    });
   });
 
-  ['default', 'custom'].forEach((type) => {
+  ['default', 'custom', 'component'].forEach((type) => {
     const fixtures = {
       default: `
         <vaadin-details summary="Summary">
@@ -75,6 +81,12 @@ describe('vaadin-details', () => {
       custom: `
         <vaadin-details>
           <vaadin-details-summary slot="summary">Summary</vaadin-details-summary>
+          <div>Content</div>
+        </vaadin-details>
+      `,
+      component: `
+        <vaadin-details>
+          <vaadin-details-summary slot="summary"><div>Summary<div></vaadin-details-summary>
           <div>Content</div>
         </vaadin-details>
       `,
@@ -94,6 +106,17 @@ describe('vaadin-details', () => {
 
         summary.click();
         expect(details.opened).to.be.false;
+      });
+
+      it(`should toggle opened on ${type} summary child click`, () => {
+        const child = summary.firstChild;
+        if (child.nodeType === Node.ELEMENT_NODE) {
+          child.click();
+          expect(details.opened).to.be.true;
+
+          child.click();
+          expect(details.opened).to.be.false;
+        }
       });
 
       it(`should toggle opened on ${type} summary Enter`, async () => {


### PR DESCRIPTION
## Description

The `vaadin-detail` component summary can also contain elements or other components, like this:

```
<vaadin-details>
     <vaadin-details-summary slot="summary">
         <div>Summary<div>
     </vaadin-details-summary>
     <div>Content</div>
</vaadin-details>
```

There is even flow API for it. The unit tests for `vaadin-details` and `vaadin-accordion` did not cover such usecase.
I've added tests for this usecase and then fixed the referenced issue -> when the summary contained child elements, then clicks on this child elemens did not cause the detail to open/close. The click event is now processed not only when the `focusElement` is clicked, but also when any of it's children is clicked. 

Fixes vaadin/flow-components#4795

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
