### PR TITLE
fix: prevent diacritics from being cut off

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -20,6 +20,10 @@ const requiredField = css`
     line-height: 1;
     padding-right: 1em;
     padding-bottom: 0.5em;
+    /* As a workaround for diacritics being cut off, add a top padding and a 
+    negative margin to compensate */
+    padding-top: 0.25em;
+    margin-top: -0.25em;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Description

Adds a top-padding, and respective negative margin, to input field labels to prevent diacritics from being cut off.

Decided to go with the top padding solution based on the reasoning here: https://github.com/vaadin/web-components/pull/5501#issuecomment-1521433948

Fixes #5386

## Type of change

- Bugfix