### PR TITLE
refactor: update Material tab pseudo element to use inset

### DIFF
--- a/packages/tabs/theme/material/vaadin-tab-styles.js
+++ b/packages/tabs/theme/material/vaadin-tab-styles.js
@@ -45,10 +45,7 @@ registerStyles(
     :host::before {
       content: '';
       position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
+      inset: 0;
       background-color: var(--material-primary-color);
       opacity: 0;
       transition: opacity 0.1s linear;


### PR DESCRIPTION
## Description

Updated to use [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) shorthand instead of individual position properties.

## Type of change

- Refactor