### PR TITLE
fix!: align how clear button works with combo box behavior

### DIFF
--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
+import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { InputMixin } from './input-mixin.js';
 
 /**
@@ -52,7 +53,6 @@ export const ClearButtonMixin = (superclass) =>
 
       if (this.clearElement) {
         this.clearElement.addEventListener('mousedown', (event) => this._onClearButtonMouseDown(event));
-        this.clearElement.addEventListener('touchend', () => this._onClearButtonTouchEnd());
         this.clearElement.addEventListener('click', (event) => this._onClearButtonClick(event));
       }
     }
@@ -72,14 +72,9 @@ export const ClearButtonMixin = (superclass) =>
      */
     _onClearButtonMouseDown(event) {
       event.preventDefault();
-      this.inputElement.focus();
-    }
-
-    /**
-     * @protected
-     */
-    _onClearButtonTouchEnd() {
-      this._onClearAction();
+      if (!isTouch) {
+        this.inputElement.focus();
+      }
     }
 
     /**

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -52,7 +52,7 @@ export const ClearButtonMixin = (superclass) =>
 
       if (this.clearElement) {
         this.clearElement.addEventListener('mousedown', (event) => this._onClearButtonMouseDown(event));
-        this.clearElement.addEventListener('touchend', (event) => this._onClearButtonTouchEnd(event));
+        this.clearElement.addEventListener('touchend', () => this._onClearButtonTouchEnd());
         this.clearElement.addEventListener('click', (event) => this._onClearButtonClick(event));
       }
     }
@@ -76,12 +76,9 @@ export const ClearButtonMixin = (superclass) =>
     }
 
     /**
-     * @param {Event} event
-     * @param {boolean} focusInputElement
      * @protected
      */
-    _onClearButtonTouchEnd(event) {
-      event.preventDefault();
+    _onClearButtonTouchEnd() {
       this._onClearAction();
     }
 

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -51,6 +51,8 @@ export const ClearButtonMixin = (superclass) =>
       super.ready();
 
       if (this.clearElement) {
+        this.clearElement.addEventListener('mousedown', (event) => this._onClearButtonAction(event));
+        this.clearElement.addEventListener('touchstart', (event) => this._onClearButtonAction(event, false));
         this.clearElement.addEventListener('click', (event) => this._onClearButtonClick(event));
       }
     }
@@ -60,8 +62,21 @@ export const ClearButtonMixin = (superclass) =>
      * @protected
      */
     _onClearButtonClick(event) {
+      if (event.composedPath()[0] === this.clearElement) {
+        this._onClearButtonAction(event);
+      }
+    }
+
+    /**
+     * @param {Event} event
+     * @param {boolean} focusInputElement
+     * @protected
+     */
+    _onClearButtonAction(event, focusInputElement = true) {
       event.preventDefault();
-      this.inputElement.focus();
+      if (focusInputElement) {
+        this.inputElement.focus();
+      }
       this._onClearAction();
     }
 

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -67,7 +67,7 @@ export const ClearButtonMixin = (superclass) =>
     }
 
     /**
-     * @param {Event} event
+     * @param {MouseEvent} event
      * @protected
      */
     _onClearButtonMouseDown(event) {

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -51,8 +51,8 @@ export const ClearButtonMixin = (superclass) =>
       super.ready();
 
       if (this.clearElement) {
-        this.clearElement.addEventListener('mousedown', (event) => this._onClearButtonAction(event));
-        this.clearElement.addEventListener('touchstart', (event) => this._onClearButtonAction(event, false));
+        this.clearElement.addEventListener('mousedown', (event) => this._onClearButtonMouseDown(event));
+        this.clearElement.addEventListener('touchend', (event) => this._onClearButtonTouchEnd(event));
         this.clearElement.addEventListener('click', (event) => this._onClearButtonClick(event));
       }
     }
@@ -62,9 +62,17 @@ export const ClearButtonMixin = (superclass) =>
      * @protected
      */
     _onClearButtonClick(event) {
-      if (event.composedPath()[0] === this.clearElement) {
-        this._onClearButtonAction(event);
-      }
+      event.preventDefault();
+      this._onClearAction();
+    }
+
+    /**
+     * @param {Event} event
+     * @protected
+     */
+    _onClearButtonMouseDown(event) {
+      event.preventDefault();
+      this.inputElement.focus();
     }
 
     /**
@@ -72,11 +80,8 @@ export const ClearButtonMixin = (superclass) =>
      * @param {boolean} focusInputElement
      * @protected
      */
-    _onClearButtonAction(event, focusInputElement = true) {
+    _onClearButtonTouchEnd(event) {
       event.preventDefault();
-      if (focusInputElement) {
-        this.inputElement.focus();
-      }
       this._onClearAction();
     }
 

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -6,8 +6,11 @@ import {
   fire,
   fixtureSync,
   keyboardEventFor,
+  mousedown,
   nextFrame,
   nextRender,
+  touchend,
+  touchstart,
 } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
@@ -66,7 +69,28 @@ const runTests = (defineHelper, baseMixin) => {
     it('should focus the input on clear button click', () => {
       const spy = sinon.spy(input, 'focus');
       clearButton.click();
+      mousedown(clearButton);
       expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should clear the input value on clear button touch', async () => {
+      touchstart(clearButton);
+      touchend(clearButton);
+      await nextFrame();
+      expect(input.value).to.equal('');
+    });
+
+    it('should not focus the input on clear button touch', () => {
+      const spy = sinon.spy(input, 'focus');
+      touchstart(clearButton);
+      touchend(clearButton);
+      expect(spy.called).to.be.false;
+    });
+
+    it('should keep focus at the input on clear button touch', () => {
+      input.focus();
+      touchstart(clearButton);
+      expect(document.activeElement).to.be.equal(input);
     });
 
     it('should dispatch input event on clear button click', () => {

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import {
+  click,
   defineLit,
   definePolymer,
   escKeyDown,
@@ -65,14 +66,22 @@ const runTests = (defineHelper, baseMixin) => {
       expect(input.value).to.equal('');
     });
 
-    it('should focus the input on clear button mousedown', () => {
+    (!isTouch ? it : it.skip)('should focus the input on clear button mousedown', () => {
+      console.log('got here!!!hhhh');
       const spy = sinon.spy(input, 'focus');
       mousedown(clearButton);
       expect(spy.calledOnce).to.be.true;
     });
 
+    it('should prevent default on clear button mousedown', () => {
+      const event = new CustomEvent('mousedown', { cancelable: true });
+      clearButton.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
     (isTouch ? it : it.skip)('should clear the input value on clear button touch', async () => {
       mousedown(clearButton);
+      click(clearButton);
       await nextFrame();
       expect(input.value).to.equal('');
     });

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -9,11 +9,10 @@ import {
   mousedown,
   nextFrame,
   nextRender,
-  touchend,
-  touchstart,
 } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
+import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ClearButtonMixin } from '../src/clear-button-mixin.js';
@@ -72,24 +71,21 @@ const runTests = (defineHelper, baseMixin) => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should clear the input value on clear button touch', async () => {
-      touchstart(clearButton);
-      touchend(clearButton);
+    (isTouch ? it : it.skip)('should clear the input value on clear button touch', async () => {
+      mousedown(clearButton);
       await nextFrame();
       expect(input.value).to.equal('');
     });
 
-    it('should not focus the input on clear button touch', () => {
+    (isTouch ? it : it.skip)('should not focus the input on clear button touch', () => {
       const spy = sinon.spy(input, 'focus');
-      touchstart(clearButton);
-      touchend(clearButton);
+      mousedown(clearButton);
       expect(spy.called).to.be.false;
     });
 
-    it('should keep focus at the input on clear button touch', () => {
+    (isTouch ? it : it.skip)('should keep focus at the input on clear button touch', () => {
       input.focus();
-      touchstart(clearButton);
-      touchend(clearButton);
+      mousedown(clearButton);
       expect(document.activeElement).to.be.equal(input);
     });
 

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -89,6 +89,7 @@ const runTests = (defineHelper, baseMixin) => {
     it('should keep focus at the input on clear button touch', () => {
       input.focus();
       touchstart(clearButton);
+      touchend(clearButton);
       expect(document.activeElement).to.be.equal(input);
     });
 

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -66,9 +66,8 @@ const runTests = (defineHelper, baseMixin) => {
       expect(input.value).to.equal('');
     });
 
-    it('should focus the input on clear button click', () => {
+    it('should focus the input on clear button mousedown', () => {
       const spy = sinon.spy(input, 'focus');
-      clearButton.click();
       mousedown(clearButton);
       expect(spy.calledOnce).to.be.true;
     });

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -67,7 +67,6 @@ const runTests = (defineHelper, baseMixin) => {
     });
 
     (!isTouch ? it : it.skip)('should focus the input on clear button mousedown', () => {
-      console.log('got here!!!hhhh');
       const spy = sinon.spy(input, 'focus');
       mousedown(clearButton);
       expect(spy.calledOnce).to.be.true;

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -78,13 +78,6 @@ const runTests = (defineHelper, baseMixin) => {
       expect(event.defaultPrevented).to.be.true;
     });
 
-    (isTouch ? it : it.skip)('should clear the input value on clear button touch', async () => {
-      mousedown(clearButton);
-      click(clearButton);
-      await nextFrame();
-      expect(input.value).to.equal('');
-    });
-
     (isTouch ? it : it.skip)('should not focus the input on clear button touch', () => {
       const spy = sinon.spy(input, 'focus');
       mousedown(clearButton);

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import {
-  click,
   defineLit,
   definePolymer,
   escKeyDown,

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -1,13 +1,16 @@
 import { expect } from '@esm-bundle/chai';
 import {
+  click,
   defineLit,
   definePolymer,
   escKeyDown,
   fixtureSync,
   keyboardEventFor,
   keyDownOn,
+  mousedown,
   nextFrame,
   nextRender,
+  touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
@@ -78,6 +81,30 @@ const runTests = (defineHelper, baseMixin) => {
       const spy = sinon.spy(input, 'focus');
       button.click();
       expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should clear the input value on clear button mousedown', async () => {
+      mousedown(button);
+      await nextFrame();
+      expect(input.value).to.equal('');
+    });
+
+    it('should clear the input value on clear button touch', async () => {
+      touchstart(button);
+      await nextFrame();
+      expect(input.value).to.equal('');
+    });
+
+    it('should not focus the input on clear button touch', () => {
+      const spy = sinon.spy(input, 'focus');
+      touchstart(button);
+      expect(spy.called).to.be.false;
+    });
+
+    it('should keep focus at the input on clear button touch', () => {
+      input.focus();
+      touchstart(button);
+      expect(document.activeElement).to.be.equal(input);
     });
 
     it('should dispatch input event on clear button click', () => {

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -11,6 +11,7 @@ import {
   nextRender,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
+import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputControlMixin } from '../src/input-control-mixin.js';
@@ -75,7 +76,7 @@ const runTests = (defineHelper, baseMixin) => {
       expect(input.value).to.equal('');
     });
 
-    it('should focus the input on clear button mousedown', () => {
+    (!isTouch ? it : it.skip)('should focus the input on clear clearButton mousedown', () => {
       const spy = sinon.spy(input, 'focus');
       mousedown(button);
       expect(spy.calledOnce).to.be.true;

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import {
-  click,
   defineLit,
   definePolymer,
   escKeyDown,
@@ -10,7 +9,6 @@ import {
   mousedown,
   nextFrame,
   nextRender,
-  touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
@@ -77,34 +75,10 @@ const runTests = (defineHelper, baseMixin) => {
       expect(input.value).to.equal('');
     });
 
-    it('should focus the input on clear button click', () => {
+    it('should focus the input on clear button mousedown', () => {
       const spy = sinon.spy(input, 'focus');
-      button.click();
-      expect(spy.calledOnce).to.be.true;
-    });
-
-    it('should clear the input value on clear button mousedown', async () => {
       mousedown(button);
-      await nextFrame();
-      expect(input.value).to.equal('');
-    });
-
-    it('should clear the input value on clear button touch', async () => {
-      touchstart(button);
-      await nextFrame();
-      expect(input.value).to.equal('');
-    });
-
-    it('should not focus the input on clear button touch', () => {
-      const spy = sinon.spy(input, 'focus');
-      touchstart(button);
-      expect(spy.called).to.be.false;
-    });
-
-    it('should keep focus at the input on clear button touch', () => {
-      input.focus();
-      touchstart(button);
-      expect(document.activeElement).to.be.equal(input);
+      expect(spy.calledOnce).to.be.true;
     });
 
     it('should dispatch input event on clear button click', () => {


### PR DESCRIPTION
## Description

Make the behavior of clicking the clear button to be aligned with how `<vaadin-combo-box>` works.

This change:
- adds a `touchstart` listener that prevent default, and clears the input element, **BUT** does not focus it
- adds a `mousedown` listener that prevents default, focuses the input element, **AND** clears it
- keep a click listener that does the same `mousedown` behavior, mostly used for programmatic clicks on the button

These changes also fix the issue described in https://github.com/vaadin/flow-components/issues/5137, since it prevents the `focusout` event and the editor won't close after clicking the clear button.


Fixes #4130
Part of https://github.com/vaadin/flow-components/issues/5137

## Type of change

- [X] Bugfix
- [ ] Feature
