### PR TITLE
fix: allow setting custom preserveAspectRatio attribute

### DIFF
--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -85,7 +85,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(PolymerElement))) 
         xmlns="http://www.w3.org/2000/svg"
         xmlns:xlink="http://www.w3.org/1999/xlink"
         viewBox="[[__computeViewBox(size, __viewBox)]]"
-        preserveAspectRatio="xMidYMid meet"
+        preserveAspectRatio="[[__computePAR(__defaultPAR, __preserveAspectRatio)]]"
         aria-hidden="true"
       ></svg>
 
@@ -130,6 +130,15 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(PolymerElement))) 
       },
 
       /** @private */
+      __defaultPAR: {
+        type: String,
+        value: 'xMidYMid meet',
+      },
+
+      /** @private */
+      __preserveAspectRatio: String,
+
+      /** @private */
       __svgElement: Object,
 
       /** @private */
@@ -166,10 +175,14 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(PolymerElement))) 
 
   /** @protected */
   _applyIcon() {
-    const { svg, size, viewBox } = Iconset.getIconSvg(this.icon);
+    const { preserveAspectRatio, svg, size, viewBox } = Iconset.getIconSvg(this.icon);
 
     if (viewBox) {
       this.__viewBox = viewBox;
+    }
+
+    if (preserveAspectRatio) {
+      this.__preserveAspectRatio = preserveAspectRatio;
     }
 
     if (size && size !== this.size) {
@@ -195,6 +208,11 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(PolymerElement))) 
     }
 
     renderSvg(svg, svgElement);
+  }
+
+  /** @private */
+  __computePAR(defaultPAR, preserveAspectRatio) {
+    return preserveAspectRatio || defaultPAR;
   }
 
   /** @private */

--- a/packages/icon/src/vaadin-iconset.d.ts
+++ b/packages/icon/src/vaadin-iconset.d.ts
@@ -30,7 +30,15 @@ declare class Iconset extends ElementMixin(HTMLElement) {
    * Returns SVGTemplateResult for the `icon` ID matching `name` of the
    * iconset, or `nothing` literal if there is no matching icon found.
    */
-  static getIconSvg(icon: string, name?: string): { svg: IconSvgLiteral; size?: number; viewBox?: string | null };
+  static getIconSvg(
+    icon: string,
+    name?: string,
+  ): {
+    preserveAspectRatio?: string | null;
+    svg: IconSvgLiteral;
+    size?: number;
+    viewBox?: string | null;
+  };
 
   /**
    * The name of the iconset. Every iconset is required to have its own unique name.

--- a/packages/icon/src/vaadin-iconset.js
+++ b/packages/icon/src/vaadin-iconset.js
@@ -114,6 +114,7 @@ class Iconset extends ElementMixin(PolymerElement) {
     const iconSvg = iconset._icons[iconId];
 
     return {
+      preserveAspectRatio: iconSvg ? iconSvg.getAttribute('preserveAspectRatio') : null,
       svg: cloneSvgNode(iconSvg),
       size: iconset.size,
       viewBox: iconSvg ? iconSvg.getAttribute('viewBox') : null,

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -7,6 +7,7 @@ import { Iconset } from '../vaadin-iconset.js';
 
 const ANGLE_DOWN = '<path d="M13 4v2l-5 5-5-5v-2l5 5z"></path>';
 const ANGLE_UP = '<path d="M3 12v-2l5-5 5 5v2l-5-5z"></path>';
+const ANGLE_RIGHT = '<path d="M4 13h2l5-5-5-5h-2l5 5z"></path>';
 const PLUS = '<path d="M3.5,7V0M0,3.5h7"></path>';
 const MINUS = '<path d="M2 7h12v2h-12v-2z"></path>';
 
@@ -127,6 +128,7 @@ describe('vaadin-icon', () => {
             <defs>
               <g id="vaadin:angle-down">${ANGLE_DOWN}</g>
               <g id="vaadin:angle-up">${ANGLE_UP}</g>
+              <g id="vaadin:angle-right" preserveAspectRatio="xMidYMin slice">${ANGLE_RIGHT}</g>
               <g id="vaadin:plus" viewBox="0 0 7 7">${PLUS}</g>
               <svg id="vaadin:minus" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="red">${MINUS}</svg>
             </defs>
@@ -180,6 +182,11 @@ describe('vaadin-icon', () => {
         icon.icon = 'vaadin:minus';
         const child = svgElement.firstElementChild;
         expect(child.getAttribute('fill')).to.equal('red');
+      });
+
+      it('should preserve the preserveAspectRatio attribute set on the icon', () => {
+        icon.icon = 'vaadin:angle-right';
+        expect(svgElement.getAttribute('preserveAspectRatio')).to.equal('xMidYMin slice');
       });
 
       it('should preserve the viewBox attribute set on the icon', () => {


### PR DESCRIPTION
## Description

Fixes #5847

The solution is almost the same as in #4002 except the fact that we don't have public API for the default attribute value.

## Type of change

- Bugfix

## Note

While we extend the return type of the `Iconset.getIconSvg()` API, this is kind of internal feature needed to fix a bug.