### PR TITLE
refactor: cleanup side-nav item toggle styles, use mixin

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -28,6 +28,10 @@ export const sideNavItemBaseStyles = css`
     -webkit-appearance: none;
     appearance: none;
     flex: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
   }
 
   [part='children'] {

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -4,6 +4,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
+import { fieldButton } from '@vaadin/vaadin-lumo-styles/mixins/field-button.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const sideNavItemStyles = css`
@@ -25,17 +26,9 @@ export const sideNavItemStyles = css`
 
   [part='toggle-button'] {
     position: relative;
-    border: 0;
-    margin: calc((var(--lumo-icon-size-m) - var(--lumo-size-s)) / 2) 0;
     margin-inline-end: calc(var(--lumo-space-xs) * -1);
-    padding: 0;
-    background: transparent;
-    font: inherit;
-    color: var(--lumo-tertiary-text-color);
     width: var(--lumo-size-s);
     height: var(--lumo-size-s);
-    cursor: var(--lumo-clickable-cursor, default);
-    transition: color 140ms;
   }
 
   :host([has-children]) [part='content'] {
@@ -57,11 +50,7 @@ export const sideNavItemStyles = css`
   }
 
   [part='toggle-button']::before {
-    font-family: lumo-icons;
     content: var(--lumo-icons-dropdown);
-    font-size: 1.5em;
-    line-height: var(--lumo-size-s);
-    display: inline-block;
     transform: rotate(-90deg);
     transition: transform 140ms;
   }
@@ -113,4 +102,4 @@ export const sideNavItemStyles = css`
   }
 `;
 
-registerStyles('vaadin-side-nav-item', sideNavItemStyles, { moduleId: 'lumo-side-nav-item' });
+registerStyles('vaadin-side-nav-item', [fieldButton, sideNavItemStyles], { moduleId: 'lumo-side-nav-item' });


### PR DESCRIPTION
## Description

Updated the `toggle-button` part of the `vaadin-side-nav-item` to use the Lumo button mixin.

Note, `width` and `height` are still needed because the icon size has to be 30px, not 24px.

## Type of change

- Refactor