### PR TITLE
refactor: do not clear combo-box-light on change from clear button

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -196,18 +196,6 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
   }
 
   /**
-   * @param {!Event} event
-   * @protected
-   */
-  _onChange(event) {
-    super._onChange(event);
-
-    if (this._isClearButton(event)) {
-      this._onClearAction();
-    }
-  }
-
-  /**
    * @protected
    * @override
    */


### PR DESCRIPTION
## Description

It seems unnecessary to clear `combo-box-light` on change events generated by the clear button, as clearing already happens on clear button click. 

For the record, the related change handler was introduced during the slotted input refactoring ([link](https://github.com/vaadin/web-components/commit/f5c2ec5f4fd36bb1fd6cee372382099ddf30d9b7#diff-7b3209e8e6ef17cdad592230144268dfec125c16d28f8d39878ab92224bcd223R185-R191)) and, apparently, it became redundant at some point later.

## Type of change

- [x] Refactor
