### PR TITLE
test: update dialog tests to pass with the Lit based version

### DIFF
--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, click, esc, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, click, esc, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-dialog.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
@@ -48,7 +48,7 @@ describe('vaadin-dialog', () => {
       dialog.renderer = (root) => {
         root.innerHTML = '<div>Simple dialog</div>';
       };
-      await nextFrame();
+      await nextUpdate(dialog);
 
       overlay = dialog.$.overlay;
       backdrop = overlay.$.backdrop;
@@ -66,7 +66,7 @@ describe('vaadin-dialog', () => {
 
       it('overlay should have the `aria-label` attribute (if set)', async () => {
         dialog.ariaLabel = 'accessible';
-        await nextFrame();
+        await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.eql('accessible');
       });
 
@@ -76,25 +76,25 @@ describe('vaadin-dialog', () => {
 
       it('overlay should not have `aria-label` attribute if set to undefined', async () => {
         dialog.ariaLabel = 'accessible';
-        await nextFrame();
+        await nextUpdate(dialog);
         dialog.ariaLabel = undefined;
-        await nextFrame();
+        await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.null;
       });
 
       it('overlay should not have `aria-label` attribute if set to null', async () => {
         dialog.ariaLabel = 'accessible';
-        await nextFrame();
+        await nextUpdate(dialog);
         dialog.ariaLabel = null;
-        await nextFrame();
+        await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.null;
       });
 
       it('overlay should not have `aria-label` attribute if set to empty string', async () => {
         dialog.ariaLabel = 'accessible';
-        await nextFrame();
+        await nextUpdate(dialog);
         dialog.ariaLabel = '';
-        await nextFrame();
+        await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.null;
       });
 
@@ -106,13 +106,13 @@ describe('vaadin-dialog', () => {
     describe('no-close-on-esc', () => {
       it('should close itself on ESC press by default', async () => {
         esc(document.body);
-        await nextFrame();
+        await nextUpdate(dialog);
         expect(dialog.opened).to.be.false;
       });
 
       it('should not close itself on ESC press when no-close-on-esc is true', async () => {
         dialog.noCloseOnEsc = true;
-        await nextFrame();
+        await nextUpdate(dialog);
         esc(document.body);
         expect(dialog.opened).to.be.true;
       });
@@ -121,13 +121,13 @@ describe('vaadin-dialog', () => {
     describe('no-close-on-outside-click', () => {
       it('should close itself on outside click by default', async () => {
         click(backdrop);
-        await nextFrame();
+        await nextUpdate(dialog);
         expect(dialog.opened).to.be.false;
       });
 
       it('should not close itself on outside click when no-close-on-outside-click is true', async () => {
         dialog.noCloseOnOutsideClick = true;
-        await nextFrame();
+        await nextUpdate(dialog);
         click(backdrop);
         expect(dialog.opened).to.be.true;
       });
@@ -181,7 +181,7 @@ describe('vaadin-dialog', () => {
 
       it('should not be modal when modeless is true', async () => {
         dialog.modeless = true;
-        await nextFrame();
+        await nextUpdate(dialog);
         expect(overlay.modeless).to.be.true;
         expect(backdrop.hidden).to.be.true;
       });
@@ -239,15 +239,15 @@ describe('vaadin-dialog', () => {
 
     it('should move focus to the dialog on open', async () => {
       dialog.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
+      await nextRender();
       expect(getDeepActiveElement()).to.equal(overlay.$.overlay);
     });
 
     it('should restore focus on dialog close', async () => {
       dialog.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
+      await nextRender();
       dialog.opened = false;
-      await aTimeout(0);
+      await nextRender();
       expect(getDeepActiveElement()).to.equal(button);
     });
   });

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -129,6 +129,7 @@ describe('vaadin-dialog', () => {
         dialog.noCloseOnOutsideClick = true;
         await nextUpdate(dialog);
         click(backdrop);
+        await nextUpdate(dialog);
         expect(dialog.opened).to.be.true;
       });
     });

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-area/vaadin-text-area.js';
 import './not-animated-styles.js';
@@ -68,6 +68,7 @@ describe('helper methods', () => {
     dialog2.renderer = (root) => {
       root.innerHTML = '<div>Modeless dialog 2</div>';
     };
+    await nextFrame();
     overlay = dialog1.$.overlay;
     overlayPart = overlay.$.overlay;
     container = overlay.$.resizerContainer;
@@ -102,8 +103,9 @@ describe('helper methods', () => {
     expect(dialog1.$.overlay._last).to.be.true;
   });
 
-  it('should not move to top if not modeless', () => {
+  it('should not move to top if not modeless', async () => {
     dialog1.modeless = false;
+    await nextFrame();
     const spy = sinon.spy(dialog1.$.overlay, 'bringToFront');
     dispatchMouseEvent(container, 'mousedown');
     expect(spy.called).to.be.false;
@@ -116,12 +118,14 @@ describe('resizable', () => {
 
   beforeEach(async () => {
     dialog = fixtureSync(`
-      <vaadin-dialog resizable opened modeless></vaadin-dialog>
+      <vaadin-dialog resizable modeless></vaadin-dialog>
     `);
     await nextRender();
     dialog.renderer = (root) => {
       root.innerHTML = '<div>Resizable dialog</div>';
     };
+    dialog.opened = true;
+    await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
     overlayPart = dialog.$.overlay.$.overlay;
     bounds = overlayPart.getBoundingClientRect();
     dx = 30;
@@ -349,7 +353,7 @@ describe('draggable', () => {
 
   beforeEach(async () => {
     dialog = fixtureSync(`
-      <vaadin-dialog draggable opened modeless></vaadin-dialog>
+      <vaadin-dialog draggable modeless></vaadin-dialog>
     `);
     await nextRender();
     dialog.renderer = (root) => {
@@ -360,6 +364,10 @@ describe('draggable', () => {
         <button>OK</button>
       `;
     };
+    await nextFrame();
+
+    dialog.opened = true;
+    await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
 
     container = dialog.$.overlay.$.resizerContainer;
     content = dialog.$.overlay.$.content;
@@ -614,6 +622,7 @@ describe('touch', () => {
         <button>OK</button>
       `;
     };
+    await nextRender();
 
     resizableOverlay = resizable.$.overlay;
     draggableOverlay = draggable.$.overlay;
@@ -705,13 +714,14 @@ describe('touch', () => {
 describe('bring to front', () => {
   let wrapper, modalDialog, modelessDialog;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     wrapper = fixtureSync(`
       <div>
         <vaadin-dialog id="modalDialog"></vaadin-dialog>
         <vaadin-dialog id="modelessDialog" modeless></vaadin-dialog>
       </div>
     `);
+    await nextRender();
     [modalDialog, modelessDialog] = wrapper.children;
 
     modalDialog.renderer = (root) => {

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-area/vaadin-text-area.js';
 import './not-animated-styles.js';
@@ -125,7 +125,7 @@ describe('resizable', () => {
       root.innerHTML = '<div>Resizable dialog</div>';
     };
     dialog.opened = true;
-    await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
+    await nextRender();
     overlayPart = dialog.$.overlay.$.overlay;
     bounds = overlayPart.getBoundingClientRect();
     dx = 30;
@@ -367,7 +367,7 @@ describe('draggable', () => {
     await nextUpdate(dialog);
 
     dialog.opened = true;
-    await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
+    await nextRender();
 
     container = dialog.$.overlay.$.resizerContainer;
     content = dialog.$.overlay.$.content;

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-area/vaadin-text-area.js';
 import './not-animated-styles.js';
@@ -63,12 +63,12 @@ describe('helper methods', () => {
     dialog1.renderer = (root) => {
       root.innerHTML = '<div>Modeless dialog 1</div>';
     };
-
+    await nextUpdate(dialog1);
     dialog2 = dialogs[1];
     dialog2.renderer = (root) => {
       root.innerHTML = '<div>Modeless dialog 2</div>';
     };
-    await nextFrame();
+    await nextUpdate(dialog2);
     overlay = dialog1.$.overlay;
     overlayPart = overlay.$.overlay;
     container = overlay.$.resizerContainer;
@@ -105,7 +105,7 @@ describe('helper methods', () => {
 
   it('should not move to top if not modeless', async () => {
     dialog1.modeless = false;
-    await nextFrame();
+    await nextUpdate(dialog1);
     const spy = sinon.spy(dialog1.$.overlay, 'bringToFront');
     dispatchMouseEvent(container, 'mousedown');
     expect(spy.called).to.be.false;
@@ -364,7 +364,7 @@ describe('draggable', () => {
         <button>OK</button>
       `;
     };
-    await nextFrame();
+    await nextUpdate(dialog);
 
     dialog.opened = true;
     await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
@@ -530,7 +530,7 @@ describe('draggable', () => {
     dialog.modeless = true;
     button.style.marginBottom = '200px';
     dialog.$.overlay.setBounds({ height: '100px' });
-    await nextFrame();
+    await nextUpdate(dialog);
     container.scrollTop = 100;
     expect(container.scrollTop).to.equal(100);
     drag(container);

--- a/packages/dialog/test/header-footer.test.js
+++ b/packages/dialog/test/header-footer.test.js
@@ -573,7 +573,7 @@ describe('header/footer feature', () => {
     describe('scroll', () => {
       beforeEach(async () => {
         dialog.renderer = createRenderer(Array(100).join('Lorem ipsum dolor sit amet\n'));
-        await nextRender();
+        await nextUpdate(dialog);
       });
 
       it('should set overflow to "bottom" when scrollbar appears after re-render', () => {

--- a/packages/dialog/test/header-footer.test.js
+++ b/packages/dialog/test/header-footer.test.js
@@ -8,13 +8,15 @@ import { createRenderer } from './helpers.js';
 describe('header/footer feature', () => {
   let dialog, overlay;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+    await nextRender();
     overlay = dialog.$.overlay;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     dialog.opened = false;
+    await nextRender();
   });
 
   describe('vaadin-dialog header-title attribute', () => {
@@ -50,6 +52,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerTitle = null;
+      await nextRender();
       expect(overlay.querySelector('[slot=title]')).to.not.exist;
     });
 
@@ -59,6 +62,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerTitle = '';
+      await nextRender();
       expect(overlay.querySelector('[slot=title]')).to.not.exist;
     });
 
@@ -82,6 +86,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerTitle = null;
+      await nextRender();
 
       expect(overlay.hasAttribute('has-title')).to.be.not.ok;
     });
@@ -119,6 +124,7 @@ describe('header/footer feature', () => {
         await nextRender();
 
         dialog.headerTitle = null;
+        await nextRender();
         expect(overlay.hasAttribute('aria-label')).to.be.false;
       });
 
@@ -159,6 +165,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerRenderer = null;
+      await nextRender();
 
       expect(overlay.textContent).to.not.include(HEADER_CONTENT);
       expect(overlay.querySelector('div[slot=header-content]')).to.not.exist;
@@ -171,6 +178,7 @@ describe('header/footer feature', () => {
 
       const NEW_HEADER_CONTENT = '__NEW_HEADER_CONTENT__';
       dialog.headerRenderer = createRenderer(NEW_HEADER_CONTENT);
+      await nextRender();
 
       expect(overlay.textContent).to.include(NEW_HEADER_CONTENT);
       expect(overlay.textContent).to.not.include(HEADER_CONTENT);
@@ -196,6 +204,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerRenderer = null;
+      await nextRender();
       expect(overlay.hasAttribute('has-header')).to.be.not.ok;
     });
 
@@ -239,6 +248,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.footerRenderer = null;
+      await nextRender();
 
       expect(overlay.textContent).to.not.include(FOOTER_CONTENT);
       expect(overlay.querySelector('div[slot=footer]')).to.not.exist;
@@ -251,6 +261,7 @@ describe('header/footer feature', () => {
 
       const NEW_FOOTER_CONTENT = '__NEW_FOOTER_CONTENT__';
       dialog.footerRenderer = createRenderer(NEW_FOOTER_CONTENT);
+      await nextRender();
 
       expect(overlay.textContent).to.include(NEW_FOOTER_CONTENT);
       expect(overlay.textContent).to.not.include(FOOTER_CONTENT);
@@ -276,6 +287,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.footerRenderer = null;
+      await nextRender();
       expect(overlay.hasAttribute('has-footer')).to.be.not.ok;
     });
 
@@ -325,6 +337,7 @@ describe('header/footer feature', () => {
 
       const NEW_BODY_CONTENT = '__NEW_BODY_CONTENT__';
       dialog.renderer = createRenderer(NEW_BODY_CONTENT);
+      await nextRender();
 
       expect(overlay.textContent).to.include(HEADER_CONTENT);
 
@@ -343,9 +356,11 @@ describe('header/footer feature', () => {
 
       const NEW_HEADER_CONTENT = '__NEW_HEADER_CONTENT__';
       dialog.headerRenderer = createRenderer(NEW_HEADER_CONTENT);
+      await nextRender();
 
       const NEW_FOOTER_CONTENT = '__NEW_FOOTER_CONTENT__';
       dialog.footerRenderer = createRenderer(NEW_FOOTER_CONTENT);
+      await nextRender();
 
       expect(overlay.textContent).to.not.include(HEADER_CONTENT);
       expect(overlay.textContent).to.include(NEW_HEADER_CONTENT);
@@ -391,6 +406,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.renderer = createRenderer(NEW_BODY_CONTENT);
+      await nextRender();
 
       expect(overlay.textContent).to.include(HEADER_TITLE);
       expect(overlay.textContent).to.not.include(BODY_CONTENT);
@@ -424,6 +440,7 @@ describe('header/footer feature', () => {
       expect(getComputedStyle(headerPart).display).to.not.be.equal('none');
 
       dialog.headerTitle = null;
+      await nextRender();
       expect(getComputedStyle(headerPart).display).to.not.be.equal('none');
     });
 
@@ -438,6 +455,7 @@ describe('header/footer feature', () => {
       expect(getComputedStyle(headerPart).display).to.not.be.equal('none');
 
       dialog.headerRenderer = null;
+      await nextRender();
       expect(getComputedStyle(headerPart).display).to.not.be.equal('none');
     });
 
@@ -453,6 +471,7 @@ describe('header/footer feature', () => {
 
       dialog.headerTitle = null;
       dialog.headerRenderer = null;
+      await nextRender();
       expect(getComputedStyle(headerPart).display).to.be.equal('none');
     });
   });
@@ -494,6 +513,7 @@ describe('header/footer feature', () => {
         await nextResize(overlay);
 
         dialog.headerRenderer = null;
+        await nextRender();
 
         expect(overlay.hasAttribute('overflow')).to.be.false;
       });
@@ -503,6 +523,7 @@ describe('header/footer feature', () => {
         await nextResize(overlay);
 
         dialog.footerRenderer = null;
+        await nextRender();
 
         expect(overlay.hasAttribute('overflow')).to.be.false;
       });
@@ -516,6 +537,7 @@ describe('header/footer feature', () => {
         expect(overlay.hasAttribute('overflow')).to.be.false;
 
         dialog.headerTitle = 'Title';
+        await nextRender();
         expect(overlay.getAttribute('overflow')).to.equal('bottom');
       });
 
@@ -527,6 +549,7 @@ describe('header/footer feature', () => {
         await nextResize(overlay);
 
         dialog.headerTitle = null;
+        await nextRender();
 
         expect(overlay.hasAttribute('overflow')).to.be.false;
       });
@@ -539,14 +562,16 @@ describe('header/footer feature', () => {
         dialog.headerRenderer = null;
         dialog.footerRenderer = null;
         dialog.headerTitle = null;
+        await nextRender();
 
         expect(overlay.hasAttribute('overflow')).to.be.false;
       });
     });
 
     describe('scroll', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         dialog.renderer = createRenderer(Array(100).join('Lorem ipsum dolor sit amet\n'));
+        await nextRender();
       });
 
       it('should set overflow to "bottom" when scrollbar appears after re-render', () => {

--- a/packages/dialog/test/header-footer.test.js
+++ b/packages/dialog/test/header-footer.test.js
@@ -165,7 +165,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerRenderer = null;
-      await nextRender();
+      await nextUpdate(dialog);
 
       expect(overlay.textContent).to.not.include(HEADER_CONTENT);
       expect(overlay.querySelector('div[slot=header-content]')).to.not.exist;
@@ -178,7 +178,7 @@ describe('header/footer feature', () => {
 
       const NEW_HEADER_CONTENT = '__NEW_HEADER_CONTENT__';
       dialog.headerRenderer = createRenderer(NEW_HEADER_CONTENT);
-      await nextRender();
+      await nextUpdate(dialog);
 
       expect(overlay.textContent).to.include(NEW_HEADER_CONTENT);
       expect(overlay.textContent).to.not.include(HEADER_CONTENT);
@@ -531,6 +531,7 @@ describe('header/footer feature', () => {
       it('should set overflow attribute when header title property is set', async () => {
         dialog.headerRenderer = null;
         dialog.footerRenderer = null;
+        await nextUpdate(dialog);
 
         overlay.style.maxHeight = '200px';
         await nextResize(overlay);
@@ -544,6 +545,7 @@ describe('header/footer feature', () => {
       it('should remove overflow attribute when header title is removed', async () => {
         dialog.headerRenderer = null;
         dialog.headerTitle = 'Title';
+        await nextUpdate(dialog);
 
         overlay.style.maxHeight = '300px';
         await nextResize(overlay);

--- a/packages/dialog/test/header-footer.test.js
+++ b/packages/dialog/test/header-footer.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-dialog.js';
@@ -52,7 +52,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerTitle = null;
-      await nextRender();
+      await nextUpdate(dialog);
       expect(overlay.querySelector('[slot=title]')).to.not.exist;
     });
 
@@ -62,7 +62,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerTitle = '';
-      await nextRender();
+      await nextUpdate(dialog);
       expect(overlay.querySelector('[slot=title]')).to.not.exist;
     });
 
@@ -86,7 +86,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerTitle = null;
-      await nextRender();
+      await nextUpdate(dialog);
 
       expect(overlay.hasAttribute('has-title')).to.be.not.ok;
     });
@@ -124,7 +124,7 @@ describe('header/footer feature', () => {
         await nextRender();
 
         dialog.headerTitle = null;
-        await nextRender();
+        await nextUpdate(dialog);
         expect(overlay.hasAttribute('aria-label')).to.be.false;
       });
 
@@ -204,7 +204,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.headerRenderer = null;
-      await nextRender();
+      await nextUpdate(dialog);
       expect(overlay.hasAttribute('has-header')).to.be.not.ok;
     });
 
@@ -248,7 +248,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.footerRenderer = null;
-      await nextRender();
+      await nextUpdate(dialog);
 
       expect(overlay.textContent).to.not.include(FOOTER_CONTENT);
       expect(overlay.querySelector('div[slot=footer]')).to.not.exist;
@@ -261,7 +261,7 @@ describe('header/footer feature', () => {
 
       const NEW_FOOTER_CONTENT = '__NEW_FOOTER_CONTENT__';
       dialog.footerRenderer = createRenderer(NEW_FOOTER_CONTENT);
-      await nextRender();
+      await nextUpdate(dialog);
 
       expect(overlay.textContent).to.include(NEW_FOOTER_CONTENT);
       expect(overlay.textContent).to.not.include(FOOTER_CONTENT);
@@ -287,7 +287,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.footerRenderer = null;
-      await nextRender();
+      await nextUpdate(dialog);
       expect(overlay.hasAttribute('has-footer')).to.be.not.ok;
     });
 
@@ -337,7 +337,7 @@ describe('header/footer feature', () => {
 
       const NEW_BODY_CONTENT = '__NEW_BODY_CONTENT__';
       dialog.renderer = createRenderer(NEW_BODY_CONTENT);
-      await nextRender();
+      await nextUpdate(dialog);
 
       expect(overlay.textContent).to.include(HEADER_CONTENT);
 
@@ -356,11 +356,11 @@ describe('header/footer feature', () => {
 
       const NEW_HEADER_CONTENT = '__NEW_HEADER_CONTENT__';
       dialog.headerRenderer = createRenderer(NEW_HEADER_CONTENT);
-      await nextRender();
+      await nextUpdate(dialog);
 
       const NEW_FOOTER_CONTENT = '__NEW_FOOTER_CONTENT__';
       dialog.footerRenderer = createRenderer(NEW_FOOTER_CONTENT);
-      await nextRender();
+      await nextUpdate(dialog);
 
       expect(overlay.textContent).to.not.include(HEADER_CONTENT);
       expect(overlay.textContent).to.include(NEW_HEADER_CONTENT);
@@ -406,7 +406,7 @@ describe('header/footer feature', () => {
       await nextRender();
 
       dialog.renderer = createRenderer(NEW_BODY_CONTENT);
-      await nextRender();
+      await nextUpdate(dialog);
 
       expect(overlay.textContent).to.include(HEADER_TITLE);
       expect(overlay.textContent).to.not.include(BODY_CONTENT);
@@ -440,7 +440,7 @@ describe('header/footer feature', () => {
       expect(getComputedStyle(headerPart).display).to.not.be.equal('none');
 
       dialog.headerTitle = null;
-      await nextRender();
+      await nextUpdate(dialog);
       expect(getComputedStyle(headerPart).display).to.not.be.equal('none');
     });
 
@@ -455,7 +455,7 @@ describe('header/footer feature', () => {
       expect(getComputedStyle(headerPart).display).to.not.be.equal('none');
 
       dialog.headerRenderer = null;
-      await nextRender();
+      await nextUpdate(dialog);
       expect(getComputedStyle(headerPart).display).to.not.be.equal('none');
     });
 
@@ -471,7 +471,7 @@ describe('header/footer feature', () => {
 
       dialog.headerTitle = null;
       dialog.headerRenderer = null;
-      await nextRender();
+      await nextUpdate(dialog);
       expect(getComputedStyle(headerPart).display).to.be.equal('none');
     });
   });
@@ -513,7 +513,7 @@ describe('header/footer feature', () => {
         await nextResize(overlay);
 
         dialog.headerRenderer = null;
-        await nextRender();
+        await nextUpdate(dialog);
 
         expect(overlay.hasAttribute('overflow')).to.be.false;
       });
@@ -523,7 +523,7 @@ describe('header/footer feature', () => {
         await nextResize(overlay);
 
         dialog.footerRenderer = null;
-        await nextRender();
+        await nextUpdate(dialog);
 
         expect(overlay.hasAttribute('overflow')).to.be.false;
       });
@@ -537,7 +537,7 @@ describe('header/footer feature', () => {
         expect(overlay.hasAttribute('overflow')).to.be.false;
 
         dialog.headerTitle = 'Title';
-        await nextRender();
+        await nextUpdate(dialog);
         expect(overlay.getAttribute('overflow')).to.equal('bottom');
       });
 
@@ -549,7 +549,7 @@ describe('header/footer feature', () => {
         await nextResize(overlay);
 
         dialog.headerTitle = null;
-        await nextRender();
+        await nextUpdate(dialog);
 
         expect(overlay.hasAttribute('overflow')).to.be.false;
       });
@@ -562,7 +562,7 @@ describe('header/footer feature', () => {
         dialog.headerRenderer = null;
         dialog.footerRenderer = null;
         dialog.headerTitle = null;
-        await nextRender();
+        await nextUpdate(dialog);
 
         expect(overlay.hasAttribute('overflow')).to.be.false;
       });

--- a/packages/dialog/test/renderer.test.js
+++ b/packages/dialog/test/renderer.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-dialog.js';
 
@@ -52,7 +52,7 @@ describe('vaadin-dialog renderer', () => {
     expect(overlay.textContent).to.equal('foo');
 
     dialog.renderer = null;
-    await nextFrame();
+    await nextUpdate(dialog);
 
     expect(overlay.textContent).to.equal('');
   });

--- a/packages/dialog/test/renderer.test.js
+++ b/packages/dialog/test/renderer.test.js
@@ -1,30 +1,33 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-dialog.js';
 
 describe('vaadin-dialog renderer', () => {
   let dialog, overlay;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+    await nextRender();
     overlay = dialog.$.overlay;
   });
 
-  it('should render the content of renderer function when renderer function provided', () => {
+  it('should render the content of renderer function when renderer function provided', async () => {
     dialog.renderer = (root) => {
       const div = document.createElement('div');
       div.textContent = 'The content of the dialog';
       root.appendChild(div);
     };
     dialog.opened = true;
+    await nextRender();
 
     expect(overlay.textContent).to.include('The content of the dialog');
   });
 
-  it('should run renderers when requesting content update', () => {
+  it('should run renderers when requesting content update', async () => {
     dialog.renderer = sinon.spy();
     dialog.opened = true;
+    await nextRender();
 
     expect(dialog.renderer.calledOnce).to.be.true;
 
@@ -39,15 +42,17 @@ describe('vaadin-dialog renderer', () => {
     expect(() => dialog.requestContentUpdate()).not.to.throw();
   });
 
-  it('should clear the content when removing the renderer', () => {
+  it('should clear the content when removing the renderer', async () => {
     dialog.renderer = (root) => {
       root.innerHTML = 'foo';
     };
     dialog.opened = true;
+    await nextRender();
 
     expect(overlay.textContent).to.equal('foo');
 
     dialog.renderer = null;
+    await nextFrame();
 
     expect(overlay.textContent).to.equal('');
   });


### PR DESCRIPTION
## Description

Added missing `await` to ensure property updates are correctly handled with Lit.

Check out [`lit/dialog`](https://github.com/vaadin/web-components/compare/lit/dialog) branch for the actual implementation  using LitElement.

## Type of change

- Tests