### PR TITLE
refactor: extract grid selection column base mixin

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+export declare function GridSelectionColumnBaseMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<GridSelectionColumnBaseMixinClass> & T;
+
+/**
+ * A mixin that provides basic functionality for the
+ * `<vaadin-grid-selection-column>`. This includes properties, cell rendering,
+ * and overridable methods for handling changes to the selection state.
+ *
+ * **NOTE**: This mixin is re-used by the Flow component, and as such must not
+ * implement any selection state updates for the column element or the grid.
+ * Web component-specific selection state updates must be implemented in the
+ * `<vaadin-grid-selection-column>` itself, by overriding the protected methods
+ * provided by this mixin.
+ *
+ * @polymerMixin
+ */
+export declare class GridSelectionColumnBaseMixinClass {
+  /**
+   * When true, all the items are selected.
+   * @attr {boolean} select-all
+   */
+  selectAll: boolean;
+
+  /**
+   * When true, the active gets automatically selected.
+   * @attr {boolean} auto-select
+   */
+  autoSelect: boolean;
+}

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
@@ -5,9 +5,9 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
-export declare function GridSelectionColumnBaseMixin<T extends Constructor<HTMLElement>>(
+export declare function GridSelectionColumnBaseMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<GridSelectionColumnBaseMixinClass> & T;
+): Constructor<GridSelectionColumnBaseMixinClass<TItem>> & T;
 
 /**
  * A mixin that provides basic functionality for the
@@ -22,7 +22,7 @@ export declare function GridSelectionColumnBaseMixin<T extends Constructor<HTMLE
  *
  * @polymerMixin
  */
-export declare class GridSelectionColumnBaseMixinClass {
+export declare class GridSelectionColumnBaseMixinClass<TItem> {
   /**
    * When true, all the items are selected.
    * @attr {boolean} select-all
@@ -34,4 +34,24 @@ export declare class GridSelectionColumnBaseMixinClass {
    * @attr {boolean} auto-select
    */
   autoSelect: boolean;
+
+  /**
+   * Override to handle the user selecting all items.
+   */
+  protected _selectAll(): void;
+
+  /**
+   * Override to handle the user deselecting all items.
+   */
+  protected _deselectAll(): void;
+
+  /**
+   * Override to handle the user selecting an item.
+   */
+  protected _selectItem(item: TItem): void;
+
+  /**
+   * Override to handle the user deselecting an item.
+   */
+  protected _deselectItem(item: TItem): void;
 }

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -16,7 +16,6 @@
  * provided by this mixin.
  *
  * @polymerMixin
- * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
 export const GridSelectionColumnBaseMixin = (superClass) =>
   class GridSelectionColumnBaseMixin extends superClass {

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A mixin that provides basic functionality for the
+ * `<vaadin-grid-selection-column>`. This includes properties, cell rendering,
+ * and overridable methods for handling changes to the selection state.
+ *
+ * **NOTE**: This mixin is re-used by the Flow component, and as such must not
+ * implement any selection state updates for the column element or the grid.
+ * Web component-specific selection state updates must be implemented in the
+ * `<vaadin-grid-selection-column>` itself, by overriding the protected methods
+ * provided by this mixin.
+ *
+ * @polymerMixin
+ * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
+ */
+export const GridSelectionColumnBaseMixin = (superClass) =>
+  class GridSelectionColumnBaseMixin extends superClass {
+    static get properties() {
+      return {
+        /**
+         * Width of the cells for this column.
+         */
+        width: {
+          type: String,
+          value: '58px',
+        },
+
+        /**
+         * Flex grow ratio for the cell widths. When set to 0, cell width is fixed.
+         * @attr {number} flex-grow
+         * @type {number}
+         */
+        flexGrow: {
+          type: Number,
+          value: 0,
+        },
+
+        /**
+         * When true, all the items are selected.
+         * @attr {boolean} select-all
+         * @type {boolean}
+         */
+        selectAll: {
+          type: Boolean,
+          value: false,
+          notify: true,
+        },
+
+        /**
+         * When true, the active gets automatically selected.
+         * @attr {boolean} auto-select
+         * @type {boolean}
+         */
+        autoSelect: {
+          type: Boolean,
+          value: false,
+        },
+
+        /** @protected */
+        _indeterminate: Boolean,
+
+        /** @protected */
+        _selectAllHidden: Boolean,
+      };
+    }
+
+    static get observers() {
+      return [
+        '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, selectAll, _indeterminate, _selectAllHidden)',
+      ];
+    }
+
+    /**
+     * Renders the Select All checkbox to the header cell.
+     *
+     * @override
+     */
+    _defaultHeaderRenderer(root, _column) {
+      let checkbox = root.firstElementChild;
+      if (!checkbox) {
+        checkbox = document.createElement('vaadin-checkbox');
+        checkbox.setAttribute('aria-label', 'Select All');
+        checkbox.classList.add('vaadin-grid-select-all-checkbox');
+        root.appendChild(checkbox);
+        // Add listener after appending, so we can skip the initial change event
+        checkbox.addEventListener('checked-changed', this.__onSelectAllCheckedChanged.bind(this));
+      }
+
+      const checked = this.__isChecked(this.selectAll, this._indeterminate);
+      checkbox.__rendererChecked = checked;
+      checkbox.checked = checked;
+      checkbox.hidden = this._selectAllHidden;
+      checkbox.indeterminate = this._indeterminate;
+    }
+
+    /**
+     * Renders the Select Row checkbox to the body cell.
+     *
+     * @override
+     */
+    _defaultRenderer(root, _column, { item, selected }) {
+      let checkbox = root.firstElementChild;
+      if (!checkbox) {
+        checkbox = document.createElement('vaadin-checkbox');
+        checkbox.setAttribute('aria-label', 'Select Row');
+        root.appendChild(checkbox);
+        // Add listener after appending, so we can skip the initial change event
+        checkbox.addEventListener('checked-changed', this.__onSelectRowCheckedChanged.bind(this));
+      }
+
+      checkbox.__item = item;
+      checkbox.__rendererChecked = selected;
+      checkbox.checked = selected;
+    }
+
+    /**
+     * Updates the select all state when the Select All checkbox is switched.
+     * The listener handles only user-fired events.
+     *
+     * @private
+     */
+    __onSelectAllCheckedChanged(e) {
+      // Skip if the state is changed by the renderer.
+      if (e.target.checked === e.target.__rendererChecked) {
+        return;
+      }
+
+      if (this._indeterminate || e.target.checked) {
+        this._selectAll();
+      } else {
+        this._deselectAll();
+      }
+    }
+
+    /**
+     * Selects or deselects the row when the Select Row checkbox is switched.
+     * The listener handles only user-fired events.
+     *
+     * @private
+     */
+    __onSelectRowCheckedChanged(e) {
+      // Skip if the state is changed by the renderer.
+      if (e.target.checked === e.target.__rendererChecked) {
+        return;
+      }
+
+      if (e.target.checked) {
+        this._selectItem(e.target.__item);
+      } else {
+        this._deselectItem(e.target.__item);
+      }
+    }
+
+    /**
+     * Override to handle the user selecting all items.
+     * @protected
+     */
+    _selectAll() {}
+
+    /**
+     * Override to handle the user deselecting all items.
+     * @protected
+     */
+    _deselectAll() {}
+
+    /**
+     * Override to handle the user selecting an item.
+     * @param {Object} item the item to select
+     * @protected
+     */
+    _selectItem(item) {}
+
+    /**
+     * Override to handle the user deselecting an item.
+     * @param {Object} item the item to deselect
+     * @protected
+     */
+    _deselectItem(item) {}
+
+    /**
+     * IOS needs indeterminate + checked at the same time
+     * @private
+     */
+    __isChecked(selectAll, indeterminate) {
+      return indeterminate || selectAll;
+    }
+  };

--- a/packages/grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column.d.ts
@@ -56,7 +56,7 @@ declare class GridSelectionColumn<TItem = GridDefaultItem> extends GridColumn<TI
   ): void;
 }
 
-interface GridSelectionColumn extends GridSelectionColumnBaseMixinClass {}
+interface GridSelectionColumn<TItem = GridDefaultItem> extends GridSelectionColumnBaseMixinClass<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column.d.ts
@@ -5,6 +5,7 @@
  */
 import type { GridDefaultItem } from './vaadin-grid.js';
 import { GridColumn } from './vaadin-grid-column.js';
+import type { GridSelectionColumnBaseMixinClass } from './vaadin-grid-selection-column-base-mixin.js';
 
 /**
  * Fired when the `selectAll` property changes.
@@ -39,21 +40,10 @@ export interface GridSelectionColumnEventMap extends HTMLElementEventMap, GridSe
  *
  * __The default content can also be overridden__
  *
+ * @mixes GridSelectionColumnBaseMixin
  * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
 declare class GridSelectionColumn<TItem = GridDefaultItem> extends GridColumn<TItem> {
-  /**
-   * When true, all the items are selected.
-   * @attr {boolean} select-all
-   */
-  selectAll: boolean;
-
-  /**
-   * When true, the active gets automatically selected.
-   * @attr {boolean} auto-select
-   */
-  autoSelect: boolean;
-
   addEventListener<K extends keyof GridSelectionColumnEventMap>(
     type: K,
     listener: (this: GridSelectionColumn<TItem>, ev: GridSelectionColumnEventMap[K]) => void,
@@ -66,6 +56,8 @@ declare class GridSelectionColumn<TItem = GridDefaultItem> extends GridColumn<TI
     options?: EventListenerOptions | boolean,
   ): void;
 }
+
+interface GridSelectionColumn extends GridSelectionColumnBaseMixinClass {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column.d.ts
@@ -40,7 +40,6 @@ export interface GridSelectionColumnEventMap extends HTMLElementEventMap, GridSe
  *
  * __The default content can also be overridden__
  *
- * @mixes GridSelectionColumnBaseMixin
  * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
 declare class GridSelectionColumn<TItem = GridDefaultItem> extends GridColumn<TItem> {

--- a/packages/grid/src/vaadin-grid-selection-column.js
+++ b/packages/grid/src/vaadin-grid-selection-column.js
@@ -29,6 +29,8 @@ import { GridSelectionColumnBaseMixin } from './vaadin-grid-selection-column-bas
  *
  * __The default content can also be overridden__
  *
+ * @mixes GridSelectionColumnBaseMixin
+ * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
 class GridSelectionColumn extends GridSelectionColumnBaseMixin(GridColumn) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-selection-column.js
+++ b/packages/grid/src/vaadin-grid-selection-column.js
@@ -5,6 +5,7 @@
  */
 import '@vaadin/checkbox/src/vaadin-checkbox.js';
 import { GridColumn } from './vaadin-grid-column.js';
+import { GridSelectionColumnBaseMixin } from './vaadin-grid-selection-column-base-mixin.js';
 
 /**
  * `<vaadin-grid-selection-column>` is a helper element for the `<vaadin-grid>`
@@ -28,9 +29,8 @@ import { GridColumn } from './vaadin-grid-column.js';
  *
  * __The default content can also be overridden__
  *
- * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
-class GridSelectionColumn extends GridColumn {
+class GridSelectionColumn extends GridSelectionColumnBaseMixin(GridColumn) {
   static get is() {
     return 'vaadin-grid-selection-column';
   }
@@ -38,64 +38,16 @@ class GridSelectionColumn extends GridColumn {
   static get properties() {
     return {
       /**
-       * Width of the cells for this column.
-       */
-      width: {
-        type: String,
-        value: '58px',
-      },
-
-      /**
-       * Flex grow ratio for the cell widths. When set to 0, cell width is fixed.
-       * @attr {number} flex-grow
-       * @type {number}
-       */
-      flexGrow: {
-        type: Number,
-        value: 0,
-      },
-
-      /**
-       * When true, all the items are selected.
-       * @attr {boolean} select-all
-       * @type {boolean}
-       */
-      selectAll: {
-        type: Boolean,
-        value: false,
-        notify: true,
-      },
-
-      /**
-       * When true, the active gets automatically selected.
-       * @attr {boolean} auto-select
-       * @type {boolean}
-       */
-      autoSelect: {
-        type: Boolean,
-        value: false,
-      },
-
-      /** @private */
-      __indeterminate: Boolean,
-
-      /**
        * The previous state of activeItem. When activeItem turns to `null`,
        * previousActiveItem will have an Object with just unselected activeItem
        * @private
        */
       __previousActiveItem: Object,
-
-      /** @private */
-      __selectAllHidden: Boolean,
     };
   }
 
   static get observers() {
-    return [
-      '__onSelectAllChanged(selectAll)',
-      '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, selectAll, __indeterminate, __selectAllHidden)',
-    ];
+    return ['__onSelectAllChanged(selectAll)'];
   }
 
   constructor() {
@@ -125,47 +77,6 @@ class GridSelectionColumn extends GridColumn {
       this._grid.addEventListener('filter-changed', this.__boundOnSelectedItemsChanged);
       this._grid.addEventListener('selected-items-changed', this.__boundOnSelectedItemsChanged);
     }
-  }
-
-  /**
-   * Renders the Select All checkbox to the header cell.
-   *
-   * @override
-   */
-  _defaultHeaderRenderer(root, _column) {
-    let checkbox = root.firstElementChild;
-    if (!checkbox) {
-      checkbox = document.createElement('vaadin-checkbox');
-      checkbox.setAttribute('aria-label', 'Select All');
-      checkbox.classList.add('vaadin-grid-select-all-checkbox');
-      checkbox.addEventListener('checked-changed', this.__onSelectAllCheckedChanged.bind(this));
-      root.appendChild(checkbox);
-    }
-
-    const checked = this.__isChecked(this.selectAll, this.__indeterminate);
-    checkbox.__rendererChecked = checked;
-    checkbox.checked = checked;
-    checkbox.hidden = this.__selectAllHidden;
-    checkbox.indeterminate = this.__indeterminate;
-  }
-
-  /**
-   * Renders the Select Row checkbox to the body cell.
-   *
-   * @override
-   */
-  _defaultRenderer(root, _column, { item, selected }) {
-    let checkbox = root.firstElementChild;
-    if (!checkbox) {
-      checkbox = document.createElement('vaadin-checkbox');
-      checkbox.setAttribute('aria-label', 'Select Row');
-      checkbox.addEventListener('checked-changed', this.__onSelectRowCheckedChanged.bind(this));
-      root.appendChild(checkbox);
-    }
-
-    checkbox.__item = item;
-    checkbox.__rendererChecked = selected;
-    checkbox.checked = selected;
   }
 
   /** @private */
@@ -203,45 +114,49 @@ class GridSelectionColumn extends GridColumn {
   }
 
   /**
-   * Enables or disables the Select All mode once the Select All checkbox is switched.
-   * The listener handles only user-fired events.
+   * Override a method from `GridSelectionColumnBaseMixin` to handle the user
+   * selecting all items.
    *
-   * @private
+   * @protected
+   * @override
    */
-  __onSelectAllCheckedChanged(e) {
-    // Skip if the state is changed by the renderer.
-    if (e.target.checked === e.target.__rendererChecked) {
-      return;
-    }
-
-    this.selectAll = this.__indeterminate || e.target.checked;
+  _selectAll() {
+    this.selectAll = true;
   }
 
   /**
-   * Selects or deselects the row once the Select Row checkbox is switched.
-   * The listener handles only user-fired events.
+   * Override a method from `GridSelectionColumnBaseMixin` to handle the user
+   * deselecting all items.
    *
-   * @private
+   * @protected
+   * @override
    */
-  __onSelectRowCheckedChanged(e) {
-    // Skip if the state is changed by the renderer.
-    if (e.target.checked === e.target.__rendererChecked) {
-      return;
-    }
-
-    if (e.target.checked) {
-      this._grid.selectItem(e.target.__item);
-    } else {
-      this._grid.deselectItem(e.target.__item);
-    }
+  _deselectAll() {
+    this.selectAll = false;
   }
 
   /**
-   * IOS needs indeterminate + checked at the same time
-   * @private
+   * Override a method from `GridSelectionColumnBaseMixin` to handle the user
+   * selecting an item.
+   *
+   * @param {Object} item the item to select
+   * @protected
+   * @override
    */
-  __isChecked(selectAll, indeterminate) {
-    return indeterminate || selectAll;
+  _selectItem(item) {
+    this._grid.selectItem(item);
+  }
+
+  /**
+   * Override a method from `GridSelectionColumnBaseMixin` to handle the user
+   * deselecting an item.
+   *
+   * @param {Object} item the item to deselect
+   * @protected
+   * @override
+   */
+  _deselectItem(item) {
+    this._grid.deselectItem(item);
   }
 
   /** @private */
@@ -268,13 +183,13 @@ class GridSelectionColumn extends GridColumn {
       this.__withFilteredItemsArray((items) => {
         if (!this._grid.selectedItems.length) {
           this.selectAll = false;
-          this.__indeterminate = false;
+          this._indeterminate = false;
         } else if (this.__arrayContains(this._grid.selectedItems, items)) {
           this.selectAll = true;
-          this.__indeterminate = false;
+          this._indeterminate = false;
         } else {
           this.selectAll = false;
-          this.__indeterminate = true;
+          this._indeterminate = true;
         }
       });
     }
@@ -283,7 +198,7 @@ class GridSelectionColumn extends GridColumn {
 
   /** @private */
   __onDataProviderChanged() {
-    this.__selectAllHidden = !Array.isArray(this._grid.items);
+    this._selectAllHidden = !Array.isArray(this._grid.items);
   }
 
   /**

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -282,10 +282,10 @@ assertType<string | null | undefined>(narrowedFilterColumn.path);
 /* GridSelectionColumn */
 const genericSelectionColumn = document.createElement('vaadin-grid-selection-column');
 assertType<GridSelectionColumn>(genericSelectionColumn);
-assertType<GridSelectionColumnBaseMixinClass>(genericSelectionColumn);
 
 const narrowedSelectionColumn = genericSelectionColumn as GridSelectionColumn<TestGridItem>;
 assertType<GridColumn<TestGridItem>>(narrowedSelectionColumn);
+assertType<GridSelectionColumnBaseMixinClass<TestGridItem>>(narrowedSelectionColumn);
 
 narrowedSelectionColumn.addEventListener('select-all-changed', (event) => {
   assertType<GridSelectionColumnSelectAllChangedEvent>(event);

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -25,6 +25,7 @@ import type { DragAndDropMixinClass } from '../../src/vaadin-grid-drag-and-drop-
 import type { EventContextMixinClass } from '../../src/vaadin-grid-event-context-mixin';
 import type { RowDetailsMixinClass } from '../../src/vaadin-grid-row-details-mixin';
 import type { ScrollMixinClass } from '../../src/vaadin-grid-scroll-mixin';
+import type { GridSelectionColumnBaseMixinClass } from '../../src/vaadin-grid-selection-column-base-mixin';
 import type { SelectionMixinClass } from '../../src/vaadin-grid-selection-mixin';
 import type { SortMixinClass } from '../../src/vaadin-grid-sort-mixin';
 import type { StylingMixinClass } from '../../src/vaadin-grid-styling-mixin';
@@ -281,6 +282,7 @@ assertType<string | null | undefined>(narrowedFilterColumn.path);
 /* GridSelectionColumn */
 const genericSelectionColumn = document.createElement('vaadin-grid-selection-column');
 assertType<GridSelectionColumn>(genericSelectionColumn);
+assertType<GridSelectionColumnBaseMixinClass>(genericSelectionColumn);
 
 const narrowedSelectionColumn = genericSelectionColumn as GridSelectionColumn<TestGridItem>;
 assertType<GridColumn<TestGridItem>>(narrowedSelectionColumn);


### PR DESCRIPTION
## Description

Extracts a mixin with basic grid selection column functionality in order to reuse common logic in the custom column element of the Flow component, and to be able to reuse the upcoming lasso selection feature. The common functionality mostly includes property definitions and column rendering logic. The mixin provides protected methods that need to be implemented by the respective column elements in order to change the selection state.

The respective changes for the Flow component can be found here: https://github.com/vaadin/flow-components/compare/main...refactor/grid_selection_column_reuse

As for the upcoming lasso selection feature, in order to reuse that in the Flow component, it could either be implemented in the new base mixin, or in a separate mixin class (preferrable IMO).

Part of https://github.com/vaadin/web-components/issues/6103

## Type of change

- Refactoring
