### PR TITLE
fix: restore focus on dialog close

### DIFF
--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/a11y-base": "24.1.0-alpha9",
+    "@vaadin/a11y-base": "24.1.0-alpha10",
     "@vaadin/testing-helpers": "^0.4.0",
     "@vaadin/text-area": "24.1.0-beta1",
     "lit": "^2.0.0",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/a11y-base": "24.1.0-alpha10",
+    "@vaadin/a11y-base": "24.1.0-beta1",
     "@vaadin/testing-helpers": "^0.4.0",
     "@vaadin/text-area": "24.1.0-beta1",
     "lit": "^2.0.0",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/a11y-base": "24.1.0-alpha9",
     "@vaadin/testing-helpers": "^0.4.0",
     "@vaadin/text-area": "24.1.0-beta1",
     "lit": "^2.0.0",

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -103,6 +103,7 @@ class Dialog extends OverlayClassMixin(
         modeless="[[modeless]]"
         with-backdrop="[[!modeless]]"
         resizable$="[[resizable]]"
+        restore-focus-on-close
         focus-trap
       ></vaadin-dialog-overlay>
     `;

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -167,12 +167,17 @@ describe('vaadin-dialog', () => {
     let dialog, button;
 
     beforeEach(() => {
-      dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
-      button = fixtureSync('<button></button>');
+      const wrapper = fixtureSync(`
+        <div>
+          <vaadin-dialog></vaadin-dialog>
+          <button></button>
+        </div>
+      `);
+      [dialog, button] = wrapper.children;
       button.focus();
     });
 
-    it('should move focus to dialog on open', async () => {
+    it('should move focus to the dialog on open', async () => {
       dialog.opened = true;
       await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
       expect(isElementFocused(dialog.$.overlay)).to.be.true;

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { esc, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, esc, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-dialog.js';
+import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('vaadin-dialog', () => {
   describe('custom element definition', () => {
@@ -159,6 +160,30 @@ describe('vaadin-dialog', () => {
       dialog.opened = true;
       const contentMinWidth = parseFloat(getComputedStyle(dialog.$.overlay.$.content).minWidth);
       expect(contentMinWidth).to.be.gt(0);
+    });
+  });
+
+  describe('focus restoring', () => {
+    let dialog, button;
+
+    beforeEach(() => {
+      dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+      button = fixtureSync('<button></button>');
+      button.focus();
+    });
+
+    it('should move focus to dialog on open', async () => {
+      dialog.opened = true;
+      await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
+      expect(isElementFocused(dialog.$.overlay)).to.be.true;
+    });
+
+    it('should restore focus on dialog close', async () => {
+      dialog.opened = true;
+      await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
+      dialog.opened = false;
+      await aTimeout(0);
+      expect(isElementFocused(button)).to.be.true;
     });
   });
 });

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -163,7 +163,7 @@ describe('vaadin-dialog', () => {
     });
   });
 
-  describe('focus restoring', () => {
+  describe('focus restoration', () => {
     let dialog, button;
 
     beforeEach(() => {

--- a/packages/dialog/test/dom/__snapshots__/dialog.test.snap.js
+++ b/packages/dialog/test/dom/__snapshots__/dialog.test.snap.js
@@ -6,6 +6,7 @@ snapshots["vaadin-dialog overlay"] =
   focus-trap=""
   id="overlay"
   opened=""
+  restore-focus-on-close=""
   role="dialog"
   with-backdrop=""
 >
@@ -20,6 +21,7 @@ snapshots["vaadin-dialog overlay modeless"] =
   id="overlay"
   modeless=""
   opened=""
+  restore-focus-on-close=""
   role="dialog"
 >
   content
@@ -32,6 +34,7 @@ snapshots["vaadin-dialog overlay theme"] =
   focus-trap=""
   id="overlay"
   opened=""
+  restore-focus-on-close=""
   role="dialog"
   theme="custom"
   with-backdrop=""
@@ -47,6 +50,7 @@ snapshots["vaadin-dialog overlay class"] =
   focus-trap=""
   id="overlay"
   opened=""
+  restore-focus-on-close=""
   role="dialog"
   with-backdrop=""
 >


### PR DESCRIPTION
## Description

The PR enables the overlay logic to restore focus on dialog close.

Fixes https://github.com/vaadin/web-components/issues/139

## Type of change

- [x] Feature
