### PR TITLE
fix: hide bottom navbar when it's empty

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -784,10 +784,10 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
       this.$.navbarTop.removeAttribute('hidden');
     }
 
-    if (touchOptimized) {
-      this.$.navbarBottom.removeAttribute('hidden');
-    } else {
+    if (this.$.navbarBottom.querySelector('[name=navbar-bottom]').assignedNodes().length === 0) {
       this.$.navbarBottom.setAttribute('hidden', '');
+    } else {
+      this.$.navbarBottom.removeAttribute('hidden');
     }
 
     this._updateOffsetSize();

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -142,7 +142,17 @@ describe('vaadin-app-layout', () => {
         expect(toggle.offsetHeight).to.be.greaterThan(0);
       });
 
-      it('should remove hidden attribute on navbar-bottom on resize', () => {
+      it('should not show empty navbar-bottom on resize', () => {
+        expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.true;
+        window.dispatchEvent(new Event('resize'));
+        expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.true;
+      });
+
+      it('should remove hidden attribute on non-empty navbar-bottom on resize', () => {
+        const header = document.createElement('h1');
+        header.textContent = 'Header';
+        header.setAttribute('slot', 'navbar touch-optimized');
+        layout.appendChild(header);
         expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.true;
         window.dispatchEvent(new Event('resize'));
         expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.false;


### PR DESCRIPTION
## Description

The problem here is that when using `app-layout` on mobile (or when emulating in Chrome dev tools using touch-optimized desktop view), the bottom navigation bar is always visible, although it has no content in it. Such behaviour is seen as buggy and unexpected.

@rolfsmeds suggested ([in this comment](https://github.com/vaadin/flow-components/issues/4878#issuecomment-1488939615)) modifying the bottom navbar CSS, so it's able to collapse to zero height when empty. However, I'd propose a slightly different solution in this PR: there is a javascript code which ensures that the **top** navbar is hidden when it has no content. I'd suggest, for consistency's sake, doing the same for the bottom navbar - hide it when it has no content regardles of the touch-optimization mode. This would also keep the CSS of `app-layout` a little bit simpler and cleaner.

Fixes vaadin/flow-components#4878

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
