### PR TITLE
chore: add Lumo style file for side-nav-item

### DIFF
--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item.js
@@ -3,5 +3,5 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import './vaadin-side-nav-item.js';
-import '../../src/vaadin-side-nav.js';
+import './vaadin-side-nav-styles.js';
+import '../../src/vaadin-side-nav-item.js';


### PR DESCRIPTION
## Description

The Lumo styles are not applied for `vaadin-nav-side-item` when used from Flow.

The reason for this is that Flow generates the `generated-flow-imports.js` with the following content:
![image](https://user-images.githubusercontent.com/1890879/235898287-2507a30f-b10d-47d5-995b-ac1e74af161b.png)

You can see that only Lumo import for the `vaadin-nav-side` is generated for flow. It's true that this import registers styles also for `vaadin-nav-side-item`, however it seems that the order of things is the trouble here: the styles are registered _after_ the `vaadin-nav-side-item` was defined, which means that the styles are not used.

This PR fixes this by creating another file in the `theme/lumo` directory named `vaadin-side-nav-item.js`. This ensures that the file is detected by Flow while generating `generated-flow-imports.js` and the Lumo theme file is imported there instead of the `src` bare version.

Inspiration took in the `vaadin-accordion` component, which also consists of two tightly coupled "subcomponents".

This is how the `generated-flow-imports.js` looks like after the PR is applied:
![image](https://user-images.githubusercontent.com/1890879/235899268-034113db-3804-43b3-8b87-03267601ede4.png)


## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
