### PR TITLE
fix: restore focus-ring attribute on overlay close

### DIFF
--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -530,7 +530,7 @@ class Overlay extends ThemableMixin(DirMixin(ControllerMixin(PolymerElement))) {
     // Determine and store the node that has the `focus-ring` attribute
     // in order to restore the attribute when the overlay closes.
     const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;
-    if (this.restoreFocusOnClose && restoreFocusNode) {
+    if (restoreFocusNode) {
       const restoreFocusNodeHost = (restoreFocusNode.assignedSlot || restoreFocusNode).getRootNode().host;
       this.__restoreFocusRingNode = [restoreFocusNode, restoreFocusNodeHost].find((node) => {
         return node && node.hasAttribute('focus-ring');

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -10,7 +10,6 @@ import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { getAncestorRootNodes } from '@vaadin/component-base/src/dom-utils.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -158,7 +158,7 @@ describe('restore focus', () => {
         focusInput.setAttribute('focus-ring', '');
         await open(overlay);
         focusInput.removeAttribute('focus-ring');
-        document.body.focus();
+        overlay.blur();
         await close(overlay);
         expect(focusInput.hasAttribute('focus-ring')).to.be.true;
       });


### PR DESCRIPTION
## Description

The PR includes a fix for `overlay` to restore not only focus but also the `focus-ring` attribute on overlay close when `restoreFocusOnClose` is enabled.

Part of https://github.com/vaadin/web-components/issues/139

## Type of change

- [x] Bugfix
