### PR TITLE
fix: TypeScript typings for clearButtonVisible prop in field components

### DIFF
--- a/packages/number-field/src/vaadin-number-field-mixin.d.ts
+++ b/packages/number-field/src/vaadin-number-field-mixin.d.ts
@@ -10,6 +10,7 @@ import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
@@ -24,7 +25,8 @@ import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.j
  */
 export declare function NumberFieldMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<ControllerMixinClass> &
+): Constructor<ClearButtonMixinClass> &
+  Constructor<ControllerMixinClass> &
   Constructor<DelegateFocusMixinClass> &
   Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &

--- a/packages/number-field/test/typings/number-field.types.ts
+++ b/packages/number-field/test/typings/number-field.types.ts
@@ -1,6 +1,7 @@
 import '../../vaadin-number-field.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
 import type { SlotStylesMixinClass } from '@vaadin/field-base/src/slot-styles-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -17,6 +18,7 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 const field = document.createElement('vaadin-number-field');
 
 // Mixins
+assertType<ClearButtonMixinClass>(field);
 assertType<ControllerMixinClass>(field);
 assertType<ElementMixinClass>(field);
 assertType<InputFieldMixinClass>(field);

--- a/packages/text-area/src/vaadin-text-area-mixin.d.ts
+++ b/packages/text-area/src/vaadin-text-area-mixin.d.ts
@@ -11,6 +11,7 @@ import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
@@ -25,7 +26,8 @@ import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.j
  */
 export declare function TextAreaMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<ControllerMixinClass> &
+): Constructor<ClearButtonMixinClass> &
+  Constructor<ControllerMixinClass> &
   Constructor<DelegateFocusMixinClass> &
   Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &

--- a/packages/text-area/test/typings/text-area.types.ts
+++ b/packages/text-area/test/typings/text-area.types.ts
@@ -1,6 +1,7 @@
 import '../../vaadin-text-area.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
 import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -17,6 +18,7 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 const area = document.createElement('vaadin-text-area');
 
 // Mixins
+assertType<ClearButtonMixinClass>(area);
 assertType<ControllerMixinClass>(area);
 assertType<ElementMixinClass>(area);
 assertType<InputFieldMixinClass>(area);

--- a/packages/text-field/src/vaadin-text-field-mixin.d.ts
+++ b/packages/text-field/src/vaadin-text-field-mixin.d.ts
@@ -10,6 +10,7 @@ import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputControlMixinClass } from '@vaadin/field-base/src/input-control-mixin.js';
@@ -24,7 +25,8 @@ import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.j
  */
 export declare function TextFieldMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<ControllerMixinClass> &
+): Constructor<ClearButtonMixinClass> &
+  Constructor<ControllerMixinClass> &
   Constructor<DelegateFocusMixinClass> &
   Constructor<DelegateStateMixinClass> &
   Constructor<DisabledMixinClass> &

--- a/packages/text-field/test/typings/text-field.types.ts
+++ b/packages/text-field/test/typings/text-field.types.ts
@@ -1,6 +1,7 @@
 import '../../vaadin-text-field.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
 import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -17,6 +18,7 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 const field = document.createElement('vaadin-text-field');
 
 // Mixins
+assertType<ClearButtonMixinClass>(field);
 assertType<ControllerMixinClass>(field);
 assertType<ElementMixinClass>(field);
 assertType<InputFieldMixinClass>(field);


### PR DESCRIPTION
## Description

The `clearButtonVisible` property of the text-field and derivatives was missing the TypeScript definition. Using the property resulted in TypeScript error in Hilla / React as a result, although the JS works in the browser. This change exposes the propery by exposing the corresponding `ClearButtonMixinClass` mixin typings for the affected components.

Fixes vaadin/react-components#69

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.