### PR TITLE
test: update dialog visual and integration tests to use await

### DIFF
--- a/integration/tests/dialog-accordion.test.js
+++ b/integration/tests/dialog-accordion.test.js
@@ -26,10 +26,10 @@ describe('accordion in dialog', () => {
         </vaadin-accordion>
       `;
     };
+    await nextRender();
     dialog.opened = true;
     overlay = dialog.$.overlay;
     await oneEvent(overlay, 'vaadin-overlay-open');
-    await nextRender();
     accordion = overlay.querySelector('vaadin-accordion');
     panels = accordion.items;
   });

--- a/integration/tests/dialog-combo-box.test.js
+++ b/integration/tests/dialog-combo-box.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, mousedown, nextFrame, touchstart } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, nextFrame, nextRender, touchstart } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';
 import '@vaadin/combo-box';
@@ -14,8 +14,7 @@ describe('combo-box in dialog', () => {
       root.innerHTML = '<vaadin-combo-box></vaadin-combo-box>';
     };
     dialog.opened = true;
-    dialog.opened = true;
-    await nextFrame();
+    await nextRender();
     comboBox = dialog.$.overlay.querySelector('vaadin-combo-box');
     comboBox.items = ['foo', 'bar'];
     comboBox.inputElement.focus();

--- a/integration/tests/dialog-combo-box.test.js
+++ b/integration/tests/dialog-combo-box.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, mousedown, nextFrame, nextRender, touchstart } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, nextFrame, nextUpdate, oneEvent, touchstart } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';
 import '@vaadin/combo-box';
@@ -10,11 +10,12 @@ describe('combo-box in dialog', () => {
 
   beforeEach(async () => {
     dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+    await nextUpdate(dialog);
     dialog.renderer = (root) => {
       root.innerHTML = '<vaadin-combo-box></vaadin-combo-box>';
     };
     dialog.opened = true;
-    await nextRender();
+    await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
     comboBox = dialog.$.overlay.querySelector('vaadin-combo-box');
     comboBox.items = ['foo', 'bar'];
     comboBox.inputElement.focus();
@@ -23,7 +24,7 @@ describe('combo-box in dialog', () => {
   describe('opened', () => {
     beforeEach(async () => {
       comboBox.open();
-      await nextFrame();
+      await nextUpdate(comboBox);
     });
 
     it('should not close the dialog when closing time-picker on input element Escape', async () => {

--- a/integration/tests/dialog-grid-pro.test.js
+++ b/integration/tests/dialog-grid-pro.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, fixtureSync, focusin, focusout, nextFrame, outsideClick } from '@vaadin/testing-helpers';
+import { enter, fixtureSync, focusin, focusout, nextFrame, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import '@vaadin/date-picker';
 import '@vaadin/dialog';
 import '@vaadin/grid-pro';
@@ -51,8 +51,9 @@ const fixtures = {
   describe(`${type} grid-pro in dialog`, () => {
     let dialog, grid, dateCell;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       dialog = fixtureSync(fixtures[type]);
+      await nextRender();
       grid = dialog.$.overlay.querySelector('vaadin-grid-pro');
       grid.items = createItems();
       grid.style.width = '100px'; // Column default min width is 100px

--- a/integration/tests/dialog-template.test.js
+++ b/integration/tests/dialog-template.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/dialog';
 
@@ -12,13 +12,13 @@ describe('vaadin-dialog template', () => {
         <template>foo</template>
       </vaadin-dialog>
     `);
-    await nextRender();
+    await nextUpdate(dialog);
     overlay = dialog.$.overlay;
   });
 
   it('should render the template', async () => {
     dialog.opened = true;
-    await nextRender();
+    await oneEvent(overlay, 'vaadin-overlay-open');
     expect(overlay.textContent).to.equal('foo');
   });
 });

--- a/integration/tests/dialog-template.test.js
+++ b/integration/tests/dialog-template.test.js
@@ -1,22 +1,24 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/dialog';
 
 describe('vaadin-dialog template', () => {
   let dialog, overlay;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dialog = fixtureSync(`
       <vaadin-dialog>
         <template>foo</template>
       </vaadin-dialog>
     `);
+    await nextRender();
     overlay = dialog.$.overlay;
   });
 
-  it('should render the template', () => {
+  it('should render the template', async () => {
     dialog.opened = true;
+    await nextRender();
     expect(overlay.textContent).to.equal('foo');
   });
 });

--- a/packages/dialog/test/visual/lumo/dialog.test.js
+++ b/packages/dialog/test/visual/lumo/dialog.test.js
@@ -1,4 +1,4 @@
-import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../not-animated-styles.js';
 import '../../../theme/lumo/vaadin-dialog.js';
@@ -7,13 +7,14 @@ import { createRenderer } from '../../helpers.js';
 describe('dialog', () => {
   let div, element;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     div = document.createElement('div');
     div.style.height = '100%';
 
     element = fixtureSync(`<vaadin-dialog></vaadin-dialog>`, div);
     element.renderer = createRenderer('Simple dialog with text');
     element.opened = true;
+    await nextRender();
   });
 
   it('basic', async () => {
@@ -22,33 +23,39 @@ describe('dialog', () => {
 
   it('modeless', async () => {
     element.modeless = true;
+    await nextUpdate(element);
     await visualDiff(div, 'modeless');
   });
 
   it('title', async () => {
     element.headerTitle = 'Title';
+    await nextUpdate(element);
     await visualDiff(div, 'header-title');
   });
 
   it('header renderer', async () => {
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-renderer');
   });
 
   it('title and header renderer', async () => {
     element.headerTitle = 'Title';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-renderer');
   });
 
   it('footer renderer', async () => {
     element.footerRenderer = createRenderer('Footer');
+    await nextUpdate(element);
     await visualDiff(div, 'footer-renderer');
   });
 
   it('header and footer renderer', async () => {
     element.headerRenderer = createRenderer('Header');
     element.footerRenderer = createRenderer('Footer');
+    await nextUpdate(element);
     await visualDiff(div, 'header-footer-renderer');
   });
 
@@ -56,6 +63,7 @@ describe('dialog', () => {
     element.$.overlay.style.maxWidth = '20rem';
     element.headerTitle = 'Long title that wraps in multiple lines';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-multiple-lines');
   });
 
@@ -63,6 +71,7 @@ describe('dialog', () => {
     element.$.overlay.style.maxWidth = '20rem';
     element.headerTitle = 'InternationalizationConfigurationHelper';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-long-single-word');
   });
 });

--- a/packages/dialog/test/visual/material/dialog.test.js
+++ b/packages/dialog/test/visual/material/dialog.test.js
@@ -1,4 +1,4 @@
-import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../not-animated-styles.js';
 import '../../../theme/material/vaadin-dialog.js';
@@ -7,13 +7,14 @@ import { createRenderer } from '../../helpers.js';
 describe('dialog', () => {
   let div, element;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     div = document.createElement('div');
     div.style.height = '100%';
 
     element = fixtureSync(`<vaadin-dialog></vaadin-dialog>`, div);
     element.renderer = createRenderer('Simple dialog with text');
     element.opened = true;
+    await nextRender();
   });
 
   it('basic', async () => {
@@ -22,33 +23,39 @@ describe('dialog', () => {
 
   it('modeless', async () => {
     element.modeless = true;
+    await nextUpdate(element);
     await visualDiff(div, 'modeless');
   });
 
   it('title', async () => {
     element.headerTitle = 'Title';
+    await nextUpdate(element);
     await visualDiff(div, 'header-title');
   });
 
   it('header renderer', async () => {
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-renderer');
   });
 
   it('title and header renderer', async () => {
     element.headerTitle = 'Title';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-renderer');
   });
 
   it('footer renderer', async () => {
     element.footerRenderer = createRenderer('Footer');
+    await nextUpdate(element);
     await visualDiff(div, 'footer-renderer');
   });
 
   it('header and footer renderer', async () => {
     element.headerRenderer = createRenderer('Header');
     element.footerRenderer = createRenderer('Footer');
+    await nextUpdate(element);
     await visualDiff(div, 'header-footer-renderer');
   });
 
@@ -56,6 +63,7 @@ describe('dialog', () => {
     element.$.overlay.style.maxWidth = '20rem';
     element.headerTitle = 'Long title that wraps in multiple lines';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-multiple-lines');
   });
 
@@ -63,6 +71,7 @@ describe('dialog', () => {
     element.$.overlay.style.maxWidth = '20rem';
     element.headerTitle = 'InternationalizationConfigurationHelper';
     element.headerRenderer = createRenderer('Header');
+    await nextUpdate(element);
     await visualDiff(div, 'header-title-long-single-word');
   });
 });


### PR DESCRIPTION
## Description

Extracted from #6183

Updated visual tests and integration tests to pass with LitElement based version of `vaadin-dialog`.

## Type of change

- Tests