### PR TITLE
test: update radio-group snapshot tests to cover name attribute

### DIFF
--- a/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
@@ -18,6 +18,7 @@ snapshots["vaadin-radio-group host default"] =
     </label>
     <input
       id="input-vaadin-radio-button-6"
+      name="vaadin-radio-group-5"
       slot="input"
       type="radio"
       value="1"
@@ -38,6 +39,7 @@ snapshots["vaadin-radio-group host default"] =
     </label>
     <input
       id="input-vaadin-radio-button-7"
+      name="vaadin-radio-group-5"
       slot="input"
       type="radio"
       value="2"
@@ -79,6 +81,7 @@ snapshots["vaadin-radio-group host label"] =
     </label>
     <input
       id="input-vaadin-radio-button-6"
+      name="vaadin-radio-group-5"
       slot="input"
       type="radio"
       value="1"
@@ -99,6 +102,7 @@ snapshots["vaadin-radio-group host label"] =
     </label>
     <input
       id="input-vaadin-radio-button-7"
+      name="vaadin-radio-group-5"
       slot="input"
       type="radio"
       value="2"
@@ -144,6 +148,7 @@ snapshots["vaadin-radio-group host disabled"] =
     <input
       disabled=""
       id="input-vaadin-radio-button-6"
+      name="vaadin-radio-group-5"
       slot="input"
       tabindex="-1"
       type="radio"
@@ -168,6 +173,7 @@ snapshots["vaadin-radio-group host disabled"] =
     <input
       disabled=""
       id="input-vaadin-radio-button-7"
+      name="vaadin-radio-group-5"
       slot="input"
       tabindex="-1"
       type="radio"
@@ -210,6 +216,7 @@ snapshots["vaadin-radio-group host required"] =
     </label>
     <input
       id="input-vaadin-radio-button-6"
+      name="vaadin-radio-group-5"
       slot="input"
       type="radio"
       value="1"
@@ -230,6 +237,7 @@ snapshots["vaadin-radio-group host required"] =
     </label>
     <input
       id="input-vaadin-radio-button-7"
+      name="vaadin-radio-group-5"
       slot="input"
       type="radio"
       value="2"
@@ -271,6 +279,7 @@ snapshots["vaadin-radio-group host helper"] =
     </label>
     <input
       id="input-vaadin-radio-button-6"
+      name="vaadin-radio-group-5"
       slot="input"
       type="radio"
       value="1"
@@ -291,6 +300,7 @@ snapshots["vaadin-radio-group host helper"] =
     </label>
     <input
       id="input-vaadin-radio-button-7"
+      name="vaadin-radio-group-5"
       slot="input"
       type="radio"
       value="2"

--- a/packages/radio-group/test/dom/radio-button.test.js
+++ b/packages/radio-group/test/dom/radio-button.test.js
@@ -4,27 +4,27 @@ import '../../vaadin-radio-button.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
 describe('vaadin-radio-button', () => {
-  let checkbox;
+  let radio;
 
   beforeEach(() => {
     resetUniqueId();
-    checkbox = fixtureSync('<vaadin-radio-button label="Radio button"></vaadin-radio-button>');
+    radio = fixtureSync('<vaadin-radio-button label="Radio button"></vaadin-radio-button>');
   });
 
   describe('host', () => {
     it('default', async () => {
-      await expect(checkbox).dom.to.equalSnapshot();
+      await expect(radio).dom.to.equalSnapshot();
     });
 
     it('disabled', async () => {
-      checkbox.disabled = true;
-      await expect(checkbox).dom.to.equalSnapshot();
+      radio.disabled = true;
+      await expect(radio).dom.to.equalSnapshot();
     });
   });
 
   describe('shadow', () => {
     it('default', async () => {
-      await expect(checkbox).shadowDom.to.equalSnapshot();
+      await expect(radio).shadowDom.to.equalSnapshot();
     });
   });
 });

--- a/packages/radio-group/test/dom/radio-group.test.js
+++ b/packages/radio-group/test/dom/radio-group.test.js
@@ -1,12 +1,12 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../vaadin-radio-group.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
 describe('vaadin-radio-group', () => {
   let group;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetUniqueId();
     group = fixtureSync(`
       <vaadin-radio-group>
@@ -14,6 +14,7 @@ describe('vaadin-radio-group', () => {
         <vaadin-radio-button value="2" label="Radio 2"></vaadin-radio-button>
       </vaadin-radio-group>
     `);
+    await nextRender();
   });
 
   describe('host', () => {


### PR DESCRIPTION
## Description

While looking into replacing `FlattenedNodesObserver`, I noticed that related logic isn't covered by snapshots.
This PR fixes that. Also, removed some copy-paste leftovers from `vaadin-checkbox` snapshot tests.

## Type of change

- Tests