### PR TITLE
fix!: align how clear button works with combo-box behavior (#6100) (CP: 23.3)

### DIFF
--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { timeOut } from '@vaadin/component-base/src/async.js';
+import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { DelegateFocusMixin } from './delegate-focus-mixin.js';
@@ -139,6 +140,7 @@ export const InputControlMixin = (superclass) =>
 
       if (this.clearElement) {
         this.clearElement.addEventListener('click', (e) => this._onClearButtonClick(e));
+        this.clearElement.addEventListener('mousedown', (e) => this._onClearButtonMouseDown(e));
       }
     }
 
@@ -148,8 +150,18 @@ export const InputControlMixin = (superclass) =>
      */
     _onClearButtonClick(event) {
       event.preventDefault();
-      this.inputElement.focus();
       this.__clear();
+    }
+
+    /**
+     * @param {Event} event
+     * @protected
+     */
+    _onClearButtonMouseDown(event) {
+      event.preventDefault();
+      if (!isTouch) {
+        this.inputElement.focus();
+      }
     }
 
     /**

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { escKeyDown, fixtureSync, keyboardEventFor, keyDownOn } from '@vaadin/testing-helpers';
+import { escKeyDown, fixtureSync, keyboardEventFor, keyDownOn, mousedown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { InputControlMixin } from '../src/input-control-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
@@ -63,10 +64,28 @@ describe('input-control-mixin', () => {
       expect(input.value).to.equal('');
     });
 
-    it('should focus the input on clear button click', () => {
+    (!isTouch ? it : it.skip)('should focus the input on clear button click', () => {
       const spy = sinon.spy(input, 'focus');
-      button.click();
+      mousedown(button);
       expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should prevent default on clear button mousedown', () => {
+      const event = new CustomEvent('mousedown', { cancelable: true });
+      button.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    (isTouch ? it : it.skip)('should not focus the input on clear button touch', () => {
+      const spy = sinon.spy(input, 'focus');
+      mousedown(button);
+      expect(spy.called).to.be.false;
+    });
+
+    (isTouch ? it : it.skip)('should keep focus at the input on clear button touch', () => {
+      input.focus();
+      mousedown(button);
+      expect(document.activeElement).to.be.equal(input);
     });
 
     it('should dispatch input event on clear button click', () => {


### PR DESCRIPTION
## Description

CP from #6100.

I had to manually copy the changes because the `clear-button-mixin` was introduced after V23.
