### PR TITLE
refactor!: update user-tags overlay to not extend vaadin-overlay

### DIFF
--- a/packages/field-highlighter/src/vaadin-user-tags-overlay.js
+++ b/packages/field-highlighter/src/vaadin-user-tags-overlay.js
@@ -69,7 +69,7 @@ registerStyles('vaadin-user-tags-overlay', [overlayStyles, userTagsOverlayStyles
  * @mixes ThemableMixin
  * @private
  */
-class DatePickerOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {
+class UserTagsOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-user-tags-overlay';
   }
@@ -86,4 +86,4 @@ class DatePickerOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMixi
   }
 }
 
-customElements.define(DatePickerOverlay.is, DatePickerOverlay);
+customElements.define(UserTagsOverlay.is, UserTagsOverlay);

--- a/packages/field-highlighter/src/vaadin-user-tags-overlay.js
+++ b/packages/field-highlighter/src/vaadin-user-tags-overlay.js
@@ -3,75 +3,87 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles(
-  'vaadin-user-tags-overlay',
-  css`
-    :host {
-      background: transparent;
-      box-shadow: none;
+const userTagsOverlayStyles = css`
+  :host {
+    background: transparent;
+    box-shadow: none;
+  }
+
+  [part='overlay'] {
+    box-shadow: none;
+    background: transparent;
+    position: relative;
+    left: -4px;
+    padding: 4px;
+    outline: none;
+    overflow: visible;
+  }
+
+  ::slotted([part='tags']) {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  :host([dir='rtl']) [part='overlay'] {
+    left: auto;
+    right: -4px;
+  }
+
+  [part='content'] {
+    padding: 0;
+  }
+
+  :host([opening]),
+  :host([closing]) {
+    animation: 0.14s user-tags-overlay-dummy-animation;
+  }
+
+  @keyframes user-tags-overlay-dummy-animation {
+    0% {
+      opacity: 1;
     }
 
-    [part='overlay'] {
-      box-shadow: none;
-      background: transparent;
-      position: relative;
-      left: -4px;
-      padding: 4px;
-      outline: none;
-      overflow: visible;
+    100% {
+      opacity: 1;
     }
+  }
+`;
 
-    ::slotted([part='tags']) {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-    }
-
-    :host([dir='rtl']) [part='overlay'] {
-      left: auto;
-      right: -4px;
-    }
-
-    [part='content'] {
-      padding: 0;
-    }
-
-    :host([opening]),
-    :host([closing]) {
-      animation: 0.14s user-tags-overlay-dummy-animation;
-    }
-
-    @keyframes user-tags-overlay-dummy-animation {
-      0% {
-        opacity: 1;
-      }
-
-      100% {
-        opacity: 1;
-      }
-    }
-  `,
-);
+registerStyles('vaadin-user-tags-overlay', [overlayStyles, userTagsOverlayStyles]);
 
 /**
  * An element used internally by `<vaadin-field-highlighter>`. Not intended to be used separately.
  *
- * @extends Overlay
+ * @extends HTMLElement
+ * @mixes PositionMixin
+ * @mixes OverlayMixin
+ * @mixes DirMixin
+ * @mixes ThemableMixin
  * @private
  */
-class UserTagsOverlay extends PositionMixin(Overlay) {
+class DatePickerOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-user-tags-overlay';
   }
 
-  ready() {
-    super.ready();
-    this.$.overlay.setAttribute('tabindex', '-1');
+  static get template() {
+    return html`
+      <div id="backdrop" part="backdrop" hidden$="[[!withBackdrop]]"></div>
+      <div part="overlay" id="overlay">
+        <div part="content" id="content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
   }
 }
 
-customElements.define(UserTagsOverlay.is, UserTagsOverlay);
+customElements.define(DatePickerOverlay.is, DatePickerOverlay);

--- a/packages/field-highlighter/theme/lumo/vaadin-user-tags-styles.js
+++ b/packages/field-highlighter/theme/lumo/vaadin-user-tags-styles.js
@@ -7,35 +7,39 @@ import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
+import { overlay } from '@vaadin/vaadin-lumo-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
   'vaadin-user-tags-overlay',
-  css`
-    [part='overlay'] {
-      will-change: opacity, transform;
-    }
-
-    :host([opening]) [part='overlay'] {
-      animation: 0.1s lumo-user-tags-enter ease-out both;
-    }
-
-    @keyframes lumo-user-tags-enter {
-      0% {
-        opacity: 0;
+  [
+    overlay,
+    css`
+      [part='overlay'] {
+        will-change: opacity, transform;
       }
-    }
 
-    :host([closing]) [part='overlay'] {
-      animation: 0.1s lumo-user-tags-exit both;
-    }
-
-    @keyframes lumo-user-tags-exit {
-      100% {
-        opacity: 0;
+      :host([opening]) [part='overlay'] {
+        animation: 0.1s lumo-user-tags-enter ease-out both;
       }
-    }
-  `,
+
+      @keyframes lumo-user-tags-enter {
+        0% {
+          opacity: 0;
+        }
+      }
+
+      :host([closing]) [part='overlay'] {
+        animation: 0.1s lumo-user-tags-exit both;
+      }
+
+      @keyframes lumo-user-tags-exit {
+        100% {
+          opacity: 0;
+        }
+      }
+    `,
+  ],
   {
     moduleId: 'lumo-user-tags-overlay',
   },

--- a/packages/field-highlighter/theme/lumo/vaadin-user-tags.js
+++ b/packages/field-highlighter/theme/lumo/vaadin-user-tags.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-user-tags-styles.js';
 import '../../src/vaadin-user-tags.js';

--- a/packages/field-highlighter/theme/material/vaadin-user-tags-styles.js
+++ b/packages/field-highlighter/theme/material/vaadin-user-tags-styles.js
@@ -6,7 +6,12 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
 import '@vaadin/vaadin-material-styles/typography.js';
+import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles('vaadin-user-tags-overlay', [overlay], {
+  moduleId: 'material-user-tags-overlay',
+});
 
 registerStyles(
   'vaadin-user-tag',

--- a/packages/field-highlighter/theme/material/vaadin-user-tags.js
+++ b/packages/field-highlighter/theme/material/vaadin-user-tags.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-user-tags-styles.js';
 import '../../src/vaadin-user-tags.js';


### PR DESCRIPTION
## Description

Part of #5718

Updated `vaadin-user-tags-wrapper` to use `OverlayMixin` and styles as `css` literal.

## Type of change

- Refactor / Breaking change