### PR TITLE
feat: allow setting errorMessage for login fields

### DIFF
--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -65,6 +65,7 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
           <vaadin-text-field
             name="username"
             label="[[i18n.form.username]]"
+            error-message="[[i18n.errorMessage.username]]"
             id="vaadinLoginUsername"
             required
             on-keydown="_handleInputKeydown"
@@ -79,6 +80,7 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
           <vaadin-password-field
             name="password"
             label="[[i18n.form.password]]"
+            error-message="[[i18n.errorMessage.password]]"
             id="vaadinLoginPassword"
             required
             on-keydown="_handleInputKeydown"

--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -16,6 +16,8 @@ export interface LoginI18n {
   errorMessage: {
     title: string;
     message: string;
+    username: string;
+    password: string;
   };
   header?: {
     title?: string;

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -125,6 +125,8 @@ export const LoginMixin = (superClass) =>
               errorMessage: {
                 title: 'Incorrect username or password',
                 message: 'Check that you have entered the correct username and password and try again.',
+                username: 'Username is required',
+                password: 'Password is required',
               },
             };
           },

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -408,3 +408,237 @@ snapshots["vaadin-login-form shadow i18n"] =
 `;
 /* end snapshot vaadin-login-form shadow i18n */
 
+snapshots["vaadin-login-form host required"] = 
+`<vaadin-login-form>
+  <vaadin-login-form-wrapper>
+    <form
+      method="POST"
+      slot="form"
+    >
+      <input
+        id="csrf"
+        type="hidden"
+      >
+      <vaadin-text-field
+        autocapitalize="none"
+        autocomplete="username"
+        autocorrect="off"
+        focused=""
+        has-error-message=""
+        has-label=""
+        id="vaadinLoginUsername"
+        invalid=""
+        name="username"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-invalid="true"
+          aria-labelledby="label-vaadin-text-field-0"
+          autocapitalize="none"
+          autocomplete="username"
+          autocorrect="off"
+          id="input-vaadin-text-field-6"
+          invalid=""
+          name="username"
+          required=""
+          slot="input"
+          type="text"
+        >
+        <label
+          for="input-vaadin-text-field-6"
+          id="label-vaadin-text-field-0"
+          slot="label"
+        >
+          Username
+        </label>
+        <div
+          id="error-message-vaadin-text-field-2"
+          role="alert"
+          slot="error-message"
+        >
+          Username is required
+        </div>
+      </vaadin-text-field>
+      <vaadin-password-field
+        autocomplete="current-password"
+        has-error-message=""
+        has-label=""
+        id="vaadinLoginPassword"
+        invalid=""
+        name="password"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-invalid="true"
+          aria-labelledby="label-vaadin-password-field-3"
+          autocomplete="current-password"
+          id="input-vaadin-password-field-7"
+          invalid=""
+          name="password"
+          required=""
+          slot="input"
+          type="password"
+        >
+        <label
+          for="input-vaadin-password-field-7"
+          id="label-vaadin-password-field-3"
+          slot="label"
+        >
+          Password
+        </label>
+        <div
+          id="error-message-vaadin-password-field-5"
+          role="alert"
+          slot="error-message"
+        >
+          Password is required
+        </div>
+        <vaadin-password-field-button
+          aria-label="Show password"
+          aria-pressed="false"
+          role="button"
+          slot="reveal"
+          tabindex="0"
+        >
+        </vaadin-password-field-button>
+      </vaadin-password-field>
+      <vaadin-button
+        role="button"
+        tabindex="0"
+        theme="primary contained submit"
+      >
+        Log in
+      </vaadin-button>
+    </form>
+    <vaadin-button
+      role="button"
+      slot="forgot-password"
+      tabindex="0"
+      theme="tertiary small"
+    >
+      Forgot password
+    </vaadin-button>
+  </vaadin-login-form-wrapper>
+</vaadin-login-form>
+`;
+/* end snapshot vaadin-login-form host required */
+
+snapshots["vaadin-login-form host i18n-required"] = 
+`<vaadin-login-form>
+  <vaadin-login-form-wrapper>
+    <form
+      method="POST"
+      slot="form"
+    >
+      <input
+        id="csrf"
+        type="hidden"
+      >
+      <vaadin-text-field
+        autocapitalize="none"
+        autocomplete="username"
+        autocorrect="off"
+        focused=""
+        has-error-message=""
+        has-label=""
+        id="vaadinLoginUsername"
+        invalid=""
+        name="username"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-invalid="true"
+          aria-labelledby="label-vaadin-text-field-0"
+          autocapitalize="none"
+          autocomplete="username"
+          autocorrect="off"
+          id="input-vaadin-text-field-6"
+          invalid=""
+          name="username"
+          required=""
+          slot="input"
+          type="text"
+        >
+        <label
+          for="input-vaadin-text-field-6"
+          id="label-vaadin-text-field-0"
+          slot="label"
+        >
+          Käyttäjänimi
+        </label>
+        <div
+          id="error-message-vaadin-text-field-2"
+          role="alert"
+          slot="error-message"
+        >
+          Käyttäjätunnus vaaditaan
+        </div>
+      </vaadin-text-field>
+      <vaadin-password-field
+        autocomplete="current-password"
+        has-error-message=""
+        has-label=""
+        id="vaadinLoginPassword"
+        invalid=""
+        name="password"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-invalid="true"
+          aria-labelledby="label-vaadin-password-field-3"
+          autocomplete="current-password"
+          id="input-vaadin-password-field-7"
+          invalid=""
+          name="password"
+          required=""
+          slot="input"
+          type="password"
+        >
+        <label
+          for="input-vaadin-password-field-7"
+          id="label-vaadin-password-field-3"
+          slot="label"
+        >
+          Salasana
+        </label>
+        <div
+          id="error-message-vaadin-password-field-5"
+          role="alert"
+          slot="error-message"
+        >
+          Salasana vaaditaan
+        </div>
+        <vaadin-password-field-button
+          aria-label="Show password"
+          aria-pressed="false"
+          role="button"
+          slot="reveal"
+          tabindex="0"
+        >
+        </vaadin-password-field-button>
+      </vaadin-password-field>
+      <vaadin-button
+        role="button"
+        tabindex="0"
+        theme="primary contained submit"
+      >
+        Kirjaudu sisään
+      </vaadin-button>
+    </form>
+    <vaadin-button
+      role="button"
+      slot="forgot-password"
+      tabindex="0"
+      theme="tertiary small"
+    >
+      Unohtuiko salasana?
+    </vaadin-button>
+  </vaadin-login-form-wrapper>
+</vaadin-login-form>
+`;
+/* end snapshot vaadin-login-form host i18n-required */
+

--- a/packages/login/test/dom/login-form.test.js
+++ b/packages/login/test/dom/login-form.test.js
@@ -17,6 +17,8 @@ describe('vaadin-login-form', () => {
     errorMessage: {
       title: 'Väärä käyttäjätunnus tai salasana',
       message: 'Tarkista että käyttäjätunnus ja salasana ovat oikein ja yritä uudestaan.',
+      username: 'Käyttäjätunnus vaaditaan',
+      password: 'Salasana vaaditaan',
     },
     additionalInformation: 'Jos tarvitset lisätietoja käyttäjälle.',
   };
@@ -31,8 +33,23 @@ describe('vaadin-login-form', () => {
       await expect(form).dom.to.equalSnapshot();
     });
 
+    it('required', async () => {
+      form.querySelectorAll('[required]').forEach((el) => {
+        el.invalid = true;
+      });
+      await expect(form).dom.to.equalSnapshot();
+    });
+
     it('i18n', async () => {
       form.i18n = I18N_FINNISH;
+      await expect(form).dom.to.equalSnapshot();
+    });
+
+    it('i18n-required', async () => {
+      form.i18n = I18N_FINNISH;
+      form.querySelectorAll('[required]').forEach((el) => {
+        el.invalid = true;
+      });
       await expect(form).dom.to.equalSnapshot();
     });
 


### PR DESCRIPTION
## Description

Adds two properties to the `i18n` object that allow users to customize the error message when, for instance, the user leaves the field empty.

Fixes #101

## Type of change

- [ ] Bugfix
- [X] Feature
