### PR TITLE
refactor: update crud-dialog to not use dialog extension

### DIFF
--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -10,11 +10,13 @@
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { Dialog } from '@vaadin/dialog/src/vaadin-dialog.js';
+import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { DialogBaseMixin } from '@vaadin/dialog/src/vaadin-dialog-base-mixin.js';
 import { dialogOverlay, resizableOverlay } from '@vaadin/dialog/src/vaadin-dialog-styles.js';
 import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
 import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
 const crudDialogOverlay = css`
   [part='overlay'] {
@@ -101,26 +103,26 @@ class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolymerEleme
 customElements.define(CrudDialogOverlay.is, CrudDialogOverlay);
 
 /**
- * An extension of `<vaadin-dialog>` used internally by `<vaadin-crud>`.
- * Not intended to be used separately.
+ * An element used internally by `<vaadin-crud>`. Not intended to be used separately.
  * @private
  */
-class CrudDialog extends Dialog {
+class CrudDialog extends DialogBaseMixin(OverlayClassMixin(ThemePropertyMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-crud-dialog';
   }
 
   static get properties() {
     return {
+      ariaLabel: {
+        type: String,
+      },
+
       fullscreen: {
         type: Boolean,
       },
     };
   }
 
-  /**
-   * Override template to provide custom overlay tag name.
-   */
   static get template() {
     return html`
       <style>
@@ -131,6 +133,8 @@ class CrudDialog extends Dialog {
 
       <vaadin-crud-dialog-overlay
         id="overlay"
+        opened="[[opened]]"
+        aria-label$="[[ariaLabel]]"
         on-opened-changed="_onOverlayOpened"
         on-mousedown="_bringOverlayToFront"
         on-touchstart="_bringOverlayToFront"


### PR DESCRIPTION
## Description

Depends on #6165

Same as #6166 but for `vaadin-crud`.

Updated `vaadin-crud-dialog` to not extend `vaadin-dialog` internally and use `DialogBaseMixin`.
This change enables us to convert these two components to Lit independently from each other.

## Type of change

- Refactor