### PR TITLE
test: update mixins tests to use nextUpdate helper

### DIFF
--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -10,8 +10,8 @@ import {
   fixtureSync,
   home,
   keyDownChar,
-  nextFrame,
   nextRender,
+  nextUpdate,
   oneEvent,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
@@ -125,20 +125,20 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should update items when an element is added', async () => {
       list.appendChild(document.createElement(itemTag));
-      await nextFrame();
+      await nextUpdate(list);
       expect(list.items.length).to.be.equal(6);
     });
 
     it('should update items when an element is removed', async () => {
       list.removeChild(list.items[0]);
-      await nextFrame();
+      await nextUpdate(list);
       expect(list.items.length).to.be.equal(4);
     });
 
     it('should update items when an element is moved', async () => {
       const [e2, e4] = [list.items[2], list.items[4]];
       list.insertBefore(e4, e2);
-      await nextFrame();
+      await nextUpdate(list);
       expect(list.items[2]).to.be.equal(e4);
       expect(list.items[3]).to.be.equal(e2);
     });
@@ -147,7 +147,7 @@ const runTests = (defineHelper, baseMixin) => {
       const spy = sinon.spy();
       list.addEventListener('items-changed', spy);
       list.appendChild(document.createElement(itemTag));
-      await nextFrame();
+      await nextUpdate(list);
       expect(spy.calledOnce).to.be.true;
     });
 
@@ -155,7 +155,7 @@ const runTests = (defineHelper, baseMixin) => {
       const spy = sinon.spy();
       list.addEventListener('items-changed', spy);
       list.removeChild(list.items[0]);
-      await nextFrame();
+      await nextUpdate(list);
       expect(spy.calledOnce).to.be.true;
     });
 
@@ -200,7 +200,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should move focus to the next element on ArrowRight', async () => {
       list.orientation = 'horizontal';
-      await nextFrame();
+      await nextUpdate(list);
       list.focus();
       arrowRight(list);
       expect(list.items[1].focused).to.be.true;
@@ -228,16 +228,16 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should select an item when `selected` property is set', async () => {
       list.selected = 3;
-      await nextFrame();
+      await nextUpdate(list);
       expect(list.items[3].selected).to.be.true;
     });
 
     it('should clear selection when `selected` property is set to not numeric value', async () => {
       list.selected = 3;
-      await nextFrame();
+      await nextUpdate(list);
 
       list.selected = undefined;
-      await nextFrame();
+      await nextUpdate(list);
       expect(list.items[3].selected).to.be.false;
     });
 
@@ -271,19 +271,19 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should set a not disabled item focusable', async () => {
       list._setFocusable(3);
-      await nextFrame();
+      await nextUpdate(list);
       [-1, -1, -1, 0].forEach((val, idx) => expect(list.items[idx].tabIndex).to.equal(val));
     });
 
     it('should not set a disabled item focusable but the next not disabled item instead', async () => {
       list._setFocusable(1);
-      await nextFrame();
+      await nextUpdate(list);
       [-1, -1, 0, -1].forEach((val, idx) => expect(list.items[idx].tabIndex).to.equal(val));
     });
 
     it('should call focus() method on the item when setting it focusable', async () => {
       list._setFocusable(3);
-      await nextFrame();
+      await nextUpdate(list);
       const spy = sinon.spy(list.items[3], 'focus');
       list.focus();
       expect(spy.calledOnce).to.be.true;
@@ -327,7 +327,7 @@ const runTests = (defineHelper, baseMixin) => {
     describe('horizontal', () => {
       beforeEach(async () => {
         list.orientation = 'horizontal';
-        await nextFrame();
+        await nextUpdate(list);
       });
 
       describe('LTR mode', () => {
@@ -349,7 +349,7 @@ const runTests = (defineHelper, baseMixin) => {
 
         it('should move focus to the last element on End', async () => {
           list._focus(3);
-          await nextFrame();
+          await nextUpdate(list);
 
           end(list);
           expect(list.items[6].focused).to.be.true;
@@ -360,7 +360,7 @@ const runTests = (defineHelper, baseMixin) => {
         beforeEach(async () => {
           list.orientation = 'horizontal';
           list.setAttribute('dir', 'rtl');
-          await nextFrame();
+          await nextUpdate(list);
         });
 
         it('should move focus to the next element on ArrowLeft', () => {
@@ -381,7 +381,7 @@ const runTests = (defineHelper, baseMixin) => {
 
         it('should move focus to the last element on End', async () => {
           list._focus(3);
-          await nextFrame();
+          await nextUpdate(list);
           end(list);
           expect(list.items[6].focused).to.be.true;
         });
@@ -391,7 +391,7 @@ const runTests = (defineHelper, baseMixin) => {
     describe('vertical', () => {
       beforeEach(async () => {
         list.orientation = 'vertical';
-        await nextFrame();
+        await nextUpdate(list);
       });
 
       it('should move focus to the next element on ArrowDown', () => {
@@ -407,14 +407,14 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should move focus to the first element on Home', async () => {
         list._focus(3);
-        await nextFrame();
+        await nextUpdate(list);
         home(list);
         expect(list.items[0].focused).to.be.true;
       });
 
       it('should skip disabled items when moving focus on Home', async () => {
         list.items[0].disabled = true;
-        await nextFrame();
+        await nextUpdate(list);
 
         list._focus(3);
         home(list);
@@ -428,7 +428,7 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should skip disabled items when moving focus on End', async () => {
         list.items[6].disabled = true;
-        await nextFrame();
+        await nextUpdate(list);
         end(list);
         expect(list.items[5].focused).to.be.true;
       });
@@ -550,13 +550,13 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should set aria-orientation attribute to horizontal when orientation is set', async () => {
       list.orientation = 'horizontal';
-      await nextFrame();
+      await nextUpdate(list);
       expect(list.getAttribute('aria-orientation')).to.be.equal('horizontal');
     });
 
     it('should set aria-orientation attribute to horizontal when orientation is set', async () => {
       list.orientation = 'vertical';
-      await nextFrame();
+      await nextUpdate(list);
       expect(list.getAttribute('aria-orientation')).to.be.equal('vertical');
     });
 
@@ -568,7 +568,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should have orientation attribute on each item', async () => {
       list.orientation = 'horizontal';
-      await nextFrame();
+      await nextUpdate(list);
       list.querySelectorAll(itemTag).forEach((item) => {
         expect(item.getAttribute('orientation')).to.be.equal('horizontal');
       });
@@ -576,10 +576,10 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should change orientation attribute on each item', async () => {
       list.orientation = 'horizontal';
-      await nextFrame();
+      await nextUpdate(list);
 
       list.orientation = 'vertical';
-      await nextFrame();
+      await nextUpdate(list);
 
       list.querySelectorAll(itemTag).forEach((item) => {
         expect(item.getAttribute('orientation')).to.be.equal('vertical');
@@ -588,19 +588,19 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should have vertical attribute on newly added item', async () => {
       list.orientation = 'vertical';
-      await nextFrame();
+      await nextUpdate(list);
 
       const item = document.createElement(itemTag);
       item.textContent = 'foo';
       list.appendChild(item);
-      await nextFrame();
+      await nextUpdate(list);
       expect(item.hasAttribute('orientation')).to.be.true;
     });
 
     it('should have a protected boolean property to check vertical orientation', async () => {
       expect(list._vertical).to.be.true;
       list.orientation = 'horizontal';
-      await nextFrame();
+      await nextUpdate(list);
       expect(list._vertical).to.be.false;
     });
   });
@@ -621,7 +621,7 @@ const runTests = (defineHelper, baseMixin) => {
     describe('basic', () => {
       it('should update scrollLeft when scrolling to item horizontally', async () => {
         list.orientation = 'horizontal';
-        await nextFrame();
+        await nextUpdate(list);
 
         expect(list._scrollerElement.scrollLeft).to.be.equal(0);
 
@@ -631,7 +631,7 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should update scrollTop when scrolling to item vertically', async () => {
         list.orientation = 'vertical';
-        await nextFrame();
+        await nextUpdate(list);
 
         expect(list._scrollerElement.scrollTop).to.be.equal(0);
 
@@ -643,7 +643,7 @@ const runTests = (defineHelper, baseMixin) => {
     describe('scroll in advance', () => {
       beforeEach(async () => {
         list.orientation = 'horizontal';
-        await nextFrame();
+        await nextUpdate(list);
       });
 
       describe('LTR scroll', () => {
@@ -671,7 +671,7 @@ const runTests = (defineHelper, baseMixin) => {
       describe('RTL scroll', () => {
         beforeEach(async () => {
           list.setAttribute('dir', 'rtl');
-          await nextFrame();
+          await nextUpdate(list);
         });
 
         it('should scroll in advance when reaching left most visible item', () => {
@@ -715,30 +715,30 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should reset previously selected item when listbox and items are disabled', async () => {
       list.selected = 3;
-      await nextFrame();
+      await nextUpdate(list);
       expect(items[3].selected).to.be.true;
 
       list.disabled = true;
       items.forEach((item) => {
         item.disabled = true;
       });
-      await nextFrame();
+      await nextUpdate(list);
 
       expect(items[3].selected).to.be.false;
     });
 
     it('should restore previously selected item when listbox becomes re-enabled', async () => {
       list.selected = 3;
-      await nextFrame();
+      await nextUpdate(list);
 
       list.disabled = true;
       items.forEach((item) => {
         item.disabled = true;
       });
-      await nextFrame();
+      await nextUpdate(list);
 
       list.disabled = false;
-      await nextFrame();
+      await nextUpdate(list);
 
       expect(items[3].selected).to.be.true;
     });

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -125,20 +125,20 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should update items when an element is added', async () => {
       list.appendChild(document.createElement(itemTag));
-      await nextUpdate(list);
+      await nextRender();
       expect(list.items.length).to.be.equal(6);
     });
 
     it('should update items when an element is removed', async () => {
       list.removeChild(list.items[0]);
-      await nextUpdate(list);
+      await nextRender();
       expect(list.items.length).to.be.equal(4);
     });
 
     it('should update items when an element is moved', async () => {
       const [e2, e4] = [list.items[2], list.items[4]];
       list.insertBefore(e4, e2);
-      await nextUpdate(list);
+      await nextRender();
       expect(list.items[2]).to.be.equal(e4);
       expect(list.items[3]).to.be.equal(e2);
     });
@@ -147,7 +147,7 @@ const runTests = (defineHelper, baseMixin) => {
       const spy = sinon.spy();
       list.addEventListener('items-changed', spy);
       list.appendChild(document.createElement(itemTag));
-      await nextUpdate(list);
+      await nextRender();
       expect(spy.calledOnce).to.be.true;
     });
 
@@ -155,7 +155,7 @@ const runTests = (defineHelper, baseMixin) => {
       const spy = sinon.spy();
       list.addEventListener('items-changed', spy);
       list.removeChild(list.items[0]);
-      await nextUpdate(list);
+      await nextRender();
       expect(spy.calledOnce).to.be.true;
     });
 
@@ -593,7 +593,7 @@ const runTests = (defineHelper, baseMixin) => {
       const item = document.createElement(itemTag);
       item.textContent = 'foo';
       list.appendChild(item);
-      await nextUpdate(list);
+      await nextRender();
       expect(item.hasAttribute('orientation')).to.be.true;
     });
 

--- a/packages/component-base/test/delegate-state-mixin.test.js
+++ b/packages/component-base/test/delegate-state-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { DelegateStateMixin } from '../src/delegate-state-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
@@ -59,7 +59,7 @@ const runTests = (defineHelper, baseMixin) => {
         expect(target.hasAttribute('title')).to.be.false;
 
         element.setAttribute('title', 'foo');
-        await nextFrame();
+        await nextUpdate(element);
         expect(target.getAttribute('title')).to.equal('foo');
       });
     });
@@ -75,7 +75,7 @@ const runTests = (defineHelper, baseMixin) => {
         expect(target.getAttribute('title')).to.equal('foo');
 
         element.removeAttribute('title');
-        await nextFrame();
+        await nextUpdate(element);
         expect(target.hasAttribute('title')).to.be.false;
       });
     });
@@ -93,7 +93,7 @@ const runTests = (defineHelper, baseMixin) => {
         expect(target.hasAttribute('invalid')).to.be.false;
 
         element.toggleAttribute('invalid', true);
-        await nextFrame();
+        await nextUpdate(element);
         expect(target.hasAttribute('invalid')).to.be.true;
       });
 
@@ -101,7 +101,7 @@ const runTests = (defineHelper, baseMixin) => {
         expect(target.hasAttribute('aria-invalid')).to.be.false;
 
         element.toggleAttribute('invalid', true);
-        await nextFrame();
+        await nextUpdate(element);
         expect(target.hasAttribute('aria-invalid')).to.be.true;
       });
     });
@@ -117,7 +117,7 @@ const runTests = (defineHelper, baseMixin) => {
         expect(target.hasAttribute('invalid')).to.be.true;
 
         element.removeAttribute('invalid');
-        await nextFrame();
+        await nextUpdate(element);
         expect(target.hasAttribute('invalid')).to.be.false;
       });
 
@@ -125,7 +125,7 @@ const runTests = (defineHelper, baseMixin) => {
         expect(target.hasAttribute('aria-invalid')).to.be.true;
 
         element.removeAttribute('invalid');
-        await nextFrame();
+        await nextUpdate(element);
         expect(target.hasAttribute('aria-invalid')).to.be.false;
       });
     });
@@ -142,7 +142,7 @@ const runTests = (defineHelper, baseMixin) => {
       expect(target.indeterminate).to.be.true;
 
       target.indeterminate = false;
-      await nextFrame();
+      await nextUpdate(element);
       expect(target.indeterminate).to.be.false;
     });
   });

--- a/packages/component-base/test/dir-mixin.test.js
+++ b/packages/component-base/test/dir-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { nextFrame } from '@vaadin/testing-helpers';
+import { nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { LitElement } from 'lit';
@@ -31,7 +31,7 @@ const runTests = (baseClass) => {
     beforeEach(async () => {
       element = document.createElement(tag);
       document.body.appendChild(element);
-      await nextFrame();
+      await nextRender();
     });
 
     afterEach(() => {
@@ -45,45 +45,45 @@ const runTests = (baseClass) => {
 
     it('should match native behavior when setting property', async () => {
       element.dir = 'rtl';
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.dir).to.equal('rtl');
       expect(element.getAttribute('dir')).to.equal('rtl');
     });
 
     it('should match native behavior when setting attribute', async () => {
       element.setAttribute('dir', 'rtl');
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.dir).to.equal('rtl');
       expect(element.getAttribute('dir')).to.equal('rtl');
     });
 
     it('should match native behavior when clearing property', async () => {
       element.dir = 'rtl';
-      await nextFrame();
+      await nextUpdate(element);
 
       element.dir = '';
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.dir).to.equal('');
       expect(element.hasAttribute('dir')).to.be.false;
     });
 
     it('should match native behavior when clearing attribute', async () => {
       element.setAttribute('dir', 'rtl');
-      await nextFrame();
+      await nextUpdate(element);
 
       element.removeAttribute('dir');
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.dir).to.equal('');
       expect(element.hasAttribute('dir')).to.be.false;
     });
 
     it('should not call removeAttribute twice when clearing value', async () => {
       element.dir = 'rtl';
-      await nextFrame();
+      await nextUpdate(element);
 
       const spy = sinon.spy(element, 'removeAttribute');
       element.removeAttribute('dir');
-      await nextFrame();
+      await nextUpdate(element);
       expect(spy.calledOnce).to.be.true;
     });
   });
@@ -93,7 +93,7 @@ const runTests = (baseClass) => {
 
     before(async () => {
       document.body.appendChild(element);
-      await nextFrame();
+      await nextRender();
     });
 
     after(() => {
@@ -105,7 +105,7 @@ const runTests = (baseClass) => {
       // Clean up the dir attribute
       document.documentElement.removeAttribute('dir');
       element.removeAttribute('dir');
-      await nextFrame();
+      await nextUpdate(element);
     });
 
     // Toggle document dir attribute value
@@ -133,62 +133,62 @@ const runTests = (baseClass) => {
 
     it('should preserve direction if was set by the user with setAttribute', async () => {
       element.setAttribute('dir', 'ltr');
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
     });
 
     it('should preserve direction if was set by the user with property', async () => {
       element.dir = 'ltr';
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['rtl', 'ltr', '', 'rtl', null], ['ltr', 'ltr', 'ltr', 'ltr', 'ltr']);
     });
 
     it('should subscribe to the changes if set to equal the document direction using setAttribute', async () => {
       element.setAttribute('dir', 'ltr');
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
       element.setAttribute('dir', 'rtl');
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
     });
 
     it('should subscribe to the changes if set to equal the document direction using property', async () => {
       element.dir = 'ltr';
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
       element.dir = 'rtl';
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
     });
 
     it('should subscribe to the changes if attribute removed', async () => {
       element.setAttribute('dir', 'ltr');
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
       element.removeAttribute('dir');
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
     });
 
     it('should subscribe to the changes if property cleared', async () => {
       element.dir = 'ltr';
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['rtl', 'ltr', 'rtl'], ['ltr', 'ltr', 'ltr']);
 
       element.dir = '';
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'rtl', null]);
     });
@@ -197,7 +197,7 @@ const runTests = (baseClass) => {
       await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
 
       element.setAttribute('dir', 'ltr');
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
     });
@@ -206,7 +206,7 @@ const runTests = (baseClass) => {
       await expectDirections(['rtl', 'ltr', 'rtl'], ['rtl', 'ltr', 'rtl']);
 
       element.dir = 'ltr';
-      await nextFrame();
+      await nextUpdate(element);
 
       await expectDirections(['ltr', 'rtl', ''], ['ltr', 'ltr', 'ltr']);
     });

--- a/packages/component-base/test/overlay-class-mixin.test.js
+++ b/packages/component-base/test/overlay-class-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { OverlayClassMixin } from '../src/overlay-class-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
@@ -33,7 +33,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should forward class names set using property', async () => {
       element.overlayClass = 'foo bar';
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('foo')).to.be.true;
       expect(overlay.classList.contains('bar')).to.be.true;
@@ -41,7 +41,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should forward class names set using attribute', async () => {
       element.setAttribute('overlay-class', 'foo bar');
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('foo')).to.be.true;
       expect(overlay.classList.contains('bar')).to.be.true;
@@ -49,10 +49,10 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should update class names when property changes', async () => {
       element.overlayClass = 'foo bar';
-      await nextFrame();
+      await nextUpdate(element);
 
       element.overlayClass = 'foo';
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('foo')).to.be.true;
       expect(overlay.classList.contains('bar')).to.be.false;
@@ -60,10 +60,10 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should update class names when attribute changes', async () => {
       element.setAttribute('overlay-class', 'foo bar');
-      await nextFrame();
+      await nextUpdate(element);
 
       element.setAttribute('overlay-class', 'foo');
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('foo')).to.be.true;
       expect(overlay.classList.contains('bar')).to.be.false;
@@ -83,7 +83,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should not override custom static class using property', async () => {
       element.overlayClass = 'foo bar';
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('foo')).to.be.true;
       expect(overlay.classList.contains('bar')).to.be.true;
@@ -92,7 +92,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should not override custom static class using attribute', async () => {
       element.setAttribute('overlay-class', 'foo bar');
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('foo')).to.be.true;
       expect(overlay.classList.contains('bar')).to.be.true;
@@ -101,10 +101,10 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should not remove custom static class when clearing property', async () => {
       element.overlayClass = 'baz qux';
-      await nextFrame();
+      await nextUpdate(element);
 
       element.overlayClass = null;
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('baz')).to.be.false;
       expect(overlay.classList.contains('qux')).to.be.true;
@@ -112,10 +112,10 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should not remove custom static class when removing attribute', async () => {
       element.setAttribute('overlay-class', 'baz qux');
-      await nextFrame();
+      await nextUpdate(element);
 
       element.removeAttribute('overlay-class');
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('baz')).to.be.false;
       expect(overlay.classList.contains('qux')).to.be.true;
@@ -125,10 +125,10 @@ const runTests = (defineHelper, baseMixin) => {
       overlay.classList.add('xyz');
 
       element.overlayClass = 'abc xyz';
-      await nextFrame();
+      await nextUpdate(element);
 
       element.overlayClass = null;
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('abc')).to.be.false;
       expect(overlay.classList.contains('xyz')).to.be.true;
@@ -138,10 +138,10 @@ const runTests = (defineHelper, baseMixin) => {
       overlay.classList.add('xyz');
 
       element.setAttribute('overlay-class', 'abc xyz');
-      await nextFrame();
+      await nextUpdate(element);
 
       element.removeAttribute('overlay-class');
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(overlay.classList.contains('abc')).to.be.false;
       expect(overlay.classList.contains('xyz')).to.be.true;

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -7,8 +7,8 @@ import {
   fixtureSync,
   keyboardEventFor,
   mousedown,
-  nextFrame,
   nextRender,
+  nextUpdate,
 } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
@@ -55,13 +55,13 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should clear the field value on clear button click', async () => {
       clearButton.click();
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.value).to.equal('');
     });
 
     it('should clear the input value on clear button click', async () => {
       clearButton.click();
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.value).to.equal('');
     });
 
@@ -117,18 +117,18 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should reflect clearButtonVisible property to attribute', async () => {
       element.clearButtonVisible = true;
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.hasAttribute('clear-button-visible')).to.be.true;
 
       element.clearButtonVisible = false;
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.hasAttribute('clear-button-visible')).to.be.false;
     });
 
     it('should clear value on Esc when clearButtonVisible is true', async () => {
       element.clearButtonVisible = true;
       escKeyDown(clearButton);
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.value).to.equal('');
     });
 
@@ -193,14 +193,14 @@ const runTests = (defineHelper, baseMixin) => {
       beforeEach(async () => {
         input.value = 'foo';
         fire(input, 'input');
-        await nextFrame();
+        await nextUpdate(element);
         hasInputValueChangedSpy.resetHistory();
         valueChangedSpy.resetHistory();
       });
 
       it('should fire the event on clear button click', async () => {
         clearButton.click();
-        await nextFrame();
+        await nextUpdate(element);
         expect(hasInputValueChangedSpy.calledOnce).to.be.true;
         expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
       });
@@ -208,7 +208,7 @@ const runTests = (defineHelper, baseMixin) => {
       it('should fire the event on Esc', async () => {
         input.focus();
         await sendKeys({ press: 'Escape' });
-        await nextFrame();
+        await nextUpdate(element);
         expect(hasInputValueChangedSpy.calledOnce).to.be.true;
         expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
       });

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -555,16 +555,16 @@ const runTests = (defineHelper, baseMixin) => {
           div.setAttribute('slot', 'helper');
           div.textContent = 'New';
           element.replaceChild(div, helper);
-          await nextUpdate(element);
+          await nextRender();
           expect(element._helperNode).to.equal(div);
         });
 
         it('should support adding lazy helper after removing the default one', async () => {
           element.removeChild(defaultHelper);
-          await nextUpdate(element);
+          await nextRender();
 
           element.appendChild(helper);
-          await nextUpdate(element);
+          await nextRender();
 
           expect(element._helperNode).to.equal(helper);
         });

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -973,7 +973,7 @@ const runTests = (defineHelper, baseMixin) => {
       helper.id = 'helper-component';
       helper.textContent = 'Helper';
       element.appendChild(helper);
-      await nextRender(element);
+      await nextRender();
       expect(input.getAttribute('aria-describedby')).to.include('helper-component');
     });
 

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -983,7 +983,7 @@ const runTests = (defineHelper, baseMixin) => {
       helper.id = 'helper-component';
       helper.textContent = 'Helper';
       element.appendChild(helper);
-      await nextUpdate(element);
+      await nextRender();
       helper.removeAttribute('id');
       expect(input.getAttribute('aria-describedby')).to.include(helper.id);
     });

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, defineLit, definePolymer, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import sinon from 'sinon';
+import { aTimeout, defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FieldMixin } from '../src/field-mixin.js';
@@ -88,22 +87,22 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should update error message content on attribute change', async () => {
         element.setAttribute('error-message', 'This field is required');
-        await nextFrame();
+        await nextUpdate(element);
         expect(error.textContent).to.equal('This field is required');
       });
 
       it('should update error message content on property change', async () => {
         element.errorMessage = 'This field is required';
-        await nextFrame();
+        await nextUpdate(element);
         expect(error.textContent).to.equal('This field is required');
       });
 
       it('should clear error message content when field is valid', async () => {
         element.errorMessage = 'This field is required';
-        await nextFrame();
+        await nextUpdate(element);
 
         element.invalid = false;
-        await nextFrame();
+        await nextUpdate(element);
         expect(error.textContent).to.equal('');
       });
 
@@ -113,34 +112,34 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should not set has-error-message attribute when the property is an empty string', async () => {
         element.errorMessage = '';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-error-message')).to.be.false;
       });
 
       it('should not set has-error-message attribute when the property is null', async () => {
         element.errorMessage = null;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-error-message')).to.be.false;
       });
 
       it('should set has-error-message attribute when attribute is set', async () => {
         element.setAttribute('error-message', 'This field is required');
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-error-message')).to.be.true;
       });
 
       it('should set has-error-message attribute when property is set', async () => {
         element.errorMessage = 'This field is required';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-error-message')).to.be.true;
       });
 
       it('should remove has-error-message attribute when field is valid', async () => {
         element.errorMessage = 'This field is required';
-        await nextFrame();
+        await nextUpdate(element);
 
         element.invalid = false;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-error-message')).to.be.false;
       });
 
@@ -150,22 +149,22 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should set alert role when attribute is set', async () => {
         element.setAttribute('error-message', 'This field is required');
-        await nextFrame();
+        await nextUpdate(element);
         expect(error.getAttribute('role')).to.equal('alert');
       });
 
       it('should set alert role when property is set', async () => {
         element.errorMessage = 'This field is required';
-        await nextFrame();
+        await nextUpdate(element);
         expect(error.getAttribute('role')).to.equal('alert');
       });
 
       it('should remove alert role when field is valid', async () => {
         element.errorMessage = 'This field is required';
-        await nextFrame();
+        await nextUpdate(element);
 
         element.invalid = false;
-        await nextFrame();
+        await nextUpdate(element);
         expect(error.hasAttribute('role')).to.be.false;
       });
     });
@@ -235,7 +234,7 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should update slotted error message content on property change', async () => {
         element.errorMessage = 'This field is required';
-        await nextFrame();
+        await nextUpdate(element);
         expect(error.textContent).to.equal('This field is required');
       });
     });
@@ -259,14 +258,14 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should add a helper when helperText property is set', async () => {
         element.helperText = '3 digits';
-        await nextFrame();
+        await nextUpdate(element);
         helper = element.querySelector('[slot=helper]');
         expect(helper).to.be.an.instanceof(HTMLDivElement);
       });
 
       it('should add a helper when helper-text attribute is set', async () => {
         element.setAttribute('helper-text', '3 digits');
-        await nextFrame();
+        await nextUpdate(element);
         helper = element.querySelector('[slot=helper]');
         expect(helper).to.be.an.instanceof(HTMLDivElement);
       });
@@ -277,45 +276,45 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should set has-helper attribute when attribute is set', async () => {
         element.setAttribute('helper-text', '3 digits');
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-helper')).to.be.true;
       });
 
       it('should set has-helper attribute when property is set', async () => {
         element.helperText = '3 digits';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-helper')).to.be.true;
       });
 
       it('should not add a helper when helperText is whitespace string', async () => {
         element.helperText = ' ';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.querySelector('[slot=helper]')).to.be.not.ok;
       });
 
       it('should not set has-helper when helperText is whitespace string', async () => {
         element.helperText = ' ';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-helper')).to.be.false;
       });
 
       it('should clear helper when helperText is set to empty string', async () => {
         element.helperText = '3 digits';
-        await nextFrame();
+        await nextUpdate(element);
         helper = element.querySelector('[slot=helper]');
 
         element.helperText = '';
-        await nextFrame();
+        await nextUpdate(element);
         expect(helper.textContent).to.equal('');
       });
 
       it('should remove has-helper attribute when helperText is cleared', async () => {
         element.helperText = '3 digits';
-        await nextFrame();
+        await nextUpdate(element);
         helper = element.querySelector('[slot=helper]');
 
         element.helperText = '';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-helper')).to.be.false;
       });
     });
@@ -356,25 +355,25 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should update helper content on attribute change', async () => {
         element.setAttribute('helper-text', '3 digits');
-        await nextFrame();
+        await nextUpdate(element);
         expect(helper.textContent).to.equal('3 digits');
       });
 
       it('should update helper content on property change', async () => {
         element.helperText = '3 digits';
-        await nextFrame();
+        await nextUpdate(element);
         expect(helper.textContent).to.equal('3 digits');
       });
 
       it('should remove has-helper attribute when property is unset', async () => {
         element.helperText = '';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-helper')).to.be.false;
       });
 
       it('should remove has-helper attribute when property is null', async () => {
         element.helperText = null;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-helper')).to.be.false;
       });
     });
@@ -392,7 +391,7 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should remove has-helper attribute when attribute is removed', async () => {
         element.removeAttribute('helper-text');
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-helper')).to.be.false;
       });
     });
@@ -422,13 +421,13 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should not update slotted helper content on property change', async () => {
         element.helperText = '3 digits';
-        await nextFrame();
+        await nextUpdate(element);
         expect(helper.textContent).to.not.equal('3 digits');
       });
 
       it('should remove has-helper attribute when slotted helper is removed', async () => {
         element.removeChild(helper);
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-helper')).to.be.false;
       });
     });
@@ -496,120 +495,120 @@ const runTests = (defineHelper, baseMixin) => {
 
         it('should handle lazy helper added using appendChild', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
           expect(element._helperNode).to.equal(helper);
         });
 
         it('should handle lazy helper added using insertBefore', async () => {
           element.insertBefore(helper, defaultHelper);
-          await nextFrame();
+          await nextRender();
           expect(element._helperNode).to.equal(helper);
         });
 
         it('should handle lazy helper added using replaceChild', async () => {
           element.replaceChild(helper, defaultHelper);
-          await nextFrame();
+          await nextRender();
           expect(element._helperNode).to.equal(helper);
         });
 
         it('should remove the default helper from the element when using appendChild', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
           expect(defaultHelper.parentNode).to.be.null;
         });
 
         it('should remove the default helper from the element when using insertBefore', async () => {
           element.insertBefore(helper, defaultHelper);
-          await nextFrame();
+          await nextRender();
           expect(defaultHelper.parentNode).to.be.null;
         });
 
         it('should support replacing lazy helper with a new one using appendChild', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
 
           const div = document.createElement('div');
           div.setAttribute('slot', 'helper');
           div.textContent = 'New';
           element.appendChild(div);
-          await nextFrame();
+          await nextRender();
           expect(element._helperNode).to.equal(div);
         });
 
         it('should support replacing lazy helper with a new one using insertBefore', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
 
           const div = document.createElement('div');
           div.setAttribute('slot', 'helper');
           div.textContent = 'New';
           element.insertBefore(div, helper);
-          await nextFrame();
+          await nextRender();
           expect(element._helperNode).to.equal(div);
         });
 
         it('should support replacing lazy helper with a new one using replaceChild', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
 
           const div = document.createElement('div');
           div.setAttribute('slot', 'helper');
           div.textContent = 'New';
           element.replaceChild(div, helper);
-          await nextFrame();
+          await nextUpdate(element);
           expect(element._helperNode).to.equal(div);
         });
 
         it('should support adding lazy helper after removing the default one', async () => {
           element.removeChild(defaultHelper);
-          await nextFrame();
+          await nextUpdate(element);
 
           element.appendChild(helper);
-          await nextFrame();
+          await nextUpdate(element);
 
           expect(element._helperNode).to.equal(helper);
         });
 
         it('should restore the default helper when helperText property is set', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
 
           element.removeChild(helper);
-          await nextFrame();
+          await nextRender();
           expect(element._helperNode).to.equal(defaultHelper);
         });
 
         it('should restore the default helper when helperText property is restored', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
 
           element.helperText = '';
 
           element.removeChild(helper);
-          await nextFrame();
+          await nextRender();
 
           element.helperText = 'Helper';
-          await nextFrame();
+          await nextRender();
           expect(element._helperNode).to.equal(defaultHelper);
         });
 
         it('should keep has-helper attribute when the default helper is restored', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
 
           element.removeChild(helper);
-          await nextFrame();
+          await nextRender();
           expect(element.hasAttribute('has-helper')).to.be.true;
         });
 
         it('should remove has-helper attribute when helperText is set to empty', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
 
           element.helperText = '';
 
           element.removeChild(helper);
-          await nextFrame();
+          await nextRender();
           expect(element.hasAttribute('has-helper')).to.be.false;
         });
       });
@@ -626,32 +625,32 @@ const runTests = (defineHelper, baseMixin) => {
 
         it('should set id on the lazily added helper element', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
           expect(helper.getAttribute('id')).to.match(ID_REGEX);
         });
 
         it('should not override custom id on the lazily added helper', async () => {
           helper.id = 'helper-component';
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
           expect(helper.getAttribute('id')).to.equal('helper-component');
         });
 
         it('should restore default id if the custom helper id is removed', async () => {
           helper.id = 'helper-component';
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
           helper.removeAttribute('id');
-          await nextFrame();
+          await nextRender();
           expect(helper.getAttribute('id')).to.match(ID_REGEX);
         });
 
         it('should apply helper text if the custom helper is removed', async () => {
           element.appendChild(helper);
-          await nextFrame();
+          await nextRender();
           element.helperText = 'Default';
           element.removeChild(helper);
-          await nextFrame();
+          await nextRender();
           const defaultHelper = element.querySelector('[slot="helper"]');
           expect(defaultHelper.textContent).to.equal('Default');
         });
@@ -666,7 +665,7 @@ const runTests = (defineHelper, baseMixin) => {
           helper.setAttribute('slot', 'helper');
           helper.textContent = 'Lazy';
           element.appendChild(helper);
-          await nextFrame();
+          await nextUpdate(element);
         });
 
         it('should store a reference to the lazily added helper', () => {
@@ -704,7 +703,7 @@ const runTests = (defineHelper, baseMixin) => {
 
         it('should only contain label id when the field is invalid', async () => {
           element.invalid = true;
-          await nextFrame();
+          await nextUpdate(element);
           const aria = input.getAttribute('aria-labelledby');
           expect(aria).to.equal(label.id);
         });
@@ -718,7 +717,7 @@ const runTests = (defineHelper, baseMixin) => {
 
         it('should add error id asynchronously after the field becomes invalid', async () => {
           element.invalid = true;
-          await nextFrame();
+          await nextUpdate(element);
           await aTimeout(0);
           const aria = input.getAttribute('aria-describedby');
           expect(aria).to.include(helper.id);
@@ -745,30 +744,30 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should set aria-label when accessible-name is defined', async () => {
         element.accessibleName = 'accessible name';
-        await nextFrame();
+        await nextUpdate(element);
         expect(input.getAttribute('aria-label')).to.be.equal('accessible name');
       });
 
       it('should remove aria-labelledby by if no accessible name is defined', async () => {
         element.accessibleName = 'accessible name';
-        await nextFrame();
+        await nextUpdate(element);
         expect(input.hasAttribute('aria-labelledby')).to.be.false;
       });
 
       it('should remove aria-label when accessible name is cleared', async () => {
         element.accessibleName = 'accessible name';
-        await nextFrame();
+        await nextUpdate(element);
         element.accessibleName = null;
-        await nextFrame();
+        await nextUpdate(element);
         expect(input.hasAttribute('aria-label')).to.be.false;
       });
 
       it('should restore aria-labelledby value if accessible-name is cleared', async () => {
         const ariaLabelledby = input.getAttribute('aria-labelledby');
         element.accessibleName = 'accessible name';
-        await nextFrame();
+        await nextUpdate(element);
         element.accessibleName = null;
-        await nextFrame();
+        await nextUpdate(element);
         expect(input.getAttribute('aria-labelledby')).to.be.equal(ariaLabelledby);
       });
     });
@@ -809,15 +808,15 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should set aria-labelledby when accessible-name-ref is defined', async () => {
         element.accessibleNameRef = 'accessible-name-ref-0';
-        await nextFrame();
+        await nextUpdate(element);
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
 
       it('should change aria-labelledby if accessible-name-ref is changed', async () => {
         element.accessibleNameRef = 'accessible-name-ref-0';
-        await nextFrame();
+        await nextUpdate(element);
         element.accessibleNameRef = 'accessible-name-ref-1';
-        await nextFrame();
+        await nextUpdate(element);
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-1');
       });
 
@@ -825,25 +824,25 @@ const runTests = (defineHelper, baseMixin) => {
         const previousAriaLabelledBy = input.getAttribute('aria-labelledby');
         expect(previousAriaLabelledBy).to.not.be.empty;
         element.accessibleNameRef = 'accessible-name-ref-0';
-        await nextFrame();
+        await nextUpdate(element);
         element.accessibleNameRef = null;
-        await nextFrame();
+        await nextUpdate(element);
         expect(input.getAttribute('aria-labelledby')).to.be.equal(previousAriaLabelledBy);
       });
 
       it('should not remove aria-labelledby if accessible-name-ref is defined and label is cleared', async () => {
         element.accessibleNameRef = 'accessible-name-ref-0';
-        await nextFrame();
+        await nextUpdate(element);
         element.label = null;
-        await nextFrame();
+        await nextUpdate(element);
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
 
       it('should not change aria-labelledby if accessible-name-ref is defined and label is changed', async () => {
         element.accessibleNameRef = 'accessible-name-ref-0';
-        await nextFrame();
+        await nextUpdate(element);
         element.label = 'Another label';
-        await nextFrame();
+        await nextUpdate(element);
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
     });
@@ -910,7 +909,7 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should not set aria-required attribute on required property change', async () => {
         element.required = true;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('aria-required')).to.be.false;
       });
     });
@@ -938,11 +937,11 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should toggle aria-required attribute on required property change', async () => {
         element.required = true;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.getAttribute('aria-required')).to.equal('true');
 
         element.required = false;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('aria-required')).to.be.false;
       });
     });
@@ -974,7 +973,7 @@ const runTests = (defineHelper, baseMixin) => {
       helper.id = 'helper-component';
       helper.textContent = 'Helper';
       element.appendChild(helper);
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.getAttribute('aria-describedby')).to.include('helper-component');
     });
 
@@ -984,7 +983,7 @@ const runTests = (defineHelper, baseMixin) => {
       helper.id = 'helper-component';
       helper.textContent = 'Helper';
       element.appendChild(helper);
-      await nextFrame();
+      await nextUpdate(element);
       helper.removeAttribute('id');
       expect(input.getAttribute('aria-describedby')).to.include(helper.id);
     });

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -973,7 +973,7 @@ const runTests = (defineHelper, baseMixin) => {
       helper.id = 'helper-component';
       helper.textContent = 'Helper';
       element.appendChild(helper);
-      await nextUpdate(element);
+      await nextRender(element);
       expect(input.getAttribute('aria-describedby')).to.include('helper-component');
     });
 

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -665,7 +665,7 @@ const runTests = (defineHelper, baseMixin) => {
           helper.setAttribute('slot', 'helper');
           helper.textContent = 'Lazy';
           element.appendChild(helper);
-          await nextUpdate(element);
+          await nextRender();
         });
 
         it('should store a reference to the lazily added helper', () => {

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -106,30 +106,30 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should not validate on setting a constraint', async () => {
         element.required = true;
-        await nextFrame();
+        await nextUpdate(element);
         expect(validateSpy.called).to.be.false;
       });
 
       it('should not validate on removing a non-final constraint when the field is valid', async () => {
         element.pattern = '\\d*';
         element.minlength = 2;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.invalid).to.be.false;
         validateSpy.resetHistory();
         element.minlength = 2;
-        await nextFrame();
+        await nextUpdate(element);
         expect(validateSpy.called).to.be.false;
       });
 
       it('should validate on removing a non-final constraint when the field is invalid', async () => {
         element.required = true;
         element.pattern = '\\d*';
-        await nextFrame();
+        await nextUpdate(element);
         element.validate();
         expect(element.invalid).to.be.true;
         validateSpy.resetHistory();
         element.required = false;
-        await nextFrame();
+        await nextUpdate(element);
         expect(validateSpy.calledOnce).to.be.true;
       });
     });
@@ -145,72 +145,72 @@ const runTests = (defineHelper, baseMixin) => {
       it('should call checkValidity on the input on setting a constraint', async () => {
         const spy = sinon.spy(input, 'checkValidity');
         element.minlength = 2;
-        await nextFrame();
+        await nextUpdate(element);
         expect(spy.calledOnce).to.be.true;
       });
 
       it('should validate on setting a boolean constraint', async () => {
         element.required = true;
-        await nextFrame();
+        await nextUpdate(element);
         expect(validateSpy.calledOnce).to.be.true;
       });
 
       it('should reset invalid on removing a boolean constraint', async () => {
         element.required = true;
         element.invalid = true;
-        await nextFrame();
+        await nextUpdate(element);
 
         element.required = false;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.invalid).to.be.false;
       });
 
       it('should validate on setting a number constraint', async () => {
         element.minlength = 2;
-        await nextFrame();
+        await nextUpdate(element);
         expect(validateSpy.calledOnce).to.be.true;
       });
 
       it('should validate on setting a number constraint to 0', async () => {
         element.minlength = 0;
-        await nextFrame();
+        await nextUpdate(element);
         expect(validateSpy.calledOnce).to.be.true;
       });
 
       it('should reset invalid on removing a number constraint', async () => {
         element.minlength = 50;
         element.invalid = true;
-        await nextFrame();
+        await nextUpdate(element);
 
         element.minlength = null;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.invalid).to.be.false;
       });
 
       it('should validate on setting a string constraint', async () => {
         element.pattern = '[-+\\d]';
-        await nextFrame();
+        await nextUpdate(element);
         expect(validateSpy.calledOnce).to.be.true;
       });
 
       it('should reset invalid on removing a string constraint', async () => {
         element.pattern = '[-+\\d]';
         element.invalid = true;
-        await nextFrame();
+        await nextUpdate(element);
 
         element.pattern = '';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.invalid).to.be.false;
       });
 
       it('should validate on removing a non-final constraint', async () => {
         element.required = true;
         element.minlength = 2;
-        await nextFrame();
+        await nextUpdate(element);
         validateSpy.resetHistory();
 
         element.minlength = null;
-        await nextFrame();
+        await nextUpdate(element);
         expect(validateSpy.calledOnce).to.be.true;
       });
     });

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -7,8 +7,8 @@ import {
   keyboardEventFor,
   keyDownOn,
   mousedown,
-  nextFrame,
   nextRender,
+  nextUpdate,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
@@ -66,13 +66,13 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should clear the field value on clear button click', async () => {
       button.click();
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.value).to.equal('');
     });
 
     it('should clear the input value on clear button click', async () => {
       button.click();
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.value).to.equal('');
     });
 
@@ -110,18 +110,18 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should reflect clearButtonVisible property to attribute', async () => {
       element.clearButtonVisible = true;
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.hasAttribute('clear-button-visible')).to.be.true;
 
       element.clearButtonVisible = false;
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.hasAttribute('clear-button-visible')).to.be.false;
     });
 
     it('should clear value on Esc when clearButtonVisible is true', async () => {
       element.clearButtonVisible = true;
       escKeyDown(button);
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.value).to.equal('');
     });
 
@@ -181,7 +181,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should propagate name property to the input', async () => {
       element.name = 'bar';
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.getAttribute('name')).to.equal('bar');
     });
   });
@@ -199,7 +199,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should propagate title property to the input', async () => {
       element.title = 'bar';
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.getAttribute('title')).to.equal('bar');
     });
   });
@@ -217,7 +217,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should propagate placeholder property to the input', async () => {
       element.placeholder = 'bar';
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.placeholder).to.equal('bar');
     });
   });
@@ -235,7 +235,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should propagate readonly property to the input', async () => {
       element.readonly = false;
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.readOnly).to.be.false;
     });
   });
@@ -253,7 +253,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should propagate required property to the input', async () => {
       element.required = false;
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.required).to.be.false;
     });
   });
@@ -279,13 +279,13 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should remove invalid attribute when valid', async () => {
       element.invalid = false;
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.hasAttribute('invalid')).to.be.false;
     });
 
     it('should remove aria-invalid attribute when valid', async () => {
       element.invalid = false;
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.hasAttribute('aria-invalid')).to.be.false;
     });
   });

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
@@ -53,19 +53,19 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should propagate autocomplete property to the input', async () => {
       element.autocomplete = 'on';
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.autocomplete).to.equal('on');
     });
 
     it('should propagate autocorrect property to the input', async () => {
       element.autocorrect = 'on';
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.getAttribute('autocorrect')).to.equal('on');
     });
 
     it('should propagate autocapitalize property to the input', async () => {
       element.autocapitalize = 'none';
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.getAttribute('autocapitalize')).to.equal('none');
     });
   });
@@ -171,7 +171,7 @@ const runTests = (defineHelper, baseMixin) => {
     it('should validate on input event', async () => {
       element.required = true;
       element.invalid = true;
-      await nextFrame();
+      await nextUpdate(element);
       const spy = sinon.spy(element, 'validate');
       input.focus();
       await sendKeys({ type: 'f' });
@@ -183,7 +183,7 @@ const runTests = (defineHelper, baseMixin) => {
       const spy = sinon.spy(element, 'validate');
       element.invalid = true;
       element.value = 'foo';
-      await nextFrame();
+      await nextUpdate(element);
       expect(spy.calledOnce).to.be.true;
     });
 

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -37,7 +37,7 @@ const runTests = (defineHelper, baseMixin) => {
       input.setAttribute('slot', 'input');
       element.appendChild(input);
       element._setInputElement(input);
-      await nextUpdate(element);
+      await nextRender();
     });
 
     it('should set property to empty string by default', () => {

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -23,7 +23,7 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.type).to.be.undefined;
 
       element.type = 'number';
-      await nextFrame();
+      await nextUpdate(element);
 
       expect(element.type).to.be.undefined;
     });
@@ -37,7 +37,7 @@ const runTests = (defineHelper, baseMixin) => {
       input.setAttribute('slot', 'input');
       element.appendChild(input);
       element._setInputElement(input);
-      await nextFrame();
+      await nextUpdate(element);
     });
 
     it('should set property to empty string by default', () => {
@@ -50,43 +50,43 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should set has-value attribute when value attribute is set', async () => {
       element.setAttribute('value', 'test');
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.hasAttribute('has-value')).to.be.true;
     });
 
     it('should set has-value attribute when value property is set', async () => {
       element.value = 'test';
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.hasAttribute('has-value')).to.be.true;
     });
 
     it('should remove has-value attribute when value is removed', async () => {
       element.value = 'foo';
-      await nextFrame();
+      await nextUpdate(element);
       element.value = '';
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.hasAttribute('has-value')).to.be.false;
     });
 
     it('should propagate value to the input element', async () => {
       element.value = 'foo';
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.value).to.equal('foo');
     });
 
     it('should clear input value when value is set to null', async () => {
       element.value = 'foo';
-      await nextFrame();
+      await nextUpdate(element);
       element.value = null;
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.value).to.equal('');
     });
 
     it('should clear input value when value is set to undefined', async () => {
       element.value = 'foo';
-      await nextFrame();
+      await nextUpdate(element);
       element.value = undefined;
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.value).to.equal('');
     });
 
@@ -98,17 +98,17 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should clear the field value on clear method call', async () => {
       element.value = 'foo';
-      await nextFrame();
+      await nextUpdate(element);
       element.clear();
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.value).to.equal('');
     });
 
     it('should clear the input value on clear method call', async () => {
       element.value = 'foo';
-      await nextFrame();
+      await nextUpdate(element);
       element.clear();
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.value).to.equal('');
     });
   });
@@ -142,7 +142,7 @@ const runTests = (defineHelper, baseMixin) => {
       input = document.createElement('input');
       element.appendChild(input);
       element._setInputElement(input);
-      await nextFrame();
+      await nextUpdate(element);
     });
 
     afterEach(() => {
@@ -163,7 +163,7 @@ const runTests = (defineHelper, baseMixin) => {
     it('should not call an input event listener when input is unset', async () => {
       element.removeChild(input);
       element._setInputElement(undefined);
-      await nextFrame();
+      await nextUpdate(element);
       input.dispatchEvent(new CustomEvent('input'));
       expect(inputSpy.called).to.be.false;
     });
@@ -171,7 +171,7 @@ const runTests = (defineHelper, baseMixin) => {
     it('should not call a change event listener when input is unset', async () => {
       element.removeChild(input);
       element._setInputElement(undefined);
-      await nextFrame();
+      await nextUpdate(element);
       input.dispatchEvent(new CustomEvent('change'));
       expect(changeSpy.called).to.be.false;
     });
@@ -198,21 +198,21 @@ const runTests = (defineHelper, baseMixin) => {
       input = document.createElement('input');
       element.appendChild(input);
       element._setInputElement(input);
-      await nextFrame();
+      await nextUpdate(element);
     });
 
     describe('without user input', () => {
       it('should fire the event once when entering input', async () => {
         input.value = 'foo';
         fire(input, 'input');
-        await nextFrame();
+        await nextUpdate(element);
         expect(hasInputValueChangedSpy.calledOnce).to.be.true;
         expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
       });
 
       it('should not fire the event on programmatic clear', async () => {
         element.clear();
-        await nextFrame();
+        await nextUpdate(element);
         expect(hasInputValueChangedSpy.called).to.be.false;
       });
     });
@@ -221,7 +221,7 @@ const runTests = (defineHelper, baseMixin) => {
       beforeEach(async () => {
         input.value = 'foo';
         fire(input, 'input');
-        await nextFrame();
+        await nextUpdate(element);
         hasInputValueChangedSpy.resetHistory();
         valueChangedSpy.resetHistory();
       });
@@ -229,21 +229,21 @@ const runTests = (defineHelper, baseMixin) => {
       it('should not fire the event when modifying input', async () => {
         input.value = 'foobar';
         fire(input, 'input');
-        await nextFrame();
+        await nextUpdate(element);
         expect(hasInputValueChangedSpy.called).to.be.false;
       });
 
       it('should fire the event once when removing input', async () => {
         input.value = '';
         fire(input, 'input');
-        await nextFrame();
+        await nextUpdate(element);
         expect(hasInputValueChangedSpy.calledOnce).to.be.true;
         expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
       });
 
       it('should fire the event once on programmatic clear', async () => {
         element.clear();
-        await nextFrame();
+        await nextUpdate(element);
         expect(hasInputValueChangedSpy.calledOnce).to.be.true;
         expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
       });

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -142,7 +142,7 @@ const runTests = (defineHelper, baseMixin) => {
       input = document.createElement('input');
       element.appendChild(input);
       element._setInputElement(input);
-      await nextUpdate(element);
+      await nextRender();
     });
 
     afterEach(() => {
@@ -163,7 +163,7 @@ const runTests = (defineHelper, baseMixin) => {
     it('should not call an input event listener when input is unset', async () => {
       element.removeChild(input);
       element._setInputElement(undefined);
-      await nextUpdate(element);
+      await nextRender();
       input.dispatchEvent(new CustomEvent('input'));
       expect(inputSpy.called).to.be.false;
     });
@@ -171,7 +171,7 @@ const runTests = (defineHelper, baseMixin) => {
     it('should not call a change event listener when input is unset', async () => {
       element.removeChild(input);
       element._setInputElement(undefined);
-      await nextUpdate(element);
+      await nextRender();
       input.dispatchEvent(new CustomEvent('change'));
       expect(changeSpy.called).to.be.false;
     });
@@ -198,7 +198,7 @@ const runTests = (defineHelper, baseMixin) => {
       input = document.createElement('input');
       element.appendChild(input);
       element._setInputElement(input);
-      await nextUpdate(element);
+      await nextRender();
     });
 
     describe('without user input', () => {

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { LabelMixin } from '../src/label-mixin.js';
@@ -37,17 +37,17 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should reflect label attribute to the property', async () => {
         element.setAttribute('label', 'Email');
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.label).to.equal('Email');
 
         element.removeAttribute('label');
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.label).to.equal(null);
       });
 
       it('should update label content on property change', async () => {
         element.label = 'Email';
-        await nextFrame();
+        await nextUpdate(element);
         expect(label.textContent).to.equal('Email');
       });
     });
@@ -59,23 +59,23 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should toggle the attribute on label property change', async () => {
         element.label = 'Email';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-label')).to.be.true;
 
         element.label = null;
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-label')).to.be.false;
       });
 
       it('should not set the attribute when label is only whitespaces', async () => {
         element.label = ' ';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-label')).to.be.false;
       });
 
       it('should not set the attribute when label is empty', async () => {
         element.label = '';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-label')).to.be.false;
       });
     });
@@ -117,7 +117,7 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should not update slotted label content on property change', async () => {
         element.label = 'Email';
-        await nextFrame();
+        await nextUpdate(element);
         expect(label.textContent).to.equal('Custom');
       });
 
@@ -127,20 +127,20 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should remove has-label attribute when label content is whitespace string', async () => {
         label.textContent = ' ';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-label')).to.be.false;
       });
 
       it('should remove has-label attribute when label content is empty', async () => {
         label.textContent = '';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-label')).to.be.false;
       });
 
       it('should attach default label when removing the custom label', async () => {
         element.label = 'Fallback';
         element.removeChild(label);
-        await nextFrame();
+        await nextUpdate(element);
         expect(element._labelNode.textContent).to.equal('Fallback');
       });
     });
@@ -162,7 +162,7 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should add has-label attribute when mutating a child text node', async () => {
         label.childNodes[0].textContent = 'Label';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-label')).to.be.true;
       });
     });
@@ -184,7 +184,7 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should not remove has-label attribute when label children are empty', async () => {
         label.firstChild.textContent = '';
-        await nextFrame();
+        await nextUpdate(element);
         expect(element.hasAttribute('has-label')).to.be.true;
       });
     });
@@ -214,7 +214,7 @@ const runTests = (defineHelper, baseMixin) => {
         element = fixtureSync(`<${tag}></${tag}>`);
         await nextRender();
         element.label = 'Default label';
-        await nextFrame();
+        await nextUpdate(element);
         label = element._labelNode;
         lazyLabel = document.createElement('label');
         lazyLabel.setAttribute('slot', 'label');
@@ -223,109 +223,109 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should handle lazy label added using appendChild', async () => {
         element.appendChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
         expect(element._labelNode).to.equal(lazyLabel);
       });
 
       it('should handle lazy label added using insertBefore', async () => {
         element.insertBefore(lazyLabel, label);
-        await nextFrame();
+        await nextRender();
         expect(element._labelNode).to.equal(lazyLabel);
       });
 
       it('should handle lazy label added using replaceChild', async () => {
         element.replaceChild(lazyLabel, label);
-        await nextFrame();
+        await nextRender();
         expect(element._labelNode).to.equal(lazyLabel);
       });
 
       it('should remove the default label from the element when using appendChild', async () => {
         element.appendChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
         expect(label.parentNode).to.be.null;
       });
 
       it('should remove the default label from the element when using insertBefore', async () => {
         element.insertBefore(lazyLabel, label);
-        await nextFrame();
+        await nextRender();
         expect(label.parentNode).to.be.null;
       });
 
       it('should support replacing lazy label with a new one using appendChild', async () => {
         element.appendChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
 
         const newLabel = document.createElement('label');
         newLabel.setAttribute('slot', 'label');
         newLabel.textContent = 'New';
         element.appendChild(newLabel);
 
-        await nextFrame();
+        await nextRender();
         expect(element._labelNode).to.equal(newLabel);
       });
 
       it('should support replacing lazy label with a new one using insertBefore', async () => {
         element.appendChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
 
         const newLabel = document.createElement('label');
         newLabel.setAttribute('slot', 'label');
         newLabel.textContent = 'New';
         element.insertBefore(newLabel, lazyLabel);
 
-        await nextFrame();
+        await nextRender();
         expect(element._labelNode).to.equal(newLabel);
       });
 
       it('should support replacing lazy label with a new one using replaceChild', async () => {
         element.appendChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
 
         const newLabel = document.createElement('label');
         newLabel.setAttribute('slot', 'label');
         newLabel.textContent = 'New';
         element.replaceChild(newLabel, lazyLabel);
 
-        await nextFrame();
+        await nextRender();
         expect(element._labelNode).to.equal(newLabel);
       });
 
       it('should support adding lazy label after removing the default one', async () => {
         element.removeChild(label);
-        await nextFrame();
+        await nextRender();
 
         element.appendChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
 
         expect(element._labelNode).to.equal(lazyLabel);
       });
 
       it('should restore the default label when removing the lazy label', async () => {
         element.appendChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
 
         element.removeChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
         expect(element._labelNode).to.equal(label);
       });
 
       it('should keep has-label attribute when the default label is restored', async () => {
         element.appendChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
 
         element.removeChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
         expect(element.hasAttribute('has-label')).to.be.true;
       });
 
       it('should remove has-label attribute when label is set to empty', async () => {
         element.appendChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
 
         element.label = '';
 
         element.removeChild(lazyLabel);
-        await nextFrame();
+        await nextRender();
 
         expect(element.hasAttribute('has-label')).to.be.false;
       });

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -61,112 +61,112 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should propagate pattern property to the input', async () => {
       element.pattern = '[-+\\d]';
-      await nextFrame();
+      await nextUpdate(element);
       expect(input.pattern).to.equal('[-+\\d]');
     });
 
     it('should not validate the field when pattern is set', async () => {
       element.pattern = '[-+\\d]';
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.invalid).to.be.false;
     });
 
     it('should validate the field when invalid after pattern is changed', async () => {
       element.invalid = true;
-      await nextFrame();
+      await nextUpdate(element);
       const spy = sinon.spy(element, 'validate');
       element.pattern = '[-+\\d]';
-      await nextFrame();
+      await nextUpdate(element);
       expect(spy.calledOnce).to.be.true;
     });
 
     it('should update invalid state when pattern is removed', async () => {
       input.value = '123foo';
       element.pattern = '\\d+';
-      await nextFrame();
+      await nextUpdate(element);
 
       element.validate();
       expect(element.invalid).to.be.true;
 
       element.pattern = '';
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.invalid).to.be.false;
     });
 
     // https://github.com/web-platform-tests/wpt/blob/7b0ebaccc62b566a1965396e5be7bb2bc06f841f/html/semantics/forms/constraints/form-validation-validity-patternMismatch.html
     it('should pass validation when pattern property is not set', async () => {
       element.pattern = null;
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('abc');
       expect(element.checkValidity()).to.be.true;
     });
 
     it('should pass validation when value property is empty', async () => {
       element.pattern = '[A-Z]+';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('');
       expect(element.checkValidity()).to.be.true;
     });
 
     it('should pass validation when value property matches the pattern', async () => {
       element.pattern = '[A-Z]{1}';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('A');
       expect(element.checkValidity()).to.be.true;
     });
 
     it('should pass validation when unicode value property matches the pattern', async () => {
       element.pattern = '[A-Z]+';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('\u0041\u0042\u0043');
       expect(element.checkValidity()).to.be.true;
     });
 
     it('should fail validation when value property mismatches the pattern', async () => {
       element.pattern = '[a-z]{3,}';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('ABCD');
       expect(element.checkValidity()).to.be.false;
     });
 
     it('should fail validation when value property mismatches the pattern, even if a subset matches', async () => {
       element.pattern = '[A-Z]+';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('ABC123');
       expect(element.checkValidity()).to.be.false;
     });
 
     it('should pass validation when pattern contains invalid regular expression', async () => {
       element.pattern = '(abc';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('de');
       expect(element.checkValidity()).to.be.true;
     });
 
     it('should pass validation when pattern tries to escape a group', async () => {
       element.pattern = 'a)(b';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('de');
       expect(element.checkValidity()).to.be.true;
     });
 
     it('should pass validation when pattern uses Unicode features', async () => {
       element.pattern = 'a\u{10FFFF}';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('a\u{10FFFF}');
       expect(element.checkValidity()).to.be.true;
     });
 
     it('should pass validation when value matches JavaScript-specific regular expression', async () => {
       element.pattern = '\\u1234\\cx[5-\\[]{2}';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('\u1234\x18[6');
       expect(element.checkValidity()).to.be.true;
     });
 
     it('should fail validation when value mismatches JavaScript-specific regular expression', async () => {
       element.pattern = '\\u1234\\cx[5-\\[]{2}';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('\u1234\x18[4');
       expect(element.checkValidity()).to.be.false;
     });
@@ -181,7 +181,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should pass validation when value property matches the pattern (multiline)', async () => {
       element.pattern = '[A-Z\n]{3}';
-      await nextFrame();
+      await nextUpdate(element);
       commitInputValue('A\nJ');
       expect(element.checkValidity()).to.be.true;
     });

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { defineLit, definePolymer, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -20,7 +20,7 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.hasAttribute('required')).to.be.false;
 
       element.required = true;
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.hasAttribute('required')).to.be.true;
     });
 
@@ -28,7 +28,7 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.hasAttribute('invalid')).to.be.false;
 
       element.invalid = true;
-      await nextFrame();
+      await nextUpdate(element);
       expect(element.hasAttribute('invalid')).to.be.true;
     });
 
@@ -36,12 +36,12 @@ const runTests = (defineHelper, baseMixin) => {
       const spy = sinon.spy();
       element.addEventListener('invalid-changed', spy);
       element.invalid = true;
-      await nextFrame();
+      await nextUpdate(element);
       expect(spy.calledOnce).to.be.true;
 
       spy.resetHistory();
       element.invalid = false;
-      await nextFrame();
+      await nextUpdate(element);
       expect(spy.calledOnce).to.be.true;
     });
   });


### PR DESCRIPTION
## Description

Updated tests for mixins to replace `nextFrame()` with `nextUpdate()` where it makes sense.
Otherwise changed to use `nextRender()` - especially for tests with DOM manipulation.

## Type of change

- Tests