### PR TITLE
refactor!: rename anchor item part to link, update Lumo to use it

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -14,7 +14,7 @@ export const sideNavItemBaseStyles = css`
     display: none !important;
   }
 
-  a {
+  [part='link'] {
     flex: auto;
     min-width: 0;
     display: flex;

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -183,7 +183,7 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
   /** @protected */
   render() {
     return html`
-      <a href="${ifDefined(this.path)}" part="item" aria-current="${this.active ? 'page' : 'false'}">
+      <a href="${ifDefined(this.path)}" part="link" aria-current="${this.active ? 'page' : 'false'}">
         <slot name="prefix"></slot>
         <slot></slot>
         <slot name="suffix"></slot>

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -167,7 +167,7 @@ snapshots["vaadin-side-nav-item item with path"] =
 snapshots["vaadin-side-nav-item shadow default"] = 
 `<a
   aria-current="false"
-  part="item"
+  part="link"
 >
   <slot name="prefix">
   </slot>
@@ -196,7 +196,7 @@ snapshots["vaadin-side-nav-item shadow default"] =
 snapshots["vaadin-side-nav-item shadow expanded"] = 
 `<a
   aria-current="false"
-  part="item"
+  part="link"
 >
   <slot name="prefix">
   </slot>
@@ -223,7 +223,7 @@ snapshots["vaadin-side-nav-item shadow active"] =
 `<a
   aria-current="page"
   href=""
-  part="item"
+  part="link"
 >
   <slot name="prefix">
   </slot>
@@ -311,7 +311,7 @@ snapshots["vaadin-side-nav-item shadow path"] =
 `<a
   aria-current="false"
   href="path"
-  part="item"
+  part="link"
 >
   <slot name="prefix">
   </slot>

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -7,7 +7,7 @@ import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const sideNavItemStyles = css`
-  a {
+  [part='link'] {
     gap: var(--lumo-space-xs);
     padding: var(--lumo-space-s);
     padding-inline-start: calc(var(--lumo-space-s) + var(--_child-indent, 0px));
@@ -32,7 +32,7 @@ export const sideNavItemStyles = css`
   }
 
   @media (any-hover: hover) {
-    a:hover {
+    [part='link']:hover {
       color: var(--lumo-header-text-color);
     }
 
@@ -41,7 +41,7 @@ export const sideNavItemStyles = css`
     }
   }
 
-  a:active:focus {
+  [part='link']:active:focus {
     background-color: var(--lumo-contrast-5pct);
   }
 
@@ -60,19 +60,19 @@ export const sideNavItemStyles = css`
   }
 
   @supports selector(:focus-visible) {
-    a,
+    [part='link'],
     button {
       outline: none;
     }
 
-    a:focus-visible,
+    [part='link']:focus-visible,
     button:focus-visible {
       border-radius: var(--lumo-border-radius-m);
       box-shadow: 0 0 0 2px var(--lumo-primary-color-50pct);
     }
   }
 
-  a:active {
+  [part='link']:active {
     color: var(--lumo-header-text-color);
   }
 
@@ -96,7 +96,7 @@ export const sideNavItemStyles = css`
     --_child-indent-2: var(--_child-indent);
   }
 
-  :host([active]) a {
+  :host([active]) [part='link'] {
     color: var(--lumo-primary-text-color);
     background-color: var(--lumo-primary-color-10pct);
   }


### PR DESCRIPTION
## Description

Extracted from #5991

1. Renamed `item` part to `link` which is more semantically correct,
2. Updated theme to use `[part]` selector instead of the `<a>` tag

## Type of change

- Breaking change

## Note

As `vaadin-side-nav` is still behind the feature flag, this is OK to release in minor.