### PR TITLE
test: prefer getDeepActiveElement in assertions

### DIFF
--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, esc, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-dialog.js';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('vaadin-dialog', () => {
   describe('custom element definition', () => {
@@ -180,7 +180,7 @@ describe('vaadin-dialog', () => {
     it('should move focus to the dialog on open', async () => {
       dialog.opened = true;
       await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
-      expect(isElementFocused(dialog.$.overlay)).to.be.true;
+      expect(getDeepActiveElement()).to.equal(dialog.$.overlay);
     });
 
     it('should restore focus on dialog close', async () => {
@@ -188,7 +188,7 @@ describe('vaadin-dialog', () => {
       await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
       dialog.opened = false;
       await aTimeout(0);
-      expect(isElementFocused(button)).to.be.true;
+      expect(getDeepActiveElement()).to.equal(button);
     });
   });
 });

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -164,7 +164,7 @@ describe('vaadin-dialog', () => {
   });
 
   describe('focus restoration', () => {
-    let dialog, button;
+    let dialog, button, overlay;
 
     beforeEach(() => {
       const wrapper = fixtureSync(`
@@ -174,18 +174,19 @@ describe('vaadin-dialog', () => {
         </div>
       `);
       [dialog, button] = wrapper.children;
+      overlay = dialog.$.overlay;
       button.focus();
     });
 
     it('should move focus to the dialog on open', async () => {
       dialog.opened = true;
-      await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
-      expect(getDeepActiveElement()).to.equal(dialog.$.overlay);
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      expect(getDeepActiveElement()).to.equal(overlay.$.overlay);
     });
 
     it('should restore focus on dialog close', async () => {
       dialog.opened = true;
-      await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
+      await oneEvent(overlay, 'vaadin-overlay-open');
       dialog.opened = false;
       await aTimeout(0);
       expect(getDeepActiveElement()).to.equal(button);

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, esc, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-dialog.js';
-import { getDeepActiveElement, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('vaadin-dialog', () => {
   describe('custom element definition', () => {

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -3,7 +3,7 @@ import { fixtureSync, listenOnce, nextRender } from '@vaadin/testing-helpers';
 import { resetMouse, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-grid.js';
-import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { setNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
 import {
   flushGrid,
@@ -367,9 +367,9 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
           }
           const yCoordinate = boundingClientRect.y + Math.floor(boundingClientRect.height / 2);
 
-          expect(getDeepActiveElement()).to.not.equal(grid);
+          expect(isElementFocused(grid)).to.be.false;
           await sendMouse({ type: 'click', position: [xCoordinate, yCoordinate] });
-          expect(getDeepActiveElement()).to.equal(grid);
+          expect(isElementFocused(grid)).to.be.true;
         });
       });
     });

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -3,7 +3,7 @@ import { fixtureSync, listenOnce, nextRender } from '@vaadin/testing-helpers';
 import { resetMouse, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-grid.js';
-import { getDeepActiveElement, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { setNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
 import {
   flushGrid,

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -3,7 +3,7 @@ import { fixtureSync, listenOnce, nextRender } from '@vaadin/testing-helpers';
 import { resetMouse, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-grid.js';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { setNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
 import {
   flushGrid,
@@ -367,9 +367,9 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
           }
           const yCoordinate = boundingClientRect.y + Math.floor(boundingClientRect.height / 2);
 
-          expect(isElementFocused(grid)).to.be.false;
+          expect(getDeepActiveElement()).to.not.equal(grid);
           await sendMouse({ type: 'click', position: [xCoordinate, yCoordinate] });
-          expect(isElementFocused(grid)).to.be.true;
+          expect(getDeepActiveElement()).to.equal(grid);
         });
       });
     });

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -19,7 +19,7 @@ import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
 import '../vaadin-grid-column-group.js';
 import '../vaadin-grid-selection-column.js';
-import { getDeepActiveElement, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import {
   attributeRenderer,
   flushGrid,

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -19,7 +19,7 @@ import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
 import '../vaadin-grid-column-group.js';
 import '../vaadin-grid-selection-column.js';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import {
   attributeRenderer,
   flushGrid,
@@ -1606,7 +1606,7 @@ describe('keyboard navigation', () => {
 
       enter();
 
-      expect(isElementFocused(focusable)).to.be.true;
+      expect(getDeepActiveElement()).to.equal(focusable);
     });
 
     it('should exit interaction mode from focused single-line input with enter', () => {

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../src/vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { getDeepActiveElement, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { close, open } from './helpers.js';
 
 customElements.define(

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../src/vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { close, open } from './helpers.js';
 
 customElements.define(
@@ -66,7 +66,7 @@ describe('restore focus', () => {
       focusInput.focus();
       await open(overlay);
       await close(overlay);
-      expect(isElementFocused(focusInput)).to.be.false;
+      expect(getDeepActiveElement()).to.not.equal(focusInput);
     });
 
     it('should not restore focus-ring attribute on close by default', async () => {
@@ -87,7 +87,7 @@ describe('restore focus', () => {
         focusInput.focus();
         await open(overlay);
         await close(overlay);
-        expect(isElementFocused(focusInput)).to.be.false;
+        expect(getDeepActiveElement()).to.not.equal(focusInput);
       });
 
       it('should not restore focus-ring attribute on close by default', async () => {
@@ -119,7 +119,7 @@ describe('restore focus', () => {
         focusInput.focus();
         await open(overlay);
         await close(overlay);
-        expect(isElementFocused(focusInput)).to.be.true;
+        expect(getDeepActiveElement()).to.equal(focusInput);
       });
 
       it('should restore focus-ring attribute on close', async () => {
@@ -142,7 +142,7 @@ describe('restore focus', () => {
         focusable.focus();
         await open(overlay);
         await close(overlay);
-        expect(isElementFocused(focusable)).to.be.true;
+        expect(getDeepActiveElement()).to.equal(focusable);
       });
 
       it('should restore focus on close if focus was moved to body', async () => {
@@ -150,7 +150,7 @@ describe('restore focus', () => {
         await open(overlay);
         overlay.blur();
         await close(overlay);
-        expect(isElementFocused(focusInput)).to.be.true;
+        expect(getDeepActiveElement()).to.equal(focusInput);
       });
 
       it('should restore focus-ring attribute on close if focus was moved to body', async () => {
@@ -168,7 +168,7 @@ describe('restore focus', () => {
         await open(overlay);
         focusable.focus();
         await close(overlay);
-        expect(isElementFocused(focusable)).to.be.true;
+        expect(getDeepActiveElement()).to.equal(focusable);
       });
 
       it('should not restore focus-ring attribute if focus was moved outside overlay', async () => {
@@ -190,7 +190,7 @@ describe('restore focus', () => {
           focusable.focus();
           await open(overlay);
           await close(overlay);
-          expect(isElementFocused(focusInput)).to.be.true;
+          expect(getDeepActiveElement()).to.equal(focusInput);
         });
 
         it('should restore focus-ring attribute on the restoreFocusNode', async () => {


### PR DESCRIPTION
## Description

It's better to prefer `getDeepActiveElement` over `isElementFocused` in test assertions where possible because the former will log an actual focused element if the test fails, which can be helpful information for the further investigation.

## Type of change

- [x] Internal
