### PR TITLE
refactor: extract basic dialog logic to separate mixin

### DIFF
--- a/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+export declare function DialogBaseMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<DialogBaseMixinClass> & T;
+
+export declare class DialogBaseMixinClass {
+  /**
+   * True if the overlay is currently displayed.
+   */
+  opened: boolean;
+
+  /**
+   * Set to true to disable closing dialog on outside click
+   * @attr {boolean} no-close-on-outside-click
+   */
+  noCloseOnOutsideClick: boolean;
+
+  /**
+   * Set to true to disable closing dialog on Escape press
+   * @attr {boolean} no-close-on-esc
+   */
+  noCloseOnEsc: boolean;
+
+  /**
+   * Set to true to remove backdrop and allow click events on background elements.
+   */
+  modeless: boolean;
+}

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * @polymerMixin
+ */
+export const DialogBaseMixin = (superClass) =>
+  class DialogBaseMixin extends superClass {
+    static get properties() {
+      return {
+        /**
+         * True if the overlay is currently displayed.
+         * @type {boolean}
+         */
+        opened: {
+          type: Boolean,
+          value: false,
+          notify: true,
+        },
+
+        /**
+         * Set to true to disable closing dialog on outside click
+         * @attr {boolean} no-close-on-outside-click
+         * @type {boolean}
+         */
+        noCloseOnOutsideClick: {
+          type: Boolean,
+          value: false,
+        },
+
+        /**
+         * Set to true to disable closing dialog on Escape press
+         * @attr {boolean} no-close-on-esc
+         * @type {boolean}
+         */
+        noCloseOnEsc: {
+          type: Boolean,
+          value: false,
+        },
+
+        /**
+         * Set to true to remove backdrop and allow click events on background elements.
+         * @type {boolean}
+         */
+        modeless: {
+          type: Boolean,
+          value: false,
+        },
+      };
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      const overlay = this.$.overlay;
+
+      overlay.addEventListener('vaadin-overlay-outside-click', this._handleOutsideClick.bind(this));
+      overlay.addEventListener('vaadin-overlay-escape-press', this._handleEscPress.bind(this));
+
+      this._overlayElement = overlay;
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+      // Restore opened state if overlay was opened when disconnecting
+      if (this.__restoreOpened) {
+        this.opened = true;
+      }
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      // Automatically close the overlay when dialog is removed from DOM
+      // Using a timeout to avoid toggling opened state, and dispatching change
+      // events, when just moving the dialog in the DOM
+      setTimeout(() => {
+        if (!this.isConnected) {
+          this.__restoreOpened = this.opened;
+          this.opened = false;
+        }
+      });
+    }
+
+    /** @private */
+    _onOverlayOpened(e) {
+      if (e.detail.value === false) {
+        this.opened = false;
+      }
+    }
+
+    /**
+     * Close the dialog if `noCloseOnOutsideClick` isn't set to true
+     * @private
+     */
+    _handleOutsideClick(e) {
+      if (this.noCloseOnOutsideClick) {
+        e.preventDefault();
+      }
+    }
+
+    /**
+     * Close the dialog if `noCloseOnEsc` isn't set to true
+     * @private
+     */
+    _handleEscPress(e) {
+      if (this.noCloseOnEsc) {
+        e.preventDefault();
+      }
+    }
+
+    /** @private */
+    _bringOverlayToFront() {
+      if (this.modeless) {
+        this._overlayElement.bringToFront();
+      }
+    }
+  };

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -87,7 +87,7 @@ export const DialogBaseMixin = (superClass) =>
       });
     }
 
-    /** @private */
+    /** @protected */
     _onOverlayOpened(e) {
       if (e.detail.value === false) {
         this.opened = false;

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -6,6 +6,7 @@
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import { DialogBaseMixin } from './vaadin-dialog-base-mixin.js';
 import { DialogDraggableMixin } from './vaadin-dialog-draggable-mixin.js';
 import { DialogResizableMixin } from './vaadin-dialog-resizable-mixin.js';
 
@@ -101,8 +102,8 @@ export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
-declare class Dialog extends OverlayClassMixin(
-  ThemePropertyMixin(ElementMixin(DialogDraggableMixin(DialogResizableMixin(HTMLElement)))),
+declare class Dialog extends DialogDraggableMixin(
+  DialogResizableMixin(DialogBaseMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement))))),
 ) {
   /**
    * True if the overlay is currently displayed.

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -9,6 +9,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import { DialogBaseMixin } from './vaadin-dialog-base-mixin.js';
 import { DialogDraggableMixin } from './vaadin-dialog-draggable-mixin.js';
 import { DialogResizableMixin } from './vaadin-dialog-resizable-mixin.js';
 
@@ -78,12 +79,13 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  * @extends HTMLElement
  * @mixes ThemePropertyMixin
  * @mixes ElementMixin
+ * @mixes DialogBaseMixin
  * @mixes DialogDraggableMixin
  * @mixes DialogResizableMixin
  * @mixes OverlayClassMixin
  */
-class Dialog extends OverlayClassMixin(
-  ThemePropertyMixin(ElementMixin(DialogDraggableMixin(DialogResizableMixin(PolymerElement)))),
+class Dialog extends DialogDraggableMixin(
+  DialogResizableMixin(DialogBaseMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerElement))))),
 ) {
   static get template() {
     return html`
@@ -115,36 +117,6 @@ class Dialog extends OverlayClassMixin(
 
   static get properties() {
     return {
-      /**
-       * True if the overlay is currently displayed.
-       * @type {boolean}
-       */
-      opened: {
-        type: Boolean,
-        value: false,
-        notify: true,
-      },
-
-      /**
-       * Set to true to disable closing dialog on outside click
-       * @attr {boolean} no-close-on-outside-click
-       * @type {boolean}
-       */
-      noCloseOnOutsideClick: {
-        type: Boolean,
-        value: false,
-      },
-
-      /**
-       * Set to true to disable closing dialog on Escape press
-       * @attr {boolean} no-close-on-esc
-       * @type {boolean}
-       */
-      noCloseOnEsc: {
-        type: Boolean,
-        value: false,
-      },
-
       /**
        * Set the `aria-label` attribute for assistive technologies like
        * screen readers. An empty string value for this property (the
@@ -204,15 +176,6 @@ class Dialog extends OverlayClassMixin(
        * @type {DialogRenderer | undefined}
        */
       footerRenderer: Function,
-
-      /**
-       * Set to true to remove backdrop and allow click events on background elements.
-       * @type {boolean}
-       */
-      modeless: {
-        type: Boolean,
-        value: false,
-      },
     };
   }
 
@@ -228,13 +191,7 @@ class Dialog extends OverlayClassMixin(
   ready() {
     super.ready();
 
-    const overlay = this.$.overlay;
-    overlay.setAttribute('role', 'dialog');
-
-    overlay.addEventListener('vaadin-overlay-outside-click', this._handleOutsideClick.bind(this));
-    overlay.addEventListener('vaadin-overlay-escape-press', this._handleEscPress.bind(this));
-
-    this._overlayElement = overlay;
+    this._overlayElement.setAttribute('role', 'dialog');
 
     processTemplates(this);
   }
@@ -266,20 +223,6 @@ class Dialog extends OverlayClassMixin(
     }
   }
 
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    // Automatically close the overlay when dialog is removed from DOM
-    // Using a timeout to avoid toggling opened state, and dispatching change
-    // events, when just moving the dialog in the DOM
-    setTimeout(() => {
-      if (!this.isConnected) {
-        this.__restoreOpened = this.opened;
-        this.opened = false;
-      }
-    });
-  }
-
   /** @private */
   _openedChanged(opened) {
     this.$.overlay.opened = opened;
@@ -291,40 +234,6 @@ class Dialog extends OverlayClassMixin(
       this.$.overlay.setAttribute('aria-label', ariaLabel || headerTitle);
     } else {
       this.$.overlay.removeAttribute('aria-label');
-    }
-  }
-
-  /** @private */
-  _onOverlayOpened(e) {
-    if (e.detail.value === false) {
-      this.opened = false;
-    }
-  }
-
-  /**
-   * Close the dialog if `noCloseOnOutsideClick` isn't set to true
-   * @private
-   */
-  _handleOutsideClick(e) {
-    if (this.noCloseOnOutsideClick) {
-      e.preventDefault();
-    }
-  }
-
-  /**
-   * Close the dialog if `noCloseOnEsc` isn't set to true
-   * @private
-   */
-  _handleEscPress(e) {
-    if (this.noCloseOnEsc) {
-      e.preventDefault();
-    }
-  }
-
-  /** @private */
-  _bringOverlayToFront() {
-    if (this.modeless) {
-      this.$.overlay.bringToFront();
     }
   }
 }

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -214,15 +214,6 @@ class Dialog extends DialogDraggableMixin(
     this.$.overlay.setProperties({ owner: this, renderer, headerRenderer, footerRenderer });
   }
 
-  /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-    // Restore opened state if overlay was opened when disconnecting
-    if (this.__restoreOpened) {
-      this.opened = true;
-    }
-  }
-
   /** @private */
   _openedChanged(opened) {
     this.$.overlay.opened = opened;


### PR DESCRIPTION
## Description

Currently, converting `vaadin-dialog` and depending components to LitElement is a bit complicated.

This PR aims to decouple extensions e.g. to make `vaadin-crud-dialog` still on Polymer for now.
We could achieve that by not extending `vaadin-dialog` and using `DialogBaseMixin` instead.

## Type of change

- Refactor