### PR TITLE
fix: close notification on detach only if not immediately reattached

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,1 @@
+  <component name="Vcs.Log.Tabs.Properties">

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -404,7 +404,11 @@ class Notification extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(Pol
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.opened = false;
+    queueMicrotask(() => {
+      if (!this.isConnected) {
+        this.opened = false;
+      }
+    });
   }
 
   /**

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -45,6 +45,14 @@ describe('vaadin-notification', () => {
     expect(notification.opened).to.be.false;
   });
 
+  it('should stay open after immediate reattach', async () => {
+    expect(notification.opened).to.be.true;
+    const parent = notification.parentNode;
+    sinon.spy(notification, '_openedChanged');
+    parent.appendChild(notification);
+    expect(notification._openedChanged.called).to.be.false;
+  });
+
   describe('vaadin-notification-container', () => {
     it('should be in the body when notification opens', () => {
       expect(document.body.querySelectorAll('vaadin-notification-container').length).to.be.equal(1);

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -50,7 +50,7 @@ describe('vaadin-notification', () => {
     const parent = notification.parentNode;
     parent.appendChild(notification);
     await aTimeout(0);
-    expect(notification.opened).to.be.false;
+    expect(notification.opened).to.be.true;
   });
 
   describe('vaadin-notification-container', () => {

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -38,9 +38,10 @@ describe('vaadin-notification', () => {
     expect(getComputedStyle(notification).display).to.equal('none');
   });
 
-  it('should close on detach', () => {
+  it('should close on detach', async () => {
     expect(notification.opened).to.be.true;
     notification.remove();
+    await aTimeout(0);
     expect(notification.opened).to.be.false;
   });
 

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -48,9 +48,9 @@ describe('vaadin-notification', () => {
   it('should stay open after immediate reattach', async () => {
     expect(notification.opened).to.be.true;
     const parent = notification.parentNode;
-    sinon.spy(notification, '_openedChanged');
     parent.appendChild(notification);
-    expect(notification._openedChanged.called).to.be.false;
+    await aTimeout(0);
+    expect(notification.opened).to.be.false;
   });
 
   describe('vaadin-notification-container', () => {


### PR DESCRIPTION
## Description

As a [solution](https://github.com/vaadin/web-components/pull/3830) to a previous [issue](https://github.com/vaadin/web-components/issues/3823), notification is closed on detach. But in cases where there are changes in the children of the parent element, notification can be detached and immediately get reattached. In those cases, the notification should stay open without flickering. This PR wraps the execution of close on detach in a microtask. This way, if the notification is still attached at that point, the closing operation will not be executed.

Fixes #5665

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.