### PR TITLE
refactor!: update avatar-group overlay to not extend vaadin-overlay

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group-overlay.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-overlay.js
@@ -3,8 +3,16 @@
  * Copyright (c) 2020 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles('vaadin-avatar-group-overlay', [overlayStyles], {
+  moduleId: 'vaadin-avatar-group-overlay-styles',
+});
 
 /**
  * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
@@ -12,9 +20,20 @@ import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin
  * @extends Overlay
  * @private
  */
-class AvatarGroupOverlay extends PositionMixin(Overlay) {
+class AvatarGroupOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-avatar-group-overlay';
+  }
+
+  static get template() {
+    return html`
+      <div id="backdrop" part="backdrop" hidden$="[[!withBackdrop]]"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <div part="content" id="content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/packages/avatar-group/theme/lumo/vaadin-avatar-group.js
+++ b/packages/avatar-group/theme/lumo/vaadin-avatar-group.js
@@ -1,4 +1,3 @@
 import '@vaadin/avatar/theme/lumo/vaadin-avatar.js';
-import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-avatar-group-styles.js';
 import '../../src/vaadin-avatar-group.js';

--- a/packages/avatar-group/theme/material/vaadin-avatar-group.js
+++ b/packages/avatar-group/theme/material/vaadin-avatar-group.js
@@ -1,4 +1,3 @@
 import '@vaadin/avatar/theme/material/vaadin-avatar.js';
-import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-avatar-group-styles.js';
 import '../../src/vaadin-avatar-group.js';


### PR DESCRIPTION
## Description

Part of #5718

Updated `vaadin-avatar-group-overlay` to use `OverlayMixin` and styles exposed as `css` literal.

## Type of change

- Refactor