### PR TITLE
refactor: rename getVisibleRows() to getRenderedRows()

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -408,7 +408,7 @@ export const DataProviderMixin = (superClass) =>
           this._effectiveSize = this._cache.effectiveSize;
 
           // After updating the cache, check if some of the expanded items should have sub-caches loaded
-          this._getVisibleRows().forEach((row) => {
+          this._getRenderedRows().forEach((row) => {
             const { cache, scaledIndex } = this._cache.getCacheAndIndex(row.index);
             const item = cache.items[scaledIndex];
             if (item && this._isExpanded(item)) {
@@ -425,7 +425,7 @@ export const DataProviderMixin = (superClass) =>
           this._debouncerApplyCachedData = Debouncer.debounce(this._debouncerApplyCachedData, timeOut.after(0), () => {
             this._setLoading(false);
 
-            this._getVisibleRows().forEach((row) => {
+            this._getRenderedRows().forEach((row) => {
               const cachedItem = this._cache.getItemForIndex(row.index);
               if (cachedItem) {
                 this._getItem(row.index, row);

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -177,7 +177,7 @@ export const KeyboardNavigationMixin = (superClass) =>
 
       const wasFocused = this.shadowRoot.activeElement === this._itemsFocusable;
 
-      this._getVisibleRows().forEach((row) => {
+      this._getRenderedRows().forEach((row) => {
         if (row.index === this._focusedItemIndex) {
           if (this.__rowFocusMode) {
             // Row focus mode

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -463,12 +463,12 @@ class Grid extends ElementMixin(
 
   /** @private */
   __getFirstVisibleItem() {
-    return this._getVisibleRows().find((row) => this._isInViewport(row));
+    return this._getRenderedRows().find((row) => this._isInViewport(row));
   }
 
   /** @private */
   __getLastVisibleItem() {
-    return this._getVisibleRows()
+    return this._getRenderedRows()
       .reverse()
       .find((row) => this._isInViewport(row));
   }
@@ -485,7 +485,7 @@ class Grid extends ElementMixin(
   }
 
   /** @private */
-  _getVisibleRows() {
+  _getRenderedRows() {
     return Array.from(this.$.items.children)
       .filter((item) => !item.hidden)
       .sort((a, b) => a.index - b.index);
@@ -530,7 +530,7 @@ class Grid extends ElementMixin(
 
   /** @private */
   __focusBodyCell({ item, column }) {
-    const row = this._getVisibleRows().find((row) => row._item === item);
+    const row = this._getRenderedRows().find((row) => row._item === item);
     const cell = row && [...row.children].find((cell) => cell._column === column);
     if (cell) {
       cell.focus();
@@ -635,7 +635,7 @@ class Grid extends ElementMixin(
     // Cache the viewport rows to avoid unnecessary reflows while measuring the column widths
     const fvi = this._firstVisibleIndex;
     const lvi = this._lastVisibleIndex;
-    this.__viewportRowsCache = this._getVisibleRows().filter((row) => row.index >= fvi && row.index <= lvi);
+    this.__viewportRowsCache = this._getRenderedRows().filter((row) => row.index >= fvi && row.index <= lvi);
 
     // Pre-cache the intrinsic width of each column
     this.__calculateAndCacheIntrinsicWidths(cols);

--- a/packages/grid/test/column-rendering.test.js
+++ b/packages/grid/test/column-rendering.test.js
@@ -15,7 +15,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
     }
 
     function getBodyCell(rowIndex, columnIndex) {
-      const row = grid._getVisibleRows()[rowIndex];
+      const row = grid.$.items.children[rowIndex];
       return [...row.children].find((cell) => cell.firstElementChild.assignedNodes()[0].__columnIndex === columnIndex);
     }
 
@@ -209,7 +209,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
        * Expect the cells DOM order to match the column order
        */
       function expectCellsDomOrderToMatchColumnOrder() {
-        const firstRow = grid._getVisibleRows()[0];
+        const firstRow = grid.$.items.firstElementChild;
         const expectedOrder = [...firstRow.children].sort(
           (a, b) => columns.indexOf(a._column) - columns.indexOf(b._column),
         );
@@ -220,7 +220,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
        * Expect the cells visual order to match the column order
        */
       function expectCellsVisualOrderToMatchColumnOrder() {
-        const firstRow = grid._getVisibleRows()[0];
+        const firstRow = grid.$.items.firstElementChild;
         [...firstRow.children].forEach((cell) => {
           expect(cell.getBoundingClientRect().left).to.equal(cell._column._headerCell.getBoundingClientRect().left);
           expect(cell.getBoundingClientRect().right).to.equal(cell._column._headerCell.getBoundingClientRect().right);

--- a/packages/grid/test/column-rendering.test.js
+++ b/packages/grid/test/column-rendering.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, keyDownOn, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import Sinon from 'sinon';
 import '../vaadin-grid.js';
-import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './helpers.js';
+import { flushGrid, getCellContent, getHeaderCellContent, getRows, onceResized } from './helpers.js';
 
 ['ltr', 'rtl'].forEach((dir) => {
   describe(`lazy column rendering - ${dir}`, () => {
@@ -15,7 +15,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
     }
 
     function getBodyCell(rowIndex, columnIndex) {
-      const row = grid.$.items.children[rowIndex];
+      const row = grid._getRenderedRows()[rowIndex];
       return [...row.children].find((cell) => cell.firstElementChild.assignedNodes()[0].__columnIndex === columnIndex);
     }
 
@@ -209,7 +209,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
        * Expect the cells DOM order to match the column order
        */
       function expectCellsDomOrderToMatchColumnOrder() {
-        const firstRow = grid.$.items.firstElementChild;
+        const firstRow = grid._getRenderedRows()[0];
         const expectedOrder = [...firstRow.children].sort(
           (a, b) => columns.indexOf(a._column) - columns.indexOf(b._column),
         );
@@ -220,7 +220,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
        * Expect the cells visual order to match the column order
        */
       function expectCellsVisualOrderToMatchColumnOrder() {
-        const firstRow = grid.$.items.firstElementChild;
+        const firstRow = grid._getRenderedRows()[0];
         [...firstRow.children].forEach((cell) => {
           expect(cell.getBoundingClientRect().left).to.equal(cell._column._headerCell.getBoundingClientRect().left);
           expect(cell.getBoundingClientRect().right).to.equal(cell._column._headerCell.getBoundingClientRect().right);

--- a/packages/grid/test/column-rendering.test.js
+++ b/packages/grid/test/column-rendering.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, keyDownOn, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import Sinon from 'sinon';
 import '../vaadin-grid.js';
-import { flushGrid, getCellContent, getHeaderCellContent, getRows, onceResized } from './helpers.js';
+import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './helpers.js';
 
 ['ltr', 'rtl'].forEach((dir) => {
   describe(`lazy column rendering - ${dir}`, () => {


### PR DESCRIPTION
## Description

The PR renames `getVisibleRows()` to `getRenderedRows()` to avoid potential confusion with methods like `getFirstVisibleItem` that retrieves rendered rows that are specifically in the viewport.

Part of https://github.com/vaadin/web-components/pull/5898

## Type of change

- [x] Refactor
