### PR TITLE
fix: synchronize expanded/collapsed state to server

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -9,6 +9,17 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
+ * Fired when the `expanded` property changes.
+ */
+export type SideNavItemExpandedChangedEvent = CustomEvent<{ value: boolean }>;
+
+export interface SideNavItemCustomEventMap {
+  'expanded-changed': SideNavItemExpandedChangedEvent;
+}
+
+export type SideNavItemEventMap = HTMLElementEventMap & SideNavItemCustomEventMap;
+
+/**
  * An element used internally by `<vaadin-side-nav>`. Represents a navigation target.
  * Not intended to be used separately.
  *
@@ -42,6 +53,8 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *     <span theme="badge primary" slot="suffix">Suffix</span>
  *   </vaadin-side-nav-item>
  * ```
+ *
+ * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  */
 declare class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
   /**
@@ -58,6 +71,18 @@ declare class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitEle
    * Toggles the `active` attribute.
    */
   active: boolean;
+
+  addEventListener<K extends keyof SideNavItemEventMap>(
+    type: K,
+    listener: (this: SideNavItem, ev: SideNavItemEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof SideNavItemEventMap>(
+    type: K,
+    listener: (this: SideNavItem, ev: SideNavItemEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
 }
 
 declare global {

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -78,6 +78,7 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
       expanded: {
         type: Boolean,
         value: false,
+        notify: true,
         reflectToAttribute: true,
       },
 

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -49,6 +49,8 @@ function isEnabled() {
  *   </vaadin-side-nav-item>
  * ```
  *
+ * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
+ *
  * @extends LitElement
  * @mixes PolylitMixin
  * @mixes ThemableMixin

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -9,6 +9,17 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
+ * Fired when the `collapsed` property changes.
+ */
+export type SideNavCollapsedChangedEvent = CustomEvent<{ value: boolean }>;
+
+export interface SideNavCustomEventMap {
+  'collapsed-changed': SideNavCollapsedChangedEvent;
+}
+
+export type SideNavEventMap = HTMLElementEventMap & SideNavCustomEventMap;
+
+/**
  * `<vaadin-side-nav>` is a Web Component for navigation menus.
  *
  * ```
@@ -36,6 +47,8 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *     <vaadin-side-nav-item>Item</vaadin-side-nav-item>
  *   </vaadin-side-nav>
  * ```
+ *
+ * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.
  */
 declare class SideNav extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
   /**
@@ -47,6 +60,18 @@ declare class SideNav extends ElementMixin(ThemableMixin(PolylitMixin(LitElement
    * When present, the side nav is collapsed to hide the items.
    */
   collapsed: boolean;
+
+  addEventListener<K extends keyof SideNavEventMap>(
+    type: K,
+    listener: (this: SideNav, ev: SideNavEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof SideNavEventMap>(
+    type: K,
+    listener: (this: SideNav, ev: SideNavEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
 }
 
 declare global {

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -44,6 +44,8 @@ function isEnabled() {
  *   </vaadin-side-nav>
  * ```
  *
+ * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.
+ *
  * @extends LitElement
  * @mixes PolylitMixin
  * @mixes ThemableMixin

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -79,6 +79,7 @@ class SideNav extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
       collapsed: {
         type: Boolean,
         value: false,
+        notify: true,
         reflectToAttribute: true,
       },
     };

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../enable.js';
 import '../vaadin-side-nav-item.js';
 
@@ -65,6 +66,14 @@ describe('expand', () => {
       passiveItemWithChildren._button.click();
       passiveItemWithChildren._button.click();
       expect(passiveItemWithChildren.expanded).to.be.false;
+    });
+
+    it('should dispatch expanded-changed event when expanded changes', async () => {
+      const spy = sinon.spy();
+      passiveItemWithChildren.addEventListener('expanded-changed', spy);
+      passiveItemWithChildren._button.click();
+      await nextRender(passiveItemWithChildren);
+      expect(spy.calledOnce).to.be.true;
     });
   });
 

--- a/packages/side-nav/test/side-nav.test.js
+++ b/packages/side-nav/test/side-nav.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../enable.js';
 import '../vaadin-side-nav.js';
 
@@ -50,6 +51,14 @@ describe('side-nav', () => {
       sideNav.collapsed = true;
       await nextRender(sideNav);
       expect(sideNav.collapsed).to.be.true;
+    });
+
+    it('should dispatch collapsed-changed event when collapsed changes', async () => {
+      const spy = sinon.spy();
+      sideNav.addEventListener('collapsed-changed', spy);
+      await nextRender(sideNav);
+      sideNav.shadowRoot.querySelector('summary[part="label"]').click();
+      expect(spy.calledOnce).to.be.true;
     });
   });
 });

--- a/packages/side-nav/test/typings/side-nav.types.ts
+++ b/packages/side-nav/test/typings/side-nav.types.ts
@@ -3,8 +3,8 @@ import '../../vaadin-side-nav-item.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { PolylitMixinClass } from '@vaadin/component-base/src/polylit-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import type { SideNav } from '../../src/vaadin-side-nav';
-import type { SideNavItem } from '../../src/vaadin-side-nav-item';
+import type { SideNav, SideNavCollapsedChangedEvent } from '../../src/vaadin-side-nav';
+import type { SideNavItem, SideNavItemExpandedChangedEvent } from '../../src/vaadin-side-nav-item';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -19,6 +19,12 @@ assertType<ElementMixinClass>(sideNav);
 assertType<PolylitMixinClass>(sideNav);
 assertType<ThemableMixinClass>(sideNav);
 
+// Events
+sideNav.addEventListener('collapsed-changed', (event) => {
+  assertType<SideNavCollapsedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
 const sideNavItem: SideNavItem = document.createElement('vaadin-side-nav-item');
 
 // Item properties
@@ -30,3 +36,9 @@ assertType<boolean>(sideNavItem.expanded);
 assertType<ElementMixinClass>(sideNavItem);
 assertType<PolylitMixinClass>(sideNavItem);
 assertType<ThemableMixinClass>(sideNavItem);
+
+// Item Events
+sideNavItem.addEventListener('expanded-changed', (event) => {
+  assertType<SideNavItemExpandedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});


### PR DESCRIPTION
## Description

The Flow API has `setExpanded()` method to have the ability to programmatically expand/collapse SideNav and SideNavItems (if they have a hierarchical structure). There is also `isExpanded()` method on both components to check the expanded state. However, this method does not return the correct state if the user clicks on the expand/collapse button in the browser. The state of the client property _is not_ synchronized back to the server.

This PR solves this issue together with https://github.com/vaadin/flow-components/pull/5007
I've checked the other components how they do it, namely `vaadin-details` or `vaadin-accordion` (both have `opened` properties, which are being synchronized to the server).
The fix is to produce the events on the client when the given property changes (by using `notify: true`), and then use `@Synchronize` in the Flow API code so the server is updated when such `expanded-changed`/`collapsed-changed` event happens.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
