### PR TITLE
refactor: schedule SlotObserver calls using queueMicrotask

### DIFF
--- a/packages/component-base/src/slot-observer.js
+++ b/packages/component-base/src/slot-observer.js
@@ -18,17 +18,32 @@ export class SlotObserver {
     /** @type {Node[]} */
     this._storedNodes = [];
 
-    this._processNodes();
+    this._scheduled = false;
 
     slot.addEventListener('slotchange', () => {
-      this._processNodes();
+      this._schedule();
     });
+
+    this._schedule();
+  }
+
+  /** @private */
+  _schedule() {
+    if (!this._scheduled) {
+      this._scheduled = true;
+
+      queueMicrotask(() => {
+        this.flush();
+      });
+    }
   }
 
   /**
    * Run the observer callback synchronously.
    */
   flush() {
+    this._scheduled = false;
+
     this._processNodes();
   }
 

--- a/packages/component-base/test/slot-observer.test.js
+++ b/packages/component-base/test/slot-observer.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { SlotObserver } from '../src/slot-observer.js';
 
@@ -24,7 +23,7 @@ describe('SlotObserver', () => {
     observer = new SlotObserver(slot, spy);
     expect(spy.called).to.be.false;
 
-    await aTimeout(0);
+    await Promise.resolve();
 
     const addedNodes = spy.firstCall.args[0].addedNodes;
 
@@ -38,12 +37,16 @@ describe('SlotObserver', () => {
   it('should run callback asynchronously after node is added', async () => {
     spy = sinon.spy();
     observer = new SlotObserver(slot, spy);
-    await aTimeout(0);
+    await Promise.resolve();
     spy.resetHistory();
 
     const div = document.createElement('div');
     host.appendChild(div);
-    await aTimeout(0);
+
+    // Wait for slotchange
+    await Promise.resolve();
+    // Wait for microtask
+    await Promise.resolve();
 
     expect(spy.called).to.be.true;
     const addedNodes = spy.firstCall.args[0].addedNodes;
@@ -54,12 +57,16 @@ describe('SlotObserver', () => {
   it('should run callback asynchronously after node is removed', async () => {
     spy = sinon.spy();
     observer = new SlotObserver(slot, spy);
-    await aTimeout(0);
+    await Promise.resolve();
     spy.resetHistory();
 
     const div = host.firstElementChild;
     host.removeChild(div);
-    await aTimeout(0);
+
+    // Wait for slotchange
+    await Promise.resolve();
+    // Wait for microtask
+    await Promise.resolve();
 
     expect(spy.calledOnce).to.be.true;
     const removedNodes = spy.firstCall.args[0].removedNodes;
@@ -70,12 +77,16 @@ describe('SlotObserver', () => {
   it('should run callback asynchronously after node is moved', async () => {
     spy = sinon.spy();
     observer = new SlotObserver(slot, spy);
-    await aTimeout(0);
+    await Promise.resolve();
     spy.resetHistory();
 
     const nodes = host.children;
     host.insertBefore(nodes[1], nodes[0]);
-    await aTimeout(0);
+
+    // Wait for slotchange
+    await Promise.resolve();
+    // Wait for microtask
+    await Promise.resolve();
 
     expect(spy.calledOnce).to.be.true;
     const movedNodes = spy.firstCall.args[0].movedNodes;
@@ -87,7 +98,7 @@ describe('SlotObserver', () => {
   it('should run callback synchronously when calling flush()', async () => {
     spy = sinon.spy();
     observer = new SlotObserver(slot, spy);
-    await aTimeout(0);
+    await Promise.resolve();
     spy.resetHistory();
 
     const div = document.createElement('div');

--- a/packages/component-base/test/slot-observer.test.js
+++ b/packages/component-base/test/slot-observer.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@esm-bundle/chai';
+import { aTimeout } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { SlotObserver } from '../src/slot-observer.js';
 
@@ -18,10 +19,12 @@ describe('SlotObserver', () => {
     host.remove();
   });
 
-  it('should run callback for initial nodes synchronously', () => {
+  it('should run callback for initial nodes asynchronously', async () => {
     spy = sinon.spy();
     observer = new SlotObserver(slot, spy);
-    expect(spy.called).to.be.true;
+    expect(spy.called).to.be.false;
+
+    await aTimeout(0);
 
     const addedNodes = spy.firstCall.args[0].addedNodes;
 
@@ -35,15 +38,14 @@ describe('SlotObserver', () => {
   it('should run callback asynchronously after node is added', async () => {
     spy = sinon.spy();
     observer = new SlotObserver(slot, spy);
+    await aTimeout(0);
     spy.resetHistory();
 
     const div = document.createElement('div');
     host.appendChild(div);
+    await aTimeout(0);
 
-    // Wait for microtask
-    await Promise.resolve();
-
-    expect(spy.calledOnce).to.be.true;
+    expect(spy.called).to.be.true;
     const addedNodes = spy.firstCall.args[0].addedNodes;
     expect(addedNodes.length).to.equal(1);
     expect(addedNodes[0]).to.equal(div);
@@ -52,13 +54,12 @@ describe('SlotObserver', () => {
   it('should run callback asynchronously after node is removed', async () => {
     spy = sinon.spy();
     observer = new SlotObserver(slot, spy);
+    await aTimeout(0);
     spy.resetHistory();
 
     const div = host.firstElementChild;
     host.removeChild(div);
-
-    // Wait for microtask
-    await Promise.resolve();
+    await aTimeout(0);
 
     expect(spy.calledOnce).to.be.true;
     const removedNodes = spy.firstCall.args[0].removedNodes;
@@ -69,13 +70,12 @@ describe('SlotObserver', () => {
   it('should run callback asynchronously after node is moved', async () => {
     spy = sinon.spy();
     observer = new SlotObserver(slot, spy);
+    await aTimeout(0);
     spy.resetHistory();
 
     const nodes = host.children;
     host.insertBefore(nodes[1], nodes[0]);
-
-    // Wait for microtask
-    await Promise.resolve();
+    await aTimeout(0);
 
     expect(spy.calledOnce).to.be.true;
     const movedNodes = spy.firstCall.args[0].movedNodes;
@@ -84,9 +84,10 @@ describe('SlotObserver', () => {
     expect(movedNodes[1]).to.equal(nodes[0]);
   });
 
-  it('should run callback synchronously when calling flush()', () => {
+  it('should run callback synchronously when calling flush()', async () => {
     spy = sinon.spy();
     observer = new SlotObserver(slot, spy);
+    await aTimeout(0);
     spy.resetHistory();
 
     const div = document.createElement('div');


### PR DESCRIPTION
## Description

Turns out we need to defer `SlotObserver` initial call until the microtask to ensure `children` have been upgraded.
This change makes the behavior aligned with `FlattenedNodesObserver`, including the way how `flush()` works.

Note, this change in particular fixes `vaadin-accordion` ITs failing in #6217 where `vaadin-accordion-panel` elements are not yet upgraded by the time when `ready()` callback is called for the `vaadin-accordion` itself.

## Type of change

- Refactor