### PR TITLE
feat: add rowHeader property to vaadin-grid-column for screen readers

### DIFF
--- a/packages/grid/src/vaadin-grid-column.d.ts
+++ b/packages/grid/src/vaadin-grid-column.d.ts
@@ -44,6 +44,17 @@ export declare class ColumnBaseMixinClass<TItem> {
   frozenToEnd: boolean;
 
   /**
+   * When true, the cells for this column will be rendered with the `role` attribute
+   * set as `rowheader`, instead of the `gridcell` role value used by default.
+   *
+   * When a column is set as row header, its cells will be announced by screen readers
+   * while navigating to help user identify the current row as uniquely as possible.
+   *
+   * @attr {boolean} row-header
+   */
+  rowHeader: boolean;
+
+  /**
    * When set to true, the cells for this column are hidden.
    */
   hidden: boolean;

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -47,7 +47,13 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * When true, the column will be handled as a rowHeader and read properly by screen readers.
+         * When true, then in the shadow DOM, the column cells will be rendered with the `role="rowheader"` attribute.
+         * - This will cause the column will be handled as a rowHeader and read properly by screen readers.
+         *
+         * When false, then in the shadow DOM, the column cells will be rendered with the `role="gridcell"` attribute.
+         *
+         * @attr {boolean} row-header
+         * @type {boolean}
          */
         rowHeader: {
           type: Boolean,

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -47,21 +47,6 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * When true, the cells for this column will be rendered with the `role` attribute
-         * set as `rowheader`, instead of the `gridcell` role value used by default.
-         *
-         * When a column is set as row header, its cells will be announced by screen readers
-         * while navigating to help user identify the current row as uniquely as possible.
-         *
-         * @attr {boolean} row-header
-         * @type {boolean}
-         */
-        rowHeader: {
-          type: Boolean,
-          value: false,
-        },
-
-        /**
          * When true, the column is frozen to end of grid.
          *
          * When a column inside of a column group is frozen to end, all of the sibling columns
@@ -72,6 +57,21 @@ export const ColumnBaseMixin = (superClass) =>
          * @type {boolean}
          */
         frozenToEnd: {
+          type: Boolean,
+          value: false,
+        },
+
+        /**
+         * When true, the cells for this column will be rendered with the `role` attribute
+         * set as `rowheader`, instead of the `gridcell` role value used by default.
+         *
+         * When a column is set as row header, its cells will be announced by screen readers
+         * while navigating to help user identify the current row as uniquely as possible.
+         *
+         * @attr {boolean} row-header
+         * @type {boolean}
+         */
+        rowHeader: {
           type: Boolean,
           value: false,
         },

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -270,11 +270,6 @@ export const ColumnBaseMixin = (superClass) =>
 
       cells.value.forEach((cell) => {
         cell.setAttribute('role', rowHeader ? 'rowheader' : 'gridcell');
-        if (rowHeader) {
-          cell.setAttribute('scope', 'row');
-        } else {
-          cell.removeAttribute('scope');
-        }
       });
     }
 

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -47,10 +47,11 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * When true, then in the shadow DOM, the column cells will be rendered with the `role="rowheader"` attribute.
-         * - This will cause the column will be handled as a rowHeader and read properly by screen readers.
+         * When true, the cells for this column will be rendered with the `role` attribute
+         * set as `rowheader`, instead of the `gridcell` role value used by default.
          *
-         * When false, then in the shadow DOM, the column cells will be rendered with the `role="gridcell"` attribute.
+         * When a column is set as row header, its cells will be announced by screen readers
+         * while navigating to help user identify the current row as uniquely as possible.
          *
          * @attr {boolean} row-header
          * @type {boolean}

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -265,21 +265,6 @@ export const ColumnBaseMixin = (superClass) =>
         .filter((cell) => cell);
     }
 
-    /**
-     * @param rowHeader
-     * @param cells
-     * @private
-     */
-    _rowHeaderChanged(rowHeader, cells) {
-      if (!cells.value) {
-        return;
-      }
-
-      cells.value.forEach((cell) => {
-        cell.setAttribute('role', rowHeader ? 'rowheader' : 'gridcell');
-      });
-    }
-
     /** @protected */
     connectedCallback() {
       super.connectedCallback();
@@ -436,6 +421,17 @@ export const ColumnBaseMixin = (superClass) =>
       if (this.parentElement && this.parentElement._columnPropChanged) {
         this.parentElement._firstFrozenToEnd = firstFrozenToEnd;
       }
+    }
+
+    /** @private */
+    _rowHeaderChanged(rowHeader, cells) {
+      if (!cells.value) {
+        return;
+      }
+
+      cells.value.forEach((cell) => {
+        cell.setAttribute('role', rowHeader ? 'rowheader' : 'gridcell');
+      });
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -47,6 +47,14 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
+         * When true, the column will be handled as a rowHeader and read properly by screen readers.
+         */
+        rowHeader: {
+          type: Boolean,
+          value: false,
+        },
+
+        /**
          * When true, the column is frozen to end of grid.
          *
          * When a column inside of a column group is frozen to end, all of the sibling columns
@@ -222,6 +230,7 @@ export const ColumnBaseMixin = (superClass) =>
         '_resizableChanged(resizable, _headerCell)',
         '_reorderStatusChanged(_reorderStatus, _headerCell, _footerCell, _cells.*)',
         '_hiddenChanged(hidden, _headerCell, _footerCell, _cells.*)',
+        '_rowHeaderChanged(rowHeader, _cells.*)',
       ];
     }
 
@@ -247,6 +256,26 @@ export const ColumnBaseMixin = (superClass) =>
         .concat(this._headerCell)
         .concat(this._footerCell)
         .filter((cell) => cell);
+    }
+
+    /**
+     * @param rowHeader
+     * @param cells
+     * @private
+     */
+    _rowHeaderChanged(rowHeader, cells) {
+      if (!cells.value) {
+        return;
+      }
+
+      cells.value.forEach((cell) => {
+        cell.setAttribute('role', rowHeader ? 'rowheader' : 'gridcell');
+        if (rowHeader) {
+          cell.setAttribute('scope', 'row');
+        } else {
+          cell.removeAttribute('scope');
+        }
+      });
     }
 
     /** @protected */

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -10,6 +10,8 @@ describe('accessibility', () => {
     grid = fixtureSync('<vaadin-grid></vaadin-grid>');
     const col1 = document.createElement('vaadin-grid-column');
     const col2 = document.createElement('vaadin-grid-column');
+    const col3 = document.createElement('vaadin-grid-column');
+    col3.setAttribute('row-header', '');
     if (grouped) {
       const grp = document.createElement('vaadin-grid-column-group');
       grp.headerRenderer = (root) => {
@@ -20,10 +22,12 @@ describe('accessibility', () => {
       };
       grp.appendChild(col1);
       grp.appendChild(col2);
+      grp.appendChild(col3);
       grid.appendChild(grp);
     } else {
       grid.appendChild(col1);
       grid.appendChild(col2);
+      grid.appendChild(col3);
     }
 
     col1.headerRenderer = col2.headerRenderer = (root) => {
@@ -82,14 +86,25 @@ describe('accessibility', () => {
         expect(grid.$.footer.children[0].getAttribute('role')).to.equal('row');
       });
 
+      it('should have scope row on table cell for the rowheader columns and role gridcell row for other columns', () => {
+        for (const child of grid.$.items.children) {
+          expect(child.children[0].getAttribute('role')).to.equal('gridcell');
+          expect(child.children[0].tagName.toLowerCase()).to.equal('td');
+          expect(child.children[1].getAttribute('role')).to.equal('gridcell');
+          expect(child.children[1].tagName.toLowerCase()).to.equal('td');
+          expect(child.children[2].getAttribute('role')).to.equal('rowheader');
+          expect(child.children[2].getAttribute('scope')).not.exist;
+          expect(child.children[2].tagName.toLowerCase()).to.equal('td');
+        }
+      });
+
+      it('should row-header for the last grid column as we added', () => {
+        expect(grid.children[2].getAttribute('row-header')).to.exist;
+      });
+
       it('should have role columnheader on header cells', () => {
         expect(grid.$.header.children[0].children[0].getAttribute('role')).to.equal('columnheader');
         expect(grid.$.header.children[0].children[1].getAttribute('role')).to.equal('columnheader');
-      });
-
-      it('should have role gridcell on body cells', () => {
-        expect(grid.$.items.children[0].children[0].getAttribute('role')).to.equal('gridcell');
-        expect(grid.$.items.children[0].children[1].getAttribute('role')).to.equal('gridcell');
       });
     });
 
@@ -210,7 +225,7 @@ describe('accessibility', () => {
 
     describe('column count', () => {
       it('should have aria-colcount on the table', () => {
-        expect(grid.$.table.getAttribute('aria-colcount')).to.equal('2');
+        expect(grid.$.table.getAttribute('aria-colcount')).to.equal('3');
       });
 
       it('should update aria-colcount when column is added', async () => {
@@ -220,7 +235,7 @@ describe('accessibility', () => {
         };
         grid.appendChild(column);
         await nextFrame();
-        expect(grid.$.table.getAttribute('aria-colcount')).to.equal('3');
+        expect(grid.$.table.getAttribute('aria-colcount')).to.equal('4');
       });
     });
 
@@ -324,7 +339,7 @@ describe('accessibility', () => {
 
     describe('column groups', () => {
       it('should have aria-colspan on group header cell', () => {
-        expect(grid.$.header.children[0].children[0].getAttribute('aria-colspan')).to.equal('2');
+        expect(grid.$.header.children[0].children[0].getAttribute('aria-colspan')).to.equal('3');
       });
     });
   });

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -86,7 +86,7 @@ describe('accessibility', () => {
         expect(grid.$.footer.children[0].getAttribute('role')).to.equal('row');
       });
 
-      it('should have scope row on table cell for the rowheader columns and role gridcell row for other columns', () => {
+      it('should have role=rowheader for cells marked row-header, and role=gridcell row for other columns not marked with row-header', () => {
         for (const child of grid.$.items.children) {
           expect(child.children[0].getAttribute('role')).to.equal('gridcell');
           expect(child.children[0].tagName.toLowerCase()).to.equal('td');
@@ -98,7 +98,7 @@ describe('accessibility', () => {
         }
       });
 
-      it('should row-header for the last grid column as we added', () => {
+      it('the last column should have a row-header attribute added', () => {
         expect(grid.children[2].getAttribute('row-header')).to.exist;
       });
 

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -86,25 +86,26 @@ describe('accessibility', () => {
         expect(grid.$.footer.children[0].getAttribute('role')).to.equal('row');
       });
 
-      it('should have role=rowheader for cells marked row-header, and role=gridcell row for other columns not marked with row-header', () => {
-        for (const child of grid.$.items.children) {
-          expect(child.children[0].getAttribute('role')).to.equal('gridcell');
-          expect(child.children[0].tagName.toLowerCase()).to.equal('td');
-          expect(child.children[1].getAttribute('role')).to.equal('gridcell');
-          expect(child.children[1].tagName.toLowerCase()).to.equal('td');
-          expect(child.children[2].getAttribute('role')).to.equal('rowheader');
-          expect(child.children[2].getAttribute('scope')).not.exist;
-          expect(child.children[2].tagName.toLowerCase()).to.equal('td');
-        }
-      });
-
-      it('the last column should have a row-header attribute added', () => {
-        expect(grid.children[2].getAttribute('row-header')).to.exist;
-      });
-
       it('should have role columnheader on header cells', () => {
         expect(grid.$.header.children[0].children[0].getAttribute('role')).to.equal('columnheader');
         expect(grid.$.header.children[0].children[1].getAttribute('role')).to.equal('columnheader');
+      });
+
+      it('should have role gridcell on body cells by default', () => {
+        expect(grid.$.items.children[0].children[0].getAttribute('role')).to.equal('gridcell');
+        expect(grid.$.items.children[0].children[1].getAttribute('role')).to.equal('gridcell');
+      });
+
+      it('should have role rowheader on body cells when `rowHeader` is set to true', () => {
+        expect(grid.$.items.children[0].children[2].getAttribute('role')).to.equal('rowheader');
+        expect(grid.$.items.children[1].children[2].getAttribute('role')).to.equal('rowheader');
+      });
+
+      it('should change role from rowheader to gridcell when `rowHeader` is set to false', () => {
+        const columns = grid.querySelectorAll('vaadin-grid-column');
+        columns[2].rowHeader = false;
+        expect(grid.$.items.children[0].children[2].getAttribute('role')).to.equal('gridcell');
+        expect(grid.$.items.children[1].children[2].getAttribute('role')).to.equal('gridcell');
       });
     });
 

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -571,12 +571,11 @@ describe('column - simple grid with rowHeader', () => {
     await nextFrame();
   });
 
-  it('should look properly in the shadow dom (th tag and scope=row)', async () => {
+  it('should look properly in the shadow dom (role=rowheader)', async () => {
     await nextFrame();
     const firstCell = grid.shadowRoot.querySelector('tbody tr:first-child td:first-child');
     expect(firstCell).to.be.ok;
     expect(firstCell.getAttribute('role')).to.equal('rowheader');
-    // expect(firstCell.tagName).to.equal('TH');
     expect(column.rowHeader).to.be.true;
   });
 });

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -555,27 +555,3 @@ describe('column - simple grid', () => {
     expect(getBodyCellContent(grid, 1, 0).textContent.trim()).to.equal('foo1');
   });
 });
-
-describe('column - simple grid with rowHeader', () => {
-  let grid, column;
-
-  beforeEach(async () => {
-    grid = fixtureSync(`
-      <vaadin-grid>
-        <vaadin-grid-column row-header path="value"></vaadin-grid-column>
-      </vaadin-grid>
-    `);
-    column = grid.querySelector('vaadin-grid-column');
-    grid.size = 1;
-    grid.dataProvider = infiniteDataProvider;
-    await nextFrame();
-  });
-
-  it('should look properly in the shadow dom (role=rowheader)', async () => {
-    await nextFrame();
-    const firstCell = grid.shadowRoot.querySelector('tbody tr:first-child td:first-child');
-    expect(firstCell).to.be.ok;
-    expect(firstCell.getAttribute('role')).to.equal('rowheader');
-    expect(column.rowHeader).to.be.true;
-  });
-});

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -555,3 +555,28 @@ describe('column - simple grid', () => {
     expect(getBodyCellContent(grid, 1, 0).textContent.trim()).to.equal('foo1');
   });
 });
+
+describe('column - simple grid with rowHeader', () => {
+  let grid, column;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column row-header path="value"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    column = grid.querySelector('vaadin-grid-column');
+    grid.size = 1;
+    grid.dataProvider = infiniteDataProvider;
+    await nextFrame();
+  });
+
+  it('should look properly in the shadow dom (th tag and scope=row)', async () => {
+    await nextFrame();
+    const firstCell = grid.shadowRoot.querySelector('tbody tr:first-child td:first-child');
+    expect(firstCell).to.be.ok;
+    expect(firstCell.getAttribute('role')).to.equal('rowheader');
+    // expect(firstCell.tagName).to.equal('TH');
+    expect(column.rowHeader).to.be.true;
+  });
+});

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -244,6 +244,7 @@ assertType<boolean | null | undefined>(narrowedColumn.resizable);
 assertType<boolean>(narrowedColumn.frozen);
 assertType<boolean>(narrowedColumn.frozenToEnd);
 assertType<boolean>(narrowedColumn.hidden);
+assertType<boolean>(narrowedColumn.rowHeader);
 assertType<string | null | undefined>(narrowedColumn.header);
 assertType<GridColumnTextAlign | null | undefined>(narrowedColumn.textAlign);
 assertType<string | null | undefined>(narrowedColumn.path);


### PR DESCRIPTION
## Context

I had an older [PR](https://github.com/vaadin/web-components/pull/5843), which was fulfilling an older version of Acceptance Criteria (https://github.com/vaadin/web-components/issues/5321). 

Through the PR review and testing (thanks to  @tomivirkki ). Tomi find out that this approach is not working properly for Safari VoiceOver, also we found out that it was creating a different (bold) style for the marked cells (which could cause further problems, more info in the previous PR)

Then we had chats and **discussions** with **@rolfsmeds, and @tomivirkki** (after Tomi thorough testing it as well), and we settled that the new approach is to only use  `role="rowheader"`

- The new Acceptance Criteria ( https://github.com/vaadin/web-components/issues/5321) is describing the new idea.
- The other https://github.com/vaadin/web-components/pull/5843 will be closed in favor of this one.
- This PR is tested in **MacOs Ventura 13.4.1**
- **Thank you to all previous participants**, helpers (Tomi, Rolf 🙇 ).

## Description:
This will mark the cells as row headers and screen readers will pronounce it properly, putting it in the first of a new next cell:
![image](https://github.com/vaadin/web-components/assets/61667986/f0616ee7-5c9e-4644-a2ae-a67f00a10446)


Fixes # (issue)
- https://github.com/vaadin/web-components/issues/5321

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and correct misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria was created.
