### PR TITLE
test: update CRUD snapshot tests to use nextRender helper

### DIFF
--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -111,6 +111,7 @@ snapshots["vaadin-crud host default"] =
     </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-13">
       <vaadin-crud-edit
+        aria-label="Edit"
         role="button"
         tabindex="0"
       >

--- a/packages/crud/test/dom/crud.test.js
+++ b/packages/crud/test/dom/crud.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../vaadin-crud.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -15,7 +15,7 @@ describe('vaadin-crud', () => {
         age: 30,
       },
     ];
-    await nextFrame();
+    await nextRender();
   });
 
   describe('host', () => {


### PR DESCRIPTION
## Description

Turns out `nextFrame()` isn't enough for `vaadin-crud` to finish rendering, so I updated the test to use `nextRender()`.

## Type of change

- Tests