### PR TITLE
refactor: set aria-hidden on elements outside overlay drawer

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -8,6 +8,7 @@ import './detect-ios-navbar.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { afterNextRender, beforeNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { hideOthers } from '@vaadin/a11y-base/src/aria-hidden.js';
 import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
@@ -662,6 +663,9 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
 
     this.$.drawer.setAttribute('tabindex', '0');
     this.__focusTrapController.trapFocus(this.$.drawer);
+
+    // Hide all the elements except drawer toggle and the drawer content
+    this.__showOthers = hideOthers([...this.querySelectorAll('vaadin-drawer-toggle, [slot="drawer"]')]);
   }
 
   /** @private */
@@ -673,6 +677,12 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     if (this.drawerOpened) {
       // The drawer has been opened during the CSS transition.
       return;
+    }
+
+    // Un-hide content elements
+    if (this.__showOthers) {
+      this.__showOthers();
+      this.__showOthers = null;
     }
 
     this.__focusTrapController.releaseFocus();

--- a/packages/app-layout/test/keyboard-mobile.test.js
+++ b/packages/app-layout/test/keyboard-mobile.test.js
@@ -17,6 +17,7 @@ describe('mobile navigation', () => {
       <div>
         <vaadin-app-layout style="--vaadin-app-layout-transition: none;">
           <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
+          <h1 slot="navbar">App title</h1>
           <section slot="drawer">
             <input placeholder="Drawer input" />
           </section>
@@ -111,6 +112,30 @@ describe('mobile navigation', () => {
       it('should move focus from the drawer toggle to the layout content on Tab', async () => {
         await tab();
         expect(document.activeElement).to.equal(contentInput);
+      });
+    });
+
+    describe('aria-hidden', () => {
+      it('should set aria-hidden on elements outside layout', () => {
+        expect(outerInput.getAttribute('aria-hidden')).to.equal('true');
+      });
+
+      it('should set aria-hidden on the main slot content', () => {
+        expect(contentInput.parentElement.getAttribute('aria-hidden')).to.equal('true');
+      });
+
+      it('should set aria-hidden on the navbar content', () => {
+        expect(layout.querySelector('h1').getAttribute('aria-hidden')).to.equal('true');
+      });
+
+      it('should not set aria-hidden on the drawer toggle', () => {
+        expect(toggle.hasAttribute('aria-hidden')).to.be.false;
+      });
+
+      it('should remove aria-hidden from the content on close', async () => {
+        await esc();
+        await nextFrame();
+        expect(contentInput.parentElement.hasAttribute('aria-hidden')).to.be.false;
       });
     });
   });


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/92

Similar to #5870 but for `vaadin-app-layout`

## Type of change

- Refactor / bugfix