### PR TITLE
fix: ensure validation between value-changed and change events

### DIFF
--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -634,10 +634,11 @@ describe('vaadin-select', () => {
         expect(changeSpy.called).to.be.false;
       });
 
-      it('should fire `change` event when value changes when alphanumeric keys are pressed', () => {
+      it('should fire `change` event when value changes when alphanumeric keys are pressed', async () => {
         keyDownChar(valueButton, 'o');
         keyDownChar(valueButton, 'p');
         keyDownChar(valueButton, 't');
+        await nextUpdate(select);
         expect(changeSpy.callCount).to.equal(1);
       });
 

--- a/packages/select/test/validation.common.js
+++ b/packages/select/test/validation.common.js
@@ -6,7 +6,7 @@ import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
 
 describe('validation', () => {
-  let select, validateSpy, changeSpy;
+  let select, validateSpy, valueChangedSpy, changeSpy;
 
   describe('basic', () => {
     beforeEach(async () => {
@@ -19,6 +19,8 @@ describe('validation', () => {
       validateSpy = sinon.spy(select, 'validate');
       changeSpy = sinon.spy();
       select.addEventListener('change', changeSpy);
+      valueChangedSpy = sinon.spy();
+      select.addEventListener('value-changed', valueChangedSpy);
     });
 
     it('should pass validation by default', () => {
@@ -48,15 +50,17 @@ describe('validation', () => {
       expect(validateSpy.called).to.be.true;
     });
 
-    it('should validate before change event on Enter', async () => {
+    it('should validate between value-changed and change events on Enter', async () => {
       select.focus();
       select.click();
       await nextRender();
 
       await sendKeys({ press: 'Enter' });
       await nextUpdate(select);
+      expect(valueChangedSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledOnce).to.be.true;
       expect(changeSpy.calledOnce).to.be.true;
-      expect(validateSpy.called).to.be.true;
+      expect(validateSpy.calledAfter(valueChangedSpy)).to.be.true;
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 


### PR DESCRIPTION
## Description

Previously, when selecting an item in `select`, the validation was triggered several times before a change event was fired: 

1. Once on opened property change:

https://github.com/vaadin/web-components/blob/09aee177f728181ddc83888af17a9a79b4d273b7/packages/select/src/vaadin-select-base-mixin.js#L259-L264

2. Once on value property change:

https://github.com/vaadin/web-components/blob/09aee177f728181ddc83888af17a9a79b4d273b7/packages/select/src/vaadin-select-base-mixin.js#L508-L511

However, in all these cases, validation was triggered before the `value-changed` event. 

The PR ensures the `value-changed => validated => change` sequence to align `select` with other components, which trigger validation after `value-changed`.

Part of #6146 

## Type of change

- [x] Bugfix
