### PR TITLE
feat(confirm-dialog): add `aria-describedby` and `role=alertdialog`

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -343,10 +343,11 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
       initializer: (node) => {
         const wrapper = document.createElement('div');
         wrapper.style.display = 'contents';
-        wrapper.id = `confirm-dialog-message-${generateUniqueId()}`;
+        const wrapperId = `confirm-dialog-message-${generateUniqueId()}`;
+        wrapper.id = wrapperId;
         wrapper.appendChild(node);
         this.appendChild(wrapper);
-        setAriaIDReference(this._overlayElement, 'aria-describedby', { newId: wrapper.id });
+        setAriaIDReference(this._overlayElement, 'aria-describedby', { newId: wrapperId });
         this._messageNodes = [...this._messageNodes, wrapper];
       },
     });

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -9,7 +9,7 @@ import { setAriaIDReference } from '@vaadin/a11y-base/src/aria-id-reference.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
-import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils';
+import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
 /**

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -206,10 +206,10 @@ describe('vaadin-confirm-dialog', () => {
       const secondChild = '<div>Additionale content</div>';
       beforeEach(async () => {
         confirm = fixtureSync(`
-        <vaadin-confirm-dialog opened>
-          ${firstChild}
-          ${secondChild}
-        </vaadin-confirm-dialog>
+          <vaadin-confirm-dialog opened>
+            ${firstChild}
+            ${secondChild}
+          </vaadin-confirm-dialog>
         `);
         overlay = confirm.$.dialog.$.overlay;
         await oneEvent(overlay, 'vaadin-overlay-open');

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -165,6 +165,14 @@ describe('vaadin-confirm-dialog', () => {
         const messageNode = messageSlot.assignedNodes()[0];
         expect(messageNode.textContent.trim()).to.equal('New message');
       });
+
+      describe('a11y', () => {
+        it('should associate message node with aria-describedby', () => {
+          const messageNode = messageSlot.assignedNodes()[0];
+          const overlayDescribedBy = overlay.getAttribute('aria-describedby');
+          expect(overlayDescribedBy).to.equal(messageNode.id);
+        });
+      });
     });
 
     describe('slot', () => {
@@ -190,6 +198,49 @@ describe('vaadin-confirm-dialog', () => {
         confirm.message = 'New message';
         const messageNode = messageSlot.assignedNodes()[0];
         expect(messageNode.textContent.trim()).to.equal('Confirmation message');
+      });
+    });
+
+    describe('a11y', () => {
+      const firstChild = 'Confirm message';
+      const secondChild = '<div>Additionale content</div>';
+      beforeEach(async () => {
+        confirm = fixtureSync(`
+        <vaadin-confirm-dialog opened>
+          ${firstChild}
+          ${secondChild}
+        </vaadin-confirm-dialog>
+        `);
+        overlay = confirm.$.dialog.$.overlay;
+        await oneEvent(overlay, 'vaadin-overlay-open');
+        messageSlot = overlay.shadowRoot.querySelector('[part="message"] > slot');
+      });
+
+      it('should wrap slotted children inside <div> elements', () => {
+        const nodes = messageSlot.assignedNodes();
+        expect(nodes[0].textContent.trim()).to.equal(firstChild);
+        expect(nodes[1].innerHTML.trim()).to.equal(secondChild);
+      });
+
+      it('should generate id for wrapper elements', () => {
+        const nodes = messageSlot.assignedNodes();
+        nodes.forEach((node) => expect(node.id).to.be.not.null);
+      });
+
+      it('should set "display: contents" on the wrapper elements', () => {
+        const nodes = messageSlot.assignedNodes();
+        nodes.forEach((node) => expect(node.style.display).to.equal('contents'));
+      });
+
+      it('should associate generated ids with aria-describedby in overlay', () => {
+        const nodes = messageSlot.assignedNodes();
+        const overlayDescribedBy = overlay.getAttribute('aria-describedby');
+        expect(overlayDescribedBy).to.be.not.null;
+
+        const overlayDescribedByItems = overlayDescribedBy.split(' ');
+        expect(overlayDescribedByItems).to.have.lengthOf(2);
+        const wrapperIds = nodes.map((node) => node.id);
+        expect(overlayDescribedByItems).to.have.members(wrapperIds);
       });
     });
   });

--- a/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
+++ b/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
@@ -3,19 +3,22 @@ export const snapshots = {};
 
 snapshots["vaadin-confirm-dialog overlay"] = 
 `<vaadin-confirm-dialog-overlay
+  aria-describedby="confirm-dialog-message-0"
   aria-label="Unsaved changes"
   focus-trap=""
   has-footer=""
   has-header=""
   id="overlay"
   opened=""
-  role="dialog"
+  role="alertdialog"
   with-backdrop=""
 >
   <h3 slot="header">
     Unsaved changes
   </h3>
-  Do you want to save or discard the changes?
+  <div id="confirm-dialog-message-0">
+    Do you want to save or discard the changes?
+  </div>
   <vaadin-button
     hidden=""
     slot="cancel-button"
@@ -42,20 +45,23 @@ snapshots["vaadin-confirm-dialog overlay"] =
 
 snapshots["vaadin-confirm-dialog overlay theme"] = 
 `<vaadin-confirm-dialog-overlay
+  aria-describedby="confirm-dialog-message-1"
   aria-label="Unsaved changes"
   focus-trap=""
   has-footer=""
   has-header=""
   id="overlay"
   opened=""
-  role="dialog"
+  role="alertdialog"
   theme="custom"
   with-backdrop=""
 >
   <h3 slot="header">
     Unsaved changes
   </h3>
-  Do you want to save or discard the changes?
+  <div id="confirm-dialog-message-1">
+    Do you want to save or discard the changes?
+  </div>
   <vaadin-button
     hidden=""
     slot="cancel-button"
@@ -82,6 +88,7 @@ snapshots["vaadin-confirm-dialog overlay theme"] =
 
 snapshots["vaadin-confirm-dialog overlay class"] = 
 `<vaadin-confirm-dialog-overlay
+  aria-describedby="confirm-dialog-message-2"
   aria-label="Unsaved changes"
   class="confirm-dialog-overlay custom"
   focus-trap=""
@@ -89,13 +96,15 @@ snapshots["vaadin-confirm-dialog overlay class"] =
   has-header=""
   id="overlay"
   opened=""
-  role="dialog"
+  role="alertdialog"
   with-backdrop=""
 >
   <h3 slot="header">
     Unsaved changes
   </h3>
-  Do you want to save or discard the changes?
+  <div id="confirm-dialog-message-2">
+    Do you want to save or discard the changes?
+  </div>
   <vaadin-button
     hidden=""
     slot="cancel-button"

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -37,19 +37,19 @@ snapshots["vaadin-crud host default"] =
           theme="small"
         >
           <label
-            for="input-vaadin-text-field-6"
-            id="label-vaadin-text-field-0"
+            for="input-vaadin-text-field-8"
+            id="label-vaadin-text-field-2"
             slot="label"
           >
           </label>
           <div
             hidden=""
-            id="error-message-vaadin-text-field-2"
+            id="error-message-vaadin-text-field-4"
             slot="error-message"
           >
           </div>
           <input
-            id="input-vaadin-text-field-6"
+            id="input-vaadin-text-field-8"
             slot="input"
             type="text"
           >
@@ -68,19 +68,19 @@ snapshots["vaadin-crud host default"] =
           theme="small"
         >
           <label
-            for="input-vaadin-text-field-7"
-            id="label-vaadin-text-field-3"
+            for="input-vaadin-text-field-9"
+            id="label-vaadin-text-field-5"
             slot="label"
           >
           </label>
           <div
             hidden=""
-            id="error-message-vaadin-text-field-5"
+            id="error-message-vaadin-text-field-7"
             slot="error-message"
           >
           </div>
           <input
-            id="input-vaadin-text-field-7"
+            id="input-vaadin-text-field-9"
             slot="input"
             type="text"
           >
@@ -237,8 +237,13 @@ snapshots["vaadin-crud shadow default"] =
   <h3 slot="header">
     Discard changes
   </h3>
-  <div>
-    There are unsaved changes to this item.
+  <div
+    id="confirm-dialog-message-0"
+    style="display: contents;"
+  >
+    <div>
+      There are unsaved changes to this item.
+    </div>
   </div>
   <vaadin-button
     role="button"
@@ -274,8 +279,13 @@ snapshots["vaadin-crud shadow default"] =
   <h3 slot="header">
     Delete item
   </h3>
-  <div>
-    Are you sure you want to delete this item? This action cannot be undone.
+  <div
+    id="confirm-dialog-message-1"
+    style="display: contents;"
+  >
+    <div>
+      Are you sure you want to delete this item? This action cannot be undone.
+    </div>
   </div>
   <vaadin-button
     role="button"


### PR DESCRIPTION
## Description

This PR aims to enhance the announcement behavior for Confirm Dialog by changing a couple of things:
- Modfify Confirm Dialog's overlay role from `dialog` to `alertdialog`
- Set `aria-describedby` in the overlay to point to the elements inside the default slot.
  - Each element provided by the user is wrapped in a `<div>` element
  - The wrapper receives a generated id 
  - The wrapper is styled with `display: contents` to allow the children elements behave as expected.

Also:
- Tests to check the behavior have been added
- Snapshots updated to reflect the new tree

Part of #4684

## Type of change

- [ ] Bugfix
- [X] Feature
