### PR TITLE
fix: make username/password props optional in i18n

### DIFF
--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -16,8 +16,8 @@ export interface LoginI18n {
   errorMessage: {
     title: string;
     message: string;
-    username: string;
-    password: string;
+    username?: string;
+    password?: string;
   };
   header?: {
     title?: string;


### PR DESCRIPTION
## Description

Mark `username` and  `password` properties as optional in the type definition in `vaadin-login-mixin`

## Type of change

- [x] Bugfix
- [ ] Feature
