### PR TITLE
refactor: use __updateVisibleRows() instead of a custom implementation

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -273,7 +273,7 @@ export const DataProviderMixin = (superClass) =>
       el.index = index;
       const { cache, scaledIndex } = this._cache.getCacheAndIndex(index);
       const item = cache.items[scaledIndex];
-      if (item) {
+      if (item !== undefined) {
         this.__updateLoading(el, false);
         this._updateItem(el, item);
         if (this._isExpanded(item)) {

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -424,14 +424,7 @@ export const DataProviderMixin = (superClass) =>
           // Schedule a debouncer to update the visible rows
           this._debouncerApplyCachedData = Debouncer.debounce(this._debouncerApplyCachedData, timeOut.after(0), () => {
             this._setLoading(false);
-
-            this._getVisibleRows().forEach((row) => {
-              const cachedItem = this._cache.getItemForIndex(row.index);
-              if (cachedItem) {
-                this._getItem(row.index, row);
-              }
-            });
-
+            this.__updateVisibleRows();
             this.__scrollToPendingIndexes();
           });
 

--- a/packages/grid/test/data-provider.test.js
+++ b/packages/grid/test/data-provider.test.js
@@ -770,7 +770,7 @@ describe('wrapped grid', () => {
 
       container.dataProvider = (params, callback) => {
         expect(grid.loading).to.be.true;
-        callback(Array(params.pageSize));
+        callback(Array.from({ length: params.pageSize }, (_, i) => i));
         expect(grid.loading).not.to.be.true;
 
         cancelAnimationFrame(raf);
@@ -791,7 +791,7 @@ describe('wrapped grid', () => {
       container.dataProvider = (params, callback) => {
         cb = callback;
       };
-      cb(Array(25));
+      cb(Array.from({ length: 25 }, (_, i) => i));
       expect(grid.loading).not.to.be.true;
       grid.clearCache();
       expect(grid.loading).to.be.true;
@@ -812,14 +812,14 @@ describe('wrapped grid', () => {
 
     it('should clear loading attribute from rows when data received', () => {
       container.dataProvider = (params, callback) => {
-        callback([{}]);
+        callback([{}], 1);
       };
       expect(getRows(grid.$.items)[0].hasAttribute('loading')).to.be.false;
     });
 
     it('should remove loading from cells part attribute when data received', () => {
       container.dataProvider = (params, callback) => {
-        callback([{}]);
+        callback([{}], 1);
       };
       const row = getRows(grid.$.items)[0];
       getRowCells(row).forEach((cell) => {

--- a/packages/grid/test/row-details.test.js
+++ b/packages/grid/test/row-details.test.js
@@ -285,7 +285,7 @@ describe('row details', () => {
 
   describe('details opened attribute', () => {
     let dataset = [];
-    const dataProvider = (params, callback) => callback(dataset);
+    const dataProvider = (params, callback) => callback(dataset, dataset.length);
 
     const countRowsMarkedAsDetailsOpened = (grid) => {
       return grid.$.items.querySelectorAll('tr[details-opened]').length;
@@ -294,7 +294,7 @@ describe('row details', () => {
     beforeEach(async () => {
       dataset = buildDataSet(10);
       grid = fixtureSync(`
-        <vaadin-grid style="width: 50px; height: 400px" size="100">
+        <vaadin-grid style="width: 50px; height: 400px" size="10">
           <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
       `);

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -213,8 +213,8 @@ describe('scroll to index', () => {
 
     it('should not reassign the first item on scrollToIndex', () => {
       const newExpectedSize = grid.size + 1;
-      grid.size = newExpectedSize;
       data.push({ index: 11 });
+      grid.size = newExpectedSize;
       grid.scrollToIndex(grid.size - 1);
 
       expect(grid.$.items.children[0]._item.index).to.equal(0);


### PR DESCRIPTION
## Description

There is an `__updateVisibleRows()` method that updates grid rows' content and the related a11y attributes. The custom implementations based on `this._getVisibleRows().forEach(...)` can be replaced with it.

## Type of change

- [x] Internal
