### PR TITLE
[DO NOT MERGE] refactor!: validate on blur only when field is dirty

### DIFF
--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -94,7 +94,7 @@ declare class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementM
   value: string[];
 
   /**
-   * Whether the field is dirty.
+   * Whether the field is dirty. When dirty, the field validates on blur.
    *
    * The field is automatically marked as dirty once the user triggers
    * a `change` event. Additionally, the field can be manually marked

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -381,7 +381,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Validate only when the user has interacted with the field.
+    // Validate on blur only when the user has interacted with the field.
     if (!focused && this.dirty) {
       this.validate();
     }

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -141,7 +141,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
       },
 
       /**
-       * Whether the field is dirty.
+       * Whether the field is dirty. When dirty, the field validates on blur.
        *
        * The field is automatically marked as dirty once the user triggers
        * a `change` event. Additionally, the field can be manually marked

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -381,8 +381,8 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Validate on blur only after the user has triggered a `change` event,
-    // or the field has been initially marked as dirty.
+    // Validate on blur only when the field is dirty (the user has triggered
+    // a `change` event once, or the field has been manually marked as dirty).
     if (!focused && this.dirty) {
       this.validate();
     }

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -381,7 +381,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Validate on blur only when the user has interacted with the field
+    // Validate on blur only after the user has triggered a `change` event,
     // or the field has been initially marked as dirty.
     if (!focused && this.dirty) {
       this.validate();

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -381,7 +381,8 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Validate on blur only when the user has interacted with the field.
+    // Validate on blur only when the user has interacted with the field
+    // or the field has been initially marked as dirty.
     if (!focused && this.dirty) {
       this.validate();
     }

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -381,9 +381,8 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Do not validate when focusout is caused by document
-    // losing focus, which happens on browser tab switch.
-    if (!focused && document.hasFocus()) {
+    // Validate only when the user has interacted with the field.
+    if (!focused && this.dirty) {
       this.validate();
     }
   }

--- a/packages/checkbox-group/test/validation.test.js
+++ b/packages/checkbox-group/test/validation.test.js
@@ -68,8 +68,21 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate on focusout', async () => {
-      // Focus on the first checkbox.
+    it('should not validate on focusout by default', async () => {
+      // Move focus to the first checkbox.
+      await sendKeys({ press: 'Tab' });
+
+      // Move focus out of the checkbox group.
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on focusout when dirty', async () => {
+      group.dirty = true;
+
+      // Move focus to the first checkbox.
       await sendKeys({ press: 'Tab' });
       expect(validateSpy.called).to.be.false;
 
@@ -107,28 +120,6 @@ describe('validation', () => {
       expect(validatedSpy.calledOnce).to.be.true;
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', async () => {
-        // Focus on the first checkbox.
-        await sendKeys({ press: 'Tab' });
-
-        // Move focus out of the checkbox group.
-        await sendKeys({ down: 'Shift' });
-        await sendKeys({ press: 'Tab' });
-        await sendKeys({ up: 'Shift' });
-
-        expect(validateSpy.called).to.be.false;
-      });
     });
   });
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1091,7 +1091,7 @@ export const ComboBoxMixin = (subclass) =>
         this.dirty = true;
       }
 
-      // Validate on blur only when the user has interacted with the field
+      // Validate on blur only after the user has triggered an `input` or `change` event,
       // or the field has been initially marked as dirty.
       if (this.dirty) {
         this.validate();

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1091,9 +1091,7 @@ export const ComboBoxMixin = (subclass) =>
         this.dirty = true;
       }
 
-      // Do not validate when focusout is caused by document
-      // losing focus, which happens on browser tab switch.
-      if (document.hasFocus()) {
+      if (this.dirty) {
         this.validate();
       }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1091,7 +1091,8 @@ export const ComboBoxMixin = (subclass) =>
         this.dirty = true;
       }
 
-      // Validate on blur only when the user has interacted with the field.
+      // Validate on blur only when the user has interacted with the field
+      // or the field has been initially marked as dirty.
       if (this.dirty) {
         this.validate();
       }

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1091,6 +1091,7 @@ export const ComboBoxMixin = (subclass) =>
         this.dirty = true;
       }
 
+      // Validate only when the user has interacted with the field.
       if (this.dirty) {
         this.validate();
       }

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1091,8 +1091,8 @@ export const ComboBoxMixin = (subclass) =>
         this.dirty = true;
       }
 
-      // Validate on blur only after the user has triggered an `input` or `change` event,
-      // or the field has been initially marked as dirty.
+      // Validate only when the field is dirty (the user has triggered an `input` or
+      // `change` event once, or the field has been manually marked as dirty).
       if (this.dirty) {
         this.validate();
       }

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1091,7 +1091,7 @@ export const ComboBoxMixin = (subclass) =>
         this.dirty = true;
       }
 
-      // Validate only when the user has interacted with the field.
+      // Validate on blur only when the user has interacted with the field.
       if (this.dirty) {
         this.validate();
       }

--- a/packages/combo-box/test/combo-box-light-validation.test.js
+++ b/packages/combo-box/test/combo-box-light-validation.test.js
@@ -31,7 +31,14 @@ describe('vaadin-combo-box-light - validation', () => {
       expect(comboBox.invalid).to.be.false;
     });
 
-    it('should validate on blur', () => {
+    it('should not validate on blur by default', () => {
+      input.focus();
+      input.blur();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on blur when dirty', () => {
+      comboBox.dirty = true;
       input.focus();
       input.blur();
       expect(validateSpy.calledOnce).to.be.true;
@@ -44,22 +51,6 @@ describe('vaadin-combo-box-light - validation', () => {
       expect(changeSpy.calledOnce).to.be.true;
       expect(validateSpy.calledOnce).to.be.true;
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', () => {
-        input.focus();
-        input.blur();
-        expect(validateSpy.called).to.be.false;
-      });
     });
   });
 

--- a/packages/combo-box/test/validation.test.js
+++ b/packages/combo-box/test/validation.test.js
@@ -26,13 +26,28 @@ describe('validation', () => {
       expect(comboBox.invalid).to.be.false;
     });
 
-    it('should validate on blur', () => {
+    it('should not validate on blur by default', () => {
+      input.focus();
+      input.blur();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on blur when dirty', () => {
+      comboBox.dirty = true;
       input.focus();
       input.blur();
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate on outside click', () => {
+    it('should not validate on outside click by default', () => {
+      input.focus();
+      input.click();
+      outsideClick();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on outside click when dirty', () => {
+      comboBox.dirty = true;
       input.focus();
       input.click();
       outsideClick();
@@ -96,22 +111,6 @@ describe('validation', () => {
       expect(validatedSpy.calledOnce).to.be.true;
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', () => {
-        input.focus();
-        input.blur();
-        expect(validateSpy.called).to.be.false;
-      });
     });
   });
 

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -107,7 +107,7 @@ export const CustomFieldMixin = (superClass) =>
         },
 
         /**
-         * Whether the field is dirty.
+         * Whether the field is dirty. When dirty, the field validates on blur.
          *
          * The field is automatically marked as dirty once the user triggers
          * an `input` or `change` event. Additionally, the field can be manually
@@ -170,7 +170,9 @@ export const CustomFieldMixin = (superClass) =>
     _setFocused(focused) {
       super._setFocused(focused);
 
-      if (!focused) {
+      // Validate on blur only when the field is dirty (the user has triggered
+      // an `input` or `change` event once, or the field has been manually marked as dirty).
+      if (!focused && this.dirty) {
         this.validate();
       }
     }

--- a/packages/custom-field/test/validation.test.js
+++ b/packages/custom-field/test/validation.test.js
@@ -25,7 +25,14 @@ describe('validation', () => {
       expect(customField.checkValidity()).to.be.true;
     });
 
-    it('should validate on blur', () => {
+    it('should not validate on blur by default', () => {
+      customField.inputs[0].focus();
+      customField.inputs[0].blur();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on blur when dirty', () => {
+      customField.dirty = true;
       customField.inputs[0].focus();
       customField.inputs[0].blur();
       expect(validateSpy.calledOnce).to.be.true;

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -449,7 +449,8 @@ export const DatePickerMixin = (subclass) =>
       if (!this.opened) {
         this._selectParsedOrFocusedDate();
 
-        // Validate on blur only when the user has interacted with the field.
+        // Validate on blur only after the user has triggered an `input` or `change` event,
+        // or the field has been initially marked as dirty.
         if (this.dirty) {
           this.validate();
         }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -449,8 +449,8 @@ export const DatePickerMixin = (subclass) =>
       if (!this.opened) {
         this._selectParsedOrFocusedDate();
 
-        // Validate on blur only after the user has triggered an `input` or `change` event,
-        // or the field has been initially marked as dirty.
+        // Validate on blur only when the field is dirty (the user has triggered
+        // an `input` or `change` event once, or the field has been manually marked as dirty).
         if (this.dirty) {
           this.validate();
         }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -449,6 +449,7 @@ export const DatePickerMixin = (subclass) =>
       if (!this.opened) {
         this._selectParsedOrFocusedDate();
 
+        // Validate on blur only when the user has interacted with the field.
         if (this.dirty) {
           this.validate();
         }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -449,9 +449,7 @@ export const DatePickerMixin = (subclass) =>
       if (!this.opened) {
         this._selectParsedOrFocusedDate();
 
-        // Do not validate when focusout is caused by document
-        // losing focus, which happens on browser tab switch.
-        if (document.hasFocus()) {
+        if (this.dirty) {
           this.validate();
         }
       }
@@ -949,7 +947,7 @@ export const DatePickerMixin = (subclass) =>
       }
       // No need to revalidate the value after `_selectedDateChanged`
       // Needed in case the value was not changed: open and close dropdown.
-      if (!this.value) {
+      if (this.dirty && !this.value) {
         this.validate();
       }
     }

--- a/packages/date-picker/test/validation.common.js
+++ b/packages/date-picker/test/validation.common.js
@@ -104,8 +104,8 @@ describe('validation', () => {
     });
 
     it('should validate on blur when dirty', () => {
-      input.focus();
       datePicker.dirty = true;
+      input.focus();
       input.blur();
       expect(validateSpy.calledOnce).to.be.true;
     });

--- a/packages/date-picker/test/validation.common.js
+++ b/packages/date-picker/test/validation.common.js
@@ -97,8 +97,15 @@ describe('validation', () => {
       expect(datePicker.validate()).to.be.true;
     });
 
-    it('should validate on blur', () => {
+    it('should not validate on blur by default', () => {
       input.focus();
+      input.blur();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on blur when dirty', () => {
+      input.focus();
+      datePicker.dirty = true;
       input.blur();
       expect(validateSpy.calledOnce).to.be.true;
     });
@@ -115,7 +122,17 @@ describe('validation', () => {
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
-    it('should validate on outside click', async () => {
+    it('should not validate on outside click by default', async () => {
+      input.focus();
+      input.click();
+      await waitForOverlayRender();
+      outsideClick();
+      await nextUpdate(datePicker);
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on outside click when dirty', async () => {
+      datePicker.dirty = true;
       input.focus();
       input.click();
       await waitForOverlayRender();
@@ -274,22 +291,6 @@ describe('validation', () => {
       expect(validatedSpy.calledOnce).to.be.true;
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', () => {
-        input.focus();
-        input.blur();
-        expect(validateSpy.called).to.be.false;
-      });
     });
   });
 

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -223,7 +223,7 @@ declare class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(Themabl
   autofocus: boolean;
 
   /**
-   * Whether the field is dirty.
+   * Whether the field is dirty. When dirty, the field validates on blur.
    *
    * The field is automatically marked as dirty once the user triggers
    * an `input` or `change` event on the child pickers. Additionally, the field

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -479,7 +479,8 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Validate on blur only when the user has interacted with the field.
+    // Validate on blur only after the user has triggered an `input` or `change` event,
+    // or the field has been initially marked as dirty.
     if (!focused && this.dirty) {
       this.validate();
     }

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -323,7 +323,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
       },
 
       /**
-       * Whether the field is dirty.
+       * Whether the field is dirty. When dirty, the field validates on blur.
        *
        * The field is automatically marked as dirty once the user triggers
        * an `input` or `change` event on the child pickers. Additionally, the field

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -479,9 +479,8 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Do not validate when focusout is caused by document
-    // losing focus, which happens on browser tab switch.
-    if (!focused && document.hasFocus()) {
+    // Validate on blur only when the user has interacted with the field.
+    if (!focused && this.dirty) {
       this.validate();
     }
   }

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -59,13 +59,27 @@ const fixtures = {
       expect(dateTimePicker.invalid).to.equal(false);
     });
 
-    it('should validate on date-picker blur', () => {
+    it('should not validate on date-picker blur by default', () => {
+      datePicker.focus();
+      datePicker.blur();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should not validate on time-picker blur by default', () => {
+      timePicker.focus();
+      timePicker.blur();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on date-picker blur when dirty', () => {
+      dateTimePicker.dirty = true;
       datePicker.focus();
       datePicker.blur();
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate on time-picker blur', () => {
+    it('should validate on date-picker blur when dirty', () => {
+      dateTimePicker.dirty = true;
       timePicker.focus();
       timePicker.blur();
       expect(validateSpy.calledOnce).to.be.true;
@@ -199,28 +213,6 @@ const fixtures = {
       it('should be invalid after validate() if value is not set', () => {
         dateTimePicker.validate();
         expect(dateTimePicker.invalid).to.be.true;
-      });
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on date-picker blur when document does not have focus', () => {
-        datePicker.focus();
-        datePicker.blur();
-        expect(validateSpy.called).to.be.false;
-      });
-
-      it('should not validate on time-picker blur when document does not have focus', () => {
-        timePicker.focus();
-        timePicker.blur();
-        expect(validateSpy.called).to.be.false;
       });
     });
   });

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -94,7 +94,8 @@ export const InputFieldMixin = (superclass) =>
     _setFocused(focused) {
       super._setFocused(focused);
 
-      // Validate on blur only when the user has interacted with the field.
+      // Validate on blur only after the user has triggered an `input` or `change` event,
+      // or the field has been initially marked as dirty.
       if (!focused && this.dirty) {
         this.validate();
       }

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -94,9 +94,8 @@ export const InputFieldMixin = (superclass) =>
     _setFocused(focused) {
       super._setFocused(focused);
 
-      // Do not validate when focusout is caused by document
-      // losing focus, which happens on browser tab switch.
-      if (!focused && document.hasFocus()) {
+      // Validate on blur only when the user has interacted with the field.
+      if (!focused && this.dirty) {
         this.validate();
       }
     }

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -94,8 +94,8 @@ export const InputFieldMixin = (superclass) =>
     _setFocused(focused) {
       super._setFocused(focused);
 
-      // Validate on blur only after the user has triggered an `input` or `change` event,
-      // or the field has been initially marked as dirty.
+      // Validate on blur only when the field is dirty (the user has triggered
+      // an `input` or `change` event once, or the field has been manually marked as dirty).
       if (!focused && this.dirty) {
         this.validate();
       }

--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -29,7 +29,7 @@ export declare class InputMixinClass {
   value: string;
 
   /**
-   * Whether the field is dirty.
+   * Whether the field is dirty. When dirty, the field validates on blur.
    *
    * The field is automatically marked as dirty once the user triggers
    * an `input` or `change` event. Additionally, the field can be manually

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -54,7 +54,7 @@ export const InputMixin = dedupingMixin(
           },
 
           /**
-           * Whether the field is dirty.
+           * Whether the field is dirty. When dirty, the field validates on blur.
            *
            * The field is automatically marked as dirty once the user triggers
            * an `input` or `change` event. Additionally, the field can be manually

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -178,7 +178,7 @@ const runTests = (defineHelper, baseMixin) => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should validate on input event when invalid', async () => {
+    it('should validate on input event', async () => {
       element.required = true;
       element.invalid = true;
       await nextUpdate(element);

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -155,21 +155,30 @@ const runTests = (defineHelper, baseMixin) => {
       input = element.querySelector('[slot=input]');
     });
 
-    it('should validate on input blur', () => {
+    it('should not validate on input blur by default', () => {
       const spy = sinon.spy(element, 'validate');
+      input.focus();
+      input.blur();
+      expect(spy.called).to.be.false;
+    });
+
+    it('should validate on input blur when dirty', () => {
+      const spy = sinon.spy(element, 'validate');
+      element.dirty = true;
       input.focus();
       input.blur();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should validate on programmatic blur', () => {
+    it('should validate on programmatic blur when dirty', () => {
       const spy = sinon.spy(element, 'validate');
+      element.dirty = true;
       element.focus();
       element.blur();
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should validate on input event', async () => {
+    it('should validate on input event when invalid', async () => {
       element.required = true;
       element.invalid = true;
       await nextUpdate(element);
@@ -199,23 +208,6 @@ const runTests = (defineHelper, baseMixin) => {
       const spy = sinon.spy(input, 'checkValidity');
       element.checkValidity();
       expect(spy.calledOnce).to.be.false;
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', () => {
-        const spy = sinon.spy(element, 'validate');
-        input.focus();
-        input.blur();
-        expect(spy.called).to.be.false;
-      });
     });
   });
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -616,7 +616,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Validate on blur only when the user has interacted with the field.
+    // Validate on blur only after the user has triggered an `input` or `change` event,
+    // or the field has been initially marked as dirty.
     if (!focused && this.dirty) {
       this._focusedChipIndex = -1;
       this.validate();

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -616,8 +616,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Validate on blur only after the user has triggered an `input` or `change` event,
-    // or the field has been initially marked as dirty.
+    // Validate on blur only when the field is dirty (the user has triggered
+    // an `input` or `change` event once, or the field has been manually marked as dirty).
     if (!focused && this.dirty) {
       this._focusedChipIndex = -1;
       this.validate();

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -616,9 +616,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Do not validate when focusout is caused by document
-    // losing focus, which happens on browser tab switch.
-    if (!focused && document.hasFocus()) {
+    // Validate on blur only when the user has interacted with the field.
+    if (!focused && this.dirty) {
       this._focusedChipIndex = -1;
       this.validate();
     }

--- a/packages/multi-select-combo-box/test/validation.test.js
+++ b/packages/multi-select-combo-box/test/validation.test.js
@@ -51,13 +51,28 @@ describe('validation', () => {
       comboBox.addEventListener('change', changeSpy);
     });
 
-    it('should validate on blur', () => {
+    it('should not validate on blur by default', () => {
+      input.focus();
+      input.blur();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on blur when dirty', () => {
+      comboBox.dirty = true;
       input.focus();
       input.blur();
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate on outside click', () => {
+    it('should not validate on outside click by default', () => {
+      input.focus();
+      input.click();
+      outsideClick();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on outside click when dirty', () => {
+      comboBox.dirty = true;
       input.focus();
       input.click();
       outsideClick();

--- a/packages/multi-select-combo-box/test/validation.test.js
+++ b/packages/multi-select-combo-box/test/validation.test.js
@@ -125,22 +125,5 @@ describe('validation', () => {
       comboBox.selectedItems = ['apple'];
       expect(comboBox.checkValidity()).to.be.true;
     });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', () => {
-        const spy = sinon.spy(comboBox, 'validate');
-        comboBox.inputElement.focus();
-        comboBox.inputElement.blur();
-        expect(spy.called).to.be.false;
-      });
-    });
   });
 });

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -102,7 +102,7 @@ declare class RadioGroup extends FieldMixin(
   readonly: boolean;
 
   /**
-   * Whether the field is dirty.
+   * Whether the field is dirty. When dirty, the field validates on blur.
    *
    * The field is automatically marked as dirty once the user triggers
    * a `change` event. Additionally, the field can be manually marked

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -486,7 +486,8 @@ class RadioGroup extends FieldMixin(
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Validate on blur only when the field has been manually marked as dirty.
+    // Validate on blur only after the user has triggered a `change` event,
+    // or the field has been initially marked as dirty.
     if (!focused && this.dirty) {
       this.validate();
     }

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -165,7 +165,7 @@ class RadioGroup extends FieldMixin(
       },
 
       /**
-       * Whether the field is dirty.
+       * Whether the field is dirty. When dirty, the field validates on blur.
        *
        * The field is automatically marked as dirty once the user triggers
        * a `change` event. Additionally, the field can be manually marked

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -486,8 +486,8 @@ class RadioGroup extends FieldMixin(
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Validate on blur only after the user has triggered a `change` event,
-    // or the field has been initially marked as dirty.
+    // Validate on blur only when the field is dirty (the user has triggered
+    // a `change` event once, or the field has been manually marked as dirty).
     if (!focused && this.dirty) {
       this.validate();
     }

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -486,9 +486,8 @@ class RadioGroup extends FieldMixin(
   _setFocused(focused) {
     super._setFocused(focused);
 
-    // Do not validate when focusout is caused by document
-    // losing focus, which happens on browser tab switch.
-    if (!focused && document.hasFocus()) {
+    // Validate on blur only when the field has been manually marked as dirty.
+    if (!focused && this.dirty) {
       this.validate();
     }
   }

--- a/packages/radio-group/test/validation.test.js
+++ b/packages/radio-group/test/validation.test.js
@@ -70,12 +70,25 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate on focusout', async () => {
-      // Focus on the first radio button.
+    it('should not validate on focusout by default', async () => {
+      // Move focus to the first radio button.
+      await sendKeys({ press: 'Tab' });
+
+      // Move focus out of the radio group.
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on focusout when dirty', async () => {
+      group.dirty = true;
+
+      // Move focus to the first radio button.
       await sendKeys({ press: 'Tab' });
       expect(validateSpy.called).to.be.false;
 
-      // Move focus out of the group.
+      // Move focus out of the radio group.
       await sendKeys({ down: 'Shift' });
       await sendKeys({ press: 'Tab' });
       await sendKeys({ up: 'Shift' });
@@ -101,28 +114,6 @@ describe('validation', () => {
       expect(validatedSpy.calledOnce).to.be.true;
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', async () => {
-        // Focus on the first checkbox.
-        await sendKeys({ press: 'Tab' });
-
-        // Move focus out of the checkbox group.
-        await sendKeys({ down: 'Shift' });
-        await sendKeys({ press: 'Tab' });
-        await sendKeys({ up: 'Shift' });
-
-        expect(validateSpy.called).to.be.false;
-      });
     });
   });
 

--- a/packages/select/src/vaadin-select-base-mixin.d.ts
+++ b/packages/select/src/vaadin-select-base-mixin.d.ts
@@ -97,7 +97,7 @@ export declare class SelectBaseMixinClass {
   readonly: boolean;
 
   /**
-   * Whether the field is dirty.
+   * Whether the field is dirty. When dirty, the field validates on blur.
    *
    * The field is automatically marked as dirty once the user triggers
    * a `change` event. Additionally, the field can be manually marked

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -582,7 +582,8 @@ export const SelectBaseMixin = (superClass) =>
     _setFocused(focused) {
       super._setFocused(focused);
 
-      // Validate on blur only when the user has interacted with the field.
+      // Validate on blur only after the user has triggered a `change` event,
+      // or the field has been initially marked as dirty.
       if (!focused && this.dirty) {
         this.validate();
       }

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -128,7 +128,7 @@ export const SelectBaseMixin = (superClass) =>
         },
 
         /**
-         * Whether the field is dirty.
+         * Whether the field is dirty. When dirty, the field validates on blur.
          *
          * The field is automatically marked as dirty once the user triggers
          * a `change` event. Additionally, the field can be manually marked

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -293,9 +293,10 @@ export const SelectBaseMixin = (superClass) =>
     _valueChanged(value, oldValue) {
       this.toggleAttribute('has-value', Boolean(value));
 
-      // Skip validation during initialization and when
-      // a change event is scheduled, as validation will be
-      // triggered by `__dispatchChange()` in that case.
+      // Validate only when
+      // 1. The component has already initialized.
+      // 2. There is no pending change event, as otherwise
+      // validation is triggered by `__dispatchChange()`.
       if (oldValue !== undefined && !this.__dispatchChangePending) {
         this.validate();
       }
@@ -386,9 +387,11 @@ export const SelectBaseMixin = (superClass) =>
           this.setAttribute('focus-ring', '');
         }
 
-        // Skip validation when a change event is scheduled, as validation
-        // will be triggered by `__dispatchChange()` in that case.
-        if (!this.__dispatchChangePending) {
+        // Validate on close only when
+        // 1. The user has interacted with the field.
+        // 2. There is no pending change event, as otherwise
+        // validation is triggered by `__dispatchChange()`.
+        if (this.dirty && !this.__dispatchChangePending) {
           this.validate();
         }
       }
@@ -579,9 +582,8 @@ export const SelectBaseMixin = (superClass) =>
     _setFocused(focused) {
       super._setFocused(focused);
 
-      // Do not validate when focusout is caused by document
-      // losing focus, which happens on browser tab switch.
-      if (!focused && document.hasFocus()) {
+      // Validate on blur only when the user has interacted with the field.
+      if (!focused && this.dirty) {
         this.validate();
       }
     }

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -295,8 +295,8 @@ export const SelectBaseMixin = (superClass) =>
 
       // Validate only when
       // 1. The component has already initialized.
-      // 2. There is no pending change event, as otherwise
-      // validation is triggered by `__dispatchChange()`.
+      // 2. There is no pending change event at the moment, as otherwise
+      // validation will be triggered by `__dispatchChange()`.
       if (oldValue !== undefined && !this.__dispatchChangePending) {
         this.validate();
       }
@@ -387,10 +387,9 @@ export const SelectBaseMixin = (superClass) =>
           this.setAttribute('focus-ring', '');
         }
 
-        // Validate on close only when
-        // 1. The user has interacted with the field.
-        // 2. There is no pending change event, as otherwise
-        // validation is triggered by `__dispatchChange()`.
+        // Validate on close only when the field is dirty, and
+        // there is no pending change event at the moment, as
+        // otherwise validation will be triggered by `__dispatchChange()`.
         if (this.dirty && !this.__dispatchChangePending) {
           this.validate();
         }
@@ -582,8 +581,8 @@ export const SelectBaseMixin = (superClass) =>
     _setFocused(focused) {
       super._setFocused(focused);
 
-      // Validate on blur only after the user has triggered a `change` event,
-      // or the field has been initially marked as dirty.
+      // Validate on blur only when the field is dirty (the user has triggered
+      // a `change` event once, or the field has been manually marked as dirty).
       if (!focused && this.dirty) {
         this.validate();
       }

--- a/packages/select/test/validation.common.js
+++ b/packages/select/test/validation.common.js
@@ -29,13 +29,31 @@ describe('validation', () => {
       expect(select.invalid).to.be.false;
     });
 
-    it('should validate on blur', () => {
+    it('should not validate on blur by default', () => {
+      select.focus();
+      select.blur();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on blur when dirty', () => {
+      select.dirty = true;
       select.focus();
       select.blur();
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate on outside click', async () => {
+    it('should not validate on outside click by default', async () => {
+      select.focus();
+      select.click();
+      await nextRender();
+
+      outsideClick();
+      await nextUpdate(select);
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on outside click when dirty', async () => {
+      select.dirty = true;
       select.focus();
       select.click();
       await nextRender();
@@ -99,21 +117,6 @@ describe('validation', () => {
       expect(validatedSpy.calledOnce).to.be.true;
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', () => {
-        select.blur();
-        expect(validateSpy.called).to.be.false;
-      });
     });
   });
 

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -88,13 +88,28 @@ describe('validation', () => {
       expect(validateSpy.called).to.be.false;
     });
 
-    it('should validate on blur', () => {
+    it('should not validate on blur by default', () => {
+      input.focus();
+      input.blur();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on blur when dirty', () => {
+      timePicker.dirty = true;
       input.focus();
       input.blur();
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate on outside click', () => {
+    it('should not validate on outside click by default', () => {
+      input.focus();
+      input.click();
+      outsideClick();
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate on outside click when dirty', () => {
+      timePicker.dirty = true;
       input.focus();
       input.click();
       outsideClick();


### PR DESCRIPTION
## Description

Updates the field components to validate on blur only when they are dirty. A field is considered dirty after the user has triggered an input or change event on it. To enforce the old behavior for a component, you can preemptively mark it as dirty:

```html
<vaadin-text-field dirty></vaadin-text-field>
```

Depends on 
- https://github.com/vaadin/web-components/pull/6160

Part of https://github.com/vaadin/web-components/issues/6146

## Type of change

- [x] Refactor
