### PR TITLE
chore: fix a11y-base dev dependency version in RTE

### DIFF
--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/a11y-base": "24.1.0-beta1",
+    "@vaadin/a11y-base": "24.2.0-alpha0",
     "@vaadin/testing-helpers": "^0.4.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",


### PR DESCRIPTION
## Description

This version was incorrectly updated, let's align it with other dev dependencies.

## Type of change

- Internal change