### PR TITLE
fix: use cached references to iterate cells instead of DOM state

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { iterateChildren } from './vaadin-grid-helpers.js';
+import { iterateChildren, iterateRowCells } from './vaadin-grid-helpers.js';
 
 /**
  * @polymerMixin
@@ -72,7 +72,7 @@ export const A11yMixin = (superClass) =>
     _a11yUpdateRowSelected(row, selected) {
       // Jaws reads selection only for rows, NVDA only for cells
       row.setAttribute('aria-selected', Boolean(selected));
-      iterateChildren(row, (cell) => {
+      iterateRowCells(row, (cell) => {
         cell.setAttribute('aria-selected', Boolean(selected));
       });
     }
@@ -111,7 +111,7 @@ export const A11yMixin = (superClass) =>
      * @protected
      */
     _a11ySetRowDetailsCell(row, detailsCell) {
-      iterateChildren(row, (cell) => {
+      iterateRowCells(row, (cell) => {
         if (cell !== detailsCell) {
           cell.setAttribute('aria-controls', detailsCell.id);
         }

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -3,7 +3,12 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { iterateChildren, updateBooleanRowStates, updateStringRowStates } from './vaadin-grid-helpers.js';
+import {
+  iterateChildren,
+  iterateRowCells,
+  updateBooleanRowStates,
+  updateStringRowStates,
+} from './vaadin-grid-helpers.js';
 
 const DropMode = {
   BETWEEN: 'between',
@@ -390,7 +395,7 @@ export const DragAndDropMixin = (superClass) =>
       const dragDisabled = !this.rowsDraggable || loading || (this.dragFilter && !this.dragFilter(model));
       const dropDisabled = !this.dropMode || loading || (this.dropFilter && !this.dropFilter(model));
 
-      iterateChildren(row, (cell) => {
+      iterateRowCells(row, (cell) => {
         if (dragDisabled) {
           cell._content.removeAttribute('draggable');
         } else {

--- a/packages/grid/src/vaadin-grid-styling-mixin.js
+++ b/packages/grid/src/vaadin-grid-styling-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { iterateChildren, updatePart } from './vaadin-grid-helpers.js';
+import { iterateChildren, iterateRowCells, updatePart } from './vaadin-grid-helpers.js';
 
 /**
  * @polymerMixin
@@ -105,7 +105,7 @@ export const StylingMixin = (superClass) =>
 
     /** @private */
     _generateCellClassNames(row, model) {
-      iterateChildren(row, (cell) => {
+      iterateRowCells(row, (cell) => {
         if (cell.__generatedClasses) {
           cell.__generatedClasses.forEach((className) => cell.classList.remove(className));
         }
@@ -121,7 +121,7 @@ export const StylingMixin = (superClass) =>
 
     /** @private */
     _generateCellPartNames(row, model) {
-      iterateChildren(row, (cell) => {
+      iterateRowCells(row, (cell) => {
         if (cell.__generatedParts) {
           cell.__generatedParts.forEach((partName) => {
             // Remove previously generated part names

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -27,7 +27,13 @@ import { DragAndDropMixin } from './vaadin-grid-drag-and-drop-mixin.js';
 import { DynamicColumnsMixin } from './vaadin-grid-dynamic-columns-mixin.js';
 import { EventContextMixin } from './vaadin-grid-event-context-mixin.js';
 import { FilterMixin } from './vaadin-grid-filter-mixin.js';
-import { getBodyRowCells, iterateChildren, updateBooleanRowStates, updateCellsPart } from './vaadin-grid-helpers.js';
+import {
+  getBodyRowCells,
+  iterateChildren,
+  iterateRowCells,
+  updateBooleanRowStates,
+  updateCellsPart,
+} from './vaadin-grid-helpers.js';
 import { KeyboardNavigationMixin } from './vaadin-grid-keyboard-navigation-mixin.js';
 import { RowDetailsMixin } from './vaadin-grid-row-details-mixin.js';
 import { ScrollMixin } from './vaadin-grid-scroll-mixin.js';
@@ -862,7 +868,7 @@ class Grid extends ElementMixin(
   _updateRow(row, columns, section = 'body', isColumnRow = false, noNotify = false) {
     const contentsFragment = document.createDocumentFragment();
 
-    iterateChildren(row, (cell) => {
+    iterateRowCells(row, (cell) => {
       cell._vacant = true;
     });
     row.innerHTML = '';

--- a/packages/grid/test/column-rendering.test.js
+++ b/packages/grid/test/column-rendering.test.js
@@ -441,7 +441,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
         // Scroll back to the beginning
         await scrollHorizontally(-grid.$.table.scrollWidth);
 
-        // Expect the cell that was previously not visible to have the odd part
+        // Expect the cell that was previously not visible to have the last-row-cell part
         expect(getBodyCell(1, 0).getAttribute('part')).to.include('last-row-cell');
       });
     });

--- a/packages/grid/test/column-rendering.test.js
+++ b/packages/grid/test/column-rendering.test.js
@@ -332,6 +332,118 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
 
         expectCellsVisualOrderToMatchColumnOrder();
       });
+
+      it('should have cell class names on the revealed cells', async () => {
+        // Add a class name generator
+        grid.cellClassNameGenerator = () => 'foo';
+        await nextFrame();
+        expect(getBodyCell(0, getLastVisibleColumnIndex()).classList.contains('foo')).to.be.true;
+
+        // Scroll back to the beginning
+        await scrollHorizontally(-grid.$.table.scrollWidth);
+        // Expect the cell that was previously not visible to have the class name
+        expect(getBodyCell(0, 0).classList.contains('foo')).to.be.true;
+      });
+
+      it('should have cell part names on the revealed cells', async () => {
+        // Add a part name generator
+        grid.cellPartNameGenerator = () => 'foo';
+        await nextFrame();
+        expect(getBodyCell(0, getLastVisibleColumnIndex()).getAttribute('part')).to.include('foo');
+
+        // Scroll back to the beginning
+        await scrollHorizontally(-grid.$.table.scrollWidth);
+        // Expect the cell that was previously not visible to have the part name
+        expect(getBodyCell(0, 0).getAttribute('part')).to.include('foo');
+      });
+
+      it('should have area-selected on the revealed cells', async () => {
+        // Select the first item
+        grid.selectedItems = [grid.items[0]];
+        await nextFrame();
+        expect(getBodyCell(0, getLastVisibleColumnIndex()).getAttribute('aria-selected')).to.equal('true');
+
+        // Scroll back to the beginning
+        await scrollHorizontally(-grid.$.table.scrollWidth);
+        // Expect the cell that was previously not visible to have the aria-selected attribute
+        expect(getBodyCell(0, 0).getAttribute('aria-selected')).to.equal('true');
+      });
+
+      it('should relate revealed cells to the details cell', async () => {
+        // Add row details
+        grid.rowDetailsRenderer = (root) => {
+          root.innerHTML = `<div>Details</div>`;
+        };
+        await nextFrame();
+
+        const detailsCellId = grid.shadowRoot.querySelector('[part~="details-cell"]').id;
+        expect(getBodyCell(0, getLastVisibleColumnIndex()).getAttribute('aria-controls')).to.equal(detailsCellId);
+
+        // Scroll back to the beginning
+        await scrollHorizontally(-grid.$.table.scrollWidth);
+        // Expect the cell that was previously not visible to have the aria-controls attribute
+        expect(getBodyCell(0, 0).getAttribute('aria-controls')).to.equal(detailsCellId);
+      });
+
+      it('should mark revealed cells as draggable', async () => {
+        // Make rows draggable
+        grid.rowsDraggable = true;
+        await nextFrame();
+
+        expect(getBodyCellContent(getLastVisibleColumnIndex()).getAttribute('draggable')).to.equal('true');
+
+        // Scroll back to the beginning
+        await scrollHorizontally(-grid.$.table.scrollWidth);
+        // Expect the cell that was previously not visible to have the draggable attribute
+        expect(getBodyCellContent(0).getAttribute('draggable')).to.equal('true');
+      });
+
+      it('should not create excess cells for a row', async () => {
+        // Scroll back to the beginning
+        await scrollHorizontally(-grid.$.table.scrollWidth);
+
+        const cellCount = grid.shadowRoot.querySelector('tbody tr').childElementCount;
+
+        // Add row details (this will cause the row to be restructured)
+        grid.rowDetailsRenderer = (root) => {
+          root.innerHTML = `<div>Details</div>`;
+        };
+        await nextFrame();
+
+        // Scroll back to the end
+        await scrollHorizontally(grid.$.table.scrollWidth);
+
+        // Expect the row to have the same number plus one cell
+        expect(grid.shadowRoot.querySelector('tbody tr').childElementCount).to.equal(cellCount + 1);
+      });
+
+      it('should have loading state on the revealed cell', async () => {
+        // Add a data provider that never resolves
+        grid.dataProvider = () => {};
+        await nextFrame();
+
+        expect(getBodyCell(0, getLastVisibleColumnIndex()).getAttribute('part')).to.include('loading-row-cell');
+
+        // Scroll back to the beginning
+        await scrollHorizontally(-grid.$.table.scrollWidth);
+
+        // Expect the cell that was previously not visible to have the loading state
+        expect(getBodyCell(0, 0).getAttribute('part')).to.include('loading-row-cell');
+      });
+
+      it('should have last-row-cell part on the revealed cell', async () => {
+        // Add new item
+        grid.items = [...grid.items, { name: `Item 2` }];
+        await nextFrame();
+
+        expect(getBodyCell(1, getLastVisibleColumnIndex()).getAttribute('part')).to.include('last-row-cell');
+
+        // Scroll back to the beginning
+        await scrollHorizontally(-grid.$.table.scrollWidth);
+
+        // Expect the cell that was previously not visible to have the odd part
+        expect(getBodyCell(1, 0).getAttribute('part')).to.include('last-row-cell');
+      });
     });
 
     describe(`keyboard navigation - ${dir}`, () => {


### PR DESCRIPTION
## Description

This PR fixes an issue specific to using grid lazy column rendering mode where some body row cells would not have their attributes updated due to being temporarily detached from the row. The issue occurs because some grid [utility methods](https://github.com/vaadin/web-components/blob/c459396942620baea42b57c76e5d75391d8ad048/packages/grid/src/vaadin-grid-helpers.js#L12-L22) relied on the DOM state to obtain cells of a row and this wasn't taken into account when the lazy column rendering feature was implemented.

The change includes one new utility method for specifically iterating over row cells (`iterateRowCells `), taking into account that some of the row cells may not be physically attached to the row. An existing utility method (`getBodyRowCells`) was also modified to take into account the detached cells when obtaining body row cells.

Fixes https://github.com/vaadin/flow-components/issues/5168

## Type of change

Bugfix