### PR TITLE
feat: add dateLabel/timeLabel props to i18n object

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -11,8 +11,22 @@ import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import type { TimePickerI18n } from '@vaadin/time-picker/src/vaadin-time-picker.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export interface DateTimePickerI18n extends DatePickerI18n, TimePickerI18n {}
-
+export interface DateTimePickerI18n extends DatePickerI18n, TimePickerI18n {
+  /**
+   * Accessible label to the date picker.
+   * The property works in conjunction with label and accessibleName defined on the field.
+   * If both properties are defined, then accessibleName takes precedence.
+   * Then, the dateLabel value is concatenated with it.
+   */
+  dateLabel: string | null | undefined;
+  /**
+   * Accessible label to the time picker.
+   * The property works in conjunction with label and accessibleName defined on the field.
+   * If both properties are defined, then accessibleName takes precedence.
+   * Then, the dateLabel value is concatenated with it.
+   */
+  timeLabel: string | null | undefined;
+}
 /**
  * Fired when the user commits a value change.
  */

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -395,6 +395,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
       '__themeChanged(_theme, __datePicker, __timePicker)',
       '__overlayClassChanged(overlayClass, __datePicker, __timePicker)',
       '__pickersChanged(__datePicker, __timePicker)',
+      '__labelOrAccessibleNameChanged(label, accessibleName, i18n, __datePicker, __timePicker)',
     ];
   }
 
@@ -638,6 +639,19 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
 
     if (timePicker) {
       timePicker.i18n = { ...timePicker.i18n, ...i18n };
+    }
+  }
+
+  /** @private */
+  __labelOrAccessibleNameChanged(label, accessibleName, i18n, datePicker, timePicker) {
+    const name = accessibleName || label || '';
+
+    if (datePicker) {
+      datePicker.accessibleName = `${name} ${i18n.dateLabel || ''}`.trim();
+    }
+
+    if (timePicker) {
+      timePicker.accessibleName = `${name} ${i18n.timeLabel || ''}`.trim();
     }
   }
 

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -330,6 +330,7 @@ snapshots["vaadin-date-time-picker host label"] =
     <input
       aria-expanded="false"
       aria-haspopup="dialog"
+      aria-label="Label"
       autocomplete="off"
       id="input-vaadin-date-picker-6"
       role="combobox"
@@ -352,6 +353,7 @@ snapshots["vaadin-date-time-picker host label"] =
     <input
       aria-autocomplete="list"
       aria-expanded="false"
+      aria-label="Label"
       autocapitalize="off"
       autocomplete="off"
       autocorrect="off"

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -177,8 +177,19 @@ describe('accessibility', () => {
         pickerFocusElement = dateTimePicker.querySelector(`[slot=${part}-picker]`).focusElement;
       });
 
-      it(`should have accessibleName + ${part}Label set on the input`, () => {
+      it(`should have accessible-name + ${part}Label set on the input`, () => {
         expect(pickerFocusElement.getAttribute('aria-label')).to.equal('dtp-accessible-name picker-label');
+      });
+
+      it(`should use label + ${part}Label if accessible-name is removed`, () => {
+        dateTimePicker.accessibleName = null;
+        expect(pickerFocusElement.getAttribute('aria-label')).to.equal('dtp-label picker-label');
+      });
+
+      it(`should use ${part}Label if accessible-name and label are removed`, () => {
+        dateTimePicker.accessibleName = null;
+        dateTimePicker.label = null;
+        expect(pickerFocusElement.getAttribute('aria-label')).to.equal('picker-label');
       });
     });
   });

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../vaadin-date-time-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
@@ -116,6 +116,70 @@ describe('setting i18n on a slotted picker before connected to the DOM', () => {
       await aTimeout(0);
       document.body.appendChild(dateTimePicker);
       expect(datePicker.i18n.cancel).to.equal('Peruuta');
+    });
+  });
+});
+
+describe('accessibility', () => {
+  ['date', 'time'].forEach((part) => {
+    let dateTimePicker, pickerFocusElement;
+
+    beforeEach(() => {
+      dateTimePicker = fixtureSync('<vaadin-date-time-picker></vaadin-date-time-picker>');
+      pickerFocusElement = dateTimePicker.querySelector(`[slot=${part}-picker]`).focusElement;
+    });
+
+    it(`should be undefined by default`, () => {
+      expect(dateTimePicker.i18n[`${part}Label`]).to.be.undefined;
+      expect(pickerFocusElement.getAttribute('aria-label')).to.be.null;
+    });
+
+    it(`should update aria-label of ${part}-picker when ${part}Label is changed`, () => {
+      dateTimePicker.i18n = { ...dateTimePicker.i18n, [`${part}Label`]: 'picker-label' };
+      expect(pickerFocusElement.getAttribute('aria-label')).to.equal('picker-label');
+    });
+
+    it(`should remove aria-label of ${part}-picker when ${part}Label is set to null`, () => {
+      const originalI18n = dateTimePicker.i18n;
+      dateTimePicker.i18n = { ...originalI18n, [`${part}Label`]: 'picker-label' };
+      dateTimePicker.i18n = originalI18n;
+      expect(pickerFocusElement.getAttribute('aria-label')).to.be.null;
+    });
+
+    it(`should prepend ${part}Label value with date-time-picker accessible-name value`, () => {
+      dateTimePicker.accessibleName = 'dtp-accessible-name';
+      dateTimePicker.i18n = { ...dateTimePicker.i18n, [`${part}Label`]: 'picker-label' };
+      expect(pickerFocusElement.getAttribute('aria-label')).to.equal('dtp-accessible-name picker-label');
+    });
+
+    it(`should prepend ${part}Label value with date-time-picker label value`, () => {
+      dateTimePicker.label = 'dtp-label';
+      dateTimePicker.i18n = { ...dateTimePicker.i18n, [`${part}Label`]: 'picker-label' };
+      expect(pickerFocusElement.getAttribute('aria-label')).to.equal('dtp-label picker-label');
+    });
+
+    it(`should prepend ${part}label value with date-time-picker accessible-name value when label also set`, () => {
+      dateTimePicker.label = 'dtp-label';
+      dateTimePicker.accessibleName = 'dtp-accessible-name';
+      dateTimePicker.i18n = { ...dateTimePicker.i18n, [`${part}Label`]: 'picker-label' };
+      expect(pickerFocusElement.getAttribute('aria-label')).to.equal('dtp-accessible-name picker-label');
+    });
+
+    describe('property set before attach', () => {
+      beforeEach(() => {
+        const parent = fixtureSync('<div></div>');
+        dateTimePicker = document.createElement('vaadin-date-time-picker');
+        dateTimePicker.label = 'dtp-label';
+        dateTimePicker.accessibleName = 'dtp-accessible-name';
+        dateTimePicker.i18n = { ...dateTimePicker.i18n, [`${part}Label`]: 'picker-label' };
+
+        parent.appendChild(dateTimePicker);
+        pickerFocusElement = dateTimePicker.querySelector(`[slot=${part}-picker]`).focusElement;
+      });
+
+      it(`should have accessibleName + ${part}Label set on the input`, () => {
+        expect(pickerFocusElement.getAttribute('aria-label')).to.equal('dtp-accessible-name picker-label');
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Add two new properties `dateLabel` and `timeLabel` to the `i18n` object ultimately used to set the `aria-label` attribute on each field, through the `accessible-name` API.

The values are concatenated with one of the following properties (if defined)
- accessible-name; or
- label

Part of https://github.com/vaadin/flow-components/issues/4719

## Type of change

- [ ] Bugfix
- [X] Feature
