### PR TITLE
fix: restore focus on crud editor close (#5898) (CP: 24.1)

### DIFF
--- a/packages/a11y-base/index.d.ts
+++ b/packages/a11y-base/index.d.ts
@@ -12,6 +12,7 @@ export {
   isKeyboardActive,
 } from './src/focus-utils.js';
 export { FocusTrapController } from './src/focus-trap-controller.js';
+export { FocusRestorationController } from './src/focus-restoration-controller.js';
 export { KeyboardDirectionMixin } from './src/keyboard-direction-mixin.js';
 export { KeyboardMixin } from './src/keyboard-mixin.js';
 export { ListMixin } from './src/list-mixin.js';

--- a/packages/a11y-base/index.js
+++ b/packages/a11y-base/index.js
@@ -5,6 +5,7 @@ export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaController } from './src/field-aria-controller.js';
 export { FocusMixin } from './src/focus-mixin.js';
 export { FocusTrapController } from './src/focus-trap-controller.js';
+export { FocusRestorationController } from './src/focus-restoration-controller.js';
 export {
   getFocusableElements,
   isElementFocusable,

--- a/packages/a11y-base/src/focus-restoration-controller.d.ts
+++ b/packages/a11y-base/src/focus-restoration-controller.d.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+/**
+ * A controller for saving a focused node and restoring focus to it later.
+ */
+export declare function FocusRestorationController<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<FocusRestorationControllerClass> & T;
+
+export declare class FocusRestorationControllerClass {
+  /**
+   * Saves the given node as a target for restoring focus to
+   * when `restoreFocus()` is called. If no node is provided,
+   * the currently focused node in the DOM is saved as a target.
+   */
+  saveFocus(node: Node | null | undefined): void;
+
+  /**
+   * Restores focus to the target node that was saved previously with `saveFocus()`.
+   */
+  restoreFocus(): void;
+}

--- a/packages/a11y-base/src/focus-restoration-controller.js
+++ b/packages/a11y-base/src/focus-restoration-controller.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { getDeepActiveElement } from './focus-utils.js';
+
+/**
+ * A controller for saving a focused node and restoring focus to it later.
+ */
+export class FocusRestorationController {
+  /**
+   * Saves the given node as a target for restoring focus to
+   * when `restoreFocus()` is called. If no node is provided,
+   * the currently focused node in the DOM is saved as a target.
+   *
+   * @param {Node | null | undefined} focusNode
+   */
+  saveFocus(focusNode) {
+    this.focusNode = focusNode || getDeepActiveElement();
+  }
+
+  /**
+   * Restores focus to the target node that was saved previously with `saveFocus()`.
+   */
+  restoreFocus() {
+    const focusNode = this.focusNode;
+    if (!focusNode) {
+      return;
+    }
+
+    if (getDeepActiveElement() === document.body) {
+      // In Firefox and Safari, focusing the node synchronously
+      // doesn't work as expected when the overlay is closing on outside click.
+      // These browsers force focus to move to the body element and retain it
+      // there until the next event loop iteration.
+      setTimeout(() => focusNode.focus());
+    } else {
+      focusNode.focus();
+    }
+
+    this.focusNode = null;
+  }
+}

--- a/packages/a11y-base/test/focus-restoration-controller.test.js
+++ b/packages/a11y-base/test/focus-restoration-controller.test.js
@@ -1,0 +1,61 @@
+import { expect } from '@esm-bundle/chai';
+import { aTimeout, fixtureSync, outsideClick } from '@vaadin/testing-helpers';
+import { FocusRestorationController } from '../src/focus-restoration-controller.js';
+import { getDeepActiveElement } from '../src/focus-utils.js';
+
+describe('focus-restoration-controller', () => {
+  let controller, button1, button2;
+
+  beforeEach(() => {
+    controller = new FocusRestorationController();
+
+    const wrapper = fixtureSync(`
+      <div>
+        <button>Button 1</button>
+        <button>Button 2</button>
+      </div>
+    `);
+
+    [button1, button2] = wrapper.children;
+  });
+
+  it('should restore focus to the previously focused node by default', () => {
+    button1.focus();
+    controller.saveFocus();
+    button2.focus();
+    controller.restoreFocus();
+    expect(getDeepActiveElement()).to.equal(button1);
+  });
+
+  it('should restore focus to a specific node when provided', () => {
+    button1.focus();
+    controller.saveFocus(button2);
+    controller.restoreFocus();
+    expect(getDeepActiveElement()).to.equal(button2);
+  });
+
+  it('should restore focus asynchronously if an outside click happened in between', async () => {
+    button1.focus();
+    controller.saveFocus();
+    outsideClick();
+    controller.restoreFocus();
+    expect(getDeepActiveElement()).to.equal(document.body);
+    await aTimeout(0);
+    expect(getDeepActiveElement()).to.equal(button1);
+  });
+
+  it('should not restore focus if no node was saved', () => {
+    button1.focus();
+    controller.restoreFocus();
+    expect(getDeepActiveElement()).to.equal(button1);
+  });
+
+  it('should not restore focus again if it was already restored', () => {
+    button1.focus();
+    controller.saveFocus();
+    controller.restoreFocus();
+    button2.focus();
+    controller.restoreFocus();
+    expect(getDeepActiveElement()).to.equal(button2);
+  });
+});

--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -13,6 +13,7 @@ import '@vaadin/grid/src/vaadin-grid-column-group.js';
 import '@vaadin/grid/src/vaadin-grid-sorter.js';
 import '@vaadin/grid/src/vaadin-grid-filter.js';
 import './vaadin-crud-edit-column.js';
+import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { capitalize, getProperty } from './vaadin-crud-helpers.js';
 import { IncludedMixin } from './vaadin-crud-include-mixin.js';
@@ -56,6 +57,30 @@ class CrudGrid extends IncludedMixin(Grid) {
 
   static get observers() {
     return ['__onItemsChange(items)', '__onHideEditColumnChange(hideEditColumn)'];
+  }
+
+  /** @protected */
+  _getRowContainingNode(node) {
+    const content = getClosestElement('vaadin-grid-cell-content', node);
+    if (!content) {
+      return;
+    }
+
+    const cell = content.assignedSlot.parentElement;
+    return cell.parentElement;
+  }
+
+  /** @protected */
+  _isItemAssigedToRow(item, row) {
+    const model = this.__getRowModel(row);
+    return this.getItemId(item) === this.getItemId(model.item);
+  }
+
+  /** @protected */
+  _focusFirstVisibleRow() {
+    const row = this.__getFirstVisibleItem();
+    this.__rowFocusMode = true;
+    row.focus();
   }
 
   /** @private */

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -17,6 +17,7 @@ import './vaadin-crud-form.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { FocusRestorationController } from '@vaadin/a11y-base/src/focus-restoration-controller.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
@@ -664,6 +665,8 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     this.__onGridSizeChanged = this.__onGridSizeChanged.bind(this);
     this.__onGridActiveItemChanged = this.__onGridActiveItemChanged.bind(this);
 
+    this.__focusRestorationController = new FocusRestorationController();
+
     this._observer = new FlattenedNodesObserver(this, (info) => {
       this.__onDomChange(info.addedNodes);
     });
@@ -717,6 +720,8 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
         this._fullscreen = matches;
       }),
     );
+
+    this.addController(this.__focusRestorationController);
   }
 
   /**
@@ -1234,6 +1239,8 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
 
   /** @private */
   __openEditor(type, item) {
+    this.__focusRestorationController.saveFocus();
+
     this.__isDirty = false;
     this.__isNew = !item;
     const evt = this.dispatchEvent(
@@ -1243,6 +1250,31 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       this.editedItem = item || {};
     } else {
       this.editorOpened = true;
+    }
+  }
+
+  /** @private */
+  __restoreFocusOnDelete() {
+    if (this._grid._effectiveSize === 1) {
+      this._newButton.focus();
+    } else {
+      this._grid._focusFirstVisibleRow();
+    }
+  }
+
+  /** @private */
+  __restoreFocusOnSaveOrCancel() {
+    const focusNode = this.__focusRestorationController.focusNode;
+    const row = this._grid._getRowContainingNode(focusNode);
+    if (!row) {
+      this.__focusRestorationController.restoreFocus();
+      return;
+    }
+
+    if (this._grid._isItemAssigedToRow(this.editedItem, row) && this._grid._isInViewport(row)) {
+      this.__focusRestorationController.restoreFocus();
+    } else {
+      this._grid._focusFirstVisibleRow();
     }
   }
 
@@ -1273,6 +1305,8 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
         }
         Object.assign(this.editedItem, item);
       }
+
+      this.__restoreFocusOnSaveOrCancel();
       this._grid.clearCache();
       this.__closeEditor();
     }
@@ -1291,6 +1325,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
   __confirmCancel() {
     const evt = this.dispatchEvent(new CustomEvent('cancel', { detail: { item: this.editedItem }, cancelable: true }));
     if (evt) {
+      this.__restoreFocusOnSaveOrCancel();
       this.__closeEditor();
     }
   }
@@ -1307,6 +1342,8 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       if (this.items && this.items.indexOf(this.editedItem) >= 0) {
         this.items.splice(this.items.indexOf(this.editedItem), 1);
       }
+
+      this.__restoreFocusOnDelete();
       this._grid.clearCache();
       this.__closeEditor();
     }

--- a/packages/crud/test/a11y.test.js
+++ b/packages/crud/test/a11y.test.js
@@ -1,0 +1,243 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { setViewport } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
+import '../src/vaadin-crud.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getVisibleRows } from './helpers.js';
+
+describe('a11y', () => {
+  let crud;
+
+  before(async () => {
+    await setViewport({ width: 1024, height: 768 });
+  });
+
+  describe('focus restoration', () => {
+    let grid, form, overlay, newButton, saveButton, cancelButton, editButtons;
+
+    describe('create item', () => {
+      beforeEach(async () => {
+        crud = fixtureSync('<vaadin-crud></vaadin-crud>');
+        crud.items = [{ title: 'Item 1' }];
+        await nextRender();
+        overlay = crud.$.dialog.$.overlay;
+        form = crud.querySelector('vaadin-crud-form');
+        newButton = crud.querySelector('[slot=new-button]');
+        saveButton = crud.querySelector('[slot=save-button]');
+        cancelButton = crud.querySelector('[slot=cancel-button]');
+        editButtons = crud.querySelectorAll('vaadin-crud-edit');
+      });
+
+      it('should move focus to the dialog on new dialog open', async () => {
+        newButton.focus();
+        newButton.click();
+        await nextRender();
+        expect(getDeepActiveElement()).to.equal(overlay.$.overlay);
+      });
+
+      it('should restore focus to previous element on new dialog close', async () => {
+        newButton.focus();
+        newButton.click();
+        await nextRender();
+        await sendKeys({ press: 'Escape' });
+        expect(getDeepActiveElement()).to.equal(newButton);
+      });
+
+      it('should restore focus to previous element on save', async () => {
+        newButton.focus();
+        newButton.click();
+        await nextRender();
+
+        form.querySelector('vaadin-text-field').focus();
+        await sendKeys({ type: 'something' });
+
+        saveButton.focus();
+        saveButton.click();
+        expect(getDeepActiveElement()).to.equal(newButton);
+      });
+
+      it('should restore focus to previous element on cancel', async () => {
+        newButton.focus();
+        newButton.click();
+        await nextRender();
+
+        cancelButton.focus();
+        cancelButton.click();
+        expect(getDeepActiveElement()).to.equal(newButton);
+      });
+    });
+
+    describe('edit item', () => {
+      beforeEach(async () => {
+        crud = fixtureSync('<vaadin-crud editor-position="aside"></vaadin-crud>');
+        crud.items = Array.from({ length: 50 }, (_, i) => {
+          return { title: `Item ${i}` };
+        });
+        await nextRender();
+        grid = crud.querySelector('vaadin-crud-grid');
+        form = crud.querySelector('vaadin-crud-form');
+        newButton = crud.querySelector('[slot=new-button]');
+        saveButton = crud.querySelector('[slot=save-button]');
+        cancelButton = crud.querySelector('[slot=cancel-button]');
+        editButtons = crud.querySelectorAll('vaadin-crud-edit');
+      });
+
+      it('should restore focus to previous element on save', async () => {
+        editButtons[0].focus();
+        editButtons[0].click();
+        await nextRender();
+
+        // Edit the item
+        form.querySelector('vaadin-text-field').focus();
+        await sendKeys({ type: 'something' });
+
+        saveButton.focus();
+        saveButton.click();
+        expect(getDeepActiveElement()).to.equal(editButtons[0]);
+      });
+
+      it('should restore focus to first visible row on save if previous element has been re-used for another item', async () => {
+        editButtons[0].focus();
+        editButtons[0].click();
+        await nextRender();
+
+        // Scroll to the end to trigger the grid to re-use
+        // the saved focused element (the edit button) for another item.
+        grid.scrollToIndex(crud.items.length - 1);
+        await nextRender();
+
+        // Edit the item
+        form.querySelector('vaadin-text-field').focus();
+        await sendKeys({ type: 'something' });
+
+        saveButton.focus();
+        saveButton.click();
+
+        const firstVisibleRow = getVisibleRows(grid.$.items)[0];
+        expect(getDeepActiveElement()).to.equal(firstVisibleRow);
+      });
+
+      it('should restore focus to previous element on cancel', async () => {
+        editButtons[0].focus();
+        editButtons[0].click();
+        await nextRender();
+
+        // Edit the item
+        form.querySelector('vaadin-text-field').focus();
+        await sendKeys({ type: 'something' });
+
+        cancelButton.focus();
+        cancelButton.click();
+        await nextRender();
+
+        const confirmButton = getDeepActiveElement();
+        confirmButton.focus();
+        confirmButton.click();
+        expect(getDeepActiveElement()).to.equal(editButtons[0]);
+      });
+
+      it('should restore focus to first visible row on cancel if previous element has been re-used for another item', async () => {
+        editButtons[0].focus();
+        editButtons[0].click();
+        await nextRender();
+
+        // Scroll to the end to trigger the grid to re-use
+        // the saved focused element (the edit button) for another item.
+        grid.scrollToIndex(crud.items.length - 1);
+        await nextRender();
+
+        cancelButton.focus();
+        cancelButton.click();
+        await nextRender();
+
+        const firstVisibleRow = getVisibleRows(grid.$.items)[0];
+        expect(getDeepActiveElement()).to.equal(firstVisibleRow);
+      });
+
+      it('should switch to row focus mode when restoring focus to first visible row', async () => {
+        editButtons[0].focus();
+        editButtons[0].click();
+        await nextRender();
+
+        // Scroll to the end to trigger the grid to re-use
+        // the saved focused element (the edit button) for another item.
+        grid.scrollToIndex(crud.items.length - 1);
+        await nextRender();
+
+        cancelButton.focus();
+        cancelButton.click();
+        await nextRender();
+
+        await sendKeys({ press: 'ArrowDown' });
+        const secondVisibleRow = getVisibleRows(grid.$.items)[1];
+        expect(getDeepActiveElement()).to.equal(secondVisibleRow);
+      });
+    });
+
+    describe('delete item', () => {
+      let deleteButton;
+
+      beforeEach(() => {
+        crud = fixtureSync('<vaadin-crud editor-position="aside"></vaadin-crud>');
+        newButton = crud.querySelector('[slot=new-button]');
+        deleteButton = crud.querySelector('[slot=delete-button]');
+      });
+
+      describe('multiple rows', () => {
+        beforeEach(async () => {
+          crud.items = Array.from({ length: 50 }, (_, i) => {
+            return { title: `Item ${i}` };
+          });
+          await nextRender();
+          grid = crud.querySelector('vaadin-crud-grid');
+          editButtons = [...crud.querySelectorAll('vaadin-crud-edit')];
+        });
+
+        it('should restore focus to first visible row on delete', async () => {
+          editButtons[8].focus();
+          editButtons[8].click();
+          await nextRender();
+
+          // Scroll a bit to get a couple of rows out of the grid's viewport.
+          grid.scrollToIndex(2);
+          await nextRender();
+
+          deleteButton.focus();
+          deleteButton.click();
+          await nextRender();
+
+          const confirmButton = getDeepActiveElement();
+          confirmButton.focus();
+          confirmButton.click();
+
+          const firstVisibleRow = getVisibleRows(grid.$.items)[0];
+          expect(getDeepActiveElement()).to.equal(firstVisibleRow);
+        });
+      });
+
+      describe('single row', () => {
+        beforeEach(async () => {
+          crud.items = [{ title: 'Item 1' }];
+          await nextRender();
+          editButtons = [...crud.querySelectorAll('vaadin-crud-edit')];
+        });
+
+        it('should restore focus to new button on delete', async () => {
+          editButtons[0].focus();
+          editButtons[0].click();
+          await nextRender();
+
+          deleteButton.focus();
+          deleteButton.click();
+          await nextRender();
+
+          const confirmButton = getDeepActiveElement();
+          confirmButton.focus();
+          confirmButton.click();
+          expect(getDeepActiveElement()).to.equal(newButton);
+        });
+      });
+    });
+  });
+});

--- a/packages/crud/test/helpers.js
+++ b/packages/crud/test/helpers.js
@@ -1,7 +1,16 @@
 export { flushGrid } from '@vaadin/grid/test/helpers.js';
 
+function isRowVisible(row) {
+  const grid = row.getRootNode().host;
+  const scrollTargetRect = grid.$.table.getBoundingClientRect();
+  const itemRect = row.getBoundingClientRect();
+  const headerHeight = grid.$.header.getBoundingClientRect().height;
+  const footerHeight = grid.$.footer.getBoundingClientRect().height;
+  return itemRect.bottom > scrollTargetRect.top + headerHeight && itemRect.top < scrollTargetRect.bottom - footerHeight;
+}
+
 export const getRows = (container) => {
-  return container.querySelectorAll('tr');
+  return [...container.querySelectorAll('tr')];
 };
 
 export const getRowCells = (row) => {
@@ -36,3 +45,7 @@ export const getBodyCellContent = (grid, row, col) => {
   const container = grid.$.items;
   return getContainerCellContent(container, row, col);
 };
+
+export function getVisibleRows(container) {
+  return getRows(container).filter((row) => isRowVisible(row));
+}

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
@@ -36,9 +36,9 @@ export declare class OverlayFocusMixinClass {
   protected _resetFocus(): void;
 
   /**
-   * Store previously focused node when the overlay starts to open.
+   * Save the previously focused node when the overlay starts to open.
    */
-  protected _storeFocus(): void;
+  protected _saveFocus(): void;
 
   /**
    * Trap focus within the overlay after opening has completed.

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -141,16 +141,6 @@ export const OverlayFocusMixin = (superClass) =>
     __storeFocus() {
       // Store the focused node.
       this.__restoreFocusNode = getDeepActiveElement();
-
-      // Determine and store the node that has the `focus-ring` attribute
-      // in order to restore the attribute when the overlay closes.
-      const restoreFocusNode = this.restoreFocusNode || this.__restoreFocusNode;
-      if (restoreFocusNode) {
-        const restoreFocusNodeHost = (restoreFocusNode.assignedSlot || restoreFocusNode).getRootNode().host;
-        this.__restoreFocusRingNode = [restoreFocusNode, restoreFocusNodeHost].find((node) => {
-          return node && node.hasAttribute('focus-ring');
-        });
-      }
     }
 
     /** @private */
@@ -170,13 +160,6 @@ export const OverlayFocusMixin = (superClass) =>
         }
 
         this.__restoreFocusNode = null;
-      }
-
-      // Restore the `focus-ring` attribute if it was present
-      // when the overlay was opening.
-      if (this.__restoreFocusRingNode) {
-        this.__restoreFocusRingNode.setAttribute('focus-ring', '');
-        this.__restoreFocusRingNode = null;
       }
     }
   };

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -449,7 +449,7 @@ class Overlay extends OverlayFocusMixin(ThemableMixin(DirMixin(PolymerElement)))
   /** @private */
   _openedChanged(opened, wasOpened) {
     if (opened) {
-      this._storeFocus();
+      this._saveFocus();
 
       this._animatedOpening();
 

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -69,16 +69,6 @@ describe('restore focus', () => {
       expect(getDeepActiveElement()).to.not.equal(focusInput);
     });
 
-    it('should not restore focus-ring attribute on close by default', async () => {
-      focusInput.focus();
-      focusInput.setAttribute('focus-ring', '');
-      overlay.opened = true;
-      await nextRender();
-      focusInput.removeAttribute('focus-ring');
-      overlay.opened = false;
-      expect(focusInput.hasAttribute('focus-ring')).to.be.false;
-    });
-
     describe('restoreFocusNode', () => {
       beforeEach(() => {
         overlay.restoreFocusNode = focusInput;
@@ -90,16 +80,6 @@ describe('restore focus', () => {
         await nextRender();
         overlay.opened = false;
         expect(getDeepActiveElement()).to.not.equal(focusInput);
-      });
-
-      it('should not restore focus-ring attribute on close by default', async () => {
-        focusInput.focus();
-        focusInput.setAttribute('focus-ring', '');
-        overlay.opened = true;
-        await nextRender();
-        focusInput.removeAttribute('focus-ring');
-        overlay.opened = false;
-        expect(focusInput.hasAttribute('focus-ring')).to.be.false;
       });
     });
   });
@@ -126,24 +106,6 @@ describe('restore focus', () => {
         expect(getDeepActiveElement()).to.equal(focusInput);
       });
 
-      it('should restore focus-ring attribute on close', async () => {
-        focusInput.focus();
-        focusInput.setAttribute('focus-ring', '');
-        overlay.opened = true;
-        await nextRender();
-        focusInput.removeAttribute('focus-ring');
-        overlay.opened = false;
-        expect(focusInput.hasAttribute('focus-ring')).to.be.true;
-      });
-
-      it('should not restore focus-ring attribute on close if it was not present', async () => {
-        focusInput.focus();
-        overlay.opened = true;
-        await nextRender();
-        overlay.opened = false;
-        expect(focusInput.hasAttribute('focus-ring')).to.be.false;
-      });
-
       it('should restore focus on close in Shadow DOM', async () => {
         focusable.focus();
         overlay.opened = true;
@@ -161,16 +123,6 @@ describe('restore focus', () => {
         expect(getDeepActiveElement()).to.equal(focusInput);
       });
 
-      it('should restore focus-ring attribute on outside click', async () => {
-        focusInput.focus();
-        focusInput.setAttribute('focus-ring', '');
-        overlay.opened = true;
-        await nextRender();
-        focusInput.removeAttribute('focus-ring');
-        outsideClick();
-        expect(focusInput.hasAttribute('focus-ring')).to.be.true;
-      });
-
       it('should not restore focus on close if focus was moved outside overlay', async () => {
         focusInput.focus();
         overlay.opened = true;
@@ -178,17 +130,6 @@ describe('restore focus', () => {
         focusable.focus();
         overlay.opened = false;
         expect(getDeepActiveElement()).to.equal(focusable);
-      });
-
-      it('should not restore focus-ring attribute if focus was moved outside overlay', async () => {
-        focusInput.focus();
-        focusInput.setAttribute('focus-ring', '');
-        overlay.opened = true;
-        await nextRender();
-        focusInput.removeAttribute('focus-ring');
-        focusable.focus();
-        overlay.opened = false;
-        expect(focusInput.hasAttribute('focus-ring')).to.be.false;
       });
 
       describe('restoreFocusNode', () => {
@@ -203,54 +144,6 @@ describe('restore focus', () => {
           overlay.opened = false;
           expect(getDeepActiveElement()).to.equal(focusInput);
         });
-
-        it('should restore focus-ring attribute on the restoreFocusNode', async () => {
-          focusable.focus();
-          focusInput.setAttribute('focus-ring', '');
-          overlay.opened = true;
-          await nextRender();
-          focusInput.removeAttribute('focus-ring');
-          overlay.opened = false;
-          expect(focusInput.hasAttribute('focus-ring')).to.be.true;
-        });
-      });
-    });
-
-    describe('focus node inside a slot', () => {
-      let focusInputWrapper;
-
-      beforeEach(() => {
-        focusInputWrapper = fixtureSync('<focus-input-wrapper></focus-input-wrapper>');
-        focusInputWrapper.appendChild(focusInput);
-      });
-
-      it('should restore focus-ring attribute on the host component', async () => {
-        focusInput.focus();
-        focusInputWrapper.setAttribute('focus-ring', '');
-        overlay.opened = true;
-        await nextRender();
-        focusInputWrapper.removeAttribute('focus-ring');
-        overlay.opened = false;
-        expect(focusInputWrapper.hasAttribute('focus-ring')).to.be.true;
-      });
-    });
-
-    describe('focus node inside Shadow DOM', () => {
-      let focusInputWrapper;
-
-      beforeEach(() => {
-        focusInputWrapper = fixtureSync('<focus-input-wrapper></focus-input-wrapper>');
-        focusInputWrapper.shadowRoot.appendChild(focusInput);
-      });
-
-      it('should restore focus-ring attribute on the host component', async () => {
-        focusInput.focus();
-        focusInputWrapper.setAttribute('focus-ring', '');
-        overlay.opened = true;
-        await nextRender();
-        focusInputWrapper.removeAttribute('focus-ring');
-        overlay.opened = false;
-        expect(focusInputWrapper.hasAttribute('focus-ring')).to.be.true;
       });
     });
   });

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
@@ -112,15 +112,6 @@ describe('restore focus', () => {
         await nextRender();
         overlay.opened = false;
         expect(getDeepActiveElement()).to.equal(focusable);
-      });
-
-      it('should restore focus asynchronously on outside click', async () => {
-        focusInput.focus();
-        overlay.opened = true;
-        await nextRender();
-        outsideClick();
-        await aTimeout(0);
-        expect(getDeepActiveElement()).to.equal(focusInput);
       });
 
       it('should not restore focus on close if focus was moved outside overlay', async () => {


### PR DESCRIPTION
## Description

Backports the following PRs to `24.1`:

- #5898
- https://github.com/vaadin/web-components/pull/5951
- https://github.com/vaadin/web-components/pull/5949

Depends on 
- https://github.com/vaadin/web-components/pull/5971

Fixes https://github.com/vaadin/web-components/issues/138

## Type of change

- [x] Bugfix
