### PR TITLE
fix: consider decimal values of scrollLeft and scrollTop

### DIFF
--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -251,8 +251,10 @@ class Tabs extends ResizeMixin(ElementMixin(ListMixin(ThemableMixin(PolymerEleme
       : getNormalizedScrollLeft(this._scrollerElement, this.getAttribute('dir'));
     const scrollSize = this._vertical ? this._scrollerElement.scrollHeight : this._scrollerElement.scrollWidth;
 
-    let overflow = scrollPosition > 0 ? 'start' : '';
-    overflow += scrollPosition + this._scrollOffset < scrollSize ? ' end' : '';
+    let overflow = Math.floor(scrollPosition) > 0 ? 'start' : '';
+    if (Math.ceil(scrollPosition) < Math.ceil(scrollSize - this._scrollOffset)) {
+      overflow += ' end';
+    }
 
     if (this.__direction === 1) {
       overflow = overflow.replace(/start|end/giu, (matched) => {

--- a/packages/tabs/test/tabs.test.js
+++ b/packages/tabs/test/tabs.test.js
@@ -114,6 +114,10 @@ describe('tabs', () => {
             await nextFrame();
           });
 
+          afterEach(() => {
+            document.body.style.zoom = '';
+          });
+
           it(`when orientation=${orientation} should have overflow="end" if scroll is at the beginning`, () => {
             expect(tabs.getAttribute('overflow')).to.be.equal('end');
           });
@@ -127,18 +131,22 @@ describe('tabs', () => {
             tabs._scroll(horizontalRtl ? -2 : 2);
           });
 
-          // TODO: passes locally but fails in GitHub Actions due to 1px difference.
-          const chrome = /HeadlessChrome/u.test(navigator.userAgent);
-          (horizontalRtl && chrome ? it.skip : it)(
-            `when orientation=${orientation} should have overflow="start" if scroll is at the end`,
-            (done) => {
-              listenOnce(tabs._scrollerElement, 'scroll', () => {
-                expect(tabs.getAttribute('overflow')).to.be.equal('start');
-                done();
-              });
-              tabs._scroll(horizontalRtl ? -200 : 200);
-            },
-          );
+          it(`when orientation=${orientation} should have overflow="start" if scroll is at the end`, (done) => {
+            listenOnce(tabs._scrollerElement, 'scroll', () => {
+              expect(tabs.getAttribute('overflow')).to.be.equal('start');
+              done();
+            });
+            tabs._scroll(horizontalRtl ? -200 : 200);
+          });
+
+          it(`when orientation=${orientation} should have overflow="start" if scroll is at the end on zoomed page`, (done) => {
+            document.body.style.zoom = 1.25;
+            listenOnce(tabs._scrollerElement, 'scroll', () => {
+              expect(tabs.getAttribute('overflow')).to.be.equal('start');
+              done();
+            });
+            tabs._scroll(horizontalRtl ? -200 : 200);
+          });
 
           it(`when orientation=${orientation} should not have overflow="start" when over-scrolling`, () => {
             const scroll = tabs._scrollerElement;


### PR DESCRIPTION
## Description

This PR fixes an issue that scrolling to the end of the `vaadin-tabs` does not always hide the overflow, the right arrow button is still visible, and it appears like it's possible to scroll more, although it isn't.

The issue was reproducible in Chromium browsers and Safari when you either:
- Zoomed in or out the page in the browsers - however, not all zoom levels exhibited the behaviour
- Used display scaling in your operating system - e.g. I use Windows 10, I have a high DPI monitor, and therefore I have 125% system-wide scaling so things do not appear so small -> in this environment, I was able to reproduce the issue even without zoomimg in the browser

The root cause of the problem is that in the mentioned zoom conditions, the `scrollLeft` and `scrollTop` element properties do not have to be integers anymore but can be decimal values (sub-pixel measurement). There is even a warning about [this on the API page](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft). 

The algorithm which computes if the overflow and the button should be visible was not taking this into account. I found a [similar bug related to this issue](https://github.com/vaadin/web-components/pull/5142), so I partly borrowed the solution from there.

I managed to put together a test for this issue with the help of `document.body.style.zoom = 1.25`, which seems to behave like when you set the zoom to 125% manually in the browser. 

Fixes #4744

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.