### PR TITLE
refactor!: update crud dialog overlay to not extend dialog overlay

### DIFF
--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -8,97 +8,89 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { Dialog } from '@vaadin/dialog/src/vaadin-dialog.js';
-import { DialogOverlay } from '@vaadin/dialog/src/vaadin-dialog-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { dialogOverlay, resizableOverlay } from '@vaadin/dialog/src/vaadin-dialog-styles.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles(
-  'vaadin-crud-dialog-overlay',
-  css`
-    [part='overlay'] {
-      max-width: 54em;
-      min-width: 20em;
-    }
+const crudDialogOverlay = css`
+  [part='overlay'] {
+    max-width: 54em;
+    min-width: 20em;
+  }
 
-    [part='footer'] {
-      justify-content: flex-start;
-      flex-direction: row-reverse;
-    }
+  [part='footer'] {
+    justify-content: flex-start;
+    flex-direction: row-reverse;
+  }
 
-    /* Make buttons clickable */
-    [part='footer'] ::slotted(:not([disabled])) {
-      pointer-events: all;
-    }
+  /* Make buttons clickable */
+  [part='footer'] ::slotted(:not([disabled])) {
+    pointer-events: all;
+  }
 
-    :host([fullscreen]) {
-      inset: 0;
-      padding: 0;
-    }
+  :host([fullscreen]) {
+    inset: 0;
+    padding: 0;
+  }
 
-    :host([fullscreen]) [part='overlay'] {
-      height: 100vh;
-      width: 100vw;
-      border-radius: 0 !important;
-    }
+  :host([fullscreen]) [part='overlay'] {
+    height: 100vh;
+    width: 100vw;
+    border-radius: 0 !important;
+  }
 
-    :host([fullscreen]) [part='content'] {
-      flex: 1;
-    }
-  `,
-  { moduleId: 'vaadin-crud-dialog-overlay-styles' },
-);
-
-let memoizedTemplate;
-
-const footerTemplate = html`
-  <slot name="save-button"></slot>
-  <slot name="cancel-button"></slot>
-  <slot name="delete-button"></slot>
+  :host([fullscreen]) [part='content'] {
+    flex: 1;
+  }
 `;
 
+registerStyles('vaadin-crud-dialog-overlay', [overlayStyles, dialogOverlay, resizableOverlay, crudDialogOverlay], {
+  moduleId: 'vaadin-crud-dialog-overlay-styles',
+});
+
 /**
- * An extension of `<vaadin-dialog-overlay>` used internally by `<vaadin-crud>`.
- * Not intended to be used separately.
+ * An element used internally by `<vaadin-crud>`. Not intended to be used separately.
+ *
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes OverlayMixin
+ * @mixes ThemableMixin
  * @private
  */
-class CrudDialogOverlay extends DialogOverlay {
+class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-crud-dialog-overlay';
   }
 
   static get template() {
-    if (!memoizedTemplate) {
-      memoizedTemplate = super.template.cloneNode(true);
-
-      // Replace two header slots with a single one
-      const headerPart = memoizedTemplate.content.querySelector('[part="header"]');
-      headerPart.innerHTML = '';
-      const headerSlot = document.createElement('slot');
-      headerSlot.setAttribute('name', 'header');
-      headerPart.appendChild(headerSlot);
-
-      // Replace default slot with "form" named slot
-      const contentPart = memoizedTemplate.content.querySelector('[part="content"]');
-      const defaultSlot = contentPart.querySelector('slot:not([name])');
-      defaultSlot.setAttribute('name', 'form');
-
-      // Replace footer slot with button named slots
-      const footerPart = memoizedTemplate.content.querySelector('[part="footer"]');
-      footerPart.setAttribute('role', 'toolbar');
-      const footerSlot = footerPart.querySelector('slot');
-      footerPart.removeChild(footerSlot);
-      footerPart.appendChild(footerTemplate.content.cloneNode(true));
-    }
-    return memoizedTemplate;
+    return html`
+      <div part="backdrop" id="backdrop" hidden$="[[!withBackdrop]]"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <section id="resizerContainer" class="resizer-container">
+          <header part="header"><slot name="header"></slot></header>
+          <div part="content" id="content">
+            <slot name="form"></slot>
+          </div>
+          <footer part="footer" role="toolbar">
+            <slot name="save-button"></slot>
+            <slot name="cancel-button"></slot>
+            <slot name="delete-button"></slot>
+          </footer>
+        </section>
+      </div>
+    `;
   }
 
   /**
    * @protected
    * @override
    */
-  _headerFooterRendererChange(headerRenderer, footerRenderer, opened) {
-    super._headerFooterRendererChange(headerRenderer, footerRenderer, opened);
+  ready() {
+    super.ready();
 
     // CRUD has header and footer but does not use renderers
     this.setAttribute('has-header', '');

--- a/packages/crud/theme/lumo/vaadin-crud-styles.js
+++ b/packages/crud/theme/lumo/vaadin-crud-styles.js
@@ -2,6 +2,8 @@ import '@vaadin/vaadin-lumo-styles/typography.js';
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
+import { dialogOverlay } from '@vaadin/dialog/theme/lumo/vaadin-dialog-styles.js';
+import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
@@ -133,6 +135,8 @@ registerStyles(
 registerStyles(
   'vaadin-crud-dialog-overlay',
   [
+    overlay,
+    dialogOverlay,
     editorStyles,
     css`
       [part='header'] ::slotted(h3) {

--- a/packages/crud/theme/material/vaadin-crud-styles.js
+++ b/packages/crud/theme/material/vaadin-crud-styles.js
@@ -122,6 +122,11 @@ registerStyles(
     dialogOverlay,
     editorStyles,
     css`
+      [part='overlay'] {
+        max-width: 54em;
+        min-width: 20em;
+      }
+
       @keyframes material-overlay-dummy-animation {
         0% {
           opacity: 1;

--- a/packages/crud/theme/material/vaadin-crud-styles.js
+++ b/packages/crud/theme/material/vaadin-crud-styles.js
@@ -1,5 +1,7 @@
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-material-styles/color.js';
+import { dialogOverlay } from '@vaadin/dialog/theme/material/vaadin-dialog-styles.js';
+import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
@@ -116,6 +118,8 @@ registerStyles(
 registerStyles(
   'vaadin-crud-dialog-overlay',
   [
+    overlay,
+    dialogOverlay,
     editorStyles,
     css`
       @keyframes material-overlay-dummy-animation {


### PR DESCRIPTION
## Description

Part of #5718

Same as #6141 but for `vaadin-crud`.

Updated `vaadin-crud-dialog-overlay` to use `OverlayMixin` and styles exposed as `css` literal.

## Type of change

- Refactor