### PR TITLE
refactor: update SlotObserver, add connect and disconnect

### DIFF
--- a/packages/component-base/src/slot-observer.d.ts
+++ b/packages/component-base/src/slot-observer.d.ts
@@ -14,6 +14,20 @@ export class SlotObserver {
   );
 
   /**
+   * Activates an observer. This method is automatically called when
+   * a `SlotObserver` is created. It should only be called to  re-activate
+   * an observer that has been deactivated via the `disconnect` method.
+   */
+  connect(): void;
+
+  /**
+   * Deactivates the observer. After calling this method the observer callback
+   * will not be called when changes to slotted nodes occur. The `connect` method
+   * may be subsequently called to reactivate the observer.
+   */
+  disconnect(): void;
+
+  /**
    * Run the observer callback synchronously.
    */
   flush(): void;

--- a/packages/component-base/src/slot-observer.js
+++ b/packages/component-base/src/slot-observer.js
@@ -18,13 +18,35 @@ export class SlotObserver {
     /** @type {Node[]} */
     this._storedNodes = [];
 
+    this._connected = false;
     this._scheduled = false;
 
-    slot.addEventListener('slotchange', () => {
+    this._boundSchedule = () => {
       this._schedule();
-    });
+    };
 
+    this.connect();
     this._schedule();
+  }
+
+  /**
+   * Activates an observer. This method is automatically called when
+   * a `SlotObserver` is created. It should only be called to  re-activate
+   * an observer that has been deactivated via the `disconnect` method.
+   */
+  connect() {
+    this.slot.addEventListener('slotchange', this._boundSchedule);
+    this._connected = true;
+  }
+
+  /**
+   * Deactivates the observer. After calling this method the observer callback
+   * will not be called when changes to slotted nodes occur. The `connect` method
+   * may be subsequently called to reactivate the observer.
+   */
+  disconnect() {
+    this.slot.removeEventListener('slotchange', this._boundSchedule);
+    this._connected = false;
   }
 
   /** @private */
@@ -42,6 +64,10 @@ export class SlotObserver {
    * Run the observer callback synchronously.
    */
   flush() {
+    if (!this._connected) {
+      return;
+    }
+
     this._scheduled = false;
 
     this._processNodes();

--- a/packages/component-base/test/slot-observer.test.js
+++ b/packages/component-base/test/slot-observer.test.js
@@ -110,4 +110,56 @@ describe('SlotObserver', () => {
     const addedNodes = spy.firstCall.args[0].addedNodes;
     expect(addedNodes[0]).to.equal(div);
   });
+
+  it('should not run callback after node is added if disconnected', async () => {
+    spy = sinon.spy();
+    observer = new SlotObserver(slot, spy);
+    await Promise.resolve();
+    spy.resetHistory();
+
+    observer.disconnect();
+
+    const div = document.createElement('div');
+    host.appendChild(div);
+
+    // Wait for slotchange
+    await Promise.resolve();
+    // Wait for microtask
+    await Promise.resolve();
+
+    expect(spy.called).to.be.false;
+  });
+
+  it('should not run callback when calling flush() if disconnected', async () => {
+    spy = sinon.spy();
+    observer = new SlotObserver(slot, spy);
+    await Promise.resolve();
+    spy.resetHistory();
+
+    observer.disconnect();
+
+    const div = document.createElement('div');
+    host.appendChild(div);
+
+    observer.flush();
+
+    expect(spy.called).to.be.false;
+  });
+
+  it('should run callback when calling flush() if re-connected', async () => {
+    spy = sinon.spy();
+    observer = new SlotObserver(slot, spy);
+    await Promise.resolve();
+    spy.resetHistory();
+
+    observer.disconnect();
+    observer.connect();
+
+    const div = document.createElement('div');
+    host.appendChild(div);
+
+    observer.flush();
+
+    expect(spy.calledOnce).to.be.true;
+  });
 });


### PR DESCRIPTION
## Description

This PR adds missing `connect()` and `disconnect()` methods from the `FlattenedNodesObserver` class.
They are needed in some cases where we disconnect the observer e.g. in case of `vaadin-chart:

https://github.com/vaadin/web-components/blob/b380caa150b40a72cc22f94d00d0adbfa29aceac/packages/charts/src/vaadin-chart.js#L897

https://github.com/vaadin/web-components/blob/b380caa150b40a72cc22f94d00d0adbfa29aceac/packages/charts/src/vaadin-chart.js#L1047-L1052

## Type of change

- Refactor / internal feature