### PR TITLE
refactor: set aria-hidden on elements outside modal overlay

### DIFF
--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { AriaModalController } from '@vaadin/a11y-base/src/aria-modal-controller.js';
 import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
@@ -48,6 +49,7 @@ export const OverlayFocusMixin = (superClass) =>
     constructor() {
       super();
 
+      this.__ariaModalController = new AriaModalController(this);
       this.__focusTrapController = new FocusTrapController(this);
     }
 
@@ -55,6 +57,7 @@ export const OverlayFocusMixin = (superClass) =>
     ready() {
       super.ready();
 
+      this.addController(this.__ariaModalController);
       this.addController(this.__focusTrapController);
     }
 
@@ -65,6 +68,7 @@ export const OverlayFocusMixin = (superClass) =>
      */
     _resetFocus() {
       if (this.focusTrap) {
+        this.__ariaModalController.close();
         this.__focusTrapController.releaseFocus();
       }
 
@@ -91,6 +95,7 @@ export const OverlayFocusMixin = (superClass) =>
      */
     _trapFocus() {
       if (this.focusTrap) {
+        this.__ariaModalController.showModal();
         this.__focusTrapController.trapFocus(this.$.overlay);
       }
     }

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import '../vaadin-overlay.js';
 import { getFocusableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
@@ -144,6 +144,63 @@ describe('focus-trap', () => {
       tabKeyDown(button);
 
       expect(getFocusedElementIndex()).to.equal(0);
+    });
+  });
+
+  describe('aria-hidden', () => {
+    let outer, inner, overlay;
+
+    beforeEach(async () => {
+      // Create outer element and pass it explicitly.
+      outer = document.createElement('main');
+
+      // Our `fixtureSync()` requires a single parent.
+      inner = fixtureSync(
+        `
+        <div>
+          <button>Foo</button>
+          <vaadin-overlay focus-trap></vaadin-overlay>
+          <button>Bar</button>
+        </div>
+      `,
+        outer,
+      );
+
+      overlay = inner.querySelector('vaadin-overlay');
+      await nextRender();
+      overlay.renderer = (root) => {
+        root.innerHTML = '<input placeholder="Input">';
+      };
+    });
+
+    afterEach(() => {
+      overlay.opened = false;
+    });
+
+    it('should set aria-hidden on other elements on overlay open', async () => {
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      expect(outer.getAttribute('aria-hidden')).to.equal('true');
+    });
+
+    it('should remove aria-hidden from other elements on overlay close', async () => {
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      overlay.opened = false;
+      await aTimeout(0);
+
+      expect(outer.hasAttribute('aria-hidden')).to.be.false;
+    });
+
+    it('should not set aria-hidden on other elements if focusTrap is set to false', async () => {
+      overlay.focusTrap = false;
+
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      expect(outer.hasAttribute('aria-hidden')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

Related to #92

Here's a PR that adds usage of `AriaModalController` introduced in #5611 to `OverlayFocusMixin`.

## Type of change

-  Refactor / bugfix

## Note

Implementing this change took so long because of my personal matters. Glad that it's done now.