### PR TITLE
fix: do not preserve bad input on value property change

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -626,8 +626,10 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
         this.__updateValue(parsedObj);
       }
     } else {
-      // If user input can not be parsed, keep it.
-      if (value !== '') {
+      // If the user input can not be parsed, set a flag
+      // that prevents `__valueChanged` from removing the input
+      // after setting the value property to an empty string below.
+      if (this.value !== '' && value !== '') {
         this.__keepInvalidInput = true;
       }
 

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -68,9 +68,16 @@ describe('time-picker', () => {
       expect(timePicker.value).to.be.equal('');
     });
 
-    it('should propagate value to the inputElement', () => {
+    it('should propagate value property to the input element', () => {
       timePicker.value = '12:00';
       expect(inputElement.value).to.be.equal('12:00');
+    });
+
+    it('should not preserve bad input on value property change', () => {
+      setInputValue(timePicker, 'invalid');
+      enter(inputElement);
+      timePicker.value = '12:00';
+      expect(inputElement.value).to.equal('12:00');
     });
 
     it('should format input value consistently when committing same input value', () => {
@@ -178,18 +185,6 @@ describe('time-picker', () => {
       timePicker.value = '12:00';
       timePicker.value = null;
       expect(timePicker.value).to.equal('');
-    });
-
-    it('should display the new value on value property change', () => {
-      timePicker.value = '12:00';
-      expect(inputElement.value).to.equal('12:00');
-    });
-
-    it('should not preserve bad input on value property change', () => {
-      setInputValue(timePicker, 'invalid');
-      enter(inputElement);
-      timePicker.value = '12:00';
-      expect(inputElement.value).to.equal('12:00');
     });
   });
 

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -179,6 +179,18 @@ describe('time-picker', () => {
       timePicker.value = null;
       expect(timePicker.value).to.equal('');
     });
+
+    it('should display the new value on value property change', () => {
+      timePicker.value = '12:00';
+      expect(inputElement.value).to.equal('12:00');
+    });
+
+    it('should not preserve bad input on value property change', () => {
+      setInputValue(timePicker, 'invalid');
+      enter(inputElement);
+      timePicker.value = '12:00';
+      expect(inputElement.value).to.equal('12:00');
+    });
   });
 
   describe('toggle overlay', () => {


### PR DESCRIPTION
## Description

The PR prevents `time-picker` from setting `__keepInvalidInput` when the `value` property doesn't change. This in turn prevents the value property observer from mistakenly preserving bad input on the possible next value property change.

Fixes #5695

## Type of change

- [x] Bugfix
