### PR TITLE
refactor!: convert vaadin-dialog to be based on LitElement

### DIFF
--- a/integration/tests/dialog-accordion.test.js
+++ b/integration/tests/dialog-accordion.test.js
@@ -26,10 +26,10 @@ describe('accordion in dialog', () => {
         </vaadin-accordion>
       `;
     };
+    await nextRender();
     dialog.opened = true;
     overlay = dialog.$.overlay;
     await oneEvent(overlay, 'vaadin-overlay-open');
-    await nextRender();
     accordion = overlay.querySelector('vaadin-accordion');
     panels = accordion.items;
   });

--- a/integration/tests/dialog-combo-box.test.js
+++ b/integration/tests/dialog-combo-box.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, mousedown, nextFrame, touchstart } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, nextFrame, nextRender, touchstart } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';
 import '@vaadin/combo-box';
@@ -14,8 +14,7 @@ describe('combo-box in dialog', () => {
       root.innerHTML = '<vaadin-combo-box></vaadin-combo-box>';
     };
     dialog.opened = true;
-    dialog.opened = true;
-    await nextFrame();
+    await nextRender();
     comboBox = dialog.$.overlay.querySelector('vaadin-combo-box');
     comboBox.items = ['foo', 'bar'];
     comboBox.inputElement.focus();

--- a/integration/tests/dialog-grid-pro.test.js
+++ b/integration/tests/dialog-grid-pro.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, fixtureSync, focusin, focusout, nextFrame, outsideClick } from '@vaadin/testing-helpers';
+import { enter, fixtureSync, focusin, focusout, nextFrame, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import '@vaadin/date-picker';
 import '@vaadin/dialog';
 import '@vaadin/grid-pro';
@@ -51,8 +51,9 @@ const fixtures = {
   describe(`${type} grid-pro in dialog`, () => {
     let dialog, grid, dateCell;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       dialog = fixtureSync(fixtures[type]);
+      await nextRender();
       grid = dialog.$.overlay.querySelector('vaadin-grid-pro');
       grid.items = createItems();
       grid.style.width = '100px'; // Column default min width is 100px

--- a/integration/tests/dialog-template.test.js
+++ b/integration/tests/dialog-template.test.js
@@ -1,22 +1,24 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/dialog';
 
 describe('vaadin-dialog template', () => {
   let dialog, overlay;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dialog = fixtureSync(`
       <vaadin-dialog>
         <template>foo</template>
       </vaadin-dialog>
     `);
+    await nextRender();
     overlay = dialog.$.overlay;
   });
 
-  it('should render the template', () => {
+  it('should render the template', async () => {
     dialog.opened = true;
+    await nextRender();
     expect(overlay.textContent).to.equal('foo');
   });
 });

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -45,13 +45,15 @@ export const DialogDraggableMixin = (superClass) =>
     }
 
     /** @protected */
-    ready() {
+    async ready() {
       super.ready();
       this._originalBounds = {};
       this._originalMouseCoords = {};
       this._startDrag = this._startDrag.bind(this);
       this._drag = this._drag.bind(this);
       this._stopDrag = this._stopDrag.bind(this);
+
+      await this.$.overlay.updateComplete;
       this.$.overlay.$.overlay.addEventListener('mousedown', this._startDrag);
       this.$.overlay.$.overlay.addEventListener('touchstart', this._startDrag);
     }

--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -3,67 +3,30 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
-import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { html, LitElement } from 'lit';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { dialogOverlay, resizableOverlay } from './vaadin-dialog-styles.js';
-
-registerStyles('vaadin-dialog-overlay', [dialogOverlay, resizableOverlay], {
-  moduleId: 'vaadin-dialog-overlay-styles',
-});
-
-let memoizedTemplate;
 
 /**
  * An element used internally by `<vaadin-dialog>`. Not intended to be used separately.
  *
- * @extends Overlay
+ * @extends HTMLElement
+ * @mixes OverlayMixin
+ * @mixes DirMixin
+ * @mixes ThemableMixin
  * @private
  */
-export class DialogOverlay extends Overlay {
+export class DialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   static get is() {
     return 'vaadin-dialog-overlay';
   }
 
-  static get template() {
-    if (!memoizedTemplate) {
-      memoizedTemplate = super.template.cloneNode(true);
-      const contentPart = memoizedTemplate.content.querySelector('[part="content"]');
-      const overlayPart = memoizedTemplate.content.querySelector('[part="overlay"]');
-      const resizerContainer = document.createElement('section');
-      resizerContainer.id = 'resizerContainer';
-      resizerContainer.classList.add('resizer-container');
-      resizerContainer.appendChild(contentPart);
-      overlayPart.appendChild(resizerContainer);
-
-      const headerContainer = document.createElement('header');
-      headerContainer.setAttribute('part', 'header');
-      resizerContainer.insertBefore(headerContainer, contentPart);
-
-      const titleContainer = document.createElement('div');
-      titleContainer.setAttribute('part', 'title');
-      headerContainer.appendChild(titleContainer);
-
-      const titleSlot = document.createElement('slot');
-      titleSlot.setAttribute('name', 'title');
-      titleContainer.appendChild(titleSlot);
-
-      const headerContentContainer = document.createElement('div');
-      headerContentContainer.setAttribute('part', 'header-content');
-      headerContainer.appendChild(headerContentContainer);
-
-      const headerSlot = document.createElement('slot');
-      headerSlot.setAttribute('name', 'header-content');
-      headerContentContainer.appendChild(headerSlot);
-
-      const footerContainer = document.createElement('footer');
-      footerContainer.setAttribute('part', 'footer');
-      resizerContainer.appendChild(footerContainer);
-
-      const footerSlot = document.createElement('slot');
-      footerSlot.setAttribute('name', 'footer');
-      footerContainer.appendChild(footerSlot);
-    }
-    return memoizedTemplate;
+  static get styles() {
+    return [overlayStyles, dialogOverlay, resizableOverlay];
   }
 
   static get observers() {
@@ -75,16 +38,35 @@ export class DialogOverlay extends Overlay {
 
   static get properties() {
     return {
-      modeless: Boolean,
+      headerTitle: {
+        type: String,
+      },
 
-      withBackdrop: Boolean,
+      headerRenderer: {
+        attribute: false,
+      },
 
-      headerTitle: String,
-
-      headerRenderer: Function,
-
-      footerRenderer: Function,
+      footerRenderer: {
+        attribute: false,
+      },
     };
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div id="backdrop" part="backdrop" ?hidden="${!this.withBackdrop}"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <section id="resizerContainer" class="resizer-container">
+          <header part="header">
+            <div part="title"><slot name="title"></slot></div>
+            <div part="header-content"><slot name="header-content"></slot></div>
+          </header>
+          <div part="content" id="content"><slot></slot></div>
+          <footer part="footer"><slot name="footer"></slot></footer>
+        </section>
+      </div>
+    `;
   }
 
   /** @protected */

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { eventInWindow, getMouseOrFirstTouchEvent } from './vaadin-dialog-utils.js';
+
 /**
  * @polymerMixin
  */
@@ -24,11 +25,13 @@ export const DialogResizableMixin = (superClass) =>
     }
 
     /** @protected */
-    ready() {
+    async ready() {
       super.ready();
       this._originalBounds = {};
       this._originalMouseCoords = {};
       this._resizeListeners = { start: {}, resize: {}, stop: {} };
+
+      await this.$.overlay.updateComplete;
       this._addResizeListeners();
     }
 

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -4,9 +4,11 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './vaadin-dialog-overlay.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { css, html, LitElement } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import { DialogBaseMixin } from './vaadin-dialog-base-mixin.js';
@@ -85,34 +87,18 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  * @mixes OverlayClassMixin
  */
 class Dialog extends DialogDraggableMixin(
-  DialogResizableMixin(DialogBaseMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerElement))))),
+  DialogResizableMixin(DialogBaseMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(LitElement)))))),
 ) {
-  static get template() {
-    return html`
-      <style>
-        :host {
-          display: none !important;
-        }
-      </style>
-
-      <vaadin-dialog-overlay
-        id="overlay"
-        header-title="[[headerTitle]]"
-        on-opened-changed="_onOverlayOpened"
-        on-mousedown="_bringOverlayToFront"
-        on-touchstart="_bringOverlayToFront"
-        theme$="[[_theme]]"
-        modeless="[[modeless]]"
-        with-backdrop="[[!modeless]]"
-        resizable$="[[resizable]]"
-        restore-focus-on-close
-        focus-trap
-      ></vaadin-dialog-overlay>
-    `;
-  }
-
   static get is() {
     return 'vaadin-dialog';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: none !important;
+      }
+    `;
   }
 
   static get properties() {
@@ -179,12 +165,29 @@ class Dialog extends DialogDraggableMixin(
     };
   }
 
-  static get observers() {
-    return [
-      '_openedChanged(opened)',
-      '_ariaLabelChanged(ariaLabel, headerTitle)',
-      '_rendererChanged(renderer, headerRenderer, footerRenderer)',
-    ];
+  /** @protected */
+  render() {
+    return html`
+      <vaadin-dialog-overlay
+        id="overlay"
+        .owner="${this}"
+        .opened="${this.opened}"
+        .headerTitle="${this.headerTitle}"
+        .renderer="${this.renderer}"
+        .headerRenderer="${this.headerRenderer}"
+        .footerRenderer="${this.footerRenderer}"
+        @opened-changed="${this._onOverlayOpened}"
+        @mousedown="${this._bringOverlayToFront}"
+        @touchstart="${this._bringOverlayToFront}"
+        theme="${ifDefined(this._theme)}"
+        aria-label="${ifDefined(this.ariaLabel || this.headerTitle)}"
+        .modeless="${this.modeless}"
+        .withBackdrop="${!this.modeless}"
+        ?resizable="${this.resizable}"
+        restore-focus-on-close
+        focus-trap
+      ></vaadin-dialog-overlay>
+    `;
   }
 
   /** @protected */
@@ -204,27 +207,8 @@ class Dialog extends DialogDraggableMixin(
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
   requestContentUpdate() {
-    if (this.$) {
-      this.$.overlay.requestContentUpdate();
-    }
-  }
-
-  /** @private */
-  _rendererChanged(renderer, headerRenderer, footerRenderer) {
-    this.$.overlay.setProperties({ owner: this, renderer, headerRenderer, footerRenderer });
-  }
-
-  /** @private */
-  _openedChanged(opened) {
-    this.$.overlay.opened = opened;
-  }
-
-  /** @private */
-  _ariaLabelChanged(ariaLabel, headerTitle) {
-    if (ariaLabel || headerTitle) {
-      this.$.overlay.setAttribute('aria-label', ariaLabel || headerTitle);
-    } else {
-      this.$.overlay.removeAttribute('aria-label');
+    if (this._overlayElement) {
+      this._overlayElement.requestContentUpdate();
     }
   }
 }

--- a/packages/dialog/test/dom/dialog.test.js
+++ b/packages/dialog/test/dom/dialog.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import '../../src/vaadin-dialog.js';
 
 describe('vaadin-dialog', () => {
@@ -28,16 +28,19 @@ describe('vaadin-dialog', () => {
 
   it('overlay modeless', async () => {
     dialog.modeless = true;
+    await nextUpdate(dialog);
     await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
 
   it('overlay theme', async () => {
     dialog.setAttribute('theme', 'custom');
+    await nextUpdate(dialog);
     await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
 
   it('overlay class', async () => {
     dialog.overlayClass = 'custom dialog-overlay';
+    await nextUpdate(dialog);
     await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
 });

--- a/packages/dialog/test/visual/lumo/dialog.test.js
+++ b/packages/dialog/test/visual/lumo/dialog.test.js
@@ -1,4 +1,4 @@
-import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../not-animated-styles.js';
 import '../../../theme/lumo/vaadin-dialog.js';
@@ -7,13 +7,14 @@ import { createRenderer } from '../../helpers.js';
 describe('dialog', () => {
   let div, element;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     div = document.createElement('div');
     div.style.height = '100%';
 
     element = fixtureSync(`<vaadin-dialog></vaadin-dialog>`, div);
     element.renderer = createRenderer('Simple dialog with text');
     element.opened = true;
+    await nextRender();
   });
 
   it('basic', async () => {
@@ -22,33 +23,39 @@ describe('dialog', () => {
 
   it('modeless', async () => {
     element.modeless = true;
+    await nextUpdate(element);
     await visualDiff(div, 'modeless');
   });
 
   it('title', async () => {
     element.headerTitle = 'Title';
+    await nextUpdate(element);
     await visualDiff(div, 'header-title');
   });
 
   it('header renderer', async () => {
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-renderer');
   });
 
   it('title and header renderer', async () => {
     element.headerTitle = 'Title';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-renderer');
   });
 
   it('footer renderer', async () => {
     element.footerRenderer = createRenderer('Footer');
+    await nextUpdate(element);
     await visualDiff(div, 'footer-renderer');
   });
 
   it('header and footer renderer', async () => {
     element.headerRenderer = createRenderer('Header');
     element.footerRenderer = createRenderer('Footer');
+    await nextUpdate(element);
     await visualDiff(div, 'header-footer-renderer');
   });
 
@@ -56,6 +63,7 @@ describe('dialog', () => {
     element.$.overlay.style.maxWidth = '20rem';
     element.headerTitle = 'Long title that wraps in multiple lines';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-multiple-lines');
   });
 
@@ -63,6 +71,7 @@ describe('dialog', () => {
     element.$.overlay.style.maxWidth = '20rem';
     element.headerTitle = 'InternationalizationConfigurationHelper';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-long-single-word');
   });
 });

--- a/packages/dialog/test/visual/material/dialog.test.js
+++ b/packages/dialog/test/visual/material/dialog.test.js
@@ -1,4 +1,4 @@
-import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../not-animated-styles.js';
 import '../../../theme/material/vaadin-dialog.js';
@@ -7,13 +7,14 @@ import { createRenderer } from '../../helpers.js';
 describe('dialog', () => {
   let div, element;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     div = document.createElement('div');
     div.style.height = '100%';
 
     element = fixtureSync(`<vaadin-dialog></vaadin-dialog>`, div);
     element.renderer = createRenderer('Simple dialog with text');
     element.opened = true;
+    await nextRender();
   });
 
   it('basic', async () => {
@@ -22,33 +23,39 @@ describe('dialog', () => {
 
   it('modeless', async () => {
     element.modeless = true;
+    await nextUpdate(element);
     await visualDiff(div, 'modeless');
   });
 
   it('title', async () => {
     element.headerTitle = 'Title';
+    await nextUpdate(element);
     await visualDiff(div, 'header-title');
   });
 
   it('header renderer', async () => {
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-renderer');
   });
 
   it('title and header renderer', async () => {
     element.headerTitle = 'Title';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-renderer');
   });
 
   it('footer renderer', async () => {
     element.footerRenderer = createRenderer('Footer');
+    await nextUpdate(element);
     await visualDiff(div, 'footer-renderer');
   });
 
   it('header and footer renderer', async () => {
     element.headerRenderer = createRenderer('Header');
     element.footerRenderer = createRenderer('Footer');
+    await nextUpdate(element);
     await visualDiff(div, 'header-footer-renderer');
   });
 
@@ -56,6 +63,7 @@ describe('dialog', () => {
     element.$.overlay.style.maxWidth = '20rem';
     element.headerTitle = 'Long title that wraps in multiple lines';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-multiple-lines');
   });
 
@@ -63,6 +71,7 @@ describe('dialog', () => {
     element.$.overlay.style.maxWidth = '20rem';
     element.headerTitle = 'InternationalizationConfigurationHelper';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-long-single-word');
   });
 });


### PR DESCRIPTION
## Description

This is a LitElement based version of `vaadin-dialog` web component.

## Type of change

- Breaking change

## Disclaimer

This PR can be considered a PoC. There is no ETA on when we actually decide to proceed.