### PR TITLE
refactor: cleanup no longer used pseudo element styles

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -55,15 +55,6 @@ export const sideNavItemBaseStyles = css`
     display: none !important;
   }
 
-  :host(:not([path])) button::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-  }
-
   slot[name='prefix'],
   slot[name='suffix'] {
     flex: none;


### PR DESCRIPTION
## Description

These styles are there since the [first iteration](https://github.com/vaadin/vcf-nav/commit/92256a9a3ace52a242accd7b6d07b926d3289ddb) of `vcf-nav` and they aren't used anywhere e.g. by Lumo theme.

Note, we do need `::before` pseudo element for the arrow icon, but the `::after` element is unused.

## Type of change

- Refactor