### PR TITLE
refactor!: use aria-describedby for group field components

### DIFF
--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -20,16 +20,6 @@ export class FieldAriaController {
   }
 
   /**
-   * `true` if the target element is the host component itself, `false` otherwise.
-   *
-   * @return {boolean}
-   * @private
-   */
-  get __isGroupField() {
-    return this.__target === this.host;
-  }
-
-  /**
    * Sets a target element to which ARIA attributes are added.
    *
    * @param {HTMLElement} target
@@ -150,10 +140,7 @@ export class FieldAriaController {
    * @private
    */
   __setErrorIdToAriaAttribute(errorId, oldErrorId) {
-    // For groups, add all IDs to aria-labelledby rather than aria-describedby -
-    // that should guarantee that it's announced when the group is entered.
-    const ariaAttribute = this.__isGroupField ? 'aria-labelledby' : 'aria-describedby';
-    setAriaIDReference(this.__target, ariaAttribute, { newId: errorId, oldId: oldErrorId, fromUser: false });
+    setAriaIDReference(this.__target, 'aria-describedby', { newId: errorId, oldId: oldErrorId, fromUser: false });
   }
 
   /**
@@ -162,10 +149,7 @@ export class FieldAriaController {
    * @private
    */
   __setHelperIdToAriaAttribute(helperId, oldHelperId) {
-    // For groups, add all IDs to aria-labelledby rather than aria-describedby -
-    // that should guarantee that it's announced when the group is entered.
-    const ariaAttribute = this.__isGroupField ? 'aria-labelledby' : 'aria-describedby';
-    setAriaIDReference(this.__target, ariaAttribute, { newId: helperId, oldId: oldHelperId, fromUser: false });
+    setAriaIDReference(this.__target, 'aria-describedby', { newId: helperId, oldId: oldHelperId, fromUser: false });
   }
 
   /**

--- a/packages/a11y-base/test/field-aria-controller.test.js
+++ b/packages/a11y-base/test/field-aria-controller.test.js
@@ -158,12 +158,12 @@ const runTests = (defineHelper, baseMixin) => {
         controller.setTarget(element);
       });
 
-      it('should add error id to aria-labelledby attribute', () => {
-        expect(element.getAttribute('aria-labelledby')).equal('custom-id error-id');
+      it('should add error id to aria-describedby attribute', () => {
+        expect(element.getAttribute('aria-describedby')).equal('custom-id error-id');
       });
 
       it('should not add error id to aria-describedby attribute', () => {
-        expect(element.getAttribute('aria-describedby')).not.to.include('error-id');
+        // expect(element.getAttribute('aria-describedby')).not.to.include('error-id');
       });
     });
 
@@ -173,12 +173,8 @@ const runTests = (defineHelper, baseMixin) => {
         controller.setTarget(element);
       });
 
-      it('should add helper id to aria-labelledby attribute', () => {
-        expect(element.getAttribute('aria-labelledby')).equal('custom-id helper-id');
-      });
-
-      it('should not add helper id to aria-describedby attribute', () => {
-        expect(element.getAttribute('aria-describedby')).not.to.include('helper-id');
+      it('should add helper id to aria-describedby attribute', () => {
+        expect(element.getAttribute('aria-describedby')).equal('custom-id helper-id');
       });
     });
 
@@ -202,18 +198,18 @@ const runTests = (defineHelper, baseMixin) => {
         expect(element.getAttribute('aria-labelledby')).equal('custom-id');
       });
 
-      it('should set error id to aria-labelledby attribute', () => {
+      it('should set error id to aria-describedby attribute', () => {
         controller.setErrorId('error-id');
-        expect(element.getAttribute('aria-labelledby')).equal('custom-id error-id');
+        expect(element.getAttribute('aria-describedby')).equal('custom-id error-id');
         controller.setErrorId(null);
-        expect(element.getAttribute('aria-labelledby')).equal('custom-id');
+        expect(element.getAttribute('aria-describedby')).to.equal('custom-id');
       });
 
-      it('should set helper id to aria-labelledby attribute', () => {
+      it('should set helper id to aria-describedby attribute', () => {
         controller.setHelperId('helper-id');
-        expect(element.getAttribute('aria-labelledby')).equal('custom-id helper-id');
+        expect(element.getAttribute('aria-describedby')).equal('custom-id helper-id');
         controller.setHelperId(null);
-        expect(element.getAttribute('aria-labelledby')).equal('custom-id');
+        expect(element.getAttribute('aria-describedby')).equal('custom-id');
       });
 
       it('should toggle aria-required attribute', () => {

--- a/packages/a11y-base/test/field-aria-controller.test.js
+++ b/packages/a11y-base/test/field-aria-controller.test.js
@@ -161,10 +161,6 @@ const runTests = (defineHelper, baseMixin) => {
       it('should add error id to aria-describedby attribute', () => {
         expect(element.getAttribute('aria-describedby')).equal('custom-id error-id');
       });
-
-      it('should not add error id to aria-describedby attribute', () => {
-        // expect(element.getAttribute('aria-describedby')).not.to.include('error-id');
-      });
     });
 
     describe('helper id', () => {

--- a/packages/a11y-base/test/field-aria-controller.test.js
+++ b/packages/a11y-base/test/field-aria-controller.test.js
@@ -196,16 +196,16 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should set error id to aria-describedby attribute', () => {
         controller.setErrorId('error-id');
-        expect(element.getAttribute('aria-describedby')).equal('custom-id error-id');
+        expect(element.getAttribute('aria-describedby')).to.equal('custom-id error-id');
         controller.setErrorId(null);
         expect(element.getAttribute('aria-describedby')).to.equal('custom-id');
       });
 
       it('should set helper id to aria-describedby attribute', () => {
         controller.setHelperId('helper-id');
-        expect(element.getAttribute('aria-describedby')).equal('custom-id helper-id');
+        expect(element.getAttribute('aria-describedby')).to.equal('custom-id helper-id');
         controller.setHelperId(null);
-        expect(element.getAttribute('aria-describedby')).equal('custom-id');
+        expect(element.getAttribute('aria-describedby')).to.equal('custom-id');
       });
 
       it('should toggle aria-required attribute', () => {

--- a/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
+++ b/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
@@ -281,7 +281,7 @@ snapshots["vaadin-checkbox-group host required"] =
 
 snapshots["vaadin-checkbox-group host helper"] = 
 `<vaadin-checkbox-group
-  aria-labelledby="helper-vaadin-checkbox-group-1"
+  aria-describedby="helper-vaadin-checkbox-group-1"
   has-helper=""
   role="group"
 >
@@ -348,7 +348,7 @@ snapshots["vaadin-checkbox-group host helper"] =
 
 snapshots["vaadin-checkbox-group host error"] = 
 `<vaadin-checkbox-group
-  aria-labelledby="error-message-vaadin-checkbox-group-2"
+  aria-describedby="error-message-vaadin-checkbox-group-2"
   has-error-message=""
   invalid=""
   role="group"

--- a/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
+++ b/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
@@ -63,7 +63,7 @@ snapshots["vaadin-custom-field host required"] =
 
 snapshots["vaadin-custom-field host helper"] = 
 `<vaadin-custom-field
-  aria-labelledby="helper-vaadin-custom-field-1"
+  aria-describedby="helper-vaadin-custom-field-1"
   has-helper=""
   role="group"
 >
@@ -90,7 +90,7 @@ snapshots["vaadin-custom-field host helper"] =
 
 snapshots["vaadin-custom-field host error"] = 
 `<vaadin-custom-field
-  aria-labelledby="error-message-vaadin-custom-field-2"
+  aria-describedby="error-message-vaadin-custom-field-2"
   has-error-message=""
   invalid=""
   role="group"

--- a/packages/date-time-picker/test/aria.test.js
+++ b/packages/date-time-picker/test/aria.test.js
@@ -18,19 +18,26 @@ describe('ARIA', () => {
     expect(dateTimePicker.getAttribute('role')).to.equal('group');
   });
 
-  it('should add label and helper text to aria-labelledby when field is valid', () => {
+  it('should add label text to aria-labelledby when field is valid', () => {
     const aria = dateTimePicker.getAttribute('aria-labelledby');
-    expect(aria).to.include(helper.id);
+    expect(aria).to.not.include(helper.id);
     expect(aria).to.not.include(error.id);
     expect(aria).to.include(label.id);
   });
 
-  it('should add error message to aria-labelledby when field is invalid', async () => {
+  it('should add helper text to aria-describedby when field is valid', () => {
+    const aria = dateTimePicker.getAttribute('aria-describedby');
+    expect(aria).to.include(helper.id);
+    expect(aria).to.not.include(error.id);
+    expect(aria).to.not.include(label.id);
+  });
+
+  it('should add error message to aria-describedby when field is invalid', async () => {
     dateTimePicker.invalid = true;
     await aTimeout(0);
-    const aria = dateTimePicker.getAttribute('aria-labelledby');
+    const aria = dateTimePicker.getAttribute('aria-describedby');
     expect(aria).to.include(helper.id);
     expect(aria).to.include(error.id);
-    expect(aria).to.include(label.id);
+    expect(aria).to.not.include(label.id);
   });
 });

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -369,7 +369,7 @@ snapshots["vaadin-date-time-picker host label"] =
 
 snapshots["vaadin-date-time-picker host helper"] = 
 `<vaadin-date-time-picker
-  aria-labelledby="helper-vaadin-date-time-picker-1"
+  aria-describedby="helper-vaadin-date-time-picker-1"
   has-helper=""
   role="group"
 >
@@ -443,7 +443,7 @@ snapshots["vaadin-date-time-picker host helper"] =
 
 snapshots["vaadin-date-time-picker host error"] = 
 `<vaadin-date-time-picker
-  aria-labelledby="error-message-vaadin-date-time-picker-2"
+  aria-describedby="error-message-vaadin-date-time-picker-2"
   has-error-message=""
   invalid=""
   role="group"

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -866,35 +866,6 @@ const runTests = (defineHelper, baseMixin) => {
         expect(input.getAttribute('aria-labelledby')).to.equal(label.id);
       });
     });
-
-    describe('field group', () => {
-      beforeEach(async () => {
-        element = fixtureSync(
-          `<${groupTag} label="Label" helper-text="Helper" error-message="Error Message"></${groupTag}>`,
-        );
-        await nextRender();
-        label = element.querySelector('[slot=label]');
-        error = element.querySelector('[slot=error-message]');
-        helper = element.querySelector('[slot=helper]');
-      });
-
-      describe('aria-describedby', () => {
-        it('should only contain label id and helper id when the field is valid', () => {
-          const aria = element.getAttribute('aria-describedby');
-          expect(aria).to.include(helper.id);
-          expect(aria).to.not.include(error.id);
-        });
-
-        it('should add error id asynchronously after the field becomes invalid', async () => {
-          element.invalid = true;
-          await nextFrame();
-          await aTimeout(0);
-          const aria = element.getAttribute('aria-describedby');
-          expect(aria).to.include(helper.id);
-          expect(aria).to.include(error.id);
-        });
-      });
-    });
   });
 
   describe('slotted label', () => {

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -878,10 +878,9 @@ const runTests = (defineHelper, baseMixin) => {
         helper = element.querySelector('[slot=helper]');
       });
 
-      describe('aria-labelledby', () => {
+      describe('aria-describedby', () => {
         it('should only contain label id and helper id when the field is valid', () => {
-          const aria = element.getAttribute('aria-labelledby');
-          expect(aria).to.include(label.id);
+          const aria = element.getAttribute('aria-describedby');
           expect(aria).to.include(helper.id);
           expect(aria).to.not.include(error.id);
         });
@@ -890,22 +889,9 @@ const runTests = (defineHelper, baseMixin) => {
           element.invalid = true;
           await nextFrame();
           await aTimeout(0);
-          const aria = element.getAttribute('aria-labelledby');
-          expect(aria).to.include(label.id);
+          const aria = element.getAttribute('aria-describedby');
           expect(aria).to.include(helper.id);
           expect(aria).to.include(error.id);
-        });
-      });
-
-      describe('aria-describedby', () => {
-        it('should be empty when the field is valid', () => {
-          expect(element.hasAttribute('aria-describedby')).to.be.false;
-        });
-
-        it('should be empty when the field is invalid', async () => {
-          element.invalid = true;
-          await nextFrame();
-          expect(element.hasAttribute('aria-describedby')).to.be.false;
         });
       });
     });

--- a/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
@@ -252,7 +252,7 @@ snapshots["vaadin-radio-group host required"] =
 
 snapshots["vaadin-radio-group host helper"] = 
 `<vaadin-radio-group
-  aria-labelledby="helper-vaadin-radio-group-1"
+  aria-describedby="helper-vaadin-radio-group-1"
   has-helper=""
   role="radiogroup"
 >
@@ -319,8 +319,8 @@ snapshots["vaadin-radio-group host helper"] =
 
 snapshots["vaadin-radio-group host error"] = 
 `<vaadin-radio-group
+  aria-describedby="error-message-vaadin-radio-group-2"
   aria-invalid="true"
-  aria-labelledby="error-message-vaadin-radio-group-2"
   has-error-message=""
   invalid=""
   role="radiogroup"


### PR DESCRIPTION
## Description

As both **JAWS** and **NVDA** announce `aria-describedby` correctly, and only **VoiceOver** cannot do so, we'll revert to using `aria-describedby` for content that is not semantically part of the label.

Otherwise, we would have to refactor tooltips to use `aria-labelledby` and introduce a hidden element for invisible aria-labels. Furthermore, concatenating labels, descriptions, validation errors, and tooltips into the label results in extremely verbose announcements.

We see this as choosing the less bad (and less complex) of two bad options.
