### PR TITLE
fix: set required vertical space in combo box overlay mixin

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -15,6 +15,12 @@ export const ComboBoxOverlayMixin = (superClass) =>
       return ['_setOverlayWidth(positionTarget, opened)'];
     }
 
+    constructor() {
+      super();
+
+      this.requiredVerticalSpace = 200;
+    }
+
     /** @protected */
     connectedCallback() {
       super.connectedCallback();

--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -52,12 +52,6 @@ export class ComboBoxOverlay extends ComboBoxOverlayMixin(Overlay) {
 
     return memoizedTemplate;
   }
-
-  constructor() {
-    super();
-
-    this.requiredVerticalSpace = 200;
-  }
 }
 
 customElements.define(ComboBoxOverlay.is, ComboBoxOverlay);


### PR DESCRIPTION
## Description

Moves a previous combo box overlay positioning fix to `ComboBoxOverlayMixin` so that it is reused by multi-select combo box. MSCB doesn't have a test suite of its own for the overlay, instead relying on the mixin being tested as part of `packages/combo-box/test/overlay-position.test.js`.

The mixin is also used by `vaadin-time-picker`, which apparently could also use this fix:

![Bildschirmfoto 2023-05-03 um 20 06 07](https://user-images.githubusercontent.com/357820/236005556-d8d7eb69-ec07-4daa-9c22-d02d900cf1c6.png)


Fixes https://github.com/vaadin/flow-components/issues/5014

## Type of change

- Bugfix