### PR TITLE
refactor: update login overlay wrapper styles to use inset

### DIFF
--- a/packages/login/theme/lumo/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-overlay-styles.js
@@ -6,10 +6,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 
 const loginOverlayWrapper = css`
   :host {
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    inset: 0;
   }
 
   [part='backdrop'] {

--- a/packages/login/theme/material/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/material/vaadin-login-overlay-styles.js
@@ -6,10 +6,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 
 const loginOverlayWrapper = css`
   :host {
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    inset: 0;
   }
 
   [part='backdrop'] {


### PR DESCRIPTION
## Description

Updated to use [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) shorthand instead of individual position properties.

## Type of change

- Refactor