### PR TITLE
fix: use pointer cursor for vaadin-side-nav-item links

### DIFF
--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -23,6 +23,10 @@ export const sideNavItemStyles = css`
     min-height: var(--lumo-icon-size-m);
   }
 
+  [part='link'][href] {
+    cursor: pointer;
+  }
+
   [part='toggle-button'] {
     position: relative;
     border: 0;


### PR DESCRIPTION
## Description

Fixes #5915

Changed links with `href` attribute to use `cursor: pointer` as suggested in the issue.
Note, `<a>` elements without `href` are still using `var(--lumo-clickable-cursor)`.

## Type of change

- Bugfix