### PR TITLE
refactor!: update login overlay to not extend vaadin-overlay

### DIFF
--- a/packages/login/src/vaadin-login-overlay-wrapper.js
+++ b/packages/login/src/vaadin-login-overlay-wrapper.js
@@ -3,58 +3,44 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles(
-  'vaadin-login-overlay-wrapper',
-  css`
-    [part='overlay'] {
-      outline: none;
-    }
+const loginOverlayStyles = css`
+  [part='overlay'] {
+    outline: none;
+  }
 
-    [part='card'] {
-      max-width: 100%;
-      box-sizing: border-box;
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-    }
+  [part='card'] {
+    max-width: 100%;
+    box-sizing: border-box;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
 
-    [part='brand'] {
-      box-sizing: border-box;
-      overflow: hidden;
-      flex-grow: 1;
-      flex-shrink: 0;
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-    }
+  [part='brand'] {
+    box-sizing: border-box;
+    overflow: hidden;
+    flex-grow: 1;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
 
-    [part='brand'] h1 {
-      color: inherit;
-      margin: 0;
-    }
-  `,
-  { moduleId: 'vaadin-login-overlay-wrapper-styles' },
-);
-
-const template = html`
-  <section part="card">
-    <div part="brand">
-      <slot name="title">
-        <h1 part="title">[[title]]</h1>
-      </slot>
-      <p part="description">[[description]]</p>
-    </div>
-    <div part="form">
-      <slot></slot>
-    </div>
-  </section>
+  [part='brand'] h1 {
+    color: inherit;
+    margin: 0;
+  }
 `;
 
-let memoizedTemplate;
+registerStyles('vaadin-login-overlay-wrapper', [overlayStyles, loginOverlayStyles], {
+  moduleId: 'vaadin-login-overlay-wrapper-styles',
+});
 
 /**
  * An element used internally by `<vaadin-login-overlay>`. Not intended to be used separately.
@@ -62,7 +48,7 @@ let memoizedTemplate;
  * @extends Overlay
  * @private
  */
-class LoginOverlayWrapper extends Overlay {
+class LoginOverlayWrapper extends OverlayMixin(DirMixin(ThemableMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-login-overlay-wrapper';
   }
@@ -86,17 +72,24 @@ class LoginOverlayWrapper extends Overlay {
   }
 
   static get template() {
-    if (!memoizedTemplate) {
-      // Clone the superclass template
-      memoizedTemplate = super.template.cloneNode(true);
-
-      // Replace overlay slot with card
-      const card = template.content.querySelector('[part=card]');
-      const content = memoizedTemplate.content.querySelector('#content');
-      content.replaceChild(card, content.children[0]);
-    }
-
-    return memoizedTemplate;
+    return html`
+      <div id="backdrop" part="backdrop" hidden$="[[!withBackdrop]]"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <div part="content" id="content">
+          <section part="card">
+            <div part="brand">
+              <slot name="title">
+                <h1 part="title">[[title]]</h1>
+              </slot>
+              <p part="description">[[description]]</p>
+            </div>
+            <div part="form">
+              <slot></slot>
+            </div>
+          </section>
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/packages/login/theme/lumo/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-overlay-styles.js
@@ -1,6 +1,7 @@
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import './vaadin-login-form-wrapper-styles.js';
 import { color } from '@vaadin/vaadin-lumo-styles/color.js';
+import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
 import { typography } from '@vaadin/vaadin-lumo-styles/typography.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -169,8 +170,8 @@ const loginOverlayWrapper = css`
   }
 `;
 
-registerStyles('vaadin-login-overlay-wrapper', [color, typography, loginOverlayWrapper], {
-  moduleId: 'vaadin-login-overlay-wrapper-lumo-styles',
+registerStyles('vaadin-login-overlay-wrapper', [color, typography, overlay, loginOverlayWrapper], {
+  moduleId: 'lumo-login-overlay-wrapper',
 });
 
 const loginFormWrapper = css`

--- a/packages/login/theme/lumo/vaadin-login-overlay.js
+++ b/packages/login/theme/lumo/vaadin-login-overlay.js
@@ -1,7 +1,6 @@
 import '@vaadin/text-field/theme/lumo/vaadin-text-field.js';
 import '@vaadin/password-field/theme/lumo/vaadin-password-field.js';
 import '@vaadin/button/theme/lumo/vaadin-button.js';
-import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-login-form.js';
 import './vaadin-login-overlay-styles.js';
 import '../../src/vaadin-login-overlay.js';

--- a/packages/login/theme/material/vaadin-login-overlay.js
+++ b/packages/login/theme/material/vaadin-login-overlay.js
@@ -1,7 +1,6 @@
 import '@vaadin/text-field/theme/material/vaadin-text-field.js';
 import '@vaadin/password-field/theme/material/vaadin-password-field.js';
 import '@vaadin/button/theme/material/vaadin-button.js';
-import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-login-form.js';
 import './vaadin-login-overlay-styles.js';
 import '../../src/vaadin-login-overlay.js';


### PR DESCRIPTION
## Description

Part of #5718

Updated `vaadin-login-overlay-wrapper` to use `OverlayMixin` and styles as `css` literal.

## Type of change

- Refactor / Breaking change