### PR TITLE
refactor!: update menu-bar overlay to not extend vaadin-overlay

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.d.ts
@@ -3,13 +3,15 @@
  * Copyright (c) 2019 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { MenuOverlayMixin } from '@vaadin/context-menu/src/vaadin-menu-overlay-mixin.js';
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  */
-declare class MenuBarOverlay extends MenuOverlayMixin(Overlay) {}
+declare class MenuBarOverlay extends MenuOverlayMixin(OverlayMixin(DirMixin(ThemableMixin(HTMLElement)))) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -3,23 +3,42 @@
  * Copyright (c) 2019 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { MenuOverlayMixin } from '@vaadin/context-menu/src/vaadin-menu-overlay-mixin.js';
 import { styles } from '@vaadin/context-menu/src/vaadin-menu-overlay-styles.js';
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
-import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles('vaadin-menu-bar-overlay', styles, { moduleId: 'vaadin-menu-bar-overlay-styles' });
+registerStyles('vaadin-menu-bar-overlay', [overlayStyles, styles], {
+  moduleId: 'vaadin-menu-bar-overlay-styles',
+});
 
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
- * @extends Overlay
+ * @extends HTMLElement
+ * @mixes DirMixin
  * @mixes MenuOverlayMixin
- * @private
+ * @mixes OverlayMixin
+ * @mixes ThemableMixin
+ * @protected
  */
-class MenuBarOverlay extends MenuOverlayMixin(Overlay) {
+export class MenuBarOverlay extends MenuOverlayMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-menu-bar-overlay';
+  }
+
+  static get template() {
+    return html`
+      <div id="backdrop" part="backdrop" hidden$="[[!withBackdrop]]"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <div part="content" id="content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar.js
@@ -3,5 +3,4 @@ import './vaadin-menu-bar-item-styles.js';
 import './vaadin-menu-bar-list-box-styles.js';
 import './vaadin-menu-bar-overlay-styles.js';
 import './vaadin-menu-bar-styles.js';
-import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import '../../src/vaadin-menu-bar.js';

--- a/packages/menu-bar/theme/material/vaadin-menu-bar.js
+++ b/packages/menu-bar/theme/material/vaadin-menu-bar.js
@@ -3,5 +3,4 @@ import './vaadin-menu-bar-item-styles.js';
 import './vaadin-menu-bar-list-box-styles.js';
 import './vaadin-menu-bar-styles.js';
 import './vaadin-menu-bar-overlay-styles.js';
-import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import '../../src/vaadin-menu-bar.js';


### PR DESCRIPTION
## Description

Part of #5718

Updated `vaadin-menu-bar-overlay` to use `OverlayMixin` and styles as `css` literal.

## Type of change

- Refactor / Breaking change