### PR TITLE
test: simplify and enhance focus restoration tests

### DIFF
--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -81,7 +81,6 @@ describe('restore focus', () => {
         focusInput.focus();
         await open(overlay);
         overlay.blur();
-        document.body.focus();
         await close(overlay);
         expect(isElementFocused(focusInput)).to.be.true;
       });

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../src/vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
@@ -10,7 +10,7 @@ customElements.define(
   class extends PolymerElement {
     static get template() {
       return html`
-        <vaadin-overlay id="overlay" renderer="[[renderer]]"></vaadin-overlay>
+        <vaadin-overlay id="overlay" renderer="[[renderer]]" focus-trap></vaadin-overlay>
         <input id="focusable" />
       `;
     }
@@ -54,9 +54,6 @@ describe('restore focus', () => {
     it('should not restore focus on close by default', async () => {
       focusInput.focus();
       await open(overlay);
-      // Emulate focus leaving the input
-      focusInput.blur();
-      document.body.focus();
       await close(overlay);
       expect(isElementFocused(focusInput)).to.be.false;
     });
@@ -69,9 +66,6 @@ describe('restore focus', () => {
       it('should restore focus on close', async () => {
         focusInput.focus();
         await open(overlay);
-        // Emulate focus leaving the input
-        focusInput.blur();
-        document.body.focus();
         await close(overlay);
         expect(isElementFocused(focusInput)).to.be.true;
       });
@@ -81,6 +75,15 @@ describe('restore focus', () => {
         await open(overlay);
         await close(overlay);
         expect(isElementFocused(focusable)).to.be.true;
+      });
+
+      it('should restore focus on close if focus was moved to body', async () => {
+        focusInput.focus();
+        await open(overlay);
+        overlay.blur();
+        document.body.focus();
+        await close(overlay);
+        expect(isElementFocused(focusInput)).to.be.true;
       });
 
       it('should not restore focus on close if focus was moved outside overlay', async () => {
@@ -100,9 +103,6 @@ describe('restore focus', () => {
       it('should not restore focus on close by default', async () => {
         focusInput.focus();
         await open(overlay);
-        // Emulate focus leaving the input
-        focusInput.blur();
-        document.body.focus();
         await close(overlay);
         expect(isElementFocused(focusInput)).to.be.false;
       });
@@ -115,7 +115,6 @@ describe('restore focus', () => {
         it('should restore focus to the restoreFocusNode', async () => {
           focusable.focus();
           await open(overlay);
-          focusable.blur();
           await close(overlay);
           expect(isElementFocused(focusInput)).to.be.true;
         });


### PR DESCRIPTION
## Description

The PR enables `focus-trap` in the focus restoration tests which allows getting rid of some manual focus manipulations. It also adds an explicit unit test making sure focus is restored in the case it was moved to body while the overlay was open.

Preparation for #5839

## Type of change

- [x] Internal
