### PR TITLE
refactor: update Material button pseudo element to use inset

### DIFF
--- a/packages/button/theme/lumo/vaadin-button-styles.js
+++ b/packages/button/theme/lumo/vaadin-button-styles.js
@@ -56,10 +56,7 @@ const button = css`
     /* We rely on the host always being relative */
     position: absolute;
     z-index: 1;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    inset: 0;
     background-color: currentColor;
     border-radius: inherit;
     opacity: 0;


### PR DESCRIPTION
## Description

Updated to use [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) shorthand instead of individual position properties.

## Type of change

- Refactor