### PR TITLE
fix: restore context menu opened state when moving within DOM

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -367,6 +367,11 @@ class ContextMenu extends OverlayClassMixin(
 
     this.__boundOnScroll = this.__onScroll.bind(this);
     window.addEventListener('scroll', this.__boundOnScroll, true);
+
+    // Restore opened state if overlay was opened when disconnecting
+    if (this.__restoreOpened) {
+      this._setOpened(true);
+    }
   }
 
   /** @protected */
@@ -374,6 +379,9 @@ class ContextMenu extends OverlayClassMixin(
     super.disconnectedCallback();
 
     window.removeEventListener('scroll', this.__boundOnScroll, true);
+
+    // Close overlay and memorize opened state
+    this.__restoreOpened = this.opened;
     this.close();
   }
 

--- a/packages/context-menu/test/context.test.js
+++ b/packages/context-menu/test/context.test.js
@@ -116,4 +116,15 @@ describe('context', () => {
     expect(spy.calledOnce).to.be.true;
     expect(menu.opened).to.be.false;
   });
+
+  it('should not close when moved within the DOM', () => {
+    fire(target, 'contextmenu');
+    expect(menu.opened).to.be.true;
+
+    const newParent = document.createElement('div');
+    document.body.appendChild(newParent);
+
+    newParent.appendChild(menu);
+    expect(menu.opened).to.be.true;
+  });
 });


### PR DESCRIPTION
## Description

Currently the context menu just closes when it is disconnected from the DOM, and does not reopen when it is connected again. This can be a problem with how the Dialog works now in 24, as it first adds all children to the host element, and then the renderer function moves them to the overlay. As part of moving to the overlay, the context menu becomes disconnected, and closes itself. This assumes that the Flow context menu auto-adds itself to the Dialog when it is opened, when adding the context menu manually the problem does not occur.

This change makes the context menu open again when it is connected to the DOM again. This is adapted from a similar change done for dialogs: https://github.com/vaadin/web-components/pull/3648

Fixes https://github.com/vaadin/flow-components/issues/4896

## Type of change

- Bugfix