### PR TITLE
test: make children a proper array before iterating

### DIFF
--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -698,6 +698,8 @@ const runTests = (defineHelper, baseMixin) => {
   });
 
   describe('disabled', () => {
+    let items;
+
     beforeEach(async () => {
       list = fixtureSync(`
         <${listTag}>
@@ -708,20 +710,21 @@ const runTests = (defineHelper, baseMixin) => {
         </${listTag}>
       `);
       await nextRender();
+      items = [...list.children];
     });
 
     it('should reset previously selected item when listbox and items are disabled', async () => {
       list.selected = 3;
       await nextFrame();
-      expect(list.items[3].selected).to.be.true;
+      expect(items[3].selected).to.be.true;
 
       list.disabled = true;
-      list.children.forEach((item) => {
+      items.forEach((item) => {
         item.disabled = true;
       });
       await nextFrame();
 
-      expect(list.items[3].selected).to.be.false;
+      expect(items[3].selected).to.be.false;
     });
 
     it('should restore previously selected item when listbox becomes re-enabled', async () => {
@@ -729,7 +732,7 @@ const runTests = (defineHelper, baseMixin) => {
       await nextFrame();
 
       list.disabled = true;
-      list.children.forEach((item) => {
+      items.forEach((item) => {
         item.disabled = true;
       });
       await nextFrame();
@@ -737,7 +740,7 @@ const runTests = (defineHelper, baseMixin) => {
       list.disabled = false;
       await nextFrame();
 
-      expect(list.items[3].selected).to.be.true;
+      expect(items[3].selected).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/3154

Looks like in the latest version of Web Test Runner, the version of Mocha has been updated so the above issue started to manifest in some cases where we missed to use spread or `Array.from()`. This PR aims to address this problem.

## Type of change

- Test