### PR TITLE
fix: set only vertical margins of headings to zero

### DIFF
--- a/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
+++ b/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
@@ -8,7 +8,7 @@ registerStyles(
     [part='header'] ::slotted(h3) {
       margin-top: 0 !important;
       margin-bottom: 0 !important;
-      margin-inline-start: calc(var(--lumo-space-l) - var(--lumo-space-m)) !important;
+      margin-inline-start: calc(var(--lumo-space-l) - var(--lumo-space-m));
     }
 
     [part='message'] {

--- a/packages/crud/theme/lumo/vaadin-crud-styles.js
+++ b/packages/crud/theme/lumo/vaadin-crud-styles.js
@@ -130,7 +130,7 @@ registerStyles(
       [part='header'] ::slotted(h3) {
         margin-top: 0 !important;
         margin-bottom: 0 !important;
-        margin-inline-start: var(--lumo-space-s) !important;
+        margin-inline-start: var(--lumo-space-s);
       }
     `,
   ],

--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -54,7 +54,8 @@ const typography = css`
   :where(h1, h2, h3, h4, h5, h6) {
     font-weight: 600;
     line-height: var(--lumo-line-height-xs);
-    margin: 0;
+    margin-block-start: 0;
+    margin-block-end: 0;
   }
 
   :where(h1) {

--- a/packages/vaadin-lumo-styles/typography.js
+++ b/packages/vaadin-lumo-styles/typography.js
@@ -54,8 +54,7 @@ const typography = css`
   :where(h1, h2, h3, h4, h5, h6) {
     font-weight: 600;
     line-height: var(--lumo-line-height-xs);
-    margin-block-start: 0;
-    margin-block-end: 0;
+    margin-block: 0;
   }
 
   :where(h1) {


### PR DESCRIPTION
## Description

In Vaadin 24.0 [heading margins were set to zero](https://github.com/vaadin/web-components/issues/4595). However, this affected not only vertical margins but also horizontal ones. This caused issues in some of the components, fixed by adding `!important` to the right places (see [this PR](https://github.com/vaadin/web-components/pull/5329)).

However, additional places where this is causing issues appeared, like placing a heading in a `vaadin-from-layout`.
@rolfsmeds suggested the following solution:

> Come to think of it, by far the simplest solution would be to replace `margin:0;` on the headings with `margin-block-start:0; margin-block-end:0;` to set the vertical margins to 0 without affecting horizontal margins.

So this PR is introducing it. This also removed the need to have those `!important` modifiers which were introduced in the [previous PR](https://github.com/vaadin/web-components/pull/5329).

Fixes #5673

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
