### PR TITLE
fix: avoid opened changed events when moving dialog within DOM (CP: 24.0)

### DIFF
--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -483,6 +483,10 @@ describe('vaadin-confirm-dialog', () => {
         await oneEvent(overlay, 'vaadin-overlay-open');
       });
 
+      afterEach(() => {
+        confirm.opened = false;
+      });
+
       it('should update width after opening the dialog', () => {
         confirm._contentWidth = '300px';
         expect(getComputedStyle(overlay.$.overlay).width).to.be.equal('300px');

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -268,9 +268,15 @@ class Dialog extends OverlayClassMixin(
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-    // Close overlay and memorize opened state
-    this.__restoreOpened = this.opened;
-    this.opened = false;
+    // Automatically close the overlay when dialog is removed from DOM
+    // Using a timeout to avoid toggling opened state, and dispatching change
+    // events, when just moving the dialog in the DOM
+    setTimeout(() => {
+      if (!this.isConnected) {
+        this.__restoreOpened = this.opened;
+        this.opened = false;
+      }
+    });
   }
 
   /** @private */

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { esc, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, esc, fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-dialog.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -136,18 +137,43 @@ describe('vaadin-dialog', () => {
       });
     });
 
-    describe('detaching', () => {
-      it('should close the overlay when detached', () => {
-        dialog.parentNode.removeChild(dialog);
+    describe('removing and adding to the DOM', () => {
+      it('should close the overlay when removed from DOM', async () => {
+        dialog.remove();
+        await aTimeout(0);
+
         expect(dialog.opened).to.be.false;
       });
 
-      it('should not close the overlay when moved within the DOM', () => {
+      it('should restore opened state when added to the DOM', async () => {
+        const parent = dialog.parentNode;
+        dialog.remove();
+        await aTimeout(0);
+        expect(dialog.opened).to.be.false;
+
+        parent.appendChild(dialog);
+        expect(dialog.opened).to.be.true;
+      });
+
+      it('should not close the overlay when moved within the DOM', async () => {
         const newParent = document.createElement('div');
         document.body.appendChild(newParent);
-
         newParent.appendChild(dialog);
+        await aTimeout(0);
+
         expect(dialog.opened).to.be.true;
+      });
+
+      it('should not dispatch opened changed events when moved within the DOM', async () => {
+        const onOpenedChanged = sinon.spy();
+        dialog.addEventListener('opened-changed', onOpenedChanged);
+
+        const newParent = document.createElement('div');
+        document.body.appendChild(newParent);
+        newParent.appendChild(dialog);
+        await aTimeout(0);
+
+        expect(onOpenedChanged.called).to.be.false;
       });
     });
 


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/vaadin/web-components/pull/5995
