### PR TITLE
test: restructure focus restoration tests

### DIFF
--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -42,7 +42,7 @@ describe('restore focus', () => {
     focusable = wrapper.$.focusable;
   });
 
-  describe('basic', () => {
+  describe('default', () => {
     beforeEach(() => {
       document.body.appendChild(focusInput);
     });
@@ -58,9 +58,32 @@ describe('restore focus', () => {
       expect(isElementFocused(focusInput)).to.be.false;
     });
 
-    describe('restoreFocusOnClose', () => {
+    describe('restoreFocusNode', () => {
       beforeEach(() => {
-        overlay.restoreFocusOnClose = true;
+        overlay.restoreFocusNode = focusInput;
+      });
+
+      it('should not restore focus on close by default', async () => {
+        focusInput.focus();
+        await open(overlay);
+        await close(overlay);
+        expect(isElementFocused(focusInput)).to.be.false;
+      });
+    });
+  });
+
+  describe('restoreFocusOnClose', () => {
+    beforeEach(() => {
+      overlay.restoreFocusOnClose = true;
+    });
+
+    describe('basic', () => {
+      beforeEach(() => {
+        document.body.appendChild(focusInput);
+      });
+
+      afterEach(() => {
+        document.body.removeChild(focusInput);
       });
 
       it('should restore focus on close', async () => {
@@ -92,23 +115,10 @@ describe('restore focus', () => {
         await close(overlay);
         expect(isElementFocused(focusable)).to.be.true;
       });
-    });
 
-    describe('restoreFocusNode', () => {
-      beforeEach(() => {
-        overlay.restoreFocusNode = focusInput;
-      });
-
-      it('should not restore focus on close by default', async () => {
-        focusInput.focus();
-        await open(overlay);
-        await close(overlay);
-        expect(isElementFocused(focusInput)).to.be.false;
-      });
-
-      describe('restoreFocusOnClose', () => {
+      describe('restoreFocusNode', () => {
         beforeEach(() => {
-          overlay.restoreFocusOnClose = true;
+          overlay.restoreFocusNode = focusInput;
         });
 
         it('should restore focus to the restoreFocusNode', async () => {


### PR DESCRIPTION
## Description

This is the second attempt at finding an optimal structure for the overlay's focus restoration tests that would allow seamless adding `focus-ring` tests in https://github.com/vaadin/web-components/pull/5839.

Follows-up on https://github.com/vaadin/web-components/pull/5844

> **Note**
> When reviewing, I suggest enabling the "Hide whitespace" option to miminize the diff.

## Type of change

- [x] Internal
