### PR TITLE
fix: display tooltips over notifications

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -28,6 +28,7 @@
     "@vaadin/menu-bar": "24.2.0-alpha1",
     "@vaadin/message-input": "24.2.0-alpha1",
     "@vaadin/multi-select-combo-box": "24.2.0-alpha1",
+    "@vaadin/notification": "24.2.0-alpha1",
     "@vaadin/number-field": "24.2.0-alpha1",
     "@vaadin/overlay": "24.2.0-alpha1",
     "@vaadin/password-field": "24.2.0-alpha1",

--- a/integration/tests/notification-tooltip.test.js
+++ b/integration/tests/notification-tooltip.test.js
@@ -1,0 +1,32 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '@vaadin/notification';
+import '@vaadin/tooltip';
+
+describe('notification and tooltip', () => {
+  beforeEach(async () => {
+    const wrapper = fixtureSync(`
+      <div>
+        <vaadin-notification></vaadin-notification>
+        <div id="target"></div>
+        <vaadin-tooltip for="target" text="Tooltip"></vaadin-tooltip>
+      </div>
+    `);
+    const notification = wrapper.querySelector('vaadin-notification');
+    notification.opened = true;
+    const tooltip = wrapper.querySelector('vaadin-tooltip');
+    tooltip.manual = true;
+    tooltip.opened = true;
+    await nextRender();
+  });
+
+  it('should show tooltips above notifications', () => {
+    const notificationContainer = document.querySelector('vaadin-notification-container');
+    const tooltipOverlay = document.querySelector('vaadin-tooltip-overlay');
+
+    const notificationZIndex = parseInt(getComputedStyle(notificationContainer).zIndex);
+    const tooltipZIndex = parseInt(getComputedStyle(tooltipOverlay).zIndex);
+
+    expect(tooltipZIndex).to.be.above(notificationZIndex);
+  });
+});

--- a/integration/tests/notification-tooltip.test.js
+++ b/integration/tests/notification-tooltip.test.js
@@ -9,13 +9,12 @@ describe('notification and tooltip', () => {
       <div>
         <vaadin-notification></vaadin-notification>
         <div id="target"></div>
-        <vaadin-tooltip for="target" text="Tooltip"></vaadin-tooltip>
+        <vaadin-tooltip for="target" text="Tooltip" manual></vaadin-tooltip>
       </div>
     `);
     const notification = wrapper.querySelector('vaadin-notification');
-    notification.opened = true;
     const tooltip = wrapper.querySelector('vaadin-tooltip');
-    tooltip.manual = true;
+    notification.opened = true;
     tooltip.opened = true;
     await nextRender();
   });

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -10,6 +10,10 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-tooltip-overlay',
   css`
+    :host {
+      z-index: 1100;
+    }
+
     [part='overlay'] {
       max-width: 40ch;
     }


### PR DESCRIPTION
## Description

Currently tooltips are always shown below notifications:
- Tooltip overlays use a z-index of `200` via the default `vaadin-overlay` styles: https://github.com/vaadin/web-components/blob/90992ed3d323e723ffa2d42d896465bf770d866d/packages/overlay/src/vaadin-overlay.js#L85
- Notifications use a z-index of `1000`: https://github.com/vaadin/web-components/blob/90992ed3d323e723ffa2d42d896465bf770d866d/packages/notification/src/vaadin-notification.js#L30

This increases the z-index for tooltips to be larger than the one for notifications.

Fixes https://github.com/vaadin/web-components/issues/5748

## Type of change

- Bugfix