### PR TITLE
refactor: remove no longer needed children slot styles

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -66,12 +66,6 @@ export const sideNavItemBaseStyles = css`
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-
-  slot[name='children'] {
-    /* Needed to make role="list" work */
-    display: block;
-    width: 100%;
-  }
 `;
 
 export const sideNavBaseStyles = css`


### PR DESCRIPTION
## Description

Follow-up to #5975

As you can see in that PR, `<ul>` element was added to two components.
These styles are leftovers as I forgot to remove them. Let's fix this now.

## Type of change

- Refactor