### PR TITLE
fix: set expanded attribute correctly, add navigation unit tests

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-children-mixin.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-children-mixin.d.ts
@@ -30,6 +30,11 @@ export declare class SideNavChildrenMixinClass {
   i18n: SideNavI18n;
 
   /**
+   * List of child items of this component.
+   */
+  protected readonly _items: HTMLElement[];
+
+  /**
    * Name of the slot to be used for children.
    */
   protected readonly _itemsSlotName: string;

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -236,7 +236,7 @@ class SideNavItem extends SideNavChildrenMixin(ElementMixin(ThemableMixin(Polyli
     this._setCurrent(this.__isCurrent());
     this.toggleAttribute('child-current', document.location.pathname.startsWith(this.path));
     if (this.current) {
-      this.expanded = true;
+      this.expanded = this._items.length > 0;
     }
   }
 

--- a/packages/side-nav/test/navigation.test.js
+++ b/packages/side-nav/test/navigation.test.js
@@ -1,0 +1,64 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '../enable.js';
+import '../vaadin-side-nav-item.js';
+import '../vaadin-side-nav.js';
+
+describe('navigation', () => {
+  let sideNav, items;
+
+  function navigate(url) {
+    history.pushState({}, '', url);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }
+
+  beforeEach(async () => {
+    sideNav = fixtureSync(`
+      <vaadin-side-nav>
+        <vaadin-side-nav-item path="/1">1</vaadin-side-nav-item>
+        <vaadin-side-nav-item path="/2">
+          2
+          <vaadin-side-nav-item slot="children" path="/21">21</vaadin-side-nav-item>
+          <vaadin-side-nav-item slot="children" path="/22">22</vaadin-side-nav-item>
+        </vaadin-side-nav-item>
+      </vaadin-side-nav>
+    `);
+    items = sideNav.querySelectorAll('vaadin-side-nav-item');
+    await nextRender();
+  });
+
+  it('should update current attribute on items when navigating', async () => {
+    navigate('1');
+    await nextRender();
+
+    expect(items[0].hasAttribute('current')).to.be.true;
+    expect(items[1].hasAttribute('current')).to.be.false;
+    expect(items[2].hasAttribute('current')).to.be.false;
+
+    navigate('2');
+    await nextRender();
+
+    expect(items[0].hasAttribute('current')).to.be.false;
+    expect(items[1].hasAttribute('current')).to.be.true;
+    expect(items[2].hasAttribute('current')).to.be.false;
+
+    navigate('21');
+    await nextRender();
+
+    expect(items[0].hasAttribute('current')).to.be.false;
+    expect(items[1].hasAttribute('current')).to.be.false;
+    expect(items[2].hasAttribute('current')).to.be.true;
+  });
+
+  it('should not set expanded attribute on the current leaf item', async () => {
+    navigate('1');
+    await nextRender();
+    expect(items[0].hasAttribute('expanded')).to.be.false;
+  });
+
+  it('should set expanded attribute on the current item with children', async () => {
+    navigate('2');
+    await nextRender();
+    expect(items[1].hasAttribute('expanded')).to.be.true;
+  });
+});


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5092

1. Updated the logic to only set `this.current` when the item actually has children (instead of `true`).
2. Added some basic navigation tests to cover the `popstate` logic (that was previously not tested).

## Type of change

- Bugfix