### PR TITLE
test: add missing await to confirm-dialog tests

### DIFF
--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -49,8 +49,9 @@ describe('vaadin-confirm-dialog', () => {
       expect(confirm.opened).to.be.false;
     });
 
-    it('should propagate opened to internal dialog', () => {
+    it('should propagate opened to internal dialog', async () => {
       confirm.opened = true;
+      await nextRender();
       expect(dialog.opened).to.be.true;
     });
 
@@ -607,10 +608,11 @@ describe('vaadin-confirm-dialog', () => {
         expect(getComputedStyle(overlay.$.overlay).height).to.equal('500px');
       });
 
-      it('should set `aria-describedby` when `accessibleDescriptionRef` is set before attach', () => {
+      it('should set `aria-describedby` when `accessibleDescriptionRef` is set before attach', async () => {
         confirm.accessibleDescriptionRef = 'id-0';
         confirm.opened = true;
         document.body.appendChild(confirm);
+        await nextRender();
 
         const overlay = confirm.$.dialog.$.overlay;
         expect(overlay.getAttribute('aria-describedby')).to.equal('id-0');


### PR DESCRIPTION
## Description

After adding `aria-hidden` logic to `vaadin-overlay` focus trap, we now have to wait for the overlay to fully open.

This PR addresses following console errors for `vaadin-confirm-dialog` unit tests:

```
$ yarn test --group confirm-dialog
yarn run v1.22.19
$ web-test-runner --group confirm-dialog

packages/confirm-dialog/test/confirm-dialog.test.js:

 🚧 Browser logs:
      Error: [object HTMLElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.
      Error: [object HTMLElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.

Chrome: |██████████████████████████████| 1/1 test files | 68 passed, 0 failed

Finished running tests in 1.5s, all tests passed! 🎉
```

## Type of change

- Tests