### PR TITLE
fix: allow to remove focus from RTE on Escape + Tab

### DIFF
--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/a11y-base": "24.1.0-beta1",
     "@vaadin/testing-helpers": "^0.4.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -593,6 +593,12 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
       });
     });
 
+    editorContent.addEventListener('keydown', (e /** @type {KeyboardEvent} */) => {
+      if (e.key === 'Escape') {
+        this._editor.blur();
+      }
+    });
+
     editorContent.addEventListener('focusout', () => {
       if (this._toolbarState === STATE.FOCUSED) {
         this._cleanToolbarState();

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -593,9 +593,22 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
       });
     });
 
-    editorContent.addEventListener('keydown', (e /** @type {KeyboardEvent} */) => {
+    const TAB_KEY = 9;
+
+    editorContent.addEventListener('keydown', (e) => {
       if (e.key === 'Escape') {
-        this._editor.blur();
+        this.__tabBindings = this._editor.keyboard.bindings[TAB_KEY];
+        this._editor.keyboard.bindings[TAB_KEY] = null;
+      } else if (this.__tabBindings) {
+        this._editor.keyboard.bindings[TAB_KEY] = this.__tabBindings;
+        this.__tabBindings = null;
+      }
+    });
+
+    editorContent.addEventListener('blur', () => {
+      if (this.__tabBindings) {
+        this._editor.keyboard.bindings[TAB_KEY] = this.__tabBindings;
+        this.__tabBindings = null;
       }
     });
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -596,7 +596,7 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     const TAB_KEY = 9;
 
     editorContent.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') {
+      if (e.key === 'Escape' && !this.__tabBindings) {
         this.__tabBindings = this._editor.keyboard.bindings[TAB_KEY];
         this._editor.keyboard.bindings[TAB_KEY] = null;
       } else if (this.__tabBindings) {

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -596,9 +596,11 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     const TAB_KEY = 9;
 
     editorContent.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && !this.__tabBindings) {
-        this.__tabBindings = this._editor.keyboard.bindings[TAB_KEY];
-        this._editor.keyboard.bindings[TAB_KEY] = null;
+      if (e.key === 'Escape') {
+        if (!this.__tabBindings) {
+          this.__tabBindings = this._editor.keyboard.bindings[TAB_KEY];
+          this._editor.keyboard.bindings[TAB_KEY] = null;
+        }
       } else if (this.__tabBindings) {
         this._editor.keyboard.bindings[TAB_KEY] = this.__tabBindings;
         this.__tabBindings = null;

--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -184,7 +184,7 @@ describe('accessibility', () => {
       expect(getDeepActiveElement()).to.equal(buttons[0]);
     });
 
-    it('should keep default Tab behavior if Esc is hit multiple times', async () => {
+    it('should restore default Tab behavior after multiple Esc and then Tab', async () => {
       const wrapper = fixtureSync(`<div>
         <vaadin-rich-text-editor></vaadin-rich-text-editor>
         <button>button</button>

--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -172,7 +172,7 @@ describe('accessibility', () => {
       editor.focus();
       await sendKeys({ press: 'Escape' });
       await sendKeys({ press: 'Tab' });
-      expect(document.activeElement).to.be.equal(button);
+      expect(document.activeElement).to.equal(button);
     });
 
     it('should move focus to the first toolbar button after esc followed by shift-tab are pressed', async () => {
@@ -181,7 +181,7 @@ describe('accessibility', () => {
       await sendKeys({ down: 'Shift' });
       await sendKeys({ press: 'Tab' });
       await sendKeys({ up: 'Shift' });
-      expect(getDeepActiveElement()).to.be.equal(buttons[0]);
+      expect(getDeepActiveElement()).to.equal(buttons[0]);
     });
 
     it('should change indentation and prevent shift-tab keydown in the code block', () => {

--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -185,9 +185,21 @@ describe('accessibility', () => {
     });
 
     it('should keep default Tab behavior if Esc is hit multiple times', async () => {
+      const wrapper = fixtureSync(`<div>
+        <vaadin-rich-text-editor></vaadin-rich-text-editor>
+        <button>button</button>
+      </div>`);
+      const [rte, button] = wrapper.children;
+      editor = rte._editor;
       editor.focus();
+      // Hitting Escape multiple times and Tab should move focus to next element
       await sendKeys({ press: 'Escape' });
       await sendKeys({ press: 'Escape' });
+      await sendKeys({ press: 'Tab' });
+      expect(document.activeElement).to.equal(button);
+
+      // Checking that default Tab behavior is restored
+      editor.focus();
       await sendKeys({ press: 'Tab' });
       if (rte.__debounceSetValue) {
         rte.__debounceSetValue.flush();

--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -162,12 +162,6 @@ describe('accessibility', () => {
       content.dispatchEvent(e);
     });
 
-    it('should remove focus from editor on esc', async () => {
-      editor.focus();
-      await sendKeys({ press: 'Escape' });
-      expect(document.activeElement).to.not.be.equal(rte);
-    });
-
     it('should move focus to next element after esc followed by tab are pressed', async () => {
       const wrapper = fixtureSync(`<div>
         <vaadin-rich-text-editor></vaadin-rich-text-editor>

--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -184,6 +184,17 @@ describe('accessibility', () => {
       expect(getDeepActiveElement()).to.equal(buttons[0]);
     });
 
+    it('should keep default Tab behavior if Esc is hit multiple times', async () => {
+      editor.focus();
+      await sendKeys({ press: 'Escape' });
+      await sendKeys({ press: 'Escape' });
+      await sendKeys({ press: 'Tab' });
+      if (rte.__debounceSetValue) {
+        rte.__debounceSetValue.flush();
+      }
+      expect(rte.htmlValue).to.equal('<p>\t</p>');
+    });
+
     it('should change indentation and prevent shift-tab keydown in the code block', () => {
       rte.value = '[{"insert":"  foo"},{"attributes":{"code-block":true},"insert":"\\n"}]';
       editor.focus();

--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -162,7 +162,7 @@ describe('accessibility', () => {
       content.dispatchEvent(e);
     });
 
-    it('should remove focus of editor on esc', async () => {
+    it('should remove focus from editor on esc', async () => {
       editor.focus();
       await sendKeys({ press: 'Escape' });
       expect(document.activeElement).to.not.be.equal(rte);
@@ -187,7 +187,6 @@ describe('accessibility', () => {
       await sendKeys({ down: 'Shift' });
       await sendKeys({ press: 'Tab' });
       await sendKeys({ up: 'Shift' });
-      const e = keyboardEventFor('keydown', 9, ['shift']);
       expect(getDeepActiveElement()).to.be.equal(buttons[0]);
     });
 


### PR DESCRIPTION
## Description

Make pressing <kbd>Esc</kbd> temporarily remove default bindings for the <kbd>Tab</kbd>, so users can press <kbd>Tab</kbd> to move focus to the next element on the page, therefore preventing `<vaadin-rich-text-editor>` to become a focus trap. Pressing <kbd>Esc</kbd>  followed by  <kbd>Shit+Tab</kbd> moves the focus to the first toolbar button, which is the same current behavior.

The <kbd>Tab</kbd> default bindings are restored by typing another character or when the editor loses focus.

Part of #1674

## Type of change

- [X] Bugfix
- [ ] Feature
