### PR TITLE
chore: Add global imports for Material

### DIFF
--- a/packages/vaadin-material-styles/color-global.js
+++ b/packages/vaadin-material-styles/color-global.js
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { colorLight } from './color.js';
+import { addMaterialGlobalStyles } from './global.js';
+
+addMaterialGlobalStyles('color', colorLight);

--- a/packages/vaadin-material-styles/typography-global.js
+++ b/packages/vaadin-material-styles/typography-global.js
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { addMaterialGlobalStyles } from './global.js';
+import { typography } from './typography.js';
+
+addMaterialGlobalStyles('typography', typography);


### PR DESCRIPTION
This is so we can remove https://github.com/vaadin/flow-components/blob/main/vaadin-material-theme-flow-parent/vaadin-material-theme-flow/src/main/resources/META-INF/resources/frontend/material-includes.ts