### PR TITLE
refator: move Esc  keydown listener to window

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -499,6 +499,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     window.removeEventListener('resize', this.__boundResizeListener);
     this.removeEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
     window.removeEventListener('close-overlay-drawer', this.__drawerToggleClickListener);
+    window.removeEventListener('keydown', this.__onDrawerKeyDown);
   }
 
   /**

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -276,7 +276,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
         <slot name="navbar"></slot>
       </div>
       <div part="backdrop" on-click="_onBackdropClick" on-touchend="_onBackdropTouchend"></div>
-      <div part="drawer" id="drawer" on-keydown="__onDrawerKeyDown">
+      <div part="drawer" id="drawer">
         <slot name="drawer" id="drawerSlot"></slot>
       </div>
       <div content>
@@ -399,6 +399,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     // TODO(jouni): might want to debounce
     this.__boundResizeListener = this._resize.bind(this);
     this.__drawerToggleClickListener = this._drawerToggleClick.bind(this);
+    this.__onDrawerKeyDown = this.__onDrawerKeyDown.bind(this);
     this.__closeOverlayDrawerListener = this.__closeOverlayDrawer.bind(this);
     this.__trapFocusInDrawer = this.__trapFocusInDrawer.bind(this);
     this.__releaseFocusFromDrawer = this.__releaseFocusFromDrawer.bind(this);
@@ -453,6 +454,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     this._navbarSizeObserver.observe(this.$.navbarBottom);
 
     window.addEventListener('close-overlay-drawer', this.__closeOverlayDrawerListener);
+    window.addEventListener('keydown', this.__onDrawerKeyDown);
   }
 
   /** @protected */

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -262,6 +262,11 @@ describe('vaadin-app-layout', () => {
         expect(layout.drawerOpened).to.be.true;
       });
 
+      it('should not close the drawer on global Escape press', () => {
+        esc(document.body);
+        expect(layout.drawerOpened).to.be.true;
+      });
+
       it('should set aria-expanded on the toggle to true by default', () => {
         expect(toggle.getAttribute('aria-expanded')).to.equal('true');
         layout.drawerOpened = true;
@@ -370,6 +375,11 @@ describe('vaadin-app-layout', () => {
 
         it('should close the drawer on Escape press', () => {
           esc(drawer);
+          expect(layout.drawerOpened).to.be.false;
+        });
+
+        it('should close the drawer on global Escape press', () => {
+          esc(document.body);
           expect(layout.drawerOpened).to.be.false;
         });
 


### PR DESCRIPTION
## Description

Extracts part of the changes done in #5831.

Make the `keydown` listener originally added to the `<div part="drawer" />` element become global by adding it to the `window` object, so the drawer can be closed with <kbd>Esc</kbd> in case the focus moves out it.

Part of #123 
