### PR TITLE
fix: restore focus on context menu overlay close

### DIFF
--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.d.ts
@@ -4,11 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { OverlayFocusMixinClass } from '@vaadin/overlay/src/vaadin-overlay-focus-mixin.js';
 import type { PositionMixinClass } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
 export declare function MenuOverlayMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<MenuOverlayMixinClass> & Constructor<PositionMixinClass> & T;
+): Constructor<MenuOverlayMixinClass> & Constructor<OverlayFocusMixinClass> & Constructor<PositionMixinClass> & T;
 
 export declare class MenuOverlayMixinClass {
   protected readonly parentOverlay: HTMLElement | undefined;

--- a/packages/context-menu/test/a11y.test.js
+++ b/packages/context-menu/test/a11y.test.js
@@ -6,6 +6,15 @@ import '../vaadin-context-menu.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { getMenuItems } from './helpers.js';
 
+function outsideClick() {
+  // Move focus to body
+  document.body.tabIndex = 0;
+  document.body.focus();
+  document.body.tabIndex = -1;
+  // Outside click
+  document.body.click();
+}
+
 describe('a11y', () => {
   describe('focus restoration', () => {
     let contextMenu, contextMenuButton, beforeButton, afterButton;
@@ -32,6 +41,27 @@ describe('a11y', () => {
       expect(getDeepActiveElement()).to.equal(menuItem);
     });
 
+    it('should restore focus on outside click', async () => {
+      contextMenuButton.click();
+      await nextRender();
+      outsideClick();
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(contextMenuButton);
+    });
+
+    it('should restore focus on outside click when a sub-menu is open', async () => {
+      contextMenuButton.click();
+      await nextRender();
+      // Move focus to Item 1
+      await sendKeys({ press: 'ArrowDown' });
+      // Open Item 1
+      await sendKeys({ press: 'ArrowRight' });
+      await nextRender();
+      outsideClick();
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(contextMenuButton);
+    });
+
     it('should restore focus on root menu item selection', async () => {
       contextMenuButton.click();
       await nextRender();
@@ -41,7 +71,7 @@ describe('a11y', () => {
       expect(getDeepActiveElement()).to.equal(contextMenuButton);
     });
 
-    it('should restore focus on sub menu item selection', async () => {
+    it('should restore focus on sub-menu item selection', async () => {
       contextMenuButton.click();
       await nextRender();
       // Move focus to Item 1

--- a/packages/context-menu/test/a11y.test.js
+++ b/packages/context-menu/test/a11y.test.js
@@ -4,16 +4,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';
 import '../vaadin-context-menu.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
-import { getMenuItems } from './helpers.js';
-
-function outsideClick() {
-  // Move focus to body
-  document.body.tabIndex = 0;
-  document.body.focus();
-  document.body.tabIndex = -1;
-  // Outside click
-  document.body.click();
-}
+import { getMenuItems, outsideClick } from './helpers.js';
 
 describe('a11y', () => {
   describe('focus restoration', () => {

--- a/packages/context-menu/test/a11y.test.js
+++ b/packages/context-menu/test/a11y.test.js
@@ -1,0 +1,55 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getMenuItems } from './helpers.js';
+
+describe('a11y', () => {
+  describe('focus restoration', () => {
+    let contextMenu, button, overlay;
+
+    beforeEach(() => {
+      contextMenu = fixtureSync(`
+        <vaadin-context-menu open-on="click">
+          <button>Open context menu</button>
+        </vaadin-context-menu>
+      `);
+      contextMenu.items = [{ text: 'Item 0' }, { text: 'Item 1', children: [{ text: 'Item 1/0' }] }];
+      button = contextMenu.querySelector('button');
+      overlay = contextMenu.$.overlay;
+      button.focus();
+    });
+
+    it('should move focus to the menu on open', async () => {
+      button.click();
+      await nextRender();
+      const menuItem = getMenuItems(contextMenu)[0];
+      expect(getDeepActiveElement()).to.equal(menuItem);
+    });
+
+    it('should restore focus on root menu item selection', async () => {
+      button.click();
+      await nextRender();
+      // Select Item 0
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(button);
+    });
+
+    it('should restore focus on sub menu item selection', async () => {
+      button.click();
+      await nextRender();
+      // Move focus to Item 1
+      await sendKeys({ press: 'ArrowDown' });
+      // Open Item 1
+      await sendKeys({ press: 'ArrowRight' });
+      await nextRender();
+      // Select Item 1/1
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(button);
+    });
+  });
+});

--- a/packages/context-menu/test/a11y.test.js
+++ b/packages/context-menu/test/a11y.test.js
@@ -8,7 +8,7 @@ import { getMenuItems } from './helpers.js';
 
 describe('a11y', () => {
   describe('focus restoration', () => {
-    let contextMenu, button, overlay;
+    let contextMenu, button;
 
     beforeEach(() => {
       contextMenu = fixtureSync(`
@@ -18,7 +18,6 @@ describe('a11y', () => {
       `);
       contextMenu.items = [{ text: 'Item 0' }, { text: 'Item 1', children: [{ text: 'Item 1/0' }] }];
       button = contextMenu.querySelector('button');
-      overlay = contextMenu.$.overlay;
       button.focus();
     });
 

--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -28,3 +28,12 @@ export async function openSubMenus(menu) {
     await openSubMenus(subMenu);
   }
 }
+
+export function outsideClick() {
+  // Move focus to body
+  document.body.tabIndex = 0;
+  document.body.focus();
+  document.body.tabIndex = -1;
+  // Outside click
+  document.body.click();
+}

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -72,7 +72,7 @@ export const OverlayFocusMixin = (superClass) =>
         this.__focusTrapController.releaseFocus();
       }
 
-      if (this.restoreFocusOnClose) {
+      if (this.restoreFocusOnClose && this._shouldRestoreFocus()) {
         this.__restoreFocus();
       }
     }
@@ -155,16 +155,6 @@ export const OverlayFocusMixin = (superClass) =>
 
     /** @private */
     __restoreFocus() {
-      // If the activeElement is `<body>` or inside the overlay,
-      // we are allowed to restore the focus. In all the other
-      // cases focus might have been moved elsewhere by another
-      // component or by the user interaction (e.g. click on a
-      // button outside the overlay).
-      const activeElement = getDeepActiveElement();
-      if (activeElement !== document.body && !this._deepContains(activeElement)) {
-        return;
-      }
-
       // Use restoreFocusNode if specified, otherwise fallback to the node
       // which was focused before opening the overlay.
       const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -159,9 +159,16 @@ export const OverlayFocusMixin = (superClass) =>
       // which was focused before opening the overlay.
       const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;
       if (restoreFocusNode) {
-        // Focusing the restoreFocusNode doesn't always work synchronously on Firefox and Safari
-        // (e.g. combo-box overlay close on outside click).
-        setTimeout(() => restoreFocusNode.focus());
+        if (getDeepActiveElement() === document.body) {
+          // In Firefox and Safari, focusing the restoreFocusNode synchronously
+          // doesn't work as expected when closing the overlay on outside click.
+          // In this case, these browsers force focus to move to the body element
+          // and retain it there until the next event loop iteration.
+          setTimeout(() => restoreFocusNode.focus());
+        } else {
+          restoreFocusNode.focus();
+        }
+
         this.__restoreFocusNode = null;
       }
 

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -161,9 +161,9 @@ export const OverlayFocusMixin = (superClass) =>
       if (restoreFocusNode) {
         if (getDeepActiveElement() === document.body) {
           // In Firefox and Safari, focusing the restoreFocusNode synchronously
-          // doesn't work as expected when closing the overlay on outside click.
-          // In this case, these browsers force focus to move to the body element
-          // and retain it there until the next event loop iteration.
+          // doesn't work as expected when the overlay is closed by outside click.
+          // These browsers force focus to move to the body element and retain it
+          // there until the next event loop iteration.
           setTimeout(() => restoreFocusNode.focus());
         } else {
           restoreFocusNode.focus();

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -161,7 +161,7 @@ export const OverlayFocusMixin = (superClass) =>
       if (restoreFocusNode) {
         if (getDeepActiveElement() === document.body) {
           // In Firefox and Safari, focusing the restoreFocusNode synchronously
-          // doesn't work as expected when the overlay is closed by outside click.
+          // doesn't work as expected when the overlay is closing on outside click.
           // These browsers force focus to move to the body element and retain it
           // there until the next event loop iteration.
           setTimeout(() => restoreFocusNode.focus());

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -166,6 +166,8 @@ export const OverlayFocusMixin = (superClass) =>
           // there until the next event loop iteration.
           setTimeout(() => restoreFocusNode.focus());
         } else {
+          // In other cases, restore focus synchronously to allow tabbing outside
+          // the overlay when no focus trap is present.
           restoreFocusNode.focus();
         }
 

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -166,8 +166,6 @@ export const OverlayFocusMixin = (superClass) =>
           // there until the next event loop iteration.
           setTimeout(() => restoreFocusNode.focus());
         } else {
-          // In other cases, restore focus synchronously to allow tabbing outside
-          // the overlay when no focus trap is present.
           restoreFocusNode.focus();
         }
 

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -72,7 +72,7 @@ export const OverlayFocusMixin = (superClass) =>
         this.__focusTrapController.releaseFocus();
       }
 
-      if (this.restoreFocusOnClose && this._shouldRestoreFocus()) {
+      if (this.restoreFocusOnClose) {
         this.__restoreFocus();
       }
     }
@@ -155,6 +155,16 @@ export const OverlayFocusMixin = (superClass) =>
 
     /** @private */
     __restoreFocus() {
+      // If the activeElement is `<body>` or inside the overlay,
+      // we are allowed to restore the focus. In all the other
+      // cases focus might have been moved elsewhere by another
+      // component or by the user interaction (e.g. click on a
+      // button outside the overlay).
+      const activeElement = getDeepActiveElement();
+      if (activeElement !== document.body && !this._deepContains(activeElement)) {
+        return;
+      }
+
       // Use restoreFocusNode if specified, otherwise fallback to the node
       // which was focused before opening the overlay.
       const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;


### PR DESCRIPTION
## Description

The PR enables the overlay logic to restore focus on context menu close.

Depends on 
- https://github.com/vaadin/web-components/pull/5895
- https://github.com/vaadin/web-components/pull/5896
- https://github.com/vaadin/web-components/pull/5897

Fixes https://github.com/vaadin/web-components/issues/137, https://github.com/vaadin/web-components/issues/292

## Type of change

- [x] Bugfix
