### PR TITLE
refactor: extract overlay base styles to reusable css literal

### DIFF
--- a/packages/overlay/src/vaadin-overlay-styles.js
+++ b/packages/overlay/src/vaadin-overlay-styles.js
@@ -15,10 +15,8 @@ export const overlayStyles = css`
 
     /* Default position constraints: the entire viewport. Note: themes can
           override this to introduce gaps between the overlay and the viewport. */
-    top: 0;
-    right: 0;
+    inset: 0;
     bottom: var(--vaadin-overlay-viewport-bottom);
-    left: 0;
 
     /* Use flexbox alignment for the overlay part. */
     display: flex;

--- a/packages/overlay/src/vaadin-overlay-styles.js
+++ b/packages/overlay/src/vaadin-overlay-styles.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const overlayStyles = css`
+  :host {
+    z-index: 200;
+    position: fixed;
+
+    /* Despite of what the names say, <vaadin-overlay> is just a container
+          for position/sizing/alignment. The actual overlay is the overlay part. */
+
+    /* Default position constraints: the entire viewport. Note: themes can
+          override this to introduce gaps between the overlay and the viewport. */
+    top: 0;
+    right: 0;
+    bottom: var(--vaadin-overlay-viewport-bottom);
+    left: 0;
+
+    /* Use flexbox alignment for the overlay part. */
+    display: flex;
+    flex-direction: column; /* makes dropdowns sizing easier */
+    /* Align to center by default. */
+    align-items: center;
+    justify-content: center;
+
+    /* Allow centering when max-width/max-height applies. */
+    margin: auto;
+
+    /* The host is not clickable, only the overlay part is. */
+    pointer-events: none;
+
+    /* Remove tap highlight on touch devices. */
+    -webkit-tap-highlight-color: transparent;
+
+    /* CSS API for host */
+    --vaadin-overlay-viewport-bottom: 0;
+  }
+
+  :host([hidden]),
+  :host(:not([opened]):not([closing])) {
+    display: none !important;
+  }
+
+  [part='overlay'] {
+    -webkit-overflow-scrolling: touch;
+    overflow: auto;
+    pointer-events: auto;
+
+    /* Prevent overflowing the host */
+    max-width: 100%;
+    box-sizing: border-box;
+
+    -webkit-tap-highlight-color: initial; /* reenable tap highlight inside */
+  }
+
+  [part='backdrop'] {
+    z-index: -1;
+    content: '';
+    background: rgba(0, 0, 0, 0.5);
+    position: fixed;
+    inset: 0;
+    pointer-events: auto;
+  }
+`;

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -6,8 +6,11 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { OverlayMixin } from './vaadin-overlay-mixin.js';
+import { overlayStyles } from './vaadin-overlay-styles.js';
+
+registerStyles('vaadin-overlay', overlayStyles, { moduleId: 'vaadin-overlay-styles' });
 
 /**
  * `<vaadin-overlay>` is a Web Component for creating overlays. The content of the overlay
@@ -76,71 +79,6 @@ import { OverlayMixin } from './vaadin-overlay-mixin.js';
 class Overlay extends OverlayMixin(ThemableMixin(DirMixin(PolymerElement))) {
   static get template() {
     return html`
-      <style>
-        :host {
-          z-index: 200;
-          position: fixed;
-
-          /* Despite of what the names say, <vaadin-overlay> is just a container
-          for position/sizing/alignment. The actual overlay is the overlay part. */
-
-          /* Default position constraints: the entire viewport. Note: themes can
-          override this to introduce gaps between the overlay and the viewport. */
-          top: 0;
-          right: 0;
-          bottom: var(--vaadin-overlay-viewport-bottom);
-          left: 0;
-
-          /* Use flexbox alignment for the overlay part. */
-          display: flex;
-          flex-direction: column; /* makes dropdowns sizing easier */
-          /* Align to center by default. */
-          align-items: center;
-          justify-content: center;
-
-          /* Allow centering when max-width/max-height applies. */
-          margin: auto;
-
-          /* The host is not clickable, only the overlay part is. */
-          pointer-events: none;
-
-          /* Remove tap highlight on touch devices. */
-          -webkit-tap-highlight-color: transparent;
-
-          /* CSS API for host */
-          --vaadin-overlay-viewport-bottom: 0;
-        }
-
-        :host([hidden]),
-        :host(:not([opened]):not([closing])) {
-          display: none !important;
-        }
-
-        [part='overlay'] {
-          -webkit-overflow-scrolling: touch;
-          overflow: auto;
-          pointer-events: auto;
-
-          /* Prevent overflowing the host in MSIE 11 */
-          max-width: 100%;
-          box-sizing: border-box;
-
-          -webkit-tap-highlight-color: initial; /* reenable tap highlight inside */
-        }
-
-        [part='backdrop'] {
-          z-index: -1;
-          content: '';
-          background: rgba(0, 0, 0, 0.5);
-          position: fixed;
-          top: 0;
-          left: 0;
-          bottom: 0;
-          right: 0;
-          pointer-events: auto;
-        }
-      </style>
-
       <div id="backdrop" part="backdrop" hidden$="[[!withBackdrop]]"></div>
       <div part="overlay" id="overlay" tabindex="0">
         <div part="content" id="content">


### PR DESCRIPTION
## Description

Moved the `vaadin-overlay` styles from its `<template>` to the reusable `css` literal. 
This will make Lit conversion easier and allow us to decouple overlay extensions.

## Type of change

- Refactor