### PR TITLE
refactor: store items as an array instead of an object

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -25,8 +25,8 @@ export const ItemCache = class ItemCache {
     this.parentItem = parentItem;
     /** @type {object} */
     this.itemCaches = {};
-    /** @type {object} */
-    this.items = {};
+    /** @type {object[]} */
+    this.items = [];
     /** @type {number} */
     this.effectiveSize = 0;
     /** @type {number} */


### PR DESCRIPTION
## Description

It turns out that the grid items has been internally stored as an object. This traces back to the early stages of the grid. While there seems to be no significant performance difference between objects and arrays in JS, objects lack such methods as `push`, `splice`, etc, which it could be good to have in some situations. In general, I believe it would be more natural for the items to be an array since they are ordered.

## Type of change

- [x] Refactor
