### PR TITLE
refactor: extract _shouldRestoreFocus(), make it protected

### DIFF
--- a/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
@@ -44,4 +44,14 @@ export declare class OverlayFocusMixinClass {
    * Trap focus within the overlay after opening has completed.
    */
   protected _trapFocus(): void;
+
+  /**
+   * Returns true if focus is still inside the overlay or on the body element,
+   * otherwise false.
+   *
+   * Focus shouldn't be restored if it's been moved elsewhere by another
+   * component or as a result of a user interaction e.g. the user clicked
+   * on a button outside the overlay while the overlay was open.
+   */
+  protected _shouldRestoreFocus(): boolean;
 }

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -72,7 +72,7 @@ export const OverlayFocusMixin = (superClass) =>
         this.__focusTrapController.releaseFocus();
       }
 
-      if (this.restoreFocusOnClose) {
+      if (this.restoreFocusOnClose && this._shouldRestoreFocus()) {
         this.__restoreFocus();
       }
     }
@@ -100,6 +100,22 @@ export const OverlayFocusMixin = (superClass) =>
       }
     }
 
+    /**
+     * Returns true if focus is still inside the overlay or on the body element,
+     * otherwise false.
+     *
+     * Focus shouldn't be restored if it's been moved elsewhere by another
+     * component or as a result of a user interaction e.g. the user clicked
+     * on a button outside the overlay while the overlay was open.
+     *
+     * @protected
+     * @return {boolean}
+     */
+    _shouldRestoreFocus() {
+      const activeElement = getDeepActiveElement();
+      return activeElement === document.body || this._deepContains(activeElement);
+    }
+
     /** @private */
     __storeFocus() {
       // Store the focused node.
@@ -118,16 +134,6 @@ export const OverlayFocusMixin = (superClass) =>
 
     /** @private */
     __restoreFocus() {
-      // If the activeElement is `<body>` or inside the overlay,
-      // we are allowed to restore the focus. In all the other
-      // cases focus might have been moved elsewhere by another
-      // component or by the user interaction (e.g. click on a
-      // button outside the overlay).
-      const activeElement = getDeepActiveElement();
-      if (activeElement !== document.body && !this._deepContains(activeElement)) {
-        return;
-      }
-
       // Use restoreFocusNode if specified, otherwise fallback to the node
       // which was focused before opening the overlay.
       const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;


### PR DESCRIPTION
## Description

The PR extracts the logic, which checks if the overlay is allowed to restore focus on close, into an individual protected method `_shouldRestoreFocus` to allow potential overrides.

Part of https://github.com/vaadin/web-components/pull/5881

Related to https://github.com/vaadin/web-components/issues/137

## Type of change

- [x] Refactor
