### PR TITLE
fix: set tabindex on remaining button after updating overflow

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -276,6 +276,13 @@ export const MenuBarMixin = (superClass) =>
         }
         const items = buttons.filter((_, idx) => idx >= i).map((b) => b.item);
         this.__updateOverflow(items);
+
+        const remaining = buttons.slice(0, i);
+        // Ensure there is at least one button with tabindex set to 0
+        // so that menu-bar is not skipped when navigating with Tab
+        if (i > 0 && !remaining.some((btn) => btn.getAttribute('tabindex') === '0')) {
+          this._setTabindex(remaining[i - 1], true);
+        }
       }
     }
 

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -451,6 +451,19 @@ describe('overflow button', () => {
     expect(overflow.hasAttribute('hidden')).to.be.false;
   });
 
+  it('should set tabindex on the last remaining button when width decreased', async () => {
+    buttons[0].focus();
+    arrowRight(buttons[0]);
+
+    expect(buttons[0].getAttribute('tabindex')).to.equal('-1');
+    expect(buttons[1].getAttribute('tabindex')).to.equal('0');
+
+    menu.style.width = '150px';
+    await onceResized(menu);
+
+    expect(buttons[0].getAttribute('tabindex')).to.equal('0');
+  });
+
   it('should set the aria-label of the overflow button according to the i18n of the menu bar', () => {
     const moreOptionsSv = 'Fler alternativ';
     expect(overflow.getAttribute('aria-label')).to.equal('More options');


### PR DESCRIPTION
## Description

Fixes #4683

Added logic to check if there is at least one `vaadin-menu-bar-button` with `tabindex="0"` and if not, set the attribute.

## Type of change

- Bugfix