### PR TITLE
refactor: remove unused attribute from side nav item

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -234,7 +234,6 @@ class SideNavItem extends SideNavChildrenMixin(ElementMixin(ThemableMixin(Polyli
       return;
     }
     this._setCurrent(this.__isCurrent());
-    this.toggleAttribute('child-current', document.location.pathname.startsWith(this.path));
     if (this.current) {
       this.expanded = this._items.length > 0;
     }

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -70,7 +70,6 @@ snapshots["vaadin-side-nav-item item expanded"] =
 
 snapshots["vaadin-side-nav-item item current"] = 
 `<vaadin-side-nav-item
-  child-current=""
   current=""
   expanded=""
   has-children=""


### PR DESCRIPTION
## Description

This PR removes unused attribute `child-current` from side nav item.

No related issue.

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.