### PR TITLE
feat: forced colors support

### DIFF
--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -50,6 +50,15 @@ export const buttonStyles = css`
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  @media (forced-colors: active) {
+    :host {
+      outline: 1px solid;
+    }
+    :host([focused]) {
+      outline-width: 2px;
+    }
+  }
 `;
 
 export const buttonTemplate = (html) => html`

--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -55,6 +55,7 @@ export const buttonStyles = css`
     :host {
       outline: 1px solid;
     }
+
     :host([focused]) {
       outline-width: 2px;
     }

--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -54,6 +54,7 @@ export const buttonStyles = css`
   @media (forced-colors: active) {
     :host {
       outline: 1px solid;
+      outline-offset: -1px;
     }
 
     :host([focused]) {

--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -63,8 +63,8 @@ export const checkboxStyles = css`
     :host(:is([checked], [indeterminate])) [part='checkbox']::after {
       outline: 1px solid;
     }
-    :host([focus-ring]) [part='checkbox'],
-    :host([focus-ring]) [part='checkbox']::after {
+    :host([focused]) [part='checkbox'],
+    :host([focused]) [part='checkbox']::after {
       outline-width: 2px;
     }
   }

--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -59,10 +59,12 @@ export const checkboxStyles = css`
   @media (forced-colors: active) {
     [part='checkbox'] {
       outline: 1px solid;
+      outline-offset: -1px;
     }
 
     :host(:is([checked], [indeterminate])) [part='checkbox']::after {
       outline: 1px solid;
+      outline-offset: -1px;
     }
 
     :host([focused]) [part='checkbox'],

--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -56,15 +56,16 @@ export const checkboxStyles = css`
     -webkit-appearance: none;
   }
 
-  /* Normally invisible outline for forced-colors support */
-  [part='checkbox'] {
-    outline: 1px solid transparent;
-  }
-  :host(:is([checked], [indeterminate])) [part='checkbox']::after {
-    outline: 1px solid transparent;
-  }
-  :host([focus-ring]) [part='checkbox'],
-  :host([focus-ring]) [part='checkbox']::after {
-    outline-width: 2px;
+  @media (forced-colors: active) {
+    [part='checkbox'] {
+      outline: 1px solid;
+    }
+    :host(:is([checked], [indeterminate])) [part='checkbox']::after {
+      outline: 1px solid;
+    }
+    :host([focus-ring]) [part='checkbox'],
+    :host([focus-ring]) [part='checkbox']::after {
+      outline-width: 2px;
+    }
   }
 `;

--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -60,9 +60,11 @@ export const checkboxStyles = css`
     [part='checkbox'] {
       outline: 1px solid;
     }
+
     :host(:is([checked], [indeterminate])) [part='checkbox']::after {
       outline: 1px solid;
     }
+
     :host([focused]) [part='checkbox'],
     :host([focused]) [part='checkbox']::after {
       outline-width: 2px;

--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -55,4 +55,16 @@ export const checkboxStyles = css`
     align-self: stretch;
     -webkit-appearance: none;
   }
+
+  /* Normally invisible outline for forced-colors support */
+  [part='checkbox'] {
+    outline: 1px solid transparent;
+  }
+  :host(:is([checked], [indeterminate])) [part='checkbox']::after {
+    outline: 1px solid transparent;
+  }
+  :host([focus-ring]) [part='checkbox'],
+  :host([focus-ring]) [part='checkbox']::after {
+    outline-width: 2px;
+  }
 `;

--- a/packages/context-menu/src/vaadin-menu-overlay-styles.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-styles.js
@@ -23,4 +23,10 @@ export const styles = css`
   [part='overlay'] {
     background-color: #fff;
   }
+
+  @media (forced-colors: active) {
+    [part='overlay'] {
+      outline: 3px solid !important;
+    }
+  }
 `;

--- a/packages/date-picker/src/vaadin-date-picker-overlay.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay.js
@@ -18,6 +18,12 @@ registerStyles(
     [part~='content'] {
       flex: auto;
     }
+
+    @media (forced-colors: active) {
+      [part='overlay'] {
+        outline: 3px solid;
+      }
+    }
   `,
   {
     moduleId: 'vaadin-date-picker-overlay-styles',

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -63,6 +63,15 @@ class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
         :host([week-numbers]) [part~='date'] {
           width: 12.5%;
         }
+
+        @media (forced-colors: active) {
+          [part~='date'][part~='focused'] {
+            outline: 1px solid;
+          }
+          [part~='date'][part~='selected'] {
+            outline: 3px solid;
+          }
+        }
       </style>
 
       <div part="month-header" id="month-header" aria-hidden="true">[[_getTitle(month, i18n.monthNames)]]</div>

--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -80,6 +80,12 @@ registerStyles(
     :host([has-bounds-set]) [part='overlay'] {
       max-width: none;
     }
+
+    @media (forced-colors: active) {
+      [part='overlay'] {
+        outline: 3px solid !important;
+      }
+    }
   `,
   { moduleId: 'vaadin-dialog-overlay-styles' },
 );

--- a/packages/field-base/src/styles/field-shared-styles.js
+++ b/packages/field-base/src/styles/field-shared-styles.js
@@ -26,4 +26,12 @@ export const fieldShared = css`
   :host(:not([has-label])) [part='label'] {
     display: none;
   }
+
+  /* Normally invisible outline for forced-colors support */
+  [part='input-field'] {
+    outline: inset 1px transparent;
+  }
+  :host([focus-ring]) [part='input-field'] {
+    outline-width: 2px;
+  }
 `;

--- a/packages/field-base/src/styles/field-shared-styles.js
+++ b/packages/field-base/src/styles/field-shared-styles.js
@@ -29,7 +29,8 @@ export const fieldShared = css`
 
   /* Normally invisible outline for forced-colors support */
   [part='input-field'] {
-    outline: inset 1px transparent;
+    outline: 1px solid transparent;
+    outline-offset: -1px;
   }
   :host([focus-ring]) [part='input-field'] {
     outline-width: 2px;

--- a/packages/field-base/src/styles/field-shared-styles.js
+++ b/packages/field-base/src/styles/field-shared-styles.js
@@ -32,7 +32,7 @@ export const fieldShared = css`
       outline: 1px solid;
       outline-offset: -1px;
     }
-    :host([focus-ring]) [part='input-field'] {
+    :host([focused]) [part='input-field'] {
       outline-width: 2px;
     }
   }

--- a/packages/field-base/src/styles/field-shared-styles.js
+++ b/packages/field-base/src/styles/field-shared-styles.js
@@ -27,12 +27,13 @@ export const fieldShared = css`
     display: none;
   }
 
-  /* Normally invisible outline for forced-colors support */
-  [part='input-field'] {
-    outline: 1px solid transparent;
-    outline-offset: -1px;
-  }
-  :host([focus-ring]) [part='input-field'] {
-    outline-width: 2px;
+  @media (forced-colors: active) {
+    [part='input-field'] {
+      outline: 1px solid;
+      outline-offset: -1px;
+    }
+    :host([focus-ring]) [part='input-field'] {
+      outline-width: 2px;
+    }
   }
 `;

--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -338,6 +338,21 @@ registerStyles(
       right: 0;
       left: auto;
     }
+
+    @media (forced-colors: active) {
+      [part~='selected-row'] [part~='first-column-cell']::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        border: 2px solid;
+      }
+      [part~='focused-cell']::before {
+        outline: 2px solid !important;
+        outline-offset: -1px;
+      }
+    }
   `,
   { moduleId: 'vaadin-grid-styles' },
 );

--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -348,6 +348,7 @@ registerStyles(
         bottom: 0;
         border: 2px solid;
       }
+
       [part~='focused-cell']::before {
         outline: 2px solid !important;
         outline-offset: -1px;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -479,6 +479,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       `
         ${tag}[has-value] input::placeholder {
           color: transparent !important;
+          forced-color-adjust: none;
         }
       `,
     ];

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -181,6 +181,12 @@ class NotificationCard extends ThemableMixin(PolymerElement) {
         [part='overlay'] {
           pointer-events: auto;
         }
+
+        @media (forced-colors: active) {
+          [part='overlay'] {
+            outline: 1px solid;
+          }
+        }
       </style>
 
       <div part="overlay">

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -184,7 +184,7 @@ class NotificationCard extends ThemableMixin(PolymerElement) {
 
         @media (forced-colors: active) {
           [part='overlay'] {
-            outline: 1px solid;
+            outline: 3px solid;
           }
         }
       </style>

--- a/packages/progress-bar/src/vaadin-progress-bar-styles.js
+++ b/packages/progress-bar/src/vaadin-progress-bar-styles.js
@@ -34,6 +34,7 @@ export const progressBarStyles = css`
     [part='bar'] {
       outline: 1px solid;
     }
+
     [part='value'] {
       background-color: AccentColor !important;
       forced-color-adjust: none;

--- a/packages/progress-bar/src/vaadin-progress-bar-styles.js
+++ b/packages/progress-bar/src/vaadin-progress-bar-styles.js
@@ -29,4 +29,14 @@ export const progressBarStyles = css`
   :host([dir='rtl']) [part='value'] {
     transform-origin: 100% 50%;
   }
+
+  @media (forced-colors: active) {
+    [part='bar'] {
+      outline: 1px solid;
+    }
+    [part='value'] {
+      background-color: AccentColor !important;
+      forced-color-adjust: none;
+    }
+  }
 `;

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -120,6 +120,7 @@ class RadioButton extends LabelMixin(
         @media (forced-colors: active) {
           [part='radio'] {
             outline: 1px solid;
+            outline-offset: -1px;
           }
           :host([focused]) [part='radio'] {
             outline-width: 2px;

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -121,7 +121,7 @@ class RadioButton extends LabelMixin(
           [part='radio'] {
             outline: 1px solid;
           }
-          :host([focus-ring]) [part='radio'] {
+          :host([focused]) [part='radio'] {
             outline-width: 2px;
           }
         }

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -116,6 +116,14 @@ class RadioButton extends LabelMixin(
           align-self: stretch;
           -webkit-appearance: none;
         }
+
+        /* Normally invisible outline for forced-colors support */
+        [part='radio'] {
+          outline: 1px solid transparent;
+        }
+        :host([focus-ring]) [part='radio'] {
+          outline-width: 2px;
+        }
       </style>
       <div class="vaadin-radio-button-container">
         <div part="radio" aria-hidden="true"></div>

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -117,12 +117,13 @@ class RadioButton extends LabelMixin(
           -webkit-appearance: none;
         }
 
-        /* Normally invisible outline for forced-colors support */
-        [part='radio'] {
-          outline: 1px solid transparent;
-        }
-        :host([focus-ring]) [part='radio'] {
-          outline-width: 2px;
+        @media (forced-colors: active) {
+          [part='radio'] {
+            outline: 1px solid;
+          }
+          :host([focus-ring]) [part='radio'] {
+            outline-width: 2px;
+          }
         }
       </style>
       <div class="vaadin-radio-button-container">

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-toolbar-styles.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-toolbar-styles.js
@@ -35,8 +35,16 @@ export const buttonsStyles = css`
     outline: none;
   }
 
-  [part~='toolbar-button'][on] {
-    background-color: #eee;
+  @media (forced-colors: active) {
+    [part~='toolbar-button']:focus,
+    [part~='toolbar-button']:hover {
+      outline: 1px solid !important;
+    }
+
+    [part~='toolbar-button'][on] {
+      outline: 2px solid;
+      outline-offset: -1px;
+    }
   }
 
   [part~='toolbar-button']::before {

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -14,6 +14,11 @@ registerStyles(
       align-items: flex-start;
       justify-content: flex-start;
     }
+    @media (forced-colors: active) {
+      [part='overlay'] {
+        outline: 3px solid;
+      }
+    }
   `,
   { moduleId: 'vaadin-select-overlay-styles' },
 );

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -200,6 +200,16 @@ class SplitLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
           left: 50%;
           transform: translate3d(-50%, -50%, 0);
         }
+
+        @media (forced-colors: active) {
+          [part~='splitter'] {
+            outline: 1px solid;
+          }
+          [part~='handle']::after {
+            background-color: black !important;
+            forced-color-adjust: none;
+          }
+        }
       </style>
       <slot id="primary" name="primary"></slot>
       <div part="splitter" id="splitter">

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -206,7 +206,7 @@ class SplitLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
             outline: 1px solid;
           }
           [part~='handle']::after {
-            background-color: black !important;
+            background-color: AccentColor !important;
             forced-color-adjust: none;
           }
         }

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -49,6 +49,16 @@ class Tab extends ElementMixin(ThemableMixin(ItemMixin(ControllerMixin(PolymerEl
         :host([hidden]) {
           display: none !important;
         }
+
+        @media (forced-colors: active) {
+          :host([focused]) {
+            outline: 1px solid;
+            outline-offset: -1px;
+          }
+          :host([selected]) {
+            border-bottom: 2px solid;
+          }
+        }
       </style>
       <slot></slot>
       <slot name="tooltip"></slot>

--- a/packages/tabs/theme/lumo/vaadin-tab-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tab-styles.js
@@ -49,6 +49,7 @@ registerStyles(
         outline: 1px solid;
         outline-offset: -1px;
       }
+
       :host([orientation='vertical'][selected]) {
         border-bottom: none;
         border-left: 2px solid;

--- a/packages/tabs/theme/lumo/vaadin-tab-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tab-styles.js
@@ -44,6 +44,17 @@ registerStyles(
       min-width: 0;
     }
 
+    @media (forced-colors: active) {
+      :host([focused]) {
+        outline: 1px solid;
+        outline-offset: -1px;
+      }
+      :host([orientation='vertical'][selected]) {
+        border-bottom: none;
+        border-left: 2px solid;
+      }
+    }
+
     :host(:hover),
     :host([focus-ring]) {
       color: var(--lumo-body-text-color);

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -33,6 +33,12 @@ registerStyles(
     :host([position^='end'][end-aligned]) [part='overlay'] {
       margin-inline-end: var(--vaadin-tooltip-offset-end, 0);
     }
+
+    @media (forced-colors: active) {
+      [part='overlay'] {
+        outline: 1px dashed;
+      }
+    }
   `,
   { moduleId: 'vaadin-tooltip-overlay-styles' },
 );


### PR DESCRIPTION
## Description

CSS adjustments in various components for improved `forced-colors` mode (e.g. Windows High Contrast Mode) support. The adjustments primarily consist of applying `outline`s to various elements. All adjustments are scoped in `@media(forced-colors:active)` blocks, or apply the `forced-color-adjust: none;` mechanism, and thus have no effect outside of `forced-colors` mode.

Fixes #5060

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] ~I have added tests to ensure my change is effective and works as intended.~ (No way to test with `forced-colors` mode)
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
