### PR TITLE
fix: update aria-labelledby when restoring default label

### DIFF
--- a/packages/component-base/src/slot-child-observe-controller.js
+++ b/packages/component-base/src/slot-child-observe-controller.js
@@ -169,7 +169,7 @@ export class SlotChildObserveController extends SlotController {
   __updateNodeId(node) {
     // When in multiple mode, only set ID attribute on the element in default slot.
     const isFirstNode = !this.nodes || node === this.nodes[0];
-    if (node.nodeType === Node.ELEMENT_NODE && isFirstNode && !node.id) {
+    if (node.nodeType === Node.ELEMENT_NODE && (!this.multiple || isFirstNode) && !node.id) {
       node.id = this.defaultId;
     }
   }

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -871,7 +871,7 @@ const runTests = (defineHelper, baseMixin) => {
   describe('slotted label', () => {
     beforeEach(async () => {
       element = fixtureSync(`
-        <${tag}>
+        <${tag} label="Default">
           <label slot="label">Label</label>
           <input slot="input">
         </${tag}>
@@ -885,6 +885,15 @@ const runTests = (defineHelper, baseMixin) => {
       const aria = input.getAttribute('aria-labelledby');
       expect(aria).to.be.ok;
       expect(aria).to.equal(label.id);
+    });
+
+    it('should restore aria-labelledby when removing slotted label', async () => {
+      label.remove();
+      await nextRender();
+      const defaultLabel = element.querySelector('[slot=label]');
+      const aria = input.getAttribute('aria-labelledby');
+      expect(aria).to.be.ok;
+      expect(aria).to.equal(defaultLabel.id);
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #5648

The issue with not adding `aria-labelledby` was related to the fact that ID was not set on default `label`.
As it turned out, there was an incorrect check for `multiple` mode in `SlotChildObserveController`.

## Type of change

- Bugfix

## Note

Can be tested using the following code example (click the button and observe `input` attributes):

```html
<vaadin-text-field label="Default label"></vaadin-text-field>

<button>Remove label</button>

<script type="module">
  import '@vaadin/text-field';

  const label = document.createElement('label');
  label.id = 'custom-id';
  label.textContent = 'Custom label';
  label.setAttribute('slot', 'label');
  document.querySelector('vaadin-text-field').appendChild(label);

  const button = document.querySelector('button');
  button.addEventListener('click', () => {
    label.remove();
  });
</script>
```