### PR TITLE
test: make getBodyCellContent helper use virtual row index

### DIFF
--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -160,8 +160,10 @@ export const getHeaderCellContent = (grid, row, col) => {
 };
 
 export const getBodyCellContent = (grid, row, col) => {
-  const container = grid.$.items;
-  return getContainerCellContent(container, row, col);
+  const physicalItems = getPhysicalItems(grid);
+  const physicalRow = physicalItems.find((item) => item.index === row);
+  const cells = getRowCells(physicalRow);
+  return getCellContent(cells[col]);
 };
 
 export const fire = (type, detail, options) => {


### PR DESCRIPTION
## Description

Currently the `getBodyCellContent` grid test helper uses the index of rows in the DOM, which can return cells in the wrong row if the virtualizer has reassigned rows due to scrolling for example. This changes the helper to look up rows based on their virtual index.
