### PR TITLE
docs: add side-nav and side-nav-item state attributes

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -56,12 +56,21 @@ export type SideNavItemEventMap = HTMLElementEventMap & SideNavItemCustomEventMa
  *
  * ### Styling
  *
+ * The following shadow DOM parts are available for styling:
+ *
  * Part name       | Description
  * ----------------|----------------
  * `content`       | The element that wraps link and toggle button
  * `children`      | The element that wraps child items
  * `link`          | The clickable anchor used for navigation
  * `toggle-button` | The toggle button
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute      | Description
+ * ---------------|-------------
+ * `expanded`     | Set when the element is expanded.
+ * `has-children` | Set when the element has child items.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -78,12 +78,21 @@ class ChildrenController extends SlotController {
  *
  * ### Styling
  *
+ * The following shadow DOM parts are available for styling:
+ *
  * Part name       | Description
  * ----------------|----------------
  * `content`       | The element that wraps link and toggle button
  * `children`      | The element that wraps child items
  * `link`          | The clickable anchor used for navigation
  * `toggle-button` | The toggle button
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute      | Description
+ * ---------------|-------------
+ * `expanded`     | Set when the element is expanded.
+ * `has-children` | Set when the element has child items.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -51,11 +51,21 @@ export type SideNavEventMap = HTMLElementEventMap & SideNavCustomEventMap;
  *
  * ### Styling
  *
+ * The following shadow DOM parts are available for styling:
+ *
  * Part name       | Description
  * ----------------|----------------
  * `label`         | The label element
  * `children`      | The element that wraps child items
  * `toggle-button` | The toggle button
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `collapsed`  | Set when the element is collapsed.
+ * `focus-ring` | Set when the label is focused using the keyboard.
+ * `focused`    | Set when the label is focused.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -47,11 +47,21 @@ function isEnabled() {
  *
  * ### Styling
  *
+ * The following shadow DOM parts are available for styling:
+ *
  * Part name       | Description
  * ----------------|----------------
  * `label`         | The label element
  * `children`      | The element that wraps child items
  * `toggle-button` | The toggle button
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `collapsed`  | Set when the element is collapsed.
+ * `focus-ring` | Set when the label is focused using the keyboard.
+ * `focused`    | Set when the label is focused.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

While I added shadow parts in #6002, I missed to add state attributes. This PR fixes that.

## Type of change

- Documentation