### PR TITLE
fix: add missing dedupe-mixin dependency

### DIFF
--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -35,6 +35,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@vaadin/component-base": "24.1.0-alpha9",
     "@vaadin/vaadin-lumo-styles": "24.1.0-alpha9",
     "@vaadin/vaadin-material-styles": "24.1.0-alpha9",


### PR DESCRIPTION
## Description

Add missing `dedupe-mixin` dependency.

No related issue.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.