### PR TITLE
feat: Lumo warning colors

### DIFF
--- a/packages/vaadin-lumo-styles/badge.js
+++ b/packages/vaadin-lumo-styles/badge.js
@@ -52,6 +52,11 @@ const badge = css`
     background-color: var(--lumo-error-color-10pct);
   }
 
+  [theme~='badge'][theme~='warning'] {
+    color: var(--lumo-warning-text-color);
+    background-color: var(--lumo-warning-color-10pct);
+  }
+
   [theme~='badge'][theme~='contrast'] {
     color: var(--lumo-contrast-80pct);
     background-color: var(--lumo-contrast-5pct);
@@ -72,6 +77,11 @@ const badge = css`
   [theme~='badge'][theme~='error'][theme~='primary'] {
     color: var(--lumo-error-contrast-color);
     background-color: var(--lumo-error-color);
+  }
+
+  [theme~='badge'][theme~='warning'][theme~='primary'] {
+    color: var(--lumo-warning-contrast-color);
+    background-color: var(--lumo-warning-color);
   }
 
   [theme~='badge'][theme~='contrast'][theme~='primary'] {
@@ -138,6 +148,10 @@ const badge = css`
 
   [theme~='badge'][theme~='error']:not([icon]):empty {
     background-color: var(--lumo-error-color);
+  }
+
+  [theme~='badge'][theme~='warning']:not([icon]):empty {
+    background-color: var(--lumo-warning-color);
   }
 
   /* Pill */

--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -78,6 +78,12 @@ const colorBase = css`
     --lumo-success-color-10pct: hsla(145, 72%, 31%, 0.1);
     --lumo-success-text-color: hsl(145, 85%, 25%);
     --lumo-success-contrast-color: #fff;
+
+    /* Warning */
+    --lumo-warning-color: hsl(48, 100%, 50%);
+    --lumo-warning-color-10pct: hsla(48, 100%, 50%, 0.25);
+    --lumo-warning-text-color: hsl(32, 100%, 30%);
+    --lumo-warning-contrast-color: var(--lumo-shade-90pct);
   }
 
   /* forced-colors mode adjustments */
@@ -159,6 +165,12 @@ const color = css`
     --lumo-success-color-50pct: hsla(145, 92%, 51%, 0.5);
     --lumo-success-color-10pct: hsla(145, 92%, 51%, 0.1);
     --lumo-success-text-color: hsl(145, 85%, 46%);
+
+    /* Warning */
+    --lumo-warning-color: hsl(43, 100%, 48%);
+    --lumo-warning-color-10pct: hsla(40, 100%, 50%, 0.2);
+    --lumo-warning-text-color: hsl(45, 100%, 60%);
+    --lumo-warning-contrast-color: var(--lumo-shade-90pct);
   }
 
   html {

--- a/packages/vaadin-lumo-styles/utilities/background.js
+++ b/packages/vaadin-lumo-styles/utilities/background.js
@@ -78,4 +78,11 @@ export const background = css`
   .bg-success-10 {
     background-color: var(--lumo-success-color-10pct);
   }
+
+  .bg-warning {
+    background-color: var(--lumo-warning-color);
+  }
+  .bg-warning-10 {
+    background-color: var(--lumo-warning-color-10pct);
+  }
 `;

--- a/packages/vaadin-lumo-styles/utilities/border.js
+++ b/packages/vaadin-lumo-styles/utilities/border.js
@@ -91,6 +91,16 @@ export const border = css`
     border-color: var(--lumo-success-color-10pct);
   }
 
+  .border-warning {
+    border-color: var(--lumo-warning-color);
+  }
+  .border-warning-10 {
+    border-color: var(--lumo-warning-color-10pct);
+  }
+  .border-warning-text {
+    border-color: var(--lumo-warning-text-color);
+  }
+
   /* === Border radius === */
   .rounded-none {
     border-radius: 0;

--- a/packages/vaadin-lumo-styles/utilities/border.js
+++ b/packages/vaadin-lumo-styles/utilities/border.js
@@ -97,7 +97,7 @@ export const border = css`
   .border-warning-10 {
     border-color: var(--lumo-warning-color-10pct);
   }
-  .border-warning-text {
+  .border-warning-strong {
     border-color: var(--lumo-warning-text-color);
   }
 

--- a/packages/vaadin-lumo-styles/utilities/typography.js
+++ b/packages/vaadin-lumo-styles/utilities/typography.js
@@ -128,6 +128,12 @@ export const typography = css`
   .text-success-contrast {
     color: var(--lumo-success-contrast-color);
   }
+  .text-warning {
+    color: var(--lumo-warning-text-color);
+  }
+  .text-warning-contrast {
+    color: var(--lumo-warning-contrast-color);
+  }
 
   /* === Text overflow === */
   .overflow-clip {


### PR DESCRIPTION
## Description

Adds warning colors to Lumo, including utility classes and badge styles.

Fixes #1655

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended. (No relevant tests)
- [x] New and existing tests are passing locally with my change. (No relevant tests)
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and [Acceptance Criteria](https://github.com/vaadin/platform/issues/4072) were created.
