### PR TITLE
refactor: extract date-picker styles to reusable css literals

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-styles.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const overlayContentStyles = css`
+  :host {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    outline: none;
+  }
+
+  [part='overlay-header'] {
+    display: flex;
+    flex-shrink: 0;
+    flex-wrap: nowrap;
+    align-items: center;
+  }
+
+  :host(:not([fullscreen])) [part='overlay-header'] {
+    display: none;
+  }
+
+  [part='label'] {
+    flex-grow: 1;
+  }
+
+  [hidden] {
+    display: none !important;
+  }
+
+  [part='years-toggle-button'] {
+    display: flex;
+  }
+
+  #scrollers {
+    display: flex;
+    height: 100%;
+    width: 100%;
+    position: relative;
+    overflow: hidden;
+  }
+
+  :host([desktop]) ::slotted([slot='months']) {
+    right: 50px;
+    transform: none !important;
+  }
+
+  :host([desktop]) ::slotted([slot='years']) {
+    transform: none !important;
+  }
+
+  :host(.animate) ::slotted([slot='months']),
+  :host(.animate) ::slotted([slot='years']) {
+    transition: all 200ms;
+  }
+
+  [part='toolbar'] {
+    display: flex;
+    justify-content: space-between;
+    z-index: 2;
+    flex-shrink: 0;
+  }
+`;

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -18,8 +18,13 @@ import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { addListener, setTouchAction } from '@vaadin/component-base/src/gestures.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { dateAfterXMonths, dateEquals, extractDateParts, getClosestDate } from './vaadin-date-picker-helper.js';
+import { overlayContentStyles } from './vaadin-date-picker-overlay-content-styles.js';
+
+registerStyles('vaadin-date-picker-overlay-content', overlayContentStyles, {
+  moduleId: 'vaadin-date-picker-overlay-content-styles',
+});
 
 /**
  * @extends HTMLElement
@@ -28,68 +33,6 @@ import { dateAfterXMonths, dateEquals, extractDateParts, getClosestDate } from '
 class DatePickerOverlayContent extends ControllerMixin(ThemableMixin(DirMixin(PolymerElement))) {
   static get template() {
     return html`
-      <style>
-        :host {
-          display: flex;
-          flex-direction: column;
-          height: 100%;
-          width: 100%;
-          outline: none;
-        }
-
-        [part='overlay-header'] {
-          display: flex;
-          flex-shrink: 0;
-          flex-wrap: nowrap;
-          align-items: center;
-        }
-
-        :host(:not([fullscreen])) [part='overlay-header'] {
-          display: none;
-        }
-
-        [part='label'] {
-          flex-grow: 1;
-        }
-
-        [hidden] {
-          display: none !important;
-        }
-
-        [part='years-toggle-button'] {
-          display: flex;
-        }
-
-        #scrollers {
-          display: flex;
-          height: 100%;
-          width: 100%;
-          position: relative;
-          overflow: hidden;
-        }
-
-        :host([desktop]) ::slotted([slot='months']) {
-          right: 50px;
-          transform: none !important;
-        }
-
-        :host([desktop]) ::slotted([slot='years']) {
-          transform: none !important;
-        }
-
-        :host(.animate) ::slotted([slot='months']),
-        :host(.animate) ::slotted([slot='years']) {
-          transition: all 200ms;
-        }
-
-        [part='toolbar'] {
-          display: flex;
-          justify-content: space-between;
-          z-index: 2;
-          flex-shrink: 0;
-        }
-      </style>
-
       <div part="overlay-header" on-touchend="_preventDefault" aria-hidden="true">
         <div part="label">[[_formatDisplayed(selectedDate, i18n.formatDate, label)]]</div>
         <div part="clear-button" hidden$="[[!selectedDate]]"></div>

--- a/packages/date-picker/src/vaadin-date-picker-styles.js
+++ b/packages/date-picker/src/vaadin-date-picker-styles.js
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const datePickerStyles = css`
+  :host([opened]) {
+    pointer-events: auto;
+  }
+
+  :host([dir='rtl']) [part='input-field'] {
+    direction: ltr;
+  }
+
+  :host([dir='rtl']) [part='input-field'] ::slotted(input)::placeholder {
+    direction: rtl;
+    text-align: left;
+  }
+`;

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -15,8 +15,9 @@ import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-c
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
+import { datePickerStyles } from './vaadin-date-picker-styles.js';
 
-registerStyles('vaadin-date-picker', inputFieldShared, { moduleId: 'vaadin-date-picker-styles' });
+registerStyles('vaadin-date-picker', [inputFieldShared, datePickerStyles], { moduleId: 'vaadin-date-picker-styles' });
 
 /**
  * `<vaadin-date-picker>` is an input field that allows to enter a date by typing or by selecting from a calendar overlay.
@@ -135,21 +136,6 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
 
   static get template() {
     return html`
-      <style>
-        :host([opened]) {
-          pointer-events: auto;
-        }
-
-        :host([dir='rtl']) [part='input-field'] {
-          direction: ltr;
-        }
-
-        :host([dir='rtl']) [part='input-field'] ::slotted(input)::placeholder {
-          direction: rtl;
-          text-align: left;
-        }
-      </style>
-
       <div class="vaadin-date-picker-container">
         <div part="label">
           <slot name="label"></slot>

--- a/packages/date-picker/src/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/src/vaadin-month-calendar-styles.js
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const monthCalendarStyles = css`
+  :host {
+    display: block;
+  }
+
+  #monthGrid {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  #days-container tr,
+  #weekdays-container tr {
+    display: flex;
+  }
+
+  [part~='date'] {
+    outline: none;
+  }
+
+  [part~='disabled'] {
+    pointer-events: none;
+  }
+
+  [part='week-number'][hidden],
+  [part='weekday'][hidden] {
+    display: none;
+  }
+
+  [part='weekday'],
+  [part~='date'] {
+    width: calc(100% / 7);
+    padding: 0;
+    font-weight: normal;
+  }
+
+  [part='weekday']:empty,
+  [part='week-number'] {
+    width: 12.5%;
+    flex-shrink: 0;
+    padding: 0;
+  }
+
+  :host([week-numbers]) [part='weekday']:not(:empty),
+  :host([week-numbers]) [part~='date'] {
+    width: 12.5%;
+  }
+
+  @media (forced-colors: active) {
+    [part~='date'][part~='focused'] {
+      outline: 1px solid;
+    }
+
+    [part~='date'][part~='selected'] {
+      outline: 3px solid;
+    }
+  }
+`;

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -7,8 +7,13 @@ import '@polymer/polymer/lib/elements/dom-repeat.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { addListener } from '@vaadin/component-base/src/gestures.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { dateAllowed, dateEquals, getISOWeekNumber } from './vaadin-date-picker-helper.js';
+import { monthCalendarStyles } from './vaadin-month-calendar-styles.js';
+
+registerStyles('vaadin-month-calendar', monthCalendarStyles, {
+  moduleId: 'vaadin-month-calendar-styles',
+});
 
 /**
  * @extends HTMLElement
@@ -17,63 +22,6 @@ import { dateAllowed, dateEquals, getISOWeekNumber } from './vaadin-date-picker-
 class MonthCalendar extends FocusMixin(ThemableMixin(PolymerElement)) {
   static get template() {
     return html`
-      <style>
-        :host {
-          display: block;
-        }
-
-        #monthGrid {
-          width: 100%;
-          border-collapse: collapse;
-        }
-
-        #days-container tr,
-        #weekdays-container tr {
-          display: flex;
-        }
-
-        [part~='date'] {
-          outline: none;
-        }
-
-        [part~='disabled'] {
-          pointer-events: none;
-        }
-
-        [part='week-number'][hidden],
-        [part='weekday'][hidden] {
-          display: none;
-        }
-
-        [part='weekday'],
-        [part~='date'] {
-          width: calc(100% / 7);
-          padding: 0;
-          font-weight: normal;
-        }
-
-        [part='weekday']:empty,
-        [part='week-number'] {
-          width: 12.5%;
-          flex-shrink: 0;
-          padding: 0;
-        }
-
-        :host([week-numbers]) [part='weekday']:not(:empty),
-        :host([week-numbers]) [part~='date'] {
-          width: 12.5%;
-        }
-
-        @media (forced-colors: active) {
-          [part~='date'][part~='focused'] {
-            outline: 1px solid;
-          }
-          [part~='date'][part~='selected'] {
-            outline: 3px solid;
-          }
-        }
-      </style>
-
       <div part="month-header" id="month-header" aria-hidden="true">[[_getTitle(month, i18n)]]</div>
       <table
         id="monthGrid"


### PR DESCRIPTION
## Description

This is a pre-requisite for creating `vaadin-date-picker` version based on `LitElement`.

## Type of change

- Refactor