### PR TITLE
refactor: move setBounds() and getBounds() types to the mixin

### DIFF
--- a/packages/dialog/src/vaadin-dialog-overlay-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-overlay-mixin.d.ts
@@ -7,6 +7,22 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { OverlayMixinClass } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import type { DialogRenderer } from './vaadin-dialog.js';
 
+export type DialogOverlayBounds = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
+export type DialogOverlayBoundsParam =
+  | DialogOverlayBounds
+  | {
+      top?: number | string;
+      left?: number | string;
+      width?: number | string;
+      height?: number | string;
+    };
+
 export declare function DialogOverlayMixin<T extends Constructor<HTMLElement>>(
   base: T,
 ): Constructor<DialogOverlayMixinClass> & Constructor<OverlayMixinClass> & T;
@@ -27,4 +43,14 @@ export declare class DialogOverlayMixinClass {
    * Custom function for rendering the dialog footer.
    */
   footerRenderer: DialogRenderer | null | undefined;
+
+  /**
+   * Retrieves the coordinates of the overlay.
+   */
+  getBounds(): DialogOverlayBounds;
+
+  /**
+   * Updates the coordinates of the overlay.
+   */
+  setBounds(bounds: DialogOverlayBoundsParam): void;
 }

--- a/packages/dialog/src/vaadin-dialog-overlay.d.ts
+++ b/packages/dialog/src/vaadin-dialog-overlay.d.ts
@@ -7,36 +7,12 @@ import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { DialogOverlayMixin } from './vaadin-dialog-overlay-mixin.js';
 
-export type DialogOverlayBounds = {
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-};
-
-export type DialogOverlayBoundsParam =
-  | DialogOverlayBounds
-  | {
-      top?: number | string;
-      left?: number | string;
-      width?: number | string;
-      height?: number | string;
-    };
+export { DialogOverlayBounds, DialogOverlayBoundsParam } from './vaadin-dialog-overlay-mixin.js';
 
 /**
  * An element used internally by `<vaadin-dialog>`. Not intended to be used separately.
  */
-export class DialogOverlay extends DialogOverlayMixin(DirMixin(ThemableMixin(HTMLElement))) {
-  /**
-   * Retrieves the coordinates of the overlay.
-   */
-  getBounds(): DialogOverlayBounds;
-
-  /**
-   * Updates the coordinates of the overlay.
-   */
-  setBounds(bounds: DialogOverlayBoundsParam): void;
-}
+export class DialogOverlay extends DialogOverlayMixin(DirMixin(ThemableMixin(HTMLElement))) {}
 
 declare global {
   interface HTMLElementTagNameMap {


### PR DESCRIPTION
## Description

See https://github.com/vaadin/web-components/pull/6187#discussion_r1266763947

## Type of change

- Refactor