### PR TITLE
test: add missing await to prevent aria-hidden warnings (#6119) (CP: 24.1)

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -466,8 +466,9 @@ describe('required', () => {
     datePicker = fixtureSync(`<vaadin-date-picker required></vaadin-date-picker>`);
   });
 
-  it('should focus on required indicator click', () => {
+  it('should focus on required indicator click', async () => {
     datePicker.shadowRoot.querySelector('[part="required-indicator"]').click();
+    await waitForOverlayRender();
     expect(datePicker.hasAttribute('focused')).to.be.true;
   });
 });

--- a/packages/date-picker/test/events.test.js
+++ b/packages/date-picker/test/events.test.js
@@ -3,8 +3,8 @@ import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
-import '../src/vaadin-date-picker.js';
-import { close, open, waitForScrollToFinish } from './helpers.js';
+import '../vaadin-date-picker.js';
+import { close, open, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
 
 describe('events', () => {
   let datePicker;
@@ -118,6 +118,7 @@ describe('events', () => {
       hasInputValueChangedSpy = sinon.spy();
       valueChangedSpy = sinon.spy();
       datePicker = fixtureSync('<vaadin-date-picker clear-button-visible></vaadin-date-picker>');
+      await nextRender();
       clearButton = datePicker.shadowRoot.querySelector('[part=clear-button]');
       datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
       datePicker.addEventListener('value-changed', valueChangedSpy);
@@ -161,6 +162,7 @@ describe('events', () => {
     describe('with value', () => {
       beforeEach(async () => {
         await sendKeys({ type: '1/1/2022' });
+        await waitForScrollToFinish(datePicker._overlayContent);
         await sendKeys({ press: 'Enter' });
         valueChangedSpy.resetHistory();
         hasInputValueChangedSpy.resetHistory();
@@ -169,6 +171,7 @@ describe('events', () => {
       describe('with user input', () => {
         beforeEach(async () => {
           await sendKeys({ type: 'foo' });
+          await waitForOverlayRender();
           hasInputValueChangedSpy.resetHistory();
         });
 

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -352,17 +352,22 @@ describe('validation', () => {
       expect(datePicker.checkValidity()).to.be.true;
     });
 
-    it('should be valid when committing a non-empty value', () => {
+    it('should be valid when committing a non-empty value', async () => {
       setInputValue(datePicker, '1/1/2000');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.invalid).to.be.false;
     });
 
-    it('should be invalid when committing an empty value', () => {
+    it('should be invalid when committing an empty value', async () => {
       setInputValue(datePicker, '1/1/2000');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
+
       setInputValue(datePicker, '');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
+
       expect(datePicker.invalid).to.be.true;
     });
   });
@@ -391,20 +396,23 @@ describe('validation', () => {
       expect(datePicker.checkValidity()).to.be.true;
     });
 
-    it('should be invalid when committing a value < min', () => {
+    it('should be invalid when committing a value < min', async () => {
       setInputValue(datePicker, '1/1/2000');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.invalid).to.be.true;
     });
 
-    it('should be valid when committing a value > min', () => {
+    it('should be valid when committing a value > min', async () => {
       setInputValue(datePicker, '1/1/2022');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.invalid).to.be.false;
     });
 
-    it('should be valid when committing a value = min', () => {
+    it('should be valid when committing a value = min', async () => {
       setInputValue(datePicker, '1/1/2022');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.invalid).to.be.false;
     });
@@ -434,20 +442,23 @@ describe('validation', () => {
       expect(datePicker.checkValidity()).to.be.true;
     });
 
-    it('should be invalid when committing a value > max', () => {
+    it('should be invalid when committing a value > max', async () => {
       setInputValue(datePicker, '1/1/2022');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.invalid).to.be.true;
     });
 
-    it('should be valid when committing a value < max', () => {
+    it('should be valid when committing a value < max', async () => {
       setInputValue(datePicker, '1/1/2000');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.invalid).to.be.false;
     });
 
-    it('should be valid when committing a value = max', () => {
+    it('should be valid when committing a value = max', async () => {
       setInputValue(datePicker, '1/1/2010');
+      await waitForOverlayRender();
       enter(datePicker.inputElement);
       expect(datePicker.invalid).to.be.false;
     });

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, focusin, focusout, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, focusin, focusout, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';
 import { changeInputValue } from './helpers.js';
@@ -123,9 +123,10 @@ describe('Basic features', () => {
       expect(dateTimePicker.hasAttribute('focused')).to.be.true;
     });
 
-    it('should not remove focused attribute when moving focus to overlay', () => {
+    it('should not remove focused attribute when moving focus to overlay', async () => {
       focusin(datePicker);
       datePicker.open();
+      await nextRender();
       focusout(datePicker, datePicker._overlayContent);
       expect(dateTimePicker.hasAttribute('focused')).to.be.true;
     });


### PR DESCRIPTION
## Description

Manual cherry-pick of #6119 to `24.1` branch. The merge conflict was caused by renamed variable in some tests.

## Type of change

- Cherry-pick