### PR TITLE
refactor: use slot controllers to handle CRUD grid and form

### DIFF
--- a/packages/crud/src/vaadin-crud-controllers.d.ts
+++ b/packages/crud/src/vaadin-crud-controllers.d.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2023 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+/**
+ * A controller for initializing slotted button.
+ */
+export class ButtonSlotController extends SlotController {
+  constructor(host: HTMLElement);
+}
+
+/**
+ * A controller for initializing slotted form.
+ */
+export class FormSlotController extends SlotController {
+  constructor(host: HTMLElement);
+}
+
+/**
+ * A controller for initializing slotted grid.
+ */
+export class GridSlotController extends SlotController {
+  constructor(host: HTMLElement);
+}

--- a/packages/crud/src/vaadin-crud-controllers.js
+++ b/packages/crud/src/vaadin-crud-controllers.js
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2023 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+/**
+ * A controller for initializing slotted button.
+ * @protected
+ */
+export class ButtonSlotController extends SlotController {
+  constructor(host, type, theme) {
+    super(host, `${type}-button`, 'vaadin-button');
+
+    this.type = type;
+    this.theme = theme;
+  }
+
+  /**
+   * Override method inherited from `SlotController`
+   * to mark custom slotted button as the default.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  initNode(node) {
+    // Needed by Flow counterpart to apply i18n to custom button
+    if (node._isDefault) {
+      this.defaultNode = node;
+    }
+
+    if (node === this.defaultNode) {
+      node.setAttribute('theme', this.theme);
+    }
+
+    const { host, type } = this;
+    const property = `_${type}Button`;
+    const listener = `__${type}`;
+
+    // TODO: restore default button when a corresponding slotted button is removed.
+    // This would require us to detect where to insert a button after teleporting it,
+    // which happens after opening a dialog and closing it (default editor position).
+    if (host[property] && host[property] !== node) {
+      host[property].remove();
+    }
+
+    node.addEventListener('click', host[listener]);
+    host[property] = node;
+  }
+}
+
+/**
+ * A controller for initializing slotted form.
+ * @protected
+ */
+export class FormSlotController extends SlotController {
+  constructor(host) {
+    super(host, 'form', 'vaadin-crud-form');
+  }
+
+  /**
+   * Override method inherited from `SlotController`
+   * to move slotted form to the overlay if needed.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  initNode(node) {
+    this.host._form = node;
+
+    if (this.host.editorOpened) {
+      this.host.__ensureChildren();
+    }
+  }
+}
+
+/**
+ * A controller for initializing slotted grid.
+ * @protected
+ */
+export class GridSlotController extends SlotController {
+  constructor(host) {
+    super(host, 'grid', 'vaadin-crud-grid');
+  }
+
+  /**
+   * Override method inherited from `SlotController`
+   * to initialize `active-item-changed` listener.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  initNode(node) {
+    const { host } = this;
+
+    // Wait for all the properties e.g. `noFilter` and `noSort`
+    // to be set, to ensure columns are configured correctly.
+    queueMicrotask(() => {
+      // Force to remove listener on previous grid first
+      host.__editOnClickChanged(false, host._grid);
+      host._grid = node;
+      host.__editOnClickChanged(host.editOnClick, host._grid);
+    });
+  }
+}

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -14,7 +14,6 @@ import '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
 import './vaadin-crud-dialog.js';
 import './vaadin-crud-grid.js';
 import './vaadin-crud-form.js';
-import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { FocusRestorationController } from '@vaadin/a11y-base/src/focus-restoration-controller.js';
@@ -23,53 +22,8 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ButtonSlotController, FormSlotController, GridSlotController } from './vaadin-crud-controllers.js';
 import { getProperty, setProperty } from './vaadin-crud-helpers.js';
-
-/**
- * A controller for initializing slotted button.
- * @private
- */
-class ButtonSlotController extends SlotController {
-  constructor(host, type, theme) {
-    super(host, `${type}-button`, 'vaadin-button');
-
-    this.type = type;
-    this.theme = theme;
-  }
-
-  /**
-   * Override method inherited from `SlotController`
-   * to mark custom slotted button as the default.
-   *
-   * @param {Node} node
-   * @protected
-   * @override
-   */
-  initNode(node) {
-    // Needed by Flow counterpart to apply i18n to custom button
-    if (node._isDefault) {
-      this.defaultNode = node;
-    }
-
-    if (node === this.defaultNode) {
-      node.setAttribute('theme', this.theme);
-    }
-
-    const { host, type } = this;
-    const property = `_${type}Button`;
-    const listener = `__${type}`;
-
-    // TODO: restore default button when a corresponding slotted button is removed.
-    // This would require us to detect where to insert a button after teleporting it,
-    // which happens after opening a dialog and closing it (default editor position).
-    if (host[property] && host[property] !== node) {
-      host[property].remove();
-    }
-
-    node.addEventListener('click', host[listener]);
-    host[property] = node;
-  }
-}
 
 /**
  * `<vaadin-crud>` is a Web Component for [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operations.
@@ -711,10 +665,6 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     this._deleteButtonController = new ButtonSlotController(this, 'delete', 'tertiary error');
 
     this.__focusRestorationController = new FocusRestorationController();
-
-    this._observer = new FlattenedNodesObserver(this, (info) => {
-      this.__onDomChange(info.addedNodes);
-    });
   }
 
   /** @protected */
@@ -748,10 +698,10 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     });
     this.addController(this._headerController);
 
-    this._gridController = new SlotController(this, 'grid', 'vaadin-crud-grid');
+    this._gridController = new GridSlotController(this);
     this.addController(this._gridController);
 
-    this.addController(new SlotController(this, 'form', 'vaadin-crud-form'));
+    this.addController(new FormSlotController(this));
 
     this.addController(this._newButtonController);
 
@@ -917,31 +867,6 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
   /** @private */
   __onDialogOpened(event) {
     this.editorOpened = event.detail.value;
-  }
-
-  /** @private */
-  __onDomChange(addedNodes) {
-    addedNodes
-      .filter((node) => node.nodeType === Node.ELEMENT_NODE)
-      .forEach((node) => {
-        const slotAttributeValue = node.getAttribute('slot');
-        if (!slotAttributeValue) {
-          return;
-        }
-
-        if (slotAttributeValue === 'grid') {
-          // Force to remove listener on previous grid first
-          this.__editOnClickChanged(false, this._grid);
-          this._grid = node;
-          this.__editOnClickChanged(this.editOnClick, this._grid);
-        } else if (slotAttributeValue === 'form') {
-          this._form = node;
-        }
-      });
-
-    if (this.editorOpened) {
-      this.__ensureChildren();
-    }
   }
 
   /** @private */

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -279,7 +279,7 @@ describe('crud', () => {
 
     it('should not customize the grid without a proper slot', async () => {
       crud.appendChild(grid);
-      crud._observer.flush();
+      await nextRender();
       crud.items = [1, 2];
       await nextRender(crud);
       flushGrid(grid);
@@ -289,7 +289,7 @@ describe('crud', () => {
     it('should be able to provide a custom grid', async () => {
       grid.setAttribute('slot', 'grid');
       crud.appendChild(grid);
-      crud._observer.flush();
+      await nextRender();
       crud.items = [1, 2];
       await nextRender(crud);
       flushGrid(grid);
@@ -300,7 +300,7 @@ describe('crud', () => {
 
     it('should not customize the form without a proper slot', async () => {
       crud.appendChild(form);
-      crud._observer.flush();
+      await nextRender();
       crud.items = [{ foo: 1 }];
       await nextRender(crud);
       edit(crud.items[0]);
@@ -311,7 +311,7 @@ describe('crud', () => {
     it('should be able to provide a custom form', async () => {
       form.setAttribute('slot', 'form');
       crud.appendChild(form);
-      crud._observer.flush();
+      await nextRender();
       crud.items = [{ foo: 'bar' }];
       await nextRender();
       edit(crud.items[0]);
@@ -333,7 +333,7 @@ describe('crud', () => {
     it('should not highlight the edited item', async () => {
       grid.setAttribute('slot', 'grid');
       crud.appendChild(grid);
-      crud._observer.flush();
+      await nextRender();
       crud.items = [{ foo: 'bar' }];
       edit(crud.items[0]);
       await nextRender();
@@ -343,7 +343,7 @@ describe('crud', () => {
     it('should not clear selection of a custom grid', async () => {
       grid.setAttribute('slot', 'grid');
       crud.appendChild(grid);
-      crud._observer.flush();
+      await nextRender();
       crud.items = [{ foo: 'bar' }];
       grid.selectedItems = [crud.items[0]];
 
@@ -375,7 +375,7 @@ describe('crud', () => {
       `);
       form.setAttribute('slot', 'form');
       crud.appendChild(form);
-      crud._observer.flush();
+      await nextRender();
       crud.items = [{ foo: 1, bar: 2 }];
       await nextRender(crud);
     });

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -21,8 +21,24 @@ snapshots["vaadin-crud host default"] =
     <vaadin-crud-edit-column>
     </vaadin-crud-edit-column>
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-0">
+      <vaadin-grid-sorter
+        aria-label="Sort by Name"
+        path="name"
+      >
+        Name
+      </vaadin-grid-sorter>
     </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-1">
+      <vaadin-grid-sorter
+        aria-label="Sort by Age"
+        path="age"
+      >
+        Age
+      </vaadin-grid-sorter>
+    </vaadin-grid-cell-content>
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-2">
+    </vaadin-grid-cell-content>
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-3">
       <vaadin-grid-filter
         aria-label="Filter by Name"
         path="name"
@@ -53,7 +69,7 @@ snapshots["vaadin-crud host default"] =
         </vaadin-text-field>
       </vaadin-grid-filter>
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-2">
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-4">
       <vaadin-grid-filter
         aria-label="Filter by Age"
         path="age"
@@ -84,10 +100,6 @@ snapshots["vaadin-crud host default"] =
         </vaadin-text-field>
       </vaadin-grid-filter>
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-3">
-    </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-4">
-    </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-5">
     </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-6">
@@ -101,38 +113,26 @@ snapshots["vaadin-crud host default"] =
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-10">
     </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-11">
-      John
     </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-12">
-      30
     </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-13">
+    </vaadin-grid-cell-content>
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-14">
+    </vaadin-grid-cell-content>
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-15">
+      John
+    </vaadin-grid-cell-content>
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-16">
+      30
+    </vaadin-grid-cell-content>
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-17">
       <vaadin-crud-edit
         aria-label="Edit"
         role="button"
         tabindex="0"
       >
       </vaadin-crud-edit>
-    </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-14">
-      <vaadin-grid-sorter
-        aria-label="Sort by Name"
-        path="name"
-      >
-        Name
-      </vaadin-grid-sorter>
-    </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-15">
-      <vaadin-grid-sorter
-        aria-label="Sort by Age"
-        path="age"
-      >
-        Age
-      </vaadin-grid-sorter>
-    </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-16">
-    </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-17">
     </vaadin-grid-cell-content>
   </vaadin-crud-grid>
   <vaadin-crud-form slot="form">
@@ -176,7 +176,7 @@ snapshots["vaadin-crud host default"] =
 `;
 /* end snapshot vaadin-crud host default */
 
-snapshots["vaadin-crud shadow default"] = 
+snapshots["vaadin-crud shadow default"] =
 `<div id="container">
   <div id="main">
     <slot name="grid">


### PR DESCRIPTION
## Description

Related to #6206 

Replaced `FlattenedNodesObserver` with slot controllers for `form` and `grid` slots to handle corresponding `_form` and `_grid` properties. We actually already had controllers for these, they just had to be updated accordingly.

## Type of change

- Refactor