### PR TITLE
refactor: use controller to handle side-nav label, add tests

### DIFF
--- a/packages/side-nav/test/accessibility.test.js
+++ b/packages/side-nav/test/accessibility.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../enable.js';
 import '../vaadin-side-nav-item.js';
 import '../vaadin-side-nav.js';
@@ -21,6 +21,66 @@ describe('accessibility', () => {
       const sideNavWithCustomRole = fixtureSync('<vaadin-side-nav role="custom role"></vaadin-side-nav>');
       await nextRender(sideNavWithCustomRole);
       expect(sideNavWithCustomRole.getAttribute('role')).to.equal('custom role');
+    });
+  });
+
+  describe('label', () => {
+    let sideNav;
+
+    beforeEach(async () => {
+      sideNav = fixtureSync('<vaadin-side-nav></vaadin-side-nav>');
+      await nextRender();
+    });
+
+    it('should not have aria-labelledby attribute by default', () => {
+      expect(sideNav.hasAttribute('aria-labelledby')).to.be.false;
+    });
+
+    it('should set id on the lazily added label element', async () => {
+      const label = document.createElement('label');
+      label.setAttribute('slot', 'label');
+
+      sideNav.appendChild(label);
+      await nextFrame();
+
+      const ID_REGEX = /^side-nav-label-\d+$/u;
+      expect(label.getAttribute('id')).to.match(ID_REGEX);
+    });
+
+    it('should not override custom id on the lazily added label', async () => {
+      const label = document.createElement('label');
+      label.setAttribute('slot', 'label');
+      label.id = 'custom-label';
+
+      sideNav.appendChild(label);
+      await nextFrame();
+
+      expect(label.getAttribute('id')).to.equal('custom-label');
+    });
+
+    it('should set aria-labelledby attribute when adding a label', async () => {
+      const label = document.createElement('label');
+      label.setAttribute('slot', 'label');
+
+      sideNav.appendChild(label);
+      await nextFrame();
+
+      const ID_REGEX = /^side-nav-label-\d+$/u;
+      expect(sideNav.getAttribute('aria-labelledby')).to.match(ID_REGEX);
+      expect(sideNav.getAttribute('aria-labelledby')).to.be.equal(label.id);
+    });
+
+    it('should remove aria-labelledby attribute when removing a label', async () => {
+      const label = document.createElement('label');
+      label.setAttribute('slot', 'label');
+
+      sideNav.appendChild(label);
+      await nextFrame();
+
+      sideNav.removeChild(label);
+      await nextFrame();
+
+      expect(sideNav.hasAttribute('aria-labelledby')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

This change is similar to #5969 but for `vaadin-side-nav` itself and corresponding `label` slot.

Note: the logic is simpler than the one we have in `@vaadin/field-base` and doesn't cover all the cases.
We could consider using `SlotChildObserveController` instead to track slotted label `id` changes.

## Type of change

- Refactor