### PR TITLE
test: assert synchronous focus restoration except when outside click

### DIFF
--- a/packages/overlay/test/helpers.js
+++ b/packages/overlay/test/helpers.js
@@ -29,3 +29,15 @@ export function close(overlay) {
     overlay.opened = false;
   });
 }
+
+/**
+ * Emulates clicking outside the dropdown overlay
+ */
+export function outsideClick() {
+  // Move focus to body
+  document.body.tabIndex = 0;
+  document.body.focus();
+  document.body.tabIndex = -1;
+  // Outside click
+  document.body.click();
+}

--- a/packages/overlay/test/helpers.js
+++ b/packages/overlay/test/helpers.js
@@ -12,24 +12,6 @@ export function createOverlay(text) {
   return overlay;
 }
 
-export function open(overlay) {
-  return new Promise((resolve) => {
-    overlay.addEventListener('vaadin-overlay-open', () => {
-      resolve();
-    });
-    overlay.opened = true;
-  });
-}
-
-export function close(overlay) {
-  return new Promise((resolve) => {
-    nextRender(overlay).then(() => {
-      resolve();
-    });
-    overlay.opened = false;
-  });
-}
-
 /**
  * Emulates clicking outside the dropdown overlay
  */

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
-import { close, open } from './helpers.js';
+import { outsideClick } from './helpers.js';
 
 customElements.define(
   'overlay-field-wrapper',
@@ -64,17 +64,19 @@ describe('restore focus', () => {
 
     it('should not restore focus on close by default', async () => {
       focusInput.focus();
-      await open(overlay);
-      await close(overlay);
+      overlay.opened = true;
+      await nextRender();
+      overlay.opened = false;
       expect(getDeepActiveElement()).to.not.equal(focusInput);
     });
 
     it('should not restore focus-ring attribute on close by default', async () => {
       focusInput.focus();
       focusInput.setAttribute('focus-ring', '');
-      await open(overlay);
+      overlay.opened = true;
+      await nextRender();
       focusInput.removeAttribute('focus-ring');
-      await close(overlay);
+      overlay.opened = false;
       expect(focusInput.hasAttribute('focus-ring')).to.be.false;
     });
 
@@ -85,17 +87,19 @@ describe('restore focus', () => {
 
       it('should not restore focus on close by default', async () => {
         focusInput.focus();
-        await open(overlay);
-        await close(overlay);
+        overlay.opened = true;
+        await nextRender();
+        overlay.opened = false;
         expect(getDeepActiveElement()).to.not.equal(focusInput);
       });
 
       it('should not restore focus-ring attribute on close by default', async () => {
         focusInput.focus();
         focusInput.setAttribute('focus-ring', '');
-        await open(overlay);
+        overlay.opened = true;
+        await nextRender();
         focusInput.removeAttribute('focus-ring');
-        await close(overlay);
+        overlay.opened = false;
         expect(focusInput.hasAttribute('focus-ring')).to.be.false;
       });
     });
@@ -117,67 +121,74 @@ describe('restore focus', () => {
 
       it('should restore focus on close', async () => {
         focusInput.focus();
-        await open(overlay);
-        await close(overlay);
+        overlay.opened = true;
+        await nextRender();
+        overlay.opened = false;
         expect(getDeepActiveElement()).to.equal(focusInput);
       });
 
       it('should restore focus-ring attribute on close', async () => {
         focusInput.focus();
         focusInput.setAttribute('focus-ring', '');
-        await open(overlay);
+        overlay.opened = true;
+        await nextRender();
         focusInput.removeAttribute('focus-ring');
-        await close(overlay);
+        overlay.opened = false;
         expect(focusInput.hasAttribute('focus-ring')).to.be.true;
       });
 
       it('should not restore focus-ring attribute on close if it was not present', async () => {
         focusInput.focus();
-        await open(overlay);
-        await close(overlay);
+        overlay.opened = true;
+        await nextRender();
+        overlay.opened = false;
         expect(focusInput.hasAttribute('focus-ring')).to.be.false;
       });
 
       it('should restore focus on close in Shadow DOM', async () => {
         focusable.focus();
-        await open(overlay);
-        await close(overlay);
+        overlay.opened = true;
+        await nextRender();
+        overlay.opened = false;
         expect(getDeepActiveElement()).to.equal(focusable);
       });
 
-      it('should restore focus on close if focus was moved to body', async () => {
+      it('should restore focus asynchronously on outside click', async () => {
         focusInput.focus();
-        await open(overlay);
-        overlay.blur();
-        await close(overlay);
+        overlay.opened = true;
+        await nextRender();
+        outsideClick();
+        await aTimeout(0);
         expect(getDeepActiveElement()).to.equal(focusInput);
       });
 
-      it('should restore focus-ring attribute on close if focus was moved to body', async () => {
+      it('should restore focus-ring attribute on outside click', async () => {
         focusInput.focus();
         focusInput.setAttribute('focus-ring', '');
-        await open(overlay);
+        overlay.opened = true;
+        await nextRender();
         focusInput.removeAttribute('focus-ring');
-        overlay.blur();
-        await close(overlay);
+        outsideClick();
         expect(focusInput.hasAttribute('focus-ring')).to.be.true;
       });
 
       it('should not restore focus on close if focus was moved outside overlay', async () => {
         focusInput.focus();
-        await open(overlay);
+        overlay.opened = true;
+        await nextRender();
         focusable.focus();
-        await close(overlay);
+        overlay.opened = false;
         expect(getDeepActiveElement()).to.equal(focusable);
       });
 
       it('should not restore focus-ring attribute if focus was moved outside overlay', async () => {
         focusInput.focus();
         focusInput.setAttribute('focus-ring', '');
-        await open(overlay);
+        overlay.opened = true;
+        await nextRender();
         focusInput.removeAttribute('focus-ring');
         focusable.focus();
-        await close(overlay);
+        overlay.opened = false;
         expect(focusInput.hasAttribute('focus-ring')).to.be.false;
       });
 
@@ -188,17 +199,19 @@ describe('restore focus', () => {
 
         it('should restore focus to the restoreFocusNode', async () => {
           focusable.focus();
-          await open(overlay);
-          await close(overlay);
+          overlay.opened = true;
+          await nextRender();
+          overlay.opened = false;
           expect(getDeepActiveElement()).to.equal(focusInput);
         });
 
         it('should restore focus-ring attribute on the restoreFocusNode', async () => {
           focusable.focus();
           focusInput.setAttribute('focus-ring', '');
-          await open(overlay);
+          overlay.opened = true;
+          await nextRender();
           focusInput.removeAttribute('focus-ring');
-          await close(overlay);
+          overlay.opened = false;
           expect(focusInput.hasAttribute('focus-ring')).to.be.true;
         });
       });
@@ -215,9 +228,10 @@ describe('restore focus', () => {
       it('should restore focus-ring attribute on the host component', async () => {
         focusInput.focus();
         focusInputWrapper.setAttribute('focus-ring', '');
-        await open(overlay);
+        overlay.opened = true;
+        await nextRender();
         focusInputWrapper.removeAttribute('focus-ring');
-        await close(overlay);
+        overlay.opened = false;
         expect(focusInputWrapper.hasAttribute('focus-ring')).to.be.true;
       });
     });
@@ -233,9 +247,10 @@ describe('restore focus', () => {
       it('should restore focus-ring attribute on the host component', async () => {
         focusInput.focus();
         focusInputWrapper.setAttribute('focus-ring', '');
-        await open(overlay);
+        overlay.opened = true;
+        await nextRender();
         focusInputWrapper.removeAttribute('focus-ring');
-        await close(overlay);
+        overlay.opened = false;
         expect(focusInputWrapper.hasAttribute('focus-ring')).to.be.true;
       });
     });


### PR DESCRIPTION
## Description

The PR improves the overlay's focus restoration tests to assert that focus restores synchronously on overlay close except when an overlay closes on outside click. When clicking outside, Firefox and Safari force focus to move to the body element and retain it there until the next event loop iteration, so focus needs to be restored asynchronously but only in this particular case.

The target code fragment:

https://github.com/vaadin/web-components/blob/f437f56dc36b53b997caf2b0f6f2a94b2083fdf8/packages/overlay/src/vaadin-overlay-focus-mixin.js#L162-L170

Follows up to #5881 

## Type of change

- [x] Internal
