### PR TITLE
refactor: use splice() instead of adding items one by one

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -398,10 +398,7 @@ export const DataProviderMixin = (superClass) =>
           }
 
           // Populate the cache with new items
-          items.forEach((item, itemsIndex) => {
-            const itemIndex = page * this.pageSize + itemsIndex;
-            cache.items[itemIndex] = item;
-          });
+          cache.items.splice(page * this.pageSize, items.length, ...items);
 
           // With the new items added, update the cache size and the grid's effective size
           this._cache.updateSize();


### PR DESCRIPTION
## Description

The PR aims to simplify `DataProviderMixin` of the grid component by changing it to use the `splice()` method for adding items to a cache, instead of adding them one by one. This will align the implementation with the combo-box:

https://github.com/vaadin/web-components/blob/facf47bd7d91dbee72b873adb41930c899706099/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js#L185-L187

Note, the `splice()` method has a limitation on the max number of items you can add in one batch, which is approximately 100 000. However, such large page sizes seem unlikely, especially considering that they will result in significant performance degradation.

Depends on 
- https://github.com/vaadin/web-components/pull/6093
## Type of change

- [x] Refactor
