### PR TITLE
feat: add option to enforce synchronous Lit property update

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -103,6 +103,22 @@ const PolylitMixinImplementation = (superclass) => {
         });
       }
 
+      if (options.sync) {
+        result = {
+          get: defaultDescriptor.get,
+          set(value) {
+            const oldValue = this[name];
+            this[key] = value;
+            this.requestUpdate(name, oldValue, options);
+
+            // Enforce synchronous update
+            this.performUpdate();
+          },
+          configurable: true,
+          enumerable: true,
+        };
+      }
+
       if (options.readOnly) {
         const setter = defaultDescriptor.set;
 

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -112,7 +112,9 @@ const PolylitMixinImplementation = (superclass) => {
             this.requestUpdate(name, oldValue, options);
 
             // Enforce synchronous update
-            this.performUpdate();
+            if (this.hasUpdated) {
+              this.performUpdate();
+            }
           },
           configurable: true,
           enumerable: true,

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -900,4 +900,49 @@ describe('PolylitMixin', () => {
       expect(element.items).to.eql([1, 2, 3]);
     });
   });
+
+  describe('sync', () => {
+    let element;
+
+    const tag = defineCE(
+      class extends PolylitMixin(LitElement) {
+        static get properties() {
+          return {
+            disabled: {
+              type: Boolean,
+              sync: true,
+              reflect: true,
+            },
+
+            value: {
+              type: String,
+              sync: true,
+            },
+          };
+        }
+
+        render() {
+          return html`${this.value}`;
+        }
+      },
+    );
+
+    beforeEach(async () => {
+      element = fixtureSync(`<${tag}></${tag}>`);
+      await element.updateComplete;
+    });
+
+    it('should re-render immediately when setting sync property', () => {
+      element.value = 'foo';
+      expect(element.shadowRoot.textContent).to.equal('foo');
+    });
+
+    it('should reflect immediately when setting sync property', () => {
+      element.disabled = true;
+      expect(element.hasAttribute('disabled')).to.be.true;
+
+      element.disabled = false;
+      expect(element.hasAttribute('disabled')).to.be.false;
+    });
+  });
 });

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -916,6 +916,7 @@ describe('PolylitMixin', () => {
 
             value: {
               type: String,
+              value: 'foo',
               sync: true,
             },
           };
@@ -933,8 +934,10 @@ describe('PolylitMixin', () => {
     });
 
     it('should re-render immediately when setting sync property', () => {
-      element.value = 'foo';
       expect(element.shadowRoot.textContent).to.equal('foo');
+
+      element.value = 'bar';
+      expect(element.shadowRoot.textContent).to.equal('bar');
     });
 
     it('should reflect immediately when setting sync property', () => {


### PR DESCRIPTION
## Description

Added a new property config option `sync: true` to enforce immediate updates via [`performUpdate()`](https://lit.dev/docs/components/lifecycle/#performupdate) call.
This should simplify migration of complex components to Lit, by potentially reducing changes to tests.

UPD: initial rendering is still asynchronous, as we rely on [`hasUpdated`](https://lit.dev/docs/components/lifecycle/#hasupdated) property. Further updates are sync.

## Type of change

- Internal feature