### PR TITLE
test: ensure focus is restored on menu-bar overlay close (#5892) (CP: 24.1)

### DIFF
--- a/packages/menu-bar/test/a11y.test.js
+++ b/packages/menu-bar/test/a11y.test.js
@@ -1,0 +1,83 @@
+import { expect } from '@esm-bundle/chai';
+import { arrowDown, arrowRight, enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '../src/vaadin-menu-bar.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+import { outsideClick } from './helpers.js';
+
+describe('a11y', () => {
+  describe('focus restoration', () => {
+    let menuBar, overlay, buttons;
+
+    beforeEach(async () => {
+      menuBar = fixtureSync(`<vaadin-menu-bar></vaadin-menu-bar>`);
+      menuBar.items = [
+        {
+          text: 'Item 0',
+          children: [
+            { text: 'Item 0/0' },
+            {
+              text: 'Item 0/1',
+              children: [{ text: 'Item 0/1/0' }],
+            },
+          ],
+        },
+      ];
+      overlay = menuBar._subMenu.$.overlay;
+      buttons = menuBar.querySelectorAll('vaadin-menu-bar-button');
+      buttons[0].focus();
+    });
+
+    it('should move focus to the sub-menu on open', async () => {
+      buttons[0].click();
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(overlay.$.overlay);
+    });
+
+    it('should restore focus on outside click', async () => {
+      // Open Item 0
+      arrowDown(getDeepActiveElement());
+      await nextRender();
+      outsideClick();
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(buttons[0]);
+    });
+
+    it('should restore focus on outside click when a sub-menu is open', async () => {
+      // Open Item 0
+      arrowDown(getDeepActiveElement());
+      await nextRender();
+      // Move to Item 0/1
+      arrowDown(getDeepActiveElement());
+      await nextRender();
+      // Open Item 0/1
+      arrowRight(getDeepActiveElement());
+      outsideClick();
+      await nextRender();
+      expect(getDeepActiveElement()).to.equal(buttons[0]);
+    });
+
+    it('should restore focus on sub-menu item selection', async () => {
+      // Open Item 0
+      arrowDown(getDeepActiveElement());
+      await nextRender();
+      // Select Item 0/0
+      enter(getDeepActiveElement());
+      expect(getDeepActiveElement()).to.equal(buttons[0]);
+    });
+
+    it('should restore focus on nested sub-menu item selection', async () => {
+      // Open Item 0
+      arrowDown(getDeepActiveElement());
+      await nextRender();
+      // Move to Item 0/1
+      arrowDown(getDeepActiveElement());
+      await nextRender();
+      // Open Item 0/1
+      arrowRight(getDeepActiveElement());
+      await nextRender();
+      // Select Item 0/1/0
+      enter(getDeepActiveElement());
+      expect(getDeepActiveElement()).to.equal(buttons[0]);
+    });
+  });
+});

--- a/packages/menu-bar/test/helpers.js
+++ b/packages/menu-bar/test/helpers.js
@@ -1,0 +1,11 @@
+/**
+ * Emulates clicking outside the dropdown overlay
+ */
+export function outsideClick() {
+  // Move focus to body
+  document.body.tabIndex = 0;
+  document.body.focus();
+  document.body.tabIndex = -1;
+  // Outside click
+  document.body.click();
+}


### PR DESCRIPTION
## Description

Backports the following PRs to `24.1`:

- #5892

Related to https://github.com/vaadin/web-components/issues/137

## Type of change

- [x] Internal
