### PR TITLE
fix: support using ID map when implementing createRenderRoot

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -175,7 +175,7 @@ const PolylitMixinImplementation = (superclass) => {
         this.$ = {};
       }
 
-      this.shadowRoot.querySelectorAll('[id]').forEach((node) => {
+      this.renderRoot.querySelectorAll('[id]').forEach((node) => {
         this.$[node.id] = node;
       });
     }

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -74,6 +74,31 @@ describe('PolylitMixin', () => {
     });
   });
 
+  describe('createRenderRoot', () => {
+    let element;
+
+    const tag = defineCE(
+      class extends PolylitMixin(LitElement) {
+        render() {
+          return html`<div id="foo">Component</div>`;
+        }
+
+        createRenderRoot() {
+          return this;
+        }
+      },
+    );
+
+    beforeEach(async () => {
+      element = fixtureSync(`<${tag}></${tag}>`);
+      await element.updateComplete;
+    });
+
+    it('should reference elements with id when rendering to light DOM', () => {
+      expect(element.$.foo).to.be.instanceOf(HTMLDivElement);
+    });
+  });
+
   describe('reflectToAttribute', () => {
     let element;
 


### PR DESCRIPTION
## Description

Currently, `PolylitMixin` throws when using [`createRenderRoot()`](https://lit.dev/docs/components/shadow-dom/#implementing-createrenderroot) because it assumes presence of `shadowRoot`.
Updated it to use `renderRoot` instead, so that `LitElement` returns appropriate node to get ID map from.


## Type of change

- Bugfix