### PR TITLE
refactor!: update date-picker overlay to not extend vaadin-overlay

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay.js
@@ -3,34 +3,33 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles(
-  'vaadin-date-picker-overlay',
-  css`
+const datePickerOverlayStyles = css`
+  [part='overlay'] {
+    display: flex;
+    flex: auto;
+  }
+
+  [part~='content'] {
+    flex: auto;
+  }
+
+  @media (forced-colors: active) {
     [part='overlay'] {
-      display: flex;
-      flex: auto;
+      outline: 3px solid;
     }
+  }
+`;
 
-    [part~='content'] {
-      flex: auto;
-    }
-
-    @media (forced-colors: active) {
-      [part='overlay'] {
-        outline: 3px solid;
-      }
-    }
-  `,
-  {
-    moduleId: 'vaadin-date-picker-overlay-styles',
-  },
-);
-
-let memoizedTemplate;
+registerStyles('vaadin-date-picker-overlay', [overlayStyles, datePickerOverlayStyles], {
+  moduleId: 'vaadin-date-picker-overlay-styles',
+});
 
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
@@ -38,18 +37,20 @@ let memoizedTemplate;
  * @extends Overlay
  * @private
  */
-class DatePickerOverlay extends PositionMixin(Overlay) {
+class DatePickerOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-date-picker-overlay';
   }
 
   static get template() {
-    if (!memoizedTemplate) {
-      memoizedTemplate = super.template.cloneNode(true);
-      memoizedTemplate.content.querySelector('[part~="overlay"]').removeAttribute('tabindex');
-    }
-
-    return memoizedTemplate;
+    return html`
+      <div id="backdrop" part="backdrop" hidden$="[[!withBackdrop]]"></div>
+      <div part="overlay" id="overlay">
+        <div part="content" id="content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
@@ -1,6 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
-import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import { menuOverlay } from '@vaadin/vaadin-lumo-styles/mixins/menu-overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-styles.js
@@ -1,4 +1,3 @@
-import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 


### PR DESCRIPTION
## Description

Part of #5718

Updated `vaadin-date-picker-overlay` to use `OverlayMixin` and styles exposed as `css` literal.
At the same time, this component no longer imports `vaadin-overlay` so it doesn't get defined.

## Type of change

- Refactor