### PR TITLE
chore: ignore IntelliJ Idea module files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ packages/icons/test/visual/screenshots/failed
 
 # IntelliJ project files
 .idea
+*.iml
 
 # Generated web-types JSON files
 web-types.json


### PR DESCRIPTION
## Description

Just to ignore besides `.idea` directories also IntelliJ Idea module files (`*.iml`)

## Type of change

- [x] Chore

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
