### PR TITLE
refactor: update scroller overflow indicators to use inset

### DIFF
--- a/packages/scroller/theme/lumo/vaadin-scroller-styles.js
+++ b/packages/scroller/theme/lumo/vaadin-scroller-styles.js
@@ -17,10 +17,7 @@ const scroller = css`
     content: '';
     display: none;
     position: sticky;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    inset: 0;
     z-index: 9999;
     height: 1px;
     margin-bottom: -1px;


### PR DESCRIPTION
## Description

Updated to use [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) shorthand instead of individual position properties.

## Type of change

- Refactor