### PR TITLE
docs: fix incorrect JSDoc after overlay mixins refactoring

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group-overlay.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-overlay.js
@@ -17,7 +17,11 @@ registerStyles('vaadin-avatar-group-overlay', [overlayStyles], {
 /**
  * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
  *
- * @extends Overlay
+ * @extends HTMLElement
+ * @mixes PositionMixin
+ * @mixes OverlayMixin
+ * @mixes DirMixin
+ * @mixes ThemableMixin
  * @private
  */
 class AvatarGroupOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {

--- a/packages/date-picker/src/vaadin-date-picker-overlay.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay.js
@@ -34,7 +34,11 @@ registerStyles('vaadin-date-picker-overlay', [overlayStyles, datePickerOverlaySt
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *
- * @extends Overlay
+ * @extends HTMLElement
+ * @mixes PositionMixin
+ * @mixes OverlayMixin
+ * @mixes DirMixin
+ * @mixes ThemableMixin
  * @private
  */
 class DatePickerOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {


### PR DESCRIPTION
## Description

These components incorrectly have `@extends Overlay` which is no longer true. Let's update them.

## Type of change

- Documentation