### PR TITLE
feat: add url utils

### DIFF
--- a/packages/component-base/src/url-utils.d.ts
+++ b/packages/component-base/src/url-utils.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Check if two paths match
+ */
+export declare function arePathsMatching(path1: string, path2: string): boolean;

--- a/packages/component-base/src/url-utils.d.ts
+++ b/packages/component-base/src/url-utils.d.ts
@@ -7,4 +7,4 @@
 /**
  * Check if two paths match
  */
-export declare function arePathsMatching(path1: string, path2: string): boolean;
+export declare function matchPaths(path1: string, path2: string): boolean;

--- a/packages/component-base/src/url-utils.js
+++ b/packages/component-base/src/url-utils.js
@@ -10,7 +10,7 @@
  * @param {string} path1
  * @param {string} path2
  */
-export function comparePaths(path1, path2) {
+export function matchPaths(path1, path2) {
   const base = document.baseURI;
   return new URL(path1, base).pathname === new URL(path2, base).pathname;
 }

--- a/packages/component-base/src/url-utils.js
+++ b/packages/component-base/src/url-utils.js
@@ -10,7 +10,7 @@
  * @param {string} path1
  * @param {string} path2
  */
-export function arePathsMatching(path1, path2) {
+export function comparePaths(path1, path2) {
   const base = document.baseURI;
   return new URL(path1, base).pathname === new URL(path2, base).pathname;
 }

--- a/packages/component-base/src/url-utils.js
+++ b/packages/component-base/src/url-utils.js
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Check if two paths match
+ *
+ * @param {string} path1
+ * @param {string} path2
+ */
+export function arePathsMatching(path1, path2) {
+  const base = document.baseURI;
+  return new URL(path1, base).pathname === new URL(path2, base).pathname;
+}

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 import { arePathsMatching } from '../src/url-utils.js';
 
 describe('url-utils', () => {
@@ -28,6 +29,11 @@ describe('url-utils', () => {
         expect(arePathsMatching(pathWithoutLeadingSlash, pathWithLeadingSlash)).to.be.true;
         expect(arePathsMatching(pathWithLeadingSlash, pathWithoutLeadingSlash)).to.be.true;
       });
+    });
+
+    it('should ignore base uri in paths', () => {
+      sinon.stub(document, 'baseURI').value('https://base');
+      expect(arePathsMatching('https://base/path', 'path')).to.be.true;
     });
   });
 });

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -31,11 +31,15 @@ describe('url-utils', () => {
       });
     });
 
-    it('should use document.baseURI as a base url', () => {
-      sinon.stub(document, 'baseURI').value('https://vaadin.com/docs/');
-      const pathsMatching = arePathsMatching('https://vaadin.com/docs/components', 'components');
-      sinon.restore();
-      expect(pathsMatching).to.be.true;
+    describe('base url', () => {
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('should use document.baseURI as a base url', () => {
+        sinon.stub(document, 'baseURI').value('https://vaadin.com/docs/');
+        expect(arePathsMatching('https://vaadin.com/docs/components', 'components')).to.be.true;
+      });
     });
   });
 });

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -32,12 +32,18 @@ describe('url-utils', () => {
     });
 
     describe('base url', () => {
+      let baseUri;
+
+      beforeEach(() => {
+        baseUri = sinon.stub(document, 'baseURI');
+      });
+
       afterEach(() => {
-        sinon.restore();
+        baseUri.restore();
       });
 
       it('should use document.baseURI as a base url', () => {
-        sinon.stub(document, 'baseURI').value('https://vaadin.com/docs/');
+        baseUri.value('https://vaadin.com/docs/');
         expect(arePathsMatching('https://vaadin.com/docs/components', 'components')).to.be.true;
       });
     });

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -13,7 +13,7 @@ describe('url-utils', () => {
       expect(arePathsMatching('/path1', '/path2')).to.be.false;
     });
 
-    it('should return true if only one of the paths has trailing and leading spaces', () => {
+    it('should ignore leading and trailing spaces in paths', () => {
       paths.forEach((path) => {
         const pathWithExtraSpace = ` ${path} `;
         expect(arePathsMatching(pathWithExtraSpace, path)).to.be.true;
@@ -21,7 +21,7 @@ describe('url-utils', () => {
       });
     });
 
-    it('should return true if only one of the paths has a leading slash', () => {
+    it('should ignore a leading slash in paths', () => {
       paths.forEach((path) => {
         const pathWithoutLeadingSlash = path.startsWith('/') ? path.substring(1) : path;
         const pathWithLeadingSlash = path.startsWith('/') ? path : `/${path}`;

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -32,8 +32,8 @@ describe('url-utils', () => {
     });
 
     it('should ignore base uri in paths', () => {
-      sinon.stub(document, 'baseURI').value('https://base');
-      expect(arePathsMatching('https://base/path', 'path')).to.be.true;
+      sinon.stub(document, 'baseURI').value('https://vaadin.com/docs');
+      expect(arePathsMatching('https://vaadin.com/docs/components', 'components')).to.be.true;
     });
   });
 });

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -1,0 +1,33 @@
+import { expect } from '@esm-bundle/chai';
+import { arePathsMatching } from '../src/url-utils.js';
+
+describe('url-utils', () => {
+  describe('arePathsMatching', () => {
+    const paths = ['', '/', '/path', 'base/path'];
+
+    it('should return true when paths match', () => {
+      paths.forEach((path) => expect(arePathsMatching(path, path)).to.be.true);
+    });
+
+    it('should return false when paths do not match', () => {
+      expect(arePathsMatching('/path1', '/path2')).to.be.false;
+    });
+
+    it('should return true if only one of the paths has trailing and leading spaces', () => {
+      paths.forEach((path) => {
+        const pathWithExtraSpace = ` ${path} `;
+        expect(arePathsMatching(pathWithExtraSpace, path)).to.be.true;
+        expect(arePathsMatching(path, pathWithExtraSpace)).to.be.true;
+      });
+    });
+
+    it('should return true if only one of the paths has a leading slash', () => {
+      paths.forEach((path) => {
+        const pathWithoutLeadingSlash = path.startsWith('/') ? path.substring(1) : path;
+        const pathWithLeadingSlash = path.startsWith('/') ? path : `/${path}`;
+        expect(arePathsMatching(pathWithoutLeadingSlash, pathWithLeadingSlash)).to.be.true;
+        expect(arePathsMatching(pathWithLeadingSlash, pathWithoutLeadingSlash)).to.be.true;
+      });
+    });
+  });
+});

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -31,7 +31,7 @@ describe('url-utils', () => {
       });
     });
 
-    it('should ignore base uri in paths', () => {
+    it('should use document.baseURI as a base url', () => {
       sinon.stub(document, 'baseURI').value('https://vaadin.com/docs');
       expect(arePathsMatching('https://vaadin.com/docs/components', 'components')).to.be.true;
     });

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -32,8 +32,10 @@ describe('url-utils', () => {
     });
 
     it('should use document.baseURI as a base url', () => {
-      sinon.stub(document, 'baseURI').value('https://vaadin.com/docs');
-      expect(arePathsMatching('https://vaadin.com/docs/components', 'components')).to.be.true;
+      sinon.stub(document, 'baseURI').value('https://vaadin.com/docs/');
+      const pathsMatching = arePathsMatching('https://vaadin.com/docs/components', 'components');
+      sinon.restore();
+      expect(pathsMatching).to.be.true;
     });
   });
 });

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { matchPaths } from '../src/url-utils.js';
 
 describe('url-utils', () => {
-  describe('comparePaths', () => {
+  describe('matchPaths', () => {
     const paths = ['', '/', '/path', 'base/path'];
 
     it('should return true when paths match', () => {

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -1,24 +1,24 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { comparePaths } from '../src/url-utils.js';
+import { matchPaths } from '../src/url-utils.js';
 
 describe('url-utils', () => {
   describe('comparePaths', () => {
     const paths = ['', '/', '/path', 'base/path'];
 
     it('should return true when paths match', () => {
-      paths.forEach((path) => expect(comparePaths(path, path)).to.be.true);
+      paths.forEach((path) => expect(matchPaths(path, path)).to.be.true);
     });
 
     it('should return false when paths do not match', () => {
-      expect(comparePaths('/path1', '/path2')).to.be.false;
+      expect(matchPaths('/path1', '/path2')).to.be.false;
     });
 
     it('should ignore leading and trailing spaces in paths', () => {
       paths.forEach((path) => {
         const pathWithExtraSpace = ` ${path} `;
-        expect(comparePaths(pathWithExtraSpace, path)).to.be.true;
-        expect(comparePaths(path, pathWithExtraSpace)).to.be.true;
+        expect(matchPaths(pathWithExtraSpace, path)).to.be.true;
+        expect(matchPaths(path, pathWithExtraSpace)).to.be.true;
       });
     });
 
@@ -26,8 +26,8 @@ describe('url-utils', () => {
       paths.forEach((path) => {
         const pathWithoutLeadingSlash = path.startsWith('/') ? path.substring(1) : path;
         const pathWithLeadingSlash = path.startsWith('/') ? path : `/${path}`;
-        expect(comparePaths(pathWithoutLeadingSlash, pathWithLeadingSlash)).to.be.true;
-        expect(comparePaths(pathWithLeadingSlash, pathWithoutLeadingSlash)).to.be.true;
+        expect(matchPaths(pathWithoutLeadingSlash, pathWithLeadingSlash)).to.be.true;
+        expect(matchPaths(pathWithLeadingSlash, pathWithoutLeadingSlash)).to.be.true;
       });
     });
 
@@ -44,7 +44,7 @@ describe('url-utils', () => {
 
       it('should use document.baseURI as a base url', () => {
         baseUri.value('https://vaadin.com/docs/');
-        expect(comparePaths('https://vaadin.com/docs/components', 'components')).to.be.true;
+        expect(matchPaths('https://vaadin.com/docs/components', 'components')).to.be.true;
       });
     });
   });

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -1,24 +1,24 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { arePathsMatching } from '../src/url-utils.js';
+import { comparePaths } from '../src/url-utils.js';
 
 describe('url-utils', () => {
-  describe('arePathsMatching', () => {
+  describe('comparePaths', () => {
     const paths = ['', '/', '/path', 'base/path'];
 
     it('should return true when paths match', () => {
-      paths.forEach((path) => expect(arePathsMatching(path, path)).to.be.true);
+      paths.forEach((path) => expect(comparePaths(path, path)).to.be.true);
     });
 
     it('should return false when paths do not match', () => {
-      expect(arePathsMatching('/path1', '/path2')).to.be.false;
+      expect(comparePaths('/path1', '/path2')).to.be.false;
     });
 
     it('should ignore leading and trailing spaces in paths', () => {
       paths.forEach((path) => {
         const pathWithExtraSpace = ` ${path} `;
-        expect(arePathsMatching(pathWithExtraSpace, path)).to.be.true;
-        expect(arePathsMatching(path, pathWithExtraSpace)).to.be.true;
+        expect(comparePaths(pathWithExtraSpace, path)).to.be.true;
+        expect(comparePaths(path, pathWithExtraSpace)).to.be.true;
       });
     });
 
@@ -26,8 +26,8 @@ describe('url-utils', () => {
       paths.forEach((path) => {
         const pathWithoutLeadingSlash = path.startsWith('/') ? path.substring(1) : path;
         const pathWithLeadingSlash = path.startsWith('/') ? path : `/${path}`;
-        expect(arePathsMatching(pathWithoutLeadingSlash, pathWithLeadingSlash)).to.be.true;
-        expect(arePathsMatching(pathWithLeadingSlash, pathWithoutLeadingSlash)).to.be.true;
+        expect(comparePaths(pathWithoutLeadingSlash, pathWithLeadingSlash)).to.be.true;
+        expect(comparePaths(pathWithLeadingSlash, pathWithoutLeadingSlash)).to.be.true;
       });
     });
 
@@ -44,7 +44,7 @@ describe('url-utils', () => {
 
       it('should use document.baseURI as a base url', () => {
         baseUri.value('https://vaadin.com/docs/');
-        expect(arePathsMatching('https://vaadin.com/docs/components', 'components')).to.be.true;
+        expect(comparePaths('https://vaadin.com/docs/components', 'components')).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## Description

Extracts and adds `url-utils` first introduced in Side Nav route alias feature [PR](https://github.com/vaadin/web-components/pull/5974). 

Related to [5141](url)