### PR TITLE
refactor: update input container Lumo styles to use inset

### DIFF
--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -40,10 +40,7 @@ registerStyles(
     :host::after {
       content: '';
       position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
+      inset: 0;
       border-radius: inherit;
       pointer-events: none;
       background-color: var(--lumo-contrast-50pct);


### PR DESCRIPTION
## Description

Updated to use [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) shorthand instead of individual position properties.

## Type of change

- Refactor