### PR TITLE
refactor: update date-picker infinite scroller to not use Polymer

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-month-scroller.js
+++ b/packages/date-picker/src/vaadin-date-picker-month-scroller.js
@@ -3,11 +3,11 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { dateAfterXMonths } from './vaadin-date-picker-helper.js';
 import { InfiniteScroller } from './vaadin-infinite-scroller.js';
 
-const stylesTemplate = html`
+const stylesTemplate = document.createElement('template');
+stylesTemplate.innerHTML = `
   <style>
     :host {
       --vaadin-infinite-scroller-item-height: 270px;
@@ -21,8 +21,6 @@ const stylesTemplate = html`
   </style>
 `;
 
-let memoizedTemplate;
-
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *
@@ -34,22 +32,11 @@ class DatePickerMonthScroller extends InfiniteScroller {
     return 'vaadin-date-picker-month-scroller';
   }
 
-  static get template() {
-    if (!memoizedTemplate) {
-      memoizedTemplate = super.template.cloneNode(true);
-      memoizedTemplate.content.appendChild(stylesTemplate.content.cloneNode(true));
-    }
+  constructor() {
+    super();
 
-    return memoizedTemplate;
-  }
-
-  static get properties() {
-    return {
-      bufferSize: {
-        type: Number,
-        value: 3,
-      },
-    };
+    this.bufferSize = 3;
+    this.shadowRoot.appendChild(stylesTemplate.content.cloneNode(true));
   }
 
   /**

--- a/packages/date-picker/src/vaadin-date-picker-year-scroller.js
+++ b/packages/date-picker/src/vaadin-date-picker-year-scroller.js
@@ -3,10 +3,10 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { InfiniteScroller } from './vaadin-infinite-scroller.js';
 
-const stylesTemplate = html`
+const stylesTemplate = document.createElement('template');
+stylesTemplate.innerHTML = `
   <style>
     :host {
       --vaadin-infinite-scroller-item-height: 80px;
@@ -48,7 +48,6 @@ let memoizedTemplate;
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *
  * @extends InfiniteScroller
- * @mixes ThemableMixin
  * @private
  */
 class DatePickerYearScroller extends InfiniteScroller {
@@ -56,22 +55,11 @@ class DatePickerYearScroller extends InfiniteScroller {
     return 'vaadin-date-picker-year-scroller';
   }
 
-  static get template() {
-    if (!memoizedTemplate) {
-      memoizedTemplate = super.template.cloneNode(true);
-      memoizedTemplate.content.appendChild(stylesTemplate.content.cloneNode(true));
-    }
+  constructor() {
+    super();
 
-    return memoizedTemplate;
-  }
-
-  static get properties() {
-    return {
-      bufferSize: {
-        type: Number,
-        value: 12,
-      },
-    };
+    this.bufferSize = 12;
+    this.shadowRoot.appendChild(stylesTemplate.content.cloneNode(true));
   }
 
   /**

--- a/packages/date-picker/test/scroller.test.js
+++ b/packages/date-picker/test/scroller.test.js
@@ -21,7 +21,8 @@ describe('vaadin-infinite-scroller', () => {
   let scroller;
 
   beforeEach(async () => {
-    scroller = fixtureSync('<vaadin-infinite-scroller buffer-size="80"></vaadin-infinite-scroller>');
+    scroller = fixtureSync('<vaadin-infinite-scroller></vaadin-infinite-scroller>');
+    scroller.bufferSize = 80;
     scroller.style.setProperty('--vaadin-infinite-scroller-item-height', '30px');
     await activateScroller(scroller);
   });


### PR DESCRIPTION
## Description

While experimenting with `vaadin-date-picker` Lit conversion, I noticed that scrollers actually don't need `LitElement`.
They have very little logic and rely on synchronous rendering, which can be easily done with plain `HTMLElement`.

## Type of change

- Refactor