### PR TITLE
chore: update change detection to 24.1

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -40,7 +40,7 @@ const hasAllParam = process.argv.includes('--all');
  * Check if lockfile has changed.
  */
 const isLockfileChanged = () => {
-  const log = execSync('git diff --name-only origin/main HEAD').toString();
+  const log = execSync('git diff --name-only origin/24.1 HEAD').toString();
   return log.split('\n').some((line) => line.includes('yarn.lock'));
 };
 
@@ -49,7 +49,7 @@ const isLockfileChanged = () => {
  */
 const getChangedPackages = () => {
   const pathToLerna = path.normalize('./node_modules/.bin/lerna');
-  const output = execSync(`${pathToLerna} la --since origin/main --json --loglevel silent`); // NOSONAR
+  const output = execSync(`${pathToLerna} la --since origin/24.1 --json --loglevel silent`); // NOSONAR
   return JSON.parse(output.toString()).map((project) => project.name.replace('@vaadin/', ''));
 };
 


### PR DESCRIPTION
Update the web-test-runner change detection script to use `24.1` as a base branch for Vaadin 24.1