### PR TITLE
refactor: reuse existing TS definitions for Lit-based elements

### DIFF
--- a/packages/avatar/src/vaadin-lit-avatar.d.ts
+++ b/packages/avatar/src/vaadin-lit-avatar.d.ts
@@ -3,29 +3,4 @@
  * Copyright (c) 2020 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LitElement } from 'lit';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { AvatarMixin } from './vaadin-avatar-mixin.js';
-
-export { AvatarI18n } from './vaadin-avatar-mixin.js';
-
-/**
- * LitElement based version of `<vaadin-avatar>` web component.
- *
- * ## Disclaimer
- *
- * This component is an experiment not intended for publishing to npm.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
- */
-declare class Avatar extends AvatarMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'vaadin-avatar': Avatar;
-  }
-}
-
-export { Avatar };
+export * from './vaadin-avatar.js';

--- a/packages/button/src/vaadin-lit-button.d.ts
+++ b/packages/button/src/vaadin-lit-button.d.ts
@@ -3,21 +3,4 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LitElement } from 'lit';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { ButtonMixin } from './vaadin-button-mixin.js';
-
-/**
- * LitElement based version of `<vaadin-button>` web component.
- *
- * ## Disclaimer
- *
- * This component is an experiment not intended for publishing to npm.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
- */
-declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
-
-export { Button };
+export * from './vaadin-button.js';

--- a/packages/checkbox/src/vaadin-lit-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-lit-checkbox.d.ts
@@ -3,21 +3,4 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LitElement } from 'lit';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
-
-/**
- * LitElement based version of `<vaadin-checkbox>` web component.
- *
- * ## Disclaimer
- *
- * This component is an experiment not intended for publishing to npm.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
- */
-declare class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
-
-export { Checkbox };
+export * from './vaadin-checkbox.js';

--- a/packages/email-field/src/vaadin-lit-email-field.d.ts
+++ b/packages/email-field/src/vaadin-lit-email-field.d.ts
@@ -3,17 +3,4 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { TextField } from '@vaadin/text-field/src/vaadin-lit-text-field.js';
-
-/**
- * LitElement based version of `<vaadin-email-field>` web component.
- *
- * ## Disclaimer
- *
- * This component is an experiment not intended for publishing to npm.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
- */
-declare class EmailField extends TextField {}
-
-export { EmailField };
+export * from './vaadin-email-field.js';

--- a/packages/number-field/src/vaadin-lit-number-field.d.ts
+++ b/packages/number-field/src/vaadin-lit-number-field.d.ts
@@ -3,21 +3,4 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LitElement } from 'lit';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
-
-/**
- * LitElement based version of `<vaadin-number-field>` web component.
- *
- * ## Disclaimer
- *
- * This component is an experiment not intended for publishing to npm.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
- */
-declare class NumberField extends NumberFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {}
-
-export { NumberField };
+export * from './vaadin-number-field.js';

--- a/packages/progress-bar/src/vaadin-lit-progress-bar.d.ts
+++ b/packages/progress-bar/src/vaadin-lit-progress-bar.d.ts
@@ -3,21 +3,4 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LitElement } from 'lit';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { ProgressMixin } from './vaadin-progress-mixin.js';
-
-/**
- * LitElement based version of `<vaadin-progress-bar>` web component.
- *
- * ## Disclaimer
- *
- * This component is an experiment not intended for publishing to npm.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
- */
-declare class ProgressBar extends ProgressMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {}
-
-export { ProgressBar };
+export * from './vaadin-progress-bar.js';

--- a/packages/text-area/src/vaadin-lit-text-area.d.ts
+++ b/packages/text-area/src/vaadin-lit-text-area.d.ts
@@ -3,21 +3,4 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LitElement } from 'lit';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { TextAreaMixin } from './vaadin-text-area-mixin.js';
-
-/**
- * LitElement based version of `<vaadin-text-area>` web component.
- *
- * ## Disclaimer
- *
- * This component is an experiment not intended for publishing to npm.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
- */
-declare class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {}
-
-export { TextArea };
+export * from './vaadin-text-area.js';

--- a/packages/text-field/src/vaadin-lit-text-field.d.ts
+++ b/packages/text-field/src/vaadin-lit-text-field.d.ts
@@ -3,21 +3,4 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LitElement } from 'lit';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { TextFieldMixin } from './vaadin-text-field-mixin.js';
-
-/**
- * LitElement based version of `<vaadin-text-field>` web component.
- *
- * ## Disclaimer
- *
- * This component is an experiment not intended for publishing to npm.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
- */
-declare class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {}
-
-export { TextField };
+export * from './vaadin-text-field.js';


### PR DESCRIPTION
## Description

As discussed [here](https://github.com/vaadin/web-components/pull/6187#discussion_r1266769489), for now we want to reuse existing Typescript definitions for Lit-based elements in order to not increase the conversion effort. This aligns the TS definitions of existing Lit-based elements to do so, which also fixes some issues with missing types or events.