### PR TITLE
test: properly reset global tooltip state

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -27,6 +27,18 @@ let warmUpTimeout = null;
 let cooldownTimeout = null;
 
 /**
+ * Resets the global tooltip warmup and cooldown state.
+ * Only for internal use in tests.
+ * @private
+ */
+export function resetGlobalTooltipState() {
+  warmedUp = false;
+  clearTimeout(warmUpTimeout);
+  clearTimeout(cooldownTimeout);
+  closing.clear();
+}
+
+/**
  * Controller for handling tooltip opened state.
  */
 class TooltipStateController {

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -11,7 +11,7 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
-import { Tooltip } from '../vaadin-tooltip.js';
+import { resetGlobalTooltipState, Tooltip } from '../vaadin-tooltip.js';
 import { mouseenter, mouseleave } from './helpers.js';
 
 describe('timers', () => {
@@ -42,8 +42,7 @@ describe('timers', () => {
     });
 
     afterEach(async () => {
-      // Wait for cooldown timeout.
-      await aTimeout(0);
+      resetGlobalTooltipState();
     });
 
     it('should open the overlay after a delay on mouseenter', async () => {
@@ -73,8 +72,7 @@ describe('timers', () => {
     });
 
     afterEach(async () => {
-      // Wait for cooldown timeout.
-      await aTimeout(0);
+      resetGlobalTooltipState();
     });
 
     it('should open the overlay after a delay on keyboard focus', async () => {
@@ -104,8 +102,7 @@ describe('timers', () => {
     });
 
     afterEach(async () => {
-      // Wait for cooldown timeout.
-      await aTimeout(1);
+      resetGlobalTooltipState();
     });
 
     it('should close the overlay after a hide delay on mouseleave', async () => {
@@ -432,8 +429,7 @@ describe('timers', () => {
     });
 
     afterEach(async () => {
-      // Wait for cooldown timeout.
-      await aTimeout(2);
+      resetGlobalTooltipState();
     });
 
     it('should close first tooltip and open the second one without waiting for hover delay', async () => {


### PR DESCRIPTION
## Description

It seems that individual tooltip timer tests can cause the global tooltip warmup/cooldown state get stuck, so that for subsequent tests the tooltip is identified as warmed up and shown immediately.

This adds an internal function for resetting the tooltip state and uses that for tearing down tests.

This should fix the following flaky test:
```
packages/tooltip/test/tooltip-timers.test.js:
	❌ timers > warmup and cooldown > should not open on mouseleave during the initial warm up hover delay
	AssertionError: expected true to be falsy
	at o.<anonymous> (packages/tooltip/test/tooltip-timers.test.js:527:43)
```
