### PR TITLE
refactor: cache body row cells

### DIFF
--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -6,17 +6,14 @@
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 
 /**
+ * Returns the cells of the given row, excluding the details cell.
+ *
  * @param {HTMLTableRowElement} row the table row
  * @return {HTMLTableCellElement[]} array of cells
  */
 export function getBodyRowCells(row) {
-  if (row.__cells) {
-    // If available, use the cells cached in the row to make sure also any
-    // physically detached cells (due to lazy column rendering) are included
-    return row.__cells;
-  }
-  // In any other case, query the cells directly from the row
-  return Array.from(row.querySelectorAll('[part~="cell"]:not([part~="details-cell"])'));
+  // If available, return the cached cells. Otherwise, query the cells directly from the row.
+  return row.__cells || Array.from(row.querySelectorAll('[part~="cell"]:not([part~="details-cell"])'));
 }
 
 /**

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -10,13 +10,10 @@ import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component
  * @return {HTMLTableCellElement[]} array of cells
  */
 export function getBodyRowCells(row) {
-  if (row.parentElement && row.parentElement.localName === 'tbody') {
-    // In case dealing with an attached body row, use the cells cached in the
-    // column to make sure also any physically detached cells
-    // (due to lazy column rendering) are included
-    const grid = row.getRootNode().host;
-    const columns = grid._getColumnsInOrder();
-    return columns.flatMap((column) => (column._cells && column._cells.find((cell) => cell.__parentRow === row)) || []);
+  if (row.__cells) {
+    // If available, use the cells cached in the row to make sure also any
+    // physically detached cells (due to lazy column rendering) are included
+    return row.__cells;
   }
   // In any other case, query the cells directly from the row
   return Array.from(row.querySelectorAll('[part~="cell"]:not([part~="details-cell"])'));
@@ -39,7 +36,10 @@ export function iterateChildren(container, callback) {
  * @param {Function} callback function to call on each cell
  */
 export function iterateRowCells(row, callback) {
-  [...getBodyRowCells(row), ...row.querySelectorAll('[part~="details-cell"]')].forEach(callback);
+  getBodyRowCells(row).forEach(callback);
+  if (row.__detailsCell) {
+    callback(row.__detailsCell);
+  }
 }
 
 /**

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -872,6 +872,11 @@ class Grid extends ElementMixin(
       cell._vacant = true;
     });
     row.innerHTML = '';
+    if (section === 'body') {
+      // Clear the cached cell references
+      row.__cells = [];
+      row.__detailsCell = null;
+    }
 
     columns
       .filter((column) => !column.hidden)
@@ -890,6 +895,8 @@ class Grid extends ElementMixin(
           }
           cell.setAttribute('part', 'cell body-cell');
           cell.__parentRow = row;
+          // Cache the cell reference
+          row.__cells.push(cell);
           if (!column._bodyContentHidden) {
             row.appendChild(cell);
           }
@@ -912,6 +919,8 @@ class Grid extends ElementMixin(
             }
             this._configureDetailsCell(detailsCell);
             row.appendChild(detailsCell);
+            // Cache the details cell reference
+            row.__detailsCell = detailsCell;
             this._a11ySetRowDetailsCell(row, detailsCell);
             detailsCell._vacant = false;
           }


### PR DESCRIPTION
## Description

Follow-up for https://github.com/vaadin/web-components/pull/6011

The [`getBodyRowCells`](https://github.com/vaadin/web-components/blob/0061f02f6ac82397481cd5e821d58032b19cc12f/packages/grid/src/vaadin-grid-helpers.js#L12) grid helper gets called *a lot* during init and especially while scrolling.

This PR makes grid cache the body row cells when they're being created. The cached references can then be passed as such from the `getBodyRowCells` helper instead of having to perform excess [computation](https://github.com/vaadin/web-components/blob/0061f02f6ac82397481cd5e821d58032b19cc12f/packages/grid/src/vaadin-grid-helpers.js#L17-L19) or [querying](https://github.com/vaadin/web-components/blob/0061f02f6ac82397481cd5e821d58032b19cc12f/packages/grid/src/vaadin-grid-helpers.js#L42) for the cells.

## Type of change

Refactor