### PR TITLE
refactor: extract login overlay and form reusable mixins

### DIFF
--- a/packages/login/src/vaadin-login-form-mixin.d.ts
+++ b/packages/login/src/vaadin-login-form-mixin.d.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { LoginMixinClass } from './vaadin-login-mixin.js';
+
+export declare function LoginFormMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<LoginFormMixinClass> & Constructor<LoginMixinClass> & T;
+
+export declare class LoginFormMixinClass {
+  /**
+   * Submits the form.
+   */
+  submit(): void;
+}

--- a/packages/login/src/vaadin-login-form-mixin.js
+++ b/packages/login/src/vaadin-login-form-mixin.js
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { LoginMixin } from './vaadin-login-mixin.js';
+
+/**
+ * @polymerMixin
+ * @mixes LoginMixin
+ */
+export const LoginFormMixin = (superClass) =>
+  class LoginFormMixin extends LoginMixin(superClass) {
+    static get observers() {
+      return ['_errorChanged(error)'];
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      if (!this.noAutofocus) {
+        this.$.vaadinLoginUsername.focus();
+      }
+    }
+
+    /** @private */
+    _errorChanged() {
+      if (this.error && !this._preventAutoEnable) {
+        this.disabled = false;
+      }
+    }
+
+    /**
+     * Submits the form.
+     */
+    submit() {
+      const userName = this.$.vaadinLoginUsername;
+      const password = this.$.vaadinLoginPassword;
+
+      if (this.disabled || !(userName.validate() && password.validate())) {
+        return;
+      }
+
+      this.error = false;
+      this.disabled = true;
+
+      const loginEventDetails = {
+        bubbles: true,
+        cancelable: true,
+        detail: {
+          username: userName.value,
+          password: password.value,
+        },
+      };
+
+      const firedEvent = this.dispatchEvent(new CustomEvent('login', loginEventDetails));
+      if (this.action && firedEvent) {
+        const csrfMetaName = document.querySelector('meta[name=_csrf_parameter]');
+        const csrfMetaValue = document.querySelector('meta[name=_csrf]');
+        if (csrfMetaName && csrfMetaValue) {
+          this.$.csrf.name = csrfMetaName.content;
+          this.$.csrf.value = csrfMetaValue.content;
+        }
+        this.querySelector('form').submit();
+      }
+    }
+
+    /** @protected */
+    _handleInputKeydown(e) {
+      if (e.key === 'Enter') {
+        const { currentTarget: inputActive } = e;
+        const nextInput =
+          inputActive.id === 'vaadinLoginUsername' ? this.$.vaadinLoginPassword : this.$.vaadinLoginUsername;
+        if (inputActive.validate()) {
+          if (nextInput.checkValidity()) {
+            this.submit();
+          } else {
+            nextInput.focus();
+          }
+        }
+      }
+    }
+
+    /** @protected */
+    _handleInputKeyup(e) {
+      const input = e.currentTarget;
+      if (e.key === 'Tab' && input instanceof HTMLInputElement) {
+        input.select();
+      }
+    }
+
+    /** @protected */
+    _onForgotPasswordClick() {
+      this.dispatchEvent(new CustomEvent('forgot-password'));
+    }
+  };

--- a/packages/login/src/vaadin-login-form.d.ts
+++ b/packages/login/src/vaadin-login-form.d.ts
@@ -5,7 +5,7 @@
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { LoginMixin } from './vaadin-login-mixin.js';
+import { LoginFormMixin } from './vaadin-login-form-mixin.js';
 export { LoginI18n } from './vaadin-login-mixin.js';
 
 /**
@@ -69,9 +69,7 @@ export interface LoginFormEventMap extends HTMLElementEventMap, LoginFormCustomE
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  */
-declare class LoginForm extends ElementMixin(ThemableMixin(LoginMixin(HTMLElement))) {
-  submit(): void;
-
+declare class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   addEventListener<K extends keyof LoginFormEventMap>(
     type: K,
     listener: (this: LoginForm, ev: LoginFormEventMap[K]) => void,

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -10,7 +10,7 @@ import './vaadin-login-form-wrapper.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { LoginMixin } from './vaadin-login-mixin.js';
+import { LoginFormMixin } from './vaadin-login-form-mixin.js';
 
 /**
  * `<vaadin-login-form>` is a Web Component providing an easy way to require users
@@ -49,9 +49,9 @@ import { LoginMixin } from './vaadin-login-mixin.js';
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin
- * @mixes LoginMixin
+ * @mixes LoginFormMixin
  */
-class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) {
+class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   static get template() {
     return html`
       <style>
@@ -111,19 +111,6 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     return 'vaadin-login-form';
   }
 
-  static get observers() {
-    return ['_errorChanged(error)'];
-  }
-
-  /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-
-    if (!this.noAutofocus) {
-      this.$.vaadinLoginUsername.focus();
-    }
-  }
-
   /**
    * @param {StampedTemplate} dom
    * @return {null}
@@ -131,74 +118,6 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
    */
   _attachDom(dom) {
     this.appendChild(dom);
-  }
-
-  /** @private */
-  _errorChanged() {
-    if (this.error && !this._preventAutoEnable) {
-      this.disabled = false;
-    }
-  }
-
-  submit() {
-    const userName = this.$.vaadinLoginUsername;
-    const password = this.$.vaadinLoginPassword;
-
-    if (this.disabled || !(userName.validate() && password.validate())) {
-      return;
-    }
-
-    this.error = false;
-    this.disabled = true;
-
-    const loginEventDetails = {
-      bubbles: true,
-      cancelable: true,
-      detail: {
-        username: userName.value,
-        password: password.value,
-      },
-    };
-
-    const firedEvent = this.dispatchEvent(new CustomEvent('login', loginEventDetails));
-    if (this.action && firedEvent) {
-      const csrfMetaName = document.querySelector('meta[name=_csrf_parameter]');
-      const csrfMetaValue = document.querySelector('meta[name=_csrf]');
-      if (csrfMetaName && csrfMetaValue) {
-        this.$.csrf.name = csrfMetaName.content;
-        this.$.csrf.value = csrfMetaValue.content;
-      }
-      this.querySelector('form').submit();
-    }
-  }
-
-  /** @private */
-  _handleInputKeydown(e) {
-    if (e.key === 'Enter') {
-      const { currentTarget: inputActive } = e;
-      const nextInput =
-        inputActive.id === 'vaadinLoginUsername' ? this.$.vaadinLoginPassword : this.$.vaadinLoginUsername;
-      if (inputActive.validate()) {
-        if (nextInput.checkValidity()) {
-          this.submit();
-        } else {
-          nextInput.focus();
-        }
-      }
-    }
-  }
-
-  /** @private */
-  _handleInputKeyup(e) {
-    const input = e.currentTarget;
-    if (e.key === 'Tab' && input instanceof HTMLInputElement) {
-      input.select();
-    }
-  }
-
-  /** @private */
-  _onForgotPasswordClick() {
-    this.dispatchEvent(new CustomEvent('forgot-password'));
   }
 }
 

--- a/packages/login/src/vaadin-login-overlay-mixin.d.ts
+++ b/packages/login/src/vaadin-login-overlay-mixin.d.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { LoginMixinClass } from './vaadin-login-mixin.js';
+
+export declare function LoginOverlayMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<LoginMixinClass> & Constructor<LoginOverlayMixinClass> & T;
+
+export declare class LoginOverlayMixinClass {
+  /**
+   * Defines the application description
+   */
+  description: string;
+
+  /**
+   * True if the overlay is currently displayed.
+   */
+  opened: boolean;
+
+  /**
+   * Defines the application title
+   */
+  title: string;
+}

--- a/packages/login/src/vaadin-login-overlay-mixin.d.ts
+++ b/packages/login/src/vaadin-login-overlay-mixin.d.ts
@@ -4,11 +4,12 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { LoginMixinClass } from './vaadin-login-mixin.js';
 
 export declare function LoginOverlayMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<LoginMixinClass> & Constructor<LoginOverlayMixinClass> & T;
+): Constructor<LoginMixinClass> & Constructor<LoginOverlayMixinClass> & Constructor<OverlayClassMixinClass> & T;
 
 export declare class LoginOverlayMixinClass {
   /**

--- a/packages/login/src/vaadin-login-overlay-mixin.js
+++ b/packages/login/src/vaadin-login-overlay-mixin.js
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { LoginMixin } from './vaadin-login-mixin.js';
+
+/**
+ * @polymerMixin
+ * @mixes LoginMixin
+ * @mixes OverlayClassMixin
+ */
+export const LoginOverlayMixin = (superClass) =>
+  class LoginOverlayMixin extends OverlayClassMixin(LoginMixin(superClass)) {
+    static get properties() {
+      return {
+        /**
+         * Defines the application description
+         * @type {string}
+         */
+        description: {
+          type: String,
+          value: 'Application description',
+          notify: true,
+        },
+
+        /**
+         * True if the overlay is currently displayed.
+         * @type {boolean}
+         */
+        opened: {
+          type: Boolean,
+          value: false,
+          observer: '_onOpenedChange',
+        },
+
+        /**
+         * Defines the application title
+         * @type {string}
+         */
+        title: {
+          type: String,
+          value: 'App name',
+        },
+      };
+    }
+
+    static get observers() {
+      return ['__i18nChanged(i18n)'];
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this._overlayElement = this.$.vaadinLoginOverlayWrapper;
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      // Restore opened state if overlay was open when disconnecting
+      if (this.__restoreOpened) {
+        this.opened = true;
+      }
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+
+      // Close overlay and memorize opened state
+      this.__restoreOpened = this.opened;
+      this.opened = false;
+    }
+
+    /** @private */
+    __i18nChanged(i18n) {
+      const header = i18n && i18n.header;
+      if (!header) {
+        return;
+      }
+      this.title = header.title;
+      this.description = header.description;
+    }
+
+    /** @protected */
+    _preventClosingLogin(e) {
+      e.preventDefault();
+    }
+
+    /**
+     * @param {!Event} e
+     * @protected
+     */
+    _retargetEvent(e) {
+      e.stopPropagation();
+      const { detail, composed, cancelable, bubbles } = e;
+
+      const firedEvent = this.dispatchEvent(new CustomEvent(e.type, { bubbles, cancelable, composed, detail }));
+      // Check if `eventTarget.preventDefault()` was called to prevent default in the original event
+      if (!firedEvent) {
+        e.preventDefault();
+      }
+    }
+
+    /** @private */
+    _onOpenedChange() {
+      if (!this.opened) {
+        this.$.vaadinLoginForm.$.vaadinLoginUsername.value = '';
+        this.$.vaadinLoginForm.$.vaadinLoginPassword.value = '';
+        this.disabled = false;
+
+        if (this._undoTeleport) {
+          this._undoTeleport();
+        }
+      } else {
+        this._undoTeleport = this._teleport(this._getElementsToTeleport());
+
+        // Overlay sets pointerEvents on body to `none`, which breaks LastPass popup
+        // Reverting it back to the previous state
+        // https://github.com/vaadin/vaadin-overlay/blob/041cde4481b6262eac68d3a699f700216d897373/src/vaadin-overlay.html#L660
+        document.body.style.pointerEvents = this.$.vaadinLoginOverlayWrapper._previousDocumentPointerEvents;
+      }
+    }
+
+    /** @private */
+    _teleport(elements) {
+      const teleported = Array.from(elements).map((e) => {
+        return this.$.vaadinLoginOverlayWrapper.appendChild(e);
+      });
+      // Function to undo the teleport
+      return () => {
+        while (teleported.length > 0) {
+          this.appendChild(teleported.shift());
+        }
+      };
+    }
+
+    /** @private */
+    _getElementsToTeleport() {
+      return this.querySelectorAll('[slot=title]');
+    }
+  };

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -6,8 +6,9 @@
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-export { LoginI18n } from './vaadin-login-mixin.js';
 import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
+
+export { LoginI18n } from './vaadin-login-mixin.js';
 
 /**
  * Fired when the `description` property changes.

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -6,8 +6,8 @@
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { LoginMixin } from './vaadin-login-mixin.js';
 export { LoginI18n } from './vaadin-login-mixin.js';
+import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
 
 /**
  * Fired when the `description` property changes.
@@ -76,22 +76,7 @@ export interface LoginOverlayEventMap extends HTMLElementEventMap, LoginOverlayC
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  */
-declare class LoginOverlay extends LoginMixin(OverlayClassMixin(ElementMixin(ThemableMixin(HTMLElement)))) {
-  /**
-   * Defines the application description
-   */
-  description: string;
-
-  /**
-   * True if the overlay is currently displayed.
-   */
-  opened: boolean;
-
-  /**
-   * Defines the application title
-   */
-  title: string;
-
+declare class LoginOverlay extends LoginOverlayMixin(OverlayClassMixin(ElementMixin(ThemableMixin(HTMLElement)))) {
   addEventListener<K extends keyof LoginOverlayEventMap>(
     type: K,
     listener: (this: LoginOverlay, ev: LoginOverlayEventMap[K]) => void,

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
 
@@ -77,7 +76,7 @@ export interface LoginOverlayEventMap extends HTMLElementEventMap, LoginOverlayC
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  */
-declare class LoginOverlay extends LoginOverlayMixin(OverlayClassMixin(ElementMixin(ThemableMixin(HTMLElement)))) {
+declare class LoginOverlay extends LoginOverlayMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   addEventListener<K extends keyof LoginOverlayEventMap>(
     type: K,
     listener: (this: LoginOverlay, ev: LoginOverlayEventMap[K]) => void,

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -7,7 +7,6 @@ import './vaadin-login-form.js';
 import './vaadin-login-overlay-wrapper.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
 
@@ -47,10 +46,9 @@ import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin
- * @mixes LoginMixin
- * @mixes OverlayClassMixin
+ * @mixes LoginOverlayMixin
  */
-class LoginOverlay extends LoginOverlayMixin(OverlayClassMixin(ElementMixin(ThemableMixin(PolymerElement)))) {
+class LoginOverlay extends LoginOverlayMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   static get template() {
     return html`
       <vaadin-login-overlay-wrapper

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -9,7 +9,7 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { LoginMixin } from './vaadin-login-mixin.js';
+import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
 
 /**
  * `<vaadin-login-overlay>` is a wrapper of the `<vaadin-login-form>` which opens a login form in an overlay and
@@ -50,7 +50,7 @@ import { LoginMixin } from './vaadin-login-mixin.js';
  * @mixes LoginMixin
  * @mixes OverlayClassMixin
  */
-class LoginOverlay extends LoginMixin(OverlayClassMixin(ElementMixin(ThemableMixin(PolymerElement)))) {
+class LoginOverlay extends LoginOverlayMixin(OverlayClassMixin(ElementMixin(ThemableMixin(PolymerElement)))) {
   static get template() {
     return html`
       <vaadin-login-overlay-wrapper
@@ -82,137 +82,6 @@ class LoginOverlay extends LoginMixin(OverlayClassMixin(ElementMixin(ThemableMix
 
   static get is() {
     return 'vaadin-login-overlay';
-  }
-
-  static get properties() {
-    return {
-      /**
-       * Defines the application description
-       * @type {string}
-       */
-      description: {
-        type: String,
-        value: 'Application description',
-        notify: true,
-      },
-
-      /**
-       * True if the overlay is currently displayed.
-       * @type {boolean}
-       */
-      opened: {
-        type: Boolean,
-        value: false,
-        observer: '_onOpenedChange',
-      },
-
-      /**
-       * Defines the application title
-       * @type {string}
-       */
-      title: {
-        type: String,
-        value: 'App name',
-      },
-    };
-  }
-
-  static get observers() {
-    return ['__i18nChanged(i18n.header.*)'];
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this._overlayElement = this.$.vaadinLoginOverlayWrapper;
-  }
-
-  /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-
-    // Restore opened state if overlay was open when disconnecting
-    if (this.__restoreOpened) {
-      this.opened = true;
-    }
-  }
-
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-
-    // Close overlay and memorize opened state
-    this.__restoreOpened = this.opened;
-    this.opened = false;
-  }
-
-  /** @private */
-  __i18nChanged(i18n) {
-    const header = i18n.base;
-    if (!header) {
-      return;
-    }
-    this.title = header.title;
-    this.description = header.description;
-  }
-
-  /** @private */
-  _preventClosingLogin(e) {
-    e.preventDefault();
-  }
-
-  /**
-   * @param {!Event} e
-   * @private
-   */
-  _retargetEvent(e) {
-    e.stopPropagation();
-    const { detail, composed, cancelable, bubbles } = e;
-
-    const firedEvent = this.dispatchEvent(new CustomEvent(e.type, { bubbles, cancelable, composed, detail }));
-    // Check if `eventTarget.preventDefault()` was called to prevent default in the original event
-    if (!firedEvent) {
-      e.preventDefault();
-    }
-  }
-
-  /** @private */
-  _onOpenedChange() {
-    if (!this.opened) {
-      this.$.vaadinLoginForm.$.vaadinLoginUsername.value = '';
-      this.$.vaadinLoginForm.$.vaadinLoginPassword.value = '';
-      this.disabled = false;
-
-      if (this._undoTeleport) {
-        this._undoTeleport();
-      }
-    } else {
-      this._undoTeleport = this._teleport(this._getElementsToTeleport());
-
-      // Overlay sets pointerEvents on body to `none`, which breaks LastPass popup
-      // Reverting it back to the previous state
-      // https://github.com/vaadin/vaadin-overlay/blob/041cde4481b6262eac68d3a699f700216d897373/src/vaadin-overlay.html#L660
-      document.body.style.pointerEvents = this.$.vaadinLoginOverlayWrapper._previousDocumentPointerEvents;
-    }
-  }
-
-  /** @private */
-  _teleport(elements) {
-    const teleported = Array.from(elements).map((e) => {
-      return this.$.vaadinLoginOverlayWrapper.appendChild(e);
-    });
-    // Function to undo the teleport
-    return () => {
-      while (teleported.length > 0) {
-        this.appendChild(teleported.shift());
-      }
-    };
-  }
-
-  /** @private */
-  _getElementsToTeleport() {
-    return this.querySelectorAll('[slot=title]');
   }
 }
 


### PR DESCRIPTION
## Description

Added `LoginOverlayMixin` and `LoginFormMixin` to be used by Polymer and Lit versions of corresponding components.

## Type of change

- Refactor