### PR TITLE
feat: add getDeepActiveElement helper to focus utils

### DIFF
--- a/packages/a11y-base/src/focus-utils.d.ts
+++ b/packages/a11y-base/src/focus-utils.d.ts
@@ -8,7 +8,7 @@
  * Returns the actually focused element by traversing shadow
  * trees recursively to ensure it's the leaf element.
  */
-export declare function getDeepActiveElement(): Element | null;
+export declare function getDeepActiveElement(): Element;
 
 /**
  * Returns true if the window has received a keydown

--- a/packages/a11y-base/src/focus-utils.d.ts
+++ b/packages/a11y-base/src/focus-utils.d.ts
@@ -5,6 +5,12 @@
  */
 
 /**
+ * Returns the actually focused element by traversing shadow
+ * trees recursively to ensure it's the leaf element.
+ */
+export declare function getDeepActiveElement(): Element | null;
+
+/**
  * Returns true if the window has received a keydown
  * event since the last mousedown event.
  */

--- a/packages/a11y-base/src/focus-utils.js
+++ b/packages/a11y-base/src/focus-utils.js
@@ -27,6 +27,20 @@ window.addEventListener(
 );
 
 /**
+ * Returns the actually focused element by traversing shadow
+ * trees recursively to ensure it's the leaf element.
+ *
+ * @return {Element}
+ */
+export function getDeepActiveElement() {
+  let host = document.activeElement || document.body;
+  while (host.shadowRoot && host.shadowRoot.activeElement) {
+    host = host.shadowRoot.activeElement;
+  }
+  return host;
+}
+
+/**
  * Returns true if the window has received a keydown
  * event since the last mousedown event.
  *


### PR DESCRIPTION
## Description

Extracted this function to focus utils in order to have it properly tested without relying on implicit overlay unit tests:

https://github.com/vaadin/web-components/blob/4065e6c5f3525ce77ae425c6147a390ef59c9c08/packages/overlay/src/vaadin-overlay.js#L754-L762

Note, this helper [also exists](https://github.com/ing-bank/lion/blob/d938e464b499bf48460829be0eeba596a41bd724/packages/ui/components/overlays/src/utils/get-deep-active-element.js#L8) in Lion Web Components (our libraries are similar and we copy each other's homework).
Furthermore, newly added unit tests are actually adapted from [Lion overlays utils tests](https://github.com/ing-bank/lion/blob/d938e464b499bf48460829be0eeba596a41bd724/packages/ui/components/overlays/test/utils-tests/active-element.test.js#L5) with a few small tweaks.

## Type of change

- Internal feature / refactor