### PR TITLE
test: add missing await to vaadin-overlay unit tests

### DIFF
--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -13,8 +13,6 @@ describe('focus-trap', () => {
   describe('focusable elements', () => {
     beforeEach(async () => {
       overlay = fixtureSync('<vaadin-overlay focus-trap></vaadin-overlay>');
-      await nextRender();
-      overlayPart = overlay.$.overlay;
       overlay.renderer = (root) => {
         if (!root.firstChild) {
           root.innerHTML = `
@@ -28,12 +26,15 @@ describe('focus-trap', () => {
           `;
         }
       };
+      await nextRender();
+      overlayPart = overlay.$.overlay;
       overlay.requestContentUpdate();
       focusableElements = getFocusableElements(overlayPart);
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       overlay.opened = false;
+      await nextRender();
     });
 
     it('should properly detect focusable elements inside the content', () => {

--- a/packages/overlay/test/multiple.test.js
+++ b/packages/overlay/test/multiple.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { click, escKeyDown, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { click, escKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
@@ -8,127 +8,185 @@ describe('multiple overlays', () => {
   describe('modal', () => {
     let parent, overlay1, overlay2, overlay3;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       parent = fixtureSync('<div></div>');
       overlay1 = createOverlay('overlay 1');
       overlay2 = createOverlay('overlay 2');
       overlay3 = createOverlay('overlay 3');
       parent.append(overlay1, overlay2, overlay3);
+      await nextRender();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       overlay1.opened = false;
       overlay2.opened = false;
       overlay3.opened = false;
+      await nextRender();
     });
 
-    it('should be the last when only one overlay is opened', () => {
-      overlay1.opened = true;
-      expect(overlay1._last).to.be.true;
+    describe('last flag', () => {
+      it('should be the last when only one overlay is opened', async () => {
+        overlay1.opened = true;
+        await nextRender();
+        expect(overlay1._last).to.be.true;
+      });
+
+      it('should not be the last when another overlay is opened after this', async () => {
+        overlay1.opened = true;
+        await nextRender();
+
+        overlay2.opened = true;
+        await nextRender();
+
+        expect(overlay1._last).not.to.be.true;
+        expect(overlay2._last).to.be.true;
+      });
+
+      it('should become last when the last overlay is closed', async () => {
+        overlay1.opened = true;
+        await nextRender();
+
+        overlay2.opened = true;
+        await nextRender();
+
+        overlay2.opened = false;
+        await nextRender();
+
+        expect(overlay1._last).to.be.true;
+      });
     });
 
-    it('should not be the last when another overlay is opened after this', () => {
-      overlay1.opened = true;
-      overlay2.opened = true;
-      expect(overlay1._last).not.to.be.true;
-      expect(overlay2._last).to.be.true;
+    describe('vaadin-overlay-escape-press', () => {
+      let spy;
+
+      beforeEach(() => {
+        spy = sinon.spy();
+        overlay1.addEventListener('vaadin-overlay-escape-press', spy);
+      });
+
+      it('should fire the vaadin-overlay-escape-press if it is the only overlay opened', async () => {
+        overlay1.opened = true;
+        await nextRender();
+        escKeyDown(document.body);
+        expect(spy.called).to.be.true;
+      });
+
+      it('should not fire the vaadin-overlay-escape-press if there is a recent overlay opened', async () => {
+        overlay1.opened = true;
+        await nextRender();
+
+        overlay2.opened = true;
+        await nextRender();
+
+        escKeyDown(document.body);
+        expect(spy.called).to.be.false;
+      });
     });
 
-    it('should become last when the last overlay is closed', () => {
-      overlay1.opened = true;
-      overlay2.opened = true;
-      overlay2.opened = false;
-      expect(overlay1._last).to.be.true;
+    describe('vaadin-overlay-outside-click', () => {
+      let spy;
+
+      beforeEach(() => {
+        spy = sinon.spy();
+        overlay1.addEventListener('vaadin-overlay-outside-click', spy);
+      });
+
+      it('should fire the vaadin-overlay-outside-click if it is the only overlay opened', async () => {
+        overlay1.opened = true;
+        await nextRender();
+        click(parent);
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should not fire the vaadin-overlay-outside-click if there is a recent overlay opened', async () => {
+        overlay1.opened = true;
+        await nextRender();
+        overlay2.opened = true;
+        await nextRender();
+        click(parent);
+        expect(spy.called).to.be.false;
+      });
     });
 
-    it('should fire the vaadin-overlay-escape-press if it is the only overlay opened', async () => {
-      const spy = sinon.spy();
-      overlay1.addEventListener('vaadin-overlay-escape-press', spy);
-      overlay1.opened = true;
-      await oneEvent(overlay1, 'vaadin-overlay-open');
-      escKeyDown(document.body);
-      expect(spy.called).to.be.true;
-    });
+    describe('pointer-events', () => {
+      it('should restore pointer-events correctly when overlays are not closed in order', async () => {
+        overlay1.opened = true;
+        await nextRender();
 
-    it('should not fire the vaadin-overlay-escape-press if there is a recent overlay opened', () => {
-      const spy = sinon.spy();
-      overlay1.addEventListener('vaadin-overlay-escape-press', spy);
-      overlay1.opened = true;
-      overlay2.opened = true;
-      escKeyDown(document.body);
-      expect(spy.called).to.be.false;
-    });
+        overlay2.opened = true;
+        await nextRender();
+        expect(document.body.style.pointerEvents).to.eql('none');
 
-    it('should fire the vaadin-overlay-outside-click if it is the only overlay opened', () => {
-      const spy = sinon.spy();
-      overlay1.addEventListener('vaadin-overlay-outside-click', spy);
-      overlay1.opened = true;
-      click(parent);
-      expect(spy.calledOnce).to.be.true;
-    });
+        overlay1.opened = false;
+        await nextRender();
 
-    it('should not fire the vaadin-overlay-outside-click if there is a recent overlay opened', () => {
-      const spy = sinon.spy();
-      overlay1.addEventListener('vaadin-overlay-outside-click', spy);
-      overlay1.opened = true;
-      overlay2.opened = true;
-      click(parent);
-      expect(spy.called).to.be.false;
-    });
+        overlay2.opened = false;
+        await nextRender();
+        expect(document.body.style.pointerEvents).to.eql('');
+      });
 
-    it('should restore correctly pointer events when overlays are not closed in order', () => {
-      overlay1.opened = true;
-      overlay2.opened = true;
-      expect(document.body.style.pointerEvents).to.eql('none');
+      it('should disable pointer-events in first overlay when second opens', async () => {
+        const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
+        overlay1.opened = true;
+        await nextRender();
 
-      overlay1.opened = false;
-      overlay2.opened = false;
-      expect(document.body.style.pointerEvents).to.eql('');
-    });
+        overlay2.opened = true;
+        await nextRender();
 
-    it('should disable pointer-events in first overlay when second opens', () => {
-      const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
-      overlay1.opened = true;
-      overlay2.opened = true;
+        expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('none');
+      });
 
-      expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('none');
-    });
+      it('should restore pointer-events in first overlay when second closes', async () => {
+        const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
+        overlay1.opened = true;
+        await nextRender();
 
-    it('should restore pointer-events in first overlay when second closes', () => {
-      const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
-      overlay1.opened = true;
-      overlay2.opened = true;
-      overlay2.opened = false;
+        overlay2.opened = true;
+        await nextRender();
 
-      expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('auto');
-    });
+        overlay2.opened = false;
+        await nextRender();
+        expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('auto');
+      });
 
-    it('should restore pointer-events in second overlay when third closes', () => {
-      const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
-      const overlay2Part = overlay2.shadowRoot.querySelector('[part="overlay"]');
-      overlay1.opened = true;
-      overlay2.opened = true;
-      overlay3.opened = true;
-      overlay3.opened = false;
+      it('should restore pointer-events in second overlay when third closes', async () => {
+        const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
+        const overlay2Part = overlay2.shadowRoot.querySelector('[part="overlay"]');
+        overlay1.opened = true;
+        await nextRender();
 
-      expect(getComputedStyle(overlay2Part).pointerEvents).to.equal('auto');
-      expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('none');
-    });
+        overlay2.opened = true;
+        await nextRender();
 
-    it('should clear pointer events', () => {
-      const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
-      // Step 1: Opening overlay 1 so it's physically moved under the body
-      overlay1.opened = true;
-      // Step 2: As overlay2 is modal, it will set overlay 1's pointer events to none
-      overlay2.opened = true;
-      // Step 3: Closing overlay 1 so it's physically moved back from under the body
-      overlay1.opened = false;
-      // Step 4: Closing overlay 2 restores pointer-events of an overlay it
-      // finds under the body node, but overlay 1 is no longer there.
-      overlay2.opened = false;
-      // The fix: Clear pointer-events whenever an overlay is closed
-      // (in this case overlay 1 at step 3)
-      expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('auto');
+        overlay3.opened = true;
+        await nextRender();
+
+        overlay3.opened = false;
+        await nextRender();
+
+        expect(getComputedStyle(overlay2Part).pointerEvents).to.equal('auto');
+        expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('none');
+      });
+
+      it('should clear pointer events after closing overlays', async () => {
+        const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
+        // Step 1: Opening overlay 1 so it's physically moved under the body
+        overlay1.opened = true;
+        await nextRender();
+        // Step 2: As overlay2 is modal, it will set overlay 1's pointer events to none
+        overlay2.opened = true;
+        await nextRender();
+        // Step 3: Closing overlay 1 so it's physically moved back from under the body
+        overlay1.opened = false;
+        await nextRender();
+        // Step 4: Closing overlay 2 restores pointer-events of an overlay it
+        // finds under the body node, but overlay 1 is no longer there.
+        overlay2.opened = false;
+        await nextRender();
+        // The fix: Clear pointer-events whenever an overlay is closed
+        // (in this case overlay 1 at step 3)
+        expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('auto');
+      });
     });
   });
 
@@ -143,7 +201,7 @@ describe('multiple overlays', () => {
       return elementFromPoint;
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
       parent = fixtureSync(`
         <div id="parent">
           <vaadin-overlay modeless></vaadin-overlay>
@@ -166,16 +224,20 @@ describe('multiple overlays', () => {
           root.appendChild(input);
         }
       };
+      await nextRender();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       modeless1.opened = false;
       modeless2.opened = false;
+      await nextRender();
     });
 
-    it('should bring the overlay to front with bringToFront', () => {
+    it('should bring the overlay to front with bringToFront', async () => {
       modeless1.opened = true;
+      await nextRender();
       modeless2.opened = true;
+      await nextRender();
       modeless1.bringToFront();
 
       expect(modeless1._last).to.be.true;
@@ -184,8 +246,9 @@ describe('multiple overlays', () => {
       expect(frontmost).to.equal(modeless1);
     });
 
-    it('should not lose scroll position when brought to front', () => {
+    it('should not lose scroll position when brought to front', async () => {
       modeless1.opened = true;
+      await nextRender();
       modeless1.$.content.style.height = '200px';
 
       const overlay = modeless1.$.overlay;
@@ -193,13 +256,16 @@ describe('multiple overlays', () => {
       overlay.scrollTop = 100;
 
       modeless2.opened = true;
+      await nextRender();
       modeless1.bringToFront();
       expect(overlay.scrollTop).to.equal(100);
     });
 
-    it('should grow the z-index by 1', () => {
+    it('should grow the z-index by 1', async () => {
       modeless1.opened = true;
+      await nextRender();
       modeless2.opened = true;
+      await nextRender();
       modeless1.bringToFront();
 
       const zIndex1 = parseFloat(getComputedStyle(modeless1).zIndex);
@@ -207,44 +273,58 @@ describe('multiple overlays', () => {
       expect(zIndex1).to.equal(zIndex2 + 1);
     });
 
-    it('should bring the newly opened overlay to front', () => {
+    it('should bring the newly opened overlay to front', async () => {
       modeless1.opened = true;
+      await nextRender();
       modeless2.opened = true;
+      await nextRender();
       modeless1.bringToFront();
+
       modeless2.opened = false;
+      await nextRender();
       modeless2.opened = true;
+      await nextRender();
 
       const frontmost = getFrontmostOverlayFromScreenCenter();
       expect(frontmost).to.equal(modeless2);
     });
 
-    it('should reset z-indexes', () => {
+    it('should reset z-indexes', async () => {
       modeless1.opened = true;
+      await nextRender();
       modeless2.opened = true;
+      await nextRender();
 
       const zIndex1 = parseFloat(getComputedStyle(modeless1).zIndex);
       expect(parseFloat(modeless2.style.zIndex)).to.equal(zIndex1 + 1);
 
-      modeless1.opened = modeless2.opened = false;
+      modeless1.opened = false;
+      await nextRender();
+      modeless2.opened = false;
+      await nextRender();
+
       modeless2.opened = true;
+      await nextRender();
       expect(modeless2.style.zIndex).to.be.empty;
     });
 
-    it('should not fire the vaadin-overlay-escape-press if the overlay does not contain focus', () => {
+    it('should not fire the vaadin-overlay-escape-press if the overlay does not contain focus', async () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
 
       modeless1.opened = true;
+      await nextRender();
 
       escKeyDown(document.body);
       expect(spy.called).to.be.false;
     });
 
-    it('should not fire the vaadin-overlay-escape-press if the overlay contains focus', () => {
+    it('should not fire the vaadin-overlay-escape-press if the overlay contains focus', async () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
 
       modeless1.opened = true;
+      await nextRender();
 
       const input = modeless1.querySelector('input');
       input.focus();
@@ -253,12 +333,15 @@ describe('multiple overlays', () => {
       expect(spy.called).to.be.true;
     });
 
-    it('should fire the vaadin-overlay-escape-press if the overlay is the frontmost one', () => {
+    it('should fire the vaadin-overlay-escape-press if the overlay is the frontmost one', async () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
 
       modeless1.opened = true;
+      await nextRender();
+
       modeless2.opened = true;
+      await nextRender();
       modeless1.bringToFront();
 
       const input = modeless1.querySelector('input');
@@ -268,12 +351,14 @@ describe('multiple overlays', () => {
       expect(spy.called).to.be.true;
     });
 
-    it('should not fire the vaadin-overlay-escape-press if the overlay is not the frontmost', () => {
+    it('should not fire the vaadin-overlay-escape-press if the overlay is not the frontmost', async () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
 
       modeless1.opened = true;
+      await nextRender();
       modeless2.opened = true;
+      await nextRender();
 
       const input = modeless2.querySelector('input');
       input.focus();

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -45,9 +45,10 @@ customElements.define(
 describe('restore focus', () => {
   let wrapper, overlay, focusable, focusInput;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     focusInput = document.createElement('input');
     wrapper = fixtureSync('<overlay-field-wrapper></overlay-field-wrapper>');
+    await nextRender();
     overlay = wrapper.$.overlay;
     focusable = wrapper.$.focusable;
   });
@@ -66,6 +67,7 @@ describe('restore focus', () => {
       overlay.opened = true;
       await nextRender();
       overlay.opened = false;
+      await nextRender();
       expect(getDeepActiveElement()).to.not.equal(focusInput);
     });
 
@@ -79,6 +81,7 @@ describe('restore focus', () => {
         overlay.opened = true;
         await nextRender();
         overlay.opened = false;
+        await nextRender();
         expect(getDeepActiveElement()).to.not.equal(focusInput);
       });
     });
@@ -103,6 +106,7 @@ describe('restore focus', () => {
         overlay.opened = true;
         await nextRender();
         overlay.opened = false;
+        await nextRender();
         expect(getDeepActiveElement()).to.equal(focusInput);
       });
 
@@ -111,6 +115,7 @@ describe('restore focus', () => {
         overlay.opened = true;
         await nextRender();
         overlay.opened = false;
+        await nextRender();
         expect(getDeepActiveElement()).to.equal(focusable);
       });
 
@@ -120,6 +125,7 @@ describe('restore focus', () => {
         await nextRender();
         focusable.focus();
         overlay.opened = false;
+        await nextRender();
         expect(getDeepActiveElement()).to.equal(focusable);
       });
 
@@ -133,6 +139,7 @@ describe('restore focus', () => {
           overlay.opened = true;
           await nextRender();
           overlay.opened = false;
+          await nextRender();
           expect(getDeepActiveElement()).to.equal(focusInput);
         });
       });


### PR DESCRIPTION
## Description

Some adjustments to `vaadni-overlay` unit tests with adding missing `await` based on my Lit conversion research:

- `focus-trap.test.js`
- `multiple.test.js`
- `restore-focus.test.js`

## Type of change

- Tests