### PR TITLE
Revert "refactor: update rows with __updateVisibleRows() when receiving a page (#5733)"

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -273,7 +273,7 @@ export const DataProviderMixin = (superClass) =>
       el.index = index;
       const { cache, scaledIndex } = this._cache.getCacheAndIndex(index);
       const item = cache.items[scaledIndex];
-      if (item !== undefined) {
+      if (item) {
         this.__updateLoading(el, false);
         this._updateItem(el, item);
         if (this._isExpanded(item)) {
@@ -424,7 +424,14 @@ export const DataProviderMixin = (superClass) =>
           // Schedule a debouncer to update the visible rows
           this._debouncerApplyCachedData = Debouncer.debounce(this._debouncerApplyCachedData, timeOut.after(0), () => {
             this._setLoading(false);
-            this.__updateVisibleRows();
+
+            this._getVisibleRows().forEach((row) => {
+              const cachedItem = this._cache.getItemForIndex(row.index);
+              if (cachedItem) {
+                this._getItem(row.index, row);
+              }
+            });
+
             this.__scrollToPendingIndexes();
           });
 

--- a/packages/grid/test/data-provider.test.js
+++ b/packages/grid/test/data-provider.test.js
@@ -770,7 +770,7 @@ describe('wrapped grid', () => {
 
       container.dataProvider = (params, callback) => {
         expect(grid.loading).to.be.true;
-        callback(Array.from({ length: params.pageSize }, (_, i) => i));
+        callback(Array(params.pageSize));
         expect(grid.loading).not.to.be.true;
 
         cancelAnimationFrame(raf);
@@ -791,7 +791,7 @@ describe('wrapped grid', () => {
       container.dataProvider = (params, callback) => {
         cb = callback;
       };
-      cb(Array.from({ length: 25 }, (_, i) => i));
+      cb(Array(25));
       expect(grid.loading).not.to.be.true;
       grid.clearCache();
       expect(grid.loading).to.be.true;
@@ -812,14 +812,14 @@ describe('wrapped grid', () => {
 
     it('should clear loading attribute from rows when data received', () => {
       container.dataProvider = (params, callback) => {
-        callback([{}], 1);
+        callback([{}]);
       };
       expect(getRows(grid.$.items)[0].hasAttribute('loading')).to.be.false;
     });
 
     it('should remove loading from cells part attribute when data received', () => {
       container.dataProvider = (params, callback) => {
-        callback([{}], 1);
+        callback([{}]);
       };
       const row = getRows(grid.$.items)[0];
       getRowCells(row).forEach((cell) => {

--- a/packages/grid/test/row-details.test.js
+++ b/packages/grid/test/row-details.test.js
@@ -285,7 +285,7 @@ describe('row details', () => {
 
   describe('details opened attribute', () => {
     let dataset = [];
-    const dataProvider = (params, callback) => callback(dataset, dataset.length);
+    const dataProvider = (params, callback) => callback(dataset);
 
     const countRowsMarkedAsDetailsOpened = (grid) => {
       return grid.$.items.querySelectorAll('tr[details-opened]').length;
@@ -294,7 +294,7 @@ describe('row details', () => {
     beforeEach(async () => {
       dataset = buildDataSet(10);
       grid = fixtureSync(`
-        <vaadin-grid style="width: 50px; height: 400px" size="10">
+        <vaadin-grid style="width: 50px; height: 400px" size="100">
           <vaadin-grid-column></vaadin-grid-column>
         </vaadin-grid>
       `);

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -213,8 +213,8 @@ describe('scroll to index', () => {
 
     it('should not reassign the first item on scrollToIndex', () => {
       const newExpectedSize = grid.size + 1;
-      data.push({ index: 11 });
       grid.size = newExpectedSize;
+      data.push({ index: 11 });
       grid.scrollToIndex(grid.size - 1);
 
       expect(grid.$.items.children[0]._item.index).to.equal(0);


### PR DESCRIPTION
This reverts commit b16f960e73943529c60dd327d0a9a5075cf113e2.

The changes done #5733 introduced some issues that causes a series of test failures as can be seen in [the PR](https://github.com/vaadin/flow-components/pull/4927) updating the WC version in the Flow Components.

For instance, in [this test](https://github.com/vaadin/flow-components/blob/fb3089cd8dbb1b7559fbcad0aaa9a4cec7bd6fc3/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridMultiSelectionColumnPageIT.java#L186), the Grid is stuck in a infinite loop.
