### PR TITLE
refactor: rename side-nav toggle part to align with the item

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -122,7 +122,7 @@ class SideNav extends FocusMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElem
         aria-controls="children"
       >
         <slot name="label" @slotchange="${this._onLabelSlotChange}"></slot>
-        <span part="toggle" aria-hidden="true"></span>
+        <span part="toggle-button" aria-hidden="true"></span>
       </button>
       <ul id="children" part="children" ?hidden="${this.collapsed}" aria-hidden="${this.collapsed ? 'true' : 'false'}">
         <slot></slot>

--- a/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
@@ -76,7 +76,7 @@ snapshots["vaadin-side-nav shadow default"] =
   </slot>
   <span
     aria-hidden="true"
-    part="toggle"
+    part="toggle-button"
   >
   </span>
 </button>
@@ -101,7 +101,7 @@ snapshots["vaadin-side-nav shadow collapsible"] =
   </slot>
   <span
     aria-hidden="true"
-    part="toggle"
+    part="toggle-button"
   >
   </span>
 </button>
@@ -126,7 +126,7 @@ snapshots["vaadin-side-nav shadow collapsed"] =
   </slot>
   <span
     aria-hidden="true"
-    part="toggle"
+    part="toggle-button"
   >
   </span>
 </button>

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-styles.js
@@ -38,7 +38,7 @@ export const sideNavStyles = css`
     box-shadow: 0 0 0 2px var(--lumo-primary-color-50pct);
   }
 
-  [part='toggle'] {
+  [part='toggle-button'] {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -53,20 +53,20 @@ export const sideNavStyles = css`
     cursor: var(--lumo-clickable-cursor);
   }
 
-  [part='toggle']::before {
+  [part='toggle-button']::before {
     content: var(--lumo-icons-angle-right);
   }
 
-  :host(:not([collapsible])) [part='toggle'] {
+  :host(:not([collapsible])) [part='toggle-button'] {
     display: none !important;
   }
 
-  :host(:not([collapsed])) [part='toggle'] {
+  :host(:not([collapsed])) [part='toggle-button'] {
     transform: rotate(90deg);
   }
 
   @media (any-hover: hover) {
-    [part='label']:hover [part='toggle'] {
+    [part='label']:hover [part='toggle-button'] {
       color: var(--lumo-body-text-color);
     }
   }


### PR DESCRIPTION
## Description

Follow-up to #5978

Currently there are two similar part names that aren't named consistently:

https://github.com/vaadin/web-components/blob/316e453ce2b49eb18a20b241dcbda25e51afbe5a/packages/side-nav/src/vaadin-side-nav.js#L125

https://github.com/vaadin/web-components/blob/316e453ce2b49eb18a20b241dcbda25e51afbe5a/packages/side-nav/src/vaadin-side-nav-item.js#L190-L191

Let's use `toggle-button` which is also aligned with `vaadin-combo-box` and other overlay components.

## Type of change

- Refactor