### PR TITLE
refactor: update dialog resizer edge styles to use inset

### DIFF
--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -51,10 +51,7 @@ registerStyles(
     .resizer.edge {
       height: 8px;
       width: 8px;
-      top: -4px;
-      right: -4px;
-      bottom: -4px;
-      left: -4px;
+      inset: -4px;
     }
 
     .resizer.edge.n {


### PR DESCRIPTION
## Description

Updated to use [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) shorthand instead of individual position properties.

## Type of change

- Refactor