### PR TITLE
refactor: debounce tasks ran after creating grid rows

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -7,7 +7,7 @@ import './vaadin-grid-column.js';
 import './vaadin-grid-styles.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { TabindexMixin } from '@vaadin/a11y-base/src/tabindex-mixin.js';
-import { microTask } from '@vaadin/component-base/src/async.js';
+import { animationFrame, microTask } from '@vaadin/component-base/src/async.js';
 import { isAndroid, isChrome, isFirefox, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
@@ -742,7 +742,7 @@ class Grid extends ElementMixin(
 
     this.__afterCreateScrollerRowsDebouncer = Debouncer.debounce(
       this.__afterCreateScrollerRowsDebouncer,
-      microTask,
+      animationFrame,
       () => {
         this._afterScroll();
         this.__itemsReceived();

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -5,7 +5,6 @@
  */
 import './vaadin-grid-column.js';
 import './vaadin-grid-styles.js';
-import { beforeNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { TabindexMixin } from '@vaadin/a11y-base/src/tabindex-mixin.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
@@ -741,12 +740,14 @@ class Grid extends ElementMixin(
       );
     }
 
-    beforeNextRender(this, () => {
-      this._updateFirstAndLastColumn();
-      this._resetKeyboardNavigation();
-      this._afterScroll();
-      this.__itemsReceived();
-    });
+    this.__afterCreateScrollerRowsDebouncer = Debouncer.debounce(
+      this.__afterCreateScrollerRowsDebouncer,
+      microTask,
+      () => {
+        this._afterScroll();
+        this.__itemsReceived();
+      },
+    );
     return rows;
   }
 


### PR DESCRIPTION
## Description

Debounce the tasks scheduled to be run after virtualizer requests new rows from the grid.

The change has a 6% impact on the `rendertime` metric in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

## Type of change

Performance enhancement