### PR TITLE
refactor: update small and minimal Lumo splitter to use inset

### DIFF
--- a/packages/split-layout/theme/lumo/vaadin-split-layout-styles.js
+++ b/packages/split-layout/theme/lumo/vaadin-split-layout-styles.js
@@ -73,10 +73,7 @@ registerStyles(
     :host([theme~='minimal']) > [part='splitter']::after {
       content: '';
       position: absolute;
-      top: -4px;
-      right: -4px;
-      bottom: -4px;
-      left: -4px;
+      inset: -4px;
     }
 
     :host([theme~='small']) > [part='splitter'] > [part='handle']::after,


### PR DESCRIPTION
## Description

Updated to use [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) shorthand instead of individual position properties.

## Type of change

- Refactor