### PR TITLE
fix: allow returning additional types from Lit renderers

### DIFF
--- a/packages/combo-box/src/lit/renderer-directives.d.ts
+++ b/packages/combo-box/src/lit/renderer-directives.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive.js';
+import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { ComboBox, ComboBoxItemModel } from '../vaadin-combo-box.js';
 
@@ -12,7 +12,7 @@ export type ComboBoxLitRenderer<TItem> = (
   item: TItem,
   model: ComboBoxItemModel<TItem>,
   comboBox: ComboBox<TItem>,
-) => TemplateResult;
+) => LitRendererResult;
 
 export class ComboBoxRendererDirective<TItem> extends LitRendererDirective<ComboBox, ComboBoxLitRenderer<TItem>> {
   /**

--- a/packages/context-menu/src/lit/renderer-directives.d.ts
+++ b/packages/context-menu/src/lit/renderer-directives.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive.js';
+import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { ContextMenu, ContextMenuRendererContext } from '../vaadin-context-menu.js';
 
-export type ContextMenuLitRenderer = (context: ContextMenuRendererContext, menu: ContextMenu) => TemplateResult;
+export type ContextMenuLitRenderer = (context: ContextMenuRendererContext, menu: ContextMenu) => LitRendererResult;
 
 export class ContextMenuRendererDirective extends LitRendererDirective<ContextMenu, ContextMenuLitRenderer> {
   /**

--- a/packages/dialog/src/lit/renderer-directives.d.ts
+++ b/packages/dialog/src/lit/renderer-directives.d.ts
@@ -4,12 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 /* eslint-disable max-classes-per-file */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive.js';
+import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { Dialog } from '../vaadin-dialog.js';
 
-export type DialogLitRenderer = (dialog: Dialog) => TemplateResult;
+export type DialogLitRenderer = (dialog: Dialog) => LitRendererResult;
 
 declare abstract class AbstractDialogRendererDirective extends LitRendererDirective<Dialog, DialogLitRenderer> {
   /**

--- a/packages/grid-pro/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid-pro/src/lit/column-renderer-directives.d.ts
@@ -8,9 +8,9 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive';
 import type { GridItemModel } from '@vaadin/grid';
+import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { GridProEditColumn } from '../vaadin-grid-pro-edit-column.js';
 
@@ -18,7 +18,7 @@ export type GridProColumnEditModeLitRenderer<TItem> = (
   item: TItem,
   model: GridItemModel<TItem>,
   column: GridProEditColumn,
-) => TemplateResult;
+) => LitRendererResult;
 
 export declare class GridProColumnEditModeRendererDirective<TItem> extends LitRendererDirective<
   GridProEditColumn,

--- a/packages/grid/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid/src/lit/column-renderer-directives.d.ts
@@ -4,9 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 /* eslint-disable max-classes-per-file */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive';
-import type { LitRenderer } from '@vaadin/lit-renderer';
+import type { LitRenderer, LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { GridItemModel } from '../vaadin-grid.js';
 import type { GridColumn } from '../vaadin-grid-column.js';
@@ -15,10 +14,10 @@ export type GridColumnBodyLitRenderer<TItem> = (
   item: TItem,
   model: GridItemModel<TItem>,
   column: GridColumn,
-) => TemplateResult;
+) => LitRendererResult;
 
-export type GridColumnHeaderLitRenderer = (column: GridColumn) => TemplateResult;
-export type GridColumnFooterLitRenderer = (column: GridColumn) => TemplateResult;
+export type GridColumnHeaderLitRenderer = (column: GridColumn) => LitRendererResult;
+export type GridColumnFooterLitRenderer = (column: GridColumn) => LitRendererResult;
 
 declare abstract class AbstractGridColumnRendererDirective<R extends LitRenderer> extends LitRendererDirective<
   GridColumn,

--- a/packages/grid/src/lit/renderer-directives.d.ts
+++ b/packages/grid/src/lit/renderer-directives.d.ts
@@ -3,12 +3,16 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive';
+import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { Grid, GridItemModel } from '../vaadin-grid.js';
 
-export type GridRowDetailsLitRenderer<TItem> = (item: TItem, model: GridItemModel<TItem>, grid: Grid) => TemplateResult;
+export type GridRowDetailsLitRenderer<TItem> = (
+  item: TItem,
+  model: GridItemModel<TItem>,
+  grid: Grid,
+) => LitRendererResult;
 
 export declare class GridRowDetailsRendererDirective<TItem> extends LitRendererDirective<
   Grid,

--- a/packages/lit-renderer/src/lit-renderer.d.ts
+++ b/packages/lit-renderer/src/lit-renderer.d.ts
@@ -3,10 +3,16 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { ElementPart, nothing, RenderOptions, TemplateResult } from 'lit';
+import type { ElementPart, noChange, nothing, RenderOptions, TemplateResult } from 'lit';
 import { AsyncDirective } from 'lit/async-directive.js';
 
-export type LitRenderer = (...args: any[]) => TemplateResult;
+// Opinionated union of types allowed to be returned from Lit renderers.
+// Theoretically Lit allows to render pretty much everything, but in practice
+// these seem the mose useful ones, without allowing developers to return things
+// like objects or dates that probably don't render the way they expect.
+export type LitRendererResult = TemplateResult | string | typeof noChange | typeof nothing | null;
+
+export type LitRenderer = (...args: any[]) => LitRendererResult;
 
 export abstract class LitRendererDirective<E extends Element, R extends LitRenderer> extends AsyncDirective {
   protected host: RenderOptions['host'];

--- a/packages/lit-renderer/src/lit-renderer.js
+++ b/packages/lit-renderer/src/lit-renderer.js
@@ -77,6 +77,10 @@ export class LitRendererDirective extends AsyncDirective {
 
   /** @protected */
   renderRenderer(container, ...args) {
+    // Note that a renderer result is not necessarily a `TemplateResult`
+    // instance, as Lit allows returning any value from a renderer. The concrete
+    // list of types we allow as render results is defined in the Typescript
+    // `LitRendererResult` type.
     const templateResult = this.renderer.call(this.host, ...args);
     render(templateResult, container, { host: this.host });
   }

--- a/packages/lit-renderer/test/typings/lit.types.ts
+++ b/packages/lit-renderer/test/typings/lit.types.ts
@@ -1,0 +1,10 @@
+import { html, noChange, nothing } from 'lit';
+import type { LitRenderer } from '../../src/lit-renderer';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+assertType<LitRenderer>(() => html`foo`);
+assertType<LitRenderer>(() => 'foo');
+assertType<LitRenderer>(() => noChange);
+assertType<LitRenderer>(() => nothing);
+assertType<LitRenderer>(() => null);

--- a/packages/multi-select-combo-box/src/lit/renderer-directives.d.ts
+++ b/packages/multi-select-combo-box/src/lit/renderer-directives.d.ts
@@ -3,9 +3,9 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive.js';
 import type { ComboBoxItemModel } from '@vaadin/combo-box/src/vaadin-combo-box.js';
+import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { MultiSelectComboBox } from '../vaadin-multi-select-combo-box.js';
 
@@ -13,7 +13,7 @@ export type MultiSelectComboBoxLitRenderer<TItem> = (
   item: TItem,
   model: ComboBoxItemModel<TItem>,
   comboBox: MultiSelectComboBox<TItem>,
-) => TemplateResult;
+) => LitRendererResult;
 
 export class MultiSelectComboBoxRendererDirective<TItem> extends LitRendererDirective<
   MultiSelectComboBox,

--- a/packages/notification/src/lit/renderer-directives.d.ts
+++ b/packages/notification/src/lit/renderer-directives.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive.js';
+import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { Notification } from '../vaadin-notification.js';
 
-export type NotificationLitRenderer = (notification: Notification) => TemplateResult;
+export type NotificationLitRenderer = (notification: Notification) => LitRendererResult;
 
 export class NotificationRendererDirective extends LitRendererDirective<Notification, NotificationLitRenderer> {
   /**

--- a/packages/select/src/lit/renderer-directives.d.ts
+++ b/packages/select/src/lit/renderer-directives.d.ts
@@ -3,12 +3,12 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive.js';
+import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { Select } from '../vaadin-select.js';
 
-export type SelectLitRenderer = (select: Select) => TemplateResult;
+export type SelectLitRenderer = (select: Select) => LitRendererResult;
 
 export class SelectRendererDirective extends LitRendererDirective<Select, SelectLitRenderer> {
   /**

--- a/packages/virtual-list/src/lit/renderer-directives.d.ts
+++ b/packages/virtual-list/src/lit/renderer-directives.d.ts
@@ -3,8 +3,8 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { TemplateResult } from 'lit';
 import type { DirectiveResult } from 'lit/directive.js';
+import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { VirtualList, VirtualListItemModel } from '../vaadin-virtual-list.js';
 
@@ -12,7 +12,7 @@ export type VirtualListLitRenderer<TItem> = (
   item: TItem,
   model: VirtualListItemModel<TItem>,
   virtualList: VirtualList<TItem>,
-) => TemplateResult;
+) => LitRendererResult;
 
 export class VirtualListRendererDirective<TItem> extends LitRendererDirective<
   VirtualList,


### PR DESCRIPTION
## Description

Allows to return additional types from Lit renderers when using Typescript.

Fixes https://github.com/vaadin/web-components/issues/6149

## Type of change

- Bugfix