### PR TITLE
fix: restore focus on context menu overlay close (#5881) (CP: 24.1)

### DIFF
--- a/packages/component-base/src/dom-utils.d.ts
+++ b/packages/component-base/src/dom-utils.d.ts
@@ -14,6 +14,12 @@
 export function getAncestorRootNodes(node: Node): Node[];
 
 /**
+ * Traverses the given node and its parents, including those that are across
+ * the shadow root boundaries, until it finds a node that matches the selector.
+ */
+export function getClosestElement(selector: string, node: Node): Node | null;
+
+/**
  * Takes a string with values separated by space and returns a set the values
  */
 export function deserializeAttributeValue(value: string): Set<string>;

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -41,6 +41,22 @@ export function getAncestorRootNodes(node) {
 }
 
 /**
+ * Traverses the given node and its parents, including those that are across
+ * the shadow root boundaries, until it finds a node that matches the selector.
+ *
+ * @param {string} selector The CSS selector to match against
+ * @param {Node} node The starting node for the traversal
+ * @return {Node | null} The closest matching element, or null if no match is found
+ */
+export function getClosestElement(selector, node) {
+  if (!node) {
+    return null;
+  }
+
+  return node.closest(selector) || getClosestElement(selector, node.getRootNode().host);
+}
+
+/**
  * Takes a string with values separated by space and returns a set the values
  *
  * @param {string} value

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.d.ts
@@ -4,11 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { OverlayFocusMixinClass } from '@vaadin/overlay/src/vaadin-overlay-focus-mixin.js';
 import type { PositionMixinClass } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
 export declare function MenuOverlayMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<MenuOverlayMixinClass> & Constructor<PositionMixinClass> & T;
+): Constructor<MenuOverlayMixinClass> & Constructor<OverlayFocusMixinClass> & Constructor<PositionMixinClass> & T;
 
 export declare class MenuOverlayMixinClass {
   protected readonly parentOverlay: HTMLElement | undefined;

--- a/packages/context-menu/test/a11y.test.js
+++ b/packages/context-menu/test/a11y.test.js
@@ -1,0 +1,95 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getMenuItems, outsideClick } from './helpers.js';
+
+describe('a11y', () => {
+  describe('focus restoration', () => {
+    let contextMenu, contextMenuButton, beforeButton, afterButton;
+
+    beforeEach(() => {
+      const wrapper = fixtureSync(`
+        <div>
+          <button>Before</button>
+          <vaadin-context-menu open-on="click">
+            <button>Open context menu</button>
+          </vaadin-context-menu>
+          <button>After</button>
+      `);
+      [beforeButton, contextMenu, afterButton] = wrapper.children;
+      contextMenu.items = [{ text: 'Item 0' }, { text: 'Item 1', children: [{ text: 'Item 1/0' }] }];
+      contextMenuButton = contextMenu.querySelector('button');
+      contextMenuButton.focus();
+    });
+
+    it('should move focus to the menu on open', async () => {
+      contextMenuButton.click();
+      await nextRender();
+      const menuItem = getMenuItems(contextMenu)[0];
+      expect(getDeepActiveElement()).to.equal(menuItem);
+    });
+
+    it('should restore focus on outside click', async () => {
+      contextMenuButton.click();
+      await nextRender();
+      outsideClick();
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(contextMenuButton);
+    });
+
+    it('should restore focus on outside click when a sub-menu is open', async () => {
+      contextMenuButton.click();
+      await nextRender();
+      // Move focus to Item 1
+      await sendKeys({ press: 'ArrowDown' });
+      // Open Item 1
+      await sendKeys({ press: 'ArrowRight' });
+      await nextRender();
+      outsideClick();
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(contextMenuButton);
+    });
+
+    it('should restore focus on root menu item selection', async () => {
+      contextMenuButton.click();
+      await nextRender();
+      // Select Item 0
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(contextMenuButton);
+    });
+
+    it('should restore focus on sub-menu item selection', async () => {
+      contextMenuButton.click();
+      await nextRender();
+      // Move focus to Item 1
+      await sendKeys({ press: 'ArrowDown' });
+      // Open Item 1
+      await sendKeys({ press: 'ArrowRight' });
+      await nextRender();
+      // Select Item 1/1
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(contextMenuButton);
+    });
+
+    it('should move focus to the prev element outside the menu on Shift+Tab pressed inside', async () => {
+      contextMenuButton.click();
+      await nextRender();
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+      expect(getDeepActiveElement()).to.equal(beforeButton);
+    });
+
+    it('should move focus to the next element outside the menu on Tab pressed inside', async () => {
+      contextMenuButton.click();
+      await nextRender();
+      await sendKeys({ press: 'Tab' });
+      expect(getDeepActiveElement()).to.equal(afterButton);
+    });
+  });
+});

--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -28,3 +28,12 @@ export async function openSubMenus(menu) {
     await openSubMenus(subMenu);
   }
 }
+
+export function outsideClick() {
+  // Move focus to body
+  document.body.tabIndex = 0;
+  document.body.focus();
+  document.body.tabIndex = -1;
+  // Outside click
+  document.body.click();
+}

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
@@ -44,4 +44,14 @@ export declare class OverlayFocusMixinClass {
    * Trap focus within the overlay after opening has completed.
    */
   protected _trapFocus(): void;
+
+  /**
+   * Returns true if focus is still inside the overlay or on the body element,
+   * otherwise false.
+   *
+   * Focus shouldn't be restored if it's been moved elsewhere by another
+   * component or as a result of a user interaction e.g. the user clicked
+   * on a button outside the overlay while the overlay was open.
+   */
+  protected _shouldRestoreFocus(): boolean;
 }

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
@@ -54,4 +54,10 @@ export declare class OverlayFocusMixinClass {
    * on a button outside the overlay while the overlay was open.
    */
   protected _shouldRestoreFocus(): boolean;
+
+  /**
+   * Returns true if the overlay contains the given node,
+   * including those within shadow DOM trees.
+   */
+  protected _deepContains(node: Node): boolean;
 }

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -72,7 +72,7 @@ export const OverlayFocusMixin = (superClass) =>
         this.__focusTrapController.releaseFocus();
       }
 
-      if (this.restoreFocusOnClose) {
+      if (this.restoreFocusOnClose && this._shouldRestoreFocus()) {
         this.__restoreFocus();
       }
     }
@@ -100,6 +100,22 @@ export const OverlayFocusMixin = (superClass) =>
       }
     }
 
+    /**
+     * Returns true if focus is still inside the overlay or on the body element,
+     * otherwise false.
+     *
+     * Focus shouldn't be restored if it's been moved elsewhere by another
+     * component or as a result of a user interaction e.g. the user clicked
+     * on a button outside the overlay while the overlay was open.
+     *
+     * @protected
+     * @return {boolean}
+     */
+    _shouldRestoreFocus() {
+      const activeElement = getDeepActiveElement();
+      return activeElement === document.body || this._deepContains(activeElement);
+    }
+
     /** @private */
     __storeFocus() {
       // Store the focused node.
@@ -118,16 +134,6 @@ export const OverlayFocusMixin = (superClass) =>
 
     /** @private */
     __restoreFocus() {
-      // If the activeElement is `<body>` or inside the overlay,
-      // we are allowed to restore the focus. In all the other
-      // cases focus might have been moved elsewhere by another
-      // component or by the user interaction (e.g. click on a
-      // button outside the overlay).
-      const activeElement = getDeepActiveElement();
-      if (activeElement !== document.body && !this._deepContains(activeElement)) {
-        return;
-      }
-
       // Use restoreFocusNode if specified, otherwise fallback to the node
       // which was focused before opening the overlay.
       const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -116,6 +116,27 @@ export const OverlayFocusMixin = (superClass) =>
       return activeElement === document.body || this._deepContains(activeElement);
     }
 
+    /**
+     * Returns true if the overlay contains the given node,
+     * including those within shadow DOM trees.
+     *
+     * @param {Node} node
+     * @return {boolean}
+     * @protected
+     */
+    _deepContains(node) {
+      if (this.contains(node)) {
+        return true;
+      }
+      let n = node;
+      const doc = node.ownerDocument;
+      // Walk from node to `this` or `document`
+      while (n && n !== doc && n !== this) {
+        n = n.parentNode || n.host;
+      }
+      return n === this;
+    }
+
     /** @private */
     __storeFocus() {
       // Store the focused node.

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -159,9 +159,16 @@ export const OverlayFocusMixin = (superClass) =>
       // which was focused before opening the overlay.
       const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;
       if (restoreFocusNode) {
-        // Focusing the restoreFocusNode doesn't always work synchronously on Firefox and Safari
-        // (e.g. combo-box overlay close on outside click).
-        setTimeout(() => restoreFocusNode.focus());
+        if (getDeepActiveElement() === document.body) {
+          // In Firefox and Safari, focusing the restoreFocusNode synchronously
+          // doesn't work as expected when the overlay is closing on outside click.
+          // These browsers force focus to move to the body element and retain it
+          // there until the next event loop iteration.
+          setTimeout(() => restoreFocusNode.focus());
+        } else {
+          restoreFocusNode.focus();
+        }
+
         this.__restoreFocusNode = null;
       }
 

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -690,24 +690,6 @@ class Overlay extends OverlayFocusMixin(ThemableMixin(DirMixin(PolymerElement)))
   }
 
   /**
-   * @param {!Node} node
-   * @return {boolean}
-   * @private
-   */
-  _deepContains(node) {
-    if (this.contains(node)) {
-      return true;
-    }
-    let n = node;
-    const doc = node.ownerDocument;
-    // Walk from node to `this` or `document`
-    while (n && n !== doc && n !== this) {
-      n = n.parentNode || n.host;
-    }
-    return n === this;
-  }
-
-  /**
    * Brings the overlay as visually the frontmost one
    */
   bringToFront() {


### PR DESCRIPTION
## Description

Backports the following PRs to `24.1`:

- https://github.com/vaadin/web-components/pull/5881
- https://github.com/vaadin/web-components/pull/5895
- https://github.com/vaadin/web-components/pull/5896
- https://github.com/vaadin/web-components/pull/5897

Fixes https://github.com/vaadin/web-components/issues/137, https://github.com/vaadin/web-components/issues/292

## Type of change

- [x] Bugfix
