### PR TITLE
fix: add missing dedupe-mixin dependency

### DIFF
--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -35,6 +35,7 @@
     "polymer"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "24.1.0-alpha8",
     "@vaadin/component-base": "24.1.0-alpha8",


### PR DESCRIPTION
## Description

Added the missing `@open-wc/dedupe-mixin` dependency to `list-box` to fix TypeScript compilation errors in user projects.

Fixes https://github.com/vaadin/web-components/issues/5780

## Type of change

- [x] Bugfix
