### PR TITLE
fix: avoid opened changed events when moving dialog within DOM

### DIFF
--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -549,6 +549,10 @@ describe('vaadin-confirm-dialog', () => {
         await oneEvent(overlay, 'vaadin-overlay-open');
       });
 
+      afterEach(() => {
+        confirm.opened = false;
+      });
+
       it('should update width after opening the dialog', () => {
         confirm._contentWidth = '300px';
         expect(getComputedStyle(overlay.$.overlay).width).to.be.equal('300px');

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -269,9 +269,15 @@ class Dialog extends OverlayClassMixin(
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-    // Close overlay and memorize opened state
-    this.__restoreOpened = this.opened;
-    this.opened = false;
+    // Automatically close the overlay when dialog is removed from DOM
+    // Using a timeout to avoid toggling opened state, and dispatching change
+    // events, when just moving the dialog in the DOM
+    setTimeout(() => {
+      if (!this.isConnected) {
+        this.__restoreOpened = this.opened;
+        this.opened = false;
+      }
+    });
   }
 
   /** @private */


### PR DESCRIPTION
## Description

Currently `vaadin-dialog` closes its overlay when it is removed from the DOM and opens it again when being added to the DOM again. When just moving the dialog within the DOM that results in two additional `opened-changed` events being fired. That in turn is problematic when using nested dialogs in Flow, where all elements are first added to the dialog root element, and then moved to the overlay by the dialog render function. In that case every dialog that is added to another dialog will effectively dispatch three opened changed events (1 initial, 2 from being moved within DOM).

Arguably a dialog should not dispatch these events when just being moved within the DOM. This PR changes the dialog to use a timeout to detect whether it was just moved within the DOM or actually removed, and only changes the `opened` state if it stays disconnected.

There is a similar opened state restoration logic in other components that have not been changed:
- in `vaadin-login-overlay` changing `opened` state does not trigger events
- `vaadin-context-menu` uses the `_setOpened` function for changing the opened state, which does not trigger events

Fixes https://github.com/vaadin/flow-components/issues/5103

## Type of change

- Bugfix