### PR TITLE
fix: make focus restoration work with slotted grid

### DIFF
--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -13,7 +13,6 @@ import '@vaadin/grid/src/vaadin-grid-column-group.js';
 import '@vaadin/grid/src/vaadin-grid-sorter.js';
 import '@vaadin/grid/src/vaadin-grid-filter.js';
 import './vaadin-crud-edit-column.js';
-import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { capitalize, getProperty } from './vaadin-crud-helpers.js';
 import { IncludedMixin } from './vaadin-crud-include-mixin.js';
@@ -57,30 +56,6 @@ class CrudGrid extends IncludedMixin(Grid) {
 
   static get observers() {
     return ['__onItemsChange(items)', '__onHideEditColumnChange(hideEditColumn)'];
-  }
-
-  /** @protected */
-  _getRowContainingNode(node) {
-    const content = getClosestElement('vaadin-grid-cell-content', node);
-    if (!content) {
-      return;
-    }
-
-    const cell = content.assignedSlot.parentElement;
-    return cell.parentElement;
-  }
-
-  /** @protected */
-  _isItemAssigedToRow(item, row) {
-    const model = this.__getRowModel(row);
-    return this.getItemId(item) === this.getItemId(model.item);
-  }
-
-  /** @protected */
-  _focusFirstVisibleRow() {
-    const row = this.__getFirstVisibleItem();
-    this.__rowFocusMode = true;
-    row.focus();
   }
 
   /** @private */

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -1296,7 +1296,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       return;
     }
 
-    if (this._grid._isItemAssigedToRow(this.editedItem, row) && this._grid._isInViewport(row)) {
+    if (this._grid._isItemAssignedToRow(this.editedItem, row) && this._grid._isInViewport(row)) {
       this.__focusRestorationController.restoreFocus();
     } else {
       this._grid._focusFirstVisibleRow();

--- a/packages/crud/test/a11y.test.js
+++ b/packages/crud/test/a11y.test.js
@@ -13,231 +13,247 @@ describe('a11y', () => {
     await setViewport({ width: 1024, height: 768 });
   });
 
-  describe('focus restoration', () => {
-    let grid, form, overlay, newButton, saveButton, cancelButton, editButtons;
+  function focusRestorationTests(testId, createFixture) {
+    describe(`focus restoration - ${testId}`, () => {
+      let grid, form, overlay, newButton, saveButton, cancelButton, editButtons;
 
-    describe('create item', () => {
-      beforeEach(async () => {
-        crud = fixtureSync('<vaadin-crud></vaadin-crud>');
-        crud.items = [{ title: 'Item 1' }];
-        await nextRender();
-        overlay = crud.$.dialog.$.overlay;
-        form = crud.querySelector('vaadin-crud-form');
-        newButton = crud.querySelector('[slot=new-button]');
-        saveButton = crud.querySelector('[slot=save-button]');
-        cancelButton = crud.querySelector('[slot=cancel-button]');
-        editButtons = crud.querySelectorAll('vaadin-crud-edit');
-      });
-
-      it('should move focus to the dialog on new dialog open', async () => {
-        newButton.focus();
-        newButton.click();
-        await nextRender();
-        expect(getDeepActiveElement()).to.equal(overlay.$.overlay);
-      });
-
-      it('should restore focus to previous element on new dialog close', async () => {
-        newButton.focus();
-        newButton.click();
-        await nextRender();
-        await sendKeys({ press: 'Escape' });
-        expect(getDeepActiveElement()).to.equal(newButton);
-      });
-
-      it('should restore focus to previous element on save', async () => {
-        newButton.focus();
-        newButton.click();
-        await nextRender();
-
-        form.querySelector('vaadin-text-field').focus();
-        await sendKeys({ type: 'something' });
-
-        saveButton.focus();
-        saveButton.click();
-        expect(getDeepActiveElement()).to.equal(newButton);
-      });
-
-      it('should restore focus to previous element on cancel', async () => {
-        newButton.focus();
-        newButton.click();
-        await nextRender();
-
-        cancelButton.focus();
-        cancelButton.click();
-        expect(getDeepActiveElement()).to.equal(newButton);
-      });
-    });
-
-    describe('edit item', () => {
-      beforeEach(async () => {
-        crud = fixtureSync('<vaadin-crud editor-position="aside"></vaadin-crud>');
-        crud.items = Array.from({ length: 50 }, (_, i) => {
-          return { title: `Item ${i}` };
-        });
-        await nextRender();
-        grid = crud.querySelector('vaadin-crud-grid');
-        form = crud.querySelector('vaadin-crud-form');
-        newButton = crud.querySelector('[slot=new-button]');
-        saveButton = crud.querySelector('[slot=save-button]');
-        cancelButton = crud.querySelector('[slot=cancel-button]');
-        editButtons = crud.querySelectorAll('vaadin-crud-edit');
-      });
-
-      it('should restore focus to previous element on save', async () => {
-        editButtons[0].focus();
-        editButtons[0].click();
-        await nextRender();
-
-        // Edit the item
-        form.querySelector('vaadin-text-field').focus();
-        await sendKeys({ type: 'something' });
-
-        saveButton.focus();
-        saveButton.click();
-        expect(getDeepActiveElement()).to.equal(editButtons[0]);
-      });
-
-      it('should restore focus to first visible row on save if previous element has been re-used for another item', async () => {
-        editButtons[0].focus();
-        editButtons[0].click();
-        await nextRender();
-
-        // Scroll to the end to trigger the grid to re-use
-        // the saved focused element (the edit button) for another item.
-        grid.scrollToIndex(crud.items.length - 1);
-        await nextRender();
-
-        // Edit the item
-        form.querySelector('vaadin-text-field').focus();
-        await sendKeys({ type: 'something' });
-
-        saveButton.focus();
-        saveButton.click();
-
-        const firstVisibleRow = getVisibleRows(grid.$.items)[0];
-        expect(getDeepActiveElement()).to.equal(firstVisibleRow);
-      });
-
-      it('should restore focus to previous element on cancel', async () => {
-        editButtons[0].focus();
-        editButtons[0].click();
-        await nextRender();
-
-        // Edit the item
-        form.querySelector('vaadin-text-field').focus();
-        await sendKeys({ type: 'something' });
-
-        cancelButton.focus();
-        cancelButton.click();
-        await nextRender();
-
-        const confirmButton = getDeepActiveElement();
-        confirmButton.focus();
-        confirmButton.click();
-        expect(getDeepActiveElement()).to.equal(editButtons[0]);
-      });
-
-      it('should restore focus to first visible row on cancel if previous element has been re-used for another item', async () => {
-        editButtons[0].focus();
-        editButtons[0].click();
-        await nextRender();
-
-        // Scroll to the end to trigger the grid to re-use
-        // the saved focused element (the edit button) for another item.
-        grid.scrollToIndex(crud.items.length - 1);
-        await nextRender();
-
-        cancelButton.focus();
-        cancelButton.click();
-        await nextRender();
-
-        const firstVisibleRow = getVisibleRows(grid.$.items)[0];
-        expect(getDeepActiveElement()).to.equal(firstVisibleRow);
-      });
-
-      it('should switch to row focus mode when restoring focus to first visible row', async () => {
-        editButtons[0].focus();
-        editButtons[0].click();
-        await nextRender();
-
-        // Scroll to the end to trigger the grid to re-use
-        // the saved focused element (the edit button) for another item.
-        grid.scrollToIndex(crud.items.length - 1);
-        await nextRender();
-
-        cancelButton.focus();
-        cancelButton.click();
-        await nextRender();
-
-        await sendKeys({ press: 'ArrowDown' });
-        const secondVisibleRow = getVisibleRows(grid.$.items)[1];
-        expect(getDeepActiveElement()).to.equal(secondVisibleRow);
-      });
-    });
-
-    describe('delete item', () => {
-      let deleteButton;
-
-      beforeEach(() => {
-        crud = fixtureSync('<vaadin-crud editor-position="aside"></vaadin-crud>');
-        newButton = crud.querySelector('[slot=new-button]');
-        deleteButton = crud.querySelector('[slot=delete-button]');
-      });
-
-      describe('multiple rows', () => {
+      describe('create item', () => {
         beforeEach(async () => {
+          crud = createFixture();
+          crud.items = [{ title: 'Item 1' }];
+          await nextRender();
+          overlay = crud.$.dialog.$.overlay;
+          form = crud.querySelector('vaadin-crud-form');
+          newButton = crud.querySelector('[slot=new-button]');
+          saveButton = crud.querySelector('[slot=save-button]');
+          cancelButton = crud.querySelector('[slot=cancel-button]');
+          editButtons = crud.querySelectorAll('vaadin-crud-edit');
+        });
+
+        it('should move focus to the dialog on new dialog open', async () => {
+          newButton.focus();
+          newButton.click();
+          await nextRender();
+          expect(getDeepActiveElement()).to.equal(overlay.$.overlay);
+        });
+
+        it('should restore focus to previous element on new dialog close', async () => {
+          newButton.focus();
+          newButton.click();
+          await nextRender();
+          await sendKeys({ press: 'Escape' });
+          expect(getDeepActiveElement()).to.equal(newButton);
+        });
+
+        it('should restore focus to previous element on save', async () => {
+          newButton.focus();
+          newButton.click();
+          await nextRender();
+
+          form.querySelector('vaadin-text-field').focus();
+          await sendKeys({ type: 'something' });
+
+          saveButton.focus();
+          saveButton.click();
+          expect(getDeepActiveElement()).to.equal(newButton);
+        });
+
+        it('should restore focus to previous element on cancel', async () => {
+          newButton.focus();
+          newButton.click();
+          await nextRender();
+
+          cancelButton.focus();
+          cancelButton.click();
+          expect(getDeepActiveElement()).to.equal(newButton);
+        });
+      });
+
+      describe('edit item', () => {
+        beforeEach(async () => {
+          crud = createFixture();
+          crud.editorPosition = 'aside';
           crud.items = Array.from({ length: 50 }, (_, i) => {
             return { title: `Item ${i}` };
           });
           await nextRender();
-          grid = crud.querySelector('vaadin-crud-grid');
-          editButtons = [...crud.querySelectorAll('vaadin-crud-edit')];
+          grid = crud.querySelector('vaadin-crud-grid') || crud.querySelector('vaadin-grid');
+          form = crud.querySelector('vaadin-crud-form');
+          newButton = crud.querySelector('[slot=new-button]');
+          saveButton = crud.querySelector('[slot=save-button]');
+          cancelButton = crud.querySelector('[slot=cancel-button]');
+          editButtons = crud.querySelectorAll('vaadin-crud-edit');
         });
 
-        it('should restore focus to first visible row on delete', async () => {
-          editButtons[8].focus();
-          editButtons[8].click();
-          await nextRender();
-
-          // Scroll a bit to get a couple of rows out of the grid's viewport.
-          grid.scrollToIndex(2);
-          await nextRender();
-
-          deleteButton.focus();
-          deleteButton.click();
-          await nextRender();
-
-          const confirmButton = getDeepActiveElement();
-          confirmButton.focus();
-          confirmButton.click();
-
-          const firstVisibleRow = getVisibleRows(grid.$.items)[0];
-          expect(getDeepActiveElement()).to.equal(firstVisibleRow);
-        });
-      });
-
-      describe('single row', () => {
-        beforeEach(async () => {
-          crud.items = [{ title: 'Item 1' }];
-          await nextRender();
-          editButtons = [...crud.querySelectorAll('vaadin-crud-edit')];
-        });
-
-        it('should restore focus to new button on delete', async () => {
+        it('should restore focus to previous element on save', async () => {
           editButtons[0].focus();
           editButtons[0].click();
           await nextRender();
 
-          deleteButton.focus();
-          deleteButton.click();
+          // Edit the item
+          form.querySelector('vaadin-text-field').focus();
+          await sendKeys({ type: 'something' });
+
+          saveButton.focus();
+          saveButton.click();
+          expect(getDeepActiveElement()).to.equal(editButtons[0]);
+        });
+
+        it('should restore focus to first visible row on save if previous element has been re-used for another item', async () => {
+          editButtons[0].focus();
+          editButtons[0].click();
+          await nextRender();
+
+          // Scroll to the end to trigger the grid to re-use
+          // the saved focused element (the edit button) for another item.
+          grid.scrollToIndex(crud.items.length - 1);
+          await nextRender();
+
+          // Edit the item
+          form.querySelector('vaadin-text-field').focus();
+          await sendKeys({ type: 'something' });
+
+          saveButton.focus();
+          saveButton.click();
+
+          const firstVisibleRow = getVisibleRows(grid.$.items)[0];
+          expect(getDeepActiveElement()).to.equal(firstVisibleRow);
+        });
+
+        it('should restore focus to previous element on cancel', async () => {
+          editButtons[0].focus();
+          editButtons[0].click();
+          await nextRender();
+
+          // Edit the item
+          form.querySelector('vaadin-text-field').focus();
+          await sendKeys({ type: 'something' });
+
+          cancelButton.focus();
+          cancelButton.click();
           await nextRender();
 
           const confirmButton = getDeepActiveElement();
           confirmButton.focus();
           confirmButton.click();
-          expect(getDeepActiveElement()).to.equal(newButton);
+          expect(getDeepActiveElement()).to.equal(editButtons[0]);
+        });
+
+        it('should restore focus to first visible row on cancel if previous element has been re-used for another item', async () => {
+          editButtons[0].focus();
+          editButtons[0].click();
+          await nextRender();
+
+          // Scroll to the end to trigger the grid to re-use
+          // the saved focused element (the edit button) for another item.
+          grid.scrollToIndex(crud.items.length - 1);
+          await nextRender();
+
+          cancelButton.focus();
+          cancelButton.click();
+          await nextRender();
+
+          const firstVisibleRow = getVisibleRows(grid.$.items)[0];
+          expect(getDeepActiveElement()).to.equal(firstVisibleRow);
+        });
+
+        it('should switch to row focus mode when restoring focus to first visible row', async () => {
+          editButtons[0].focus();
+          editButtons[0].click();
+          await nextRender();
+
+          // Scroll to the end to trigger the grid to re-use
+          // the saved focused element (the edit button) for another item.
+          grid.scrollToIndex(crud.items.length - 1);
+          await nextRender();
+
+          cancelButton.focus();
+          cancelButton.click();
+          await nextRender();
+
+          await sendKeys({ press: 'ArrowDown' });
+          const secondVisibleRow = getVisibleRows(grid.$.items)[1];
+          expect(getDeepActiveElement()).to.equal(secondVisibleRow);
+        });
+      });
+
+      describe('delete item', () => {
+        let deleteButton;
+
+        beforeEach(() => {
+          crud = createFixture();
+          crud.editorPosition = 'aside';
+          newButton = crud.querySelector('[slot=new-button]');
+          deleteButton = crud.querySelector('[slot=delete-button]');
+        });
+
+        describe('multiple rows', () => {
+          beforeEach(async () => {
+            crud.items = Array.from({ length: 50 }, (_, i) => {
+              return { title: `Item ${i}` };
+            });
+            await nextRender();
+            grid = crud.querySelector('vaadin-crud-grid') || crud.querySelector('vaadin-grid');
+            editButtons = [...crud.querySelectorAll('vaadin-crud-edit')];
+          });
+
+          it('should restore focus to first visible row on delete', async () => {
+            editButtons[8].focus();
+            editButtons[8].click();
+            await nextRender();
+
+            // Scroll a bit to get a couple of rows out of the grid's viewport.
+            grid.scrollToIndex(2);
+            await nextRender();
+
+            deleteButton.focus();
+            deleteButton.click();
+            await nextRender();
+
+            const confirmButton = getDeepActiveElement();
+            confirmButton.focus();
+            confirmButton.click();
+
+            const firstVisibleRow = getVisibleRows(grid.$.items)[0];
+            expect(getDeepActiveElement()).to.equal(firstVisibleRow);
+          });
+        });
+
+        describe('single row', () => {
+          beforeEach(async () => {
+            crud.items = [{ title: 'Item 1' }];
+            await nextRender();
+            editButtons = [...crud.querySelectorAll('vaadin-crud-edit')];
+          });
+
+          it('should restore focus to new button on delete', async () => {
+            editButtons[0].focus();
+            editButtons[0].click();
+            await nextRender();
+
+            deleteButton.focus();
+            deleteButton.click();
+            await nextRender();
+
+            const confirmButton = getDeepActiveElement();
+            confirmButton.focus();
+            confirmButton.click();
+            expect(getDeepActiveElement()).to.equal(newButton);
+          });
         });
       });
     });
-  });
+  }
+
+  focusRestorationTests('default grid', () => fixtureSync('<vaadin-crud></vaadin-crud>'));
+  focusRestorationTests('slotted grid', () =>
+    fixtureSync(`
+      <vaadin-crud>
+        <vaadin-grid slot="grid">
+          <vaadin-crud-edit-column></vaadin-crud-edit-column>
+          <vaadin-grid-column path="title" header="Title"></vaadin-grid-column>
+        </vaadin-grid>
+      </vaadin-crud>
+  `),
+  );
 });

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -12,6 +12,7 @@ import { animationFrame, microTask } from '@vaadin/component-base/src/async.js';
 import { isAndroid, isChrome, isFirefox, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
@@ -498,6 +499,23 @@ class Grid extends ElementMixin(
   }
 
   /** @protected */
+  _getRowContainingNode(node) {
+    const content = getClosestElement('vaadin-grid-cell-content', node);
+    if (!content) {
+      return;
+    }
+
+    const cell = content.assignedSlot.parentElement;
+    return cell.parentElement;
+  }
+
+  /** @protected */
+  _isItemAssignedToRow(item, row) {
+    const model = this.__getRowModel(row);
+    return this.getItemId(item) === this.getItemId(model.item);
+  }
+
+  /** @protected */
   ready() {
     super.ready();
 
@@ -541,6 +559,13 @@ class Grid extends ElementMixin(
     if (cell) {
       cell.focus();
     }
+  }
+
+  /** @protected */
+  _focusFirstVisibleRow() {
+    const row = this.__getFirstVisibleItem();
+    this.__rowFocusMode = true;
+    row.focus();
   }
 
   /** @private */


### PR DESCRIPTION
## Description

https://github.com/vaadin/web-components/pull/5898 introduced a regression by adding several methods to `vaadin-crud-grid`, which are not available when using a slotted grid, causing runtime errors. This change moves the methods to `vaadin-grid` and extends the focus restoration tests to cover slotted grids.

Fixes https://github.com/vaadin/web-components/issues/6036

## Type of change

- Bugfix
