### PR TITLE
fix: compute offsetLeft using boundingClientRect

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -258,12 +258,12 @@ export const MenuBarMixin = (superClass) =>
         for (i = buttons.length; i > 0; i--) {
           const btn = buttons[i - 1];
           const btnStyle = getComputedStyle(btn);
-          const buttonOffsetLeft = btn.getBoundingClientRect().left - containerLeft;
+          const btnLeft = btn.getBoundingClientRect().left - containerLeft;
 
           // If this button isn't overflowing, then the rest aren't either
           if (
-            (!isRTL && buttonOffsetLeft + btn.offsetWidth < container.offsetWidth - overflow.offsetWidth) ||
-            (isRTL && buttonOffsetLeft >= overflow.offsetWidth)
+            (!isRTL && btnLeft + btn.offsetWidth < container.offsetWidth - overflow.offsetWidth) ||
+            (isRTL && btnLeft >= overflow.offsetWidth)
           ) {
             break;
           }

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -257,11 +257,12 @@ export const MenuBarMixin = (superClass) =>
         for (i = buttons.length; i > 0; i--) {
           const btn = buttons[i - 1];
           const btnStyle = getComputedStyle(btn);
+          const buttonOffsetLeft = btn.getBoundingClientRect().left - container.getBoundingClientRect().left;
 
           // If this button isn't overflowing, then the rest aren't either
           if (
-            (!isRTL && btn.offsetLeft + btn.offsetWidth < container.offsetWidth - overflow.offsetWidth) ||
-            (isRTL && btn.offsetLeft >= overflow.offsetWidth)
+            (!isRTL && buttonOffsetLeft + btn.offsetWidth < container.offsetWidth - overflow.offsetWidth) ||
+            (isRTL && buttonOffsetLeft >= overflow.offsetWidth)
           ) {
             break;
           }

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -252,12 +252,13 @@ export const MenuBarMixin = (superClass) =>
         this._hasOverflow = true;
 
         const isRTL = this.__isRTL;
+        const containerLeft = container.getBoundingClientRect().left;
 
         let i;
         for (i = buttons.length; i > 0; i--) {
           const btn = buttons[i - 1];
           const btnStyle = getComputedStyle(btn);
-          const buttonOffsetLeft = btn.getBoundingClientRect().left - container.getBoundingClientRect().left;
+          const buttonOffsetLeft = btn.getBoundingClientRect().left - containerLeft;
 
           // If this button isn't overflowing, then the rest aren't either
           if (

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -323,15 +323,16 @@ describe('root menu layout', () => {
 });
 
 describe('overflow button', () => {
-  let menu, buttons, overflow;
+  let wrapper, menu, buttons, overflow;
 
   beforeEach(async () => {
-    fixtureSync(
-      '<div><div style="width:100px;display:inline-block;"></div><vaadin-menu-bar style="display:inline-block;"></vaadin-menu-bar></div>',
-    );
-
-    menu = document.querySelector('vaadin-menu-bar');
-    menu.style.width = '250px';
+    wrapper = fixtureSync(`
+      <div style="display: flex">
+        <div style="width: 100px;"></div>
+        <vaadin-menu-bar style="width: 250px"></vaadin-menu-bar>
+      </div>
+    `);
+    menu = wrapper.querySelector('vaadin-menu-bar');
 
     menu.items = [
       { text: 'Item 1' },

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -326,8 +326,11 @@ describe('overflow button', () => {
   let menu, buttons, overflow;
 
   beforeEach(async () => {
-    menu = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
+    fixtureSync(
+      '<div><div style="width:100px;display:inline-block;"></div><vaadin-menu-bar style="display:inline-block;"></vaadin-menu-bar></div>',
+    );
 
+    menu = document.querySelector('vaadin-menu-bar');
     menu.style.width = '250px';
 
     menu.items = [


### PR DESCRIPTION
In v23, the parent element of menu bar buttons was the container div without a static position. After the refactoring made during the transition to v24, the direct parent element became the menu bar itself, which has a static position. This led the `offsetLeft` being calculated relative to the ancestors of the menu bar, which broke the overflow calculation. 

This PR updates the overflow calculation to use the difference between `boundingClientRect.left` of the button and the container. 

Fixes #5807 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.