### PR TITLE
test: increase visual test workflow timeout

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -31,7 +31,7 @@ jobs:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         with:
-          timeout_minutes: 5
+          timeout_minutes: 20
           retry_wait_seconds: 60
           max_attempts: 3
           command: yarn test:lumo
@@ -68,7 +68,7 @@ jobs:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         with:
-          timeout_minutes: 5
+          timeout_minutes: 20
           retry_wait_seconds: 60
           max_attempts: 3
           command: yarn test:material


### PR DESCRIPTION
## Description

When making a change that affects a lot of packages (e.g. to `components-base`), then visual tests take a lot longer than 5 minutes. This increases the timeout to 20 minutes.