### PR TITLE
fix: ensure validation is triggered before change event

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -510,8 +510,8 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
     event.stopPropagation();
 
     if (this.__dispatchChangeForValue === this.value) {
-      this.__dispatchChange();
       this.validate();
+      this.__dispatchChange();
     }
     this.__dispatchChangeForValue = undefined;
   }

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -25,11 +25,13 @@ const fixtures = {
 
 ['default', 'slotted'].forEach((set) => {
   describe(`Validation (${set})`, () => {
-    let dateTimePicker, validateSpy, datePicker, timePicker;
+    let dateTimePicker, validateSpy, changeSpy, datePicker, timePicker;
 
     beforeEach(() => {
       dateTimePicker = fixtureSync(fixtures[set]);
       validateSpy = sinon.spy(dateTimePicker, 'validate');
+      changeSpy = sinon.spy();
+      dateTimePicker.addEventListener('change', changeSpy);
       datePicker = dateTimePicker.querySelector('[slot=date-picker]');
       timePicker = dateTimePicker.querySelector('[slot=time-picker]');
     });
@@ -67,6 +69,26 @@ const fixtures = {
       timePicker.focus();
       timePicker.blur();
       expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should validate before change event on date-picker change', async () => {
+      timePicker.value = '12:00';
+      datePicker.focus();
+      await sendKeys({ type: '1/1/2023' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
+    });
+
+    it('should validate before change event on time-picker change', async () => {
+      datePicker.value = '2023-01-01';
+      timePicker.focus();
+      await sendKeys({ type: '12:00' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
     it('should not validate when moving focus between pickers', async () => {


### PR DESCRIPTION
## Description

All the field components, except for `date-time-picker`, currently perform validation before the change event is triggered. This PR aligns `date-time-picker`'s behavior with the other components in this aspect.

Part of #6146 

## Type of change

- [x] Bugfix
