### PR TITLE
[DO NOT MERGE] fix!: do not revalidate on input when invalid

### DIFF
--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -98,40 +98,4 @@ export const InputFieldMixin = (superclass) =>
         this.validate();
       }
     }
-
-    /**
-     * Override an event listener from `InputMixin`
-     * to mark as valid after user started typing.
-     * @param {Event} event
-     * @protected
-     * @override
-     */
-    _onInput(event) {
-      super._onInput(event);
-
-      if (this.invalid) {
-        this.validate();
-      }
-    }
-
-    /**
-     * Override an observer from `InputMixin` to validate the field
-     * when a new value is set programmatically.
-     *
-     * @param {string | undefined} newValue
-     * @param {string | undefined} oldValue
-     * @protected
-     * @override
-     */
-    _valueChanged(newValue, oldValue) {
-      super._valueChanged(newValue, oldValue);
-
-      if (oldValue === undefined) {
-        return;
-      }
-
-      if (this.invalid) {
-        this.validate();
-      }
-    }
   };

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -168,25 +168,6 @@ const runTests = (defineHelper, baseMixin) => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should validate on input event', async () => {
-      element.required = true;
-      element.invalid = true;
-      await nextFrame();
-      const spy = sinon.spy(element, 'validate');
-      input.focus();
-      await sendKeys({ type: 'f' });
-      expect(spy.calledOnce).to.be.true;
-      expect(element.invalid).to.be.false;
-    });
-
-    it('should validate on value change when field is invalid', async () => {
-      const spy = sinon.spy(element, 'validate');
-      element.invalid = true;
-      element.value = 'foo';
-      await nextFrame();
-      expect(spy.calledOnce).to.be.true;
-    });
-
     it('should call checkValidity on the input when required', () => {
       const spy = sinon.spy(input, 'checkValidity');
       element.required = true;


### PR DESCRIPTION
## Description

The PR removes the logic responsible for field revalidation on input when the field is invalid. This is specifically done to avoid unnecessary Flow round-trips.

> **Warning**
> This is a behavior altering change.

Fixes https://github.com/vaadin/flow-components/issues/4986

## Type of change

- [x] Bugfix
