### PR TITLE
refactor!: rename side-nav item active property to current

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -99,7 +99,7 @@ declare class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitEle
    * Set when the item is appended to DOM or when navigated back
    * to the page that contains this item using the browser.
    */
-  readonly active: boolean;
+  readonly current: boolean;
 
   addEventListener<K extends keyof SideNavItemEventMap>(
     type: K,

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -116,7 +116,7 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
        *
        * @type {boolean}
        */
-      active: {
+      current: {
         type: Boolean,
         value: false,
         readOnly: true,
@@ -131,6 +131,8 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
 
   constructor() {
     super();
+
+    this.__boundUpdateCurrent = this.__updateCurrent.bind(this);
 
     this._childrenController = new ChildrenController(this, 'children');
   }
@@ -163,7 +165,7 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
     super.updated(props);
 
     if (props.has('path') || props.has('pathAliases')) {
-      this.__updateActive();
+      this.__updateCurrent();
     }
 
     this.toggleAttribute('has-children', this._childrenController.nodes.length > 0);
@@ -172,22 +174,22 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
   /** @protected */
   connectedCallback() {
     super.connectedCallback();
-    this.__updateActive();
-    this.__boundUpdateActive = this.__updateActive.bind(this);
-    window.addEventListener('popstate', this.__boundUpdateActive);
+    this.__updateCurrent();
+
+    window.addEventListener('popstate', this.__boundUpdateCurrent);
   }
 
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-    window.removeEventListener('popstate', this.__boundUpdateActive);
+    window.removeEventListener('popstate', this.__boundUpdateCurrent);
   }
 
   /** @protected */
   render() {
     return html`
       <div part="content" @click="${this._onContentClick}">
-        <a href="${ifDefined(this.path)}" part="link" aria-current="${this.active ? 'page' : 'false'}">
+        <a href="${ifDefined(this.path)}" part="link" aria-current="${this.current ? 'page' : 'false'}">
           <slot name="prefix"></slot>
           <slot></slot>
           <slot name="suffix"></slot>
@@ -228,20 +230,20 @@ class SideNavItem extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) 
   }
 
   /** @private */
-  __updateActive() {
+  __updateCurrent() {
     if (!this.path && this.path !== '') {
-      this._setActive(false);
+      this._setCurrent(false);
       return;
     }
-    this._setActive(this.__calculateActive());
-    this.toggleAttribute('child-active', document.location.pathname.startsWith(this.path));
-    if (this.active) {
+    this._setCurrent(this.__isCurrent());
+    this.toggleAttribute('child-current', document.location.pathname.startsWith(this.path));
+    if (this.current) {
       this.expanded = true;
     }
   }
 
   /** @private */
-  __calculateActive() {
+  __isCurrent() {
     if (this.path == null) {
       return false;
     }

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -68,10 +68,10 @@ snapshots["vaadin-side-nav-item item expanded"] =
 `;
 /* end snapshot vaadin-side-nav-item item expanded */
 
-snapshots["vaadin-side-nav-item item active"] = 
+snapshots["vaadin-side-nav-item item current"] = 
 `<vaadin-side-nav-item
-  active=""
-  child-active=""
+  child-current=""
+  current=""
   expanded=""
   has-children=""
   role="listitem"
@@ -102,7 +102,7 @@ snapshots["vaadin-side-nav-item item active"] =
   </vaadin-side-nav-item>
 </vaadin-side-nav-item>
 `;
-/* end snapshot vaadin-side-nav-item item active */
+/* end snapshot vaadin-side-nav-item item current */
 
 snapshots["vaadin-side-nav-item item path"] = 
 `<vaadin-side-nav-item
@@ -196,7 +196,7 @@ snapshots["vaadin-side-nav-item shadow expanded"] =
 `;
 /* end snapshot vaadin-side-nav-item shadow expanded */
 
-snapshots["vaadin-side-nav-item shadow active"] = 
+snapshots["vaadin-side-nav-item shadow current"] = 
 `<div part="content">
   <a
     aria-current="page"
@@ -223,7 +223,7 @@ snapshots["vaadin-side-nav-item shadow active"] =
   </slot>
 </ul>
 `;
-/* end snapshot vaadin-side-nav-item shadow active */
+/* end snapshot vaadin-side-nav-item shadow current */
 
 snapshots["vaadin-side-nav-item shadow path"] = 
 `<div part="content">

--- a/packages/side-nav/test/dom/side-nav-item.test.js
+++ b/packages/side-nav/test/dom/side-nav-item.test.js
@@ -34,7 +34,7 @@ describe('vaadin-side-nav-item', () => {
       await expect(sideNavItem).dom.to.equalSnapshot();
     });
 
-    it('active', async () => {
+    it('current', async () => {
       sideNavItem.path = '';
       await nextRender(sideNavItem);
       await expect(sideNavItem).dom.to.equalSnapshot();
@@ -58,7 +58,7 @@ describe('vaadin-side-nav-item', () => {
       await expect(sideNavItem).shadowDom.to.equalSnapshot();
     });
 
-    it('active', async () => {
+    it('current', async () => {
       sideNavItem.path = '';
       await nextRender(sideNavItem);
       await expect(sideNavItem).shadowDom.to.equalSnapshot();

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -58,39 +58,39 @@ describe('side-nav-item', () => {
     });
   });
 
-  describe('active', () => {
+  describe('current', () => {
     describe('no path set initially', () => {
       beforeEach(async () => {
         item = fixtureSync(`<vaadin-side-nav-item></vaadin-side-nav-item>`);
         await nextRender();
       });
 
-      it('should be inactive', () => {
-        expect(item.active).to.be.false;
+      it('should not be current', () => {
+        expect(item.current).to.be.false;
       });
 
-      it('should be inactive even if an alias matches', async () => {
+      it('should not be current even if an alias matches', async () => {
         item.pathAliases = '/';
         await item.updateComplete;
-        expect(item.active).to.be.false;
+        expect(item.current).to.be.false;
       });
 
-      it('should be active when matching path is set', async () => {
+      it('should be current when matching path is set', async () => {
         item.path = '/';
         await item.updateComplete;
-        expect(item.active).to.be.true;
+        expect(item.current).to.be.true;
       });
 
-      it('should be active when an empty matching path is set', async () => {
+      it('should be current when an empty matching path is set', async () => {
         item.path = '';
         await item.updateComplete;
-        expect(item.active).to.be.true;
+        expect(item.current).to.be.true;
       });
 
-      it('should be inactive when not matching path is set', async () => {
+      it('should not be current when not matching path is set', async () => {
         item.path = '/path';
         await item.updateComplete;
-        expect(item.active).to.be.false;
+        expect(item.current).to.be.false;
       });
     });
 
@@ -100,20 +100,20 @@ describe('side-nav-item', () => {
         await nextRender();
       });
 
-      it('should be active', () => {
-        expect(item.active).to.be.true;
+      it('should be current', () => {
+        expect(item.current).to.be.true;
       });
 
-      it('should disallow changing active property to false', async () => {
-        item.active = false;
+      it('should disallow changing current property to false', async () => {
+        item.current = false;
         await item.updateComplete;
-        expect(item.active).to.be.true;
+        expect(item.current).to.be.true;
       });
 
-      it('should be active even when no aliases match', async () => {
+      it('should be current even when no aliases match', async () => {
         item.pathAliases = '/alias';
         await item.updateComplete;
-        expect(item.active).to.be.true;
+        expect(item.current).to.be.true;
       });
     });
 
@@ -123,30 +123,30 @@ describe('side-nav-item', () => {
         await nextRender();
       });
 
-      it('should be inactive', () => {
-        expect(item.active).to.be.false;
+      it('should not be current', () => {
+        expect(item.current).to.be.false;
       });
 
-      it('should disallow changing active property to true', async () => {
-        item.active = true;
+      it('should disallow changing current property to true', async () => {
+        item.current = true;
         await item.updateComplete;
-        expect(item.active).to.be.false;
+        expect(item.current).to.be.false;
       });
 
-      it('should be active when an alias matches', async () => {
+      it('should be current when an alias matches', async () => {
         item.pathAliases = '/, /alias';
         await item.updateComplete;
-        expect(item.active).to.be.true;
+        expect(item.current).to.be.true;
 
         item.pathAliases = '/alias, /';
         await item.updateComplete;
-        expect(item.active).to.be.true;
+        expect(item.current).to.be.true;
       });
 
-      it('should be active when an empty alias matches', async () => {
+      it('should be current when an empty alias matches', async () => {
         item.pathAliases = '';
         await item.updateComplete;
-        expect(item.active).to.be.true;
+        expect(item.current).to.be.true;
       });
     });
   });
@@ -154,7 +154,7 @@ describe('side-nav-item', () => {
   describe('expanded', () => {
     let toggle;
 
-    describe('inactive item with children', () => {
+    describe('not current item with children', () => {
       beforeEach(async () => {
         item = fixtureSync(`
           <vaadin-side-nav-item path="/another-path">
@@ -190,7 +190,7 @@ describe('side-nav-item', () => {
       });
     });
 
-    describe('active item with children', () => {
+    describe('current item with children', () => {
       beforeEach(async () => {
         item = fixtureSync(`
           <vaadin-side-nav-item path="">

--- a/packages/side-nav/test/typings/side-nav.types.ts
+++ b/packages/side-nav/test/typings/side-nav.types.ts
@@ -29,7 +29,7 @@ const sideNavItem: SideNavItem = document.createElement('vaadin-side-nav-item');
 
 // Item properties
 assertType<string | null | undefined>(sideNavItem.path);
-assertType<boolean>(sideNavItem.active);
+assertType<boolean>(sideNavItem.current);
 assertType<boolean>(sideNavItem.expanded);
 
 // Item mixins

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -89,7 +89,7 @@ export const sideNavItemStyles = css`
     color: var(--lumo-contrast-60pct);
   }
 
-  :host([active]) slot[name='prefix']::slotted(:is(vaadin-icon, [class*='icon'])) {
+  :host([current]) slot[name='prefix']::slotted(:is(vaadin-icon, [class*='icon'])) {
     color: inherit;
   }
 
@@ -101,7 +101,7 @@ export const sideNavItemStyles = css`
     --_child-indent-2: var(--_child-indent);
   }
 
-  :host([active]) [part='link'] {
+  :host([current]) [part='link'] {
     color: var(--lumo-primary-text-color);
     background-color: var(--lumo-primary-color-10pct);
   }


### PR DESCRIPTION
## Description

Closes #5963

Renamed `active` to `current` so that we could use `active` attribute for styling an item pressed by mouse.
This would make API aligned with other clickable components e.g. `vaadin-item`, `vaadin-button` etc.

## Type of change

- Breaking change