### PR TITLE
experiment: add LitElement based version of vaadin-details

### DIFF
--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -21,6 +21,10 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-details-summary.d.ts",
+    "!src/vaadin-lit-details-summary.js",
+    "!src/vaadin-lit-details.d.ts",
+    "!src/vaadin-lit-details.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/details/src/vaadin-lit-details-summary.d.ts
+++ b/packages/details/src/vaadin-lit-details-summary.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from './vaadin-details-summary.js';

--- a/packages/details/src/vaadin-lit-details-summary.js
+++ b/packages/details/src/vaadin-lit-details-summary.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css, html, LitElement } from 'lit';
+import { ButtonMixin } from '@vaadin/button/src/vaadin-button-mixin.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-details-summary>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-details-summary';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+        outline: none;
+        white-space: nowrap;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        user-select: none;
+      }
+
+      :host([hidden]) {
+        display: none !important;
+      }
+
+      :host([disabled]) {
+        pointer-events: none;
+      }
+    `;
+  }
+
+  static get properties() {
+    return {
+      /**
+       * When true, the element is opened.
+       */
+      opened: {
+        type: Boolean,
+        reflectToAttribute: true,
+      },
+    };
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <span part="toggle" aria-hidden="true"></span>
+      <div part="content"><slot></slot></div>
+    `;
+  }
+}
+
+customElements.define(DetailsSummary.is, DetailsSummary);

--- a/packages/details/src/vaadin-lit-details.d.ts
+++ b/packages/details/src/vaadin-lit-details.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from './vaadin-details.js';

--- a/packages/details/src/vaadin-lit-details.js
+++ b/packages/details/src/vaadin-lit-details.js
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import './vaadin-lit-details-summary.js';
+import { css, html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { DetailsBaseMixin } from './vaadin-details-base-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-button>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class Details extends DetailsBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-details';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+      }
+
+      :host([hidden]) {
+        display: none !important;
+      }
+
+      [part='content'] {
+        display: none;
+      }
+
+      :host([opened]) [part='content'] {
+        display: block;
+      }
+    `;
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <slot name="summary"></slot>
+
+      <div part="content">
+        <slot></slot>
+      </div>
+
+      <slot name="tooltip"></slot>
+    `;
+  }
+}
+
+customElements.define(Details.is, Details);
+
+export { Details };

--- a/packages/details/test/details-list.test.js
+++ b/packages/details/test/details-list.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-details.js';
+import './details.common.js';

--- a/packages/details/test/details-polymer.test.js
+++ b/packages/details/test/details-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-details.js';
+import './details.common.js';

--- a/packages/details/test/details.common.js
+++ b/packages/details/test/details.common.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../vaadin-details.js';
 
 describe('vaadin-details', () => {
   let details;


### PR DESCRIPTION
## Description

Added `LitElement` based version of `vaadin-details` web component.

## Type of change

- Experiment

## Disclaimer

Same as other Lit experiments, this is not supposed to be published to npm.