### PR TITLE
feat: add dirty state to field components

### DIFF
--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -15,6 +15,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 export type CheckboxGroupInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type CheckboxGroupDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type CheckboxGroupValueChangedEvent = CustomEvent<{ value: string[] }>;
@@ -26,6 +31,8 @@ export type CheckboxGroupValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface CheckboxGroupCustomEventMap {
   'invalid-changed': CheckboxGroupInvalidChangedEvent;
+
+  'dirty-changed': CheckboxGroupDirtyChangedEvent;
 
   'value-changed': CheckboxGroupValueChangedEvent;
 
@@ -73,6 +80,7 @@ export interface CheckboxGroupEventMap extends HTMLElementEventMap, CheckboxGrou
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -86,7 +86,11 @@ declare class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementM
   value: string[];
 
   /**
-   * Whether the user has interacted with the field.
+   * Whether the field is dirty.
+   *
+   * The field is automatically marked as dirty once the user triggers
+   * a `change` event. Additionally, the field can be manually marked
+   * as dirty by setting the `dirty` property to `true`.
    */
   dirty: boolean;
 

--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -90,7 +90,7 @@ declare class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementM
    *
    * The field is automatically marked as dirty once the user triggers
    * a `change` event. Additionally, the field can be manually marked
-   * as dirty by setting the `dirty` property to `true`.
+   * as dirty by setting the property to `true`.
    */
   dirty: boolean;
 

--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -85,6 +85,11 @@ declare class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementM
    */
   value: string[];
 
+  /**
+   * Whether the user has interacted with the field.
+   */
+  dirty: boolean;
+
   addEventListener<K extends keyof CheckboxGroupEventMap>(
     type: K,
     listener: (this: CheckboxGroup, ev: CheckboxGroupEventMap[K]) => void,

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -141,7 +141,11 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
       },
 
       /**
-       * Whether the user has interacted with the field.
+       * Whether the field is dirty.
+       *
+       * The field is automatically marked as dirty once the user triggers
+       * a `change` event. Additionally, the field can be manually marked
+       * as dirty by setting the `dirty` property to `true`.
        */
       dirty: {
         type: Boolean,

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -160,6 +160,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
 
     this.__registerCheckbox = this.__registerCheckbox.bind(this);
     this.__unregisterCheckbox = this.__unregisterCheckbox.bind(this);
+    this.__onCheckboxChange = this.__onCheckboxChange.bind(this);
     this.__onCheckboxCheckedChanged = this.__onCheckboxCheckedChanged.bind(this);
   }
 
@@ -240,6 +241,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
    * @private
    */
   __registerCheckbox(checkbox) {
+    checkbox.addEventListener('change', this.__onCheckboxChange);
     checkbox.addEventListener('checked-changed', this.__onCheckboxCheckedChanged);
 
     if (this.disabled) {
@@ -260,6 +262,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
    * @private
    */
   __unregisterCheckbox(checkbox) {
+    checkbox.removeEventListener('change', this.__onCheckboxChange);
     checkbox.removeEventListener('checked-changed', this.__onCheckboxCheckedChanged);
 
     if (checkbox.checked) {
@@ -313,14 +316,18 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
     }
   }
 
+  /** @private */
+  __onCheckboxChange() {
+    this.dirty = true;
+  }
+
   /**
    * @param {!CustomEvent} event
    * @private
    */
   __onCheckboxCheckedChanged(event) {
-    this.dirty = true;
-
     const checkbox = event.target;
+
     if (checkbox.checked) {
       this.__addCheckboxToValue(checkbox.value);
     } else {

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -145,7 +145,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
        *
        * The field is automatically marked as dirty once the user triggers
        * a `change` event. Additionally, the field can be manually marked
-       * as dirty by setting the `dirty` property to `true`.
+       * as dirty by setting the property to `true`.
        */
       dirty: {
         type: Boolean,

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -139,6 +139,15 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
         notify: true,
         observer: '__valueChanged',
       },
+
+      /**
+       * Whether the user has interacted with the field.
+       */
+      dirty: {
+        type: Boolean,
+        value: false,
+        notify: true,
+      },
     };
   }
 
@@ -305,8 +314,9 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
    * @private
    */
   __onCheckboxCheckedChanged(event) {
-    const checkbox = event.target;
+    this.dirty = true;
 
+    const checkbox = event.target;
     if (checkbox.checked) {
       this.__addCheckboxToValue(checkbox.value);
     } else {

--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -302,6 +302,34 @@ describe('vaadin-checkbox-group', () => {
     });
   });
 
+  describe('dirty state', () => {
+    beforeEach(async () => {
+      group = fixtureSync(`
+        <vaadin-checkbox-group>
+          <vaadin-checkbox value="1" label="Checkbox 1"></vaadin-checkbox>
+        </vaadin-checkbox-group>
+      `);
+      await nextFrame();
+      checkboxes = [...group.querySelectorAll('vaadin-checkbox')];
+    });
+
+    it('should not be dirty by default', () => {
+      expect(group.dirty).to.be.false;
+    });
+
+    it('should be dirty after selecting a checkbox', () => {
+      checkboxes[0].click();
+      expect(group.dirty).to.be.true;
+    });
+
+    it('should fire dirty-changed event when the state changes', () => {
+      const spy = sinon.spy();
+      group.addEventListener('dirty-changed', spy);
+      group.dirty = true;
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
+
   describe('wrapping', () => {
     beforeEach(async () => {
       group = fixtureSync(`

--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -317,6 +317,11 @@ describe('vaadin-checkbox-group', () => {
       expect(group.dirty).to.be.false;
     });
 
+    it('should not be dirty after programmatic value change', () => {
+      group.value = ['1'];
+      expect(group.dirty).to.be.false;
+    });
+
     it('should be dirty after selecting a checkbox', () => {
       checkboxes[0].click();
       expect(group.dirty).to.be.true;

--- a/packages/checkbox-group/test/typings/checkbox-group.types.ts
+++ b/packages/checkbox-group/test/typings/checkbox-group.types.ts
@@ -1,5 +1,6 @@
 import '../../vaadin-checkbox-group.js';
 import type {
+  CheckboxGroupDirtyChangedEvent,
   CheckboxGroupInvalidChangedEvent,
   CheckboxGroupValidatedEvent,
   CheckboxGroupValueChangedEvent,
@@ -11,6 +12,11 @@ const group = document.createElement('vaadin-checkbox-group');
 
 group.addEventListener('invalid-changed', (event) => {
   assertType<CheckboxGroupInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+group.addEventListener('dirty-changed', (event) => {
+  assertType<CheckboxGroupDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -104,6 +104,18 @@ export const CheckboxMixin = (superclass) =>
     }
 
     /**
+     * Override to mark the field as dirty on change.
+     *
+     * @param {Event} event
+     * @protected
+     * @override
+     */
+    _onChange(event) {
+      this.dirty = true;
+      super._onChange(event);
+    }
+
+    /**
      * Override method inherited from `CheckedMixin` to reset
      * `indeterminate` state checkbox is toggled by the user.
      *

--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -12,6 +12,11 @@ import { LabelMixin } from '@vaadin/field-base/src/label-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type CheckboxDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `checked` property changes.
  */
 export type CheckboxCheckedChangedEvent = CustomEvent<{ value: boolean }>;
@@ -22,6 +27,8 @@ export type CheckboxCheckedChangedEvent = CustomEvent<{ value: boolean }>;
 export type CheckboxIndeterminateChangedEvent = CustomEvent<{ value: boolean }>;
 
 export interface CheckboxCustomEventMap {
+  'dirty-changed': CheckboxDirtyChangedEvent;
+
   'checked-changed': CheckboxCheckedChangedEvent;
 
   'indeterminate-changed': CheckboxIndeterminateChangedEvent;
@@ -58,6 +65,7 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEve
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  * @fires {CustomEvent} indeterminate-changed - Fired when the `indeterminate` property changes.
  */

--- a/packages/checkbox/test/checkbox.common.js
+++ b/packages/checkbox/test/checkbox.common.js
@@ -236,4 +236,21 @@ describe('checkbox', () => {
       expect(input.indeterminate).to.be.false;
     });
   });
+
+  describe('dirty state', () => {
+    beforeEach(async () => {
+      checkbox = fixtureSync(`<vaadin-checkbox></vaadin-checkbox>`);
+      await nextRender();
+      input = checkbox.inputElement;
+    });
+
+    it('should not be dirty by default', () => {
+      expect(checkbox.dirty).to.be.false;
+    });
+
+    it('should be dirty after click', () => {
+      input.click();
+      expect(checkbox.dirty).to.be.true;
+    });
+  });
 });

--- a/packages/checkbox/test/checkbox.common.js
+++ b/packages/checkbox/test/checkbox.common.js
@@ -248,6 +248,11 @@ describe('checkbox', () => {
       expect(checkbox.dirty).to.be.false;
     });
 
+    it('should not be dirty after changing checked state programmatically', () => {
+      checkbox.checked = true;
+      expect(checkbox.dirty).to.be.false;
+    });
+
     it('should be dirty after click', () => {
       input.click();
       expect(checkbox.dirty).to.be.true;

--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -42,6 +42,11 @@ export type ComboBoxLightOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 export type ComboBoxLightInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type ComboBoxLightDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type ComboBoxLightValueChangedEvent = CustomEvent<{ value: string }>;
@@ -71,6 +76,8 @@ export interface ComboBoxLightEventMap<TItem> extends HTMLElementEventMap {
   'filter-changed': ComboBoxLightFilterChangedEvent;
 
   'invalid-changed': ComboBoxLightInvalidChangedEvent;
+
+  'dirty-changed': ComboBoxLightDirtyChangedEvent;
 
   'value-changed': ComboBoxLightValueChangedEvent;
 
@@ -122,6 +129,7 @@ export interface ComboBoxLightEventMap<TItem> extends HTMLElementEventMap {
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1086,13 +1086,18 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _detectAndDispatchChange() {
+      const isValueChanged = this.value !== this._lastCommittedValue;
+      if (isValueChanged) {
+        this.dirty = true;
+      }
+
       // Do not validate when focusout is caused by document
       // losing focus, which happens on browser tab switch.
       if (document.hasFocus()) {
         this.validate();
       }
 
-      if (this.value !== this._lastCommittedValue) {
+      if (isValueChanged) {
         this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
         this._lastCommittedValue = this.value;
       }

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -54,6 +54,11 @@ export type ComboBoxOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 export type ComboBoxInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type ComboBoxDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type ComboBoxValueChangedEvent = CustomEvent<{ value: string }>;
@@ -83,6 +88,8 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
   'filter-changed': ComboBoxFilterChangedEvent;
 
   'invalid-changed': ComboBoxInvalidChangedEvent;
+
+  'dirty-changed': ComboBoxDirtyChangedEvent;
 
   'value-changed': ComboBoxValueChangedEvent;
 
@@ -212,6 +219,7 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  * @fires {CustomEvent} filter-changed - Fired when the `filter` property changes.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.

--- a/packages/combo-box/test/dirty-state.test.js
+++ b/packages/combo-box/test/dirty-state.test.js
@@ -5,12 +5,11 @@ import '../src/vaadin-combo-box.js';
 import { getAllItems } from './helpers.js';
 
 describe('dirty state', () => {
-  let comboBox, input;
+  let comboBox;
 
   beforeEach(() => {
     comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
     comboBox.items = ['Item 1', 'Item 2', 'Item 3'];
-    input = comboBox.inputElement;
   });
 
   it('should not be dirty by default', () => {
@@ -18,48 +17,49 @@ describe('dirty state', () => {
   });
 
   it('should not be dirty after blur without change', () => {
-    input.focus();
-    input.blur();
+    comboBox.focus();
+    comboBox.blur();
     expect(comboBox.dirty).to.be.false;
   });
 
   it('should not be dirty after pressing Enter without change', async () => {
-    input.focus();
+    comboBox.focus();
     await sendKeys({ press: 'Enter' });
     expect(comboBox.dirty).to.be.false;
   });
 
   it('should not be dirty after closing the dropdown without change', async () => {
-    input.focus();
-    input.click();
+    comboBox.focus();
+    comboBox.click();
     outsideClick();
     expect(comboBox.dirty).to.be.false;
   });
 
   it('should not be dirty after cancelling selection and closing the dropdown', async () => {
-    input.focus();
-    input.click();
+    comboBox.focus();
+    comboBox.click();
     await sendKeys({ press: 'ArrowDown' });
     await sendKeys({ press: 'Escape' });
     await sendKeys({ press: 'Escape' });
     expect(comboBox.dirty).to.be.false;
   });
 
-  it('should be dirty after user input', () => {
-    fire(input, 'input');
+  it('should be dirty after user input', async () => {
+    comboBox.focus();
+    await sendKeys({ type: 'I' });
     expect(comboBox.dirty).to.be.true;
   });
 
   it('should be dirty after selecting a dropdown item with click', () => {
-    input.focus();
-    input.click();
+    comboBox.focus();
+    comboBox.click();
     getAllItems(comboBox)[0].click();
     expect(comboBox.dirty).to.be.true;
   });
 
   it('should be dirty after selecting a dropdown item with Enter', async () => {
-    input.focus();
-    input.click();
+    comboBox.focus();
+    comboBox.click();
     await sendKeys({ press: 'ArrowDown' });
     await sendKeys({ press: 'Enter' });
     expect(comboBox.dirty).to.be.true;

--- a/packages/combo-box/test/dirty-state.test.js
+++ b/packages/combo-box/test/dirty-state.test.js
@@ -16,6 +16,11 @@ describe('dirty state', () => {
     expect(comboBox.dirty).to.be.false;
   });
 
+  it('should not be dirty after programmatic value change', async () => {
+    comboBox.value = 'Item 1';
+    expect(comboBox.dirty).to.be.false;
+  });
+
   it('should not be dirty after blur without change', () => {
     comboBox.focus();
     comboBox.blur();

--- a/packages/combo-box/test/dirty-state.test.js
+++ b/packages/combo-box/test/dirty-state.test.js
@@ -65,7 +65,7 @@ describe('dirty state', () => {
     expect(comboBox.dirty).to.be.true;
   });
 
-  it('should be dirty after clicking the clear button', () => {
+  it('should be dirty after clear button click', () => {
     comboBox.clearButtonVisible = true;
     comboBox.value = 'foo';
     comboBox.$.clearButton.click();

--- a/packages/combo-box/test/dirty-state.test.js
+++ b/packages/combo-box/test/dirty-state.test.js
@@ -1,0 +1,74 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, outsideClick } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import '../src/vaadin-combo-box.js';
+import { getAllItems } from './helpers.js';
+
+describe('dirty state', () => {
+  let comboBox, input;
+
+  beforeEach(() => {
+    comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
+    comboBox.items = ['Item 1', 'Item 2', 'Item 3'];
+    input = comboBox.inputElement;
+  });
+
+  it('should not be dirty by default', () => {
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should not be dirty after blur without change', () => {
+    input.focus();
+    input.blur();
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should not be dirty after pressing Enter without change', async () => {
+    input.focus();
+    await sendKeys({ press: 'Enter' });
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should not be dirty after closing the dropdown without change', async () => {
+    input.focus();
+    input.click();
+    outsideClick();
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should not be dirty after cancelling selection and closing the dropdown', async () => {
+    input.focus();
+    input.click();
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Escape' });
+    await sendKeys({ press: 'Escape' });
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should be dirty after user input', () => {
+    fire(input, 'input');
+    expect(comboBox.dirty).to.be.true;
+  });
+
+  it('should be dirty after selecting a dropdown item with click', () => {
+    input.focus();
+    input.click();
+    getAllItems(comboBox)[0].click();
+    expect(comboBox.dirty).to.be.true;
+  });
+
+  it('should be dirty after selecting a dropdown item with Enter', async () => {
+    input.focus();
+    input.click();
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Enter' });
+    expect(comboBox.dirty).to.be.true;
+  });
+
+  it('should be dirty after clicking the clear button', () => {
+    comboBox.clearButtonVisible = true;
+    comboBox.value = 'foo';
+    comboBox.$.clearButton.click();
+    expect(comboBox.dirty).to.be.true;
+  });
+});

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -24,6 +24,7 @@ import type {
   ComboBox,
   ComboBoxChangeEvent,
   ComboBoxCustomValueSetEvent,
+  ComboBoxDirtyChangedEvent,
   ComboBoxFilterChangedEvent,
   ComboBoxInvalidChangedEvent,
   ComboBoxOpenedChangedEvent,
@@ -36,6 +37,7 @@ import type {
   ComboBoxLight,
   ComboBoxLightChangeEvent,
   ComboBoxLightCustomValueSetEvent,
+  ComboBoxLightDirtyChangedEvent,
   ComboBoxLightFilterChangedEvent,
   ComboBoxLightInvalidChangedEvent,
   ComboBoxLightOpenedChangedEvent,
@@ -73,6 +75,11 @@ narrowedComboBox.addEventListener('opened-changed', (event) => {
 
 narrowedComboBox.addEventListener('invalid-changed', (event) => {
   assertType<ComboBoxInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+narrowedComboBox.addEventListener('dirty-changed', (event) => {
+  assertType<ComboBoxDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
@@ -175,6 +182,11 @@ narrowedComboBoxLight.addEventListener('opened-changed', (event) => {
 
 narrowedComboBoxLight.addEventListener('invalid-changed', (event) => {
   assertType<ComboBoxLightInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+narrowedComboBoxLight.addEventListener('dirty-changed', (event) => {
+  assertType<ComboBoxLightDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -105,6 +105,19 @@ export const CustomFieldMixin = (superClass) =>
         parseValue: {
           type: Function,
         },
+
+        /**
+         * Whether the field is dirty.
+         *
+         * The field is automatically marked as dirty once the user triggers
+         * an `input` or `change` event. Additionally, the field can be manually
+         * marked as dirty by setting the property to `true`.
+         */
+        dirty: {
+          type: Boolean,
+          value: false,
+          notify: true,
+        },
       };
     }
 
@@ -210,9 +223,15 @@ export const CustomFieldMixin = (superClass) =>
     }
 
     /** @protected */
-    _onInputChange(event) {
+    _onInput() {
+      this.dirty = true;
+    }
+
+    /** @protected */
+    _onChange(event) {
       // Stop native change events
       event.stopPropagation();
+      this.dirty = true;
 
       this.__setValue();
       this.validate();

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -72,7 +72,7 @@ class CustomField extends CustomFieldMixin(ThemableMixin(ElementMixin(PolymerEle
           <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
-        <div class="inputs-wrapper" on-change="_onInputChange">
+        <div class="inputs-wrapper" on-change="_onChange" on-input="_onInput">
           <slot id="slot"></slot>
         </div>
 

--- a/packages/custom-field/src/vaadin-lit-custom-field.js
+++ b/packages/custom-field/src/vaadin-lit-custom-field.js
@@ -37,7 +37,7 @@ class CustomField extends CustomFieldMixin(ThemableMixin(ElementMixin(PolylitMix
           <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
-        <div class="inputs-wrapper" @change="${this._onInputChange}">
+        <div class="inputs-wrapper" @change="${this._onChange}" @input="${this._onInput}">
           <slot id="slot"></slot>
         </div>
 

--- a/packages/custom-field/test/custom-field.common.js
+++ b/packages/custom-field/test/custom-field.common.js
@@ -160,6 +160,11 @@ describe('custom field', () => {
       expect(customField.dirty).to.be.false;
     });
 
+    it('should not be dirty after programmatic value change', async () => {
+      customField.value = 'foo,1';
+      expect(customField.dirty).to.be.false;
+    });
+
     it('should be dirty after sub-field input', async () => {
       fire(input, 'input');
       expect(customField.dirty).to.be.true;

--- a/packages/custom-field/test/custom-field.common.js
+++ b/packages/custom-field/test/custom-field.common.js
@@ -148,4 +148,26 @@ describe('custom field', () => {
       });
     });
   });
+
+  describe('dirty state', () => {
+    let input;
+
+    beforeEach(() => {
+      input = customField.querySelector('input');
+    });
+
+    it('should not be dirty by default', () => {
+      expect(customField.dirty).to.be.false;
+    });
+
+    it('should be dirty after sub-field input', async () => {
+      fire(input, 'input');
+      expect(customField.dirty).to.be.true;
+    });
+
+    it('should be dirty after sub-field change', async () => {
+      fire(input, 'change');
+      expect(customField.dirty).to.be.true;
+    });
+  });
 });

--- a/packages/date-picker/src/vaadin-date-picker-light.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-light.d.ts
@@ -26,6 +26,11 @@ export type DatePickerLightOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 export type DatePickerLightInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type DatePickerLightDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type DatePickerLightValueChangedEvent = CustomEvent<{ value: string }>;
@@ -39,6 +44,8 @@ export interface DatePickerLightCustomEventMap {
   'opened-changed': DatePickerLightOpenedChangedEvent;
 
   'invalid-changed': DatePickerLightInvalidChangedEvent;
+
+  'dirty-changed': DatePickerLightDirtyChangedEvent;
 
   'value-changed': DatePickerLightValueChangedEvent;
 
@@ -80,6 +87,7 @@ export interface DatePickerLightEventMap extends HTMLElementEventMap, DatePicker
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -671,6 +671,7 @@ export const DatePickerMixin = (subclass) =>
 
       // Only set flag if the value will change.
       if (this.value !== value) {
+        this.dirty = true;
         this.__dispatchChange = true;
       }
 
@@ -1040,6 +1041,7 @@ export const DatePickerMixin = (subclass) =>
      */
     _onClearButtonClick(event) {
       event.preventDefault();
+      this.dirty = true;
       this._inputElementValue = '';
       this.value = '';
       this.validate();

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -27,6 +27,11 @@ export type DatePickerOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 export type DatePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type DatePickerDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type DatePickerValueChangedEvent = CustomEvent<{ value: string }>;
@@ -40,6 +45,8 @@ export interface DatePickerCustomEventMap {
   'opened-changed': DatePickerOpenedChangedEvent;
 
   'invalid-changed': DatePickerInvalidChangedEvent;
+
+  'dirty-changed': DatePickerDirtyChangedEvent;
 
   'value-changed': DatePickerValueChangedEvent;
 
@@ -151,6 +158,7 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/date-picker/test/dirty-state.test.js
+++ b/packages/date-picker/test/dirty-state.test.js
@@ -70,7 +70,7 @@ describe('dirty state', () => {
     expect(datePicker.dirty).to.be.true;
   });
 
-  it('should be dirty after clicking the clear button', () => {
+  it('should be dirty after clear button click', () => {
     datePicker.clearButtonVisible = true;
     datePicker.value = '2023-01-01';
     datePicker.$.clearButton.click();

--- a/packages/date-picker/test/dirty-state.test.js
+++ b/packages/date-picker/test/dirty-state.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, nextRender, outsideClick, tap } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, outsideClick, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '../src/vaadin-date-picker.js';
 import { getFocusedCell, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
@@ -30,6 +30,7 @@ describe('dirty state', () => {
   it('should not be dirty after outside click without change', async () => {
     datePicker.focus();
     datePicker.click();
+    await waitForOverlayRender();
     outsideClick();
     expect(datePicker.dirty).to.be.false;
   });
@@ -53,6 +54,7 @@ describe('dirty state', () => {
   it('should be dirty after user input', async () => {
     datePicker.focus();
     await sendKeys({ type: '1' });
+    await waitForOverlayRender();
     expect(datePicker.dirty).to.be.true;
   });
 

--- a/packages/date-picker/test/dirty-state.test.js
+++ b/packages/date-picker/test/dirty-state.test.js
@@ -16,6 +16,11 @@ describe('dirty state', () => {
     expect(datePicker.dirty).to.be.false;
   });
 
+  it('should not be dirty after programmatic value change', async () => {
+    datePicker.value = '2023-01-01';
+    expect(datePicker.dirty).to.be.false;
+  });
+
   it('should not be dirty after blur without change', () => {
     datePicker.focus();
     datePicker.blur();

--- a/packages/date-picker/test/dirty-state.test.js
+++ b/packages/date-picker/test/dirty-state.test.js
@@ -5,12 +5,11 @@ import '../src/vaadin-date-picker.js';
 import { getFocusedCell, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
 
 describe('dirty state', () => {
-  let datePicker, input;
+  let datePicker;
 
   beforeEach(async () => {
     datePicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
     await nextRender();
-    input = datePicker.inputElement;
   });
 
   it('should not be dirty by default', () => {
@@ -18,27 +17,27 @@ describe('dirty state', () => {
   });
 
   it('should not be dirty after blur without change', () => {
-    input.focus();
-    input.blur();
+    datePicker.focus();
+    datePicker.blur();
     expect(datePicker.dirty).to.be.false;
   });
 
   it('should not be dirty after outside click without change', async () => {
-    input.focus();
-    input.click();
+    datePicker.focus();
+    datePicker.click();
     outsideClick();
     expect(datePicker.dirty).to.be.false;
   });
 
   it('should not be dirty after pressing Enter without change', async () => {
-    input.focus();
+    datePicker.focus();
     await sendKeys({ press: 'Enter' });
     expect(datePicker.dirty).to.be.false;
   });
 
   it('should not be dirty after cancelling selection and closing the dropdown', async () => {
-    input.focus();
-    input.click();
+    datePicker.focus();
+    datePicker.click();
     await waitForOverlayRender();
     await sendKeys({ press: 'ArrowDown' });
     await waitForScrollToFinish(datePicker._overlayContent);
@@ -46,14 +45,15 @@ describe('dirty state', () => {
     expect(datePicker.dirty).to.be.false;
   });
 
-  it('should be dirty after user input', () => {
-    fire(input, 'input');
+  it('should be dirty after user input', async () => {
+    datePicker.focus();
+    await sendKeys({ type: '1' });
     expect(datePicker.dirty).to.be.true;
   });
 
   it('should be dirty after selecting a dropdown item with click', async () => {
-    input.focus();
-    input.click();
+    datePicker.focus();
+    datePicker.click();
     await waitForOverlayRender();
     const date = getFocusedCell(datePicker._overlayContent);
     tap(date);
@@ -61,8 +61,8 @@ describe('dirty state', () => {
   });
 
   it('should be dirty after selecting a dropdown item with Enter', async () => {
-    input.focus();
-    input.click();
+    datePicker.focus();
+    datePicker.click();
     await waitForOverlayRender();
     await sendKeys({ press: 'ArrowDown' });
     await waitForScrollToFinish(datePicker._overlayContent);

--- a/packages/date-picker/test/dirty-state.test.js
+++ b/packages/date-picker/test/dirty-state.test.js
@@ -1,0 +1,79 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, nextRender, outsideClick, tap } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import '../src/vaadin-date-picker.js';
+import { getFocusedCell, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
+
+describe('dirty state', () => {
+  let datePicker, input;
+
+  beforeEach(async () => {
+    datePicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
+    await nextRender();
+    input = datePicker.inputElement;
+  });
+
+  it('should not be dirty by default', () => {
+    expect(datePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after blur without change', () => {
+    input.focus();
+    input.blur();
+    expect(datePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after outside click without change', async () => {
+    input.focus();
+    input.click();
+    outsideClick();
+    expect(datePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after pressing Enter without change', async () => {
+    input.focus();
+    await sendKeys({ press: 'Enter' });
+    expect(datePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after cancelling selection and closing the dropdown', async () => {
+    input.focus();
+    input.click();
+    await waitForOverlayRender();
+    await sendKeys({ press: 'ArrowDown' });
+    await waitForScrollToFinish(datePicker._overlayContent);
+    await sendKeys({ press: 'Escape' });
+    expect(datePicker.dirty).to.be.false;
+  });
+
+  it('should be dirty after user input', () => {
+    fire(input, 'input');
+    expect(datePicker.dirty).to.be.true;
+  });
+
+  it('should be dirty after selecting a dropdown item with click', async () => {
+    input.focus();
+    input.click();
+    await waitForOverlayRender();
+    const date = getFocusedCell(datePicker._overlayContent);
+    tap(date);
+    expect(datePicker.dirty).to.be.true;
+  });
+
+  it('should be dirty after selecting a dropdown item with Enter', async () => {
+    input.focus();
+    input.click();
+    await waitForOverlayRender();
+    await sendKeys({ press: 'ArrowDown' });
+    await waitForScrollToFinish(datePicker._overlayContent);
+    await sendKeys({ press: 'Enter' });
+    expect(datePicker.dirty).to.be.true;
+  });
+
+  it('should be dirty after clicking the clear button', () => {
+    datePicker.clearButtonVisible = true;
+    datePicker.value = '2023-01-01';
+    datePicker.$.clearButton.click();
+    expect(datePicker.dirty).to.be.true;
+  });
+});

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -17,6 +17,7 @@ import type { DatePickerMixinClass } from '../../src/vaadin-date-picker-mixin.js
 import type {
   DatePicker,
   DatePickerChangeEvent,
+  DatePickerDirtyChangedEvent,
   DatePickerInvalidChangedEvent,
   DatePickerOpenedChangedEvent,
   DatePickerValidatedEvent,
@@ -25,6 +26,7 @@ import type {
 import type {
   DatePickerLight,
   DatePickerLightChangeEvent,
+  DatePickerLightDirtyChangedEvent,
   DatePickerLightInvalidChangedEvent,
   DatePickerLightOpenedChangedEvent,
   DatePickerLightValidatedEvent,
@@ -44,6 +46,11 @@ datePicker.addEventListener('opened-changed', (event) => {
 
 datePicker.addEventListener('invalid-changed', (event) => {
   assertType<DatePickerInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+datePicker.addEventListener('dirty-changed', (event) => {
+  assertType<DatePickerDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 
@@ -124,6 +131,11 @@ datePickerLight.addEventListener('invalid-changed', (event) => {
 datePickerLight.addEventListener('value-changed', (event) => {
   assertType<DatePickerLightValueChangedEvent>(event);
   assertType<string>(event.detail.value);
+});
+
+datePickerLight.addEventListener('dirty-changed', (event) => {
+  assertType<DatePickerLightDirtyChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 datePickerLight.addEventListener('change', (event) => {

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -40,6 +40,11 @@ export type DateTimePickerChangeEvent = Event & {
 export type DateTimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type DateTimePickerDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type DateTimePickerValueChangedEvent = CustomEvent<{ value: string }>;
@@ -51,6 +56,8 @@ export type DateTimePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface DateTimePickerCustomEventMap {
   'invalid-changed': DateTimePickerInvalidChangedEvent;
+
+  'dirty-changed': DateTimePickerDirtyChangedEvent;
 
   'value-changed': DateTimePickerValueChangedEvent;
 
@@ -113,6 +120,7 @@ export interface DateTimePickerEventMap extends DateTimePickerCustomEventMap, HT
  *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -215,6 +215,15 @@ declare class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(Themabl
   autofocus: boolean;
 
   /**
+   * Whether the field is dirty.
+   *
+   * The field is automatically marked as dirty once the user triggers
+   * an `input` or `change` event on the child pickers. Additionally, the field
+   * can be manually marked as dirty by setting the `dirty` property to `true`.
+   */
+  dirty: boolean;
+
+  /**
    * The object used to localize this component.
    * To change the default localization, replace the entire
    * `i18n` object or just the properties you want to modify.

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -219,7 +219,7 @@ declare class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(Themabl
    *
    * The field is automatically marked as dirty once the user triggers
    * an `input` or `change` event on the child pickers. Additionally, the field
-   * can be manually marked as dirty by setting the `dirty` property to `true`.
+   * can be manually marked as dirty by setting the property to `true`.
    */
   dirty: boolean;
 

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -327,7 +327,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
        *
        * The field is automatically marked as dirty once the user triggers
        * an `input` or `change` event on the child pickers. Additionally, the field
-       * can be manually marked as dirty by setting the `dirty` property to `true`.
+       * can be manually marked as dirty by setting the property to `true`.
        */
       dirty: {
         type: Boolean,

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -323,6 +323,15 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
       },
 
       /**
+       * Whether the user has interacted with the field.
+       */
+      dirty: {
+        type: Boolean,
+        value: false,
+        notify: true,
+      },
+
+      /**
        * The current selected date time.
        * @private
        */
@@ -409,6 +418,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
     this.__defaultTimeMaxValue = '23:59:59.999';
 
     this.__changeEventHandler = this.__changeEventHandler.bind(this);
+    this.__dirtyChangedEventHandler = this.__dirtyChangedEventHandler.bind(this);
     this.__valueChangedEventHandler = this.__valueChangedEventHandler.bind(this);
   }
 
@@ -517,14 +527,21 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   }
 
   /** @private */
+  __dirtyChangedEventHandler() {
+    this.dirty = true;
+  }
+
+  /** @private */
   __addInputListeners(node) {
     node.addEventListener('change', this.__changeEventHandler);
+    node.addEventListener('dirty-changed', this.__dirtyChangedEventHandler);
     node.addEventListener('value-changed', this.__valueChangedEventHandler);
   }
 
   /** @private */
   __removeInputListeners(node) {
     node.removeEventListener('change', this.__changeEventHandler);
+    node.removeEventListener('dirty-changed', this.__dirtyChangedEventHandler);
     node.removeEventListener('value-changed', this.__valueChangedEventHandler);
   }
 

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -527,8 +527,10 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   }
 
   /** @private */
-  __dirtyChangedEventHandler() {
-    this.dirty = true;
+  __dirtyChangedEventHandler(event) {
+    if (event.detail.value) {
+      this.dirty = true;
+    }
   }
 
   /** @private */

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -323,7 +323,11 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
       },
 
       /**
-       * Whether the user has interacted with the field.
+       * Whether the field is dirty.
+       *
+       * The field is automatically marked as dirty once the user triggers
+       * an `input` or `change` event on the child pickers. Additionally, the field
+       * can be manually marked as dirty by setting the `dirty` property to `true`.
        */
       dirty: {
         type: Boolean,

--- a/packages/date-time-picker/test/dirty-state.test.js
+++ b/packages/date-time-picker/test/dirty-state.test.js
@@ -31,6 +31,11 @@ describe('dirty state', () => {
         expect(dateTimePicker.dirty).to.be.false;
       });
 
+      it('should not be dirty after programmatic value change', async () => {
+        dateTimePicker.value = '2023-01-01T00:00';
+        expect(dateTimePicker.dirty).to.be.false;
+      });
+
       it('should not be dirty after date-picker blur without change', () => {
         datePicker.focus();
         datePicker.blur();

--- a/packages/date-time-picker/test/dirty-state.test.js
+++ b/packages/date-time-picker/test/dirty-state.test.js
@@ -1,0 +1,67 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import '../src/vaadin-date-time-picker.js';
+import { waitForOverlayRender } from '@vaadin/date-picker/test/helpers.js';
+
+describe('dirty state', () => {
+  let dateTimePicker, datePicker, timePicker;
+
+  beforeEach(async () => {
+    dateTimePicker = fixtureSync('<vaadin-date-time-picker></vaadin-date-time-picker>');
+    await nextRender();
+    datePicker = dateTimePicker.querySelector('[slot=date-picker]');
+    timePicker = dateTimePicker.querySelector('[slot=time-picker]');
+  });
+
+  it('should not be dirty by default', () => {
+    expect(dateTimePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after date-picker blur without change', () => {
+    datePicker.focus();
+    datePicker.blur();
+    expect(dateTimePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after time-picker blur without change', () => {
+    timePicker.focus();
+    timePicker.blur();
+    expect(dateTimePicker.dirty).to.be.false;
+  });
+
+  it('should be dirty after date-picker change', async () => {
+    datePicker.focus();
+    datePicker.click();
+    await waitForOverlayRender();
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Enter' });
+    expect(dateTimePicker.dirty).to.be.true;
+  });
+
+  it('should be dirty after time-picker change', async () => {
+    timePicker.focus();
+    timePicker.click();
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Enter' });
+    expect(dateTimePicker.dirty).to.be.true;
+  });
+
+  it('should be dirty after time-picker user input', () => {
+    fire(timePicker.inputElement, 'input');
+    expect(dateTimePicker.dirty).to.be.true;
+  });
+
+  it('should be dirty after date-picker user input', () => {
+    fire(datePicker.inputElement, 'input');
+    expect(dateTimePicker.dirty).to.be.true;
+  });
+
+  it('should fire dirty-changed event when the state changes', () => {
+    const spy = sinon.spy();
+    dateTimePicker.addEventListener('dirty-changed', spy);
+    dateTimePicker.dirty = true;
+    expect(spy.calledOnce).to.be.true;
+  });
+});

--- a/packages/date-time-picker/test/dirty-state.test.js
+++ b/packages/date-time-picker/test/dirty-state.test.js
@@ -8,60 +8,74 @@ import { waitForOverlayRender } from '@vaadin/date-picker/test/helpers.js';
 describe('dirty state', () => {
   let dateTimePicker, datePicker, timePicker;
 
-  beforeEach(async () => {
-    dateTimePicker = fixtureSync('<vaadin-date-time-picker></vaadin-date-time-picker>');
-    await nextRender();
-    datePicker = dateTimePicker.querySelector('[slot=date-picker]');
-    timePicker = dateTimePicker.querySelector('[slot=time-picker]');
-  });
+  const fixtures = {
+    default: '<vaadin-date-time-picker></vaadin-date-time-picker>',
+    slotted: `
+      <vaadin-date-time-picker>
+        <vaadin-date-picker slot="date-picker"></vaadin-date-picker>
+        <vaadin-time-picker slot="time-picker"></vaadin-time-picker>
+      </vaadin-date-time-picker>
+    `,
+  };
 
-  it('should not be dirty by default', () => {
-    expect(dateTimePicker.dirty).to.be.false;
-  });
+  ['default', 'slotted'].forEach((type) => {
+    describe(type, () => {
+      beforeEach(async () => {
+        dateTimePicker = fixtureSync(fixtures[type]);
+        await nextRender();
+        datePicker = dateTimePicker.querySelector('[slot=date-picker]');
+        timePicker = dateTimePicker.querySelector('[slot=time-picker]');
+      });
 
-  it('should not be dirty after date-picker blur without change', () => {
-    datePicker.focus();
-    datePicker.blur();
-    expect(dateTimePicker.dirty).to.be.false;
-  });
+      it('should not be dirty by default', () => {
+        expect(dateTimePicker.dirty).to.be.false;
+      });
 
-  it('should not be dirty after time-picker blur without change', () => {
-    timePicker.focus();
-    timePicker.blur();
-    expect(dateTimePicker.dirty).to.be.false;
-  });
+      it('should not be dirty after date-picker blur without change', () => {
+        datePicker.focus();
+        datePicker.blur();
+        expect(dateTimePicker.dirty).to.be.false;
+      });
 
-  it('should be dirty after date-picker change', async () => {
-    datePicker.focus();
-    datePicker.click();
-    await waitForOverlayRender();
-    await sendKeys({ press: 'ArrowDown' });
-    await sendKeys({ press: 'Enter' });
-    expect(dateTimePicker.dirty).to.be.true;
-  });
+      it('should not be dirty after time-picker blur without change', () => {
+        timePicker.focus();
+        timePicker.blur();
+        expect(dateTimePicker.dirty).to.be.false;
+      });
 
-  it('should be dirty after time-picker change', async () => {
-    timePicker.focus();
-    timePicker.click();
-    await sendKeys({ press: 'ArrowDown' });
-    await sendKeys({ press: 'Enter' });
-    expect(dateTimePicker.dirty).to.be.true;
-  });
+      it('should be dirty after date-picker change', async () => {
+        datePicker.focus();
+        datePicker.click();
+        await waitForOverlayRender();
+        await sendKeys({ press: 'ArrowDown' });
+        await sendKeys({ press: 'Enter' });
+        expect(dateTimePicker.dirty).to.be.true;
+      });
 
-  it('should be dirty after time-picker user input', () => {
-    fire(timePicker.inputElement, 'input');
-    expect(dateTimePicker.dirty).to.be.true;
-  });
+      it('should be dirty after time-picker change', async () => {
+        timePicker.focus();
+        timePicker.click();
+        await sendKeys({ press: 'ArrowDown' });
+        await sendKeys({ press: 'Enter' });
+        expect(dateTimePicker.dirty).to.be.true;
+      });
 
-  it('should be dirty after date-picker user input', () => {
-    fire(datePicker.inputElement, 'input');
-    expect(dateTimePicker.dirty).to.be.true;
-  });
+      it('should be dirty after time-picker user input', () => {
+        fire(timePicker.inputElement, 'input');
+        expect(dateTimePicker.dirty).to.be.true;
+      });
 
-  it('should fire dirty-changed event when the state changes', () => {
-    const spy = sinon.spy();
-    dateTimePicker.addEventListener('dirty-changed', spy);
-    dateTimePicker.dirty = true;
-    expect(spy.calledOnce).to.be.true;
+      it('should be dirty after date-picker user input', () => {
+        fire(datePicker.inputElement, 'input');
+        expect(dateTimePicker.dirty).to.be.true;
+      });
+
+      it('should fire dirty-changed event when the state changes', () => {
+        const spy = sinon.spy();
+        dateTimePicker.addEventListener('dirty-changed', spy);
+        dateTimePicker.dirty = true;
+        expect(spy.calledOnce).to.be.true;
+      });
+    });
   });
 });

--- a/packages/date-time-picker/test/typings/date-time-picker.types.ts
+++ b/packages/date-time-picker/test/typings/date-time-picker.types.ts
@@ -2,6 +2,7 @@ import '../../vaadin-date-time-picker.js';
 import type {
   DateTimePicker,
   DateTimePickerChangeEvent,
+  DateTimePickerDirtyChangedEvent,
   DateTimePickerInvalidChangedEvent,
   DateTimePickerValidatedEvent,
   DateTimePickerValueChangedEvent,
@@ -18,6 +19,11 @@ picker.addEventListener('change', (event) => {
 
 picker.addEventListener('invalid-changed', (event) => {
   assertType<DateTimePickerInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+picker.addEventListener('dirty-changed', (event) => {
+  assertType<DateTimePickerDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/email-field/src/vaadin-email-field.d.ts
+++ b/packages/email-field/src/vaadin-email-field.d.ts
@@ -18,6 +18,11 @@ export type EmailFieldChangeEvent = Event & {
 export type EmailFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type EmailFieldDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type EmailFieldValueChangedEvent = CustomEvent<{ value: string }>;
@@ -29,6 +34,8 @@ export type EmailFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface EmailFieldCustomEventMap {
   'invalid-changed': EmailFieldInvalidChangedEvent;
+
+  'dirty-changed': EmailFieldDirtyChangedEvent;
 
   'value-changed': EmailFieldValueChangedEvent;
 
@@ -56,6 +63,7 @@ export interface EmailFieldEventMap extends HTMLElementEventMap, EmailFieldCusto
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/email-field/test/typings/email-field.types.ts
+++ b/packages/email-field/test/typings/email-field.types.ts
@@ -2,6 +2,7 @@ import '../../vaadin-email-field.js';
 import type {
   EmailField,
   EmailFieldChangeEvent,
+  EmailFieldDirtyChangedEvent,
   EmailFieldInvalidChangedEvent,
   EmailFieldValidatedEvent,
   EmailFieldValueChangedEvent,
@@ -18,6 +19,11 @@ field.addEventListener('change', (event) => {
 
 field.addEventListener('invalid-changed', (event) => {
   assertType<EmailFieldInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+field.addEventListener('dirty-changed', (event) => {
+  assertType<EmailFieldDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -29,6 +29,11 @@ export declare class InputMixinClass {
   value: string;
 
   /**
+   * Whether the user has interacted with the field.
+   */
+  dirty: boolean;
+
+  /**
    * Indicates whether the value is different from the default one.
    * Override if the `value` property has a type other than `string`.
    */

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -33,7 +33,7 @@ export declare class InputMixinClass {
    *
    * The field is automatically marked as dirty once the user triggers
    * an `input` or `change` event. Additionally, the field can be manually
-   * marked as dirty by setting the `dirty` property to `true`.
+   * marked as dirty by setting the property to `true`.
    */
   dirty: boolean;
 

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -29,7 +29,11 @@ export declare class InputMixinClass {
   value: string;
 
   /**
-   * Whether the user has interacted with the field.
+   * Whether the field is dirty.
+   *
+   * The field is automatically marked as dirty once the user triggers
+   * an `input` or `change` event. Additionally, the field can be manually
+   * marked as dirty by setting the `dirty` property to `true`.
    */
   dirty: boolean;
 

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -58,7 +58,7 @@ export const InputMixin = dedupingMixin(
            *
            * The field is automatically marked as dirty once the user triggers
            * an `input` or `change` event. Additionally, the field can be manually
-           * marked as dirty by setting the `dirty` property to `true`.
+           * marked as dirty by setting the property to `true`.
            */
           dirty: {
             type: Boolean,

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -54,6 +54,15 @@ export const InputMixin = dedupingMixin(
           },
 
           /**
+           * Whether the user has interacted with the field.
+           */
+          dirty: {
+            type: Boolean,
+            value: false,
+            notify: true,
+          },
+
+          /**
            * Whether the input element has a non-empty value.
            *
            * @protected
@@ -194,7 +203,7 @@ export const InputMixin = dedupingMixin(
       }
 
       /**
-       * An input event listener used to update `_hasInputValue` property.
+       * An input event listener used to update `_hasInputValue` and `dirty` properties.
        * Do not override this method.
        *
        * @param {Event} event
@@ -202,6 +211,7 @@ export const InputMixin = dedupingMixin(
        */
       __onInput(event) {
         this._setHasInputValue(event);
+        this.dirty = true;
         this._onInput(event);
       }
 

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -54,7 +54,11 @@ export const InputMixin = dedupingMixin(
           },
 
           /**
-           * Whether the user has interacted with the field.
+           * Whether the field is dirty.
+           *
+           * The field is automatically marked as dirty once the user triggers
+           * an `input` or `change` event. Additionally, the field can be manually
+           * marked as dirty by setting the `dirty` property to `true`.
            */
           dirty: {
             type: Boolean,

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -65,6 +65,12 @@ const runTests = (defineHelper, baseMixin) => {
       expect(input.value).to.equal('');
     });
 
+    it('should mark the field as dirty on clear button click', async () => {
+      clearButton.click();
+      await nextUpdate(element);
+      expect(element.dirty).to.be.true;
+    });
+
     (!isTouch ? it : it.skip)('should focus the input on clear button mousedown', () => {
       const spy = sinon.spy(input, 'focus');
       mousedown(clearButton);

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -113,6 +113,35 @@ const runTests = (defineHelper, baseMixin) => {
     });
   });
 
+  describe('dirty state', () => {
+    beforeEach(async () => {
+      element = fixtureSync(`<${tag}></${tag}>`);
+      await nextRender();
+      input = document.createElement('input');
+      input.setAttribute('slot', 'input');
+      element.appendChild(input);
+      element._setInputElement(input);
+      await nextUpdate();
+    });
+
+    it('should not be dirty by default', () => {
+      expect(element.dirty).to.be.false;
+    });
+
+    it('should be dirty after user input', () => {
+      fire(input, 'input');
+      expect(element.dirty).to.be.true;
+    });
+
+    it('should fire dirty-changed event when the state changes', async () => {
+      const spy = sinon.spy();
+      element.addEventListener('dirty-changed', spy);
+      element.dirty = true;
+      await nextUpdate();
+      expect(spy.calledOnce).to.be.true;
+    });
+  });
+
   describe('events', () => {
     let eventsTag, inputSpy, changeSpy;
 

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -128,6 +128,12 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.dirty).to.be.false;
     });
 
+    it('should not be dirty after programmatic value change', async () => {
+      element.value = 'foo';
+      await nextUpdate(element);
+      expect(element.dirty).to.be.false;
+    });
+
     it('should be dirty after user input', () => {
       fire(input, 'input');
       expect(element.dirty).to.be.true;

--- a/packages/integer-field/src/vaadin-integer-field.d.ts
+++ b/packages/integer-field/src/vaadin-integer-field.d.ts
@@ -18,6 +18,11 @@ export type IntegerFieldChangeEvent = Event & {
 export type IntegerFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type IntegerFieldDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type IntegerFieldValueChangedEvent = CustomEvent<{ value: string }>;
@@ -29,6 +34,8 @@ export type IntegerFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface IntegerFieldCustomEventMap {
   'invalid-changed': IntegerFieldInvalidChangedEvent;
+
+  'dirty-changed': IntegerFieldDirtyChangedEvent;
 
   'value-changed': IntegerFieldValueChangedEvent;
 
@@ -63,6 +70,7 @@ export interface IntegerFieldEventMap extends HTMLElementEventMap, IntegerFieldC
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/integer-field/test/typings/integer-field.types.ts
+++ b/packages/integer-field/test/typings/integer-field.types.ts
@@ -2,6 +2,7 @@ import '../../vaadin-integer-field.js';
 import type {
   IntegerField,
   IntegerFieldChangeEvent,
+  IntegerFieldDirtyChangedEvent,
   IntegerFieldInvalidChangedEvent,
   IntegerFieldValidatedEvent,
   IntegerFieldValueChangedEvent,
@@ -18,6 +19,11 @@ field.addEventListener('change', (event) => {
 
 field.addEventListener('invalid-changed', (event) => {
   assertType<IntegerFieldInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+field.addEventListener('dirty-changed', (event) => {
+  assertType<IntegerFieldDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -159,6 +159,7 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
  * @fires {CustomEvent} custom-value-set - Fired when the user sets a custom value.
  * @fires {CustomEvent} filter-changed - Fired when the `filter` property changes.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -812,6 +812,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   /** @private */
   __updateSelection(selectedItems) {
+    this.dirty = true;
     this.selectedItems = selectedItems;
 
     this.validate();

--- a/packages/multi-select-combo-box/test/dirty-state.test.js
+++ b/packages/multi-select-combo-box/test/dirty-state.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '../src/vaadin-multi-select-combo-box.js';
 import { getAllItems } from './helpers.js';
@@ -13,6 +13,11 @@ describe('dirty state', () => {
   });
 
   it('should not be dirty by default', () => {
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should not be dirty after programmatic value change', async () => {
+    comboBox.value = ['Item 1'];
     expect(comboBox.dirty).to.be.false;
   });
 

--- a/packages/multi-select-combo-box/test/dirty-state.test.js
+++ b/packages/multi-select-combo-box/test/dirty-state.test.js
@@ -5,12 +5,11 @@ import '../src/vaadin-multi-select-combo-box.js';
 import { getAllItems } from './helpers.js';
 
 describe('dirty state', () => {
-  let comboBox, input;
+  let comboBox;
 
   beforeEach(() => {
     comboBox = fixtureSync('<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>');
     comboBox.items = ['Item 1', 'Item 2', 'Item 3'];
-    input = comboBox.inputElement;
   });
 
   it('should not be dirty by default', () => {
@@ -18,48 +17,49 @@ describe('dirty state', () => {
   });
 
   it('should not be dirty after blur without change', () => {
-    input.focus();
-    input.blur();
+    comboBox.focus();
+    comboBox.blur();
     expect(comboBox.dirty).to.be.false;
   });
 
   it('should not be dirty after pressing Enter without change', async () => {
-    input.focus();
+    comboBox.focus();
     await sendKeys({ press: 'Enter' });
     expect(comboBox.dirty).to.be.false;
   });
 
   it('should not be dirty after closing the dropdown without change', async () => {
-    input.focus();
-    input.click();
+    comboBox.focus();
+    comboBox.click();
     outsideClick();
     expect(comboBox.dirty).to.be.false;
   });
 
   it('should not be dirty after cancelling selection and closing the dropdown', async () => {
-    input.focus();
-    input.click();
+    comboBox.focus();
+    comboBox.click();
     await sendKeys({ press: 'ArrowDown' });
     await sendKeys({ press: 'Escape' });
     await sendKeys({ press: 'Escape' });
     expect(comboBox.dirty).to.be.false;
   });
 
-  it('should be dirty after user input', () => {
-    fire(input, 'input');
+  it('should be dirty after user input', async () => {
+    comboBox.focus();
+    await sendKeys({ press: 'I' });
     expect(comboBox.dirty).to.be.true;
   });
 
   it('should be dirty after selecting a dropdown item with click', () => {
-    input.focus();
-    input.click();
+    comboBox.focus();
+    comboBox.click();
     getAllItems(comboBox)[0].click();
     expect(comboBox.dirty).to.be.true;
   });
 
   it('should be dirty after selecting a dropdown item with Enter', async () => {
-    input.focus();
-    input.click();
+    comboBox.focus();
+    comboBox.click();
     await sendKeys({ press: 'ArrowDown' });
     await sendKeys({ press: 'Enter' });
     expect(comboBox.dirty).to.be.true;

--- a/packages/multi-select-combo-box/test/dirty-state.test.js
+++ b/packages/multi-select-combo-box/test/dirty-state.test.js
@@ -65,7 +65,7 @@ describe('dirty state', () => {
     expect(comboBox.dirty).to.be.true;
   });
 
-  it('should be dirty after clicking the clear button', () => {
+  it('should be dirty after clear button click', () => {
     comboBox.clearButtonVisible = true;
     comboBox.value = 'foo';
     comboBox.$.clearButton.click();

--- a/packages/multi-select-combo-box/test/dirty-state.test.js
+++ b/packages/multi-select-combo-box/test/dirty-state.test.js
@@ -1,0 +1,74 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, outsideClick } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import '../src/vaadin-multi-select-combo-box.js';
+import { getAllItems } from './helpers.js';
+
+describe('dirty state', () => {
+  let comboBox, input;
+
+  beforeEach(() => {
+    comboBox = fixtureSync('<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>');
+    comboBox.items = ['Item 1', 'Item 2', 'Item 3'];
+    input = comboBox.inputElement;
+  });
+
+  it('should not be dirty by default', () => {
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should not be dirty after blur without change', () => {
+    input.focus();
+    input.blur();
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should not be dirty after pressing Enter without change', async () => {
+    input.focus();
+    await sendKeys({ press: 'Enter' });
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should not be dirty after closing the dropdown without change', async () => {
+    input.focus();
+    input.click();
+    outsideClick();
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should not be dirty after cancelling selection and closing the dropdown', async () => {
+    input.focus();
+    input.click();
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Escape' });
+    await sendKeys({ press: 'Escape' });
+    expect(comboBox.dirty).to.be.false;
+  });
+
+  it('should be dirty after user input', () => {
+    fire(input, 'input');
+    expect(comboBox.dirty).to.be.true;
+  });
+
+  it('should be dirty after selecting a dropdown item with click', () => {
+    input.focus();
+    input.click();
+    getAllItems(comboBox)[0].click();
+    expect(comboBox.dirty).to.be.true;
+  });
+
+  it('should be dirty after selecting a dropdown item with Enter', async () => {
+    input.focus();
+    input.click();
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Enter' });
+    expect(comboBox.dirty).to.be.true;
+  });
+
+  it('should be dirty after clicking the clear button', () => {
+    comboBox.clearButtonVisible = true;
+    comboBox.value = 'foo';
+    comboBox.$.clearButton.click();
+    expect(comboBox.dirty).to.be.true;
+  });
+});

--- a/packages/multi-select-combo-box/test/helpers.js
+++ b/packages/multi-select-combo-box/test/helpers.js
@@ -15,3 +15,12 @@ export const getAsyncDataProvider = (allItems) => {
     }, 0);
   };
 };
+
+/**
+ * Returns all the items of the combo box dropdown.
+ */
+export const getAllItems = (comboBox) => {
+  return Array.from(comboBox.$.comboBox._scroller.querySelectorAll('vaadin-multi-select-combo-box-item'))
+    .filter((item) => !item.hidden)
+    .sort((a, b) => a.index - b.index);
+};

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -21,6 +21,11 @@ export type NumberFieldChangeEvent = Event & {
 export type NumberFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type NumberFieldDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type NumberFieldValueChangedEvent = CustomEvent<{ value: string }>;
@@ -32,6 +37,8 @@ export type NumberFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface NumberFieldCustomEventMap {
   'invalid-changed': NumberFieldInvalidChangedEvent;
+
+  'dirty-changed': NumberFieldDirtyChangedEvent;
 
   'value-changed': NumberFieldValueChangedEvent;
 
@@ -66,6 +73,7 @@ export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCus
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/number-field/test/typings/number-field.types.ts
+++ b/packages/number-field/test/typings/number-field.types.ts
@@ -8,6 +8,7 @@ import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-th
 import type {
   NumberField,
   NumberFieldChangeEvent,
+  NumberFieldDirtyChangedEvent,
   NumberFieldInvalidChangedEvent,
   NumberFieldValidatedEvent,
   NumberFieldValueChangedEvent,
@@ -33,6 +34,11 @@ field.addEventListener('change', (event) => {
 
 field.addEventListener('invalid-changed', (event) => {
   assertType<NumberFieldInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+field.addEventListener('dirty-changed', (event) => {
+  assertType<NumberFieldDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -18,6 +18,11 @@ export type PasswordFieldChangeEvent = Event & {
 export type PasswordFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type PasswordFieldDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type PasswordFieldValueChangedEvent = CustomEvent<{ value: string }>;
@@ -29,6 +34,8 @@ export type PasswordFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface PasswordFieldCustomEventMap {
   'invalid-changed': PasswordFieldInvalidChangedEvent;
+
+  'dirty-changed': PasswordFieldDirtyChangedEvent;
 
   'value-changed': PasswordFieldValueChangedEvent;
 
@@ -68,6 +75,7 @@ export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFiel
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/password-field/test/typings/password-field.types.ts
+++ b/packages/password-field/test/typings/password-field.types.ts
@@ -2,6 +2,7 @@ import '../../vaadin-password-field.js';
 import type {
   PasswordField,
   PasswordFieldChangeEvent,
+  PasswordFieldDirtyChangedEvent,
   PasswordFieldInvalidChangedEvent,
   PasswordFieldValidatedEvent,
   PasswordFieldValueChangedEvent,
@@ -18,6 +19,11 @@ field.addEventListener('change', (event) => {
 
 field.addEventListener('invalid-changed', (event) => {
   assertType<PasswordFieldInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+field.addEventListener('dirty-changed', (event) => {
+  assertType<PasswordFieldDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -16,6 +16,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 export type RadioGroupInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type RadioGroupDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type RadioGroupValueChangedEvent = CustomEvent<{ value: string }>;
@@ -27,6 +32,8 @@ export type RadioGroupValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface RadioGroupCustomEventMap {
   'invalid-changed': RadioGroupInvalidChangedEvent;
+
+  'dirty-changed': RadioGroupDirtyChangedEvent;
 
   'value-changed': RadioGroupValueChangedEvent;
 
@@ -74,6 +81,7 @@ export interface RadioGroupEventMap extends HTMLElementEventMap, RadioGroupCusto
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -93,6 +93,11 @@ declare class RadioGroup extends FieldMixin(
    */
   readonly: boolean;
 
+  /**
+   * Whether the user has interacted with the field.
+   */
+  dirty: boolean;
+
   addEventListener<K extends keyof RadioGroupEventMap>(
     type: K,
     listener: (this: RadioGroup, ev: RadioGroupEventMap[K]) => void,

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -94,7 +94,11 @@ declare class RadioGroup extends FieldMixin(
   readonly: boolean;
 
   /**
-   * Whether the user has interacted with the field.
+   * Whether the field is dirty.
+   *
+   * The field is automatically marked as dirty once the user triggers
+   * a `change` event. Additionally, the field can be manually marked
+   * as dirty by setting the `dirty` property to `true`.
    */
   dirty: boolean;
 

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -98,7 +98,7 @@ declare class RadioGroup extends FieldMixin(
    *
    * The field is automatically marked as dirty once the user triggers
    * a `change` event. Additionally, the field can be manually marked
-   * as dirty by setting the `dirty` property to `true`.
+   * as dirty by setting the property to `true`.
    */
   dirty: boolean;
 

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -169,7 +169,7 @@ class RadioGroup extends FieldMixin(
        *
        * The field is automatically marked as dirty once the user triggers
        * a `change` event. Additionally, the field can be manually marked
-       * as dirty by setting the `dirty` property to `true`.
+       * as dirty by setting the property to `true`.
        */
       dirty: {
         type: Boolean,

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -163,6 +163,15 @@ class RadioGroup extends FieldMixin(
       _fieldName: {
         type: String,
       },
+
+      /**
+       * Whether the user has interacted with the field.
+       */
+      dirty: {
+        type: Boolean,
+        value: false,
+        notify: true,
+      },
     };
   }
 
@@ -353,6 +362,8 @@ class RadioGroup extends FieldMixin(
    * @private
    */
   __onRadioButtonCheckedChange(event) {
+    this.dirty = true;
+
     if (event.target.checked) {
       this.__selectRadioButton(event.target);
     }

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -165,7 +165,11 @@ class RadioGroup extends FieldMixin(
       },
 
       /**
-       * Whether the user has interacted with the field.
+       * Whether the field is dirty.
+       *
+       * The field is automatically marked as dirty once the user triggers
+       * a `change` event. Additionally, the field can be manually marked
+       * as dirty by setting the `dirty` property to `true`.
        */
       dirty: {
         type: Boolean,

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -184,6 +184,7 @@ class RadioGroup extends FieldMixin(
 
     this.__registerRadioButton = this.__registerRadioButton.bind(this);
     this.__unregisterRadioButton = this.__unregisterRadioButton.bind(this);
+    this.__onRadioButtonChange = this.__onRadioButtonChange.bind(this);
     this.__onRadioButtonCheckedChange = this.__onRadioButtonCheckedChange.bind(this);
   }
 
@@ -336,6 +337,7 @@ class RadioGroup extends FieldMixin(
    */
   __registerRadioButton(radioButton) {
     radioButton.name = this._fieldName;
+    radioButton.addEventListener('change', this.__onRadioButtonChange);
     radioButton.addEventListener('checked-changed', this.__onRadioButtonCheckedChange);
 
     if (this.disabled || this.readonly) {
@@ -354,6 +356,7 @@ class RadioGroup extends FieldMixin(
    * @private
    */
   __unregisterRadioButton(radioButton) {
+    radioButton.removeEventListener('change', this.__onRadioButtonChange);
     radioButton.removeEventListener('checked-changed', this.__onRadioButtonCheckedChange);
 
     if (radioButton.value === this.value) {
@@ -361,13 +364,16 @@ class RadioGroup extends FieldMixin(
     }
   }
 
+  /** @private */
+  __onRadioButtonChange() {
+    this.dirty = true;
+  }
+
   /**
    * @param {!CustomEvent} event
    * @private
    */
   __onRadioButtonCheckedChange(event) {
-    this.dirty = true;
-
     if (event.target.checked) {
       this.__selectRadioButton(event.target);
     }

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -492,6 +492,11 @@ describe('radio-group', () => {
       expect(group.dirty).to.be.false;
     });
 
+    it('should not be dirty after programmatic value change', () => {
+      group.value = '1';
+      expect(group.dirty).to.be.false;
+    });
+
     it('should be dirty after selecting a radio button', () => {
       buttons[0].click();
       expect(group.dirty).to.be.true;

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-radio-group.js';
@@ -473,6 +473,35 @@ describe('radio-group', () => {
       await nextFrame();
 
       expect(group.value).to.equal('value2');
+    });
+  });
+
+  describe('dirty state', () => {
+    beforeEach(async () => {
+      group = fixtureSync(`
+        <vaadin-radio-group>
+          <vaadin-radio-button label="Button 1" value="1"></vaadin-radio-button>
+          <vaadin-radio-button label="Button 2" value="2"></vaadin-radio-button>
+        </vaadin-radio-group>
+      `);
+      await nextRender();
+      buttons = [...group.querySelectorAll('vaadin-radio-button')];
+    });
+
+    it('should not be dirty by default', () => {
+      expect(group.dirty).to.be.false;
+    });
+
+    it('should be dirty after selecting a radio button', () => {
+      buttons[0].click();
+      expect(group.dirty).to.be.true;
+    });
+
+    it('should fire dirty-changed event when the state changes', () => {
+      const spy = sinon.spy();
+      group.addEventListener('dirty-changed', spy);
+      group.dirty = true;
+      expect(spy.calledOnce).to.be.true;
     });
   });
 

--- a/packages/radio-group/test/typings/radio-button.types.ts
+++ b/packages/radio-group/test/typings/radio-button.types.ts
@@ -12,6 +12,7 @@ import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { RadioButtonCheckedChangedEvent } from '../../vaadin-radio-button.js';
 import type {
+  RadioGroupDirtyChangedEvent,
   RadioGroupInvalidChangedEvent,
   RadioGroupValidatedEvent,
   RadioGroupValueChangedEvent,
@@ -51,6 +52,11 @@ const group = document.createElement('vaadin-radio-group');
 
 group.addEventListener('invalid-changed', (event) => {
   assertType<RadioGroupInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+group.addEventListener('dirty-changed', (event) => {
+  assertType<RadioGroupDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/select/src/vaadin-select-base-mixin.d.ts
+++ b/packages/select/src/vaadin-select-base-mixin.d.ts
@@ -97,6 +97,15 @@ export declare class SelectBaseMixinClass {
   readonly: boolean;
 
   /**
+   * Whether the field is dirty.
+   *
+   * The field is automatically marked as dirty once the user triggers
+   * a `change` event. Additionally, the field can be manually marked
+   * as dirty by setting the `dirty` property to `true`.
+   */
+  dirty: boolean;
+
+  /**
    * Requests an update for the content of the select.
    * While performing the update, it invokes the renderer passed in the `renderer` property.
    *

--- a/packages/select/src/vaadin-select-base-mixin.d.ts
+++ b/packages/select/src/vaadin-select-base-mixin.d.ts
@@ -101,7 +101,7 @@ export declare class SelectBaseMixinClass {
    *
    * The field is automatically marked as dirty once the user triggers
    * a `change` event. Additionally, the field can be manually marked
-   * as dirty by setting the `dirty` property to `true`.
+   * as dirty by setting the property to `true`.
    */
   dirty: boolean;
 

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -132,7 +132,7 @@ export const SelectBaseMixin = (superClass) =>
          *
          * The field is automatically marked as dirty once the user triggers
          * a `change` event. Additionally, the field can be manually marked
-         * as dirty by setting the `dirty` property to `true`.
+         * as dirty by setting the property to `true`.
          */
         dirty: {
           type: Boolean,

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -128,7 +128,11 @@ export const SelectBaseMixin = (superClass) =>
         },
 
         /**
-         * Whether the user has interacted with the field.
+         * Whether the field is dirty.
+         *
+         * The field is automatically marked as dirty once the user triggers
+         * a `change` event. Additionally, the field can be manually marked
+         * as dirty by setting the `dirty` property to `true`.
          */
         dirty: {
           type: Boolean,

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -623,6 +623,7 @@ export const SelectBaseMixin = (superClass) =>
         await this.updateComplete;
       }
 
+      this.dirty = true;
       this.validate();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
       this.__dispatchChangePending = false;

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -127,6 +127,15 @@ export const SelectBaseMixin = (superClass) =>
           reflectToAttribute: true,
         },
 
+        /**
+         * Whether the user has interacted with the field.
+         */
+        dirty: {
+          type: Boolean,
+          value: false,
+          notify: true,
+        },
+
         /** @private */
         _phone: Boolean,
 

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -42,6 +42,11 @@ export type SelectOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 export type SelectInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type SelectDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type SelectValueChangedEvent = CustomEvent<{ value: string }>;
@@ -55,6 +60,8 @@ export interface SelectCustomEventMap {
   'opened-changed': SelectOpenedChangedEvent;
 
   'invalid-changed': SelectInvalidChangedEvent;
+
+  'dirty-changed': SelectDirtyChangedEvent;
 
   'value-changed': SelectValueChangedEvent;
 
@@ -167,6 +174,7 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/select/test/dirty-state-lit.test.js
+++ b/packages/select/test/dirty-state-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-select.js';
+import './dirty-state.common.js';

--- a/packages/select/test/dirty-state-polymer.test.js
+++ b/packages/select/test/dirty-state-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-select.js';
+import './dirty-state.common.js';

--- a/packages/select/test/dirty-state.common.js
+++ b/packages/select/test/dirty-state.common.js
@@ -20,6 +20,12 @@ describe('dirty state', () => {
     expect(select.dirty).to.be.false;
   });
 
+  it('should not be dirty after programmatic value change', async () => {
+    select.value = 'item-1';
+    await nextUpdate(select);
+    expect(select.dirty).to.be.false;
+  });
+
   it('should not be dirty after blur without change', () => {
     select.focus();
     select.blur();

--- a/packages/select/test/dirty-state.common.js
+++ b/packages/select/test/dirty-state.common.js
@@ -39,6 +39,7 @@ describe('dirty state', () => {
     await nextRender();
     const menuItem = getDeepActiveElement();
     menuItem.click();
+    await nextUpdate(select._menuElement);
     await nextUpdate(select);
     expect(select.dirty).to.be.true;
   });
@@ -48,6 +49,7 @@ describe('dirty state', () => {
     select.click();
     await nextRender();
     await sendKeys({ press: 'Enter' });
+    await nextUpdate(select._menuElement);
     await nextUpdate(select);
     expect(select.dirty).to.be.true;
   });

--- a/packages/select/test/dirty-state.common.js
+++ b/packages/select/test/dirty-state.common.js
@@ -1,12 +1,11 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../src/vaadin-select.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('dirty state', () => {
-  let select, menu, valueButton;
+  let select;
 
   beforeEach(async () => {
     select = fixtureSync('<vaadin-select></vaadin-select>');
@@ -14,8 +13,7 @@ describe('dirty state', () => {
       { label: 'Item 1', value: 'item-1' },
       { label: 'Item 2', value: 'item-2' },
     ];
-    menu = select._menuElement;
-    valueButton = select.querySelector('vaadin-select-value-button');
+    await nextRender();
   });
 
   it('should not be dirty by default', () => {
@@ -41,6 +39,7 @@ describe('dirty state', () => {
     await nextRender();
     const menuItem = getDeepActiveElement();
     menuItem.click();
+    await nextUpdate(select);
     expect(select.dirty).to.be.true;
   });
 
@@ -49,13 +48,15 @@ describe('dirty state', () => {
     select.click();
     await nextRender();
     await sendKeys({ press: 'Enter' });
+    await nextUpdate(select);
     expect(select.dirty).to.be.true;
   });
 
-  it('should fire dirty-changed event when the state changes', () => {
+  it('should fire dirty-changed event when the state changes', async () => {
     const spy = sinon.spy();
     select.addEventListener('dirty-changed', spy);
     select.dirty = true;
+    await nextUpdate(select);
     expect(spy.calledOnce).to.be.true;
   });
 });

--- a/packages/select/test/dirty-state.test.js
+++ b/packages/select/test/dirty-state.test.js
@@ -1,0 +1,61 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, nextFrame, outsideClick } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import '../src/vaadin-select.js';
+import { html, render } from 'lit';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+
+describe('dirty state', () => {
+  let select, menu, valueButton;
+
+  beforeEach(async () => {
+    select = fixtureSync(`<vaadin-select value="v2"></vaadin-select>`);
+    select.items = [
+      { label: 'Item 1', value: 'item-1' },
+      { label: 'Item 2', value: 'item-2' },
+    ];
+    menu = select._menuElement;
+    valueButton = select.querySelector('vaadin-select-value-button');
+    await nextFrame();
+  });
+
+  it('should not be dirty by default', () => {
+    expect(select.dirty).to.be.false;
+  });
+
+  it('should not be dirty after blur without change', () => {
+    select.focus();
+    select.blur();
+    expect(select.dirty).to.be.false;
+  });
+
+  it('should not be dirty after closing the overlay without change', () => {
+    select.focus();
+    select.click();
+    outsideClick();
+    expect(select.dirty).to.be.false;
+  });
+
+  it('should be dirty after selecting a menu item with click', () => {
+    select.focus();
+    select.click();
+    const menuItem = getDeepActiveElement();
+    menuItem.click();
+    expect(select.dirty).to.be.true;
+  });
+
+  it('should be dirty after selecting a menu item with Enter', async () => {
+    select.focus();
+    select.click();
+    await sendKeys({ press: 'Enter' });
+    expect(select.dirty).to.be.true;
+  });
+
+  it('should fire dirty-changed event when the state changes', () => {
+    const spy = sinon.spy();
+    select.addEventListener('dirty-changed', spy);
+    select.dirty = true;
+    expect(spy.calledOnce).to.be.true;
+  });
+});

--- a/packages/select/test/dirty-state.test.js
+++ b/packages/select/test/dirty-state.test.js
@@ -1,23 +1,21 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, nextFrame, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-select.js';
-import { html, render } from 'lit';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('dirty state', () => {
   let select, menu, valueButton;
 
   beforeEach(async () => {
-    select = fixtureSync(`<vaadin-select value="v2"></vaadin-select>`);
+    select = fixtureSync('<vaadin-select></vaadin-select>');
     select.items = [
       { label: 'Item 1', value: 'item-1' },
       { label: 'Item 2', value: 'item-2' },
     ];
     menu = select._menuElement;
     valueButton = select.querySelector('vaadin-select-value-button');
-    await nextFrame();
   });
 
   it('should not be dirty by default', () => {
@@ -30,16 +28,17 @@ describe('dirty state', () => {
     expect(select.dirty).to.be.false;
   });
 
-  it('should not be dirty after closing the overlay without change', () => {
+  it('should not be dirty after closing the overlay without change', async () => {
     select.focus();
     select.click();
     outsideClick();
     expect(select.dirty).to.be.false;
   });
 
-  it('should be dirty after selecting a menu item with click', () => {
+  it('should be dirty after selecting a menu item with click', async () => {
     select.focus();
     select.click();
+    await nextRender();
     const menuItem = getDeepActiveElement();
     menuItem.click();
     expect(select.dirty).to.be.true;
@@ -48,6 +47,7 @@ describe('dirty state', () => {
   it('should be dirty after selecting a menu item with Enter', async () => {
     select.focus();
     select.click();
+    await nextRender();
     await sendKeys({ press: 'Enter' });
     expect(select.dirty).to.be.true;
   });

--- a/packages/select/test/dirty-state.test.js
+++ b/packages/select/test/dirty-state.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-select.js';

--- a/packages/select/test/dirty-state.test.js
+++ b/packages/select/test/dirty-state.test.js
@@ -28,7 +28,7 @@ describe('dirty state', () => {
     expect(select.dirty).to.be.false;
   });
 
-  it('should not be dirty after closing the overlay without change', async () => {
+  it('should not be dirty after outside click without change', async () => {
     select.focus();
     select.click();
     outsideClick();

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -9,6 +9,7 @@ import type { SelectListBox } from '../../src/vaadin-select-list-box.js';
 import type {
   Select,
   SelectChangeEvent,
+  SelectDirtyChangedEvent,
   SelectInvalidChangedEvent,
   SelectItem as Item,
   SelectOpenedChangedEvent,
@@ -57,6 +58,11 @@ select.addEventListener('opened-changed', (event) => {
 
 select.addEventListener('invalid-changed', (event) => {
   assertType<SelectInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+select.addEventListener('dirty-changed', (event) => {
+  assertType<SelectDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -20,6 +20,11 @@ export type TextAreaChangeEvent = Event & {
 export type TextAreaInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type TextAreaDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type TextAreaValueChangedEvent = CustomEvent<{ value: string }>;
@@ -31,6 +36,8 @@ export type TextAreaValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface TextAreaCustomEventMap {
   'invalid-changed': TextAreaInvalidChangedEvent;
+
+  'dirty-changed': TextAreaDirtyChangedEvent;
 
   'value-changed': TextAreaValueChangedEvent;
 
@@ -80,6 +87,7 @@ export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEve
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/text-area/test/typings/text-area.types.ts
+++ b/packages/text-area/test/typings/text-area.types.ts
@@ -8,6 +8,7 @@ import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-th
 import type {
   TextArea,
   TextAreaChangeEvent,
+  TextAreaDirtyChangedEvent,
   TextAreaInvalidChangedEvent,
   TextAreaValidatedEvent,
   TextAreaValueChangedEvent,
@@ -33,6 +34,11 @@ area.addEventListener('change', (event) => {
 
 area.addEventListener('invalid-changed', (event) => {
   assertType<TextAreaInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+area.addEventListener('dirty-changed', (event) => {
+  assertType<TextAreaDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -20,6 +20,11 @@ export type TextFieldChangeEvent = Event & {
 export type TextFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type TextFieldDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type TextFieldValueChangedEvent = CustomEvent<{ value: string }>;
@@ -31,6 +36,8 @@ export type TextFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface TextFieldCustomEventMap {
   'invalid-changed': TextFieldInvalidChangedEvent;
+
+  'dirty-changed': TextFieldDirtyChangedEvent;
 
   'value-changed': TextFieldValueChangedEvent;
 
@@ -101,6 +108,7 @@ export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomE
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/text-field/test/typings/text-field.types.ts
+++ b/packages/text-field/test/typings/text-field.types.ts
@@ -8,6 +8,7 @@ import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-th
 import type {
   TextField,
   TextFieldChangeEvent,
+  TextFieldDirtyChangedEvent,
   TextFieldInvalidChangedEvent,
   TextFieldValidatedEvent,
   TextFieldValueChangedEvent,
@@ -33,6 +34,11 @@ field.addEventListener('change', (event) => {
 
 field.addEventListener('invalid-changed', (event) => {
   assertType<TextFieldInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+field.addEventListener('dirty-changed', (event) => {
+  assertType<TextFieldDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -38,6 +38,11 @@ export type TimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
 export type TimePickerOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type TimePickerDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type TimePickerValueChangedEvent = CustomEvent<{ value: string }>;
@@ -51,6 +56,8 @@ export interface TimePickerCustomEventMap {
   'invalid-changed': TimePickerInvalidChangedEvent;
 
   'opened-changed': TimePickerOpenedChangedEvent;
+
+  'dirty-changed': TimePickerDirtyChangedEvent;
 
   'value-changed': TimePickerValueChangedEvent;
 
@@ -115,6 +122,7 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -115,6 +115,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
         <vaadin-time-picker-combo-box
           id="comboBox"
           filtered-items="[[__dropdownItems]]"
+          dirty="{{dirty}}"
           value="{{_comboBoxValue}}"
           opened="{{opened}}"
           disabled="[[disabled]]"

--- a/packages/time-picker/test/dirty-state.test.js
+++ b/packages/time-picker/test/dirty-state.test.js
@@ -64,7 +64,7 @@ describe('dirty state', () => {
     expect(timePicker.dirty).to.be.true;
   });
 
-  it('should be dirty after clicking the clear button', () => {
+  it('should be dirty after clear button click', () => {
     timePicker.clearButtonVisible = true;
     timePicker.value = '12:00';
     timePicker.$.clearButton.click();

--- a/packages/time-picker/test/dirty-state.test.js
+++ b/packages/time-picker/test/dirty-state.test.js
@@ -1,15 +1,14 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '../src/vaadin-time-picker.js';
 import { getAllItems } from './helpers.js';
 
 describe('dirty state', () => {
-  let timePicker, input;
+  let timePicker;
 
   beforeEach(() => {
     timePicker = fixtureSync('<vaadin-time-picker></vaadin-time-picker>');
-    input = timePicker.inputElement;
   });
 
   it('should not be dirty by default', () => {
@@ -17,48 +16,49 @@ describe('dirty state', () => {
   });
 
   it('should not be dirty after blur without change', () => {
-    input.focus();
-    input.blur();
+    timePicker.focus();
+    timePicker.blur();
     expect(timePicker.dirty).to.be.false;
   });
 
   it('should not be dirty after outside click without change', async () => {
-    input.focus();
-    input.click();
+    timePicker.focus();
+    timePicker.click();
     outsideClick();
     expect(timePicker.dirty).to.be.false;
   });
 
   it('should not be dirty after pressing Enter without change', async () => {
-    input.focus();
+    timePicker.focus();
     await sendKeys({ press: 'Enter' });
     expect(timePicker.dirty).to.be.false;
   });
 
   it('should not be dirty after cancelling selection and closing the dropdown', async () => {
-    input.focus();
-    input.click();
+    timePicker.focus();
+    timePicker.click();
     await sendKeys({ press: 'ArrowDown' });
     await sendKeys({ press: 'Escape' });
     await sendKeys({ press: 'Escape' });
     expect(timePicker.dirty).to.be.false;
   });
 
-  it('should be dirty after user input', () => {
-    fire(input, 'input');
+  it('should be dirty after user input', async () => {
+    timePicker.focus();
+    await sendKeys({ type: '1' });
     expect(timePicker.dirty).to.be.true;
   });
 
   it('should be dirty after selecting a dropdown item with click', () => {
-    input.focus();
-    input.click();
+    timePicker.focus();
+    timePicker.click();
     getAllItems(timePicker)[0].click();
     expect(timePicker.dirty).to.be.true;
   });
 
   it('should be dirty after selecting a dropdown item with Enter', async () => {
-    input.focus();
-    input.click();
+    timePicker.focus();
+    timePicker.click();
     await sendKeys({ press: 'ArrowDown' });
     await sendKeys({ press: 'Enter' });
     expect(timePicker.dirty).to.be.true;

--- a/packages/time-picker/test/dirty-state.test.js
+++ b/packages/time-picker/test/dirty-state.test.js
@@ -1,0 +1,73 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, outsideClick } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import '../src/vaadin-time-picker.js';
+import { getAllItems } from './helpers.js';
+
+describe('dirty state', () => {
+  let timePicker, input;
+
+  beforeEach(() => {
+    timePicker = fixtureSync('<vaadin-time-picker></vaadin-time-picker>');
+    input = timePicker.inputElement;
+  });
+
+  it('should not be dirty by default', () => {
+    expect(timePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after blur without change', () => {
+    input.focus();
+    input.blur();
+    expect(timePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after outside click without change', async () => {
+    input.focus();
+    input.click();
+    outsideClick();
+    expect(timePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after pressing Enter without change', async () => {
+    input.focus();
+    await sendKeys({ press: 'Enter' });
+    expect(timePicker.dirty).to.be.false;
+  });
+
+  it('should not be dirty after cancelling selection and closing the dropdown', async () => {
+    input.focus();
+    input.click();
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Escape' });
+    await sendKeys({ press: 'Escape' });
+    expect(timePicker.dirty).to.be.false;
+  });
+
+  it('should be dirty after user input', () => {
+    fire(input, 'input');
+    expect(timePicker.dirty).to.be.true;
+  });
+
+  it('should be dirty after selecting a dropdown item with click', () => {
+    input.focus();
+    input.click();
+    getAllItems(timePicker)[0].click();
+    expect(timePicker.dirty).to.be.true;
+  });
+
+  it('should be dirty after selecting a dropdown item with Enter', async () => {
+    input.focus();
+    input.click();
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Enter' });
+    expect(timePicker.dirty).to.be.true;
+  });
+
+  it('should be dirty after clicking the clear button', () => {
+    timePicker.clearButtonVisible = true;
+    timePicker.value = '12:00';
+    timePicker.$.clearButton.click();
+    expect(timePicker.dirty).to.be.true;
+  });
+});

--- a/packages/time-picker/test/helpers.js
+++ b/packages/time-picker/test/helpers.js
@@ -10,3 +10,13 @@ export function setInputValue(timePicker, value) {
   timePicker.inputElement.value = value;
   fire(timePicker.inputElement, 'input');
 }
+
+/**
+ * Returns all the items of the time-picker dropdown.
+ */
+export const getAllItems = (timePicker) => {
+  const { comboBox } = timePicker.$;
+  return Array.from(comboBox._scroller.querySelectorAll('vaadin-time-picker-item'))
+    .filter((item) => !item.hidden)
+    .sort((a, b) => a.index - b.index);
+};

--- a/packages/time-picker/test/typings/time-picker.types.ts
+++ b/packages/time-picker/test/typings/time-picker.types.ts
@@ -15,6 +15,7 @@ import type { TimePickerItem } from '../../src/vaadin-time-picker-item.js';
 import type {
   TimePicker,
   TimePickerChangeEvent,
+  TimePickerDirtyChangedEvent,
   TimePickerInvalidChangedEvent,
   TimePickerOpenedChangedEvent,
   TimePickerValidatedEvent,
@@ -56,6 +57,11 @@ timePicker.addEventListener('invalid-changed', (event) => {
 
 timePicker.addEventListener('opened-changed', (event) => {
   assertType<TimePickerOpenedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+timePicker.addEventListener('dirty-changed', (event) => {
+  assertType<TimePickerDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 


### PR DESCRIPTION
## Description

Introduces a `dirty` boolean property to the field components. The component automatically becomes dirty once the user triggers an input or change event. Additionally, the component can be manually marked as dirty by setting the property to `true`.

Precedes:

- https://github.com/vaadin/flow-components/pull/5312
- https://github.com/vaadin/web-components/pull/6238

Part of #6146 

## Type of change

- [x] Feature