### PR TITLE
test: update overlay animation tests, add missing await

### DIFF
--- a/packages/overlay/test/animated-styles.js
+++ b/packages/overlay/test/animated-styles.js
@@ -1,0 +1,17 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-overlay',
+  css`
+    :host([animate][opening]),
+    :host([animate][closing]) {
+      animation: 50ms overlay-dummy-animation;
+    }
+
+    @keyframes overlay-dummy-animation {
+      to {
+        opacity: 1 !important; /* stylelint-disable-line keyframe-declaration-no-important */
+      }
+    }
+  `,
+);


### PR DESCRIPTION
## Description

1. Updated `animation.test.js` and added some missing `await` in preparation for Lit conversion;
2. Moved styles to separate file to make sure they are registered before custom element is defined.

## Type of change

- Tests