### PR TITLE
refactor: extend side-nav item src styles, add hidden attribute

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -10,8 +10,14 @@ export const sideNavItemBaseStyles = css`
     display: block;
   }
 
+  :host([hidden]),
   [hidden] {
     display: none !important;
+  }
+
+  [part='content'] {
+    display: flex;
+    align-items: center;
   }
 
   [part='link'] {
@@ -28,6 +34,7 @@ export const sideNavItemBaseStyles = css`
     -webkit-appearance: none;
     appearance: none;
     flex: none;
+    position: relative;
     margin: 0;
     padding: 0;
     border: 0;
@@ -42,10 +49,6 @@ export const sideNavItemBaseStyles = css`
 
   :host(:not([has-children])) button {
     display: none !important;
-  }
-
-  :host(:not([path])) a {
-    position: relative;
   }
 
   :host(:not([path])) button::after {

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -8,11 +8,6 @@ import { fieldButton } from '@vaadin/vaadin-lumo-styles/mixins/field-button.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const sideNavItemStyles = css`
-  [part='content'] {
-    display: flex;
-    align-items: center;
-  }
-
   [part='link'] {
     width: 100%;
     gap: var(--lumo-space-xs);
@@ -29,7 +24,6 @@ export const sideNavItemStyles = css`
   }
 
   [part='toggle-button'] {
-    position: relative;
     margin-inline-end: calc(var(--lumo-space-xs) * -1);
     width: var(--lumo-size-s);
     height: var(--lumo-size-s);


### PR DESCRIPTION
## Description

1. Moved some CSS from Lumo theme to `src` as it will be needed for the Material theme,
2. Removed no longer used `position: relative` from the `<a>` element without `href`,
3. Added missing `:host([hidden])` CSS to the `<vaadin-side-nav-item>` base styles.

## Type of change

- Refactor