### PR TITLE
test: exclude internal custom CSS property from snapshots

### DIFF
--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -95,10 +95,7 @@ snapshots["vaadin-text-area shadow default"] =
     >
     </span>
   </div>
-  <vaadin-input-container
-    part="input-field"
-    style="--_text-area-vertical-scroll-position:0px;"
-  >
+  <vaadin-input-container part="input-field">
     <slot
       name="prefix"
       slot="prefix"
@@ -147,7 +144,6 @@ snapshots["vaadin-text-area shadow disabled"] =
   <vaadin-input-container
     disabled=""
     part="input-field"
-    style="--_text-area-vertical-scroll-position:0px;"
   >
     <slot
       name="prefix"
@@ -197,7 +193,6 @@ snapshots["vaadin-text-area shadow readonly"] =
   <vaadin-input-container
     part="input-field"
     readonly=""
-    style="--_text-area-vertical-scroll-position:0px;"
   >
     <slot
       name="prefix"
@@ -247,7 +242,6 @@ snapshots["vaadin-text-area shadow invalid"] =
   <vaadin-input-container
     invalid=""
     part="input-field"
-    style="--_text-area-vertical-scroll-position:0px;"
   >
     <slot
       name="prefix"
@@ -296,7 +290,6 @@ snapshots["vaadin-text-area shadow theme"] =
   </div>
   <vaadin-input-container
     part="input-field"
-    style="--_text-area-vertical-scroll-position:0px;"
     theme="align-right"
   >
     <slot

--- a/packages/text-area/test/dom/text-area.test.js
+++ b/packages/text-area/test/dom/text-area.test.js
@@ -30,28 +30,34 @@ describe('vaadin-text-area', () => {
   });
 
   describe('shadow', () => {
+    const SNAPSHOT_CONFIG = {
+      // Exclude custom CSS property set as inline style,
+      // as corresponding logic is covered by unit tests.
+      ignoreAttributes: ['style'],
+    };
+
     it('default', async () => {
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
 
     it('disabled', async () => {
       textArea.disabled = true;
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
 
     it('readonly', async () => {
       textArea.readonly = true;
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
 
     it('invalid', async () => {
       textArea.invalid = true;
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
 
     it('theme', async () => {
       textArea.setAttribute('theme', 'align-right');
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
   });
 });


### PR DESCRIPTION
## Description

Updated `text-area` package to exclude inline `style` attribute that currently causes snapshots to fail:

```
packages/text-area/test/dom/text-area.test.js:

 ❌ vaadin-text-area > shadow > default
      AssertionError: Snapshot vaadin-text-area shadow default does not match the saved snapshot on disk
      + expected - actual

           </span>
         </div>
         <vaadin-input-container
           part="input-field"
      -    style="--_text-area-vertical-scroll-position: 0px;"
      +    style="--_text-area-vertical-scroll-position:0px;"
         >
           <slot
             name="prefix"
             slot="prefix"
```

## Type of change

- Tests

## Note

- Scroll position logic is covered by unit tests
- Visual appearance is covered by visual tests