### PR TITLE
test: update components with Lit versions to use nextUpdate

### DIFF
--- a/packages/button/test/button.common.js
+++ b/packages/button/test/button.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
@@ -68,7 +68,7 @@ describe('vaadin-button', () => {
         const spy = sinon.spy();
         button.addEventListener('click', spy);
         button.disabled = true;
-        await nextFrame();
+        await nextUpdate(button);
 
         await sendKeys({ down: key });
 

--- a/packages/checkbox/test/checkbox.common.js
+++ b/packages/checkbox/test/checkbox.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, mousedown, mouseup, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, mouseup, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
@@ -30,8 +30,7 @@ describe('checkbox', () => {
           <label slot="label">I accept <a href="#">the terms and conditions</a></label>
         </vaadin-checkbox>
       `);
-      // Wait for MutationObserver.
-      await nextFrame();
+      await nextRender();
       input = checkbox.inputElement;
       label = checkbox._labelNode;
       link = label.children[0];
@@ -65,7 +64,7 @@ describe('checkbox', () => {
 
     it('should not toggle checked property on click when disabled', async () => {
       checkbox.disabled = true;
-      await nextFrame();
+      await nextUpdate(checkbox);
       checkbox.click();
       expect(checkbox.checked).to.be.false;
     });
@@ -81,7 +80,7 @@ describe('checkbox', () => {
     it('should be checked on Space press when initially checked is false and indeterminate is true', async () => {
       checkbox.checked = false;
       checkbox.indeterminate = true;
-      await nextFrame();
+      await nextUpdate(checkbox);
 
       // Focus on the input
       await sendKeys({ press: 'Tab' });
@@ -95,7 +94,7 @@ describe('checkbox', () => {
     it('should not be checked on Space press when initially checked is true and indeterminate is true', async () => {
       checkbox.checked = true;
       checkbox.indeterminate = true;
-      await nextFrame();
+      await nextUpdate(checkbox);
 
       // Focus on the input
       await sendKeys({ press: 'Tab' });
@@ -109,7 +108,7 @@ describe('checkbox', () => {
     it('should be checked on click when initially checked is false and indeterminate is true', async () => {
       checkbox.checked = false;
       checkbox.indeterminate = true;
-      await nextFrame();
+      await nextUpdate(checkbox);
 
       checkbox.click();
 
@@ -120,7 +119,7 @@ describe('checkbox', () => {
     it('should not be checked on click when initially checked is true and indeterminate is true', async () => {
       checkbox.checked = true;
       checkbox.indeterminate = true;
-      await nextFrame();
+      await nextUpdate(checkbox);
 
       checkbox.click();
 
@@ -223,17 +222,17 @@ describe('checkbox', () => {
   describe('indeterminate property', () => {
     beforeEach(async () => {
       checkbox = fixtureSync(`<vaadin-checkbox></vaadin-checkbox>`);
-      await nextFrame();
+      await nextRender();
       input = checkbox.inputElement;
     });
 
     it('should delegate the property to the input', async () => {
       checkbox.indeterminate = true;
-      await nextFrame();
+      await nextUpdate(checkbox);
       expect(input.indeterminate).to.be.true;
 
       checkbox.indeterminate = false;
-      await nextFrame();
+      await nextUpdate(checkbox);
       expect(input.indeterminate).to.be.false;
     });
   });

--- a/packages/email-field/test/email-field.common.js
+++ b/packages/email-field/test/email-field.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 
 const validAddresses = [
@@ -43,7 +43,7 @@ describe('email-field', () => {
       validAddresses.forEach((address) => {
         it(`should treat ${address} as valid`, async () => {
           emailField.value = address;
-          await nextFrame();
+          await nextUpdate(emailField);
           emailField.validate();
           expect(emailField.invalid).to.be.false;
         });
@@ -54,7 +54,7 @@ describe('email-field', () => {
       invalidAddresses.forEach((address) => {
         it(`should treat ${address} as invalid`, async () => {
           emailField.value = address;
-          await nextFrame();
+          await nextUpdate(emailField);
           emailField.validate();
           expect(emailField.invalid).to.be.true;
         });
@@ -148,7 +148,7 @@ describe('email-field', () => {
 
     it('should fire a validated event on validation failure', async () => {
       field.required = true;
-      await nextFrame();
+      await nextUpdate(field);
       field.validate();
 
       expect(validatedSpy.calledOnce).to.be.true;

--- a/packages/number-field/test/number-field.common.js
+++ b/packages/number-field/test/number-field.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDown, arrowUp, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { arrowDown, arrowUp, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
@@ -36,7 +36,7 @@ describe('number-field', () => {
       it('should set value with correct decimal places regardless of step', async () => {
         numberField.step = 2;
         numberField.value = 9.99;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         expect(numberField.value).equal('9.99');
       });
@@ -45,7 +45,7 @@ describe('number-field', () => {
         numberField.step = 3;
         numberField.min = 4;
         numberField.value = 4;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
 
@@ -54,14 +54,14 @@ describe('number-field', () => {
 
       it('should increment value on arrow up', async () => {
         numberField.step = 3;
-        await nextFrame();
+        await nextUpdate(numberField);
         arrowUp(input);
         expect(numberField.value).equal('3');
       });
 
       it('should decrement value on arrow down', async () => {
         numberField.step = 3;
-        await nextFrame();
+        await nextUpdate(numberField);
         arrowDown(input);
         expect(numberField.value).equal('-3');
       });
@@ -69,7 +69,7 @@ describe('number-field', () => {
       it('should not change value on arrow keys when readonly', async () => {
         numberField.readonly = true;
         numberField.value = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         arrowUp(input);
         expect(numberField.value).to.be.equal('0');
@@ -82,7 +82,7 @@ describe('number-field', () => {
     describe('value control buttons', () => {
       it('should increase value by 1 on plus button click', async () => {
         numberField.value = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
 
@@ -94,7 +94,7 @@ describe('number-field', () => {
         numberField.addEventListener('change', changeSpy);
 
         decreaseButton.click();
-        await nextFrame();
+        await nextUpdate(numberField);
 
         expect(changeSpy.callCount).to.equal(1);
       });
@@ -104,7 +104,7 @@ describe('number-field', () => {
         numberField.addEventListener('change', changeSpy);
 
         increaseButton.click();
-        await nextFrame();
+        await nextUpdate(numberField);
 
         expect(changeSpy.callCount).to.equal(1);
       });
@@ -114,7 +114,7 @@ describe('number-field', () => {
         numberField.addEventListener('value-changed', spy);
 
         decreaseButton.click();
-        await nextFrame();
+        await nextUpdate(numberField);
 
         expect(spy.callCount).to.equal(1);
       });
@@ -124,7 +124,7 @@ describe('number-field', () => {
         numberField.addEventListener('value-changed', spy);
 
         increaseButton.click();
-        await nextFrame();
+        await nextUpdate(numberField);
 
         expect(spy.callCount).to.equal(1);
       });
@@ -138,7 +138,7 @@ describe('number-field', () => {
       it('should increase value by 0.2 when step is 0.2 on plus button click', async () => {
         numberField.step = 0.2;
         numberField.value = 0.6;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
 
@@ -148,7 +148,7 @@ describe('number-field', () => {
       it('should adjust value to exact step on plus button click', async () => {
         numberField.step = 0.2;
         numberField.value = 0.5;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
 
@@ -157,7 +157,7 @@ describe('number-field', () => {
 
       it('should decrease value by 1 on minus button click', async () => {
         numberField.value = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         decreaseButton.click();
 
@@ -167,7 +167,7 @@ describe('number-field', () => {
       it('should decrease value by 0.2 on minus button click', async () => {
         numberField.value = 0;
         numberField.step = 0.2;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         decreaseButton.click();
 
@@ -177,7 +177,7 @@ describe('number-field', () => {
       it('should adjust value to exact step on minus button click', async () => {
         numberField.value = 7;
         numberField.step = 2;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         decreaseButton.click();
 
@@ -187,7 +187,7 @@ describe('number-field', () => {
       it('should adjust decimals based on the step value when control button is pressed', async () => {
         numberField.value = 1;
         numberField.step = 0.001;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
         expect(numberField.value).to.be.equal('1.001');
@@ -197,7 +197,7 @@ describe('number-field', () => {
         numberField.value = 1;
         numberField.step = 0.001;
         numberField.min = 0.0001;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
         expect(numberField.value).to.be.equal('1.0001');
@@ -206,7 +206,7 @@ describe('number-field', () => {
       it('should not increase value on plus button click when max value is reached', async () => {
         numberField.value = 0;
         numberField.max = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
 
@@ -216,7 +216,7 @@ describe('number-field', () => {
       it('should not decrease value on minus button click when min value is reached', async () => {
         numberField.value = 0;
         numberField.min = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         decreaseButton.click();
 
@@ -231,7 +231,7 @@ describe('number-field', () => {
       it('should disable minus button if min limit is reached', async () => {
         numberField.value = 0;
         numberField.min = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
         expect(decreaseButton.hasAttribute('disabled')).to.be.true;
         expect(increaseButton.hasAttribute('disabled')).to.be.false;
       });
@@ -239,7 +239,7 @@ describe('number-field', () => {
       it('should disable plus button if max limit is reached', async () => {
         numberField.value = 1;
         numberField.max = 1;
-        await nextFrame();
+        await nextUpdate(numberField);
         expect(decreaseButton.hasAttribute('disabled')).to.be.false;
         expect(increaseButton.hasAttribute('disabled')).to.be.true;
       });
@@ -247,7 +247,7 @@ describe('number-field', () => {
       it('should not change value when the field is disabled and controls are clicked', async () => {
         numberField.disabled = true;
         numberField.value = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
         expect(numberField.value).to.be.equal('0');
@@ -259,7 +259,7 @@ describe('number-field', () => {
       it('should not change value on minus button click when min limit is reached', async () => {
         numberField.min = -1;
         numberField.value = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         decreaseButton.click();
         expect(numberField.value).to.be.equal('-1');
@@ -271,7 +271,7 @@ describe('number-field', () => {
       it('should not change value on plus button click when max limit is reached', async () => {
         numberField.max = 1;
         numberField.value = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
         expect(numberField.value).to.be.equal('1');
@@ -285,7 +285,7 @@ describe('number-field', () => {
         numberField.max = 10;
         numberField.step = 6;
         numberField.value = 2;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
         expect(numberField.value).to.be.equal('8');
@@ -296,7 +296,7 @@ describe('number-field', () => {
 
       it('should prevent touchend event on value control buttons', async () => {
         numberField.value = 0;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         let e = new CustomEvent('touchend', { cancelable: true });
         increaseButton.dispatchEvent(e);
@@ -312,7 +312,7 @@ describe('number-field', () => {
       it('should decrease value to max value on minus button click when value is over max', async () => {
         numberField.value = 50;
         numberField.max = 10;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         decreaseButton.click();
 
@@ -323,7 +323,7 @@ describe('number-field', () => {
         numberField.min = -17;
         numberField.value = -8;
         numberField.step = 4;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         decreaseButton.click();
 
@@ -334,7 +334,7 @@ describe('number-field', () => {
         numberField.min = -20;
         numberField.value = -1;
         numberField.step = 4;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         [-4, -8, -12, -16, -20].forEach((step) => {
           decreaseButton.click();
@@ -345,7 +345,7 @@ describe('number-field', () => {
       it('should increase value to min value on plus button click when value is under min', async () => {
         numberField.value = -40;
         numberField.min = -10;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
 
@@ -356,7 +356,7 @@ describe('number-field', () => {
         numberField.min = -17;
         numberField.value = -8;
         numberField.step = 4;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
 
@@ -368,7 +368,7 @@ describe('number-field', () => {
         numberField.max = 18;
         numberField.value = -1;
         numberField.step = 4;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         [1, 5, 9, 13, 17].forEach((step) => {
           increaseButton.click();
@@ -381,7 +381,7 @@ describe('number-field', () => {
         numberField.max = 0.02;
         numberField.value = -0.03;
         numberField.step = 0.01;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         [-0.02, -0.01, 0, 0.01, 0.02].forEach((step) => {
           increaseButton.click();
@@ -392,7 +392,7 @@ describe('number-field', () => {
       it('should correctly calculate the precision with decimal value', async () => {
         numberField.value = 5.1;
         numberField.step = 0.01;
-        await nextFrame();
+        await nextUpdate(numberField);
 
         increaseButton.click();
         expect(numberField.value).to.be.equal('5.11');
@@ -445,7 +445,7 @@ describe('number-field', () => {
           it('should set value to the first positive step value when min < 0 on plus button click', async () => {
             numberField.min = -19;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             increaseButton.click();
 
@@ -455,7 +455,7 @@ describe('number-field', () => {
           it('should set value to the first negative step value when min < 0 zero on plus button click', async () => {
             numberField.min = -19;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             decreaseButton.click();
 
@@ -467,7 +467,7 @@ describe('number-field', () => {
           it('should set value to min when min > 0 on pus button click', async () => {
             numberField.min = 19;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             increaseButton.click();
 
@@ -477,7 +477,7 @@ describe('number-field', () => {
           it('should set value to min when min > 0 on minus button click', async () => {
             numberField.min = 19;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             decreaseButton.click();
 
@@ -489,7 +489,7 @@ describe('number-field', () => {
           it('should set value to the first positive step value when min = 0 on plus button click', async () => {
             numberField.min = 0;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             increaseButton.click();
 
@@ -499,7 +499,7 @@ describe('number-field', () => {
           it('should set value to 0 when min = 0 on minus button click', async () => {
             numberField.min = 0;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             decreaseButton.click();
 
@@ -515,7 +515,7 @@ describe('number-field', () => {
             // The closest is -24, cause with the next stepUp it will become -18
             numberField.max = -19;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             increaseButton.click();
 
@@ -525,7 +525,7 @@ describe('number-field', () => {
             numberField.value = '';
             numberField.max = -18;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             increaseButton.click();
 
@@ -535,7 +535,7 @@ describe('number-field', () => {
           it('should set value to max when max < 0 on minus button click', async () => {
             numberField.max = -19;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             decreaseButton.click();
 
@@ -547,7 +547,7 @@ describe('number-field', () => {
           it('should set value to the first positive step value when max > 0 on minus button click', async () => {
             numberField.max = 19;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             increaseButton.click();
 
@@ -557,7 +557,7 @@ describe('number-field', () => {
           it('should set value to the first step negative step value when max > 0 on minus button click', async () => {
             numberField.max = 19;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             decreaseButton.click();
 
@@ -569,7 +569,7 @@ describe('number-field', () => {
           it('should set value to 0 when max = 0 on plus button click', async () => {
             numberField.max = 0;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             increaseButton.click();
 
@@ -579,7 +579,7 @@ describe('number-field', () => {
           it('should set value to the first negative step value when max = 0 on minus button click', async () => {
             numberField.max = 0;
             numberField.step = 6;
-            await nextFrame();
+            await nextUpdate(numberField);
 
             decreaseButton.click();
 
@@ -593,7 +593,7 @@ describe('number-field', () => {
           numberField.min = -20;
           numberField.max = -3;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           increaseButton.click();
 
@@ -603,7 +603,7 @@ describe('number-field', () => {
           numberField.value = '';
           numberField.min = -24;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           increaseButton.click();
 
@@ -614,7 +614,7 @@ describe('number-field', () => {
           numberField.min = 0;
           numberField.max = 0;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           decreaseButton.click();
           expect(numberField.value).to.be.equal('0');
@@ -627,7 +627,7 @@ describe('number-field', () => {
           numberField.min = 3;
           numberField.max = 19;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           increaseButton.click();
 
@@ -638,7 +638,7 @@ describe('number-field', () => {
           numberField.min = 19;
           numberField.max = -3;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           increaseButton.click();
 
@@ -649,7 +649,7 @@ describe('number-field', () => {
           numberField.min = -19;
           numberField.max = 19;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           increaseButton.click();
 
@@ -660,7 +660,7 @@ describe('number-field', () => {
           numberField.min = -19;
           numberField.max = -3;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           decreaseButton.click();
 
@@ -671,7 +671,7 @@ describe('number-field', () => {
           numberField.min = 3;
           numberField.max = 19;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           decreaseButton.click();
 
@@ -682,7 +682,7 @@ describe('number-field', () => {
           numberField.min = 19;
           numberField.max = -3;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           decreaseButton.click();
 
@@ -693,7 +693,7 @@ describe('number-field', () => {
           numberField.min = -19;
           numberField.max = 19;
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           decreaseButton.click();
 
@@ -704,7 +704,7 @@ describe('number-field', () => {
       describe('min and max values are undefined', () => {
         it('should set value to the first positive step value on minus button click', async () => {
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           increaseButton.click();
 
@@ -713,7 +713,7 @@ describe('number-field', () => {
 
         it('should set value to the first negative step value on minus button click', async () => {
           numberField.step = 6;
-          await nextFrame();
+          await nextUpdate(numberField);
 
           decreaseButton.click();
 

--- a/packages/number-field/test/validation.common.js
+++ b/packages/number-field/test/validation.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
@@ -21,7 +21,7 @@ describe('validation', () => {
 
     it('should not pass validation when the field is required and has no value', async () => {
       field.required = true;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.checkValidity()).to.be.false;
       expect(field.validate()).to.be.false;
       expect(field.invalid).to.be.true;
@@ -30,7 +30,7 @@ describe('validation', () => {
     it('should pass validation when the field is required and has a valid value', async () => {
       field.required = true;
       field.value = '1';
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.checkValidity()).to.be.true;
       expect(field.validate()).to.be.true;
       expect(field.invalid).to.be.false;
@@ -38,14 +38,14 @@ describe('validation', () => {
 
     it('should be valid with numeric values', async () => {
       field.value = '1';
-      await nextFrame();
+      await nextUpdate(field);
       expect(input.value).to.be.equal('1');
       expect(field.validate()).to.be.true;
     });
 
     it('should prevent setting non-numeric values', async () => {
       field.value = 'foo';
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.value).to.be.empty;
       expect(field.validate()).to.be.true;
     });
@@ -53,61 +53,61 @@ describe('validation', () => {
     it('should align checkValidity with the native input element', async () => {
       field.value = -1;
       field.min = 0;
-      await nextFrame();
+      await nextUpdate(field);
 
       expect(field.checkValidity()).to.equal(input.checkValidity());
     });
 
     it('should allow setting decimals', async () => {
       field.value = 7.6;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.value).to.be.equal('7.6');
     });
 
     it('should not prevent invalid values applied programmatically (step)', async () => {
       field.step = 0.1;
       field.value = 7.686;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.value).to.be.equal('7.686');
     });
 
     it('should not prevent invalid values applied programmatically (min)', async () => {
       field.min = 2;
       field.value = 1;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.value).to.be.equal('1');
     });
 
     it('should not prevent invalid values applied programmatically (max)', async () => {
       field.max = 2;
       field.value = 3;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.value).to.be.equal('3');
     });
 
     it('should validate when setting limits', async () => {
       field.min = 2;
       field.max = 4;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.value = '';
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.validate(), 'empty value is allowed because not required').to.be.true;
 
       field.value = '3';
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.validate(), 'valid value should be in the range').to.be.true;
 
       field.value = '1';
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.validate(), 'value should not be below min').to.be.false;
 
       field.value = '3';
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.validate(), 'invalid status should be reset when setting valid value').to.be.true;
 
       field.value = '5';
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.validate(), 'value should not be greater than max').to.be.false;
     });
 
@@ -118,7 +118,7 @@ describe('validation', () => {
       field.addEventListener('change', changeSpy);
       input.value = '123';
       input.dispatchEvent(new CustomEvent('change'));
-      await nextFrame();
+      await nextUpdate(field);
       expect(validateSpy.calledOnce).to.be.true;
       expect(changeSpy.calledAfter(validateSpy)).to.be.true;
     });
@@ -138,7 +138,7 @@ describe('validation', () => {
       field.addEventListener('validated', validatedSpy);
 
       field.required = true;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
 
@@ -170,7 +170,7 @@ describe('validation', () => {
 
     it('should set an empty value when trying to commit an invalid number', async () => {
       field.value = '1';
-      await nextFrame();
+      await nextUpdate(field);
       await sendKeys({ type: '1--' });
       await sendKeys({ type: 'Enter' });
       expect(field.value).to.equal('');
@@ -258,7 +258,7 @@ describe('validation', () => {
         field.min = 1;
         field.max = 5;
         field.value = 1.5; // Would be invalid by default step=1
-        await nextFrame();
+        await nextUpdate(field);
         expect(field.validate()).to.be.true;
       });
     });
@@ -273,7 +273,7 @@ describe('validation', () => {
       [-6, -1.5, 0, 1.5, 4.5].forEach((validValue) => {
         it(`should validate valid value "${validValue}" by step when defined by user`, async () => {
           field.value = validValue;
-          await nextFrame();
+          await nextUpdate(field);
           expect(field.validate()).to.be.true;
         });
       });
@@ -281,7 +281,7 @@ describe('validation', () => {
       [-3.5, -1, 2, 2.5].forEach((invalidValue) => {
         it(`should validate invalid value "${invalidValue}" by step when defined by user`, async () => {
           field.value = invalidValue;
-          await nextFrame();
+          await nextUpdate(field);
           expect(field.validate()).to.be.false;
         });
       });
@@ -298,7 +298,7 @@ describe('validation', () => {
       [1, 2.5, 4, 5.5].forEach((validValue) => {
         it(`should validate valid value "${validValue}" using min as basis`, async () => {
           field.value = validValue;
-          await nextFrame();
+          await nextUpdate(field);
           expect(field.validate()).to.be.true;
         });
       });
@@ -306,7 +306,7 @@ describe('validation', () => {
       [1.5, 3, 5].forEach((invalidValue) => {
         it(`should validate invalid value "${invalidValue}" using min as basis`, async () => {
           field.value = invalidValue;
-          await nextFrame();
+          await nextUpdate(field);
           expect(field.validate()).to.be.false;
         });
       });
@@ -320,11 +320,11 @@ describe('validation', () => {
 
       it('should validate by step when default value defined as attribute', async () => {
         field.value = 1.5;
-        await nextFrame();
+        await nextUpdate(field);
         expect(field.validate()).to.be.false;
 
         field.value = 1;
-        await nextFrame();
+        await nextUpdate(field);
         expect(field.validate()).to.be.true;
       });
     });
@@ -337,11 +337,11 @@ describe('validation', () => {
 
       it('should validate by step when defined as attribute', async () => {
         field.value = 1;
-        await nextFrame();
+        await nextUpdate(field);
         expect(field.validate()).to.be.false;
 
         field.value = 1.5;
-        await nextFrame();
+        await nextUpdate(field);
         expect(field.validate()).to.be.true;
       });
     });
@@ -355,13 +355,13 @@ describe('validation', () => {
 
     it('should update "invalid" state when "required" is removed', async () => {
       field.required = true;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.required = false;
-      await nextFrame();
+      await nextUpdate(field);
 
       expect(field.invalid).to.be.false;
     });
@@ -369,13 +369,13 @@ describe('validation', () => {
     it('should update "invalid" state when "min" is removed', async () => {
       field.value = '42';
       field.min = 50;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.min = '';
-      await nextFrame();
+      await nextUpdate(field);
 
       expect(field.invalid).to.be.false;
     });
@@ -383,13 +383,13 @@ describe('validation', () => {
     it('should update "invalid" state when "max" is removed', async () => {
       field.value = '42';
       field.max = 20;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.max = '';
-      await nextFrame();
+      await nextUpdate(field);
 
       expect(field.invalid).to.be.false;
     });
@@ -398,13 +398,13 @@ describe('validation', () => {
       field.value = '3';
       field.min = 0;
       field.step = 2;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.step = null;
-      await nextFrame();
+      await nextUpdate(field);
 
       expect(field.invalid).to.be.false;
     });
@@ -412,13 +412,13 @@ describe('validation', () => {
     it('should not update "invalid" when "step" is removed but the field is still required', async () => {
       field.required = true;
       field.step = 2;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.step = null;
-      await nextFrame();
+      await nextUpdate(field);
 
       expect(field.invalid).to.be.true;
     });
@@ -426,13 +426,13 @@ describe('validation', () => {
     it('should not set "invalid" to false when "min" is set to 0', async () => {
       field.value = '-5';
       field.min = -1;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.min = 0;
-      await nextFrame();
+      await nextUpdate(field);
 
       expect(field.invalid).to.be.true;
     });
@@ -440,13 +440,13 @@ describe('validation', () => {
     it('should not set "invalid" to false when "max" is set to 0', async () => {
       field.value = '5';
       field.max = 1;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.max = 0;
-      await nextFrame();
+      await nextUpdate(field);
 
       expect(field.invalid).to.be.true;
     });

--- a/packages/progress-bar/test/progress-bar.common.js
+++ b/packages/progress-bar/test/progress-bar.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 
 describe('progress bar', () => {
   let progress;
@@ -32,13 +32,13 @@ describe('progress bar', () => {
 
     it('should have proper scale', async () => {
       progress.value = 0.1;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(value.getBoundingClientRect().width / progress.offsetWidth).to.be.closeTo(0.1, 0.002);
     });
 
     it('should set progress-value custom variable properly', async () => {
       progress.value = 0.1;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.equal('0.1');
     });
 
@@ -46,7 +46,7 @@ describe('progress bar', () => {
       progress.max = 20;
       progress.min = 10;
       progress.value = 15;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(value.getBoundingClientRect().width / progress.offsetWidth).to.be.closeTo(0.5, 0.002);
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.equal('0.5');
     });
@@ -55,7 +55,7 @@ describe('progress bar', () => {
       progress.value = 10;
       progress.max = 12;
       progress.min = 13;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('1');
     });
 
@@ -63,57 +63,57 @@ describe('progress bar', () => {
       progress.value = 10;
       progress.max = 10;
       progress.min = 10;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('1');
     });
 
     it('should set normalized value to 0 if the value is undefined', async () => {
       progress.value = undefined;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('0');
     });
 
     it('should set normalized value to 0.5 if the value is 0 and min is -1', async () => {
       progress.min = -1;
       progress.value = 0;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('0.5');
     });
 
     it('should clamp normalized value between 0 and 1', async () => {
       progress.value = -1;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('0');
 
       progress.value = 2;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(getComputedStyle(progress).getPropertyValue('--vaadin-progress-value')).to.be.equal('1');
     });
 
     it('should set proper aria-valuenow on value change', async () => {
       progress.max = 100;
       progress.value = 50;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(progress.getAttribute('aria-valuenow')).to.equal('50');
     });
 
     it('should set proper aria-valuemin on min change', async () => {
       progress.max = 100;
       progress.min = 10;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(progress.getAttribute('aria-valuemin')).to.equal('10');
     });
 
     it('should set proper aria-valuemax on max change', async () => {
       progress.max = 100;
       progress.min = 10;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(progress.getAttribute('aria-valuemax')).to.equal('100');
     });
 
     it('should set indeterminate attribute', async () => {
       progress.indeterminate = true;
-      await nextFrame();
+      await nextUpdate(progress);
       expect(progress.hasAttribute('indeterminate')).to.be.true;
     });
   });

--- a/packages/text-area/test/text-area.common.js
+++ b/packages/text-area/test/text-area.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, nextFrame, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 
 describe('text-area', () => {
@@ -25,7 +25,7 @@ describe('text-area', () => {
     describe('native', () => {
       async function assertAttrCanBeSet(prop, value) {
         textArea[prop] = value;
-        await nextFrame();
+        await nextUpdate(textArea);
 
         const attrValue = native.getAttribute(prop);
 
@@ -41,7 +41,7 @@ describe('text-area', () => {
       ['placeholder', 'value'].forEach((prop) => {
         it(`should set string property ${prop}`, async () => {
           textArea[prop] = 'foo';
-          await nextFrame();
+          await nextUpdate(textArea);
           expect(native[prop]).to.be.equal('foo');
         });
       });
@@ -49,11 +49,11 @@ describe('text-area', () => {
       ['disabled'].forEach((prop) => {
         it(`should set boolean property ${prop}`, async () => {
           textArea[prop] = true;
-          await nextFrame();
+          await nextUpdate(textArea);
           expect(native[prop]).to.be.true;
 
           textArea[prop] = false;
-          await nextFrame();
+          await nextUpdate(textArea);
           expect(native[prop]).to.be.false;
         });
       });
@@ -96,32 +96,32 @@ describe('text-area', () => {
 
       it('should update has-value attribute when value is set', async () => {
         textArea.value = 'foo';
-        await nextFrame();
+        await nextUpdate(textArea);
         expect(textArea.hasAttribute('has-value')).to.be.true;
       });
 
       it('should not update has-value attribute when value is set to undefined', async () => {
         textArea.value = undefined;
-        await nextFrame();
+        await nextUpdate(textArea);
         expect(textArea.hasAttribute('has-value')).to.be.false;
       });
 
       it('should not update has-value attribute when value is set to empty string', async () => {
         textArea.value = '';
-        await nextFrame();
+        await nextUpdate(textArea);
         expect(textArea.hasAttribute('has-value')).to.be.false;
       });
 
       // User could accidentally set a 0 or false value
       it('should update has-value attribute when numeric value is set', async () => {
         textArea.value = 0;
-        await nextFrame();
+        await nextUpdate(textArea);
         expect(textArea.hasAttribute('has-value')).to.be.true;
       });
 
       it('should update has-value attribute when boolean value is set', async () => {
         textArea.value = false;
-        await nextFrame();
+        await nextUpdate(textArea);
         expect(textArea.hasAttribute('has-value')).to.be.true;
       });
     });
@@ -161,7 +161,7 @@ describe('text-area', () => {
 
       // Make sure there are enough characters to grow the textarea
       textArea.value = Array(400).join('400');
-      await nextFrame();
+      await nextUpdate(textArea);
 
       const newHeight = parseInt(window.getComputedStyle(inputField).height);
       expect(newHeight).to.be.at.least(originalHeight + 10);
@@ -180,7 +180,7 @@ describe('text-area', () => {
         lot
         of
         rows`;
-      await nextFrame();
+      await nextUpdate(textArea);
 
       expect(parseFloat(window.getComputedStyle(textArea).height)).to.be.lte(100);
       expect(parseFloat(window.getComputedStyle(container).height)).to.be.lte(100);
@@ -196,7 +196,7 @@ describe('text-area', () => {
 
       // Check that value modification doesn't break min-height rule
       textArea.value = '1 row';
-      await nextFrame();
+      await nextUpdate(textArea);
 
       expect(window.getComputedStyle(textArea).height).to.be.equal('125px');
       expect(window.getComputedStyle(container).height).to.be.equal('125px');
@@ -224,7 +224,7 @@ describe('text-area', () => {
         and
         even
         more`;
-      await nextFrame();
+      await nextUpdate(textArea);
 
       expect(window.getComputedStyle(textArea).height).to.be.equal('175px');
       expect(window.getComputedStyle(container).height).to.be.equal('175px');
@@ -234,29 +234,29 @@ describe('text-area', () => {
     it('should increase input container height', async () => {
       textArea.style.height = '200px';
       textArea.value = 'foo';
-      await nextFrame();
+      await nextUpdate(textArea);
       expect(inputField.clientHeight).to.be.closeTo(200, 10);
     });
 
     it('should maintain scroll top', async () => {
       textArea.style.maxHeight = '100px';
       textArea.value = Array(400).join('400');
-      await nextFrame();
+      await nextUpdate(textArea);
 
       inputField.scrollTop = 200;
       textArea.value += 'foo';
-      await nextFrame();
+      await nextUpdate(textArea);
 
       expect(inputField.scrollTop).to.equal(200);
     });
 
     it('should decrease height automatically', async () => {
       textArea.value = Array(400).join('400');
-      await nextFrame();
+      await nextUpdate(textArea);
 
       const height = textArea.clientHeight;
       textArea.value = '';
-      await nextFrame();
+      await nextUpdate(textArea);
 
       expect(textArea.clientHeight).to.be.below(height);
     });
@@ -266,11 +266,11 @@ describe('text-area', () => {
 
       const value = Array(400).join('400');
       setInputValue(textArea, value);
-      await nextFrame();
+      await nextUpdate(textArea);
       const height = textArea.clientHeight;
 
       setInputValue(textArea, value.slice(0, -1));
-      await nextFrame();
+      await nextUpdate(textArea);
       expect(textArea.clientHeight).to.equal(height);
     });
 
@@ -294,10 +294,10 @@ describe('text-area', () => {
       textArea.style.maxHeight = '100px';
 
       textArea.value = Array(400).join('400');
-      await nextFrame();
+      await nextUpdate(textArea);
 
       textArea.value = textArea.value.slice(0, -1);
-      await nextFrame();
+      await nextUpdate(textArea);
       expect(native.clientHeight).to.equal(inputField.scrollHeight);
     });
 
@@ -308,7 +308,7 @@ describe('text-area', () => {
       textArea.style.padding = '0';
 
       textArea.value = 'foo';
-      await nextFrame();
+      await nextUpdate(textArea);
 
       expect(native.clientHeight).to.equal(
         Math.round(
@@ -341,7 +341,7 @@ describe('text-area', () => {
       beforeEach(async () => {
         textArea.style.height = '100px';
         textArea.value = 'a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\nm\nn\no\np\nq\nr\ns\nt\nu\nv\nw\nx\ny\nz';
-        await nextFrame();
+        await nextUpdate(textArea);
       });
 
       it('should be 0 initially', () => {
@@ -376,9 +376,9 @@ describe('text-area', () => {
 
       it('should update value on resize', async () => {
         inputField.scrollTop = 10;
-        await nextFrame();
+        await nextUpdate(textArea);
         textArea.style.height = `${inputField.scrollHeight}px`;
-        await nextFrame();
+        await nextUpdate(textArea);
         expect(getVerticalScrollPosition()).to.equal('0px');
       });
     });

--- a/packages/text-area/test/validation.common.js
+++ b/packages/text-area/test/validation.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 
 describe('validation', () => {
@@ -75,7 +75,7 @@ describe('validation', () => {
 
     it('should fire a validated event on validation failure', async () => {
       textArea.required = true;
-      await nextFrame();
+      await nextUpdate(textArea);
       textArea.validate();
 
       expect(validatedSpy.calledOnce).to.be.true;
@@ -92,16 +92,16 @@ describe('validation', () => {
 
     it('should not validate the field when minlength is set', async () => {
       textArea.minlength = 2;
-      await nextFrame();
+      await nextUpdate(textArea);
       expect(textArea.invalid).to.be.false;
     });
 
     it('should validate the field when invalid after minlength is changed', async () => {
       textArea.invalid = true;
-      await nextFrame();
+      await nextUpdate(textArea);
       const spy = sinon.spy(textArea, 'validate');
       textArea.minlength = 2;
-      await nextFrame();
+      await nextUpdate(textArea);
       expect(spy.calledOnce).to.be.true;
     });
   });
@@ -114,16 +114,16 @@ describe('validation', () => {
 
     it('should not validate the field when maxlength is set', async () => {
       textArea.maxlength = 6;
-      await nextFrame();
+      await nextUpdate(textArea);
       expect(textArea.invalid).to.be.false;
     });
 
     it('should validate the field when invalid after maxlength is changed', async () => {
       textArea.invalid = true;
-      await nextFrame();
+      await nextUpdate(textArea);
       const spy = sinon.spy(textArea, 'validate');
       textArea.maxlength = 6;
-      await nextFrame();
+      await nextUpdate(textArea);
       expect(spy.calledOnce).to.be.true;
     });
   });

--- a/packages/text-field/test/text-field.common.js
+++ b/packages/text-field/test/text-field.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 
 describe('text-field', () => {
@@ -15,7 +15,7 @@ describe('text-field', () => {
     describe('native', () => {
       async function assertAttrCanBeSet(prop, value) {
         textField[prop] = value;
-        await nextFrame();
+        await nextUpdate(textField);
 
         const attrValue = input.getAttribute(prop);
 
@@ -31,7 +31,7 @@ describe('text-field', () => {
       ['pattern', 'placeholder', 'value', 'title'].forEach((prop) => {
         it(`should set string property ${prop}`, async () => {
           textField[prop] = 'foo';
-          await nextFrame();
+          await nextUpdate(textField);
           expect(input[prop]).to.be.equal('foo');
         });
       });
@@ -39,11 +39,11 @@ describe('text-field', () => {
       ['disabled'].forEach((prop) => {
         it(`should set boolean property ${prop}`, async () => {
           textField[prop] = true;
-          await nextFrame();
+          await nextUpdate(textField);
           expect(input[prop]).to.be.true;
 
           textField[prop] = false;
-          await nextFrame();
+          await nextUpdate(textField);
           expect(input[prop]).to.be.false;
         });
       });
@@ -82,7 +82,7 @@ describe('text-field', () => {
       it('should clear the value when clear button is clicked', async () => {
         textField.clearButtonVisible = true;
         textField.value = 'Foo';
-        await nextFrame();
+        await nextUpdate(textField);
         textField.$.clearButton.click();
         expect(textField.value).not.to.be.ok;
       });
@@ -90,7 +90,7 @@ describe('text-field', () => {
       it('should clear the native input value when clear button is clicked', async () => {
         textField.clearButtonVisible = true;
         textField.value = 'Foo';
-        await nextFrame();
+        await nextUpdate(textField);
         textField.$.clearButton.click();
         expect(input.value).to.equal('');
       });
@@ -101,7 +101,7 @@ describe('text-field', () => {
 
         textField.clearButtonVisible = true;
         textField.value = 'Foo';
-        await nextFrame();
+        await nextUpdate(textField);
 
         textField.$.clearButton.click();
         expect(inputSpy.calledOnce).to.be.true;
@@ -113,7 +113,7 @@ describe('text-field', () => {
 
         textField.clearButtonVisible = true;
         textField.value = 'Foo';
-        await nextFrame();
+        await nextUpdate(textField);
 
         textField.$.clearButton.click();
         expect(changeSpy.calledOnce).to.be.true;
@@ -139,10 +139,10 @@ describe('text-field', () => {
 
       it('setting value to undefined should clear the native input value', async () => {
         textField.value = 'foo';
-        await nextFrame();
+        await nextUpdate(textField);
 
         textField.value = undefined;
-        await nextFrame();
+        await nextUpdate(textField);
         expect(input.value).to.equal('');
       });
     });
@@ -150,7 +150,7 @@ describe('text-field', () => {
     describe('required', () => {
       beforeEach(async () => {
         textField.required = true;
-        await nextFrame();
+        await nextUpdate(textField);
       });
 
       it('should focus on required indicator click', () => {
@@ -174,7 +174,7 @@ describe('text-field', () => {
       it('should select content on focus when autoselect is true', async () => {
         textField.value = '123';
         textField.autoselect = true;
-        await nextFrame();
+        await nextUpdate(textField);
         input.dispatchEvent(new CustomEvent('focus', { bubbles: false }));
         await aTimeout(1);
         expect(input.selectionEnd - input.selectionStart).to.equal(3);
@@ -185,30 +185,30 @@ describe('text-field', () => {
   describe('has-value attribute', () => {
     it('should toggle the attribute on value change', async () => {
       textField.value = 'foo';
-      await nextFrame();
+      await nextUpdate(textField);
       expect(textField.hasAttribute('has-value')).to.be.true;
 
       textField.value = undefined;
-      await nextFrame();
+      await nextUpdate(textField);
       expect(textField.hasAttribute('has-value')).to.be.false;
     });
 
     it('should not add the attribute when the value is an empty string', async () => {
       textField.value = '';
-      await nextFrame();
+      await nextUpdate(textField);
       expect(textField.hasAttribute('has-value')).to.be.false;
     });
 
     // User could accidentally set a 0 or false value
     it('should add the attribute when the value is a number', async () => {
       textField.value = 0;
-      await nextFrame();
+      await nextUpdate(textField);
       expect(textField.hasAttribute('has-value')).to.be.true;
     });
 
     it('should add the attribute when the value is a boolean', async () => {
       textField.value = false;
-      await nextFrame();
+      await nextUpdate(textField);
       expect(textField.hasAttribute('has-value')).to.be.true;
     });
   });
@@ -222,7 +222,7 @@ describe('text-field', () => {
       input.dispatchEvent(event);
 
       textField.value = 'foo';
-      await nextFrame();
+      await nextUpdate(textField);
       expect(input.value).to.equal('foo');
     });
   });
@@ -243,14 +243,14 @@ describe('text-field', () => {
   describe(`methods`, () => {
     it('should clear the value when clear() is called', async () => {
       textField.value = 'Foo';
-      await nextFrame();
+      await nextUpdate(textField);
       textField.clear();
       expect(textField.value).not.to.be.ok;
     });
 
     it('should clear the value of native input when clear() is called', async () => {
       textField.value = 'Foo';
-      await nextFrame();
+      await nextUpdate(textField);
       textField.clear();
       expect(input.value).to.equal('');
     });

--- a/packages/text-field/test/validation.common.js
+++ b/packages/text-field/test/validation.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 
 describe('validation', () => {
@@ -75,7 +75,7 @@ describe('validation', () => {
 
     it('should fire a validated event on validation failure', async () => {
       field.required = true;
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
 
@@ -93,12 +93,12 @@ describe('validation', () => {
 
     it('should update "invalid" state when "required" is removed', async () => {
       field.required = true;
-      await nextFrame();
+      await nextUpdate(field);
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.required = false;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.invalid).to.be.false;
     });
   });
@@ -111,24 +111,24 @@ describe('validation', () => {
 
     it('should not validate the field when minlength is set', async () => {
       field.minlength = 2;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.invalid).to.be.false;
     });
 
     it('should validate the field when invalid after minlength is changed', async () => {
       field.invalid = true;
-      await nextFrame();
+      await nextUpdate(field);
 
       const spy = sinon.spy(field, 'validate');
       field.minlength = 2;
-      await nextFrame();
+      await nextUpdate(field);
       expect(spy.calledOnce).to.be.true;
     });
 
     it.skip('should update "invalid" state when "minlength" is removed', async () => {
       field.minlength = 5;
       field.value = 'foo';
-      await nextFrame();
+      await nextUpdate(field);
 
       // There seems to be no way to make minlength/maxlength trigger invalid
       // state in a native input programmatically. It can only become invalid
@@ -144,7 +144,7 @@ describe('validation', () => {
       expect(field.invalid).to.be.true; // Fails here
 
       field.minlength = undefined;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.invalid).to.be.false;
     });
   });
@@ -157,23 +157,23 @@ describe('validation', () => {
 
     it('should not validate the field when maxlength is set', async () => {
       field.maxlength = 6;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.invalid).to.be.false;
     });
 
     it('should validate the field when invalid after maxlength is changed', async () => {
       field.invalid = true;
-      await nextFrame();
+      await nextUpdate(field);
       const spy = sinon.spy(field, 'validate');
       field.maxlength = 2;
-      await nextFrame();
+      await nextUpdate(field);
       expect(spy.calledOnce).to.be.true;
     });
 
     it.skip('should update "invalid" state when "maxlength" is removed', async () => {
       field.maxlength = 3;
       field.value = 'foobar';
-      await nextFrame();
+      await nextUpdate(field);
 
       // There seems to be no way to make minlength/maxlength trigger invalid
       // state in a native input programmatically. It can only become invalid
@@ -189,7 +189,7 @@ describe('validation', () => {
       expect(field.invalid).to.be.true; // Fails here
 
       field.maxlength = undefined;
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.invalid).to.be.false;
     });
   });
@@ -203,13 +203,13 @@ describe('validation', () => {
     it('should update "invalid" state when "pattern" is removed', async () => {
       field.value = '123foo';
       field.pattern = '\\d+';
-      await nextFrame();
+      await nextUpdate(field);
 
       field.validate();
       expect(field.invalid).to.be.true;
 
       field.pattern = '';
-      await nextFrame();
+      await nextUpdate(field);
       expect(field.invalid).to.be.false;
     });
   });


### PR DESCRIPTION
## Description

Updated components that have Lit based experimental versions to use the newly added [`nextUpdate` helper](https://github.com/vaadin/testing-helpers/pull/9).

## Type of change

- Tests