### PR TITLE
fix: prevent duplicate validation on blur

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -180,7 +180,7 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
    * @return {boolean}
    */
   checkValidity() {
-    if (this.inputElement.validate) {
+    if (this.inputElement && this.inputElement.validate) {
       return this.inputElement.validate();
     }
     return super.checkValidity();
@@ -193,22 +193,6 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
       (event.type === 'input' && !event.isTrusted) || // Fake input event dispatched by clear button
       event.composedPath()[0].getAttribute('part') === 'clear-button'
     );
-  }
-
-  /**
-   * Override method inherited from `FocusMixin` to validate on blur.
-   * @param {boolean} focused
-   * @protected
-   * @override
-   */
-  _setFocused(focused) {
-    super._setFocused(focused);
-
-    // Do not validate when focusout is caused by document
-    // losing focus, which happens on browser tab switch.
-    if (!focused && document.hasFocus()) {
-      this.validate();
-    }
   }
 
   /**

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -9,6 +9,7 @@ import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ComboBox } from './vaadin-combo-box.js';
 import type { ComboBoxDefaultItem, ComboBoxItemModel, ComboBoxItemRenderer } from './vaadin-combo-box-item-mixin.js';
 
@@ -24,6 +25,7 @@ export declare function ComboBoxMixin<TItem, T extends Constructor<HTMLElement>>
   Constructor<InputMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<OverlayClassMixinClass> &
+  Constructor<ValidateMixinClass> &
   T;
 
 export declare class ComboBoxMixinClass<TItem> {

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -12,6 +12,7 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
+import { ValidateMixin } from '@vaadin/field-base/src/validate-mixin.js';
 import { VirtualKeyboardController } from '@vaadin/field-base/src/virtual-keyboard-controller.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
 
@@ -46,6 +47,7 @@ function findItemIndex(items, callback) {
 /**
  * @polymerMixin
  * @mixes ControllerMixin
+ * @mixes ValidateMixin
  * @mixes DisabledMixin
  * @mixes InputMixin
  * @mixes KeyboardMixin
@@ -55,7 +57,7 @@ function findItemIndex(items, callback) {
  */
 export const ComboBoxMixin = (subclass) =>
   class ComboBoxMixinClass extends OverlayClassMixin(
-    ControllerMixin(FocusMixin(KeyboardMixin(InputMixin(DisabledMixin(subclass))))),
+    ControllerMixin(ValidateMixin(FocusMixin(KeyboardMixin(InputMixin(DisabledMixin(subclass)))))),
   ) {
     static get properties() {
       return {
@@ -1084,6 +1086,12 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _detectAndDispatchChange() {
+      // Do not validate when focusout is caused by document
+      // losing focus, which happens on browser tab switch.
+      if (document.hasFocus()) {
+        this.validate();
+      }
+
       if (this.value !== this._lastCommittedValue) {
         this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
         this._lastCommittedValue = this.value;

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -255,22 +255,6 @@ class ComboBox extends ComboBoxDataProviderMixin(
   }
 
   /**
-   * Override method inherited from `FocusMixin` to validate on blur.
-   * @param {boolean} focused
-   * @protected
-   * @override
-   */
-  _setFocused(focused) {
-    super._setFocused(focused);
-
-    // Do not validate when focusout is caused by document
-    // losing focus, which happens on browser tab switch.
-    if (!focused && document.hasFocus()) {
-      this.validate();
-    }
-  }
-
-  /**
    * Override the method from `InputControlMixin`
    * to stop event propagation to prevent `ComboBoxMixin`
    * from handling this click event also on its own.

--- a/packages/combo-box/test/combo-box-light-validation.test.js
+++ b/packages/combo-box/test/combo-box-light-validation.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box-light.js';
@@ -8,7 +9,7 @@ describe('vaadin-combo-box-light - validation', () => {
   let comboBox, input;
 
   describe('basic', () => {
-    let validateSpy;
+    let validateSpy, changeSpy;
 
     beforeEach(async () => {
       comboBox = fixtureSync(`
@@ -20,6 +21,8 @@ describe('vaadin-combo-box-light - validation', () => {
       await nextRender();
       input = comboBox.inputElement;
       validateSpy = sinon.spy(comboBox, 'validate');
+      changeSpy = sinon.spy();
+      comboBox.addEventListener('change', changeSpy);
     });
 
     it('should pass validation by default', () => {
@@ -32,6 +35,15 @@ describe('vaadin-combo-box-light - validation', () => {
       input.focus();
       input.blur();
       expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should validate before change event on blur', async () => {
+      input.focus();
+      await sendKeys({ type: 'foo' });
+      input.blur();
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
     describe('document losing focus', () => {

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -125,6 +125,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
           position-target="[[_inputContainer]]"
           theme$="[[_theme]]"
           on-change="__onComboBoxChange"
+          on-validated="__onComboBoxValidated"
           on-has-input-value-changed="__onComboBoxHasInputValueChanged"
         >
           <vaadin-input-container
@@ -417,19 +418,6 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     );
   }
 
-  /**
-   * Override method inherited from `FocusMixin` to validate on blur.
-   * @param {boolean} focused
-   * @protected
-   */
-  _setFocused(focused) {
-    super._setFocused(focused);
-
-    if (!focused) {
-      this.validate();
-    }
-  }
-
   /** @private */
   __validDayDivisor(step) {
     // Valid if undefined, or exact divides a day, or has millisecond resolution
@@ -640,9 +628,6 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   /** @private */
   __onComboBoxChange(event) {
     event.stopPropagation();
-
-    this.validate();
-
     this.__dispatchChange();
   }
 
@@ -653,6 +638,11 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
    */
   __onComboBoxHasInputValueChanged() {
     this._hasInputValue = this.$.comboBox._hasInputValue;
+  }
+
+  /** @private */
+  __onComboBoxValidated() {
+    this.validate();
   }
 
   /** @private */

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -83,6 +83,11 @@ describe('validation', () => {
       expect(timePicker.validate()).to.be.true;
     });
 
+    it('should not validate on user input', () => {
+      setInputValue(timePicker, '12:00');
+      expect(validateSpy.called).to.be.false;
+    });
+
     it('should validate on blur', () => {
       input.focus();
       input.blur();
@@ -96,11 +101,6 @@ describe('validation', () => {
       expect(changeSpy.calledOnce).to.be.true;
       expect(validateSpy.calledOnce).to.be.true;
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;
-    });
-
-    it('should not validate on user input', () => {
-      setInputValue(timePicker, '12:00');
-      expect(validateSpy.called).to.be.false;
     });
 
     it('should validate before change event on Enter', () => {

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -98,25 +98,27 @@ describe('validation', () => {
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
-    it('should not validate on value input', () => {
+    it('should not validate on user input', () => {
       setInputValue(timePicker, '12:00');
-      expect(validateSpy.calledOnce).to.be.false;
+      expect(validateSpy.called).to.be.false;
     });
 
-    it('should validate on value commit', () => {
+    it('should validate before change event on Enter', () => {
       setInputValue(timePicker, '12:00');
       enter(timePicker.inputElement);
+      expect(changeSpy.calledOnce).to.be.true;
       expect(validateSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
-    it('should validate on input focusout', () => {
-      focusout(timePicker.inputElement);
+    it('should validate before change event on clear button click', () => {
+      timePicker.clearButtonVisible = true;
+      timePicker.value = '12:00';
+      validateSpy.resetHistory();
+      timePicker.$.clearButton.click();
+      expect(changeSpy.calledOnce).to.be.true;
       expect(validateSpy.calledOnce).to.be.true;
-    });
-
-    it('should be possible to force invalid status', () => {
-      timePicker.invalid = true;
-      expect(timePicker.inputElement.hasAttribute('invalid')).to.be.true;
+      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
     it('should not validate on min change without value', () => {

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -68,16 +68,34 @@ describe('validation', () => {
   });
 
   describe('basic', () => {
-    let validateSpy;
+    let validateSpy, changeSpy, input;
 
     beforeEach(() => {
       timePicker = fixtureSync(`<vaadin-time-picker></vaadin-time-picker>`);
       validateSpy = sinon.spy(timePicker, 'validate');
+      changeSpy = sinon.spy();
+      timePicker.addEventListener('change', changeSpy);
+      input = timePicker.inputElement;
     });
 
     it('should pass validation by default', () => {
       expect(timePicker.checkValidity()).to.be.true;
       expect(timePicker.validate()).to.be.true;
+    });
+
+    it('should validate on blur', () => {
+      input.focus();
+      input.blur();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should validate before change event on blur', () => {
+      input.focus();
+      setInputValue(timePicker, '12:00');
+      input.blur();
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
     it('should not validate on value input', () => {


### PR DESCRIPTION
## Description

The PR refactors `time-picker` to prevent duplicate validation when blurring with an uncommitted value.

Depends on
- https://github.com/vaadin/web-components/pull/6180

Part of https://github.com/vaadin/web-components/issues/6146

## Type of change

- [x] Bugfix
