### PR TITLE
refactor: extract ChildrenController to separate file

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-children-controller.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-children-controller.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+/**
+ * A controller to manage the item content children slot.
+ */
+export class ChildrenController extends SlotController {}

--- a/packages/side-nav/src/vaadin-side-nav-children-controller.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-children-controller.d.ts
@@ -6,6 +6,8 @@
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 
 /**
- * A controller to manage the item content children slot.
+ * A controller that manages the item content children slot.
  */
-export class ChildrenController extends SlotController {}
+export class ChildrenController extends SlotController {
+  constructor(node: HTMLElement, slotName: string);
+}

--- a/packages/side-nav/src/vaadin-side-nav-children-controller.js
+++ b/packages/side-nav/src/vaadin-side-nav-children-controller.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+/**
+ * A controller to manage the item content children slot.
+ */
+export class ChildrenController extends SlotController {
+  constructor(host) {
+    super(host, 'children', null, { observe: true, multiple: true });
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  initAddedNode() {
+    this.host.requestUpdate();
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  teardownNode() {
+    this.host.requestUpdate();
+  }
+}

--- a/packages/side-nav/src/vaadin-side-nav-children-controller.js
+++ b/packages/side-nav/src/vaadin-side-nav-children-controller.js
@@ -6,11 +6,11 @@
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 
 /**
- * A controller to manage the item content children slot.
+ * A controller that manages the item content children slot.
  */
 export class ChildrenController extends SlotController {
-  constructor(host) {
-    super(host, 'children', null, { observe: true, multiple: true });
+  constructor(host, slotName) {
+    super(host, slotName, null, { observe: true, multiple: true });
   }
 
   /**

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -132,7 +132,7 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
   constructor() {
     super();
 
-    this._childrenController = new ChildrenController(this);
+    this._childrenController = new ChildrenController(this, 'children');
   }
 
   /** @protected */

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -7,38 +7,13 @@ import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { matchPaths } from '@vaadin/component-base/src/url-utils.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { sideNavItemBaseStyles } from './vaadin-side-nav-base-styles.js';
+import { ChildrenController } from './vaadin-side-nav-children-controller.js';
 
 function isEnabled() {
   return window.Vaadin && window.Vaadin.featureFlags && !!window.Vaadin.featureFlags.sideNavComponent;
-}
-
-/**
- * A controller to manage the item content children slot.
- */
-class ChildrenController extends SlotController {
-  constructor(host) {
-    super(host, 'children', null, { observe: true, multiple: true });
-  }
-
-  /**
-   * @protected
-   * @override
-   */
-  initAddedNode() {
-    this.host.requestUpdate();
-  }
-
-  /**
-   * @protected
-   * @override
-   */
-  teardownNode() {
-    this.host.requestUpdate();
-  }
 }
 
 /**


### PR DESCRIPTION
## Description

This controller might be used by `vaadin-side-nav`, e.g. it will be needed in #6014 to propagate `i18n` to items.

## Type of change

- Refactor