### PR TITLE
experiment: add LitElement based version of vaadin-split-layout

### DIFF
--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-split-layout.d.ts",
+    "!src/vaadin-lit-split-layout.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/split-layout/src/vaadin-lit-split-layout.d.ts
+++ b/packages/split-layout/src/vaadin-lit-split-layout.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+export * from './vaadin-split-layout.js';

--- a/packages/split-layout/src/vaadin-lit-split-layout.js
+++ b/packages/split-layout/src/vaadin-lit-split-layout.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { SplitLayoutMixin } from './vaadin-split-layout-mixin.js';
+import { splitLayoutStyles } from './vaadin-split-layout-styles.js';
+
+/**
+ * LitElement based version of `<vaadin-split-layout>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class SplitLayout extends SplitLayoutMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-split-layout';
+  }
+
+  static get styles() {
+    return splitLayoutStyles;
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <slot id="primary" name="primary"></slot>
+      <div part="splitter" id="splitter">
+        <div part="handle"></div>
+      </div>
+      <slot id="secondary" name="secondary"></slot>
+    `;
+  }
+}
+
+customElements.define(SplitLayout.is, SplitLayout);
+
+export { SplitLayout };

--- a/packages/split-layout/test/split-layout-lit.test.js
+++ b/packages/split-layout/test/split-layout-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-split-layout.js';
+import './split-layout.common.js';

--- a/packages/split-layout/test/split-layout-polymer.test.js
+++ b/packages/split-layout/test/split-layout-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-split-layout.js';
+import './split-layout.common.js';

--- a/packages/split-layout/test/split-layout.common.js
+++ b/packages/split-layout/test/split-layout.common.js
@@ -1,20 +1,20 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextFrame, track } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame, nextRender, track } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-split-layout.js';
 
 const initialSizes = { width: 128, height: 128 };
 
 let splitLayout, first, second;
 
 describe('split layout', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     splitLayout = fixtureSync(`
       <vaadin-split-layout>
         <div id="first">some content</div>
         <div id="second">some content</div>
       </vaadin-split-layout>
     `);
+    await nextRender();
   });
 
   describe('container', () => {
@@ -32,8 +32,7 @@ describe('split layout', () => {
   describe('content elements', () => {
     let splitter;
 
-    beforeEach(async () => {
-      await aTimeout(0);
+    beforeEach(() => {
       first = splitLayout.$.primary.assignedNodes({ flatten: true })[0];
       second = splitLayout.$.secondary.assignedNodes({ flatten: true })[0];
       splitter = splitLayout.$.splitter;


### PR DESCRIPTION
## Description

Closes #6221

Added `LitElement` based version of `vaadin-split-layout` web component.

## Type of change

- Experiment

## Disclaimer

Same as other Lit experiments, this is not supposed to be published to npm.