### PR TITLE
fix: allow setting accessibleNameRef before attaching

### DIFF
--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -37,7 +37,9 @@ export class FieldAriaController {
   setTarget(target) {
     this.__target = target;
     this.__setAriaRequiredAttribute(this.__required);
-    this.__setLabelIdToAriaAttribute(this.__labelId);
+    const isFromUser = this.__labelIdFromUser != null;
+    const labelId = isFromUser ? this.__labelIdFromUser : this.__labelId;
+    this.__setLabelIdToAriaAttribute(labelId, labelId, isFromUser);
     this.__setErrorIdToAriaAttribute(this.__errorId);
     this.__setHelperIdToAriaAttribute(this.__helperId);
     this.setAriaLabel(this.__label);

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -143,9 +143,12 @@ export const FieldMixin = (superclass) =>
 
     /** @private */
     __labelChanged(hasLabel, labelNode) {
+      if (this.accessibleName || this.accessibleNameRef) {
+        return;
+      }
       // Label ID should be only added when the label content is present.
       // Otherwise, it may conflict with an `aria-label` attribute possibly added by the user.
-      if (hasLabel && !this.accessibleName && !this.accessibleNameRef) {
+      if (hasLabel) {
         this._fieldAriaController.setLabelId(labelNode.id);
       } else {
         this._fieldAriaController.setLabelId(null);

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -145,7 +145,7 @@ export const FieldMixin = (superclass) =>
     __labelChanged(hasLabel, labelNode) {
       // Label ID should be only added when the label content is present.
       // Otherwise, it may conflict with an `aria-label` attribute possibly added by the user.
-      if (hasLabel) {
+      if (hasLabel && !this.accessibleName && !this.accessibleNameRef) {
         this._fieldAriaController.setLabelId(labelNode.id);
       } else {
         this._fieldAriaController.setLabelId(null);

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -833,6 +833,15 @@ const runTests = (defineHelper, baseMixin) => {
         await nextFrame();
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
+      it('should change aria-labellebdy when accessibleNameRef is set before element is attached', async () => {
+        const parent = element.parentNode;
+        element = document.createElement(tag);
+        element.accessibleNameRef = 'accessible-name-ref-0';
+        parent.appendChild(element);
+        await nextFrame();
+        input = element.querySelector('[slot=input]');
+        expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
+      });
     });
 
     describe('field group', () => {

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -771,17 +771,17 @@ const runTests = (defineHelper, baseMixin) => {
         await nextFrame();
         expect(input.getAttribute('aria-labelledby')).to.be.equal(ariaLabelledby);
       });
+    });
 
-      describe('accessible-name is set before attached to the DOM', () => {
-        it('should not throw if accessibleName is set before element is attached', async () => {
-          const parent = fixtureSync('<div></div>');
-          element = document.createElement(tag);
-          sinon.spy(element._fieldAriaController, 'setAriaLabel');
-          element.accessibleName = 'accessible name';
-          parent.appendChild(element);
-          await nextFrame();
-          expect(element._fieldAriaController.setAriaLabel.threw('TypeError')).to.be.false;
-        });
+    describe('accessible-name is set initially', () => {
+      it('should not throw if accessibleName is set before element is attached', async () => {
+        const parent = fixtureSync('<div></div>');
+        element = document.createElement(tag);
+        sinon.spy(element._fieldAriaController, 'setAriaLabel');
+        element.accessibleName = 'accessible name';
+        parent.appendChild(element);
+        await nextFrame();
+        expect(element._fieldAriaController.setAriaLabel.threw('TypeError')).to.be.false;
       });
     });
 
@@ -835,17 +835,17 @@ const runTests = (defineHelper, baseMixin) => {
         await nextFrame();
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
+    });
 
-      describe('accessible-name-ref is set before attached to the DOM', () => {
-        it('should change aria-labellebdy when accessibleNameRef is set before element is attached', async () => {
-          const parent = fixtureSync('<div></div>');
-          element = document.createElement(tag);
-          element.accessibleNameRef = 'accessible-name-ref-0';
-          parent.appendChild(element);
-          await nextFrame();
-          input = element.querySelector('[slot=input]');
-          expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
-        });
+    describe('accessible-name-ref is set initially', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag} label="Label" accessible-name-ref="accessible-name-ref-0"></${tag}>`);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should change aria-labellebdy when accessibleNameRef is set before element is attached', async () => {
+        expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
     });
 

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -774,14 +774,18 @@ const runTests = (defineHelper, baseMixin) => {
     });
 
     describe('accessible-name is set initially', () => {
-      it('should not throw if accessibleName is set before element is attached', async () => {
-        const parent = fixtureSync('<div></div>');
-        element = document.createElement(tag);
-        sinon.spy(element._fieldAriaController, 'setAriaLabel');
-        element.accessibleName = 'accessible name';
-        parent.appendChild(element);
-        await nextFrame();
-        expect(element._fieldAriaController.setAriaLabel.threw('TypeError')).to.be.false;
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag} label="Label" accessible-name="accessible-name"></${tag}>`);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+      });
+
+      it('should have accessibleName value in aria-label', () => {
+        expect(input.getAttribute('aria-label')).to.equal('accessible-name');
+      });
+
+      it('input should have aria-labellebdy by empty', () => {
+        expect(input.getAttribute('aria-labelledby')).to.be.null;
       });
     });
 
@@ -844,7 +848,7 @@ const runTests = (defineHelper, baseMixin) => {
         input = element.querySelector('[slot=input]');
       });
 
-      it('should change aria-labellebdy when accessibleNameRef is set before element is attached', async () => {
+      it('should contain accessibleNameRef in aria-labelledby', async () => {
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
     });

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -772,14 +772,16 @@ const runTests = (defineHelper, baseMixin) => {
         expect(input.getAttribute('aria-labelledby')).to.be.equal(ariaLabelledby);
       });
 
-      it('should not throw if accessibleName is set before element is attached', async () => {
-        const parent = element.parentNode;
-        element = document.createElement(tag);
-        sinon.spy(element._fieldAriaController, 'setAriaLabel');
-        element.accessibleName = 'accessible name';
-        parent.appendChild(element);
-        await nextFrame();
-        expect(element._fieldAriaController.setAriaLabel.threw('TypeError')).to.be.false;
+      describe('dettached element', () => {
+        it('should not throw if accessibleName is set before element is attached', async () => {
+          const parent = fixtureSync('<div></div>');
+          element = document.createElement(tag);
+          sinon.spy(element._fieldAriaController, 'setAriaLabel');
+          element.accessibleName = 'accessible name';
+          parent.appendChild(element);
+          await nextFrame();
+          expect(element._fieldAriaController.setAriaLabel.threw('TypeError')).to.be.false;
+        });
       });
     });
 
@@ -833,14 +835,17 @@ const runTests = (defineHelper, baseMixin) => {
         await nextFrame();
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
-      it('should change aria-labellebdy when accessibleNameRef is set before element is attached', async () => {
-        const parent = element.parentNode;
-        element = document.createElement(tag);
-        element.accessibleNameRef = 'accessible-name-ref-0';
-        parent.appendChild(element);
-        await nextFrame();
-        input = element.querySelector('[slot=input]');
-        expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
+
+      describe('dettached element', () => {
+        it('should change aria-labellebdy when accessibleNameRef is set before element is attached', async () => {
+          const parent = fixtureSync('<div></div>');
+          element = document.createElement(tag);
+          element.accessibleNameRef = 'accessible-name-ref-0';
+          parent.appendChild(element);
+          await nextFrame();
+          input = element.querySelector('[slot=input]');
+          expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
+        });
       });
     });
 

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -772,7 +772,7 @@ const runTests = (defineHelper, baseMixin) => {
         expect(input.getAttribute('aria-labelledby')).to.be.equal(ariaLabelledby);
       });
 
-      describe('dettached element', () => {
+      describe('accessible-name is set before attached to the DOM', () => {
         it('should not throw if accessibleName is set before element is attached', async () => {
           const parent = fixtureSync('<div></div>');
           element = document.createElement(tag);
@@ -836,7 +836,7 @@ const runTests = (defineHelper, baseMixin) => {
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
 
-      describe('dettached element', () => {
+      describe('accessible-name-ref is set before attached to the DOM', () => {
         it('should change aria-labellebdy when accessibleNameRef is set before element is attached', async () => {
           const parent = fixtureSync('<div></div>');
           element = document.createElement(tag);


### PR DESCRIPTION
## Description

Allow the user to set `accessibleNameRef` before an element implementing `FieldMixin` is attached to the page.


## Type of change

- [X] Bugfix
- [ ] Feature
