### PR TITLE
feat: add getFlattenedElements helper to get slotted elements

### DIFF
--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -7,6 +7,7 @@ import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nod
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { getNormalizedScrollLeft, setNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
+import { getFlattenedElements } from '@vaadin/component-base/src/dom-utils.js';
 import { KeyboardDirectionMixin } from './keyboard-direction-mixin.js';
 
 /**
@@ -135,7 +136,7 @@ export const ListMixin = (superClass) =>
       this.addEventListener('click', (e) => this._onClick(e));
 
       this._observer = new FlattenedNodesObserver(this, () => {
-        this._setItems(this._filterItems(FlattenedNodesObserver.getFlattenedNodes(this)));
+        this._setItems(this._filterItems(getFlattenedElements(this)));
       });
     }
 

--- a/packages/component-base/src/dom-utils.d.ts
+++ b/packages/component-base/src/dom-utils.d.ts
@@ -14,6 +14,13 @@
 export function getAncestorRootNodes(node: Node): Node[];
 
 /**
+ * Returns the list of flattened elements for the given `node`.
+ * This list consists of a node's children and, for any children that are
+ * `<slot>` elements, the expanded flattened list of `assignedElements`.
+ */
+export function getFlattenedElements(node: Node): Element[];
+
+/**
  * Traverses the given node and its parents, including those that are across
  * the shadow root boundaries, until it finds a node that matches the selector.
  */

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -41,6 +41,27 @@ export function getAncestorRootNodes(node) {
 }
 
 /**
+ * Returns the list of flattened elements for the given `node`.
+ * This list consists of a node's children and, for any children that are
+ * `<slot>` elements, the expanded flattened list of `assignedElements`.
+ *
+ * @param {Node} node
+ * @return {Element[]}
+ */
+export function getFlattenedElements(node) {
+  const result = [];
+  let elements;
+  if (node.localName === 'slot') {
+    elements = node.assignedElements({ flatten: true });
+  } else {
+    result.push(node);
+    elements = [...node.children];
+  }
+  elements.forEach((elem) => result.push(...getFlattenedElements(elem)));
+  return result;
+}
+
+/**
  * Traverses the given node and its parents, including those that are across
  * the shadow root boundaries, until it finds a node that matches the selector.
  *

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -52,7 +52,7 @@ export function getFlattenedElements(node) {
   const result = [];
   let elements;
   if (node.localName === 'slot') {
-    elements = node.assignedElements({ flatten: true });
+    elements = node.assignedElements();
   } else {
     result.push(node);
     elements = [...node.children];

--- a/packages/component-base/test/dom-utils.test.js
+++ b/packages/component-base/test/dom-utils.test.js
@@ -4,6 +4,7 @@ import {
   addValueToAttribute,
   getAncestorRootNodes,
   getClosestElement,
+  getFlattenedElements,
   isEmptyTextNode,
   removeValueFromAttribute,
 } from '../src/dom-utils.js';
@@ -146,6 +147,46 @@ describe('dom-utils', () => {
     it('should return false when node has non-empty text content', () => {
       node.textContent = '0';
       expect(isEmptyTextNode(node)).to.be.false;
+    });
+  });
+
+  describe('getFlattenedElements', () => {
+    let foo, bar, baz;
+
+    beforeEach(() => {
+      foo = document.createElement('div');
+      foo.attachShadow({ mode: 'open' });
+      foo.shadowRoot.innerHTML = '<slot></slot>';
+
+      bar = document.createElement('div');
+      bar.attachShadow({ mode: 'open' });
+      bar.shadowRoot.innerHTML = '<span>A</span><slot></slot><span>B</span>';
+
+      baz = document.createElement('span');
+      baz.textContent = 'C';
+
+      document.body.appendChild(foo);
+      bar.appendChild(baz);
+      foo.appendChild(bar);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(foo);
+    });
+
+    it('should return flattened elements for the element itself', () => {
+      expect(getFlattenedElements(foo)).to.eql([foo, bar, baz]);
+      expect(getFlattenedElements(bar)).to.eql([bar, baz]);
+    });
+
+    it('should return flatted elements for the parent slot element', () => {
+      const slot = foo.shadowRoot.querySelector('slot');
+      expect(getFlattenedElements(slot)).to.eql([bar, baz]);
+    });
+
+    it('should return flatted elements for the child slot element', () => {
+      const slot = bar.shadowRoot.querySelector('slot');
+      expect(getFlattenedElements(slot)).to.eql([baz]);
     });
   });
 });

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -3,10 +3,10 @@
  * Copyright (c) 2019 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
+import { getFlattenedElements } from '@vaadin/component-base/src/dom-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
@@ -212,24 +212,6 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
   }
 
   /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-
-    if (this.__observer) {
-      this.__observer.connect();
-    }
-  }
-
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-
-    if (this.__observer) {
-      this.__observer.disconnect();
-    }
-  }
-
-  /** @protected */
   ready() {
     super.ready();
 
@@ -239,7 +221,7 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
     this.ariaTarget = this;
 
     this.__setInputsFromSlot();
-    this.__observer = new FlattenedNodesObserver(this.$.slot, () => {
+    this.$.slot.addEventListener('slotchange', () => {
       this.__setInputsFromSlot();
     });
 
@@ -344,23 +326,6 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
     this.__settingValue = false;
   }
 
-  /**
-   * Like querySelectorAll('*') but also gets all elements through any nested slots recursively
-   * @private
-   */
-  __queryAllAssignedElements(elem) {
-    const result = [];
-    let elements;
-    if (elem.tagName === 'SLOT') {
-      elements = elem.assignedElements({ flatten: true });
-    } else {
-      result.push(elem);
-      elements = Array.from(elem.children);
-    }
-    elements.forEach((elem) => result.push(...this.__queryAllAssignedElements(elem)));
-    return result;
-  }
-
   /** @private */
   __isInput(node) {
     const isSlottedInput = node.getAttribute('slot') === 'input' || node.getAttribute('slot') === 'textarea';
@@ -369,7 +334,7 @@ class CustomField extends FieldMixin(FocusMixin(KeyboardMixin(ThemableMixin(Elem
 
   /** @private */
   __getInputsFromSlot() {
-    return this.__queryAllAssignedElements(this.$.slot).filter((node) => this.__isInput(node));
+    return getFlattenedElements(this.$.slot).filter((node) => this.__isInput(node));
   }
 
   /** @private */


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/6206

This helper is actually copied from `vaadin-custom-field` and is a bit different from the one provided by [Polymer itself](https://github.com/Polymer/polymer/blob/1e8b246d01ea99adba305ea04c45d26da31f68f1/lib/utils/flattened-nodes-observer.js#L85).
IMO we can use this version as long as it suits our needs - see `vaadin-custom-field` and `ListMixin` tests.

## Type of change

- Internal feature