### PR TITLE
fix: store generated labelledby on attach

### DIFF
--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -37,9 +37,11 @@ export class FieldAriaController {
   setTarget(target) {
     this.__target = target;
     this.__setAriaRequiredAttribute(this.__required);
-    const isFromUser = this.__labelIdFromUser != null;
-    const labelId = isFromUser ? this.__labelIdFromUser : this.__labelId;
-    this.__setLabelIdToAriaAttribute(labelId, labelId, isFromUser);
+    // We need to make sure that value in __labelId is stored
+    this.__setLabelIdToAriaAttribute(this.__labelId, this.__labelId);
+    if (this.__labelIdFromUser != null) {
+      this.__setLabelIdToAriaAttribute(this.__labelIdFromUser, this.__labelIdFromUser, true);
+    }
     this.__setErrorIdToAriaAttribute(this.__errorId);
     this.__setHelperIdToAriaAttribute(this.__helperId);
     this.setAriaLabel(this.__label);

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -143,9 +143,6 @@ export const FieldMixin = (superclass) =>
 
     /** @private */
     __labelChanged(hasLabel, labelNode) {
-      if (this.accessibleName || this.accessibleNameRef) {
-        return;
-      }
       // Label ID should be only added when the label content is present.
       // Otherwise, it may conflict with an `aria-label` attribute possibly added by the user.
       if (hasLabel) {

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -787,6 +787,13 @@ const runTests = (defineHelper, baseMixin) => {
       it('input should have aria-labellebdy by empty', () => {
         expect(input.getAttribute('aria-labelledby')).to.be.null;
       });
+
+      it('should set default label to `aria-labellebdy` when accessible-name is removed', async () => {
+        const label = element.querySelector('[slot=label]');
+        element.accessibleName = null;
+        await nextRender();
+        expect(input.getAttribute('aria-labelledby')).to.equal(label.id);
+      });
     });
 
     describe('accessible-name-ref', () => {
@@ -850,6 +857,13 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should contain accessibleNameRef in aria-labelledby', async () => {
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
+      });
+
+      it('should set default label to `aria-labellebdy` when accessible-name-ref is removed', async () => {
+        const label = element.querySelector('[slot=label]');
+        element.accessibleNameRef = null;
+        await nextRender();
+        expect(input.getAttribute('aria-labelledby')).to.equal(label.id);
       });
     });
 


### PR DESCRIPTION
## Description

The changes on #5770 make it possible to set `accessibleNameRef` before attaching the element. However, it introduced another issue when `accessibleNameRef` is removed, then the generated one is.

This is due to an early return added in the `__labelChanged` method in `field-mixin`:

https://github.com/vaadin/web-components/blob/03fbf19d6338bce8545c2c75ac2964a0ce140a53/packages/field-base/src/field-mixin.js#L146-L148

Instead, this change removes the early exit and allows the default label to be set and change `setTarget` in `field-aria-controller` to first set the default label id and then check if a custom id exists to replace the former with the latter, storing it on the process.

## Type of change

- [X] Bugfix
- [ ] Feature
