### PR TITLE
refactor: use array for path aliases

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -84,11 +84,9 @@ declare class SideNavItem extends SideNavChildrenMixin(ElementMixin(ThemableMixi
   path: string | null | undefined;
 
   /**
-   * A comma-separated list of alternative paths matching this item.
-   *
-   * @attr {string} path-aliases
+   * The list of alternative paths matching this item
    */
-  pathAliases: string | null | undefined;
+  pathAliases: string[];
 
   /**
    * Whether to show the child items or not

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -93,11 +93,14 @@ class SideNavItem extends SideNavChildrenMixin(ElementMixin(ThemableMixin(Polyli
       path: String,
 
       /**
-       * A comma-separated list of alternative paths matching this item.
+       * The list of alternative paths matching this item
        *
-       * @attr {string} path-aliases
+       * @type {!Array<string>}
        */
-      pathAliases: String,
+      pathAliases: {
+        type: Array,
+        value: () => [],
+      },
 
       /**
        * Whether to show the child items or not
@@ -229,10 +232,6 @@ class SideNavItem extends SideNavChildrenMixin(ElementMixin(ThemableMixin(Polyli
 
   /** @private */
   __updateCurrent() {
-    if (!this.path && this.path !== '') {
-      this._setCurrent(false);
-      return;
-    }
     this._setCurrent(this.__isCurrent());
     if (this.current) {
       this.expanded = true;
@@ -244,12 +243,9 @@ class SideNavItem extends SideNavChildrenMixin(ElementMixin(ThemableMixin(Polyli
     if (this.path == null) {
       return false;
     }
-    if (matchPaths(document.location.pathname, this.path)) {
-      return true;
-    }
     return (
-      this.pathAliases != null &&
-      this.pathAliases.split(',').some((alias) => matchPaths(document.location.pathname, alias))
+      matchPaths(document.location.pathname, this.path) ||
+      this.pathAliases.some((alias) => matchPaths(document.location.pathname, alias))
     );
   }
 }

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -234,7 +234,6 @@ class SideNavItem extends SideNavChildrenMixin(ElementMixin(ThemableMixin(Polyli
       return;
     }
     this._setCurrent(this.__isCurrent());
-    this.toggleAttribute('child-current', document.location.pathname.startsWith(this.path));
     if (this.current) {
       this.expanded = true;
     }

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -233,6 +233,7 @@ class SideNavItem extends SideNavChildrenMixin(ElementMixin(ThemableMixin(Polyli
   /** @private */
   __updateCurrent() {
     this._setCurrent(this.__isCurrent());
+    this.toggleAttribute('child-current', document.location.pathname.startsWith(this.path));
     if (this.current) {
       this.expanded = true;
     }

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -70,6 +70,7 @@ snapshots["vaadin-side-nav-item item expanded"] =
 
 snapshots["vaadin-side-nav-item item current"] = 
 `<vaadin-side-nav-item
+  child-current=""
   current=""
   expanded=""
   has-children=""

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -70,7 +70,6 @@ snapshots["vaadin-side-nav-item item expanded"] =
 
 snapshots["vaadin-side-nav-item item current"] = 
 `<vaadin-side-nav-item
-  child-current=""
   current=""
   expanded=""
   has-children=""

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -70,7 +70,7 @@ describe('side-nav-item', () => {
       });
 
       it('should not be current even if an alias matches', async () => {
-        item.pathAliases = '/';
+        item.pathAliases = ['/'];
         await item.updateComplete;
         expect(item.current).to.be.false;
       });
@@ -111,7 +111,7 @@ describe('side-nav-item', () => {
       });
 
       it('should be current even when no aliases match', async () => {
-        item.pathAliases = '/alias';
+        item.pathAliases = ['/alias'];
         await item.updateComplete;
         expect(item.current).to.be.true;
       });
@@ -134,17 +134,17 @@ describe('side-nav-item', () => {
       });
 
       it('should be current when an alias matches', async () => {
-        item.pathAliases = '/, /alias';
+        item.pathAliases = ['/', '/alias'];
         await item.updateComplete;
         expect(item.current).to.be.true;
 
-        item.pathAliases = '/alias, /';
+        item.pathAliases = ['/alias', '/'];
         await item.updateComplete;
         expect(item.current).to.be.true;
       });
 
       it('should be current when an empty alias matches', async () => {
-        item.pathAliases = '';
+        item.pathAliases = [''];
         await item.updateComplete;
         expect(item.current).to.be.true;
       });


### PR DESCRIPTION
## Description

This PR updates the type of `pathAliases` property to be a non-null array of strings.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.