### PR TITLE
refactor!: update context-menu overlay to not extend vaadin-overlay

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -3,23 +3,43 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
-import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
 import { styles } from './vaadin-menu-overlay-styles.js';
 
-registerStyles('vaadin-context-menu-overlay', styles, { moduleId: 'vaadin-context-menu-overlay-styles' });
+registerStyles('vaadin-context-menu-overlay', [overlayStyles, styles], {
+  moduleId: 'vaadin-context-menu-overlay-styles',
+});
 
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
  *
- * @extends Overlay
+ * @extends HTMLElement
+ * @mixes DirMixin
  * @mixes MenuOverlayMixin
+ * @mixes OverlayMixin
+ * @mixes PositionMixin
+ * @mixes ThemableMixin
  * @protected
  */
-export class ContextMenuOverlay extends MenuOverlayMixin(Overlay) {
+export class ContextMenuOverlay extends MenuOverlayMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-context-menu-overlay';
+  }
+
+  static get template() {
+    return html`
+      <div id="backdrop" part="backdrop" hidden$="[[!withBackdrop]]"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <div part="content" id="content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -22,7 +22,6 @@ registerStyles('vaadin-context-menu-overlay', [overlayStyles, styles], {
  * @mixes DirMixin
  * @mixes MenuOverlayMixin
  * @mixes OverlayMixin
- * @mixes PositionMixin
  * @mixes ThemableMixin
  * @protected
  */

--- a/packages/context-menu/theme/lumo/vaadin-context-menu.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu.js
@@ -1,5 +1,4 @@
 import './vaadin-context-menu-item-styles.js';
 import './vaadin-context-menu-list-box-styles.js';
 import './vaadin-context-menu-overlay-styles.js';
-import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import '../../src/vaadin-context-menu.js';

--- a/packages/context-menu/theme/material/vaadin-context-menu.js
+++ b/packages/context-menu/theme/material/vaadin-context-menu.js
@@ -1,5 +1,4 @@
 import './vaadin-context-menu-item-styles.js';
 import './vaadin-context-menu-list-box-styles.js';
 import './vaadin-context-menu-overlay-styles.js';
-import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import '../../src/vaadin-context-menu.js';


### PR DESCRIPTION
## Description

Part of #5718

Updated `vaadin-context-menu-overlay` to use `OverlayMixin` and styles exposed as `css` literal.

## Type of change

- Refactor