### PR TITLE
fix: prevent duplicate validation on programmatic blur

### DIFF
--- a/packages/a11y-base/src/delegate-focus-mixin.js
+++ b/packages/a11y-base/src/delegate-focus-mixin.js
@@ -82,12 +82,9 @@ export const DelegateFocusMixin = dedupingMixin(
        * @override
        */
       focus() {
-        if (!this.focusElement || this.disabled) {
-          return;
+        if (this.focusElement && !this.disabled) {
+          this.focusElement.focus();
         }
-
-        this.focusElement.focus();
-        this._setFocused(true);
       }
 
       /**
@@ -95,11 +92,9 @@ export const DelegateFocusMixin = dedupingMixin(
        * @override
        */
       blur() {
-        if (!this.focusElement) {
-          return;
+        if (this.focusElement) {
+          this.focusElement.blur();
         }
-        this.focusElement.blur();
-        this._setFocused(false);
       }
 
       /**

--- a/packages/date-picker/test/fullscreen.test.js
+++ b/packages/date-picker/test/fullscreen.test.js
@@ -108,20 +108,6 @@ describe('fullscreen mode', () => {
     });
   });
 
-  describe('focused attribute', () => {
-    it('should keep focused attribute after opening overlay', async () => {
-      datePicker.focus();
-      await open(datePicker);
-      expect(datePicker.hasAttribute('focused')).to.be.true;
-    });
-
-    it('should remove focused attribute when closing overlay', async () => {
-      await open(datePicker);
-      await sendKeys({ press: 'Escape' });
-      expect(datePicker.hasAttribute('focused')).to.be.false;
-    });
-  });
-
   describe('buttons', () => {
     let overlayContent;
 

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -164,6 +164,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should validate on programmatic blur', () => {
       const spy = sinon.spy(element, 'validate');
+      element.focus();
       element.blur();
       expect(spy.calledOnce).to.be.true;
     });

--- a/packages/select/test/validation.common.js
+++ b/packages/select/test/validation.common.js
@@ -32,12 +32,7 @@ describe('validation', () => {
     it('should validate on blur', () => {
       select.focus();
       select.blur();
-      expect(validateSpy.called).to.be.true;
-    });
-
-    it('should validate on programmatic blur', () => {
-      select.blur();
-      expect(validateSpy.called).to.be.true;
+      expect(validateSpy.calledOnce).to.be.true;
     });
 
     it('should validate on outside click', async () => {
@@ -47,7 +42,7 @@ describe('validation', () => {
 
       outsideClick();
       await nextUpdate(select);
-      expect(validateSpy.called).to.be.true;
+      expect(validateSpy.calledOnce).to.be.true;
     });
 
     it('should validate between value-changed and change events on Enter', async () => {


### PR DESCRIPTION
## Description

The PR prevents duplicate validation on programmatic blur for components extending `DelegateFocusMixin`. 

The extra validation was caused by an explicit `setFocused(false)` in `DelegateFocusMixin.blur()`, which was called despite `inputElement.blur()` triggering `focusout` that already led to `setFocused(false)`.

Part of https://github.com/vaadin/web-components/issues/6146 

## Type of change

- [x] Bugfix
