### PR TITLE
test: fix snapshots for inline styles (23.3)

### DIFF
--- a/packages/message-list/test/dom/__snapshots__/message.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message.test.snap.js
@@ -104,7 +104,7 @@ snapshots["vaadin-message userColorIndex"] =
   has-color-index=""
   part="avatar"
   role="button"
-  style="--vaadin-avatar-user-color:var(--vaadin-user-color-2);"
+  style="--vaadin-avatar-user-color: var(--vaadin-user-color-2);"
   tabindex="-1"
 >
 </vaadin-message-avatar>

--- a/packages/message-list/test/dom/__snapshots__/message.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message.test.snap.js
@@ -104,7 +104,6 @@ snapshots["vaadin-message userColorIndex"] =
   has-color-index=""
   part="avatar"
   role="button"
-  style="--vaadin-avatar-user-color: var(--vaadin-user-color-2);"
   tabindex="-1"
 >
 </vaadin-message-avatar>

--- a/packages/message-list/test/dom/message.test.js
+++ b/packages/message-list/test/dom/message.test.js
@@ -3,6 +3,12 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-message.js';
 
 describe('vaadin-message', () => {
+  const SNAPSHOT_CONFIG = {
+    // Exclude custom CSS property set as inline style,
+    // as corresponding logic is covered by unit tests.
+    ignoreAttributes: ['style'],
+  };
+
   let message;
 
   beforeEach(() => {
@@ -31,7 +37,7 @@ describe('vaadin-message', () => {
   it('userColorIndex', async () => {
     document.documentElement.style.setProperty('--vaadin-user-color-2', 'green');
     message.userColorIndex = 2;
-    await expect(message).shadowDom.to.equalSnapshot();
+    await expect(message).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
 
   it('time', async () => {

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -95,10 +95,7 @@ snapshots["vaadin-text-area shadow default"] =
     >
     </span>
   </div>
-  <vaadin-input-container
-    part="input-field"
-    style="--_text-area-vertical-scroll-position:0px;"
-  >
+  <vaadin-input-container part="input-field">
     <slot
       name="prefix"
       slot="prefix"
@@ -147,7 +144,6 @@ snapshots["vaadin-text-area shadow disabled"] =
   <vaadin-input-container
     disabled=""
     part="input-field"
-    style="--_text-area-vertical-scroll-position:0px;"
   >
     <slot
       name="prefix"
@@ -197,7 +193,6 @@ snapshots["vaadin-text-area shadow readonly"] =
   <vaadin-input-container
     part="input-field"
     readonly=""
-    style="--_text-area-vertical-scroll-position:0px;"
   >
     <slot
       name="prefix"
@@ -247,7 +242,6 @@ snapshots["vaadin-text-area shadow invalid"] =
   <vaadin-input-container
     invalid=""
     part="input-field"
-    style="--_text-area-vertical-scroll-position:0px;"
   >
     <slot
       name="prefix"
@@ -296,7 +290,6 @@ snapshots["vaadin-text-area shadow theme"] =
   </div>
   <vaadin-input-container
     part="input-field"
-    style="--_text-area-vertical-scroll-position:0px;"
     theme="align-right"
   >
     <slot

--- a/packages/text-area/test/dom/text-area.test.js
+++ b/packages/text-area/test/dom/text-area.test.js
@@ -30,28 +30,34 @@ describe('vaadin-text-area', () => {
   });
 
   describe('shadow', () => {
+    const SNAPSHOT_CONFIG = {
+      // Exclude custom CSS property set as inline style,
+      // as corresponding logic is covered by unit tests.
+      ignoreAttributes: ['style'],
+    };
+
     it('default', async () => {
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
 
     it('disabled', async () => {
       textArea.disabled = true;
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
 
     it('readonly', async () => {
       textArea.readonly = true;
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
 
     it('invalid', async () => {
       textArea.invalid = true;
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
 
     it('theme', async () => {
       textArea.setAttribute('theme', 'align-right');
-      await expect(textArea).shadowDom.to.equalSnapshot();
+      await expect(textArea).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
   });
 });

--- a/packages/upload/test/dom/__snapshots__/vaadin-upload-file.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload-file.test.snap.js
@@ -70,7 +70,6 @@ snapshots["vaadin-upload-file shadow default"] =
   id="progress"
   part="progress"
   role="progressbar"
-  style="--vaadin-progress-value:0.6;"
   value="0.6"
 >
 </vaadin-progress-bar>

--- a/packages/upload/test/dom/vaadin-upload-file.test.js
+++ b/packages/upload/test/dom/vaadin-upload-file.test.js
@@ -15,8 +15,14 @@ describe('vaadin-upload-file', () => {
   });
 
   describe('shadow', () => {
+    const SNAPSHOT_CONFIG = {
+      // Exclude inline style as we are not testing
+      // the `vaadin-progress-bar` internal logic.
+      ignoreAttributes: ['style'],
+    };
+
     it('default', async () => {
-      await expect(uploadFile).shadowDom.to.equalSnapshot();
+      await expect(uploadFile).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
   });
 });


### PR DESCRIPTION
## Description

- Remove inline styles from textarea snapshots, adapted from https://github.com/vaadin/web-components/pull/5853
- Remove inline styles from upload snapshots, adapted from https://github.com/vaadin/web-components/pull/5856
- Remove inline styles from message snapshots
