### PR TITLE
feat: keep menu bar open on item selection

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -54,12 +54,13 @@ export interface ContextMenuEventMap extends HTMLElementEventMap, ContextMenuCus
  *
  * When an item is selected, `<vaadin-context-menu>` dispatches an "item-selected" event
  * with the selected item as `event.detail.value` property.
+ * If item does not have `keepOpen` property the menu will be closed.
  *
  * ```javascript
  * contextMenu.items = [
  *   { text: 'Menu Item 1', theme: 'primary', children:
  *     [
- *       { text: 'Menu Item 1-1', checked: true },
+ *       { text: 'Menu Item 1-1', checked: true, keepOpen: true },
  *       { text: 'Menu Item 1-2' }
  *     ]
  *   },

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -27,12 +27,13 @@ import { ItemsMixin } from './vaadin-contextmenu-items-mixin.js';
  *
  * When an item is selected, `<vaadin-context-menu>` dispatches an "item-selected" event
  * with the selected item as `event.detail.value` property.
+ * If item does not have `keepOpen` property the menu will be closed.
  *
  * ```javascript
  * contextMenu.items = [
  *   { text: 'Menu Item 1', theme: 'primary', children:
  *     [
- *       { text: 'Menu Item 1-1', checked: true },
+ *       { text: 'Menu Item 1-1', checked: true, keepOpen: true },
  *       { text: 'Menu Item 1-2' }
  *     ]
  *   },

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -12,6 +12,7 @@ export interface ContextMenuItem {
   component?: HTMLElement | string;
   disabled?: boolean;
   checked?: boolean;
+  keepOpen?: boolean;
   theme?: string[] | string;
   children?: ContextMenuItem[];
 }
@@ -32,7 +33,7 @@ export declare class ItemsMixinClass {
    * contextMenu.items = [
    *   { text: 'Menu Item 1', theme: 'primary', children:
    *     [
-   *       { text: 'Menu Item 1-1', checked: true },
+   *       { text: 'Menu Item 1-1', checked: true, keepOpen: true },
    *       { text: 'Menu Item 1-2' }
    *     ]
    *   },

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -22,6 +22,7 @@ export const ItemsMixin = (superClass) =>
          * Either a tagName or an element instance. Defaults to "vaadin-context-menu-item".
          * @property {boolean} disabled - If true, the item is disabled and cannot be selected
          * @property {boolean} checked - If true, the item shows a checkmark next to it
+         * @property {boolean} keepOpen - If true, the menu will not be closed on item selection
          * @property {union: string | string[]} theme - If set, sets the given theme(s) as an attribute to the menu item component, overriding any theme set on the context menu.
          * @property {MenuItem[]} children - Array of child menu items
          */
@@ -39,7 +40,7 @@ export const ItemsMixin = (superClass) =>
          * contextMenu.items = [
          *   { text: 'Menu Item 1', theme: 'primary', children:
          *     [
-         *       { text: 'Menu Item 1-1', checked: true },
+         *       { text: 'Menu Item 1-1', checked: true, keepOpen: true },
          *       { text: 'Menu Item 1-2' }
          *     ]
          *   },

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -297,8 +297,15 @@ export const ItemsMixin = (superClass) =>
       });
 
       // Listen to the forwarded event from sub-menu.
-      this.addEventListener('item-selected', () => {
-        this.close();
+      this.addEventListener('item-selected', (e) => {
+        const menu = e.target;
+        const targetItem = e.detail.value;
+
+        if (!!targetItem.keepOpen && menu.items.includes(targetItem)) {
+          menu._overlayElement.requestContentUpdate();
+        } else if (!targetItem.keepOpen) {
+          this.close();
+        }
       });
 
       // Mark parent item as collapsed when closing.

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -300,11 +300,11 @@ export const ItemsMixin = (superClass) =>
       // Listen to the forwarded event from sub-menu.
       this.addEventListener('item-selected', (e) => {
         const menu = e.target;
-        const targetItem = e.detail.value;
+        const selectedItem = e.detail.value;
 
-        if (!!targetItem.keepOpen && menu.items.includes(targetItem)) {
+        if (!!selectedItem.keepOpen && menu.items.includes(selectedItem)) {
           menu._overlayElement.requestContentUpdate();
-        } else if (!targetItem.keepOpen) {
+        } else if (!selectedItem.keepOpen) {
           this.close();
         }
       });

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -215,10 +215,12 @@ export const ItemsMixin = (superClass) =>
         const { value } = event.detail;
         if (typeof value === 'number') {
           const item = listBox.items[value]._item;
+          // Reset selected before dispatching the event to prevent
+          // checkmark icon flashing when `keepOpen` is set to true.
+          listBox.selected = null;
           if (!item.children) {
             this.dispatchEvent(new CustomEvent('item-selected', { detail: { value: item } }));
           }
-          listBox.selected = null;
         }
       });
 
@@ -301,9 +303,15 @@ export const ItemsMixin = (superClass) =>
       this.addEventListener('item-selected', (e) => {
         const menu = e.target;
         const selectedItem = e.detail.value;
-
-        if (!!selectedItem.keepOpen && menu.items.includes(selectedItem)) {
+        const index = menu.items.indexOf(selectedItem);
+        if (!!selectedItem.keepOpen && index > -1) {
           menu._overlayElement.requestContentUpdate();
+
+          // Initialize items synchronously
+          menu._listBox._observer.flush();
+
+          const newItem = menu._listBox.items[index];
+          newItem.focus();
         } else if (!selectedItem.keepOpen) {
           this.close();
         }

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -234,7 +234,6 @@ describe('items', () => {
   it('should not close the menu if root item has keep open', () => {
     getMenuItems(rootMenu)[2].click();
     expect(rootMenu.opened).to.be.true;
-    expect(subMenu.opened).to.be.true;
   });
 
   it('should not close the menu if sub menu item has keep open', () => {

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -201,10 +201,22 @@ describe('items', () => {
     expect(getMenuItems(rootMenu)[2].hasAttribute('menu-item-checked')).to.be.true;
   });
 
+  it('should have a focused root item after click if keep open', () => {
+    rootMenu.items[2].checked = true;
+    getMenuItems(rootMenu)[2].click();
+    expect(getMenuItems(rootMenu)[2].hasAttribute('focused')).to.be.true;
+  });
+
   it('should have a checked sub menu item after click if keep open', () => {
     subMenu.items[3].checked = true;
     getMenuItems(subMenu)[3].click();
     expect(getMenuItems(subMenu)[3].hasAttribute('menu-item-checked')).to.be.true;
+  });
+
+  it('should have a focused sub menu item after click if keep open', () => {
+    subMenu.items[3].checked = true;
+    getMenuItems(subMenu)[3].click();
+    expect(getMenuItems(subMenu)[3].hasAttribute('focused')).to.be.true;
   });
 
   it('should not have a checked item', async () => {

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -39,9 +39,11 @@ describe('items', () => {
           { text: 'foo-0-0', checked: true },
           { text: 'foo-0-1', disabled: true },
           { text: 'foo-0-2', children: [{ text: 'foo-0-2-0' }] },
+          { text: 'foo-0-3', keepOpen: true },
         ],
       },
       { text: 'foo-1' },
+      { text: 'foo-2', keepOpen: true },
     ];
     await openMenu(target);
     await openMenu(getMenuItems(rootMenu)[0]);
@@ -193,6 +195,18 @@ describe('items', () => {
     expect(getMenuItems(subMenu)[0].hasAttribute('menu-item-checked')).to.be.true;
   });
 
+  it('should have a checked root item after click if keep open', () => {
+    rootMenu.items[2].checked = true;
+    getMenuItems(rootMenu)[2].click();
+    expect(getMenuItems(rootMenu)[2].hasAttribute('menu-item-checked')).to.be.true;
+  });
+
+  it('should have a checked sub menu item after click if keep open', () => {
+    subMenu.items[3].checked = true;
+    getMenuItems(subMenu)[3].click();
+    expect(getMenuItems(subMenu)[3].hasAttribute('menu-item-checked')).to.be.true;
+  });
+
   it('should not have a checked item', async () => {
     rootMenu.items[0].children[0].checked = false;
     subMenu.close();
@@ -217,10 +231,16 @@ describe('items', () => {
     expect(focusSpy.called).to.be.true;
   });
 
-  it('should close the menu', () => {
-    getMenuItems(rootMenu)[1].click();
-    expect(rootMenu.opened).to.be.false;
-    expect(subMenu.opened).to.be.false;
+  it('should not close the menu if root item has keep open', () => {
+    getMenuItems(rootMenu)[2].click();
+    expect(rootMenu.opened).to.be.true;
+    expect(subMenu.opened).to.be.true;
+  });
+
+  it('should not close the menu if sub menu item has keep open', () => {
+    getMenuItems(subMenu)[3].click();
+    expect(rootMenu.opened).to.be.true;
+    expect(subMenu.opened).to.be.true;
   });
 
   it('should close the submenu on left arrow', () => {

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -732,7 +732,6 @@ export const MenuBarMixin = (superClass) =>
     /** @private */
     __onItemSelected(e) {
       e.stopPropagation();
-      this._close();
       this.__fireItemSelected(e.detail.value);
     }
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/1005

The contribution provides a way to keep menu opened on item selection by introducing `keepOpen` property.
On item selection with `keepOpen` property will not be closed and the items will be updated (via `requestContentUpdate`)