### PR TITLE
fix: animate primary drawer open and close transition

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -384,12 +384,6 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
         value: 'vaadin-router-location-changed',
         observer: '_closeDrawerOnChanged',
       },
-
-      /** @private */
-      __isDrawerAnimating: {
-        type: Boolean,
-        observer: '__isDrawerAnimatingChanged',
-      },
     };
   }
 
@@ -472,6 +466,8 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     });
     this.$.drawer.addEventListener('transitionend', () => {
       this.__isDrawerAnimating = false;
+      this.__updateOffsetSizePending = false;
+      this._updateOffsetSize();
     });
   }
 
@@ -544,14 +540,6 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
    */
   __i18nChanged() {
     this.__updateDrawerAriaAttributes();
-  }
-
-  /** @private */
-  __isDrawerAnimatingChanged(isAnimating) {
-    if (!isAnimating && this.__updateOffsetSizePending) {
-      this.__updateOffsetSizePending = false;
-      this._updateOffsetSize();
-    }
   }
 
   /** @protected */

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -440,7 +440,11 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
 
     this._navbarSizeObserver = new ResizeObserver(() => {
       requestAnimationFrame(() => {
-        this._blockAnimationUntilAfterNextRender();
+        // Ignore resize caused by drawer toggle click
+        // to make drawer open / close transition work
+        if (!this.__drawerToggleClicked) {
+          this._blockAnimationUntilAfterNextRender();
+        }
         this._updateOffsetSize();
       });
     });
@@ -535,9 +539,18 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
   }
 
   /** @private */
-  _drawerToggleClick(e) {
+  async _drawerToggleClick(e) {
     e.stopPropagation();
+
+    // Prevent disabling the animation
+    this.__drawerToggleClicked = true;
+
     this.drawerOpened = !this.drawerOpened;
+
+    // Wait for the drawer CSS transition.
+    await this.__drawerTransitionComplete();
+
+    this.__drawerToggleClicked = false;
   }
 
   /** @private */

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -464,12 +464,19 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     this.$.drawer.addEventListener('transitionstart', () => {
       this.__isDrawerAnimating = true;
     });
+
     this.$.drawer.addEventListener('transitionend', () => {
-      this.__isDrawerAnimating = false;
+      // Update offset size after drawer animation.
       if (this.__updateOffsetSizePending) {
         this.__updateOffsetSizePending = false;
         this._updateOffsetSize();
       }
+
+      // Delay resetting the flag until animation frame
+      // to avoid updating offset size again on resize.
+      requestAnimationFrame(() => {
+        this.__isDrawerAnimating = false;
+      });
     });
   }
 

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -440,12 +440,11 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
 
     this._navbarSizeObserver = new ResizeObserver(() => {
       requestAnimationFrame(() => {
-        // Ignore resize caused by drawer toggle click
-        // to make drawer open / close transition work
+        // Avoid updating offset size multiple times
+        // during the drawer open / close transition
         if (!this.__drawerToggleClicked) {
-          this._blockAnimationUntilAfterNextRender();
+          this._updateOffsetSize();
         }
-        this._updateOffsetSize();
       });
     });
     this._navbarSizeObserver.observe(this.$.navbarTop);

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -553,7 +553,6 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
   /** @private */
   _drawerToggleClick(e) {
     e.stopPropagation();
-
     this.drawerOpened = !this.drawerOpened;
   }
 

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -466,8 +466,10 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     });
     this.$.drawer.addEventListener('transitionend', () => {
       this.__isDrawerAnimating = false;
-      this.__updateOffsetSizePending = false;
-      this._updateOffsetSize();
+      if (this.__updateOffsetSizePending) {
+        this.__updateOffsetSizePending = false;
+        this._updateOffsetSize();
+      }
     });
   }
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -275,18 +275,17 @@ describe('vaadin-app-layout', () => {
         expect(toggle.getAttribute('aria-expanded')).to.equal('true');
       });
 
-      it('should not disable transition by setting attribute on toggle click', async () => {
+      it('should not update offset size during the drawer open transition', async () => {
         layout.style.setProperty('--vaadin-app-layout-transition', '100ms');
         layout.primarySection = 'drawer';
 
         await onceResized(layout);
         await nextRender();
 
-        const spy = sinon.spy(layout, 'setAttribute');
+        const spy = sinon.spy(layout, '_updateOffsetSize');
         toggle.click();
 
-        await onceResized(layout);
-        await nextRender();
+        await oneEvent(drawer, 'transitionend');
 
         expect(spy.called).to.be.false;
       });

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -275,7 +275,7 @@ describe('vaadin-app-layout', () => {
         expect(toggle.getAttribute('aria-expanded')).to.equal('true');
       });
 
-      it('should not update offset size during the drawer open transition', async () => {
+      it('should not update offset size until end of the drawer transition', async () => {
         layout.style.setProperty('--vaadin-app-layout-transition', '100ms');
         layout.primarySection = 'drawer';
 
@@ -286,7 +286,6 @@ describe('vaadin-app-layout', () => {
         toggle.click();
 
         await oneEvent(drawer, 'transitionend');
-
         expect(spy.called).to.be.false;
       });
     });

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -274,6 +274,22 @@ describe('vaadin-app-layout', () => {
         layout.drawerOpened = true;
         expect(toggle.getAttribute('aria-expanded')).to.equal('true');
       });
+
+      it('should not disable transition by setting attribute on toggle click', async () => {
+        layout.style.setProperty('--vaadin-app-layout-transition', '100ms');
+        layout.primarySection = 'drawer';
+
+        await onceResized(layout);
+        await nextRender();
+
+        const spy = sinon.spy(layout, 'setAttribute');
+        toggle.click();
+
+        await onceResized(layout);
+        await nextRender();
+
+        expect(spy.called).to.be.false;
+      });
     });
 
     describe('mobile layout', () => {

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -275,18 +275,18 @@ describe('vaadin-app-layout', () => {
         expect(toggle.getAttribute('aria-expanded')).to.equal('true');
       });
 
-      it('should not update offset size until end of the drawer transition', async () => {
-        layout.style.setProperty('--vaadin-app-layout-transition', '100ms');
+      it('should only update offset size once during the drawer transition', async () => {
         layout.primarySection = 'drawer';
-
         await onceResized(layout);
         await nextRender();
 
+        layout.style.setProperty('--vaadin-app-layout-transition', '100ms');
+
         const spy = sinon.spy(layout, '_updateOffsetSize');
         toggle.click();
-
         await oneEvent(drawer, 'transitionend');
-        expect(spy.called).to.be.false;
+
+        expect(spy.callCount).to.be.equal(1);
       });
     });
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -287,6 +287,9 @@ describe('vaadin-app-layout', () => {
         await oneEvent(drawer, 'transitionend');
 
         expect(spy.callCount).to.be.equal(1);
+        await nextFrame();
+
+        expect(spy.callCount).to.be.equal(1);
       });
     });
 


### PR DESCRIPTION
## Description

Fixes #5123

Added a flag to distinguish the resize caused by drawer click and to prevent disabling animation in this case.

## Type of change

- Bugfix