### PR TITLE
refactor: replace querySelector in render with controller

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -30,6 +30,10 @@ export const sideNavItemBaseStyles = css`
     flex: none;
   }
 
+  :host(:not([has-children])) button {
+    display: none !important;
+  }
+
   :host(:not([path])) a {
     position: relative;
   }

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -2,7 +2,10 @@
 export const snapshots = {};
 
 snapshots["vaadin-side-nav-item item default"] = 
-`<vaadin-side-nav-item role="listitem">
+`<vaadin-side-nav-item
+  has-children=""
+  role="listitem"
+>
   <vaadin-icon
     icon="vaadin:chart"
     slot="prefix"
@@ -34,6 +37,7 @@ snapshots["vaadin-side-nav-item item default"] =
 snapshots["vaadin-side-nav-item item expanded"] = 
 `<vaadin-side-nav-item
   expanded=""
+  has-children=""
   role="listitem"
 >
   <vaadin-icon
@@ -69,6 +73,7 @@ snapshots["vaadin-side-nav-item item active"] =
   active=""
   child-active=""
   expanded=""
+  has-children=""
   role="listitem"
 >
   <vaadin-icon
@@ -341,7 +346,10 @@ snapshots["vaadin-side-nav-item shadow path"] =
 /* end snapshot vaadin-side-nav-item shadow path */
 
 snapshots["vaadin-side-nav-item item path"] = 
-`<vaadin-side-nav-item role="listitem">
+`<vaadin-side-nav-item
+  has-children=""
+  role="listitem"
+>
   <vaadin-icon
     icon="vaadin:chart"
     slot="prefix"

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -24,6 +24,40 @@ describe('side-nav-item', () => {
     });
   });
 
+  describe('has-children', () => {
+    beforeEach(async () => {
+      item = fixtureSync('<vaadin-side-nav-item></vaadin-side-nav-item>');
+      await nextRender();
+    });
+
+    it('should not have has-children attribute by default', () => {
+      expect(item.hasAttribute('has-children')).to.be.false;
+    });
+
+    it('should set has-children attribute when adding child item', async () => {
+      const child = document.createElement('vaadin-side-nav-item');
+      child.setAttribute('slot', 'children');
+
+      item.appendChild(child);
+      await nextRender();
+
+      expect(item.hasAttribute('has-children')).to.be.true;
+    });
+
+    it('should remove has-children attribute when removing child item', async () => {
+      const child = document.createElement('vaadin-side-nav-item');
+      child.setAttribute('slot', 'children');
+
+      item.appendChild(child);
+      await nextRender();
+
+      item.removeChild(child);
+      await nextRender();
+
+      expect(item.hasAttribute('has-children')).to.be.false;
+    });
+  });
+
   describe('active', () => {
     beforeEach(async () => {
       item = fixtureSync(`<vaadin-side-nav-item path=""></vaadin-side-nav-item>`);


### PR DESCRIPTION
## Description

Depends on #5968

This PR changes the `render()` method to avoid performing `querySelector()` on each call.
Instead, I added `SlotController` which observes slot as necessary and stores DOM nodes.

## Type of change

- Refactor