### PR TITLE
fix: check validity on next input in login-form

### DIFF
--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -179,7 +179,7 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       const nextInput =
         inputActive.id === 'vaadinLoginUsername' ? this.$.vaadinLoginPassword : this.$.vaadinLoginUsername;
       if (inputActive.validate()) {
-        if (nextInput.validate()) {
+        if (nextInput.checkValidity()) {
           this.submit();
         } else {
           nextInput.focus();

--- a/packages/login/test/login-form.test.js
+++ b/packages/login/test/login-form.test.js
@@ -95,6 +95,14 @@ describe('login form', () => {
     expect(vaadinLoginPassword.hasAttribute('focused')).to.be.true;
   });
 
+  it('should not mark password as invalid if username is filled and user hits ENTER (password is empty)', () => {
+    const { vaadinLoginUsername, vaadinLoginPassword } = login.$;
+    vaadinLoginUsername.value = 'username';
+
+    enter(vaadinLoginUsername);
+    expect(vaadinLoginPassword.hasAttribute('invalid')).to.be.false;
+  });
+
   it('should mark password as invalid if user hits ENTER when field is empty', () => {
     const { vaadinLoginUsername, vaadinLoginPassword } = login.$;
 


### PR DESCRIPTION
## Description

Replace `input.validate()` with `input.checkValidity()` to check whether the following field is valid or not to prevent it from being marked as invalid when, for instance, the user is focused on the username field hits <kbd>Enter</kbd> and focus is moved to the password field.

## Type of change

- Bugfix