### PR TITLE
fix: close top-most open menu on Escape

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -248,11 +248,14 @@ export const ItemsMixin = (superClass) =>
         if ((!isRTL && isArrowRight) || (isRTL && isArrowLeft) || key === 'Enter' || key === ' ') {
           // Open a sub-menu
           this.__showSubMenu(event);
-        } else if ((!isRTL && isArrowLeft) || (isRTL && isArrowRight)) {
+        } else if ((!isRTL && isArrowLeft) || (isRTL && isArrowRight) || key === 'Escape') {
+          if (key === 'Escape') {
+            event.stopPropagation();
+          }
           // Close the menu
           this.close();
           this.listenOn.focus();
-        } else if (key === 'Escape' || key === 'Tab') {
+        } else if (key === 'Tab') {
           // Close all menus
           this.dispatchEvent(new CustomEvent('close-all-menus'));
         }

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -244,6 +244,7 @@ describe('items', () => {
     escKeyDown(getMenuItems(subMenu)[0]);
     expect(subMenu.opened).to.be.false;
     expect(rootMenu.opened).to.be.true;
+    expect(getMenuItems(rootMenu)[0].hasAttribute('focused')).to.be.true;
   });
 
   it('should close all menus on Tab', () => {

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -240,9 +240,10 @@ describe('items', () => {
     document.documentElement.setAttribute('dir', 'ltr');
   });
 
-  it('should close all menus on esc', () => {
+  it('should close top-most menu on esc', () => {
     escKeyDown(getMenuItems(subMenu)[0]);
-    expect(rootMenu.opened).to.be.false;
+    expect(subMenu.opened).to.be.false;
+    expect(rootMenu.opened).to.be.true;
   });
 
   it('should close all menus on Tab', () => {


### PR DESCRIPTION
## Description

Close the last opened sub-menu on Escape instead of closing the root menu.

This change is done to align with [ARIA Authoring Practices Guide (APG) for Menu / Menu Bar](https://www.w3.org/WAI/ARIA/apg/patterns/menu/) where it's described as the following:

> Escape: Close the menu that contains focus and return focus to the element or context, e.g., menu button or parent menuitem, from _which the menu was opened_.

Fixes #4768

## Type of change

- Bugfix
