### PR TITLE
feat: close overlay drawer on global Escape key press

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -184,7 +184,7 @@ declare class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(HTMLE
 
   /**
    * Set to true to disable closing the drawer on Escape press
-   * Pressing Escape only closes the drawer if it is opened as overlay
+   * Pressing Escape only closes the drawer if it is opened as overlay on small devices.
    *
    * @attr {boolean} no-close-drawer-on-esc
    */

--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -183,7 +183,7 @@ declare class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(HTMLE
   closeDrawerOn: string;
 
   /**
-   * Set to true to disable closing the drawer on Escape press
+   * Set to true to disable closing the drawer on Escape press.
    * Pressing Escape only closes the drawer if it is opened as overlay on small devices.
    *
    * @attr {boolean} no-close-drawer-on-esc

--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -182,6 +182,14 @@ declare class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(HTMLE
    */
   closeDrawerOn: string;
 
+  /**
+   * Set to true to disable closing the drawer on Escape press
+   * Pressing Escape only closes the drawer if it is opened as overlay
+   *
+   * @attr {boolean} no-close-drawer-on-esc
+   */
+  noCloseDrawerOnEsc: boolean;
+
   addEventListener<K extends keyof AppLayoutEventMap>(
     type: K,
     listener: (this: AppLayout, ev: AppLayoutEventMap[K]) => void,

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -482,6 +482,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     window.removeEventListener('resize', this.__boundResizeListener);
     this.removeEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
     window.removeEventListener('close-overlay-drawer', this.__drawerToggleClickListener);
+    window.removeEventListener('keydown', this.__closeDrawerOnEscListener);
   }
 
   /**

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -383,6 +383,17 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
         value: 'vaadin-router-location-changed',
         observer: '_closeDrawerOnChanged',
       },
+
+      /**
+       * Set to true to disable closing the drawer on Escape press
+       * Pressing Escape only closes the drawer if it is opened as overlay
+       *
+       * @type {boolean}
+       */
+      noCloseDrawerOnEsc: {
+        type: Boolean,
+        value: false,
+      },
     };
   }
 
@@ -401,6 +412,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     this.__closeOverlayDrawerListener = this.__closeOverlayDrawer.bind(this);
     this.__trapFocusInDrawer = this.__trapFocusInDrawer.bind(this);
     this.__releaseFocusFromDrawer = this.__releaseFocusFromDrawer.bind(this);
+    this.__closeDrawerOnEscListener = this.__closeDrawerOnEscListener.bind(this);
     this.__focusTrapController = new FocusTrapController(this);
   }
 
@@ -412,6 +424,8 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
 
     window.addEventListener('resize', this.__boundResizeListener);
     this.addEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
+
+    window.addEventListener('keydown', this.__closeDrawerOnEscListener);
 
     beforeNextRender(this, this._afterFirstRender);
 
@@ -537,6 +551,21 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
   /** @private */
   __closeOverlayDrawer() {
     if (this.overlay) {
+      this.drawerOpened = false;
+    }
+  }
+
+  /**
+   * @param {KeyboardEvent} e
+   * @private
+   */
+  __closeDrawerOnEscListener(e) {
+    if (this.noCloseDrawerOnEsc) {
+      return;
+    }
+
+    // Only close if drawer is opened in overlay mode
+    if (e.key === 'Escape' && this.overlay) {
       this.drawerOpened = false;
     }
   }

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -385,8 +385,8 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
       },
 
       /**
-       * Set to true to disable closing the drawer on Escape press
-       * Pressing Escape only closes the drawer if it is opened as overlay
+       * Set to true to disable closing the drawer on Escape press.
+       * Pressing Escape only closes the drawer if it is opened as overlay on small devices.
        *
        * @type {boolean}
        */

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -275,7 +275,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
         <slot name="navbar"></slot>
       </div>
       <div part="backdrop" on-click="_onBackdropClick" on-touchend="_onBackdropTouchend"></div>
-      <div part="drawer" id="drawer" on-keydown="__onDrawerKeyDown">
+      <div part="drawer" id="drawer">
         <slot name="drawer" id="drawerSlot"></slot>
       </div>
       <div content>
@@ -713,18 +713,6 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     if (toggle) {
       toggle.focus();
       toggle.setAttribute('focus-ring', 'focus');
-    }
-  }
-
-  /**
-   * Closes the drawer on Escape press if it has been opened in the overlay mode.
-   *
-   * @param {KeyboardEvent} event
-   * @private
-   */
-  __onDrawerKeyDown(event) {
-    if (event.key === 'Escape' && this.overlay) {
-      this.drawerOpened = false;
     }
   }
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -281,6 +281,7 @@ describe('vaadin-app-layout', () => {
           layout.drawerOpened = true;
           await nextFrame();
         });
+
         it('should not close drawer on pressing Escape', () => {
           escKeyDown(layout);
           expect(layout.drawerOpened).to.be.true;
@@ -427,6 +428,7 @@ describe('vaadin-app-layout', () => {
           layout.drawerOpened = true;
           await nextFrame();
         });
+
         it('should close drawer on pressing Escape', () => {
           escKeyDown(layout);
           expect(layout.drawerOpened).to.be.false;

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import {
   aTimeout,
   esc,
+  escKeyDown,
   fixtureSync,
   makeSoloTouchEvent,
   nextFrame,
@@ -274,6 +275,17 @@ describe('vaadin-app-layout', () => {
         layout.drawerOpened = true;
         expect(toggle.getAttribute('aria-expanded')).to.equal('true');
       });
+
+      describe('a11y', () => {
+        beforeEach(async () => {
+          layout.drawerOpened = true;
+          await nextFrame();
+        });
+        it('should not close drawer on pressing Escape', () => {
+          escKeyDown(layout);
+          expect(layout.drawerOpened).to.be.true;
+        });
+      });
     });
 
     describe('mobile layout', () => {
@@ -407,6 +419,23 @@ describe('vaadin-app-layout', () => {
           layout.drawerOpened = true;
           await nextFrame();
           expect(spy.called).to.be.false;
+        });
+      });
+
+      describe('a11y', () => {
+        beforeEach(async () => {
+          layout.drawerOpened = true;
+          await nextFrame();
+        });
+        it('should close drawer on pressing Escape', () => {
+          escKeyDown(layout);
+          expect(layout.drawerOpened).to.be.false;
+        });
+
+        it('should not close drawer if `noCloseDrawerOnEsc` is set to true', () => {
+          layout.noCloseDrawerOnEsc = true;
+          escKeyDown(layout);
+          expect(layout.drawerOpened).to.be.true;
         });
       });
     });

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -258,11 +258,6 @@ describe('vaadin-app-layout', () => {
         expect(layout.drawerOpened).to.be.true;
       });
 
-      it('should not close the drawer on Escape press', () => {
-        esc(drawer);
-        expect(layout.drawerOpened).to.be.true;
-      });
-
       it('should set aria-expanded on the toggle to true by default', () => {
         expect(toggle.getAttribute('aria-expanded')).to.equal('true');
         layout.drawerOpened = true;
@@ -362,11 +357,6 @@ describe('vaadin-app-layout', () => {
         beforeEach(async () => {
           layout.drawerOpened = true;
           await nextFrame();
-        });
-
-        it('should close the drawer on Escape press', () => {
-          esc(drawer);
-          expect(layout.drawerOpened).to.be.false;
         });
 
         it('should close the drawer on backdrop click', () => {


### PR DESCRIPTION
## Description

Allow users to close the drawer on Escape pressing.
This action only works when the drawer is opened as an overlay.

This feature is enabled by default, however, it can be disabled by setting `noCloseDrawerOnEsc` to `true`

Part of #123 
(not sure if this PR can fix the issue completely since it recommends adding a close button to the drawer as part of the solution for the problem described)

## Type of change

- [ ] Bugfix
- [X] Feature
