### PR TITLE
fix: show tooltips when target is partially visible

### DIFF
--- a/packages/avatar/test/avatar.test.js
+++ b/packages/avatar/test/avatar.test.js
@@ -3,6 +3,7 @@ import { fixtureSync, focusin, focusout, mousedown, nextFrame, oneEvent, tabKeyD
 import sinon from 'sinon';
 import '@vaadin/tooltip/vaadin-tooltip.js';
 import '../vaadin-avatar.js';
+import { Tooltip } from '@vaadin/tooltip';
 
 describe('vaadin-avatar', () => {
   let avatar, imgElement, iconElement, abbrElement;
@@ -192,6 +193,12 @@ describe('vaadin-avatar', () => {
     describe('tooltip', () => {
       let tooltip;
 
+      before(() => {
+        Tooltip.setDefaultFocusDelay(0);
+        Tooltip.setDefaultHoverDelay(0);
+        Tooltip.setDefaultHideDelay(0);
+      });
+
       beforeEach(async () => {
         avatar.withTooltip = true;
         await nextFrame();
@@ -246,6 +253,17 @@ describe('vaadin-avatar', () => {
       it('should remove tooltip element when withTooltip is set to false', () => {
         avatar.withTooltip = false;
         expect(tooltip.parentNode).to.be.null;
+      });
+
+      it('should show tooltip when avatar is at the edge of a scroll container', () => {
+        const container = fixtureSync('<div></div>');
+        container.setAttribute('style', 'width: 100px; height: 100px; overflow: auto;');
+        container.appendChild(avatar);
+
+        const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+        tabKeyDown(avatar);
+        avatar.focus();
+        expect(overlay.opened).to.be.true;
       });
     });
   });

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -479,7 +479,7 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
       (entries) => {
         entries.forEach((entry) => this.__onTargetVisibilityChange(entry.isIntersecting));
       },
-      { threshold: 1 },
+      { threshold: 0 },
     );
 
     this._stateController = new TooltipStateController(this);

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -480,54 +480,42 @@ describe('vaadin-tooltip', () => {
       await nextFrame();
     });
 
-    describe('target is partially visible', () => {
-      beforeEach(async () => {
-        container.scrollTop = 220;
-        await waitForIntersectionObserver();
-      });
-
-      it('should open overlay when focused target is fully visible and hide otherwise', async () => {
-        tabKeyDown(target);
-        target.focus();
-        expect(overlay.opened).to.be.not.ok;
-
-        target.scrollIntoView({ block: 'center' });
-        await waitForIntersectionObserver();
-        expect(overlay.opened).to.be.true;
-
-        container.scrollTop = 0;
-        await waitForIntersectionObserver();
-        expect(overlay.opened).to.be.false;
-      });
-
-      it('should open overlay when hovered target is fully visible and hide otherwise', async () => {
-        mouseenter(target);
-        expect(overlay.opened).to.be.not.ok;
-
-        target.scrollIntoView({ block: 'center' });
-        await waitForIntersectionObserver();
-        expect(overlay.opened).to.be.true;
-
-        container.scrollTop = 0;
-        await waitForIntersectionObserver();
-        expect(overlay.opened).to.be.false;
-      });
+    beforeEach(async () => {
+      container.scrollTop = 220;
+      await waitForIntersectionObserver();
     });
 
-    describe('target is fully visible', () => {
-      beforeEach(async () => {
-        target.scrollIntoView({ block: 'center' });
-        await waitForIntersectionObserver();
-      });
+    it('should open overlay when focused target is partially visible and hide otherwise', async () => {
+      // Partially visible
+      tabKeyDown(target);
+      target.focus();
+      expect(overlay.opened).to.be.true;
 
-      it('should hide overlay once the target is no longer visible', async () => {
-        mouseenter(target);
-        expect(overlay.opened).to.be.true;
+      // Fully visible
+      target.scrollIntoView({ block: 'center' });
+      await waitForIntersectionObserver();
+      expect(overlay.opened).to.be.true;
 
-        container.scrollTop = 0;
-        await waitForIntersectionObserver();
-        expect(overlay.opened).to.be.false;
-      });
+      // Fully hidden
+      container.scrollTop = 0;
+      await waitForIntersectionObserver();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should open overlay when hovered target is fully visible and hide otherwise', async () => {
+      // Partially visible
+      mouseenter(target);
+      expect(overlay.opened).to.be.true;
+
+      // Fully visible
+      target.scrollIntoView({ block: 'center' });
+      await waitForIntersectionObserver();
+      expect(overlay.opened).to.be.true;
+
+      // Fully hidden
+      container.scrollTop = 0;
+      await waitForIntersectionObserver();
+      expect(overlay.opened).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

Currently a tooltip is only shown when its target is fully visible. That is an issue with avatar for example, which uses a negative margin that can pull it out of its scroll container if put right at the edge of it. It can also be confusing that a tooltip doesn't show for an element where only a single pixel is scrolled outside of the view.

This change makes tooltips show if their target is partially visible (even just a single pixel). I considered using some magic number between 0 and 1 for the threshold, but again it could be confusing why tooltips show / hide based on different scroll positions, even though the element is effectively visible for the user.

Fixes https://github.com/vaadin/flow-components/issues/5105

## Type of change

- Bugfix