### PR TITLE
refactor!: replace details with custom collapsible, add tests

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -83,28 +83,19 @@ export const sideNavBaseStyles = css`
     display: none !important;
   }
 
-  summary {
+  button {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-  }
-
-  summary ::slotted([slot='label']) {
-    display: block;
-  }
-
-  summary::-webkit-details-marker {
-    display: none;
-  }
-
-  summary::marker {
-    content: '';
-  }
-
-  summary::after {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+    justify-content: inherit;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    background-color: initial;
+    color: inherit;
+    border: initial;
+    outline: none;
+    font: inherit;
+    text-align: inherit;
   }
 
   [part='children'] {

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { LitElement } from 'lit';
+import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -50,7 +51,7 @@ export type SideNavEventMap = HTMLElementEventMap & SideNavCustomEventMap;
  *
  * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.
  */
-declare class SideNav extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
+declare class SideNav extends FocusMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   /**
    * Whether the side nav is collapsible. When enabled, the toggle icon is shown.
    */

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -4,6 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, LitElement } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
@@ -50,9 +52,13 @@ function isEnabled() {
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class SideNav extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
+class SideNav extends FocusMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   static get is() {
     return 'vaadin-side-nav';
+  }
+
+  static get shadowRootOptions() {
+    return { ...LitElement.shadowRootOptions, delegatesFocus: true };
   }
 
   static get properties() {
@@ -86,6 +92,17 @@ class SideNav extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
     return sideNavBaseStyles;
   }
 
+  constructor() {
+    super();
+
+    this._labelId = `side-nav-label-${generateUniqueId()}`;
+  }
+
+  /** @protected */
+  get focusElement() {
+    return this.shadowRoot.querySelector('button');
+  }
+
   /** @protected */
   firstUpdated() {
     // By default, if the user hasn't provided a custom role,
@@ -97,36 +114,55 @@ class SideNav extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
 
   /** @protected */
   render() {
-    const label = this.querySelector('[slot="label"]');
-    if (label && this.collapsible) {
-      return html`
-        <details ?open="${!this.collapsed}" @toggle="${this.__toggleCollapsed}">${this.__renderBody(label)}</details>
-      `;
-    }
-    return this.__renderBody(label);
-  }
-
-  /** @private */
-  __renderBody(label) {
-    if (label) {
-      if (!label.id) label.id = `side-nav-label-${generateUniqueId()}`;
-      this.setAttribute('aria-labelledby', label.id);
-    } else {
-      this.removeAttribute('aria-labelledby');
-    }
     return html`
-      <summary part="label" ?hidden="${label == null}">
-        <slot name="label" @slotchange="${() => this.requestUpdate()}"></slot>
-      </summary>
-      <ul part="children">
+      <button
+        part="label"
+        @click="${this._onLabelClick}"
+        aria-expanded="${ifDefined(this.collapsible ? !this.collapsed : null)}"
+        aria-controls="children"
+      >
+        <slot name="label" @slotchange="${this._onLabelSlotChange}"></slot>
+        <span part="toggle" aria-hidden="true"></span>
+      </button>
+      <ul id="children" part="children" ?hidden="${this.collapsed}" aria-hidden="${this.collapsed ? 'true' : 'false'}">
         <slot></slot>
       </ul>
     `;
   }
 
+  /**
+   * @param {Event} event
+   * @return {boolean}
+   * @protected
+   * @override
+   */
+  _shouldSetFocus(event) {
+    return event.composedPath()[0] === this.focusElement;
+  }
+
   /** @private */
-  __toggleCollapsed(e) {
-    this.collapsed = !e.target.open;
+  _onLabelClick() {
+    if (this.collapsible) {
+      this.__toggleCollapsed();
+    }
+  }
+
+  /** @private */
+  _onLabelSlotChange() {
+    const label = this.querySelector('[slot="label"]');
+    if (label) {
+      if (!label.id) {
+        label.id = this._labelId;
+      }
+      this.setAttribute('aria-labelledby', label.id);
+    } else {
+      this.removeAttribute('aria-labelledby');
+    }
+  }
+
+  /** @private */
+  __toggleCollapsed() {
+    this.collapsed = !this.collapsed;
   }
 }
 

--- a/packages/side-nav/test/accessibility.test.js
+++ b/packages/side-nav/test/accessibility.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import '../enable.js';
 import '../vaadin-side-nav-item.js';
 import '../vaadin-side-nav.js';
@@ -21,6 +22,107 @@ describe('accessibility', () => {
       const sideNavWithCustomRole = fixtureSync('<vaadin-side-nav role="custom role"></vaadin-side-nav>');
       await nextRender(sideNavWithCustomRole);
       expect(sideNavWithCustomRole.getAttribute('role')).to.equal('custom role');
+    });
+  });
+
+  describe('label', () => {
+    let sideNav;
+
+    beforeEach(async () => {
+      sideNav = fixtureSync('<vaadin-side-nav></vaadin-side-nav>');
+      await nextRender();
+    });
+
+    it('should not have aria-labelledby attribute by default', () => {
+      expect(sideNav.hasAttribute('aria-labelledby')).to.be.false;
+    });
+
+    it('should set id on the lazily added label element', async () => {
+      const label = document.createElement('label');
+      label.setAttribute('slot', 'label');
+
+      sideNav.appendChild(label);
+      await nextFrame();
+
+      const ID_REGEX = /^side-nav-label-\d+$/u;
+      expect(label.getAttribute('id')).to.match(ID_REGEX);
+    });
+
+    it('should not override custom id on the lazily added label', async () => {
+      const label = document.createElement('label');
+      label.setAttribute('slot', 'label');
+      label.id = 'custom-label';
+
+      sideNav.appendChild(label);
+      await nextFrame();
+
+      expect(label.getAttribute('id')).to.equal('custom-label');
+    });
+
+    it('should set aria-labelledby attribute when adding a label', async () => {
+      const label = document.createElement('label');
+      label.setAttribute('slot', 'label');
+
+      sideNav.appendChild(label);
+      await nextFrame();
+
+      const ID_REGEX = /^side-nav-label-\d+$/u;
+      expect(sideNav.getAttribute('aria-labelledby')).to.match(ID_REGEX);
+      expect(sideNav.getAttribute('aria-labelledby')).to.be.equal(label.id);
+    });
+
+    it('should remove aria-labelledby attribute when removing a label', async () => {
+      const label = document.createElement('label');
+      label.setAttribute('slot', 'label');
+
+      sideNav.appendChild(label);
+      await nextFrame();
+
+      sideNav.removeChild(label);
+      await nextFrame();
+
+      expect(sideNav.hasAttribute('aria-labelledby')).to.be.false;
+    });
+  });
+
+  describe('focus', () => {
+    let wrapper, sideNav, input;
+
+    beforeEach(async () => {
+      wrapper = fixtureSync(`
+        <div>
+          <input />
+          <vaadin-side-nav>
+            <vaadin-side-nav-item path="/foo">Foo</vaadin-side-nav-item>
+            <vaadin-side-nav-item path="/bar">Bar</vaadin-side-nav-item>
+          </vaadin-side-nav>
+        </div>
+      `);
+      await nextRender();
+      [input, sideNav] = wrapper.children;
+    });
+
+    it('should delegate focus to the native button element in shadow root', async () => {
+      input.focus();
+      await sendKeys({ press: 'Tab' });
+      const button = sideNav.shadowRoot.querySelector('button');
+      expect(sideNav.shadowRoot.activeElement).to.be.equal(button);
+    });
+
+    it('should set focused and focus-ring attributes when keyboard focused', async () => {
+      input.focus();
+      await sendKeys({ press: 'Tab' });
+      expect(sideNav.hasAttribute('focused')).to.be.true;
+      expect(sideNav.hasAttribute('focus-ring')).to.be.true;
+    });
+
+    it('should remove focused and and focus-ring attributes when losing focus', async () => {
+      input.focus();
+      await sendKeys({ press: 'Tab' });
+      // Move focus to the side nav item
+      await sendKeys({ press: 'Tab' });
+      expect(sideNav.hasAttribute('focused')).to.be.false;
+      expect(sideNav.hasAttribute('focus-ring')).to.be.false;
     });
   });
 });

--- a/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
@@ -68,11 +68,23 @@ snapshots["vaadin-side-nav host collapsed"] =
 /* end snapshot vaadin-side-nav host collapsed */
 
 snapshots["vaadin-side-nav shadow default"] = 
-`<summary part="label">
+`<button
+  aria-controls="children"
+  part="label"
+>
   <slot name="label">
   </slot>
-</summary>
-<ul part="children">
+  <span
+    aria-hidden="true"
+    part="toggle"
+  >
+  </span>
+</button>
+<ul
+  aria-hidden="false"
+  id="children"
+  part="children"
+>
   <slot>
   </slot>
 </ul>
@@ -80,330 +92,53 @@ snapshots["vaadin-side-nav shadow default"] =
 /* end snapshot vaadin-side-nav shadow default */
 
 snapshots["vaadin-side-nav shadow collapsible"] = 
-`<details open="">
-  <summary part="label">
-    <slot name="label">
-    </slot>
-  </summary>
-  <ul part="children">
-    <slot>
-    </slot>
-  </ul>
-</details>
+`<button
+  aria-controls="children"
+  aria-expanded="true"
+  part="label"
+>
+  <slot name="label">
+  </slot>
+  <span
+    aria-hidden="true"
+    part="toggle"
+  >
+  </span>
+</button>
+<ul
+  aria-hidden="false"
+  id="children"
+  part="children"
+>
+  <slot>
+  </slot>
+</ul>
 `;
 /* end snapshot vaadin-side-nav shadow collapsible */
 
 snapshots["vaadin-side-nav shadow collapsed"] = 
-`<details>
-  <summary part="label">
-    <slot name="label">
-    </slot>
-  </summary>
-  <ul part="children">
-    <slot>
-    </slot>
-  </ul>
-</details>
+`<button
+  aria-controls="children"
+  aria-expanded="false"
+  part="label"
+>
+  <slot name="label">
+  </slot>
+  <span
+    aria-hidden="true"
+    part="toggle"
+  >
+  </span>
+</button>
+<ul
+  aria-hidden="true"
+  hidden=""
+  id="children"
+  part="children"
+>
+  <slot>
+  </slot>
+</ul>
 `;
 /* end snapshot vaadin-side-nav shadow collapsed */
-
-snapshots["vaadin-side-nav-item item default"] = 
-`<vaadin-side-nav-item role="listitem">
-  <vaadin-icon
-    icon="vaadin:chart"
-    slot="prefix"
-  >
-  </vaadin-icon>
-  Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
-    2
-  </span>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 1
-  </vaadin-side-nav-item>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 2
-  </vaadin-side-nav-item>
-</vaadin-side-nav-item>
-`;
-/* end snapshot vaadin-side-nav-item item default */
-
-snapshots["vaadin-side-nav-item item expanded"] = 
-`<vaadin-side-nav-item role="listitem">
-  <vaadin-icon
-    icon="vaadin:chart"
-    slot="prefix"
-  >
-  </vaadin-icon>
-  Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
-    2
-  </span>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 1
-  </vaadin-side-nav-item>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 2
-  </vaadin-side-nav-item>
-</vaadin-side-nav-item>
-`;
-/* end snapshot vaadin-side-nav-item item expanded */
-
-snapshots["vaadin-side-nav-item item active"] = 
-`<vaadin-side-nav-item role="listitem">
-  <vaadin-icon
-    icon="vaadin:chart"
-    slot="prefix"
-  >
-  </vaadin-icon>
-  Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
-    2
-  </span>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 1
-  </vaadin-side-nav-item>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 2
-  </vaadin-side-nav-item>
-</vaadin-side-nav-item>
-`;
-/* end snapshot vaadin-side-nav-item item active */
-
-snapshots["vaadin-side-nav-item item passive"] = 
-`<vaadin-side-nav-item role="listitem">
-  <vaadin-icon
-    icon="vaadin:chart"
-    slot="prefix"
-  >
-  </vaadin-icon>
-  Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
-    2
-  </span>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 1
-  </vaadin-side-nav-item>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 2
-  </vaadin-side-nav-item>
-</vaadin-side-nav-item>
-`;
-/* end snapshot vaadin-side-nav-item item passive */
-
-snapshots["vaadin-side-nav-item item with path"] = 
-`<vaadin-side-nav-item role="listitem">
-  <vaadin-icon
-    icon="vaadin:chart"
-    slot="prefix"
-  >
-  </vaadin-icon>
-  Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
-    2
-  </span>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 1
-  </vaadin-side-nav-item>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 2
-  </vaadin-side-nav-item>
-</vaadin-side-nav-item>
-`;
-/* end snapshot vaadin-side-nav-item item with path */
-
-snapshots["vaadin-side-nav-item shadow default"] = 
-`<a
-  aria-current="false"
-  part="item"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="false"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<slot
-  hidden=""
-  id="children"
-  name="children"
-  part="children"
-  role="list"
->
-</slot>
-`;
-/* end snapshot vaadin-side-nav-item shadow default */
-
-snapshots["vaadin-side-nav-item shadow expanded"] = 
-`<a
-  aria-current="false"
-  part="item"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="false"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<slot
-  hidden=""
-  id="children"
-  name="children"
-  part="children"
-  role="list"
->
-</slot>
-`;
-/* end snapshot vaadin-side-nav-item shadow expanded */
-
-snapshots["vaadin-side-nav-item shadow active"] = 
-`<a
-  aria-current="false"
-  part="item"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="false"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<slot
-  hidden=""
-  id="children"
-  name="children"
-  part="children"
-  role="list"
->
-</slot>
-`;
-/* end snapshot vaadin-side-nav-item shadow active */
-
-snapshots["vaadin-side-nav-item shadow passive"] = 
-`<a
-  aria-current="false"
-  part="item"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="false"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<slot
-  hidden=""
-  id="children"
-  name="children"
-  part="children"
-  role="list"
->
-</slot>
-`;
-/* end snapshot vaadin-side-nav-item shadow passive */
-
-snapshots["vaadin-side-nav-item shadow with path"] = 
-`<a
-  aria-current="false"
-  part="item"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="false"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<slot
-  hidden=""
-  id="children"
-  name="children"
-  part="children"
-  role="list"
->
-</slot>
-`;
-/* end snapshot vaadin-side-nav-item shadow with path */
 

--- a/packages/side-nav/test/side-nav.test.js
+++ b/packages/side-nav/test/side-nav.test.js
@@ -7,7 +7,7 @@ import '../vaadin-side-nav.js';
 describe('side-nav', () => {
   let sideNav;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     sideNav = fixtureSync(`
       <vaadin-side-nav collapsible>
         <span slot="label">Main menu</span>
@@ -15,6 +15,7 @@ describe('side-nav', () => {
         <vaadin-side-nav-item>Item 2</vaadin-side-nav-item>
       </vaadin-side-nav>
     `);
+    await nextRender();
   });
 
   describe('custom element definition', () => {
@@ -34,11 +35,41 @@ describe('side-nav', () => {
   });
 
   describe('collapsing', () => {
+    let label;
+
+    beforeEach(() => {
+      label = sideNav.shadowRoot.querySelector('[part="label"]');
+    });
+
+    it('should set collapsed property to true on button element click', async () => {
+      label.click();
+      await sideNav.updateComplete;
+      expect(sideNav.collapsed).to.be.true;
+    });
+
+    it('should set collapsed property to false on subsequent button click', async () => {
+      label.click();
+      await sideNav.updateComplete;
+      expect(sideNav.collapsed).to.be.true;
+
+      label.click();
+      await sideNav.updateComplete;
+      expect(sideNav.collapsed).to.be.false;
+    });
+
+    it('should reflect collapsed property to the corresponding attribute', async () => {
+      expect(sideNav.hasAttribute('collapsed')).to.be.false;
+
+      label.click();
+      await sideNav.updateComplete;
+      expect(sideNav.hasAttribute('collapsed')).to.be.true;
+    });
+
     it('should dispatch collapsed-changed event when collapsed changes', async () => {
       const spy = sinon.spy();
       sideNav.addEventListener('collapsed-changed', spy);
-      await nextRender(sideNav);
-      sideNav.shadowRoot.querySelector('summary[part="label"]').click();
+      label.click();
+      await sideNav.updateComplete;
       expect(spy.calledOnce).to.be.true;
     });
   });

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-styles.js
@@ -114,49 +114,58 @@ export const sideNavStyles = css`
     -webkit-tap-highlight-color: transparent;
   }
 
-  summary {
-    cursor: var(--lumo-clickable-cursor, default);
+  [part='label'] {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    outline: none;
+    box-sizing: border-box;
     border-radius: var(--lumo-border-radius-m);
+    font-family: var(--lumo-font-family);
+    font-size: var(--lumo-font-size-s);
+    font-weight: 500;
+    line-height: var(--lumo-line-height-xs);
   }
 
-  summary ::slotted([slot='label']) {
-    font-size: var(--lumo-font-size-s);
+  [part='label'] ::slotted([slot='label']) {
     color: var(--lumo-secondary-text-color);
     margin: var(--lumo-space-s);
-    border-radius: inherit;
   }
 
-  summary::after {
-    font-family: lumo-icons;
-    color: var(--lumo-tertiary-text-color);
-    font-size: var(--lumo-icon-size-m);
+  :host([focus-ring]) [part='label'] {
+    box-shadow: 0 0 0 2px var(--lumo-primary-color-50pct);
+  }
+
+  [part='toggle'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: var(--lumo-size-s);
     height: var(--lumo-size-s);
-    transition: transform 140ms;
-    margin: 0 var(--lumo-space-xs);
+    margin-inline-start: auto;
+    margin-inline-end: var(--lumo-space-xs);
+    font-size: var(--lumo-icon-size-m);
+    line-height: 1;
+    color: var(--lumo-contrast-60pct);
+    font-family: 'lumo-icons';
+    cursor: var(--lumo-clickable-cursor);
   }
 
-  :host([collapsible]) summary::after {
-    content: var(--lumo-icons-dropdown);
+  [part='toggle']::before {
+    content: var(--lumo-icons-angle-right);
+  }
+
+  :host(:not([collapsible])) [part='toggle'] {
+    display: none !important;
+  }
+
+  :host(:not([collapsed])) [part='toggle'] {
+    transform: rotate(90deg);
   }
 
   @media (any-hover: hover) {
-    summary:hover::after {
+    [part='label']:hover [part='toggle'] {
       color: var(--lumo-body-text-color);
-    }
-  }
-
-  :host([collapsed]) summary::after {
-    transform: rotate(-90deg);
-  }
-
-  @supports selector(:focus-visible) {
-    summary {
-      outline: none;
-    }
-
-    summary:focus-visible {
-      box-shadow: 0 0 0 2px var(--lumo-primary-color-50pct);
     }
   }
 `;


### PR DESCRIPTION
## Description

Closes #5809

Related to https://github.com/vaadin/web-components/issues/5809#issuecomment-1587086297

Replaced usage of `<details>` and `<summary>` elements with a mechanism similar to `vaadin-accordion-panel`:

1. Added logic to delegate focus to `<button>` in shadow DOM using `delegatesFocus: true` in shadow root options;
2. Added `FocusMixin` and implement `_shouldSetFocus()` to set `focused` and `focus-ring` attributes appropriately;
3. Adjusted Lumo theme accordingly, especially styles for the toggle button (for now copied from `vaadin-details`);
4. Added missing tests for `label` element ID and for the newly added logic to handle focus and related attributes.

## Type of change

- Refactor / behavior altering change

## Note

Tested in VoiceOver and it works the same as before:

<img width="388" alt="voiceover-new" src="https://github.com/vaadin/web-components/assets/10589913/91cd8d48-195a-437b-8857-a6eb16d5931e">