### PR TITLE
fix: prevent column width calculation when grid is not visible

### DIFF
--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -6,7 +6,7 @@
 import './vaadin-grid-column.js';
 import './vaadin-grid-styles.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { isElementHidden } from '@vaadin/a11y-base';
+import { isElementHidden } from '@vaadin/a11y-base/src/focus-utils.js';
 import { TabindexMixin } from '@vaadin/a11y-base/src/tabindex-mixin.js';
 import { animationFrame, microTask } from '@vaadin/component-base/src/async.js';
 import { isAndroid, isChrome, isFirefox, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';


### PR DESCRIPTION
## Description

When adding an existing grid to a split layout, auto-width columns can be collapsed to zero width. The cause is that elements are usually added to split layout without setting a slot name, as split layout applies the slot names automatically after elements have been added. When grid is added to the DOM, it immediately recalculates column widths, which results in a width of zero, as the grid is not assigned to a slot yet and is thus invisible.

This change adds a check for whether the grid is hidden, and in that case defers column width calculation to the resize observer, which should be triggered when the grid becomes visible again (width changes from zero to whatever width the container provides).

Fixes https://github.com/vaadin/flow-components/issues/4747

## Type of change

- Bugfix
