### PR TITLE
experiment: add LitElement based version of vaadin-overlay

### DIFF
--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-overlay.d.ts",
+    "!src/vaadin-lit-overlay.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js"

--- a/packages/overlay/src/vaadin-lit-overlay.d.ts
+++ b/packages/overlay/src/vaadin-lit-overlay.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { OverlayMixin } from './vaadin-overlay-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-overlay>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+declare class Overlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
+
+export { Overlay };

--- a/packages/overlay/src/vaadin-lit-overlay.js
+++ b/packages/overlay/src/vaadin-lit-overlay.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { OverlayMixin } from './vaadin-overlay-mixin.js';
+import { overlayStyles } from './vaadin-overlay-styles.js';
+
+/**
+ * LitElement based version of `<vaadin-overlay>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class Overlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-overlay';
+  }
+
+  static get styles() {
+    return overlayStyles;
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div id="backdrop" part="backdrop" ?hidden="${!this.withBackdrop}"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <div part="content" id="content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
+  }
+}
+
+customElements.define(Overlay.is, Overlay);
+
+export { Overlay };

--- a/packages/overlay/test/animations-lit.test.js
+++ b/packages/overlay/test/animations-lit.test.js
@@ -1,0 +1,3 @@
+import './animated-styles.js';
+import '../src/vaadin-lit-overlay.js';
+import './animations.common.js';

--- a/packages/overlay/test/animations-polymer.test.js
+++ b/packages/overlay/test/animations-polymer.test.js
@@ -1,0 +1,3 @@
+import './animated-styles.js';
+import '../src/vaadin-overlay.js';
+import './animations.common.js';

--- a/packages/overlay/test/animations.common.js
+++ b/packages/overlay/test/animations.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { escKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import './animated-styles.js';
-import '../src/vaadin-overlay.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { createOverlay } from './helpers.js';

--- a/packages/overlay/test/basic-lit.test.js
+++ b/packages/overlay/test/basic-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-overlay.js';
+import './basic.common.js';

--- a/packages/overlay/test/basic-polymer.test.js
+++ b/packages/overlay/test/basic-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-overlay.js';
+import './basic.common.js';

--- a/packages/overlay/test/basic.common.js
+++ b/packages/overlay/test/basic.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, isIOS, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
 
 describe('vaadin-overlay', () => {

--- a/packages/overlay/test/focus-trap-lit.test.js
+++ b/packages/overlay/test/focus-trap-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-overlay.js';
+import './focus-trap.common.js';

--- a/packages/overlay/test/focus-trap-polymer.test.js
+++ b/packages/overlay/test/focus-trap-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-overlay.js';
+import './focus-trap.common.js';

--- a/packages/overlay/test/focus-trap.common.js
+++ b/packages/overlay/test/focus-trap.common.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
-import '../vaadin-overlay.js';
 import { getFocusableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('focus-trap', () => {

--- a/packages/overlay/test/interactions-lit.test.js
+++ b/packages/overlay/test/interactions-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-overlay.js';
+import './interactions.common.js';

--- a/packages/overlay/test/interactions-polymer.test.js
+++ b/packages/overlay/test/interactions-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-overlay.js';
+import './interactions.common.js';

--- a/packages/overlay/test/interactions.common.js
+++ b/packages/overlay/test/interactions.common.js
@@ -10,7 +10,6 @@ import {
   oneEvent,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
 
 describe('interactions', () => {

--- a/packages/overlay/test/multiple-lit.test.js
+++ b/packages/overlay/test/multiple-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-overlay.js';
+import './multiple.common.js';

--- a/packages/overlay/test/multiple-polymer.test.js
+++ b/packages/overlay/test/multiple-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-overlay.js';
+import './multiple.common.js';

--- a/packages/overlay/test/multiple.common.js
+++ b/packages/overlay/test/multiple.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { click, escKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
 
 describe('multiple overlays', () => {

--- a/packages/overlay/test/renderer-lit.test.js
+++ b/packages/overlay/test/renderer-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-overlay.js';
+import './renderer.common.js';

--- a/packages/overlay/test/renderer-polymer.test.js
+++ b/packages/overlay/test/renderer-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-overlay.js';
+import './renderer.common.js';

--- a/packages/overlay/test/renderer.common.js
+++ b/packages/overlay/test/renderer.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-overlay.js';
 
 describe('renderer', () => {
   let overlay, content;

--- a/packages/overlay/test/restore-focus-lit.test.js
+++ b/packages/overlay/test/restore-focus-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-overlay.js';
+import './restore-focus.common.js';

--- a/packages/overlay/test/restore-focus-polymer.test.js
+++ b/packages/overlay/test/restore-focus-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-overlay.js';
+import './restore-focus.common.js';

--- a/packages/overlay/test/restore-focus.common.js
+++ b/packages/overlay/test/restore-focus.common.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import '../src/vaadin-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 


### PR DESCRIPTION
## Description

1. Created a version of `vaadin-overlay` web component using `LitElement` base class,
2. Updated most of existing unit test suites to cover both Polymer and Lit based versions,
3. Modified `"files"` entry in `package.json` to **NOT** publish new component to `npm`.

## Type of change

- Experiment

## Disclaimer

This PR can be considered a PoC. There is no ETA on when we actually decide to proceed.