### PR TITLE
refactor: minimize virtualizer item create rounds

### DIFF
--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -813,7 +813,7 @@ describe('lazy loading', () => {
         it('should render selectedItem as selected when setting it while loading more items', async () => {
           const alreadyLoadedItem = `item ${comboBox.pageSize - 1}`;
 
-          scrollToIndex(comboBox, comboBox.pageSize + 1);
+          scrollToIndex(comboBox, comboBox.pageSize - 1);
           await nextFrame();
           expect(comboBox.loading).to.be.true;
 
@@ -865,7 +865,7 @@ describe('lazy loading', () => {
             label: `label ${comboBox.pageSize - 1}`,
           };
 
-          scrollToIndex(comboBox, comboBox.pageSize + 1);
+          scrollToIndex(comboBox, comboBox.pageSize - 1);
           await nextFrame();
           expect(comboBox.loading).to.be.true;
 

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -544,6 +544,29 @@ export class IronListAdapter {
   }
 
   /**
+   * Increases the pool size.
+   * @override
+   */
+  _increasePoolIfNeeded(count) {
+    if (this._physicalCount > 2 && count) {
+      // The iron-list logic has already created some physical items and
+      // has decided to create more. Since each item creation round is
+      // expensive, let's try to create the remaining items in one go.
+
+      // Calculate the total item count that would be needed to fill the viewport
+      // plus the buffer assuming rest of the items to be of the average size
+      // of the items already created.
+      const totalItemCount = Math.ceil(this._optPhysicalSize / this._physicalAverage);
+      const missingItemCount = totalItemCount - this._physicalCount;
+      // Create the remaining items in one go. Use a maximum of 100 items
+      // as a safety measure.
+      super._increasePoolIfNeeded(Math.max(count, Math.min(100, missingItemCount)));
+    } else {
+      super._increasePoolIfNeeded(count);
+    }
+  }
+
+  /**
    * @returns {Number|undefined} - The browser's default font-size in pixels
    * @private
    */

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import { Virtualizer } from '../src/virtualizer.js';
 
 describe('virtualizer - item height', () => {
@@ -179,5 +180,60 @@ describe('virtualizer - item height - sub-pixel', () => {
 
     const containerHeight = elementsContainer.offsetHeight;
     expect(containerHeight).to.equal(Math.ceil(ITEM_HEIGHT));
+  });
+});
+
+describe('virtualizer - item height - initial render', () => {
+  let virtualizer, elementsContainer, itemHeight, createElements;
+
+  beforeEach(() => {
+    const scrollTarget = fixtureSync(`
+      <div style="height: 300px;">
+        <div class="container"></div>
+      </div>
+    `);
+    const scrollContainer = scrollTarget.firstElementChild;
+    elementsContainer = scrollContainer;
+
+    createElements = sinon.spy((count) => Array.from({ length: count }, () => document.createElement('div')));
+
+    virtualizer = new Virtualizer({
+      createElements,
+      updateElement: (el, index) => {
+        el.style.width = '100%';
+        el.style.height = itemHeight;
+        el.textContent = `Item ${index}`;
+      },
+      scrollTarget,
+      scrollContainer,
+    });
+  });
+
+  it('should have the expected amount of physical elements: 100px item height', async () => {
+    itemHeight = '100px';
+    virtualizer.size = 100;
+    await nextFrame();
+    expect(elementsContainer.childElementCount).to.equal(5);
+  });
+
+  it('should have the expected amount of physical elements: 20px item height', async () => {
+    itemHeight = '20px';
+    virtualizer.size = 100;
+    await nextFrame();
+    expect(elementsContainer.childElementCount).to.equal(20);
+  });
+
+  it('should have created the items in the expected amount of batches: 100px item height', async () => {
+    itemHeight = '100px';
+    virtualizer.size = 100;
+    await nextFrame();
+    expect(createElements.callCount).to.equal(2);
+  });
+
+  it('should have created the items in the expected amount of batches: 20px item height', async () => {
+    itemHeight = '20px';
+    virtualizer.size = 100;
+    await nextFrame();
+    expect(createElements.callCount).to.equal(2);
   });
 });

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -209,31 +209,35 @@ describe('virtualizer - item height - initial render', () => {
     });
   });
 
-  it('should have the expected amount of physical elements: 100px item height', async () => {
-    itemHeight = '100px';
-    virtualizer.size = 100;
-    await nextFrame();
-    expect(elementsContainer.childElementCount).to.equal(5);
+  describe('large item height', () => {
+    beforeEach(async () => {
+      itemHeight = '100px';
+      virtualizer.size = 100;
+      await nextFrame();
+    });
+
+    it('should have the expected amount of physical elements', () => {
+      expect(elementsContainer.childElementCount).to.equal(5);
+    });
+
+    it('should have created the items in the expected amount of batches', () => {
+      expect(createElements.callCount).to.equal(2);
+    });
   });
 
-  it('should have the expected amount of physical elements: 20px item height', async () => {
-    itemHeight = '20px';
-    virtualizer.size = 100;
-    await nextFrame();
-    expect(elementsContainer.childElementCount).to.equal(20);
-  });
+  describe('small item height', () => {
+    beforeEach(async () => {
+      itemHeight = '20px';
+      virtualizer.size = 100;
+      await nextFrame();
+    });
 
-  it('should have created the items in the expected amount of batches: 100px item height', async () => {
-    itemHeight = '100px';
-    virtualizer.size = 100;
-    await nextFrame();
-    expect(createElements.callCount).to.equal(2);
-  });
+    it('should have the expected amount of physical elements', () => {
+      expect(elementsContainer.childElementCount).to.equal(20);
+    });
 
-  it('should have created the items in the expected amount of batches: 20px item height', async () => {
-    itemHeight = '20px';
-    virtualizer.size = 100;
-    await nextFrame();
-    expect(createElements.callCount).to.equal(2);
+    it('should have created the items in the expected amount of batches', () => {
+      expect(createElements.callCount).to.equal(2);
+    });
   });
 });

--- a/packages/grid/test/filtering.test.js
+++ b/packages/grid/test/filtering.test.js
@@ -208,8 +208,8 @@ describe('filtering', () => {
     flushFilters(grid);
 
     grid.allRowsVisible = true;
-    await nextFrame();
     flushGrid(grid);
+    await nextFrame();
     expect(grid.$.items.querySelectorAll('tr:not([hidden])')).to.have.length(19);
   });
 

--- a/packages/grid/test/filtering.test.js
+++ b/packages/grid/test/filtering.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-grid.js';
 import '../vaadin-grid-filter.js';
@@ -192,7 +192,7 @@ describe('filtering', () => {
     expect(spy.calledOnce).to.be.true;
   });
 
-  it('should display all filtered items', () => {
+  it('should display all filtered items', async () => {
     flushFilters(grid);
     grid._filters[0].value = '';
     grid._filters[1].value = '';
@@ -206,8 +206,11 @@ describe('filtering', () => {
 
     grid._filters[0].value = '99';
     flushFilters(grid);
+
+    grid.allRowsVisible = true;
+    await nextFrame();
     flushGrid(grid);
-    expect(grid.$.items.querySelectorAll('tr:not([hidden])')).to.have.length(18);
+    expect(grid.$.items.querySelectorAll('tr:not([hidden])')).to.have.length(19);
   });
 
   it('should not overflow filter text field', () => {


### PR DESCRIPTION
## Description

On init, Virtualizer creates item elements in batches until the visible viewport (plus some extra buffer) has been covered. By default, this happens in multiple rounds of creating, adding, and measuring in batches of a few items.

Each round is quite expensive due to the forced layout required for measuring the resulting item height. This PR overrides the `_increasePoolIfNeeded` function from `iron-list-core` and makes it try to create the remaining items in a single batch after the first few items have been created.

The change has a 26% impact on the `rendertime` and 19% impact on the `expandedrendertime` metrics in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

## Type of change

Performance enhancement