### PR TITLE
test: automatically retry visual tests in CI

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -26,10 +26,15 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Visual tests
+        uses: nick-fields/retry@v2
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: yarn test:lumo
+        with:
+          timeout_minutes: 5
+          retry_wait_seconds: 60
+          max_attempts: 3
+          command: yarn test:lumo
 
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
@@ -58,10 +63,15 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Visual tests
+        uses: nick-fields/retry@v2
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: yarn test:material
+        with:
+          timeout_minutes: 5
+          retry_wait_seconds: 60
+          max_attempts: 3
+          command: yarn test:material
 
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}


### PR DESCRIPTION
## Description

Use the `nick-fields/retry` Github Action to automatically re-try failed visual tests. The action is configured with:
- Max attempts: 3
- Timeout per attempt: 5 mins
- Wait between attempts: 60 seconds

Below is an example log of the action. I intentionally changed a CSS property in `vaadin-avatar` so that tests would fail. However right in the first two attempts it runs into timeout errors with SauceLabs, showcasing how the retry action is useful:
- In the first attempt the retry action stops the attempt after 5 mins as that is the configured timeout for the action
- In the second attempt only some tests time out, others complete - the attempt still fails as not all tests were run
- In the third attempt all tests are run, some of them failing due to the changed CSS property. After the third attempt the retry action finally exits with an error. Without changing the CSS property the third attempt would have succeeded at least.

<details>
<summary>Action log</summary>

```
2023-06-23T09:30:42.9433159Z ##[group]Run nick-fields/retry@v2
2023-06-23T09:30:42.9433510Z with:
2023-06-23T09:30:42.9433764Z   timeout_minutes: 5
2023-06-23T09:30:42.9434075Z   retry_wait_seconds: 60
2023-06-23T09:30:42.9434370Z   max_attempts: 3
2023-06-23T09:30:42.9434660Z   command: yarn test:lumo
2023-06-23T09:30:42.9434979Z   polling_interval_seconds: 1
2023-06-23T09:30:42.9435300Z   warning_on_retry: true
2023-06-23T09:30:42.9435610Z   continue_on_error: false
2023-06-23T09:30:42.9435906Z env:
2023-06-23T09:30:42.9436388Z   SAUCE_USERNAME: ***
2023-06-23T09:30:42.9436788Z   SAUCE_ACCESS_KEY: ***
2023-06-23T09:30:42.9437085Z ##[endgroup]
2023-06-23T09:30:43.2176680Z yarn run v1.22.19
2023-06-23T09:30:43.2647573Z $ web-test-runner --config web-test-runner-lumo.config.js
2023-06-23T09:30:45.1449613Z Running tests for changed packages:
2023-06-23T09:30:45.1451126Z avatar-group
2023-06-23T09:30:45.1451501Z avatar
2023-06-23T09:30:45.1451820Z message-list
2023-06-23T09:30:45.1880958Z [Saucelabs] Setting up Sauce Connect proxy...
2023-06-23T09:31:01.3513620Z 
2023-06-23T09:31:01.3555729Z Windows 10 chrome 108: |[90m███                           [39m| 0/10 test files | [32m0 passed[39m, 0 failed
2023-06-23T09:31:01.3556253Z 
2023-06-23T09:31:01.3556726Z [1mRunning tests...[22m
2023-06-23T09:31:01.3556947Z 
2023-06-23T09:31:01.3557193Z [1mRunning 10 test files...
2023-06-23T09:31:01.3557609Z [22m
2023-06-23T09:31:01.3562433Z 
2023-06-23T09:31:31.3639331Z [2K[1A[2K[G[1m[36mpackages/avatar-group/test/visual/lumo/avatar-group.test.js[39m[22m:
2023-06-23T09:31:31.3640210Z 
2023-06-23T09:31:31.3641139Z  ❌ The browser was unable to create and start a test page after 30000ms. You can increase this timeout with the browserStartTimeout option. 
2023-06-23T09:31:31.3641557Z 
2023-06-23T09:31:31.3642275Z Windows 10 chrome 108: |[37m███[39m[90m                           [39m| 1/10 test files | [32m0 passed[39m, 0 failed
2023-06-23T09:31:31.3642585Z 
2023-06-23T09:31:31.3642800Z [1mRunning tests...[22m
2023-06-23T09:31:31.3643001Z 

... More timeout errors ...

... First attempt fails due to configured action timeout, second attempt starts ...

2023-06-23T09:36:43.4574026Z ##[warning]Attempt 1 failed. Reason: Timeout of 300000ms hit
2023-06-23T09:36:43.6256077Z yarn run v1.22.19
2023-06-23T09:36:43.6697889Z $ web-test-runner --config web-test-runner-lumo.config.js
2023-06-23T09:36:45.5369562Z Running tests for changed packages:
2023-06-23T09:36:45.5370754Z avatar-group
2023-06-23T09:36:45.5371041Z avatar
2023-06-23T09:36:45.5371342Z message-list
2023-06-23T09:36:45.5776934Z [Saucelabs] Setting up Sauce Connect proxy...
2023-06-23T09:36:59.3841185Z 
2023-06-23T09:36:59.3879675Z Windows 10 chrome 108: |[90m███                           [39m| 0/10 test files | [32m0 passed[39m, 0 failed
2023-06-23T09:36:59.3880053Z 
2023-06-23T09:36:59.3880280Z [1mRunning tests...[22m
2023-06-23T09:36:59.3880486Z 
2023-06-23T09:36:59.3881195Z [1mRunning 10 test files...
2023-06-23T09:36:59.3881515Z [22m
2023-06-23T09:36:59.3891480Z 
2023-06-23T09:37:29.3952435Z [2K[1A[2K[G[1m[36mpackages/avatar-group/test/visual/lumo/avatar-group.test.js[39m[22m:
2023-06-23T09:37:29.3953100Z 
2023-06-23T09:37:29.3954150Z  ❌ The browser was unable to create and start a test page after 30000ms. You can increase this timeout with the browserStartTimeout option. 
2023-06-23T09:37:29.3954774Z 
2023-06-23T09:37:29.3955776Z Windows 10 chrome 108: |[37m███[39m[90m                           [39m| 1/10 test files | [32m0 passed[39m, 0 failed
2023-06-23T09:37:29.3956219Z 
2023-06-23T09:37:29.3956557Z [1mRunning tests...[22m

... Again timeout errors, at some point recovers and finishes running remaining tests ...

2023-06-23T09:40:04.1492151Z 
2023-06-23T09:40:07.2174274Z [2K[1A[2K[GWindows 10 chrome 108: |[37m██████████████████████████████[39m| 10/10 test files | [32m6 passed[39m, 0 failed
2023-06-23T09:40:07.2175869Z 
2023-06-23T09:40:07.2176611Z [1m[31mError while running tests.[39m[22m
2023-06-23T09:40:07.2177126Z 
2023-06-23T09:40:07.2177280Z 
2023-06-23T09:40:12.2460162Z error Command failed with exit code 1.
2023-06-23T09:40:12.2460973Z info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

... Second attempt fails due to non-zero exit code, starts third attempt ...

2023-06-23T09:41:12.7629080Z ##[warning]Attempt 2 failed. Reason: Child_process exited with error code 1
2023-06-23T09:41:12.9339076Z yarn run v1.22.19
2023-06-23T09:41:12.9766122Z $ web-test-runner --config web-test-runner-lumo.config.js
2023-06-23T09:41:14.8249260Z Running tests for changed packages:
2023-06-23T09:41:14.8250173Z avatar-group
2023-06-23T09:41:14.8250576Z avatar
2023-06-23T09:41:14.8250969Z message-list
2023-06-23T09:41:14.8681801Z [Saucelabs] Setting up Sauce Connect proxy...
2023-06-23T09:41:23.3661188Z 
2023-06-23T09:41:23.3701798Z Windows 10 chrome 108: |[90m███                           [39m| 0/10 test files | [32m0 passed[39m, 0 failed
2023-06-23T09:41:23.3702206Z 
2023-06-23T09:41:23.3702435Z [1mRunning tests...[22m
2023-06-23T09:41:23.3702651Z 
2023-06-23T09:41:23.3702873Z [1mRunning 10 test files...
2023-06-23T09:41:23.3703204Z [22m
2023-06-23T09:41:23.3710335Z 
2023-06-23T09:41:45.4684222Z [2K[1A[2K[G[1m[36mpackages/avatar-group/test/visual/lumo/avatar-group.test.js[39m[22m:
2023-06-23T09:41:45.4684943Z 
2023-06-23T09:41:45.4685262Z  ❌ avatar-group > basic
2023-06-23T09:41:45.4685933Z       [31mError: Visual diff failed. New screenshot is 38.94% different.
2023-06-23T09:41:45.4687019Z       See diff for details: /home/runner/work/web-components/web-components/packages/avatar-group/test/visual/lumo/screenshots/avatar-group/failed/basic-diff.png[39m
2023-06-23T09:41:45.4688291Z       [90m  at async n.<anonymous> (packages/avatar-group/test/visual/lumo/avatar-group.test.js:17:5)[39m
2023-06-23T09:41:45.4688728Z 

... More (expected) test failures due to me changing some CSS property, action finally fails after third attempt ...

2023-06-23T09:42:32.3032606Z [1m[31mFinished running tests in 77.4s with 31 failed tests.[39m[22m
2023-06-23T09:42:32.3033249Z 
2023-06-23T09:42:32.3033392Z 
2023-06-23T09:42:37.3309975Z error Command failed with exit code 1.
2023-06-23T09:42:37.3311426Z info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2023-06-23T09:43:37.8826119Z ##[error]Final attempt failed. Child_process exited with error code 1
```

</details>