### PR TITLE
refactor: use list element instead of role on the slot

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -30,6 +30,12 @@ export const sideNavItemBaseStyles = css`
     flex: none;
   }
 
+  [part='children'] {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+  }
+
   :host(:not([has-children])) button {
     display: none !important;
   }
@@ -101,8 +107,9 @@ export const sideNavBaseStyles = css`
     justify-content: center;
   }
 
-  slot {
-    /* Needed to make role="list" work */
-    display: block;
+  [part='children'] {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
   }
 `;

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -195,7 +195,9 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
           aria-label="Toggle child items"
         ></button>
       </a>
-      <slot name="children" role="list" part="children" id="children" ?hidden="${!this.expanded}"></slot>
+      <ul part="children" ?hidden="${!this.expanded}">
+        <slot name="children"></slot>
+      </ul>
     `;
   }
 

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -118,7 +118,9 @@ class SideNav extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
       <summary part="label" ?hidden="${label == null}">
         <slot name="label" @slotchange="${() => this.requestUpdate()}"></slot>
       </summary>
-      <slot role="list"></slot>
+      <ul part="children">
+        <slot></slot>
+      </ul>
     `;
   }
 

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -183,14 +183,13 @@ snapshots["vaadin-side-nav-item shadow default"] =
   >
   </button>
 </a>
-<slot
+<ul
   hidden=""
-  id="children"
-  name="children"
   part="children"
-  role="list"
 >
-</slot>
+  <slot name="children">
+  </slot>
+</ul>
 `;
 /* end snapshot vaadin-side-nav-item shadow default */
 
@@ -213,13 +212,10 @@ snapshots["vaadin-side-nav-item shadow expanded"] =
   >
   </button>
 </a>
-<slot
-  id="children"
-  name="children"
-  part="children"
-  role="list"
->
-</slot>
+<ul part="children">
+  <slot name="children">
+  </slot>
+</ul>
 `;
 /* end snapshot vaadin-side-nav-item shadow expanded */
 
@@ -243,13 +239,10 @@ snapshots["vaadin-side-nav-item shadow active"] =
   >
   </button>
 </a>
-<slot
-  id="children"
-  name="children"
-  part="children"
-  role="list"
->
-</slot>
+<ul part="children">
+  <slot name="children">
+  </slot>
+</ul>
 `;
 /* end snapshot vaadin-side-nav-item shadow active */
 
@@ -334,14 +327,13 @@ snapshots["vaadin-side-nav-item shadow path"] =
   >
   </button>
 </a>
-<slot
+<ul
   hidden=""
-  id="children"
-  name="children"
   part="children"
-  role="list"
 >
-</slot>
+  <slot name="children">
+  </slot>
+</ul>
 `;
 /* end snapshot vaadin-side-nav-item shadow path */
 

--- a/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
@@ -72,8 +72,10 @@ snapshots["vaadin-side-nav shadow default"] =
   <slot name="label">
   </slot>
 </summary>
-<slot role="list">
-</slot>
+<ul part="children">
+  <slot>
+  </slot>
+</ul>
 `;
 /* end snapshot vaadin-side-nav shadow default */
 
@@ -83,8 +85,10 @@ snapshots["vaadin-side-nav shadow collapsible"] =
     <slot name="label">
     </slot>
   </summary>
-  <slot role="list">
-  </slot>
+  <ul part="children">
+    <slot>
+    </slot>
+  </ul>
 </details>
 `;
 /* end snapshot vaadin-side-nav shadow collapsible */
@@ -95,8 +99,10 @@ snapshots["vaadin-side-nav shadow collapsed"] =
     <slot name="label">
     </slot>
   </summary>
-  <slot role="list">
-  </slot>
+  <ul part="children">
+    <slot>
+    </slot>
+  </ul>
 </details>
 `;
 /* end snapshot vaadin-side-nav shadow collapsed */


### PR DESCRIPTION
## Description

Fixes #5821

Added `<ul>` elements placed around the `<slot>` in `vaadin-side-nav` and `vaadin-side-nav-item`

## Type of change

- Refactor

## Note

Below are screen reader test results:

### VoiceOver + Chrome

<img width="333" alt="voiceover-chrome-0" src="https://github.com/vaadin/web-components/assets/10589913/93cbce80-9f47-4152-b17b-cb75b987c1f0">
<img width="377" alt="voiceover-chrome-1" src="https://github.com/vaadin/web-components/assets/10589913/d4e89913-ad19-48ca-a4d6-07d438e74f7b">
<img width="374" alt="voiceover-chrome-2" src="https://github.com/vaadin/web-components/assets/10589913/3612ccdd-0a36-4e15-90da-d71b1c02866e">
<img width="382" alt="voiceover-chrome-3" src="https://github.com/vaadin/web-components/assets/10589913/ac6872a1-d74c-4103-b87f-ba77c6b6d096">
<img width="379" alt="voiceover-chrome-4" src="https://github.com/vaadin/web-components/assets/10589913/af98c5c8-b043-4fc3-84c4-be55df3948d7">
<img width="382" alt="voiceover-chrome-5" src="https://github.com/vaadin/web-components/assets/10589913/e20c11a4-fab1-41b3-9c68-952740008356">

### NVDA

<img width="339" alt="nvda-side-nav-ul" src="https://github.com/vaadin/web-components/assets/10589913/f0b5536f-9980-4056-a979-57a9f4811a11">
