### PR TITLE
fix: properly escape email pattern

### DIFF
--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -39,7 +39,7 @@ export class EmailField extends TextField {
   constructor() {
     super();
     this._setType('email');
-    this.pattern = '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-]{2,}$';
+    this.pattern = '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9\\-.]+\\.[a-zA-Z0-9\\-]{2,}$';
   }
 
   /** @protected */

--- a/packages/email-field/src/vaadin-lit-email-field.js
+++ b/packages/email-field/src/vaadin-lit-email-field.js
@@ -27,7 +27,7 @@ export class EmailField extends TextField {
   constructor() {
     super();
     this._setType('email');
-    this.pattern = '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-]{2,}$';
+    this.pattern = '^([a-zA-Z0-9_\\.\\-+])+@[a-zA-Z0-9\\-.]+\\.[a-zA-Z0-9\\-]{2,}$';
   }
 
   /** @protected */

--- a/packages/email-field/test/email-field.common.js
+++ b/packages/email-field/test/email-field.common.js
@@ -27,8 +27,7 @@ const invalidAddresses = [
   'あいうえお@example.com',
   'email@example.com (Joe Smith)',
   'email@example..com',
-  // FIXME: Fails in Chrome, see https://github.com/vaadin/web-components/issues/5938
-  // 'email@example',
+  'email@example',
 ];
 
 describe('email-field', () => {

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fire, fixtureSync, isChrome, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -158,22 +158,18 @@ const runTests = (defineHelper, baseMixin) => {
     });
 
     it('should pass validation when value matches JavaScript-specific regular expression', async () => {
-      element.pattern = '\\u1234\\cx[5-[]{2}';
+      element.pattern = '\\u1234\\cx[5-\\[]{2}';
       await nextFrame();
       commitInputValue('\u1234\x18[6');
       expect(element.checkValidity()).to.be.true;
     });
 
-    // FIXME: Fails in Chrome, see https://github.com/vaadin/web-components/issues/5938
-    (isChrome ? it.skip : it)(
-      'should fail validation when value mismatches JavaScript-specific regular expression',
-      async () => {
-        element.pattern = '\\u1234\\cx[5-[]{2}';
-        await nextFrame();
-        commitInputValue('\u1234\x18[4');
-        expect(element.checkValidity()).to.be.false;
-      },
-    );
+    it('should fail validation when value mismatches JavaScript-specific regular expression', async () => {
+      element.pattern = '\\u1234\\cx[5-\\[]{2}';
+      await nextFrame();
+      commitInputValue('\u1234\x18[4');
+      expect(element.checkValidity()).to.be.false;
+    });
   });
 
   describe('pattern + textarea', () => {


### PR DESCRIPTION
## Description

According to https://bugs.chromium.org/p/chromium/issues/detail?id=1412729#c55, Chrome changed the way how Regex are interpreted, which now requires to escape certain characters in character groups.

Fixes https://github.com/vaadin/web-components/issues/5959
Fixes https://github.com/vaadin/web-components/issues/5938

## Type of change

- Bugfix
