### PR TITLE
docs: add missing vaadin-side-nav shadow parts documentation

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -54,6 +54,17 @@ export type SideNavItemEventMap = HTMLElementEventMap & SideNavItemCustomEventMa
  * </vaadin-side-nav-item>
  * ```
  *
+ * ### Styling
+ *
+ * Part name       | Description
+ * ----------------|----------------
+ * `content`       | The element that wraps link and toggle button
+ * `children`      | The element that wraps child items
+ * `link`          | The clickable anchor used for navigation
+ * `toggle-button` | The toggle button
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  */
 declare class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -75,6 +75,17 @@ class ChildrenController extends SlotController {
  * </vaadin-side-nav-item>
  * ```
  *
+ * ### Styling
+ *
+ * Part name       | Description
+ * ----------------|----------------
+ * `content`       | The element that wraps link and toggle button
+ * `children`      | The element that wraps child items
+ * `link`          | The clickable anchor used for navigation
+ * `toggle-button` | The toggle button
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  *
  * @extends LitElement

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -49,6 +49,16 @@ export type SideNavEventMap = HTMLElementEventMap & SideNavCustomEventMap;
  * </vaadin-side-nav>
  * ```
  *
+ * ### Styling
+ *
+ * Part name       | Description
+ * ----------------|----------------
+ * `label`         | The label element
+ * `children`      | The element that wraps child items
+ * `toggle-button` | The toggle button
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
  * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.
  */
 declare class SideNav extends FocusMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -45,6 +45,16 @@ function isEnabled() {
  * </vaadin-side-nav>
  * ```
  *
+ * ### Styling
+ *
+ * Part name       | Description
+ * ----------------|----------------
+ * `label`         | The label element
+ * `children`      | The element that wraps child items
+ * `toggle-button` | The toggle button
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
  * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.
  *
  * @extends LitElement


### PR DESCRIPTION
## Description

Added missing documentation for `vaadin-side-nav` and `vaadin-side-nav-item` shadow parts.

## Type of change

- Documentation