### PR TITLE
chore: disable Stylelint formatting rules handled by Prettier

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,5 +2,10 @@
   "customSyntax": "postcss-lit",
   "extends": [
     "stylelint-config-vaadin"
-  ]
+  ],
+  "rules": {
+    "declaration-colon-newline-after": null,
+    "selector-descendant-combinator-no-non-space": null,
+    "value-list-comma-newline-after": null
+  }
 }


### PR DESCRIPTION
## Description

Follow-up to #5516. 

Updated the Stylelint config to disable some rules related to code formatting.

Without this change, the following output is produced when running `yarn lint:css` on `main` branch:

```
35 problems (35 errors, 0 warnings)
```

## Type of change

- Internal change