### PR TITLE
refactor: extract grid data provider functionality into a controller

### DIFF
--- a/packages/component-base/src/data-provider-controller/cache.js
+++ b/packages/component-base/src/data-provider-controller/cache.js
@@ -4,6 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
+/**
+ * A class that stores items with their associated sub-caches.
+ */
 export class Cache {
   /**
    * @type {{ isExpanded: (item: unknown) => boolean }}

--- a/packages/component-base/src/data-provider-controller/cache.js
+++ b/packages/component-base/src/data-provider-controller/cache.js
@@ -1,0 +1,204 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+export class Cache {
+  /**
+   * @type {{ isExpanded: (item: unknown) => boolean }}
+   */
+  context;
+
+  /**
+   * The number of items.
+   *
+   * @type {number}
+   */
+  size = 0;
+
+  /**
+   * The number of items to display per page.
+   *
+   * @type {number}
+   */
+  pageSize;
+
+  /**
+   * An array of cached items.
+   *
+   * @type {object[]}
+   */
+  items = [];
+
+  /**
+   * A map where the key is a requested page and the value is a callback
+   * that will be called with data once the request is complete.
+   *
+   * @type {Map<number, Function>}
+   */
+  pendingRequests = new Map();
+
+  /**
+   * A map where the key is the index of an item in the `items` array
+   * and the value is a sub-cache associated with that item.
+   *
+   * Note, it's intentionally defined as an object instead of a Map
+   * to ensure that Object.entries() returns an array with keys sorted
+   * in alphabetical order, rather than the order they were added.
+   *
+   * @type {Record<number, Cache>}
+   * @private
+   */
+  __subCacheByIndex = {};
+
+  /**
+   * The total number of items, including items from expanded sub-caches.
+   *
+   * @type {number}
+   * @private
+   */
+  __effectiveSize = 0;
+
+  /**
+   * @param {Cache['context']} context
+   * @param {number} pageSize
+   * @param {number | undefined} size
+   * @param {Cache | undefined} parentCache
+   * @param {number | undefined} parentCacheIndex
+   */
+  constructor(context, pageSize, size, parentCache, parentCacheIndex) {
+    this.context = context;
+    this.pageSize = pageSize;
+    this.size = size || 0;
+    this.parentCache = parentCache;
+    this.parentCacheIndex = parentCacheIndex;
+    this.__effectiveSize = size || 0;
+  }
+
+  /**
+   * An item in the parent cache that the current cache is associated with.
+   *
+   * @return {object | undefined}
+   */
+  get parentItem() {
+    return this.parentCache && this.parentCache.items[this.parentCacheIndex];
+  }
+
+  /**
+   * An array of sub-caches sorted in the same order as their associated items
+   * appear in the `items` array.
+   *
+   * @return {Cache[]}
+   */
+  get subCaches() {
+    return Object.values(this.__subCacheByIndex);
+  }
+
+  /**
+   * Whether the cache or any of its descendant caches have pending requests.
+   *
+   * @return {boolean}
+   */
+  get isLoading() {
+    if (this.pendingRequests.size > 0) {
+      return true;
+    }
+
+    return this.subCaches.some((subCache) => subCache.isLoading);
+  }
+
+  /**
+   * The total number of items, including items from expanded sub-caches.
+   *
+   * @return {number}
+   */
+  get effectiveSize() {
+    return this.__effectiveSize;
+  }
+
+  /**
+   * Recalculates the effective size for the cache and its descendant caches recursively.
+   */
+  recalculateEffectiveSize() {
+    this.__effectiveSize =
+      !this.parentItem || this.context.isExpanded(this.parentItem)
+        ? this.size +
+          this.subCaches.reduce((total, subCache) => {
+            subCache.recalculateEffectiveSize();
+            return total + subCache.effectiveSize;
+          }, 0)
+        : 0;
+  }
+
+  /**
+   * Adds an array of items corresponding to the given page
+   * to the `items` array.
+   *
+   * @param {number} page
+   * @param {object[]} items
+   */
+  setPage(page, items) {
+    const startIndex = page * this.pageSize;
+    items.forEach((item, i) => {
+      this.items[startIndex + i] = item;
+    });
+  }
+
+  /**
+   * Retrieves the sub-cache associated with the item at the given index
+   * in the `items` array.
+   *
+   * @param {number} index
+   * @return {Cache | undefined}
+   */
+  getSubCache(index) {
+    return this.__subCacheByIndex[index];
+  }
+
+  /**
+   * Removes the sub-cache associated with the item at the given index
+   * in the `items` array.
+   *
+   * @param {number} index
+   */
+  removeSubCache(index) {
+    delete this.__subCacheByIndex[index];
+  }
+
+  /**
+   * Removes all sub-caches.
+   */
+  removeSubCaches() {
+    this.__subCacheByIndex = {};
+  }
+
+  /**
+   * Creates and associates a sub-cache for the item at the given index
+   * in the `items` array.
+   *
+   * @param {number} index
+   * @return {Cache}
+   */
+  createSubCache(index) {
+    const subCache = new Cache(this.context, this.pageSize, 0, this, index);
+    this.__subCacheByIndex[index] = subCache;
+    return subCache;
+  }
+
+  /**
+   * Retrieves the flattened index corresponding to the given index
+   * of an item in the `items` array.
+   *
+   * @param {number} index
+   * @return {number}
+   */
+  getFlatIndex(index) {
+    const clampedIndex = Math.max(0, Math.min(this.size - 1, index));
+
+    return this.subCaches.reduce((prev, subCache) => {
+      const index = subCache.parentCacheIndex;
+      return clampedIndex > index ? prev + subCache.effectiveSize : prev;
+    }, clampedIndex);
+  }
+}

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -7,16 +7,27 @@ import { Cache } from './cache.js';
 import { getFlatIndexByPath, getFlatIndexContext } from './helpers.js';
 
 /**
- * A controller that stores and manages items loaded with a data provider callback.
+ * A controller that stores and manages items loaded with a data provider.
  */
 export class DataProviderController extends EventTarget {
   /**
+   * The controller host element.
+   *
+   * @param {HTMLElement}
+   */
+  host;
+
+  /**
    * A callback that returns data based on the passed params such as
    * `page`, `pageSize`, `parentItem`, etc.
-   *
-   * @type {(params: object, callback: Function) => void}
    */
   dataProvider;
+
+  /**
+   * A callback that returns additional params that need to be passed
+   * to the data provider callback with every request.
+   */
+  dataProviderParams;
 
   /**
    * A number of items in the root cache.
@@ -33,11 +44,18 @@ export class DataProviderController extends EventTarget {
   pageSize;
 
   /**
-   * A function that determines when an item is expanded.
+   * A callback that returns whether the given item is expanded.
    *
    * @type {(item: unknown) => boolean}
    */
   isExpanded;
+
+  /**
+   * A reference to the root cache instance.
+   *
+   * @param {Cache}
+   */
+  rootCache;
 
   constructor(host, { size, pageSize, isExpanded, dataProvider, dataProviderParams }) {
     super();
@@ -142,8 +160,8 @@ export class DataProviderController extends EventTarget {
 
   /**
    * Requests the data provider to load the page with the item corresponding
-   * to the given flattened index into the corresponding cache.
-   * If the item is already loaded, the method returns immediatelly.
+   * to the given flattened index. If the item is already loaded, the method
+   * returns immediatelly.
    *
    * @param {number} flatIndex
    */

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { Cache } from './cache.js';
+import { getFlatIndexByPath, getFlatIndexContext } from './helpers.js';
+
+export class DataProviderController extends EventTarget {
+  constructor(host, { size, pageSize, isExpanded, dataProvider, dataProviderParams }) {
+    super();
+    this.host = host;
+    this.size = size;
+    this.pageSize = pageSize;
+    this.isExpanded = isExpanded;
+    this.dataProvider = dataProvider;
+    this.dataProviderParams = dataProviderParams;
+    this.rootCache = this.__createRootCache();
+  }
+
+  get effectiveSize() {
+    return this.rootCache.effectiveSize;
+  }
+
+  /** @private */
+  get __cacheContext() {
+    return { isExpanded: this.isExpanded };
+  }
+
+  isLoading() {
+    return this.rootCache.isLoading;
+  }
+
+  setSize(size) {
+    this.size = size;
+    this.rootCache.size = size;
+    this.recalculateEffectiveSize();
+  }
+
+  setPageSize(pageSize) {
+    this.pageSize = pageSize;
+    this.clearCache();
+  }
+
+  setDataProvider(dataProvider) {
+    this.dataProvider = dataProvider;
+    this.clearCache();
+  }
+
+  recalculateEffectiveSize() {
+    this.rootCache.recalculateEffectiveSize();
+  }
+
+  clearCache() {
+    this.rootCache = this.__createRootCache();
+  }
+
+  getFlatIndexContext(flatIndex) {
+    return getFlatIndexContext(this.rootCache, flatIndex);
+  }
+
+  getFlatIndexByPath(path) {
+    return getFlatIndexByPath(this.rootCache, path);
+  }
+
+  ensureFlatIndexLoaded(flatIndex) {
+    const { cache, page, item } = this.getFlatIndexContext(flatIndex);
+
+    if (!item) {
+      this.__loadCachePage(cache, page);
+    }
+  }
+
+  ensureFlatIndexHierarchy(flatIndex) {
+    const { cache, item, index } = this.getFlatIndexContext(flatIndex);
+
+    if (item && this.isExpanded(item) && !cache.getSubCache(index)) {
+      const subCache = cache.createSubCache(index);
+      this.__loadCachePage(subCache, 0);
+    }
+  }
+
+  loadFirstPage() {
+    this.__loadCachePage(this.rootCache, 0);
+  }
+
+  /** @private */
+  __createRootCache() {
+    return new Cache(this.__cacheContext, this.pageSize, this.size);
+  }
+
+  /** @private */
+  __loadCachePage(cache, page) {
+    if (!this.dataProvider || cache.pendingRequests.has(page)) {
+      return;
+    }
+
+    const params = {
+      page,
+      pageSize: this.pageSize,
+      parentItem: cache.parentItem,
+      ...this.dataProviderParams(),
+    };
+
+    const callback = (items, size) => {
+      if (size !== undefined) {
+        cache.size = size;
+      } else if (params.parentItem) {
+        cache.size = items.length;
+      }
+
+      cache.setPage(page, items);
+
+      this.recalculateEffectiveSize();
+
+      this.dispatchEvent(new CustomEvent('page-received'));
+
+      cache.pendingRequests.delete(page);
+
+      this.dispatchEvent(new CustomEvent('page-loaded'));
+    };
+
+    cache.pendingRequests.set(page, callback);
+
+    this.dispatchEvent(new CustomEvent('page-requested'));
+
+    this.dataProvider(params, callback);
+  }
+}

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -14,9 +14,30 @@ export class DataProviderController extends EventTarget {
    * A callback that returns data based on the passed params such as
    * `page`, `pageSize`, `parentItem`, etc.
    *
-   * @type {Function}
+   * @type {(params: object, callback: Function) => void}
    */
   dataProvider;
+
+  /**
+   * A number of items in the root cache.
+   *
+   * @type {number}
+   */
+  size;
+
+  /**
+   * A number of items to display per page.
+   *
+   * @type {number}
+   */
+  pageSize;
+
+  /**
+   * A function that determines when an item is expanded.
+   *
+   * @type {(item: unknown) => boolean}
+   */
+  isExpanded;
 
   constructor(host, { size, pageSize, isExpanded, dataProvider, dataProviderParams }) {
     super();
@@ -151,7 +172,7 @@ export class DataProviderController extends EventTarget {
   }
 
   /**
-   * Loads the first page for the root cache.
+   * Loads the first page into the root cache.
    */
   loadFirstPage() {
     this.__loadCachePage(this.rootCache, 0);

--- a/packages/component-base/src/data-provider-controller/helpers.js
+++ b/packages/component-base/src/data-provider-controller/helpers.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * Retreives information for the given flattened index, including:
+ * Returns context for the given flattened index, including:
  * - the corresponding cache
  * - the associated item (if loaded)
  * - the corresponding index in the cache's items array.

--- a/packages/component-base/src/data-provider-controller/helpers.js
+++ b/packages/component-base/src/data-provider-controller/helpers.js
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Retreives information for the given flattened index, including:
+ * - the corresponding cache
+ * - the associated item (if loaded)
+ * - the corresponding index in the cache's items array.
+ * - the page containing the index.
+ * - the cache level
+ *
+ * @param {import('./cache.js').Cache} cache
+ * @param {number} flatIndex
+ * @return {{ cache: Cache, item: object | undefined, index: number, page: number, level: number }}
+ */
+export function getFlatIndexContext(cache, flatIndex, level = 0) {
+  let levelIndex = flatIndex;
+
+  for (const subCache of cache.subCaches) {
+    const index = subCache.parentCacheIndex;
+    if (levelIndex <= index) {
+      break;
+    } else if (levelIndex <= index + subCache.effectiveSize) {
+      return getFlatIndexContext(subCache, levelIndex - index - 1, level + 1);
+    }
+    levelIndex -= subCache.effectiveSize;
+  }
+
+  return {
+    cache,
+    item: cache.items[levelIndex],
+    index: levelIndex,
+    page: Math.floor(levelIndex / cache.pageSize),
+    level,
+  };
+}
+
+/**
+ * Recursively returns the globally flat index of the item the given indexes point to.
+ * Each index in the array points to a sub-item of the previous index.
+ * Using `Infinity` as an index will point to the last item on the level.
+ *
+ * @param {!ItemCache} cache
+ * @param {!Array<number>} indexes
+ * @param {number} flatIndex
+ * @return {number}
+ */
+export function getFlatIndexByPath(cache, [levelIndex, ...subIndexes], flatIndex = 0) {
+  if (levelIndex === Infinity) {
+    // Treat Infinity as the last index on the level
+    levelIndex = cache.size - 1;
+  }
+
+  const flatIndexOnLevel = cache.getFlatIndex(levelIndex);
+  const subCache = cache.getSubCache(levelIndex);
+  if (subCache && subCache.effectiveSize > 0 && subIndexes.length) {
+    return getFlatIndexByPath(subCache, subIndexes, flatIndex + flatIndexOnLevel + 1);
+  }
+  return flatIndex + flatIndexOnLevel;
+}

--- a/packages/component-base/src/data-provider-controller/helpers.js
+++ b/packages/component-base/src/data-provider-controller/helpers.js
@@ -43,8 +43,8 @@ export function getFlatIndexContext(cache, flatIndex, level = 0) {
  * Each index in the array points to a sub-item of the previous index.
  * Using `Infinity` as an index will point to the last item on the level.
  *
- * @param {!ItemCache} cache
- * @param {!Array<number>} indexes
+ * @param {Cache} cache
+ * @param {number[]} path
  * @param {number} flatIndex
  * @return {number}
  */

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.d.ts
@@ -33,31 +33,6 @@ export type GridDataProvider<TItem> = (
   callback: GridDataProviderCallback<TItem>,
 ) => void;
 
-export declare class ItemCache<TItem> {
-  grid: HTMLElement;
-  parentCache: ItemCache<TItem> | undefined;
-  parentItem: TItem | undefined;
-  itemCaches: object | null;
-  items: object | null;
-  effectiveSize: number;
-  size: number;
-  pendingRequests: object | null;
-
-  constructor(grid: HTMLElement, parentCache: ItemCache<TItem> | undefined, parentItem: TItem | undefined);
-
-  isLoading(): boolean;
-
-  getItemForIndex(index: number): TItem | undefined;
-
-  updateSize(): void;
-
-  ensureSubCacheForScaledIndex(scaledIndex: number): void;
-
-  getCacheAndIndex(index: number): { cache: ItemCache<TItem>; scaledIndex: number };
-
-  getFlatIndex(scaledIndex: number): number;
-}
-
 export declare function DataProviderMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
 ): Constructor<DataProviderMixinClass<TItem>> & T;

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -4,115 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { timeOut } from '@vaadin/component-base/src/async.js';
+import { DataProviderController } from '@vaadin/component-base/src/data-provider-controller/data-provider-controller.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
 import { getBodyRowCells, updateCellsPart, updateState } from './vaadin-grid-helpers.js';
-
-/**
- * @private
- */
-export const ItemCache = class ItemCache {
-  /**
-   * @param {!HTMLElement} grid
-   * @param {!ItemCache | undefined} parentCache
-   * @param {!GridItem | undefined} parentItem
-   */
-  constructor(grid, parentCache, parentItem) {
-    /** @type {!HTMLElement} */
-    this.grid = grid;
-    /** @type {!ItemCache | undefined} */
-    this.parentCache = parentCache;
-    /** @type {!GridItem | undefined} */
-    this.parentItem = parentItem;
-    /** @type {object} */
-    this.itemCaches = {};
-    /** @type {object[]} */
-    this.items = [];
-    /** @type {number} */
-    this.effectiveSize = 0;
-    /** @type {number} */
-    this.size = 0;
-    /** @type {object} */
-    this.pendingRequests = {};
-  }
-
-  /**
-   * @return {boolean}
-   */
-  isLoading() {
-    return Boolean(
-      Object.keys(this.pendingRequests).length ||
-        Object.keys(this.itemCaches).filter((index) => {
-          return this.itemCaches[index].isLoading();
-        })[0],
-    );
-  }
-
-  /**
-   * @param {number} index
-   * @return {!GridItem | undefined}
-   */
-  getItemForIndex(index) {
-    const { cache, scaledIndex } = this.getCacheAndIndex(index);
-    return cache.items[scaledIndex];
-  }
-
-  updateSize() {
-    this.effectiveSize =
-      !this.parentItem || this.grid._isExpanded(this.parentItem)
-        ? this.size +
-          Object.keys(this.itemCaches).reduce((prev, curr) => {
-            const subCache = this.itemCaches[curr];
-            subCache.updateSize();
-            return prev + subCache.effectiveSize;
-          }, 0)
-        : 0;
-  }
-
-  /**
-   * @param {number} scaledIndex
-   */
-  ensureSubCacheForScaledIndex(scaledIndex) {
-    if (!this.itemCaches[scaledIndex]) {
-      const subCache = new ItemCache(this.grid, this, this.items[scaledIndex]);
-      this.itemCaches[scaledIndex] = subCache;
-      this.grid._loadPage(0, subCache);
-    }
-  }
-
-  /**
-   * @param {number} index
-   * @return {{cache: !ItemCache, scaledIndex: number}}
-   */
-  getCacheAndIndex(index) {
-    let thisLevelIndex = index;
-    for (const [index, subCache] of Object.entries(this.itemCaches)) {
-      const numberIndex = Number(index);
-      if (thisLevelIndex <= numberIndex) {
-        return { cache: this, scaledIndex: thisLevelIndex };
-      } else if (thisLevelIndex <= numberIndex + subCache.effectiveSize) {
-        return subCache.getCacheAndIndex(thisLevelIndex - numberIndex - 1);
-      }
-      thisLevelIndex -= subCache.effectiveSize;
-    }
-    return { cache: this, scaledIndex: thisLevelIndex };
-  }
-
-  /**
-   * Gets the scaled index as flattened index on this cache level.
-   * In practice, this means that the effective size of any expanded
-   * subcaches preceding the index are added to the value.
-   * @param {number} scaledIndex
-   * @return {number} The flat index on this cache level.
-   */
-  getFlatIndex(scaledIndex) {
-    const clampedIndex = Math.max(0, Math.min(this.size - 1, scaledIndex));
-
-    return Object.entries(this.itemCaches).reduce((prev, [index, subCache]) => {
-      return clampedIndex > Number(index) ? prev + subCache.effectiveSize : prev;
-    }, clampedIndex);
-  }
-};
 
 /**
  * @polymerMixin
@@ -182,18 +77,6 @@ export const DataProviderMixin = (superClass) =>
         },
 
         /**
-         * @type {!ItemCache}
-         * @protected
-         */
-        _cache: {
-          type: Object,
-          value() {
-            const cache = new ItemCache(this);
-            return cache;
-          },
-        },
-
-        /**
          * @protected
          */
         _hasData: {
@@ -244,12 +127,32 @@ export const DataProviderMixin = (superClass) =>
       return ['_sizeChanged(size)', '_expandedItemsChanged(expandedItems.*)'];
     }
 
+    constructor() {
+      super();
+
+      /** @type {DataProviderController} */
+      this._dataProviderController = new DataProviderController(this, {
+        size: this.size,
+        pageSize: this.pageSize,
+        isExpanded: this._isExpanded.bind(this),
+        dataProvider: this.dataProvider ? this.dataProvider.bind(this) : null,
+        dataProviderParams: () => {
+          return {
+            sortOrders: this._mapSorters(),
+            filters: this._mapFilters(),
+          };
+        },
+      });
+
+      this._dataProviderController.addEventListener('page-requested', this._onDataProviderPageRequested.bind(this));
+      this._dataProviderController.addEventListener('page-received', this._onDataProviderPageReceived.bind(this));
+      this._dataProviderController.addEventListener('page-loaded', this._onDataProviderPageLoaded.bind(this));
+    }
+
     /** @private */
     _sizeChanged(size) {
-      const delta = size - this._cache.size;
-      this._cache.size += delta;
-      this._cache.effectiveSize += delta;
-      this._effectiveSize = this._cache.effectiveSize;
+      this._dataProviderController.setSize(size);
+      this._effectiveSize = this._dataProviderController.effectiveSize;
     }
 
     /** @private */
@@ -272,17 +175,17 @@ export const DataProviderMixin = (superClass) =>
       }
 
       el.index = index;
-      const { cache, scaledIndex } = this._cache.getCacheAndIndex(index);
-      const item = cache.items[scaledIndex];
+
+      const { item } = this._dataProviderController.getFlatIndexContext(index);
       if (item) {
         this.__updateLoading(el, false);
         this._updateItem(el, item);
         if (this._isExpanded(item)) {
-          cache.ensureSubCacheForScaledIndex(scaledIndex);
+          this._dataProviderController.ensureFlatIndexHierarchy(index);
         }
       } else {
         this.__updateLoading(el, true);
-        this._loadPage(this._getPageForIndex(scaledIndex), cache);
+        this._dataProviderController.ensureFlatIndexLoaded(index);
       }
     }
 
@@ -322,8 +225,8 @@ export const DataProviderMixin = (superClass) =>
 
     /** @private */
     _expandedItemsChanged() {
-      this._cache.updateSize();
-      this._effectiveSize = this._cache.effectiveSize;
+      this._dataProviderController.recalculateEffectiveSize();
+      this._effectiveSize = this._dataProviderController.effectiveSize;
       this.__updateVisibleRows();
     }
 
@@ -363,119 +266,68 @@ export const DataProviderMixin = (superClass) =>
      * @return {number}
      * @protected
      */
-    _getIndexLevel(index) {
-      let { cache } = this._cache.getCacheAndIndex(index);
-      let level = 0;
-      while (cache.parentCache) {
-        cache = cache.parentCache;
-        level += 1;
-      }
+    _getIndexLevel(index = 0) {
+      const { level } = this._dataProviderController.getFlatIndexContext(index);
       return level;
     }
 
-    /**
-     * @param {number} page
-     * @param {ItemCache} cache
-     * @protected
-     */
-    _loadPage(page, cache) {
-      // Make sure same page isn't requested multiple times.
-      if (!cache.pendingRequests[page] && this.dataProvider) {
-        this._setLoading(true);
-        cache.pendingRequests[page] = true;
-        const params = {
-          page,
-          pageSize: this.pageSize,
-          sortOrders: this._mapSorters(),
-          filters: this._mapFilters(),
-          parentItem: cache.parentItem,
-        };
-
-        this.dataProvider(params, (items, size) => {
-          if (size !== undefined) {
-            cache.size = size;
-          } else if (params.parentItem) {
-            cache.size = items.length;
-          }
-
-          // Populate the cache with new items
-          items.forEach((item, itemsIndex) => {
-            const itemIndex = page * this.pageSize + itemsIndex;
-            cache.items[itemIndex] = item;
-          });
-
-          // With the new items added, update the cache size and the grid's effective size
-          this._cache.updateSize();
-          this._effectiveSize = this._cache.effectiveSize;
-
-          // After updating the cache, check if some of the expanded items should have sub-caches loaded
-          this._getRenderedRows().forEach((row) => {
-            const { cache, scaledIndex } = this._cache.getCacheAndIndex(row.index);
-            const item = cache.items[scaledIndex];
-            if (item && this._isExpanded(item)) {
-              cache.ensureSubCacheForScaledIndex(scaledIndex);
-            }
-          });
-
-          this._hasData = true;
-
-          // Remove the pending request
-          delete cache.pendingRequests[page];
-
-          // Schedule a debouncer to update the visible rows
-          this._debouncerApplyCachedData = Debouncer.debounce(this._debouncerApplyCachedData, timeOut.after(0), () => {
-            this._setLoading(false);
-
-            this._getRenderedRows().forEach((row) => {
-              const cachedItem = this._cache.getItemForIndex(row.index);
-              if (cachedItem) {
-                this._getItem(row.index, row);
-              }
-            });
-
-            this.__scrollToPendingIndexes();
-          });
-
-          // If the grid is not loading anything, flush the debouncer immediately
-          if (!this._cache.isLoading()) {
-            this._debouncerApplyCachedData.flush();
-          }
-
-          // Notify that new data has been received
-          this._onDataProviderPageLoaded();
-        });
-      }
+    /** @protected */
+    _onDataProviderPageRequested() {
+      this._setLoading(true);
     }
 
     /** @protected */
-    _onDataProviderPageLoaded() {}
+    _onDataProviderPageReceived() {
+      // With the new items added, update the cache size and the grid's effective size
+      this._effectiveSize = this._dataProviderController.effectiveSize;
 
-    /**
-     * @param {number} index
-     * @return {number}
-     * @private
-     */
-    _getPageForIndex(index) {
-      return Math.floor(index / this.pageSize);
+      // After updating the cache, check if some of the expanded items should have sub-caches loaded
+      this._getRenderedRows().forEach((row) => {
+        this._dataProviderController.ensureFlatIndexHierarchy(row.index);
+      });
+
+      this._hasData = true;
+    }
+
+    /** @protected */
+    _onDataProviderPageLoaded() {
+      // Schedule a debouncer to update the visible rows
+      this._debouncerApplyCachedData = Debouncer.debounce(this._debouncerApplyCachedData, timeOut.after(0), () => {
+        this._setLoading(false);
+
+        this._getRenderedRows().forEach((row) => {
+          const { item } = this._dataProviderController.getFlatIndexContext(row.index);
+          if (item) {
+            this._getItem(row.index, row);
+          }
+        });
+
+        this.__scrollToPendingIndexes();
+      });
+
+      // If the grid is not loading anything, flush the debouncer immediately
+      if (!this._dataProviderController.isLoading()) {
+        this._debouncerApplyCachedData.flush();
+      }
     }
 
     /**
      * Clears the cached pages and reloads data from dataprovider when needed.
      */
     clearCache() {
-      this._cache = new ItemCache(this);
-      this._cache.size = this.size || 0;
-      this._cache.updateSize();
+      this._dataProviderController.clearCache();
       this._hasData = false;
       this.__updateVisibleRows();
 
       if (!this._effectiveSize) {
-        this._loadPage(0, this._cache);
+        this._dataProviderController.loadFirstPage();
       }
     }
 
     /** @private */
     _pageSizeChanged(pageSize, oldPageSize) {
+      this._dataProviderController.setPageSize(pageSize);
+
       if (oldPageSize !== undefined && pageSize !== oldPageSize) {
         this.clearCache();
       }
@@ -495,6 +347,8 @@ export const DataProviderMixin = (superClass) =>
 
     /** @private */
     _dataProviderChanged(dataProvider, oldDataProvider) {
+      this._dataProviderController.setDataProvider(dataProvider ? dataProvider.bind(this) : null);
+
       if (oldDataProvider !== undefined) {
         this.clearCache();
       }
@@ -513,7 +367,7 @@ export const DataProviderMixin = (superClass) =>
       if (!this._hasData) {
         // Load data before adding rows to make sure they have content when
         // rendered for the first time.
-        this._loadPage(0, this._cache);
+        this._dataProviderController.loadFirstPage();
       }
     }
 
@@ -563,37 +417,13 @@ export const DataProviderMixin = (superClass) =>
       // ending up in a loading state. Try scrolling to the index until the target
       // index stabilizes.
       let targetIndex;
-      while (targetIndex !== (targetIndex = this.__getGlobalFlatIndex(indexes))) {
+      while (targetIndex !== (targetIndex = this._dataProviderController.getFlatIndexByPath(indexes))) {
         this._scrollToFlatIndex(targetIndex);
       }
 
-      if (this._cache.isLoading() || !this.clientHeight) {
+      if (this._dataProviderController.isLoading() || !this.clientHeight) {
         this.__pendingScrollToIndexes = indexes;
       }
-    }
-
-    /**
-     * Recursively returns the globally flat index of the item the given indexes point to.
-     * Each index in the array points to a sub-item of the previous index.
-     * Using `Infinity` as an index will point to the last item on the level.
-     *
-     * @param {!Array<number>} indexes
-     * @param {!ItemCache} cache
-     * @param {number} flatIndex
-     * @return {number}
-     * @private
-     */
-    __getGlobalFlatIndex([levelIndex, ...subIndexes], cache = this._cache, flatIndex = 0) {
-      if (levelIndex === Infinity) {
-        // Treat Infinity as the last index on the level
-        levelIndex = cache.size - 1;
-      }
-      const flatIndexOnLevel = cache.getFlatIndex(levelIndex);
-      const subCache = cache.itemCaches[levelIndex];
-      if (subCache && subCache.effectiveSize && subIndexes.length) {
-        return this.__getGlobalFlatIndex(subIndexes, subCache, flatIndex + flatIndexOnLevel + 1);
-      }
-      return flatIndex + flatIndexOnLevel;
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -476,7 +476,7 @@ export const KeyboardNavigationMixin = (superClass) =>
         // Row details navigation logic
         if (activeRowGroup === this.$.items) {
           const item = activeRow._item;
-          const dstItem = this._cache.getItemForIndex(dstRowIndex);
+          const { item: dstItem } = this._dataProviderController.getFlatIndexContext(dstRowIndex);
           // Should we navigate to row details?
           if (isRowDetails) {
             dstIsRowDetails = dy === 0;

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -58,8 +58,8 @@ import { StylingMixin } from './vaadin-grid-styling-mixin.js';
  * @mixes DragAndDropMixin
  */
 export const GridMixin = (superClass) =>
-  class extends DataProviderMixin(
-    ArrayDataProviderMixin(
+  class extends ArrayDataProviderMixin(
+    DataProviderMixin(
       DynamicColumnsMixin(
         ActiveItemMixin(
           ScrollMixin(
@@ -463,7 +463,7 @@ export const GridMixin = (superClass) =>
       if (!this._columnTree) {
         return; // No columns
       }
-      if (isElementHidden(this) || this._cache.isLoading()) {
+      if (isElementHidden(this) || this._dataProviderController.isLoading()) {
         this.__pendingRecalculateColumnWidths = true;
         return;
       }
@@ -476,7 +476,7 @@ export const GridMixin = (superClass) =>
       if (
         this.__pendingRecalculateColumnWidths &&
         !isElementHidden(this) &&
-        !this._cache.isLoading() &&
+        !this._dataProviderController.isLoading() &&
         this.__hasRowsWithClientHeight()
       ) {
         this.__pendingRecalculateColumnWidths = false;

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -210,7 +210,7 @@ describe('column', () => {
         grid.rowDetailsRenderer = (root) => {
           root.textContent = 'row-details';
         };
-        grid.detailsOpenedItems = [grid._cache.items[0]];
+        grid.detailsOpenedItems = [grid._dataProviderController.rootCache.items[0]];
         column.hidden = true;
         flushGrid(grid);
         const details = grid.shadowRoot.querySelector('#items [part~="details-cell"]')._content;

--- a/packages/grid/test/data-provider.test.js
+++ b/packages/grid/test/data-provider.test.js
@@ -123,6 +123,11 @@ function simulateScrollToEnd(grid) {
 describe('data provider', () => {
   let grid;
 
+  function getItemForIndex(index) {
+    const { item } = grid._dataProviderController.getFlatIndexContext(index);
+    return item;
+  }
+
   beforeEach(() => {
     grid = fixtureSync(`
       <vaadin-grid>
@@ -240,15 +245,15 @@ describe('data provider', () => {
     }
 
     function isIndexExpanded(grid, index) {
-      return grid._isExpanded(grid._cache.getItemForIndex(index));
+      return grid._isExpanded(getItemForIndex(index));
     }
 
     function expandIndex(grid, index) {
-      grid.expandItem(grid._cache.getItemForIndex(index));
+      grid.expandItem(getItemForIndex(index));
     }
 
     function collapseIndex(grid, index) {
-      grid.collapseItem(grid._cache.getItemForIndex(index));
+      grid.collapseItem(getItemForIndex(index));
     }
 
     beforeEach(() => {
@@ -296,7 +301,7 @@ describe('data provider', () => {
 
       it('should have first level items in cache', () => {
         for (let i = 0; i < grid._effectiveSize; i++) {
-          expect(grid._cache.getItemForIndex(i)).to.deep.equal({ level: 0, value: `foo${i}` });
+          expect(getItemForIndex(i)).to.deep.equal({ level: 0, value: `foo${i}` });
         }
       });
     });
@@ -442,7 +447,7 @@ describe('data provider', () => {
         it('should have first level items in cache', () => {
           expandIndex(grid, 7);
           for (let i = 0; i < grid._effectiveSize; i++) {
-            expect(grid._cache.getItemForIndex(i)).to.deep.equal({ level: 0, value: `foo${i}` });
+            expect(getItemForIndex(i)).to.deep.equal({ level: 0, value: `foo${i}` });
           }
         });
 
@@ -504,9 +509,9 @@ describe('data provider', () => {
 
       it('should have first and second level items in cache', () => {
         expandIndex(grid, 7);
-        expect(grid._cache.getItemForIndex(7)).to.deep.equal({ level: 0, value: 'foo7' });
-        expect(grid._cache.getItemForIndex(8)).to.deep.equal({ level: 1, value: 'foo0' });
-        expect(grid._cache.getItemForIndex(18)).to.deep.equal({ level: 0, value: 'foo8' });
+        expect(getItemForIndex(7)).to.deep.equal({ level: 0, value: 'foo7' });
+        expect(getItemForIndex(8)).to.deep.equal({ level: 1, value: 'foo0' });
+        expect(getItemForIndex(18)).to.deep.equal({ level: 0, value: 'foo8' });
       });
     });
 
@@ -533,8 +538,8 @@ describe('data provider', () => {
 
       it('should have first level items in cache', () => {
         collapseIndex(grid, 7);
-        expect(grid._cache.getItemForIndex(7)).to.deep.equal({ level: 0, value: 'foo7' });
-        expect(grid._cache.getItemForIndex(8)).to.deep.equal({ level: 0, value: 'foo8' });
+        expect(getItemForIndex(7)).to.deep.equal({ level: 0, value: 'foo7' });
+        expect(getItemForIndex(8)).to.deep.equal({ level: 0, value: 'foo8' });
       });
     });
 
@@ -557,9 +562,9 @@ describe('data provider', () => {
 
       it('should have first and second level items in cache', () => {
         expandIndex(grid, 7);
-        expect(grid._cache.getItemForIndex(7)).to.deep.equal({ level: 0, value: 'foo7' });
-        expect(grid._cache.getItemForIndex(8)).to.deep.equal({ level: 1, value: 'foo0' });
-        expect(grid._cache.getItemForIndex(18)).to.deep.equal({ level: 0, value: 'foo8' });
+        expect(getItemForIndex(7)).to.deep.equal({ level: 0, value: 'foo7' });
+        expect(getItemForIndex(8)).to.deep.equal({ level: 1, value: 'foo0' });
+        expect(getItemForIndex(18)).to.deep.equal({ level: 0, value: 'foo8' });
       });
     });
 
@@ -671,6 +676,11 @@ describe('wrapped grid', () => {
   describe('data-provider', () => {
     const loadDebounceTime = 100;
 
+    function getItemForIndex(index) {
+      const { item } = grid._dataProviderController.getFlatIndexContext(index);
+      return item;
+    }
+
     beforeEach(() => {
       container = fixtureSync('<wrapped-grid></wrapped-grid>');
       grid = container.$.grid;
@@ -731,14 +741,14 @@ describe('wrapped grid', () => {
       container.dataProvider = sinon.spy(infiniteDataProvider);
       await aTimeout(loadDebounceTime * 2);
       expect(container.dataProvider.called).to.be.true;
-      const oldFirstItem = grid._cache.getItemForIndex(0);
+      const oldFirstItem = getItemForIndex(0);
       expect(oldFirstItem).to.be.ok;
       container.dataProvider.resetHistory();
       grid.clearCache();
       await aTimeout(loadDebounceTime * 2);
       expect(container.dataProvider.called).to.be.true;
-      expect(grid._cache.getItemForIndex(0)).to.be.ok;
-      expect(grid._cache.getItemForIndex(0)).not.to.equal(oldFirstItem);
+      expect(getItemForIndex(0)).to.be.ok;
+      expect(getItemForIndex(0)).not.to.equal(oldFirstItem);
     });
 
     it('should update sub properties on clearCache', () => {

--- a/packages/grid/test/filtering.test.js
+++ b/packages/grid/test/filtering.test.js
@@ -328,11 +328,11 @@ describe('array data provider', () => {
     grid.removeChild(grid.firstElementChild);
     flushGrid(grid);
 
-    expect(Object.keys(grid._cache.items).length).to.equal(1);
+    expect(Object.keys(grid._dataProviderController.rootCache.items).length).to.equal(1);
 
     parentNode.appendChild(grid);
 
-    expect(Object.keys(grid._cache.items).length).to.equal(3);
+    expect(Object.keys(grid._dataProviderController.rootCache.items).length).to.equal(3);
   });
 
   it('should sort filtered items', () => {

--- a/packages/grid/test/resizing.test.js
+++ b/packages/grid/test/resizing.test.js
@@ -94,7 +94,7 @@ describe('resizing', () => {
   });
 
   it('should update details row height', () => {
-    grid.openItemDetails(grid._cache.items[0]);
+    grid.openItemDetails(grid._dataProviderController.rootCache.items[0]);
     const bodyRows = getRows(grid.$.items);
     const cells = getRowCells(bodyRows[0]);
     const detailsCell = cells.pop();

--- a/packages/grid/test/row-details.test.js
+++ b/packages/grid/test/row-details.test.js
@@ -49,12 +49,12 @@ describe('row details', () => {
   let bodyRows;
 
   function openRowDetails(index) {
-    grid.openItemDetails(grid._cache.items[index]);
+    grid.openItemDetails(grid._dataProviderController.rootCache.items[index]);
     flushGrid(grid);
   }
 
   function closeRowDetails(index) {
-    grid.closeItemDetails(grid._cache.items[index]);
+    grid.closeItemDetails(grid._dataProviderController.rootCache.items[index]);
     flushGrid(grid);
   }
 

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -25,7 +25,7 @@ describe('selection', () => {
 
   function configureGrid() {
     grid.dataProvider = infiniteDataProvider;
-    cachedItems = grid._cache.items;
+    cachedItems = grid._dataProviderController.rootCache.items;
     grid.selectedItems = [cachedItems[0]];
     flushGrid(grid);
     rows = getRows(grid.$.items);
@@ -181,7 +181,7 @@ describe('multi selection column', () => {
           <vaadin-grid-selection-column></vaadin-grid-selection-column>
         </vaadin-grid-column-group>
 
-        <vaadin-grid-filter-column path="value"></vaadin-grid-filter-column>          
+        <vaadin-grid-filter-column path="value"></vaadin-grid-filter-column>
       </vaadin-grid>
     `);
 
@@ -194,7 +194,7 @@ describe('multi selection column', () => {
     flushGrid(grid);
 
     selectionColumn = grid._columnTree[0][0];
-    cachedItems = grid._cache.items;
+    cachedItems = grid._dataProviderController.rootCache.items;
     rows = getRows(grid.$.items);
     headerRows = getRows(grid.$.header);
 

--- a/packages/polymer-legacy-adapter/test/grid-body.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-body.test.js
@@ -173,8 +173,8 @@ describe('grid body template', () => {
     });
 
     it('should expand the item when checking', () => {
-      expect(grid._isExpanded(grid._cache.items[0])).to.be.true;
-      expect(grid._isExpanded(grid._cache.items[1])).to.be.false;
+      expect(grid._isExpanded(grid._dataProviderController.rootCache.items[0])).to.be.true;
+      expect(grid._isExpanded(grid._dataProviderController.rootCache.items[1])).to.be.false;
     });
 
     it('should re-render the row when checking', () => {
@@ -185,8 +185,8 @@ describe('grid body template', () => {
     it('should collapse the item when unchecking', () => {
       checkbox.checked = false;
 
-      expect(grid._isExpanded(grid._cache.items[0])).to.be.false;
-      expect(grid._isExpanded(grid._cache.items[1])).to.be.false;
+      expect(grid._isExpanded(grid._dataProviderController.rootCache.items[0])).to.be.false;
+      expect(grid._isExpanded(grid._dataProviderController.rootCache.items[1])).to.be.false;
     });
 
     it('should re-render the row when unchecking', () => {

--- a/packages/polymer-legacy-adapter/test/grid-row-details.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-row-details.test.js
@@ -145,21 +145,21 @@ describe('row details template', () => {
       });
 
       it('should expand the item when checking the checkbox', () => {
-        expect(grid._isExpanded(grid._cache.items[0])).to.be.true;
-        expect(grid._isExpanded(grid._cache.items[1])).to.be.false;
+        expect(grid._isExpanded(grid._dataProviderController.rootCache.items[0])).to.be.true;
+        expect(grid._isExpanded(grid._dataProviderController.rootCache.items[1])).to.be.false;
       });
 
       it('should collapse the item when unchecking the checkbox', () => {
         checkbox.checked = false;
 
-        expect(grid._isExpanded(grid._cache.items[0])).to.be.false;
-        expect(grid._isExpanded(grid._cache.items[1])).to.be.false;
+        expect(grid._isExpanded(grid._dataProviderController.rootCache.items[0])).to.be.false;
+        expect(grid._isExpanded(grid._dataProviderController.rootCache.items[1])).to.be.false;
       });
     });
 
     describe('downwards', () => {
       beforeEach(() => {
-        grid.expandItem(grid._cache.items[0]);
+        grid.expandItem(grid._dataProviderController.rootCache.items[0]);
       });
 
       it('should check the checkbox when expanding the item', () => {
@@ -167,7 +167,7 @@ describe('row details template', () => {
       });
 
       it('should uncheck the checkbox when collapsing the item', () => {
-        grid.collapseItem(grid._cache.items[0]);
+        grid.collapseItem(grid._dataProviderController.rootCache.items[0]);
 
         expect(checkbox.checked).to.equal(false);
       });


### PR DESCRIPTION
## Description

The PR extracts the grid data provider functionality into a controller in order to separate concerns, thereby reducing cognitive load, making testing easier, and potentially allowing reusing it in other components such as `combo-box`. In the future, the controller can provide some additional methods or events to be used on the Flow connector side without having to make them public web component API.

**TODO:**
- [x] Fix existing component unit tests
- [x] Update the Grid connector to make it work with the controller ([flow-components#5239](https://github.com/vaadin/flow-components/pull/5239)).
- [ ] Add basic unit tests for the controller ([can be done separately](https://github.com/vaadin/web-components/pull/5961#issuecomment-1665264080)?)
- [ ] TypeScript declarations
- [x] JSDoc descriptions

## Type of change

- [x] Refactor
