### PR TITLE
refactor: use visibility to hide loading grid cells

### DIFF
--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -122,7 +122,7 @@ registerStyles(
     }
 
     [part~='row'][loading] [part~='body-cell'] ::slotted(vaadin-grid-cell-content) {
-      opacity: 0;
+      visibility: hidden;
     }
 
     [column-rendering='lazy'] [part~='body-cell']:not([frozen]):not([frozen-to-end]) {

--- a/packages/grid/test/basic.test.js
+++ b/packages/grid/test/basic.test.js
@@ -66,19 +66,19 @@ describe('basic features', () => {
     expect(getLastVisibleItem(grid).index).to.equal(lastIndex);
   });
 
-  it('should change the opacity of cell content in loading rows from 1 to 0 and back', () => {
+  it('should change the visibility of cell content in loading rows', () => {
     const firstRow = grid.shadowRoot.querySelector('#items [part~="row"]');
     const cellContent = getBodyCellContent(grid, 0, 0);
 
-    expect(window.getComputedStyle(cellContent).opacity).to.eql('1');
+    expect(window.getComputedStyle(cellContent).visibility).to.eql('visible');
 
     firstRow.setAttribute('loading', '');
 
-    expect(window.getComputedStyle(cellContent).opacity).to.eql('0');
+    expect(window.getComputedStyle(cellContent).visibility).to.eql('hidden');
 
     firstRow.removeAttribute('loading', '');
 
-    expect(window.getComputedStyle(cellContent).opacity).to.eql('1');
+    expect(window.getComputedStyle(cellContent).visibility).to.eql('visible');
   });
 
   it('scroll to index', () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/1544

Now that we have the grid benchmark tests in place, it was possible to measure the impact of using `opacity: 0` vs `visibility: hidden` in this case.

The change has a 16% impact on the `verticalscrollframetime` metric in the [Grid benchmark tests](https://bender.vaadin.com/buildConfiguration/Flow_Components_BenchmarkTests_Grid?mode=builds).

## Type of change

Performance enhancement