### PR TITLE
refactor: pass fullscreen property to vaadin-crud overlay

### DIFF
--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -98,7 +98,7 @@ class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolymerEleme
   }
 }
 
-customElements.define('vaadin-crud-dialog-overlay', CrudDialogOverlay);
+customElements.define(CrudDialogOverlay.is, CrudDialogOverlay);
 
 /**
  * An extension of `<vaadin-dialog>` used internally by `<vaadin-crud>`.
@@ -106,6 +106,18 @@ customElements.define('vaadin-crud-dialog-overlay', CrudDialogOverlay);
  * @private
  */
 class CrudDialog extends Dialog {
+  static get is() {
+    return 'vaadin-crud-dialog';
+  }
+
+  static get properties() {
+    return {
+      fullscreen: {
+        type: Boolean,
+      },
+    };
+  }
+
   /**
    * Override template to provide custom overlay tag name.
    */
@@ -126,10 +138,11 @@ class CrudDialog extends Dialog {
         modeless="[[modeless]]"
         with-backdrop="[[!modeless]]"
         resizable$="[[resizable]]"
+        fullscreen$="[[fullscreen]]"
         focus-trap
       ></vaadin-crud-dialog-overlay>
     `;
   }
 }
 
-customElements.define('vaadin-crud-dialog', CrudDialog);
+customElements.define(CrudDialog.is, CrudDialog);

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -338,6 +338,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       <vaadin-crud-dialog
         id="dialog"
         opened="[[__computeDialogOpened(editorOpened, _fullscreen, editorPosition)]]"
+        fullscreen="[[_fullscreen]]"
         aria-label="[[__dialogAriaLabel]]"
         no-close-on-outside-click="[[__isDirty]]"
         no-close-on-esc="[[__isDirty]]"
@@ -851,7 +852,6 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       this.__ensureChildren();
 
       this.toggleAttribute('fullscreen', fullscreen);
-      this.$.dialog.$.overlay.toggleAttribute('fullscreen', fullscreen);
     }
   }
 


### PR DESCRIPTION
## Description

Extracted from #6162

This change is needed to get the component work with Lit, where nested elements aren't yet rendered by the time when the observer is called. In this case, `fullscreen` property is passed to `vaadin-crud-dialog` instead of accessing its DOM.

Also, I updated internal elements of `vaadin-crud` to use `static get is()` as we do that in other components.

## Type of change

- Refactor