### PR TITLE
refactor: remove unused method in select

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -674,17 +674,6 @@ class Select extends OverlayClassMixin(
     return labelId ? `${labelId} ${itemId}`.trim() : null;
   }
 
-  /**
-   * @returns HTMLLabelElement
-   * @private
-   */
-  _createScreenReaderLabel() {
-    const label = document.createElement('label');
-    label.id = `sr-label-vaadin-select-${generateUniqueId()}`;
-    label.setAttribute('slot', 'sr-label');
-    return label;
-  }
-
   /** @private */
   __updateValueButton() {
     const valueButton = this.focusElement;


### PR DESCRIPTION
The method was added by mistake in cb419f5bd28be028ddea7bda3691d310f32f4475 and it was part of a prototype of the feature but it's not currently used anywhere.
