### PR TITLE
fix: omit href when it's empty

### DIFF
--- a/dev/side-nav.html
+++ b/dev/side-nav.html
@@ -42,6 +42,10 @@
             Select
           </vaadin-side-nav-item>
         </vaadin-side-nav-item>
+
+        <vaadin-side-nav-item>
+          Label only (no path)
+        </vaadin-side-nav-item>
       </vaadin-side-nav>
     </div>
   </vaadin-scroller>

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, LitElement } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -66,7 +67,11 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
   /** @protected */
   render() {
     return html`
-      <a href="${this.path}" part="item" aria-current="${this.active ? 'page' : false}">
+      <a
+        href="${ifDefined(this.path ? this.path : undefined)}"
+        part="item"
+        aria-current="${this.active ? 'page' : false}"
+      >
         <slot name="prefix"></slot>
         <slot></slot>
         <slot name="suffix"></slot>

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -65,11 +65,7 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
   /** @protected */
   render() {
     return html`
-      <a
-        href="${ifDefined(this.path ? this.path : undefined)}"
-        part="item"
-        aria-current="${this.active ? 'page' : false}"
-      >
+      <a href="${ifDefined(this.path)}" part="item" aria-current="${this.active ? 'page' : false}">
         <slot name="prefix"></slot>
         <slot></slot>
         <slot name="suffix"></slot>


### PR DESCRIPTION
## Description

This PR would solve the issue that the `side-nav-item` is clickable (and redirects to "empty string") when `path` attribute is not set on `side-nav-item`. 

`ifDefined` Lit directive makes sure, that:
* if the `path` is non-empty, then `href` attribute is set using it's value
* if the `path` is undefined (default value), then `href` attribute is completely omitted from the `a` tag

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
