### PR TITLE
test: add test coverage for message avatar

### DIFF
--- a/packages/message-list/test/dom/__snapshots__/message.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message.test.snap.js
@@ -38,60 +38,6 @@ snapshots["vaadin-message userName"] =
 `;
 /* end snapshot vaadin-message userName */
 
-snapshots["vaadin-message userAbbr"] = 
-`<slot name="avatar">
-</slot>
-<div part="content">
-  <div part="header">
-    <span part="name">
-    </span>
-    <span part="time">
-    </span>
-  </div>
-  <div part="message">
-    <slot>
-    </slot>
-  </div>
-</div>
-`;
-/* end snapshot vaadin-message userAbbr */
-
-snapshots["vaadin-message userImg"] = 
-`<slot name="avatar">
-</slot>
-<div part="content">
-  <div part="header">
-    <span part="name">
-    </span>
-    <span part="time">
-    </span>
-  </div>
-  <div part="message">
-    <slot>
-    </slot>
-  </div>
-</div>
-`;
-/* end snapshot vaadin-message userImg */
-
-snapshots["vaadin-message userColorIndex"] = 
-`<slot name="avatar">
-</slot>
-<div part="content">
-  <div part="header">
-    <span part="name">
-    </span>
-    <span part="time">
-    </span>
-  </div>
-  <div part="message">
-    <slot>
-    </slot>
-  </div>
-</div>
-`;
-/* end snapshot vaadin-message userColorIndex */
-
 snapshots["vaadin-message time"] = 
 `<slot name="avatar">
 </slot>
@@ -111,3 +57,60 @@ snapshots["vaadin-message time"] =
 `;
 /* end snapshot vaadin-message time */
 
+snapshots["vaadin-message avatar username"] =
+  `<vaadin-message>
+  <vaadin-avatar
+    abbr="JD"
+    aria-hidden="true"
+    name="Joan Doe"
+    role="button"
+    slot="avatar"
+    tabindex="-1"
+  >
+  </vaadin-avatar>
+</vaadin-message>
+`;
+/* end snapshot vaadin-message avatar username */
+
+snapshots["vaadin-message avatar abbr"] =
+`<vaadin-message>
+  <vaadin-avatar
+    abbr="JD"
+    aria-hidden="true"
+    role="button"
+    slot="avatar"
+    tabindex="-1"
+  >
+  </vaadin-avatar>
+</vaadin-message>
+`;
+/* end snapshot vaadin-message avatar abbr */
+
+snapshots["vaadin-message avatar img"] =
+`<vaadin-message>
+  <vaadin-avatar
+    aria-hidden="true"
+    img="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
+    role="button"
+    slot="avatar"
+    tabindex="-1"
+  >
+  </vaadin-avatar>
+</vaadin-message>
+`;
+/* end snapshot vaadin-message avatar img */
+
+snapshots["vaadin-message avatar userColorIndex"] =
+`<vaadin-message>
+  <vaadin-avatar
+    aria-hidden="true"
+    has-color-index=""
+    role="button"
+    slot="avatar"
+    style="--vaadin-avatar-user-color: var(--vaadin-user-color-2);"
+    tabindex="-1"
+  >
+  </vaadin-avatar>
+</vaadin-message>
+`;
+/* end snapshot vaadin-message avatar userColorIndex */

--- a/packages/message-list/test/dom/message.test.js
+++ b/packages/message-list/test/dom/message.test.js
@@ -18,24 +18,29 @@ describe('vaadin-message', () => {
     await expect(message).shadowDom.to.equalSnapshot();
   });
 
-  it('userAbbr', async () => {
-    message.userAbbr = 'JD';
-    await expect(message).shadowDom.to.equalSnapshot();
-  });
-
-  it('userImg', async () => {
-    message.userImg = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
-    await expect(message).shadowDom.to.equalSnapshot();
-  });
-
-  it('userColorIndex', async () => {
-    document.documentElement.style.setProperty('--vaadin-user-color-2', 'green');
-    message.userColorIndex = 2;
-    await expect(message).shadowDom.to.equalSnapshot();
-  });
-
   it('time', async () => {
     message.time = 'long ago';
     await expect(message).shadowDom.to.equalSnapshot();
+  });
+
+  it('avatar username', async () => {
+    message.userName = 'Joan Doe';
+    await expect(message).dom.to.equalSnapshot();
+  });
+
+  it('avatar abbr', async () => {
+    message.userAbbr = 'JD';
+    await expect(message).dom.to.equalSnapshot();
+  });
+
+  it('avatar img', async () => {
+    message.userImg = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+    await expect(message).dom.to.equalSnapshot();
+  });
+
+  it('avatar userColorIndex', async () => {
+    document.documentElement.style.setProperty('--vaadin-user-color-2', 'green');
+    message.userColorIndex = 2;
+    await expect(message).dom.to.equalSnapshot();
   });
 });


### PR DESCRIPTION
## Description

Since moving the avatar to the light DOM, the following lines have no test coverage, as the snapshot tests only check the shadow DOM:
https://github.com/vaadin/web-components/blob/5ed28d8a9fb855aec9e79ca44bb9b4fec9c4a237/packages/message-list/src/vaadin-message.js#L196-L205

This changes the respective tests to check the light DOM instead.