### PR TITLE
fix: invoke setFocused only on events triggered by focusElement

### DIFF
--- a/packages/a11y-base/src/delegate-focus-mixin.js
+++ b/packages/a11y-base/src/delegate-focus-mixin.js
@@ -166,13 +166,23 @@ export const DelegateFocusMixin = dedupingMixin(
       }
 
       /**
-       * @param {Event} event
+       * @param {FocusEvent} event
        * @return {boolean}
        * @protected
        * @override
        */
       _shouldSetFocus(event) {
         return event.target === this.focusElement;
+      }
+
+      /**
+       * @param {FocusEvent} event
+       * @return {boolean}
+       * @protected
+       * @override
+       */
+      _shouldRemoveFocus(event) {
+        return event.relatedTarget === this.focusElement;
       }
 
       /**

--- a/packages/a11y-base/src/delegate-focus-mixin.js
+++ b/packages/a11y-base/src/delegate-focus-mixin.js
@@ -182,7 +182,7 @@ export const DelegateFocusMixin = dedupingMixin(
        * @override
        */
       _shouldRemoveFocus(event) {
-        return event.relatedTarget === this.focusElement;
+        return event.target === this.focusElement;
       }
 
       /**


### PR DESCRIPTION
## Description

The PR ensures that `setFocused()` of `DelegateFocusMixin` is only invoked when the focus event is triggered by `focusElement`. Components can have multiple focusable elements, e.g. an input element and a custom button in a suffix slot. Previously, `setFocused(false)` could be also invoked on a focusout triggered by an element other the `focusElement`, which led to unexpected validation in certain components.

Fixes https://github.com/vaadin/flow-components/issues/5136

## Type of change

- [x] Bugfix
