### PR TITLE
fix: set scroller styles even when overall styles are not initialized yet

### DIFF
--- a/packages/combo-box/test/lit.test.js
+++ b/packages/combo-box/test/lit.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
-import { html, render } from 'lit';
+import { html, LitElement, render } from 'lit';
 import { getViewportItems } from './helpers.js';
 
 describe('lit', () => {
@@ -34,6 +34,44 @@ describe('lit', () => {
         render(html`new-${index}`, root);
       };
       expect(getViewportItems(comboBox)[0].textContent).to.equal('new-0');
+    });
+  });
+
+  describe('complex structure', () => {
+    let container, comboBox, selector;
+
+    class TestSlotContainer extends LitElement {
+      render() {
+        return html`<slot></slot> `;
+      }
+    }
+    customElements.define('test-slot-container', TestSlotContainer);
+
+    class TestSlottedComboComponent extends LitElement {
+      render() {
+        return html`
+          <test-slot-container>
+            <vaadin-combo-box .items="${['First', 'Second', 'Third']}"></vaadin-combo-box>
+          </test-slot-container>
+        `;
+      }
+    }
+    customElements.define('test-slotted-combo-component', TestSlottedComboComponent);
+
+    beforeEach(async () => {
+      container = fixtureSync('<div></div>');
+      render(html`<test-slotted-combo-component></test-slotted-combo-component>`, container);
+      await nextFrame();
+      const component = container.querySelector('test-slotted-combo-component');
+      comboBox = component.shadowRoot.querySelector('vaadin-combo-box');
+      selector = comboBox._scroller.shadowRoot.children.selector;
+    });
+
+    it('should not show horizontal scrollbar when placed in slotted container', async () => {
+      comboBox.open();
+
+      // Is failing since Firefox 105 (other browsers unaffected)
+      expect(selector.style.position).to.equal('relative');
     });
   });
 });

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -41,11 +41,13 @@ export class IronListAdapter {
 
     this.__resizeObserver = new ResizeObserver(() => this._resizeHandler());
 
-    if (getComputedStyle(this.scrollTarget).overflow === 'visible') {
+    const overflow = getComputedStyle(this.scrollTarget).overflow;
+    if (overflow === 'visible' || overflow === '') {
       this.scrollTarget.style.overflow = 'auto';
     }
 
-    if (getComputedStyle(this.scrollContainer).position === 'static') {
+    const position = getComputedStyle(this.scrollContainer).position;
+    if (position === 'static' || position === '') {
       this.scrollContainer.style.position = 'relative';
     }
 


### PR DESCRIPTION
# PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting)
# PLEASE MAKE SURE CHECKMARKS ARE CHECKED CORRECTLY! THE PR CAN BE REJECTED OTHERWISE UNTIL CORRESPONDING ACTIONS ARE COMPLETED (This line should be removed when submitting)

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes #5590 
## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
