### PR TITLE
refactor!: update select overlay to not extend vaadin-overlay

### DIFF
--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -45,7 +45,7 @@ export class SelectOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableM
   static get template() {
     return html`
       <div id="backdrop" part="backdrop" hidden$="[[!withBackdrop]]"></div>
-      <div part="overlay" id="overlay">
+      <div part="overlay" id="overlay" tabindex="0">
         <div part="content" id="content">
           <slot></slot>
         </div>

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -3,35 +3,54 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles(
-  'vaadin-select-overlay',
-  css`
-    :host {
-      align-items: flex-start;
-      justify-content: flex-start;
+const selectOverlayStyles = css`
+  :host {
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  @media (forced-colors: active) {
+    [part='overlay'] {
+      outline: 3px solid;
     }
-    @media (forced-colors: active) {
-      [part='overlay'] {
-        outline: 3px solid;
-      }
-    }
-  `,
-  { moduleId: 'vaadin-select-overlay-styles' },
-);
+  }
+`;
+
+registerStyles('vaadin-select-overlay', [overlayStyles, selectOverlayStyles], {
+  moduleId: 'vaadin-select-overlay-styles',
+});
 
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
- * @extends Overlay
- * @protected
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes OverlayMixin
+ * @mixes PositionMixin
+ * @mixes ThemableMixin
+ * @private
  */
-class SelectOverlay extends PositionMixin(Overlay) {
+export class SelectOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-select-overlay';
+  }
+
+  static get template() {
+    return html`
+      <div id="backdrop" part="backdrop" hidden$="[[!withBackdrop]]"></div>
+      <div part="overlay" id="overlay">
+        <div part="content" id="content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
   }
 
   requestContentUpdate() {

--- a/packages/select/theme/lumo/vaadin-select.js
+++ b/packages/select/theme/lumo/vaadin-select.js
@@ -4,6 +4,5 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
-import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-select-styles.js';
 import '../../src/vaadin-select.js';

--- a/packages/select/theme/material/vaadin-select.js
+++ b/packages/select/theme/material/vaadin-select.js
@@ -4,6 +4,5 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/input-container/theme/material/vaadin-input-container.js';
-import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-select-styles.js';
 import '../../src/vaadin-select.js';


### PR DESCRIPTION
## Description

Part of #5718

Updated `vaadin-select-overlay` to use `OverlayMixin` and styles exposed as `css` literal.

## Type of change

- Refactor