### PR TITLE
experiment: add LitElement based version of vaadin-dialog

### DIFF
--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -23,6 +23,8 @@
     "lit.d.ts",
     "lit.js",
     "src",
+    "!src/vaadin-lit-dialog.d.ts",
+    "!src/vaadin-lit-dialog.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -23,6 +23,8 @@
     "lit.d.ts",
     "lit.js",
     "src",
+    "!src/vaadin-lit-dialog-overlay.d.ts",
+    "!src/vaadin-lit-dialog-overlay.js",
     "!src/vaadin-lit-dialog.d.ts",
     "!src/vaadin-lit-dialog.js",
     "theme",

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -45,13 +45,16 @@ export const DialogDraggableMixin = (superClass) =>
     }
 
     /** @protected */
-    ready() {
+    async ready() {
       super.ready();
       this._originalBounds = {};
       this._originalMouseCoords = {};
       this._startDrag = this._startDrag.bind(this);
       this._drag = this._drag.bind(this);
       this._stopDrag = this._stopDrag.bind(this);
+
+      // Wait for overlay render
+      await new Promise(requestAnimationFrame);
       this.$.overlay.$.overlay.addEventListener('mousedown', this._startDrag);
       this.$.overlay.$.overlay.addEventListener('touchstart', this._startDrag);
     }

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -24,11 +24,14 @@ export const DialogResizableMixin = (superClass) =>
     }
 
     /** @protected */
-    ready() {
+    async ready() {
       super.ready();
       this._originalBounds = {};
       this._originalMouseCoords = {};
       this._resizeListeners = { start: {}, resize: {}, stop: {} };
+
+      // Wait for overlay render
+      await new Promise(requestAnimationFrame);
       this._addResizeListeners();
     }
 

--- a/packages/dialog/src/vaadin-lit-dialog-overlay.d.ts
+++ b/packages/dialog/src/vaadin-lit-dialog-overlay.d.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { DialogOverlayMixin } from './vaadin-dialog-overlay-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-dialog>`. Not intended to be used separately.
+ */
+export class DialogOverlay extends DialogOverlayMixin(DirMixin(ThemableMixin(HTMLElement))) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-dialog-overlay': DialogOverlay;
+  }
+}

--- a/packages/dialog/src/vaadin-lit-dialog-overlay.d.ts
+++ b/packages/dialog/src/vaadin-lit-dialog-overlay.d.ts
@@ -3,17 +3,4 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { DialogOverlayMixin } from './vaadin-dialog-overlay-mixin.js';
-
-/**
- * An element used internally by `<vaadin-dialog>`. Not intended to be used separately.
- */
-export class DialogOverlay extends DialogOverlayMixin(DirMixin(ThemableMixin(HTMLElement))) {}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'vaadin-dialog-overlay': DialogOverlay;
-  }
-}
+export * from './vaadin-dialog-overlay.js';

--- a/packages/dialog/src/vaadin-lit-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-lit-dialog-overlay.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { DialogOverlayMixin } from './vaadin-dialog-overlay-mixin.js';
+import { dialogOverlay, resizableOverlay } from './vaadin-dialog-styles.js';
+
+/**
+ * An element used internally by `<vaadin-dialog>`. Not intended to be used separately.
+ *
+ * @extends HTMLElement
+ * @mixes DialogOverlayMixin
+ * @mixes DirMixin
+ * @mixes ThemableMixin
+ * @private
+ */
+export class DialogOverlay extends DialogOverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-dialog-overlay';
+  }
+
+  static get styles() {
+    return [overlayStyles, dialogOverlay, resizableOverlay];
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div id="backdrop" part="backdrop" ?hidden="${!this.withBackdrop}"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <section id="resizerContainer" class="resizer-container">
+          <header part="header">
+            <div part="title"><slot name="title"></slot></div>
+            <div part="header-content"><slot name="header-content"></slot></div>
+          </header>
+          <div part="content" id="content"><slot></slot></div>
+          <footer part="footer"><slot name="footer"></slot></footer>
+        </section>
+      </div>
+    `;
+  }
+}
+
+customElements.define(DialogOverlay.is, DialogOverlay);

--- a/packages/dialog/src/vaadin-lit-dialog.d.ts
+++ b/packages/dialog/src/vaadin-lit-dialog.d.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import { DialogBaseMixin } from './vaadin-dialog-base-mixin.js';
+import { DialogDraggableMixin } from './vaadin-dialog-draggable-mixin.js';
+import { DialogRendererMixin } from './vaadin-dialog-renderer-mixin.js';
+import { DialogResizableMixin } from './vaadin-dialog-resizable-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-dialog>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+declare class Dialog extends DialogDraggableMixin(
+  DialogResizableMixin(
+    DialogRendererMixin(DialogBaseMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement))))),
+  ),
+) {
+  /**
+   * Set the `aria-label` attribute for assistive technologies like
+   * screen readers. An empty string value for this property (the
+   * default) means that the `aria-label` attribute is not present.
+   */
+  ariaLabel: string;
+}
+
+export { Dialog };

--- a/packages/dialog/src/vaadin-lit-dialog.d.ts
+++ b/packages/dialog/src/vaadin-lit-dialog.d.ts
@@ -3,34 +3,4 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
-import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
-import { DialogBaseMixin } from './vaadin-dialog-base-mixin.js';
-import { DialogDraggableMixin } from './vaadin-dialog-draggable-mixin.js';
-import { DialogRendererMixin } from './vaadin-dialog-renderer-mixin.js';
-import { DialogResizableMixin } from './vaadin-dialog-resizable-mixin.js';
-
-/**
- * LitElement based version of `<vaadin-dialog>` web component.
- *
- * ## Disclaimer
- *
- * This component is an experiment not intended for publishing to npm.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
- */
-declare class Dialog extends DialogDraggableMixin(
-  DialogResizableMixin(
-    DialogRendererMixin(DialogBaseMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement))))),
-  ),
-) {
-  /**
-   * Set the `aria-label` attribute for assistive technologies like
-   * screen readers. An empty string value for this property (the
-   * default) means that the `aria-label` attribute is not present.
-   */
-  ariaLabel: string;
-}
-
-export { Dialog };
+export * from './vaadin-dialog.js';

--- a/packages/dialog/src/vaadin-lit-dialog.js
+++ b/packages/dialog/src/vaadin-lit-dialog.js
@@ -97,19 +97,6 @@ class Dialog extends DialogDraggableMixin(
 
     this._overlayElement.setAttribute('role', 'dialog');
   }
-
-  /**
-   * Requests an update for the content of the dialog.
-   * While performing the update, it invokes the renderer passed in the `renderer` property,
-   * as well as `headerRender` and `footerRenderer` properties, if these are defined.
-   *
-   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
-   */
-  requestContentUpdate() {
-    if (this._overlayElement) {
-      this._overlayElement.requestContentUpdate();
-    }
-  }
 }
 
 customElements.define(Dialog.is, Dialog);

--- a/packages/dialog/src/vaadin-lit-dialog.js
+++ b/packages/dialog/src/vaadin-lit-dialog.js
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import './vaadin-lit-dialog-overlay.js';
+import { css, html, LitElement } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import { DialogBaseMixin } from './vaadin-dialog-base-mixin.js';
+import { DialogDraggableMixin } from './vaadin-dialog-draggable-mixin.js';
+import { DialogRendererMixin } from './vaadin-dialog-renderer-mixin.js';
+import { DialogResizableMixin } from './vaadin-dialog-resizable-mixin.js';
+
+export { DialogOverlay } from './vaadin-lit-dialog-overlay.js';
+
+/**
+ * LitElement based version of `<vaadin-dialog>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ *
+ * @extends HTMLElement
+ * @mixes ElementMixin
+ * @mixes DialogBaseMixin
+ * @mixes DialogDraggableMixin
+ * @mixes DialogRendererMixin
+ * @mixes DialogResizableMixin
+ * @mixes OverlayClassMixin
+ * @mixes ThemePropertyMixin
+ */
+class Dialog extends DialogDraggableMixin(
+  DialogResizableMixin(
+    DialogRendererMixin(DialogBaseMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(LitElement)))))),
+  ),
+) {
+  static get is() {
+    return 'vaadin-dialog';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: none !important;
+      }
+    `;
+  }
+
+  static get properties() {
+    return {
+      /**
+       * Set the `aria-label` attribute for assistive technologies like
+       * screen readers. An empty string value for this property (the
+       * default) means that the `aria-label` attribute is not present.
+       */
+      ariaLabel: {
+        type: String,
+        value: '',
+      },
+    };
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <vaadin-dialog-overlay
+        id="overlay"
+        .owner="${this}"
+        .opened="${this.opened}"
+        .headerTitle="${this.headerTitle}"
+        .renderer="${this.renderer}"
+        .headerRenderer="${this.headerRenderer}"
+        .footerRenderer="${this.footerRenderer}"
+        @opened-changed="${this._onOverlayOpened}"
+        @mousedown="${this._bringOverlayToFront}"
+        @touchstart="${this._bringOverlayToFront}"
+        theme="${ifDefined(this._theme)}"
+        aria-label="${ifDefined(this.ariaLabel || this.headerTitle)}"
+        .modeless="${this.modeless}"
+        .withBackdrop="${!this.modeless}"
+        ?resizable="${this.resizable}"
+        restore-focus-on-close
+        focus-trap
+      ></vaadin-dialog-overlay>
+    `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._overlayElement.setAttribute('role', 'dialog');
+  }
+
+  /**
+   * Requests an update for the content of the dialog.
+   * While performing the update, it invokes the renderer passed in the `renderer` property,
+   * as well as `headerRender` and `footerRenderer` properties, if these are defined.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   */
+  requestContentUpdate() {
+    if (this._overlayElement) {
+      this._overlayElement.requestContentUpdate();
+    }
+  }
+}
+
+customElements.define(Dialog.is, Dialog);
+
+export { Dialog };

--- a/packages/dialog/test/dialog-lit.test.js
+++ b/packages/dialog/test/dialog-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-dialog.js';
+import './dialog.common.js';

--- a/packages/dialog/test/dialog-polymer.test.js
+++ b/packages/dialog/test/dialog-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-dialog.js';
+import './dialog.common.js';

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -1,15 +1,15 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, click, esc, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-dialog.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('vaadin-dialog', () => {
   describe('custom element definition', () => {
     let dialog, tagName;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+      await nextRender();
       tagName = dialog.tagName.toLowerCase();
     });
 

--- a/packages/dialog/test/draggable-resizable-lit.test.js
+++ b/packages/dialog/test/draggable-resizable-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-dialog.js';
+import './draggable-resizable.common.js';

--- a/packages/dialog/test/draggable-resizable-polymer.test.js
+++ b/packages/dialog/test/draggable-resizable-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-dialog.js';
+import './draggable-resizable.common.js';

--- a/packages/dialog/test/draggable-resizable.common.js
+++ b/packages/dialog/test/draggable-resizable.common.js
@@ -2,8 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-area/vaadin-text-area.js';
-import './not-animated-styles.js';
-import '../src/vaadin-dialog.js';
 
 customElements.define(
   'internally-draggable',

--- a/packages/dialog/test/header-footer-lit.test.js
+++ b/packages/dialog/test/header-footer-lit.test.js
@@ -1,0 +1,4 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-dialog-styles.js';
+import '../src/vaadin-lit-dialog.js';
+import './header-footer.common.js';

--- a/packages/dialog/test/header-footer-polymer.test.js
+++ b/packages/dialog/test/header-footer-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-dialog.js';
+import './header-footer.common.js';

--- a/packages/dialog/test/header-footer.common.js
+++ b/packages/dialog/test/header-footer.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-dialog.js';
 import { createRenderer } from './helpers.js';
 
 describe('header/footer feature', () => {

--- a/packages/dialog/test/lit-renderer-directives-lit.test.js
+++ b/packages/dialog/test/lit-renderer-directives-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-dialog.js';
+import './lit-renderer-directives.common.js';

--- a/packages/dialog/test/lit-renderer-directives-polymer.test.js
+++ b/packages/dialog/test/lit-renderer-directives-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-dialog.js';
+import './lit-renderer-directives.common.js';

--- a/packages/dialog/test/lit-renderer-directives.common.js
+++ b/packages/dialog/test/lit-renderer-directives.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-dialog.js';
 import { html, render } from 'lit';
 import { dialogFooterRenderer, dialogHeaderRenderer, dialogRenderer } from '../lit.js';
 

--- a/packages/dialog/test/renderer-lit.test.js
+++ b/packages/dialog/test/renderer-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-dialog.js';
+import './renderer.common.js';

--- a/packages/dialog/test/renderer-polymer.test.js
+++ b/packages/dialog/test/renderer-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-dialog.js';
+import './renderer.common.js';

--- a/packages/dialog/test/renderer.common.js
+++ b/packages/dialog/test/renderer.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-dialog.js';
 
 describe('vaadin-dialog renderer', () => {
   let dialog, overlay;


### PR DESCRIPTION
## Description

Added a `LitElement` based version of `vaadin-dialog`.

## Type of change

- Experiment

## Disclaimer

This is considered an experiment that is not published to npm, there is no ETA in which version it will be shipped.