### PR TITLE
fix: update hidden state when virtualizer container is invisible

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -281,6 +281,19 @@ export class IronListAdapter {
       this._virtualCount = this.items.length;
     }
 
+    // When reducing size while invisible, iron-list does not update items, so
+    // their hidden state is not updated and their __lastUpdatedIndex is not
+    // reset. In that case do it manually here.
+    if (!this._visible) {
+      this._iterateItems((pidx, vidx) => {
+        const el = this._physicalItems[pidx];
+        el.hidden = vidx >= size;
+        if (el.hidden) {
+          delete el.__lastUpdatedIndex;
+        }
+      });
+    }
+
     if (!this.elementsContainer.children.length) {
       requestAnimationFrame(() => this._resizeHandler());
     }

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -284,7 +284,7 @@ export class IronListAdapter {
     // When reducing size while invisible, iron-list does not update items, so
     // their hidden state is not updated and their __lastUpdatedIndex is not
     // reset. In that case do it manually here.
-    if (!this._visible) {
+    if (!this._isVisible) {
       this._iterateItems((pidx, vidx) => {
         const el = this._physicalItems[pidx];
         el.hidden = vidx >= size;

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -283,15 +283,9 @@ export class IronListAdapter {
 
     // When reducing size while invisible, iron-list does not update items, so
     // their hidden state is not updated and their __lastUpdatedIndex is not
-    // reset. In that case do it manually here.
+    // reset. In that case force an update here.
     if (!this._isVisible) {
-      this._iterateItems((pidx, vidx) => {
-        const el = this._physicalItems[pidx];
-        el.hidden = vidx >= size;
-        if (el.hidden) {
-          delete el.__lastUpdatedIndex;
-        }
-      });
+      this._assignModels();
     }
 
     if (!this.elementsContainer.children.length) {

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -277,6 +277,34 @@ describe('virtualizer', () => {
     expect(elementsContainer.firstElementChild.textContent).to.equal('bar-0');
   });
 
+  it('should re-render an unhidden item if it was hidden while container was invisible', async () => {
+    // Create a virtualizer with just one item (rendered content "foo-0")
+    let prefix = 'foo-';
+    const updateElement = (el, index) => {
+      el.textContent = `${prefix}${index}`;
+    };
+    init({ size: 1, updateElement });
+
+    // Wait for a possible resize observer flush
+    await aTimeout(100);
+
+    // Hide container and reduce the size to 0 (the item gets hidden)
+    scrollTarget.style.display = 'none';
+    elementsContainer.style.display = 'none';
+    virtualizer.size = 0;
+
+    // Update the prefix used by the renderer to "bar-"
+    prefix = 'bar-';
+
+    // Show container again, increase the size back to 1
+    scrollTarget.style.display = 'block';
+    elementsContainer.style.display = 'block';
+    virtualizer.size = 1;
+
+    // Expect the unhidden item to be re-rendered with the new prefix even though its index hasn't changed
+    expect(elementsContainer.firstElementChild.textContent).to.equal('bar-0');
+  });
+
   it('should have physical items once visible', async () => {
     init({ size: 0 });
     // Wait for possibly active resize observers to flush

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -290,7 +290,6 @@ describe('virtualizer', () => {
 
     // Hide container and reduce the size to 0 (the item gets hidden)
     scrollTarget.style.display = 'none';
-    elementsContainer.style.display = 'none';
     virtualizer.size = 0;
 
     // Update the prefix used by the renderer to "bar-"
@@ -298,7 +297,6 @@ describe('virtualizer', () => {
 
     // Show container again, increase the size back to 1
     scrollTarget.style.display = 'block';
-    elementsContainer.style.display = 'block';
     virtualizer.size = 1;
 
     // Expect the unhidden item to be re-rendered with the new prefix even though its index hasn't changed


### PR DESCRIPTION
## Description

`IronListAdapter` adds an additional `hidden` and `__lastUpdatedIndex` to items. That state is not properly updated when reducing the `size` while the container is invisible because `IronList` does not re-render / update in that case. That leads to the adapter not re-rendering items when the size is increased again, showing stale data.

This change explicitly updates the `hidden` and `__lastUpdatedIndex` state when `size` changes and the container is invisible, so that items are properly re-rendered when increasing the size again.

Fixes https://github.com/vaadin/flow-components/issues/4937

## Type of change

- Bugfix