### PR TITLE
test: exclude internal custom CSS property from snapshots

### DIFF
--- a/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
@@ -25,7 +25,6 @@ snapshots["vaadin-upload host default"] =
           aria-valuenow="0"
           role="progressbar"
           slot="progress"
-          style="--vaadin-progress-value:0;"
         >
         </vaadin-progress-bar>
       </vaadin-upload-file>
@@ -38,7 +37,6 @@ snapshots["vaadin-upload host default"] =
           aria-valuenow="0.6"
           role="progressbar"
           slot="progress"
-          style="--vaadin-progress-value:0.6;"
         >
         </vaadin-progress-bar>
       </vaadin-upload-file>
@@ -54,7 +52,6 @@ snapshots["vaadin-upload host default"] =
           aria-valuenow="0"
           role="progressbar"
           slot="progress"
-          style="--vaadin-progress-value:0;"
         >
         </vaadin-progress-bar>
       </vaadin-upload-file>
@@ -92,7 +89,6 @@ snapshots["vaadin-upload host max files"] =
           aria-valuenow="0"
           role="progressbar"
           slot="progress"
-          style="--vaadin-progress-value:0;"
         >
         </vaadin-progress-bar>
       </vaadin-upload-file>
@@ -105,7 +101,6 @@ snapshots["vaadin-upload host max files"] =
           aria-valuenow="0.6"
           role="progressbar"
           slot="progress"
-          style="--vaadin-progress-value:0.6;"
         >
         </vaadin-progress-bar>
       </vaadin-upload-file>
@@ -121,7 +116,6 @@ snapshots["vaadin-upload host max files"] =
           aria-valuenow="0"
           role="progressbar"
           slot="progress"
-          style="--vaadin-progress-value:0;"
         >
         </vaadin-progress-bar>
       </vaadin-upload-file>

--- a/packages/upload/test/dom/vaadin-upload.test.js
+++ b/packages/upload/test/dom/vaadin-upload.test.js
@@ -20,13 +20,19 @@ describe('vaadin-upload', () => {
   });
 
   describe('host', () => {
+    const SNAPSHOT_CONFIG = {
+      // Exclude inline style as we are not testing
+      // the `vaadin-progress-bar` internal logic.
+      ignoreAttributes: ['style'],
+    };
+
     it('default', async () => {
-      await expect(upload).dom.to.equalSnapshot();
+      await expect(upload).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
 
     it('max files', async () => {
       upload.maxFiles = 1;
-      await expect(upload).dom.to.equalSnapshot();
+      await expect(upload).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
   });
 


### PR DESCRIPTION
## Description

Updated `upload` package to exclude inline `style` attribute that currently causes snapshots to fail:

```
packages/upload/test/dom/vaadin-upload.test.js:

 ❌ vaadin-upload > host > default
      AssertionError: Snapshot vaadin-upload host default does not match the saved snapshot on disk
      + expected - actual

                 aria-valuemin="0"
                 aria-valuenow="0"
                 role="progressbar"
                 slot="progress"
      -          style="--vaadin-progress-value: 0;"
      +          style="--vaadin-progress-value:0;"
               >
               </vaadin-progress-bar>
             </vaadin-upload-file>
           </li>
                 aria-valuemin="0"
                 aria-valuenow="0.6"
                 role="progressbar"
                 slot="progress"
      -          style="--vaadin-progress-value: 0.6;"
      +          style="--vaadin-progress-value:0.6;"
               >
               </vaadin-progress-bar>
             </vaadin-upload-file>
```

## Type of change

- Tests