### PR TITLE
fix: ensure change event is fired on blur after prevented mousedown

### DIFF
--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -267,10 +267,6 @@ export class PasswordField extends TextField {
     // Cancel the following focusout event
     e.preventDefault();
 
-    // By preventing `focusout` event, we also suppress related `change` event.
-    // Set the flag to dispatch `change` event manually when field loses focus.
-    this.__pendingChange = true;
-
     // Focus the input to avoid problem with password still visible
     // when user clicks the reveal button and then clicks outside.
     this.inputElement.focus();

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -126,6 +126,7 @@ export class PasswordField extends TextField {
     this._setType('password');
     this.__boundRevealButtonClick = this._onRevealButtonClick.bind(this);
     this.__boundRevealButtonTouchend = this._onRevealButtonTouchend.bind(this);
+    this.__lastChange = '';
   }
 
   /** @protected */
@@ -170,6 +171,19 @@ export class PasswordField extends TextField {
     if (this.inputElement) {
       this.inputElement.autocapitalize = 'off';
     }
+  }
+
+  /**
+   * Override an event listener inherited from `InputControlMixin`
+   * to store the value at the moment of the native `change` event.
+   * @param {Event} event
+   * @protected
+   * @override
+   */
+  _onChange(event) {
+    super._onChange(event);
+
+    this.__lastChange = this.inputElement.value;
   }
 
   /**
@@ -247,6 +261,17 @@ export class PasswordField extends TextField {
     // Cancel the following click event
     e.preventDefault();
     this._togglePasswordVisibility();
+
+    // By preventing `focusout` event, we also suppress related `change` event.
+    // Detect if that was the case and if so, dispatch `change` event manually.
+    if (this.__lastChange !== this.inputElement.value) {
+      this.__lastChange = this.inputElement.value;
+
+      this.validate();
+
+      this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+    }
+
     // Focus the input to avoid problem with password still visible
     // when user clicks the reveal button and then clicks outside.
     this.inputElement.focus();

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -51,7 +51,7 @@ describe('password-field', () => {
     expect(event.defaultPrevented).to.be.true;
   });
 
-  it('should focus the input on reveal button touchend', () => {
+  it('should focus the input on reveal button mousedown', () => {
     const spy = sinon.spy(input, 'focus');
 
     fire(revealButton, 'mousedown');

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -46,45 +46,40 @@ describe('password-field', () => {
     expect(input.type).to.equal('text');
   });
 
-  it('should prevent touchend event on reveal button', () => {
-    const event1 = makeSoloTouchEvent('touchend', null, revealButton);
-    expect(event1.defaultPrevented).to.be.true;
-    expect(input.type).to.equal('text');
-
-    const event2 = makeSoloTouchEvent('touchend', null, revealButton);
-    expect(event2.defaultPrevented).to.be.true;
-    expect(input.type).to.equal('password');
+  it('should prevent mousedown event on reveal button', () => {
+    const event = fire(revealButton, 'mousedown');
+    expect(event.defaultPrevented).to.be.true;
   });
 
   it('should focus the input on reveal button touchend', () => {
     const spy = sinon.spy(input, 'focus');
 
-    makeSoloTouchEvent('touchend', null, revealButton);
+    fire(revealButton, 'mousedown');
 
     expect(spy.calledOnce).to.be.true;
   });
 
-  it('should dispatch change event on reveal button touchend', () => {
+  it('should dispatch change event on focusout after changing the value', () => {
     const spy = sinon.spy();
     passwordField.addEventListener('change', spy);
 
     input.value = 'test';
 
-    makeSoloTouchEvent('touchend', null, revealButton);
+    focusout(input);
 
     expect(spy.calledOnce).to.be.true;
   });
 
-  it('should not dispatch change on reveal button touchend if value is the same', () => {
+  it('should not dispatch change event on focusout if value is the same', () => {
     const spy = sinon.spy();
     passwordField.addEventListener('change', spy);
 
-    makeSoloTouchEvent('touchend', null, revealButton);
+    focusout(input);
 
     expect(spy.called).to.be.false;
   });
 
-  it('should not dispatch change on reveal button touchend after native change', () => {
+  it('should not dispatch change event on focusout after native change', () => {
     const spy = sinon.spy();
     passwordField.addEventListener('change', spy);
 
@@ -93,19 +88,9 @@ describe('password-field', () => {
 
     spy.resetHistory();
 
-    makeSoloTouchEvent('touchend', null, revealButton);
+    focusout(input);
 
     expect(spy.called).to.be.false;
-  });
-
-  it('should validate on prevented reveal button touchend', () => {
-    const spy = sinon.spy(passwordField, 'validate');
-
-    input.value = 'test';
-
-    makeSoloTouchEvent('touchend', null, revealButton);
-
-    expect(spy.calledOnce).to.be.true;
   });
 
   it('should toggle aria-pressed attribute on reveal button click', () => {

--- a/packages/password-field/test/password-field.test.js
+++ b/packages/password-field/test/password-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, focusout, makeSoloTouchEvent, mousedown, nextRender } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, focusout, makeSoloTouchEvent, mousedown, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-password-field.js';
@@ -58,6 +58,50 @@ describe('password-field', () => {
 
   it('should focus the input on reveal button touchend', () => {
     const spy = sinon.spy(input, 'focus');
+
+    makeSoloTouchEvent('touchend', null, revealButton);
+
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should dispatch change event on reveal button touchend', () => {
+    const spy = sinon.spy();
+    passwordField.addEventListener('change', spy);
+
+    input.value = 'test';
+
+    makeSoloTouchEvent('touchend', null, revealButton);
+
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should not dispatch change on reveal button touchend if value is the same', () => {
+    const spy = sinon.spy();
+    passwordField.addEventListener('change', spy);
+
+    makeSoloTouchEvent('touchend', null, revealButton);
+
+    expect(spy.called).to.be.false;
+  });
+
+  it('should not dispatch change on reveal button touchend after native change', () => {
+    const spy = sinon.spy();
+    passwordField.addEventListener('change', spy);
+
+    input.value = 'test';
+    fire(input, 'change');
+
+    spy.resetHistory();
+
+    makeSoloTouchEvent('touchend', null, revealButton);
+
+    expect(spy.called).to.be.false;
+  });
+
+  it('should validate on prevented reveal button touchend', () => {
+    const spy = sinon.spy(passwordField, 'validate');
+
+    input.value = 'test';
 
     makeSoloTouchEvent('touchend', null, revealButton);
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/4932

Currently, preventing `touchend` also causes the `focusout` to be prevented and that suppresses `change` event.
This PR fixes that by storing a value at the moment of the last `change` event and dispatching `change` manually. 

## Type of change

- Bugfix