### PR TITLE
test: skip unicode pattern test failing with latest Chrome

### DIFF
--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fire, fixtureSync, isChrome, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -164,12 +164,16 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.checkValidity()).to.be.true;
     });
 
-    it('should fail validation when value mismatches JavaScript-specific regular expression', async () => {
-      element.pattern = '\\u1234\\cx[5-[]{2}';
-      await nextFrame();
-      commitInputValue('\u1234\x18[4');
-      expect(element.checkValidity()).to.be.false;
-    });
+    // FIXME: Fails in Chrome, see https://github.com/vaadin/web-components/issues/5938
+    (isChrome ? it.skip : it)(
+      'should fail validation when value mismatches JavaScript-specific regular expression',
+      async () => {
+        element.pattern = '\\u1234\\cx[5-[]{2}';
+        await nextFrame();
+        commitInputValue('\u1234\x18[4');
+        expect(element.checkValidity()).to.be.false;
+      },
+    );
   });
 
   describe('pattern + textarea', () => {


### PR DESCRIPTION
## Description

Related to #5938

For some reasons, this email check didn't fail in CI when I first updated the WTR version, but now it does fail.

Let's skip it for now, and then consider investigating further (hopefully a new Chrome version fixes it).

```
packages/field-base/test/pattern-mixin.test.js:

 ❌ PatternMixin + Polymer > pattern > should fail validation when value mismatches JavaScript-specific regular expression
      AssertionError: expected true to be false
      + expected - actual
      
      -true
      +false
      
      at n.<anonymous> (packages/field-base/test/pattern-mixin.test.js:171:44)

 ❌ PatternMixin + Lit > pattern > should fail validation when value mismatches JavaScript-specific regular expression
      AssertionError: expected true to be false
      + expected - actual
      
      -true
      +false
      
      at n.<anonymous> (packages/field-base/test/pattern-mixin.test.js:171:44)
```

## Type of change

- Tests