### PR TITLE
chore: update license dates

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * Copyright (c) 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css } from 'lit';

--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * Copyright (c) 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { LitElement } from 'lit';

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * Copyright (c) 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, LitElement } from 'lit';

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * Copyright (c) 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './vaadin-side-nav-item-styles.js';

--- a/packages/side-nav/theme/lumo/vaadin-side-nav.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * Copyright (c) 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './vaadin-side-nav-item.js';

--- a/packages/side-nav/theme/material/vaadin-side-nav.js
+++ b/packages/side-nav/theme/material/vaadin-side-nav.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * Copyright (c) 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '../../src/vaadin-side-nav.js';


### PR DESCRIPTION
## Description

Updates years on license dates for Side Nav classes. First introduced in Side Nav route alias feature [PR](https://github.com/vaadin/web-components/pull/5974). 