### PR TITLE
refactor!: move button outside the anchor, add content part

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -191,7 +191,7 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
         </a>
         <button
           part="toggle-button"
-          @click="${this.__toggleExpanded}"
+          @click="${this._onButtonClick}"
           aria-controls="children"
           aria-expanded="${this.expanded}"
           aria-label="Toggle child items"
@@ -204,19 +204,23 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
   }
 
   /** @private */
-  _onContentClick(event) {
-    const [link, button] = event.currentTarget.children;
+  _onButtonClick(event) {
+    // Prevent the event from being handled
+    // by the content click listener below
+    event.stopPropagation();
+    this.__toggleExpanded();
+  }
 
-    // Toggle item expanded state unless the click event is captured by the link
-    if (!link.hasAttribute('href') && this.hasAttribute('has-children')) {
-      button.click();
+  /** @private */
+  _onContentClick() {
+    // Toggle item expanded state unless the link has a non-empty path
+    if (this.path == null && this.hasAttribute('has-children')) {
+      this.__toggleExpanded();
     }
   }
 
   /** @private */
-  __toggleExpanded(e) {
-    e.preventDefault();
-    e.stopPropagation();
+  __toggleExpanded() {
     this.expanded = !this.expanded;
   }
 

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -183,10 +183,12 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
   /** @protected */
   render() {
     return html`
-      <a href="${ifDefined(this.path)}" part="link" aria-current="${this.active ? 'page' : 'false'}">
-        <slot name="prefix"></slot>
-        <slot></slot>
-        <slot name="suffix"></slot>
+      <div part="content" @click="${this._onContentClick}">
+        <a href="${ifDefined(this.path)}" part="link" aria-current="${this.active ? 'page' : 'false'}">
+          <slot name="prefix"></slot>
+          <slot></slot>
+          <slot name="suffix"></slot>
+        </a>
         <button
           part="toggle-button"
           @click="${this.__toggleExpanded}"
@@ -194,11 +196,21 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
           aria-expanded="${this.expanded}"
           aria-label="Toggle child items"
         ></button>
-      </a>
+      </div>
       <ul part="children" ?hidden="${!this.expanded}">
         <slot name="children"></slot>
       </ul>
     `;
+  }
+
+  /** @private */
+  _onContentClick(event) {
+    const [link, button] = event.currentTarget.children;
+
+    // Toggle item expanded state unless the click event is captured by the link
+    if (!link.hasAttribute('href') && this.hasAttribute('has-children')) {
+      button.click();
+    }
   }
 
   /** @private */

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -104,239 +104,6 @@ snapshots["vaadin-side-nav-item item active"] =
 `;
 /* end snapshot vaadin-side-nav-item item active */
 
-snapshots["vaadin-side-nav-item item passive"] = 
-`<vaadin-side-nav-item role="listitem">
-  <vaadin-icon
-    icon="vaadin:chart"
-    slot="prefix"
-  >
-  </vaadin-icon>
-  Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
-    2
-  </span>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 1
-  </vaadin-side-nav-item>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 2
-  </vaadin-side-nav-item>
-</vaadin-side-nav-item>
-`;
-/* end snapshot vaadin-side-nav-item item passive */
-
-snapshots["vaadin-side-nav-item item with path"] = 
-`<vaadin-side-nav-item role="listitem">
-  <vaadin-icon
-    icon="vaadin:chart"
-    slot="prefix"
-  >
-  </vaadin-icon>
-  Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
-    2
-  </span>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 1
-  </vaadin-side-nav-item>
-  <vaadin-side-nav-item
-    role="listitem"
-    slot="children"
-  >
-    Child item 2
-  </vaadin-side-nav-item>
-</vaadin-side-nav-item>
-`;
-/* end snapshot vaadin-side-nav-item item with path */
-
-snapshots["vaadin-side-nav-item shadow default"] = 
-`<a
-  aria-current="false"
-  part="link"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="false"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<ul
-  hidden=""
-  part="children"
->
-  <slot name="children">
-  </slot>
-</ul>
-`;
-/* end snapshot vaadin-side-nav-item shadow default */
-
-snapshots["vaadin-side-nav-item shadow expanded"] = 
-`<a
-  aria-current="false"
-  part="link"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="true"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<ul part="children">
-  <slot name="children">
-  </slot>
-</ul>
-`;
-/* end snapshot vaadin-side-nav-item shadow expanded */
-
-snapshots["vaadin-side-nav-item shadow active"] = 
-`<a
-  aria-current="page"
-  href=""
-  part="link"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="true"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<ul part="children">
-  <slot name="children">
-  </slot>
-</ul>
-`;
-/* end snapshot vaadin-side-nav-item shadow active */
-
-snapshots["vaadin-side-nav-item shadow passive"] = 
-`<a
-  aria-current="false"
-  part="item"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="false"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<slot
-  hidden=""
-  id="children"
-  name="children"
-  part="children"
-  role="list"
->
-</slot>
-`;
-/* end snapshot vaadin-side-nav-item shadow passive */
-
-snapshots["vaadin-side-nav-item shadow with path"] = 
-`<a
-  aria-current="false"
-  href="path"
-  part="item"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="false"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<slot
-  hidden=""
-  id="children"
-  name="children"
-  part="children"
-  role="list"
->
-</slot>
-`;
-/* end snapshot vaadin-side-nav-item shadow with path */
-
-snapshots["vaadin-side-nav-item shadow path"] = 
-`<a
-  aria-current="false"
-  href="path"
-  part="link"
->
-  <slot name="prefix">
-  </slot>
-  <slot>
-  </slot>
-  <slot name="suffix">
-  </slot>
-  <button
-    aria-controls="children"
-    aria-expanded="false"
-    aria-label="Toggle child items"
-    part="toggle-button"
-  >
-  </button>
-</a>
-<ul
-  hidden=""
-  part="children"
->
-  <slot name="children">
-  </slot>
-</ul>
-`;
-/* end snapshot vaadin-side-nav-item shadow path */
-
 snapshots["vaadin-side-nav-item item path"] = 
 `<vaadin-side-nav-item
   has-children=""
@@ -369,4 +136,124 @@ snapshots["vaadin-side-nav-item item path"] =
 </vaadin-side-nav-item>
 `;
 /* end snapshot vaadin-side-nav-item item path */
+
+snapshots["vaadin-side-nav-item shadow default"] = 
+`<div part="content">
+  <a
+    aria-current="false"
+    part="link"
+  >
+    <slot name="prefix">
+    </slot>
+    <slot>
+    </slot>
+    <slot name="suffix">
+    </slot>
+  </a>
+  <button
+    aria-controls="children"
+    aria-expanded="false"
+    aria-label="Toggle child items"
+    part="toggle-button"
+  >
+  </button>
+</div>
+<ul
+  hidden=""
+  part="children"
+>
+  <slot name="children">
+  </slot>
+</ul>
+`;
+/* end snapshot vaadin-side-nav-item shadow default */
+
+snapshots["vaadin-side-nav-item shadow expanded"] = 
+`<div part="content">
+  <a
+    aria-current="false"
+    part="link"
+  >
+    <slot name="prefix">
+    </slot>
+    <slot>
+    </slot>
+    <slot name="suffix">
+    </slot>
+  </a>
+  <button
+    aria-controls="children"
+    aria-expanded="true"
+    aria-label="Toggle child items"
+    part="toggle-button"
+  >
+  </button>
+</div>
+<ul part="children">
+  <slot name="children">
+  </slot>
+</ul>
+`;
+/* end snapshot vaadin-side-nav-item shadow expanded */
+
+snapshots["vaadin-side-nav-item shadow active"] = 
+`<div part="content">
+  <a
+    aria-current="page"
+    href=""
+    part="link"
+  >
+    <slot name="prefix">
+    </slot>
+    <slot>
+    </slot>
+    <slot name="suffix">
+    </slot>
+  </a>
+  <button
+    aria-controls="children"
+    aria-expanded="true"
+    aria-label="Toggle child items"
+    part="toggle-button"
+  >
+  </button>
+</div>
+<ul part="children">
+  <slot name="children">
+  </slot>
+</ul>
+`;
+/* end snapshot vaadin-side-nav-item shadow active */
+
+snapshots["vaadin-side-nav-item shadow path"] = 
+`<div part="content">
+  <a
+    aria-current="false"
+    href="path"
+    part="link"
+  >
+    <slot name="prefix">
+    </slot>
+    <slot>
+    </slot>
+    <slot name="suffix">
+    </slot>
+  </a>
+  <button
+    aria-controls="children"
+    aria-expanded="false"
+    aria-label="Toggle child items"
+    part="toggle-button"
+  >
+  </button>
+</div>
+<ul
+  hidden=""
+  part="children"
+>
+  <slot name="children">
+  </slot>
+</ul>
+`;
+/* end snapshot vaadin-side-nav-item shadow path */
 

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -176,21 +176,26 @@ describe('side-nav-item', () => {
         toggle = item.shadowRoot.querySelector('button');
       });
 
-      it('should click toggle on content click when item has children', () => {
-        const spy = sinon.spy(toggle, 'click');
+      it('should toggle expanded state on content click when item has children', async () => {
+        expect(item.expanded).to.be.false;
+
         content.click();
-        expect(spy.calledOnce).to.be.true;
+        await item.updateComplete;
+        expect(item.expanded).to.be.true;
+
+        content.click();
+        await item.updateComplete;
+        expect(item.expanded).to.be.false;
       });
 
-      it('should not click toggle on content click when item has valid path', async () => {
+      it('should not change expanded state on content click when item has valid path', async () => {
         item.path = '/foo';
         await item.updateComplete;
-        const spy = sinon.spy(toggle, 'click');
         content.click();
-        expect(spy.called).to.be.false;
+        expect(item.expanded).to.be.false;
       });
 
-      it('should not click toggle on content click when item has no children', async () => {
+      it('should not change expanded state on content click when item has no children', async () => {
         [...item.children].forEach((child) => child.remove());
         await nextRender();
         const spy = sinon.spy(toggle, 'click');

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -134,8 +134,6 @@ describe('side-nav-item', () => {
     });
 
     describe('active item with children', () => {
-      let item;
-
       beforeEach(async () => {
         item = fixtureSync(`
           <vaadin-side-nav-item path="">
@@ -160,6 +158,44 @@ describe('side-nav-item', () => {
         toggle.click();
         toggle.click();
         expect(item.expanded).to.be.true;
+      });
+    });
+
+    describe('content part', () => {
+      let content;
+
+      beforeEach(async () => {
+        item = fixtureSync(`
+          <vaadin-side-nav-item>
+            <vaadin-side-nav-item slot="children">Child 1</vaadin-side-nav-item>
+            <vaadin-side-nav-item slot="children">Child 2</vaadin-side-nav-item>
+          </vaadin-side-nav-item>
+        `);
+        await nextRender();
+        content = item.shadowRoot.querySelector('[part="content"]');
+        toggle = item.shadowRoot.querySelector('button');
+      });
+
+      it('should click toggle on content click when item has children', () => {
+        const spy = sinon.spy(toggle, 'click');
+        content.click();
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should not click toggle on content click when item has valid path', async () => {
+        item.path = '/foo';
+        await item.updateComplete;
+        const spy = sinon.spy(toggle, 'click');
+        content.click();
+        expect(spy.called).to.be.false;
+      });
+
+      it('should not click toggle on content click when item has no children', async () => {
+        [...item.children].forEach((child) => child.remove());
+        await nextRender();
+        const spy = sinon.spy(toggle, 'click');
+        content.click();
+        expect(spy.called).to.be.false;
       });
     });
   });

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -173,7 +173,6 @@ describe('side-nav-item', () => {
         `);
         await nextRender();
         content = item.shadowRoot.querySelector('[part="content"]');
-        toggle = item.shadowRoot.querySelector('button');
       });
 
       it('should toggle expanded state on content click when item has children', async () => {

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -7,7 +7,12 @@ import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const sideNavItemStyles = css`
+  [part='content'] {
+    display: flex;
+  }
+
   [part='link'] {
+    width: 100%;
     gap: var(--lumo-space-xs);
     padding: var(--lumo-space-s);
     padding-inline-start: calc(var(--lumo-space-s) + var(--_child-indent, 0px));
@@ -18,6 +23,7 @@ export const sideNavItemStyles = css`
   }
 
   button {
+    position: relative;
     border: 0;
     margin: calc((var(--lumo-icon-size-m) - var(--lumo-size-s)) / 2) 0;
     margin-inline-end: calc(var(--lumo-space-xs) * -1);
@@ -29,6 +35,14 @@ export const sideNavItemStyles = css`
     height: var(--lumo-size-s);
     cursor: var(--lumo-clickable-cursor, default);
     transition: color 140ms;
+  }
+
+  :host([has-children]) [part='item'] {
+    padding-inline-end: var(--lumo-space-s);
+  }
+
+  :host([has-children]) a {
+    width: calc(100% - var(--lumo-size-s));
   }
 
   @media (any-hover: hover) {

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -9,6 +9,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 export const sideNavItemStyles = css`
   [part='content'] {
     display: flex;
+    align-items: center;
   }
 
   [part='link'] {

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -37,7 +37,7 @@ export const sideNavItemStyles = css`
     transition: color 140ms;
   }
 
-  :host([has-children]) [part='item'] {
+  :host([has-children]) [part='content'] {
     padding-inline-end: var(--lumo-space-s);
   }
 

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -42,10 +42,6 @@ export const sideNavItemStyles = css`
     padding-inline-end: var(--lumo-space-s);
   }
 
-  :host([has-children]) a {
-    width: calc(100% - var(--lumo-size-s));
-  }
-
   @media (any-hover: hover) {
     [part='link']:hover {
       color: var(--lumo-header-text-color);


### PR DESCRIPTION
## Description

Related to #5814

1. Moved `<button>` element outside the `<a>` element in `vaadin-side-nav-item`
2. Added extra wrapper with `part="content"` (name inspired by `vaadin-item` etc)
3. Added logic to catch click event on the `part="content"` and forward it to button

## Type of change

- Refactor, behavior altering changee