### PR TITLE
experiment: add LitElement based version of vaadin-avatar

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-avatar.d.ts",
+    "!src/vaadin-lit-avatar.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/avatar/src/vaadin-avatar.d.ts
+++ b/packages/avatar/src/vaadin-avatar.d.ts
@@ -6,7 +6,7 @@
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { AvatarMixin } from './vaadin-avatar-mixin';
+import { AvatarMixin } from './vaadin-avatar-mixin.js';
 
 export { AvatarI18n } from './vaadin-avatar-mixin.js';
 

--- a/packages/avatar/src/vaadin-lit-avatar.d.ts
+++ b/packages/avatar/src/vaadin-lit-avatar.d.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright (c) 2020 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { AvatarMixin } from './vaadin-avatar-mixin.js';
+
+export { AvatarI18n } from './vaadin-avatar-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-avatar>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+declare class Avatar extends AvatarMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-avatar': Avatar;
+  }
+}
+
+export { Avatar };

--- a/packages/avatar/src/vaadin-lit-avatar.js
+++ b/packages/avatar/src/vaadin-lit-avatar.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright (c) 2020 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import './vaadin-avatar-icons.js';
+import { html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { AvatarMixin } from './vaadin-avatar-mixin.js';
+import { avatarStyles } from './vaadin-avatar-styles.js';
+
+/**
+ * LitElement based version of `<vaadin-avatar>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class Avatar extends AvatarMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-avatar';
+  }
+
+  static get styles() {
+    return avatarStyles;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+  }
+
+  render() {
+    return html`
+      <img ?hidden="${!this.__imgVisible}" src="${this.img}" aria-hidden="true" @error="${this.__onImageLoadError}" />
+      <svg
+        part="icon"
+        ?hidden="${!this.__iconVisible}"
+        id="avatar-icon"
+        viewBox="-50 -50 100 100"
+        preserveAspectRatio="xMidYMid meet"
+        aria-hidden="true"
+      >
+        <text dy=".35em" text-anchor="middle">&#xea01;</text>
+      </svg>
+      <svg
+        part="abbr"
+        ?hidden="${!this.__abbrVisible}"
+        id="avatar-abbr"
+        viewBox="-50 -50 100 100"
+        preserveAspectRatio="xMidYMid meet"
+        aria-hidden="true"
+      >
+        <text dy=".35em" text-anchor="middle">${this.abbr}</text>
+      </svg>
+
+      <slot name="tooltip"></slot>
+    `;
+  }
+}
+
+customElements.define(Avatar.is, Avatar);
+
+export { Avatar };

--- a/packages/avatar/src/vaadin-lit-avatar.js
+++ b/packages/avatar/src/vaadin-lit-avatar.js
@@ -38,6 +38,7 @@ class Avatar extends AvatarMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElem
     this.addController(this._tooltipController);
   }
 
+  /** @protected */
   render() {
     return html`
       <img ?hidden="${!this.__imgVisible}" src="${this.img}" aria-hidden="true" @error="${this.__onImageLoadError}" />

--- a/packages/avatar/test/avatar-lit.test.js
+++ b/packages/avatar/test/avatar-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-avatar.js';
+import './avatar.common.js';

--- a/packages/avatar/test/avatar-polymer.test.js
+++ b/packages/avatar/test/avatar-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-avatar.js';
+import './avatar.common.js';

--- a/packages/avatar/test/avatar.common.js
+++ b/packages/avatar/test/avatar.common.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, focusin, focusout, mousedown, nextUpdate, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/tooltip/vaadin-tooltip.js';
-import '../vaadin-avatar.js';
 import { Tooltip } from '@vaadin/tooltip';
 
 describe('vaadin-avatar', () => {


### PR DESCRIPTION
## Description

Adds a `LitElement` based version of `vaadin-avatar`.

**Disclaimer:** This is considered an experiment that is not published to NPM, there is no ETA in which version it will be shipped.

## Type of change

- Experiment