### PR TITLE
refactor: move _deepContains() to OverlayFocusMixin as protected

### DIFF
--- a/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
@@ -46,16 +46,6 @@ export declare class OverlayFocusMixinClass {
   protected _trapFocus(): void;
 
   /**
-   * Returns true if focus is still inside the overlay or on the body element,
-   * otherwise false.
-   *
-   * Focus shouldn't be restored if it's been moved elsewhere by another
-   * component or as a result of a user interaction e.g. the user clicked
-   * on a button outside the overlay while the overlay was open.
-   */
-  protected _shouldRestoreFocus(): boolean;
-
-  /**
    * Returns true if the overlay contains the given node,
    * including those within shadow DOM trees.
    */

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
@@ -46,6 +46,16 @@ export declare class OverlayFocusMixinClass {
   protected _trapFocus(): void;
 
   /**
+   * Returns true if focus is still inside the overlay or on the body element,
+   * otherwise false.
+   *
+   * Focus shouldn't be restored if it's been moved elsewhere by another
+   * component or as a result of a user interaction e.g. the user clicked
+   * on a button outside the overlay while the overlay was open.
+   */
+  protected _shouldRestoreFocus(): boolean;
+
+  /**
    * Returns true if the overlay contains the given node,
    * including those within shadow DOM trees.
    */

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
@@ -54,4 +54,10 @@ export declare class OverlayFocusMixinClass {
    * on a button outside the overlay while the overlay was open.
    */
   protected _shouldRestoreFocus(): boolean;
+
+  /**
+   * Returns true if the overlay contains the given node,
+   * including those within shadow DOM trees.
+   */
+  protected _deepContains(node: Node): boolean;
 }

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -72,7 +72,7 @@ export const OverlayFocusMixin = (superClass) =>
         this.__focusTrapController.releaseFocus();
       }
 
-      if (this.restoreFocusOnClose && this._shouldRestoreFocus()) {
+      if (this.restoreFocusOnClose) {
         this.__restoreFocus();
       }
     }
@@ -98,22 +98,6 @@ export const OverlayFocusMixin = (superClass) =>
         this.__ariaModalController.showModal();
         this.__focusTrapController.trapFocus(this.$.overlay);
       }
-    }
-
-    /**
-     * Returns true if focus is still inside the overlay or on the body element,
-     * otherwise false.
-     *
-     * Focus shouldn't be restored if it's been moved elsewhere by another
-     * component or as a result of a user interaction e.g. the user clicked
-     * on a button outside the overlay while the overlay was open.
-     *
-     * @protected
-     * @return {boolean}
-     */
-    _shouldRestoreFocus() {
-      const activeElement = getDeepActiveElement();
-      return activeElement === document.body || this._deepContains(activeElement);
     }
 
     /**
@@ -155,6 +139,16 @@ export const OverlayFocusMixin = (superClass) =>
 
     /** @private */
     __restoreFocus() {
+      // If the activeElement is `<body>` or inside the overlay,
+      // we are allowed to restore the focus. In all the other
+      // cases focus might have been moved elsewhere by another
+      // component or by the user interaction (e.g. click on a
+      // button outside the overlay).
+      const activeElement = getDeepActiveElement();
+      if (activeElement !== document.body && !this._deepContains(activeElement)) {
+        return;
+      }
+
       // Use restoreFocusNode if specified, otherwise fallback to the node
       // which was focused before opening the overlay.
       const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -72,7 +72,7 @@ export const OverlayFocusMixin = (superClass) =>
         this.__focusTrapController.releaseFocus();
       }
 
-      if (this.restoreFocusOnClose) {
+      if (this.restoreFocusOnClose && this._shouldRestoreFocus()) {
         this.__restoreFocus();
       }
     }
@@ -98,6 +98,22 @@ export const OverlayFocusMixin = (superClass) =>
         this.__ariaModalController.showModal();
         this.__focusTrapController.trapFocus(this.$.overlay);
       }
+    }
+
+    /**
+     * Returns true if focus is still inside the overlay or on the body element,
+     * otherwise false.
+     *
+     * Focus shouldn't be restored if it's been moved elsewhere by another
+     * component or as a result of a user interaction e.g. the user clicked
+     * on a button outside the overlay while the overlay was open.
+     *
+     * @protected
+     * @return {boolean}
+     */
+    _shouldRestoreFocus() {
+      const activeElement = getDeepActiveElement();
+      return activeElement === document.body || this._deepContains(activeElement);
     }
 
     /**
@@ -139,16 +155,6 @@ export const OverlayFocusMixin = (superClass) =>
 
     /** @private */
     __restoreFocus() {
-      // If the activeElement is `<body>` or inside the overlay,
-      // we are allowed to restore the focus. In all the other
-      // cases focus might have been moved elsewhere by another
-      // component or by the user interaction (e.g. click on a
-      // button outside the overlay).
-      const activeElement = getDeepActiveElement();
-      if (activeElement !== document.body && !this._deepContains(activeElement)) {
-        return;
-      }
-
       // Use restoreFocusNode if specified, otherwise fallback to the node
       // which was focused before opening the overlay.
       const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -116,6 +116,27 @@ export const OverlayFocusMixin = (superClass) =>
       return activeElement === document.body || this._deepContains(activeElement);
     }
 
+    /**
+     * Returns true if the overlay contains the given node,
+     * including those within shadow DOM trees.
+     *
+     * @param {Node} node
+     * @return {boolean}
+     * @protected
+     */
+    _deepContains(node) {
+      if (this.contains(node)) {
+        return true;
+      }
+      let n = node;
+      const doc = node.ownerDocument;
+      // Walk from node to `this` or `document`
+      while (n && n !== doc && n !== this) {
+        n = n.parentNode || n.host;
+      }
+      return n === this;
+    }
+
     /** @private */
     __storeFocus() {
       // Store the focused node.

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -630,24 +630,6 @@ class Overlay extends OverlayStackMixin(OverlayFocusMixin(ThemableMixin(DirMixin
   }
 
   /**
-   * @param {!Node} node
-   * @return {boolean}
-   * @private
-   */
-  _deepContains(node) {
-    if (this.contains(node)) {
-      return true;
-    }
-    let n = node;
-    const doc = node.ownerDocument;
-    // Walk from node to `this` or `document`
-    while (n && n !== doc && n !== this) {
-      n = n.parentNode || n.host;
-    }
-    return n === this;
-  }
-
-  /**
    * @event vaadin-overlay-open
    * Fired after the overlay is opened.
    */


### PR DESCRIPTION
## Description

The PR moves the `_deepContains` method to `OverlayFocusMixin` where it's actually used and makes it protected to allow potential overrides.

Part of https://github.com/vaadin/web-components/pull/5881

Related to https://github.com/vaadin/web-components/issues/137

## Type of change

- [x] Refactor
