### PR TITLE
feat: add a getClosestElement helper

### DIFF
--- a/packages/component-base/src/dom-utils.d.ts
+++ b/packages/component-base/src/dom-utils.d.ts
@@ -14,6 +14,12 @@
 export function getAncestorRootNodes(node: Node): Node[];
 
 /**
+ * Traverses the given node and its parents, including those that are across
+ * the shadow root boundaries, until it finds a node that matches the selector.
+ */
+export function getClosestElement(selector: string, node: Node): Node | null;
+
+/**
  * Takes a string with values separated by space and returns a set the values
  */
 export function deserializeAttributeValue(value: string): Set<string>;

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -11,7 +11,7 @@
  * The array is collected by a bottom-up DOM traversing that starts with the given node
  * and involves both the light DOM and ancestor shadow DOM trees.
  *
- * @param {Node} node The starting node for the traversal
+ * @param {Node} node
  * @return {Node[]}
  */
 export function getAncestorRootNodes(node) {

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -11,7 +11,7 @@
  * The array is collected by a bottom-up DOM traversing that starts with the given node
  * and involves both the light DOM and ancestor shadow DOM trees.
  *
- * @param {Node} node
+ * @param {Node} node The starting node for the traversal
  * @return {Node[]}
  */
 export function getAncestorRootNodes(node) {
@@ -38,6 +38,22 @@ export function getAncestorRootNodes(node) {
   }
 
   return result;
+}
+
+/**
+ * Traverses the given node and its parents, including those that are across
+ * the shadow root boundaries, until it finds a node that matches the selector.
+ *
+ * @param {string} selector The CSS selector to match against
+ * @param {Node} node The starting node for the traversal
+ * @return {Node | null} The closest matching element, or null if no match is found
+ */
+export function getClosestElement(selector, node) {
+  if (!node) {
+    return null;
+  }
+
+  return node.closest(selector) || getClosestElement(selector, node.getRootNode().host);
 }
 
 /**


### PR DESCRIPTION
## Description

The standard `node.closest(selector)` is limited to searching for the closest element within the scope of the node's shadow root. The PR introduces a `getClosestElement(selector, node)` helper that allows finding elements across the boundaries of the node's shadow root.

Part of https://github.com/vaadin/web-components/pull/5881

Related to https://github.com/vaadin/web-components/issues/137

## Type of change

- [x] Feature
