### PR TITLE
refactor: introduce a protected method called when receiving data

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -441,10 +441,13 @@ export const DataProviderMixin = (superClass) =>
           }
 
           // Notify that new data has been received
-          this.__itemsReceived();
+          this._onDataProviderPageLoaded();
         });
       }
     }
+
+    /** @protected */
+    _onDataProviderPageLoaded() {}
 
     /**
      * @param {number} index


### PR DESCRIPTION
## Description

The PR moves the logic responsible for attempting to recalculate column widths from `__itemsReceived` to a separate method. Calling `__itemReceived` from places where items aren't actually received isn't accurate given its naming. It also makes the method harder to override.

Preparation for #5898 

## Type of change

- [x] Refactor
