### PR TITLE
refactor!: update confirm-dialog overlay to not extend dialog overlay

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -3,91 +3,80 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { Dialog } from '@vaadin/dialog/src/vaadin-dialog.js';
-import { DialogOverlay } from '@vaadin/dialog/src/vaadin-dialog-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { dialogOverlay } from '@vaadin/dialog/src/vaadin-dialog-styles.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles(
-  'vaadin-confirm-dialog-overlay',
-  css`
-    :host {
-      --_vaadin-confirm-dialog-content-width: auto;
-      --_vaadin-confirm-dialog-content-height: auto;
-    }
+const confirmDialogOverlay = css`
+  :host {
+    --_vaadin-confirm-dialog-content-width: auto;
+    --_vaadin-confirm-dialog-content-height: auto;
+  }
 
-    [part='overlay'] {
-      width: var(--_vaadin-confirm-dialog-content-width);
-      height: var(--_vaadin-confirm-dialog-content-height);
-    }
+  [part='overlay'] {
+    width: var(--_vaadin-confirm-dialog-content-width);
+    height: var(--_vaadin-confirm-dialog-content-height);
+  }
 
-    /* Make buttons clickable */
-    [part='footer'] > * {
-      pointer-events: all;
-    }
-  `,
-  { moduleId: 'vaadin-confirm-dialog-overlay-styles' },
-);
-
-let memoizedTemplate;
-
-const footerTemplate = html`
-  <div part="cancel-button">
-    <slot name="cancel-button"></slot>
-  </div>
-  <div part="reject-button">
-    <slot name="reject-button"></slot>
-  </div>
-  <div part="confirm-button">
-    <slot name="confirm-button"></slot>
-  </div>
+  /* Make buttons clickable */
+  [part='footer'] > * {
+    pointer-events: all;
+  }
 `;
 
+registerStyles('vaadin-confirm-dialog-overlay', [overlayStyles, dialogOverlay, confirmDialogOverlay], {
+  moduleId: 'vaadin-confirm-dialog-overlay-styles',
+});
+
 /**
- * An extension of `<vaadin-dialog-overlay>` used internally by `<vaadin-confirm-dialog>`.
- * Not intended to be used separately.
+ * An element used internally by `<vaadin-confirm-dialog>`. Not intended to be used separately.
+ *
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes OverlayMixin
+ * @mixes ThemableMixin
  * @private
  */
-class ConfirmDialogOverlay extends DialogOverlay {
+class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-confirm-dialog-overlay';
   }
 
   static get template() {
-    if (!memoizedTemplate) {
-      memoizedTemplate = super.template.cloneNode(true);
-
-      // Replace two header slots with a single one
-      const headerPart = memoizedTemplate.content.querySelector('[part="header"]');
-      headerPart.innerHTML = '';
-      const headerSlot = document.createElement('slot');
-      headerSlot.setAttribute('name', 'header');
-      headerPart.appendChild(headerSlot);
-
-      // Place default slot inside a "message" part
-      const contentPart = memoizedTemplate.content.querySelector('[part="content"]');
-      const defaultSlot = contentPart.querySelector('slot:not([name])');
-      const messagePart = document.createElement('div');
-      messagePart.setAttribute('part', 'message');
-      contentPart.appendChild(messagePart);
-      messagePart.appendChild(defaultSlot);
-
-      // Replace footer slot with button named slots
-      const footerPart = memoizedTemplate.content.querySelector('[part="footer"]');
-      footerPart.setAttribute('role', 'toolbar');
-      const footerSlot = footerPart.querySelector('slot');
-      footerPart.removeChild(footerSlot);
-      footerPart.appendChild(footerTemplate.content.cloneNode(true));
-    }
-    return memoizedTemplate;
+    return html`
+      <div part="backdrop" id="backdrop" hidden$="[[!withBackdrop]]"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <section id="resizerContainer" class="resizer-container">
+          <header part="header"><slot name="header"></slot></header>
+          <div part="content" id="content">
+            <div part="message"><slot></slot></div>
+          </div>
+          <footer part="footer" role="toolbar">
+            <div part="cancel-button">
+              <slot name="cancel-button"></slot>
+            </div>
+            <div part="reject-button">
+              <slot name="reject-button"></slot>
+            </div>
+            <div part="confirm-button">
+              <slot name="confirm-button"></slot>
+            </div>
+          </footer>
+        </section>
+      </div>
+    `;
   }
 
   /**
    * @protected
    * @override
    */
-  _headerFooterRendererChange(headerRenderer, footerRenderer, opened) {
-    super._headerFooterRendererChange(headerRenderer, footerRenderer, opened);
+  ready() {
+    super.ready();
 
     // ConfirmDialog has header and footer but does not use renderers
     this.setAttribute('has-header', '');

--- a/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
+++ b/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
@@ -1,44 +1,50 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
+import { dialogOverlay } from '@vaadin/dialog/theme/lumo/vaadin-dialog-styles.js';
+import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-confirm-dialog-overlay',
-  css`
-    [part='header'] ::slotted(h3) {
-      margin-top: 0 !important;
-      margin-bottom: 0 !important;
-      margin-inline-start: calc(var(--lumo-space-l) - var(--lumo-space-m));
-    }
-
-    [part='message'] {
-      width: 25em;
-      min-width: 100%;
-      max-width: 100%;
-    }
-
-    ::slotted([slot$='button'][theme~='tertiary']) {
-      padding-left: var(--lumo-space-s);
-      padding-right: var(--lumo-space-s);
-    }
-
-    [part='cancel-button'] {
-      flex-grow: 1;
-    }
-
-    @media (max-width: 360px) {
-      [part='footer'] {
-        flex-direction: column-reverse;
-        align-items: stretch;
-        padding: var(--lumo-space-s) var(--lumo-space-l);
-        gap: var(--lumo-space-s);
+  [
+    overlay,
+    dialogOverlay,
+    css`
+      [part='header'] ::slotted(h3) {
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        margin-inline-start: calc(var(--lumo-space-l) - var(--lumo-space-m));
       }
 
-      ::slotted([slot$='button']) {
-        width: 100%;
-        margin: 0;
+      [part='message'] {
+        width: 25em;
+        min-width: 100%;
+        max-width: 100%;
       }
-    }
-  `,
+
+      ::slotted([slot$='button'][theme~='tertiary']) {
+        padding-left: var(--lumo-space-s);
+        padding-right: var(--lumo-space-s);
+      }
+
+      [part='cancel-button'] {
+        flex-grow: 1;
+      }
+
+      @media (max-width: 360px) {
+        [part='footer'] {
+          flex-direction: column-reverse;
+          align-items: stretch;
+          padding: var(--lumo-space-s) var(--lumo-space-l);
+          gap: var(--lumo-space-s);
+        }
+
+        ::slotted([slot$='button']) {
+          width: 100%;
+          margin: 0;
+        }
+      }
+    `,
+  ],
   { moduleId: 'lumo-confirm-dialog-overlay' },
 );

--- a/packages/confirm-dialog/theme/material/vaadin-confirm-dialog-styles.js
+++ b/packages/confirm-dialog/theme/material/vaadin-confirm-dialog-styles.js
@@ -1,35 +1,41 @@
+import { dialogOverlay } from '@vaadin/dialog/theme/material/vaadin-dialog-styles.js';
+import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-confirm-dialog-overlay',
-  css`
-    [part='overlay'] {
-      max-width: 100%;
-      min-width: 0;
-    }
-
-    [part='content'] {
-      min-width: 0;
-    }
-
-    [part='header'] ::slotted(h3) {
-      margin-top: 0 !important;
-      margin-bottom: 0 !important;
-      margin-inline-start: 8px;
-    }
-
-    [part='message'] {
-      width: 25em;
-      max-width: 100%;
-      margin-inline-end: 24px;
-    }
-
-    @media (max-width: 360px) {
-      [part='footer'] {
-        flex-direction: column-reverse;
-        align-items: flex-end;
+  [
+    overlay,
+    dialogOverlay,
+    css`
+      [part='overlay'] {
+        max-width: 100%;
+        min-width: 0;
       }
-    }
-  `,
+
+      [part='content'] {
+        min-width: 0;
+      }
+
+      [part='header'] ::slotted(h3) {
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        margin-inline-start: 8px;
+      }
+
+      [part='message'] {
+        width: 25em;
+        max-width: 100%;
+        margin-inline-end: 24px;
+      }
+
+      @media (max-width: 360px) {
+        [part='footer'] {
+          flex-direction: column-reverse;
+          align-items: flex-end;
+        }
+      }
+    `,
+  ],
   { moduleId: 'material-confirm-dialog-overlay' },
 );


### PR DESCRIPTION
## Description

Part of #5718

Updated `vaadin-confirm-dialog-overlay` to use `OverlayMixin` and styles exposed as `css` literal.

## Type of change

- Refactor