### PR TITLE
fix: use correct property to set CRUD dialog aria-label

### DIFF
--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -338,7 +338,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       <vaadin-crud-dialog
         id="dialog"
         opened="[[__computeDialogOpened(editorOpened, _fullscreen, editorPosition)]]"
-        aria-label="[[__editorAriaLabel]]"
+        aria-label="[[__dialogAriaLabel]]"
         no-close-on-outside-click="[[__isDirty]]"
         no-close-on-esc="[[__isDirty]]"
         theme$="[[_theme]]"
@@ -646,7 +646,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       },
 
       /** @private */
-      __editorAriaLabel: String,
+      __dialogAriaLabel: String,
 
       /** @private */
       __isDirty: Boolean,

--- a/packages/crud/test/a11y.test.js
+++ b/packages/crud/test/a11y.test.js
@@ -291,4 +291,34 @@ describe('a11y', () => {
       });
     });
   });
+
+  describe('dialog aria-label', () => {
+    let newButton, editButtons, dialog;
+
+    beforeEach(async () => {
+      crud = fixtureSync('<vaadin-crud></vaadin-crud>');
+      crud.items = [{ title: 'Item 1' }];
+      await nextRender();
+      newButton = crud.querySelector('[slot=new-button]');
+      editButtons = crud.querySelectorAll('vaadin-crud-edit');
+      dialog = crud.$.dialog;
+    });
+
+    afterEach(async () => {
+      crud.editorOpened = false;
+      await nextRender();
+    });
+
+    it('should set correct aria-label to the new item dialog', async () => {
+      newButton.click();
+      await nextRender();
+      expect(dialog.$.overlay.getAttribute('aria-label')).to.equal('New item');
+    });
+
+    it('should set correct aria-label to the edit item dialog', async () => {
+      editButtons[0].click();
+      await nextRender();
+      expect(dialog.$.overlay.getAttribute('aria-label')).to.equal('Edit item');
+    });
+  });
 });


### PR DESCRIPTION
## Description

This PR fixes an issue introduced in https://github.com/vaadin/web-components/pull/3108 where I incorrectly used two different names: `__editorAriaLabel` as a property passed in the template, and `__dialogAriaLabel` as a property storing the actual label. From now on, a single property will be used.

## Type of change

- Bugfix