### PR TITLE
fix: do not reset scroll position when hiding grid

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -392,6 +392,11 @@ export class IronListAdapter {
   toggleScrollListener() {}
 
   _scrollHandler() {
+    // The scroll target is hidden.
+    if (this.scrollTarget.offsetHeight === 0) {
+      return;
+    }
+
     this._adjustVirtualIndexOffset(this._scrollTop - (this.__previousScrollTop || 0));
     const delta = this.scrollTarget.scrollTop - this._scrollPosition;
 

--- a/packages/grid/test/hidden-grid.test.js
+++ b/packages/grid/test/hidden-grid.test.js
@@ -1,33 +1,71 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-grid.js';
-import { flushGrid, getBodyCellContent, infiniteDataProvider } from './helpers.js';
+import { fire, flushGrid, getBodyCellContent, infiniteDataProvider } from './helpers.js';
 
 describe('hidden grid', () => {
   let grid;
 
-  beforeEach(() => {
-    grid = fixtureSync(`
+  describe('initially hidden', () => {
+    beforeEach(() => {
+      grid = fixtureSync(`
       <vaadin-grid style="height: 200px; width: 200px;" hidden size="1">
         <vaadin-grid-column header="foo"></vaadin-grid-column>
       </vaadin-grid>
     `);
-    grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
-      root.textContent = model.index;
-    };
-    grid.dataProvider = infiniteDataProvider;
-    flushGrid(grid);
+      grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+        root.textContent = model.index;
+      };
+      grid.dataProvider = infiniteDataProvider;
+      flushGrid(grid);
+    });
+
+    it('should be hidden', () => {
+      expect(grid.offsetWidth).to.equal(0);
+      expect(grid.offsetHeight).to.equal(0);
+    });
+
+    it('should have content on appear', async () => {
+      grid.removeAttribute('hidden');
+      await oneEvent(grid, 'animationend');
+      await nextFrame();
+      expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('0');
+    });
   });
 
-  it('should be hidden', () => {
-    expect(grid.offsetWidth).to.equal(0);
-    expect(grid.offsetHeight).to.equal(0);
-  });
+  describe('hiding the grid', () => {
+    beforeEach(() => {
+      grid = fixtureSync(`
+        <vaadin-grid size="1000">
+          <vaadin-grid-column header="foo"></vaadin-grid-column>
+        </vaadin-grid>
+    `);
+      grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
+        root.textContent = model.index + 1;
+      };
+      grid.dataProvider = sinon.spy(infiniteDataProvider);
+      flushGrid(grid);
+      grid.dataProvider.resetHistory();
+    });
 
-  it('should have content on appear', async () => {
-    grid.removeAttribute('hidden');
-    await oneEvent(grid, 'animationend');
-    await nextFrame();
-    expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('0');
+    it('should keep scroll position when hiding while triggering a scroll event', async () => {
+      // Scroll grid
+      grid.$.table.scrollTop = 300;
+      flushGrid(grid);
+
+      // Hide, simulate scroll event
+      // This is a simplified reproduction of something triggering a scroll
+      // event at the same time the grid is hidden.
+      grid.style.display = 'none';
+      fire('scroll', {}, { node: grid.$.table });
+
+      // Should not refresh data when hidden
+      expect(grid.dataProvider.called).to.be.false;
+
+      // Show grid again, should retain scroll position
+      grid.style.display = 'block';
+      expect(grid.$.table.scrollTop).to.equal(300);
+    });
   });
 });

--- a/packages/grid/test/hidden-grid.test.js
+++ b/packages/grid/test/hidden-grid.test.js
@@ -40,7 +40,7 @@ describe('hidden grid', () => {
         <vaadin-grid size="1000">
           <vaadin-grid-column header="foo"></vaadin-grid-column>
         </vaadin-grid>
-    `);
+      `);
       grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
         root.textContent = model.index + 1;
       };


### PR DESCRIPTION
## Description

Grid can currently lose its scroll position if it receives a scroll event when it is hidden. That seems to the case in tabsheet, where switching to an unloaded tab panel shows a loading indicator and changes the flex properties of the content container, which at least in Firefox triggers a scroll event on grids in hidden tab panels.

This change updates `IronListAdapter` to ignore scroll events if its scroll target is not visible.

Fixes https://github.com/vaadin/web-components/issues/5796

## Type of change

- Bugfix