### PR TITLE
fix: ensure ready() is not affected by setting sync property

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -220,8 +220,8 @@ const PolylitMixinImplementation = (superclass) => {
       }
 
       if (!this.__isReadyInvoked) {
-        this.ready();
         this.__isReadyInvoked = true;
+        this.ready();
       }
     }
 

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -919,7 +919,19 @@ describe('PolylitMixin', () => {
               value: 'foo',
               sync: true,
             },
+
+            count: {
+              type: Number,
+              value: 0,
+              sync: true,
+            },
           };
+        }
+
+        ready() {
+          super.ready();
+
+          this.count += 1;
         }
 
         render() {
@@ -946,6 +958,10 @@ describe('PolylitMixin', () => {
 
       element.disabled = false;
       expect(element.hasAttribute('disabled')).to.be.false;
+    });
+
+    it('should only call ready callback once during initialization', () => {
+      expect(element.count).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
## Description

Fixed an issue where property with `sync: true` triggers another update and causes infinite loop of `ready()` calls.
Note, in practice this doesn't necessarily mean infinite loop, but also e.g. multiple subsequent `ready()` calls.

## Type of change

- Bugfix