### PR TITLE
fix: validate combo-box-light on blur, add focused attribute 

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
@@ -152,6 +153,7 @@ interface ComboBoxLight<TItem = ComboBoxDefaultItem>
     InputMixinClass,
     DisabledMixinClass,
     ThemableMixinClass,
+    FocusMixinClass,
     ThemePropertyMixinClass,
     ValidateMixinClass {}
 

--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -199,16 +199,16 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
    * @protected
    * @override
    */
-  _onFocusout(event) {
+  _shouldRemoveFocus(event) {
     const isBlurringControlButtons = event.target === this._toggleElement || event.target === this.clearElement;
     const isFocusingInputElement = event.relatedTarget && event.relatedTarget === this._nativeInput;
 
     // prevent closing the overlay when moving focus from clear or toggle buttons to the internal input
     if (isBlurringControlButtons && isFocusingInputElement) {
-      return;
+      return false;
     }
 
-    super._onFocusout(event);
+    return super._shouldRemoveFocus(event);
   }
 }
 

--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -196,6 +196,22 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
   }
 
   /**
+   * Override method inherited from `FocusMixin` to validate on blur.
+   * @param {boolean} focused
+   * @protected
+   * @override
+   */
+  _setFocused(focused) {
+    super._setFocused(focused);
+
+    // Do not validate when focusout is caused by document
+    // losing focus, which happens on browser tab switch.
+    if (!focused && document.hasFocus()) {
+      this.validate();
+    }
+  }
+
+  /**
    * @protected
    * @override
    */

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -5,6 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
@@ -19,6 +20,7 @@ export declare function ComboBoxMixin<TItem, T extends Constructor<HTMLElement>>
   base: T,
 ): Constructor<ComboBoxMixinClass<TItem>> &
   Constructor<DisabledMixinClass> &
+  Constructor<FocusMixinClass> &
   Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<OverlayClassMixinClass> &

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1245,12 +1245,6 @@ export const ComboBoxMixin = (subclass) =>
           this._closeOrCommit();
         }
       }
-
-      // Do not validate when focusout is caused by document
-      // losing focus, which happens on browser tab switch.
-      if (!focused && document.hasFocus()) {
-        this.validate();
-      }
     }
 
     /**

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1227,7 +1227,8 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /**
-     * Override method inherited from `FocusMixin` to validate on blur.
+     * Override method inherited from `FocusMixin`
+     * to close the overlay on blur and commit the value.
      *
      * @param {boolean} focused
      * @protected
@@ -1241,9 +1242,10 @@ export const ComboBoxMixin = (subclass) =>
         // which will result in attempting to commit the same custom value once again.
         if (!this.opened && this.allowCustomValue && this._inputElementValue === this._lastCustomValue) {
           delete this._lastCustomValue;
-        } else {
-          this._closeOrCommit();
+          return;
         }
+
+        this._closeOrCommit();
       }
     }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
@@ -48,12 +49,13 @@ function findItemIndex(items, callback) {
  * @mixes DisabledMixin
  * @mixes InputMixin
  * @mixes KeyboardMixin
+ * @mixes FocusMixin
  * @mixes OverlayClassMixin
  * @param {function(new:HTMLElement)} subclass
  */
 export const ComboBoxMixin = (subclass) =>
   class ComboBoxMixinClass extends OverlayClassMixin(
-    ControllerMixin(KeyboardMixin(InputMixin(DisabledMixin(subclass)))),
+    ControllerMixin(FocusMixin(KeyboardMixin(InputMixin(DisabledMixin(subclass))))),
   ) {
     static get properties() {
       return {
@@ -253,7 +255,6 @@ export const ComboBoxMixin = (subclass) =>
 
     constructor() {
       super();
-      this._boundOnFocusout = this._onFocusout.bind(this);
       this._boundOverlaySelectedItemChanged = this._overlaySelectedItemChanged.bind(this);
       this._boundOnClearButtonMouseDown = this.__onClearButtonMouseDown.bind(this);
       this._boundOnClick = this._onClick.bind(this);
@@ -319,8 +320,6 @@ export const ComboBoxMixin = (subclass) =>
 
       this._initOverlay();
       this._initScroller();
-
-      this.addEventListener('focusout', this._boundOnFocusout);
 
       this._lastCommittedValue = this.value;
 
@@ -1227,29 +1226,57 @@ export const ComboBoxMixin = (subclass) =>
       }
     }
 
-    /** @private */
-    _onFocusout(event) {
-      // VoiceOver on iOS fires `focusout` event when moving focus to the item in the dropdown.
-      // Do not focus the input in this case, because it would break announcement for the item.
-      if (event.relatedTarget && event.relatedTarget.localName === `${this._tagNamePrefix}-item`) {
-        return;
-      }
+    /**
+     * Override method inherited from `FocusMixin` to validate on blur.
+     *
+     * @param {boolean} focused
+     * @protected
+     * @override
+     */
+    _setFocused(focused) {
+      super._setFocused(focused);
 
-      // Fixes the problem with `focusout` happening when clicking on the scroll bar on Edge
-      if (event.relatedTarget === this._overlayElement) {
-        event.composedPath()[0].focus();
-        return;
-      }
-      if (!this.readonly && !this._closeOnBlurIsPrevented) {
+      if (!focused && !this.readonly && !this._closeOnBlurIsPrevented) {
         // User's logic in `custom-value-set` event listener might cause input to blur,
         // which will result in attempting to commit the same custom value once again.
         if (!this.opened && this.allowCustomValue && this._inputElementValue === this._lastCustomValue) {
           delete this._lastCustomValue;
-          return;
+        } else {
+          this._closeOrCommit();
         }
-
-        this._closeOrCommit();
       }
+
+      // Do not validate when focusout is caused by document
+      // losing focus, which happens on browser tab switch.
+      if (!focused && document.hasFocus()) {
+        this.validate();
+      }
+    }
+
+    /**
+     * Override method inherited from `FocusMixin` to not remove focused
+     * state when focus moves to the overlay.
+     *
+     * @param {FocusEvent} event
+     * @return {boolean}
+     * @protected
+     * @override
+     */
+    _shouldRemoveFocus(event) {
+      // VoiceOver on iOS fires `focusout` event when moving focus to the item in the dropdown.
+      // Do not focus the input in this case, because it would break announcement for the item.
+      if (event.relatedTarget && event.relatedTarget.localName === `${this._tagNamePrefix}-item`) {
+        return false;
+      }
+
+      // Do not blur when focus moves to the overlay
+      // Also, fixes the problem with `focusout` happening when clicking on the scroll bar on Edge
+      if (event.relatedTarget === this._overlayElement) {
+        event.composedPath()[0].focus();
+        return false;
+      }
+
+      return true;
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -255,6 +255,22 @@ class ComboBox extends ComboBoxDataProviderMixin(
   }
 
   /**
+   * Override method inherited from `FocusMixin` to validate on blur.
+   * @param {boolean} focused
+   * @protected
+   * @override
+   */
+  _setFocused(focused) {
+    super._setFocused(focused);
+
+    // Do not validate when focusout is caused by document
+    // losing focus, which happens on browser tab switch.
+    if (!focused && document.hasFocus()) {
+      this.validate();
+    }
+  }
+
+  /**
    * Override the method from `InputControlMixin`
    * to stop event propagation to prevent `ComboBoxMixin`
    * from handling this click event also on its own.
@@ -278,22 +294,6 @@ class ComboBox extends ComboBoxDataProviderMixin(
     // Open dropdown only when clicking on the label or input field
     if (path.includes(this._labelNode) || path.includes(this._positionTarget)) {
       super._onHostClick(event);
-    }
-  }
-
-  /**
-   * Override method inherited from `FocusMixin` to validate on blur.
-   * @param {boolean} focused
-   * @protected
-   * @override
-   */
-  _setFocused(focused) {
-    super._setFocused(focused);
-
-    // Do not validate when focusout is caused by document
-    // losing focus, which happens on browser tab switch.
-    if (!focused && document.hasFocus()) {
-      this.validate();
     }
   }
 }

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -280,6 +280,22 @@ class ComboBox extends ComboBoxDataProviderMixin(
       super._onHostClick(event);
     }
   }
+
+  /**
+   * Override method inherited from `FocusMixin` to validate on blur.
+   * @param {boolean} focused
+   * @protected
+   * @override
+   */
+  _setFocused(focused) {
+    super._setFocused(focused);
+
+    // Do not validate when focusout is caused by document
+    // losing focus, which happens on browser tab switch.
+    if (!focused && document.hasFocus()) {
+      this.validate();
+    }
+  }
 }
 
 customElements.define(ComboBox.is, ComboBox);

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -255,40 +255,6 @@ class ComboBox extends ComboBoxDataProviderMixin(
   }
 
   /**
-   * Override method inherited from `FocusMixin` to validate on blur.
-   * @param {boolean} focused
-   * @protected
-   * @override
-   */
-  _setFocused(focused) {
-    super._setFocused(focused);
-
-    // Do not validate when focusout is caused by document
-    // losing focus, which happens on browser tab switch.
-    if (!focused && document.hasFocus()) {
-      this.validate();
-    }
-  }
-
-  /**
-   * Override method inherited from `FocusMixin` to not remove focused
-   * state when focus moves to the overlay.
-   * @param {FocusEvent} event
-   * @return {boolean}
-   * @protected
-   * @override
-   */
-  _shouldRemoveFocus(event) {
-    // Do not blur when focus moves to the overlay
-    if (event.relatedTarget === this._overlayElement) {
-      event.composedPath()[0].focus();
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
    * Override the method from `InputControlMixin`
    * to stop event propagation to prevent `ComboBoxMixin`
    * from handling this click event also on its own.

--- a/packages/combo-box/test/combo-box-light-validation.test.js
+++ b/packages/combo-box/test/combo-box-light-validation.test.js
@@ -5,7 +5,7 @@ import './not-animated-styles.js';
 import '../vaadin-combo-box-light.js';
 
 describe('vaadin-combo-box-light - validation', () => {
-  let comboBox;
+  let comboBox, input;
 
   describe('basic', () => {
     let validateSpy;
@@ -18,6 +18,7 @@ describe('vaadin-combo-box-light - validation', () => {
       `);
       comboBox.items = ['foo', 'bar', 'baz'];
       await nextRender();
+      input = comboBox.inputElement;
       validateSpy = sinon.spy(comboBox, 'validate');
     });
 
@@ -28,9 +29,25 @@ describe('vaadin-combo-box-light - validation', () => {
     });
 
     it('should validate on blur', () => {
-      comboBox.inputElement.focus();
-      comboBox.inputElement.blur();
+      input.focus();
+      input.blur();
       expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    describe('document losing focus', () => {
+      beforeEach(() => {
+        sinon.stub(document, 'hasFocus').returns(false);
+      });
+
+      afterEach(() => {
+        document.hasFocus.restore();
+      });
+
+      it('should not validate on blur when document does not have focus', () => {
+        input.focus();
+        input.blur();
+        expect(validateSpy.called).to.be.false;
+      });
     });
   });
 

--- a/packages/combo-box/test/combo-box-light-validation.test.js
+++ b/packages/combo-box/test/combo-box-light-validation.test.js
@@ -1,0 +1,62 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './not-animated-styles.js';
+import '../vaadin-combo-box-light.js';
+
+describe('vaadin-combo-box-light - validation', () => {
+  let comboBox;
+
+  describe('basic', () => {
+    let validateSpy;
+
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box-light>
+          <input class="input" />
+        </vaadin-combo-box-light>
+      `);
+      comboBox.items = ['foo', 'bar', 'baz'];
+      await nextRender();
+      validateSpy = sinon.spy(comboBox, 'validate');
+    });
+
+    it('should pass validation by default', () => {
+      expect(comboBox.checkValidity()).to.be.true;
+      expect(comboBox.validate()).to.be.true;
+      expect(comboBox.invalid).to.be.false;
+    });
+
+    it('should validate on blur', () => {
+      comboBox.inputElement.focus();
+      comboBox.inputElement.blur();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('required', () => {
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box-light>
+          <input class="input" />
+        </vaadin-combo-box-light>
+      `);
+      comboBox.items = ['foo', 'bar', 'baz'];
+      comboBox.required = true;
+      await nextRender();
+    });
+
+    it('should fail validation without value', () => {
+      expect(comboBox.checkValidity()).to.be.false;
+      expect(comboBox.validate()).to.be.false;
+      expect(comboBox.invalid).to.be.true;
+    });
+
+    it('should pass validation with a value', () => {
+      comboBox.value = 'foo';
+      expect(comboBox.checkValidity()).to.be.true;
+      expect(comboBox.validate()).to.be.true;
+      expect(comboBox.invalid).to.be.false;
+    });
+  });
+});

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -1029,7 +1029,7 @@ describe('lazy loading', () => {
         let returnedItems;
 
         const bluringDataProvider = (params, callback) => {
-          comboBox.blur();
+          comboBox.inputElement.blur();
           callback(returnedItems, returnedItems.length);
         };
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -232,18 +232,20 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   /**
    * Override method inherited from the combo-box
    * to close dropdown on blur when readonly.
-   * @param {FocusEvent} event
+   * @param {boolean} focused
    * @protected
    * @override
    */
-  _onFocusout(event) {
+  _setFocused(focused) {
     // Disable combo-box logic that updates selectedItem
     // based on the overlay focused index on input blur
-    this._ignoreCommitValue = true;
+    if (!focused) {
+      this._ignoreCommitValue = true;
+    }
 
-    super._onFocusout(event);
+    super._setFocused(focused);
 
-    if (this.readonly && !this._closeOnBlurIsPrevented) {
+    if (!focused && this.readonly && !this._closeOnBlurIsPrevented) {
       this.close();
     }
   }


### PR DESCRIPTION
## Description

The PR moves the `combo-box` focus logic into `combo-box-mixin` to share it with `combo-box-light`. This fixes `combo-box-light` not getting validated on blur and also adds the `focused` attribute to it.

Part of #6146, https://github.com/vaadin/web-components/issues/6164 

## Type of change

- [x] Bugfix
