### PR TITLE
fix: keyboard navigation when using position fixed

### DIFF
--- a/packages/a11y-base/src/focus-utils.js
+++ b/packages/a11y-base/src/focus-utils.js
@@ -148,7 +148,9 @@ export function isElementHidden(element) {
   // `offsetParent` is `null` when the element itself
   // or one of its ancestors is hidden with `display: none`.
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
-  if (element.offsetParent === null) {
+  // However `offsetParent` is also null when the element is using fixed
+  // positioning, so additionally check if the element takes up layout space.
+  if (element.offsetParent === null && element.clientWidth === 0 && element.clientHeight === 0) {
     return true;
   }
 

--- a/packages/a11y-base/test/focus-utils.test.js
+++ b/packages/a11y-base/test/focus-utils.test.js
@@ -16,7 +16,7 @@ describe('focus-utils', () => {
     beforeEach(() => {
       element = fixtureSync(`
         <div class="parent">
-          <div class="child"></div>
+          <div class="child">foo</div>
         </div>
       `);
     });
@@ -42,6 +42,11 @@ describe('focus-utils', () => {
     });
 
     it('should return false for visible elements', () => {
+      expect(isElementHidden(element)).to.be.false;
+    });
+
+    it('should return false when using fixed positioning', () => {
+      element.style.position = 'fixed';
       expect(isElementHidden(element)).to.be.false;
     });
   });


### PR DESCRIPTION
## Description

Keyboard navigation for tab bar is currently broken when the element is within the app layout's drawer. The cause is the following check which incorrectly identifies all tabs as hidden:
https://github.com/vaadin/web-components/blob/7a9fbf11acabb7fb103c7f09e3318c50d2e1e6cd/packages/a11y-base/src/focus-utils.js#L148-L153
The problem is that `offsetParent` is also null if the element is using fixed positioning. It can also be null for nested elements in a container with fixed positioning, such as for the tabs being in the app layouts drawer.

This change adds an additional check to verify that items have no client size which would be another indicator that `display: none` is being used in the hierarchy.

Fixes https://github.com/vaadin/web-components/issues/5706

## Type of change

- Bugfix