### PR TITLE
refactor: only render once when items set lazily

### DIFF
--- a/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
@@ -22,7 +22,7 @@ export const ArrayDataProviderMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['__dataProviderOrItemsChanged(dataProvider, items, isAttached, items.*, _filters, _sorters)'];
+      return ['__dataProviderOrItemsChanged(dataProvider, items, isAttached, _filters, _sorters)'];
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
@@ -22,7 +22,7 @@ export const ArrayDataProviderMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['__dataProviderOrItemsChanged(dataProvider, items, isAttached, _filters, _sorters)'];
+      return ['__dataProviderOrItemsChanged(dataProvider, items.*, isAttached, _filters, _sorters)'];
     }
 
     /** @private */
@@ -37,10 +37,11 @@ export const ArrayDataProviderMixin = (superClass) =>
     }
 
     /** @private */
-    __dataProviderOrItemsChanged(dataProvider, items, isAttached) {
+    __dataProviderOrItemsChanged(dataProvider, itemsChange, isAttached) {
       if (!isAttached) {
         return;
       }
+      const items = itemsChange ? itemsChange.value : null;
 
       if (this._arrayDataProvider) {
         // Has an items array data provider beforehand

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -416,8 +416,6 @@ export const DataProviderMixin = (superClass) =>
             }
           });
 
-          this._hasData = true;
-
           // Remove the pending request
           delete cache.pendingRequests[page];
 
@@ -439,6 +437,8 @@ export const DataProviderMixin = (superClass) =>
           if (!this._cache.isLoading()) {
             this._debouncerApplyCachedData.flush();
           }
+
+          this._hasData = true;
 
           // Notify that new data has been received
           this.__itemsReceived();

--- a/packages/grid/test/array-data-provider.test.js
+++ b/packages/grid/test/array-data-provider.test.js
@@ -46,22 +46,6 @@ describe('array data provider', () => {
       expect(getBodyCellContent(grid, 1, 0).textContent).to.equal('baz');
     });
 
-    it('should be observed for shift', () => {
-      grid.unshift('items', {
-        name: {
-          first: 'a',
-          last: 'b',
-        },
-      });
-      expect(grid.size).to.equal(3);
-      expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('a');
-    });
-
-    it('should be observed for mutation', () => {
-      grid.set('items.0.name.first', 'new');
-      expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('new');
-    });
-
     it('should handle null', () => {
       grid.items = null;
       expect(grid.size).to.equal(0);
@@ -118,6 +102,23 @@ describe('array data provider', () => {
       grid.items = [0];
       flushGrid(grid);
       expect(getRows(grid.$.items)).to.have.length(1);
+    });
+
+    it('should only render once when setting the items', () => {
+      const column = grid.querySelector('vaadin-grid-column');
+      column.renderer = sinon.spy();
+
+      grid.items = [
+        {
+          name: {
+            first: 'foo',
+            last: 'bar',
+          },
+        },
+      ];
+      flushGrid(grid);
+
+      expect(column.renderer.callCount).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
## Description

Make sure a column `renderer` is invoked for a cell just once when the `items` array is set to the grid lazily.

Fixes https://github.com/vaadin/web-components/issues/1493

## Type of change

Bugfix / Performance enhancement