### PR TITLE
refactor: set aria-hidden on the side-nav-item nested list

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -202,7 +202,7 @@ class SideNavItem extends SideNavChildrenMixin(ElementMixin(ThemableMixin(Polyli
           aria-labelledby="link i18n"
         ></button>
       </div>
-      <ul part="children" ?hidden="${!this.expanded}">
+      <ul part="children" ?hidden="${!this.expanded}" aria-hidden="${this.expanded ? 'false' : 'true'}">
         <slot name="children"></slot>
       </ul>
       <div class="sr-only" id="i18n">${this.i18n.toggle}</div>

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -159,6 +159,7 @@ snapshots["vaadin-side-nav-item shadow default"] =
   </button>
 </div>
 <ul
+  aria-hidden="true"
   hidden=""
   part="children"
 >
@@ -196,7 +197,10 @@ snapshots["vaadin-side-nav-item shadow expanded"] =
   >
   </button>
 </div>
-<ul part="children">
+<ul
+  aria-hidden="false"
+  part="children"
+>
   <slot name="children">
   </slot>
 </ul>
@@ -232,7 +236,10 @@ snapshots["vaadin-side-nav-item shadow current"] =
   >
   </button>
 </div>
-<ul part="children">
+<ul
+  aria-hidden="false"
+  part="children"
+>
   <slot name="children">
   </slot>
 </ul>
@@ -269,6 +276,7 @@ snapshots["vaadin-side-nav-item shadow path"] =
   </button>
 </div>
 <ul
+  aria-hidden="true"
   hidden=""
   part="children"
 >
@@ -307,6 +315,7 @@ snapshots["vaadin-side-nav-item shadow i18n"] =
   </button>
 </div>
 <ul
+  aria-hidden="true"
   hidden=""
   part="children"
 >


### PR DESCRIPTION
## Description

Currently, `vaadin-side-nav` sets `aria-hidden` on the `<ul>` element, but `vaadin-side-nav-item` does not:

https://github.com/vaadin/web-components/blob/b8378bd2267728e172012bcb2ea45c3e5a6e590a/packages/side-nav/src/vaadin-side-nav.js#L160

https://github.com/vaadin/web-components/blob/b8378bd2267728e172012bcb2ea45c3e5a6e590a/packages/side-nav/src/vaadin-side-nav-item.js#L205

This PR aligns the DOM structure to add missing `aria-hidden` attribute depending on the `expanded` property.

## Type of change

- Refactor