### PR TITLE
fix: ensure user input is reverted before validation on blur

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
@@ -152,6 +153,7 @@ interface ComboBoxLight<TItem = ComboBoxDefaultItem>
     InputMixinClass,
     DisabledMixinClass,
     ThemableMixinClass,
+    FocusMixinClass,
     ThemePropertyMixinClass,
     ValidateMixinClass {}
 

--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -196,19 +196,35 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
   }
 
   /**
+   * Override method inherited from `FocusMixin` to validate on blur.
+   * @param {boolean} focused
    * @protected
    * @override
    */
-  _onFocusout(event) {
+  _setFocused(focused) {
+    super._setFocused(focused);
+
+    // Do not validate when focusout is caused by document
+    // losing focus, which happens on browser tab switch.
+    if (!focused && document.hasFocus()) {
+      this.validate();
+    }
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  _shouldRemoveFocus(event) {
     const isBlurringControlButtons = event.target === this._toggleElement || event.target === this.clearElement;
     const isFocusingInputElement = event.relatedTarget && event.relatedTarget === this._nativeInput;
 
     // prevent closing the overlay when moving focus from clear or toggle buttons to the internal input
     if (isBlurringControlButtons && isFocusingInputElement) {
-      return;
+      return false;
     }
 
-    super._onFocusout(event);
+    return super._shouldRemoveFocus(event);
   }
 }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -5,6 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
@@ -19,6 +20,7 @@ export declare function ComboBoxMixin<TItem, T extends Constructor<HTMLElement>>
   base: T,
 ): Constructor<ComboBoxMixinClass<TItem>> &
   Constructor<DisabledMixinClass> &
+  Constructor<FocusMixinClass> &
   Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<OverlayClassMixinClass> &

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -271,24 +271,6 @@ class ComboBox extends ComboBoxDataProviderMixin(
   }
 
   /**
-   * Override method inherited from `FocusMixin` to not remove focused
-   * state when focus moves to the overlay.
-   * @param {FocusEvent} event
-   * @return {boolean}
-   * @protected
-   * @override
-   */
-  _shouldRemoveFocus(event) {
-    // Do not blur when focus moves to the overlay
-    if (event.relatedTarget === this._overlayElement) {
-      event.composedPath()[0].focus();
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
    * Override the method from `InputControlMixin`
    * to stop event propagation to prevent `ComboBoxMixin`
    * from handling this click event also on its own.

--- a/packages/combo-box/test/combo-box-light-validation.test.js
+++ b/packages/combo-box/test/combo-box-light-validation.test.js
@@ -1,0 +1,79 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './not-animated-styles.js';
+import '../vaadin-combo-box-light.js';
+
+describe('vaadin-combo-box-light - validation', () => {
+  let comboBox, input;
+
+  describe('basic', () => {
+    let validateSpy;
+
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box-light>
+          <input class="input" />
+        </vaadin-combo-box-light>
+      `);
+      comboBox.items = ['foo', 'bar', 'baz'];
+      await nextRender();
+      input = comboBox.inputElement;
+      validateSpy = sinon.spy(comboBox, 'validate');
+    });
+
+    it('should pass validation by default', () => {
+      expect(comboBox.checkValidity()).to.be.true;
+      expect(comboBox.validate()).to.be.true;
+      expect(comboBox.invalid).to.be.false;
+    });
+
+    it('should validate on blur', () => {
+      input.focus();
+      input.blur();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    describe('document losing focus', () => {
+      beforeEach(() => {
+        sinon.stub(document, 'hasFocus').returns(false);
+      });
+
+      afterEach(() => {
+        document.hasFocus.restore();
+      });
+
+      it('should not validate on blur when document does not have focus', () => {
+        input.focus();
+        input.blur();
+        expect(validateSpy.called).to.be.false;
+      });
+    });
+  });
+
+  describe('required', () => {
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box-light>
+          <input class="input" />
+        </vaadin-combo-box-light>
+      `);
+      comboBox.items = ['foo', 'bar', 'baz'];
+      comboBox.required = true;
+      await nextRender();
+    });
+
+    it('should fail validation without value', () => {
+      expect(comboBox.checkValidity()).to.be.false;
+      expect(comboBox.validate()).to.be.false;
+      expect(comboBox.invalid).to.be.true;
+    });
+
+    it('should pass validation with a value', () => {
+      comboBox.value = 'foo';
+      expect(comboBox.checkValidity()).to.be.true;
+      expect(comboBox.validate()).to.be.true;
+      expect(comboBox.invalid).to.be.false;
+    });
+  });
+});

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -1029,7 +1029,7 @@ describe('lazy loading', () => {
         let returnedItems;
 
         const bluringDataProvider = (params, callback) => {
-          comboBox.blur();
+          comboBox.inputElement.blur();
           callback(returnedItems, returnedItems.length);
         };
 

--- a/packages/combo-box/test/validation.test.js
+++ b/packages/combo-box/test/validation.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
@@ -86,6 +87,14 @@ describe('validation', () => {
       expect(comboBox.checkValidity()).to.be.true;
       expect(comboBox.validate()).to.be.true;
       expect(comboBox.invalid).to.be.false;
+    });
+
+    it('should be invalid after user input is reverted on blur', async () => {
+      input.focus();
+      await sendKeys({ type: 'custom' });
+      await nextRender();
+      input.blur();
+      expect(comboBox.invalid).to.be.true;
     });
   });
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -232,18 +232,20 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   /**
    * Override method inherited from the combo-box
    * to close dropdown on blur when readonly.
-   * @param {FocusEvent} event
+   * @param {boolean} focused
    * @protected
    * @override
    */
-  _onFocusout(event) {
+  _setFocused(focused) {
     // Disable combo-box logic that updates selectedItem
     // based on the overlay focused index on input blur
-    this._ignoreCommitValue = true;
+    if (!focused) {
+      this._ignoreCommitValue = true;
+    }
 
-    super._onFocusout(event);
+    super._setFocused(focused);
 
-    if (this.readonly && !this._closeOnBlurIsPrevented) {
+    if (!focused && this.readonly && !this._closeOnBlurIsPrevented) {
       this.close();
     }
   }


### PR DESCRIPTION
## Description

Fixes an issue where `<combo-box required>` didn't get invalidated after entering an invalid value and subsequently clicking outside. The issue occurred because `combo-box` triggered validation before reverting user input and from the perspective of the HTML constraint validation, it appeared as if `combo-box` had a value.

Along the way, the PR fixes `combo-box-light` not getting validated on blur and also adds the `focused` attribute for it.

Fixes https://github.com/vaadin/web-components/issues/6164

## Type of change

- [x] Bugfix
