### PR TITLE
fix: keep previously added custom elements

### DIFF
--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -211,19 +211,20 @@ export class SlotController extends EventTarget {
       }
 
       if (newNodes && newNodes.length > 0) {
-        // Custom node is added, remove the current one.
-        current.forEach((node) => {
-          if (node && node.isConnected) {
-            node.parentNode.removeChild(node);
-          }
-        });
-
         if (this.multiple) {
-          this.nodes = newNodes;
+          // Remove default node if exists
+          if (this.defaultNode) {
+            this.defaultNode.remove();
+          }
+          this.nodes = [...current, ...newNodes].filter((node) => node !== this.defaultNode);
           newNodes.forEach((node) => {
             this.initAddedNode(node);
           });
         } else {
+          // Remove previous node if exists
+          if (this.node) {
+            this.node.remove();
+          }
           this.node = newNodes[0];
           this.initAddedNode(this.node);
         }

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -359,7 +359,7 @@ describe('slot-controller', () => {
         expect(children[0]).to.be.instanceOf(HTMLButtonElement);
       });
 
-      it('should replace an element when new elements added to the slot', async () => {
+      it('should remove default node when new elements added to the slot', async () => {
         const defaultNode = children[0];
 
         const foo = document.createElement('div');
@@ -374,6 +374,20 @@ describe('slot-controller', () => {
         expect(slotChildren[0]).to.equal(foo);
         expect(slotChildren[1]).to.equal(bar);
         expect(defaultNode.isConnected).to.be.false;
+      });
+
+      it('should store a reference to the default node in nodes array', () => {
+        const nodes = controller.nodes;
+        expect(nodes).to.be.instanceOf(Array);
+        expect(nodes.length).to.equal(1);
+        expect(nodes[0]).to.equal(controller.defaultNode);
+      });
+
+      it('should remove default node from nodes array when adding new element', async () => {
+        const nodes = controller.nodes;
+        expect(nodes).to.be.instanceOf(Array);
+        expect(nodes.length).to.equal(1);
+        expect(nodes[0]).to.equal(controller.defaultNode);
       });
     });
 
@@ -394,8 +408,23 @@ describe('slot-controller', () => {
       it('should store a reference to custom slotted elements in nodes array', () => {
         const nodes = controller.nodes;
         expect(nodes).to.be.instanceOf(Array);
+        expect(nodes.length).to.equal(2);
         expect(nodes[0]).to.equal(children[0]);
         expect(nodes[1]).to.equal(children[1]);
+      });
+
+      it('should update references to custom slotted elements in nodes array', async () => {
+        const newChild = document.createElement('div');
+        element.append(newChild);
+
+        await nextFrame();
+
+        const nodes = controller.nodes;
+        expect(nodes).to.be.instanceOf(Array);
+        expect(nodes.length).to.equal(3);
+        expect(nodes[0]).to.equal(children[0]);
+        expect(nodes[1]).to.equal(children[1]);
+        expect(nodes[2]).to.equal(newChild);
       });
 
       it('should get a reference to list of elements passed to un-named slot', () => {
@@ -408,6 +437,14 @@ describe('slot-controller', () => {
         expect(initializeSpy.calledTwice).to.be.true;
         expect(initializeSpy.firstCall.args[0]).to.equal(children[0]);
         expect(initializeSpy.secondCall.args[0]).to.equal(children[1]);
+      });
+
+      it('should not remove custom elements when adding another custom element', async () => {
+        const newChild = document.createElement('div');
+        element.append(newChild);
+
+        await nextFrame();
+        expect(element.childElementCount).to.equal(3);
       });
     });
   });


### PR DESCRIPTION
## Description

`SlotController` currently removes previously added custom elements whenever a new element is added. While that is OK if the slot may only contain a single element, or only contains the default node when multiple elements are allowed, that is an issue if the slot may contain multiple elements and already has custom elements assigned. In that case previously added elements are just removed.

This changes the logic to only remove:
- the previous node in single mode
- the default node in multiple mode

I also updated the logic for calculating the current nodes in multiple mode to reflect that. I feel that the logic is still incomplete though, as the `nodes` array (as well as the `node` property) is never updated when removing elements. Then again I'm not sure if I understand the controller completely yet.

Fixes https://github.com/vaadin/web-components/issues/5852

## Type of change

- Bugfix