### PR TITLE
fix: observe DOM changes to fix wrapping inputs regression

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -117,9 +117,21 @@ export const CustomFieldMixin = (superClass) =>
 
       this.ariaTarget = this;
 
+      this.__childrenObserver = new MutationObserver(() => {
+        this.__setInputsFromSlot();
+      });
+
       this.__setInputsFromSlot();
       this.$.slot.addEventListener('slotchange', () => {
         this.__setInputsFromSlot();
+
+        // Observe changes to any children except inputs
+        // to allow wrapping `<input>` with `<div>` etc.
+        getFlattenedElements(this.$.slot)
+          .filter((el) => !this.__isInput(el))
+          .forEach((el) => {
+            this.__childrenObserver.observe(el, { childList: true });
+          });
       });
 
       this._tooltipController = new TooltipController(this);

--- a/packages/custom-field/test/slot-wrapper.test.js
+++ b/packages/custom-field/test/slot-wrapper.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-custom-field.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { dispatchChange } from './helpers.js';
@@ -75,7 +75,7 @@ Object.keys(fixtures).forEach((set) => {
   describe(`slot updates (${set})`, () => {
     let parent, customField, inputElement;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       // 'parent' is the element to add and remove inputs to/from for testing
       const root = fixtureSync(fixtures[set]);
       if (set === 'nested' || set === 'nested2') {
@@ -89,6 +89,8 @@ Object.keys(fixtures).forEach((set) => {
         customField = root; // <custom-field>
       }
       inputElement = document.createElement('input');
+      // Wait for initial slotchange
+      await nextRender();
     });
 
     it('should add new input to the input list when adding to the DOM', async () => {


### PR DESCRIPTION
## Description

The fix adds a new `MutationObserver` that handles all the effective children of `vaadin-custom-field` excluding inputs.

## Type of change

- Bugfix