### PR TITLE
test: update date-picker unit tests, add missing await

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -273,8 +273,9 @@ describe('inside flexbox', () => {
 describe('clear button', () => {
   let datePicker, clearButton;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     datePicker = fixtureSync('<vaadin-date-picker clear-button-visible></vaadin-date-picker>');
+    await nextRender();
     clearButton = datePicker.shadowRoot.querySelector('[part="clear-button"]');
   });
 
@@ -383,8 +384,9 @@ describe('wrapped', () => {
 describe('initial value attribute', () => {
   let datePicker, input;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     datePicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
+    await nextRender();
     input = datePicker.inputElement;
   });
 
@@ -396,8 +398,9 @@ describe('initial value attribute', () => {
 describe('auto open disabled', () => {
   let datePicker, input, toggleButton;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     datePicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
+    await nextRender();
     input = datePicker.inputElement;
     toggleButton = datePicker.shadowRoot.querySelector('[part="toggle-button"]');
     datePicker.autoOpenDisabled = true;
@@ -428,8 +431,9 @@ describe('auto open disabled', () => {
 describe('ios', () => {
   let datePicker, input;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     datePicker = fixtureSync('<vaadin-date-picker value="2000-01-01"></vaadin-date-picker>');
+    await nextRender();
     input = datePicker.inputElement;
     datePicker._ios = true;
   });
@@ -471,8 +475,9 @@ describe('ios', () => {
 describe('required', () => {
   let datePicker;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     datePicker = fixtureSync(`<vaadin-date-picker required></vaadin-date-picker>`);
+    await nextRender();
   });
 
   it('should focus on required indicator click', async () => {

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -17,8 +17,9 @@ import { getFocusedCell, monthsEqual, open, waitForOverlayRender } from './helpe
 describe('dropdown', () => {
   let datePicker, input, overlay;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     datePicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+    await nextRender();
     input = datePicker.inputElement;
     overlay = datePicker.$.overlay;
   });

--- a/packages/date-picker/test/fullscreen.test.js
+++ b/packages/date-picker/test/fullscreen.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, tap } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate, tap } from '@vaadin/testing-helpers';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
@@ -16,6 +16,7 @@ describe('fullscreen mode', () => {
   beforeEach(async () => {
     await setViewport({ width: 420, height });
     datePicker = fixtureSync(`<vaadin-date-picker></vaadin-date-picker>`);
+    await nextRender();
     input = datePicker.inputElement;
     overlay = datePicker.$.overlay;
   });
@@ -73,8 +74,9 @@ describe('fullscreen mode', () => {
     });
 
     describe('auto open disabled', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         datePicker.autoOpenDisabled = true;
+        await nextUpdate(datePicker);
       });
 
       it('should not open overlay on input tap', () => {

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -19,8 +19,9 @@ describe('keyboard navigation', () => {
     let input;
 
     describe('default', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         datePicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
+        await nextRender();
         input = datePicker.inputElement;
         input.focus();
       });
@@ -54,8 +55,9 @@ describe('keyboard navigation', () => {
     });
 
     describe('value', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         datePicker = fixtureSync('<vaadin-date-picker value="2001-01-01"></vaadin-date-picker>');
+        await nextRender();
         input = datePicker.inputElement;
         input.focus();
       });
@@ -88,8 +90,9 @@ describe('keyboard navigation', () => {
     });
 
     describe('initial position', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         datePicker = fixtureSync('<vaadin-date-picker initial-position="2001-01-01"></vaadin-date-picker>');
+        await nextRender();
         input = datePicker.inputElement;
         input.focus();
       });

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { enter, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
@@ -182,8 +182,9 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should be possible to force invalid status', () => {
+    it('should be possible to force invalid status', async () => {
       datePicker.invalid = true;
+      await nextUpdate(datePicker);
       expect(input.hasAttribute('invalid')).to.be.true;
     });
 
@@ -262,10 +263,11 @@ describe('validation', () => {
       expect(event.detail.valid).to.be.true;
     });
 
-    it('should fire a validated event on validation failure', () => {
+    it('should fire a validated event on validation failure', async () => {
       const validatedSpy = sinon.spy();
       datePicker.addEventListener('validated', validatedSpy);
       datePicker.required = true;
+      await nextUpdate(datePicker);
       datePicker.validate();
 
       expect(validatedSpy.calledOnce).to.be.true;
@@ -367,8 +369,9 @@ describe('validation', () => {
   describe('required', () => {
     let input;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       datePicker = fixtureSync(`<vaadin-date-picker required></vaadin-date-picker>`);
+      await nextRender();
       input = datePicker.inputElement;
     });
 
@@ -404,8 +407,9 @@ describe('validation', () => {
   describe('min', () => {
     let input;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       datePicker = fixtureSync(`<vaadin-date-picker min="2010-01-01"></vaadin-date-picker>`);
+      await nextRender();
       input = datePicker.inputElement;
     });
 
@@ -453,8 +457,9 @@ describe('validation', () => {
   describe('max', () => {
     let input;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       datePicker = fixtureSync(`<vaadin-date-picker max="2010-01-01"></vaadin-date-picker>`);
+      await nextRender();
       input = datePicker.inputElement;
     });
 


### PR DESCRIPTION
## Description

Updated `vaadin-date-picker` unit tests to add missing `nextRender()` needed for `LitElement` based version.

## Type of change

- Tests