### PR TITLE
test: update date-picker tests to support async overlay

### DIFF
--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -5,6 +5,7 @@ import {
   fixtureSync,
   mousedown,
   nextRender,
+  nextUpdate,
   oneEvent,
   outsideClick,
   touchstart,
@@ -33,6 +34,7 @@ describe('dropdown', () => {
   it('should detach overlay on datePicker detach', async () => {
     await open(datePicker);
     datePicker.parentElement.removeChild(datePicker);
+    await nextUpdate(datePicker);
     expect(overlay.parentElement).to.not.be.ok;
   });
 
@@ -55,6 +57,8 @@ describe('dropdown', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
 
       toggleButton.click();
+      await nextUpdate(datePicker);
+
       expect(datePicker.opened).to.be.false;
       expect(overlay.opened).to.be.false;
     });
@@ -68,6 +72,8 @@ describe('dropdown', () => {
   describe('scroll to date', () => {
     it('should scroll to today by default', async () => {
       datePicker.open();
+      await nextUpdate(datePicker);
+
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
@@ -80,6 +86,8 @@ describe('dropdown', () => {
       datePicker.initialPosition = '2016-01-01';
 
       datePicker.open();
+      await nextUpdate(datePicker);
+
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
@@ -92,6 +100,8 @@ describe('dropdown', () => {
       datePicker.value = '2000-02-01';
 
       datePicker.open();
+      await nextUpdate(datePicker);
+
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
@@ -114,6 +124,7 @@ describe('dropdown', () => {
 
     it('should scroll to date on reopen', async () => {
       datePicker.open();
+      await nextUpdate(datePicker);
 
       // We must scroll to initial position on reopen because
       // scrollTop can be reset while the dropdown is closed.
@@ -134,6 +145,8 @@ describe('dropdown', () => {
       datePicker.min = '2100-01-01';
 
       datePicker.open();
+      await nextUpdate(datePicker);
+
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
@@ -146,6 +159,8 @@ describe('dropdown', () => {
       datePicker.max = '2000-01-01';
 
       datePicker.open();
+      await nextUpdate(datePicker);
+
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
@@ -161,6 +176,8 @@ describe('dropdown', () => {
       datePicker.initialPosition = '2015-01-01';
 
       datePicker.open();
+      await nextUpdate(datePicker);
+
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
       await waitForOverlayRender();
@@ -175,6 +192,7 @@ describe('dropdown', () => {
       input.focus();
       await open(datePicker);
       outsideClick();
+      await nextUpdate(datePicker);
       await aTimeout(0);
       expect(document.activeElement).to.equal(input);
     });
@@ -183,6 +201,7 @@ describe('dropdown', () => {
       expect(document.activeElement).to.equal(document.body);
       await open(datePicker);
       outsideClick();
+      await nextUpdate(datePicker);
       await aTimeout(0);
       expect(document.activeElement).to.equal(input);
     });
@@ -192,6 +211,7 @@ describe('dropdown', () => {
       await sendKeys({ press: 'Tab' });
       await open(datePicker);
       outsideClick();
+      await nextUpdate(datePicker);
       await aTimeout(0);
       expect(datePicker.hasAttribute('focus-ring')).to.be.true;
     });
@@ -295,6 +315,7 @@ describe('dropdown', () => {
     it('should disable virtual keyboard on close', async () => {
       await open(datePicker);
       datePicker.close();
+      await nextUpdate(datePicker);
       expect(input.inputMode).to.equal('none');
     });
 

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, enter, fixtureSync, listenOnce, nextRender, tap } from '@vaadin/testing-helpers';
+import { aTimeout, enter, fixtureSync, listenOnce, nextRender, nextUpdate, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -117,10 +117,12 @@ describe('validation', () => {
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
-    it('should validate on outside click', () => {
+    it('should validate on outside click', async () => {
       input.focus();
       input.click();
+      await waitForOverlayRender();
       outsideClick();
+      await nextUpdate(datePicker);
       expect(validateSpy.calledOnce).to.be.true;
     });
 
@@ -131,6 +133,7 @@ describe('validation', () => {
       await sendKeys({ type: '1/1/2023' });
       await waitForScrollToFinish(datePicker._overlayContent);
       outsideClick();
+      await nextUpdate(datePicker);
       expect(changeSpy.calledOnce).to.be.true;
       expect(validateSpy.calledOnce).to.be.true;
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;
@@ -306,6 +309,7 @@ describe('validation', () => {
       setInputValue(datePicker, '1/1/2022');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.false;
     });
 
@@ -313,6 +317,7 @@ describe('validation', () => {
       setInputValue(datePicker, 'foo');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.true;
     });
 
@@ -321,6 +326,7 @@ describe('validation', () => {
       setInputValue(datePicker, 'foo');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.value).to.equal('');
       expect(input.value).to.equal('foo');
     });
@@ -388,6 +394,7 @@ describe('validation', () => {
       setInputValue(datePicker, '1/1/2000');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.false;
     });
 
@@ -399,6 +406,7 @@ describe('validation', () => {
       setInputValue(datePicker, '');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
 
       expect(datePicker.invalid).to.be.true;
     });
@@ -436,6 +444,7 @@ describe('validation', () => {
       setInputValue(datePicker, '1/1/2000');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.true;
     });
 
@@ -443,6 +452,7 @@ describe('validation', () => {
       setInputValue(datePicker, '1/1/2022');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.false;
     });
 
@@ -450,6 +460,7 @@ describe('validation', () => {
       setInputValue(datePicker, '1/1/2022');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.false;
     });
   });
@@ -486,6 +497,7 @@ describe('validation', () => {
       setInputValue(datePicker, '1/1/2022');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.true;
     });
 
@@ -493,6 +505,7 @@ describe('validation', () => {
       setInputValue(datePicker, '1/1/2000');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.false;
     });
 
@@ -500,6 +513,7 @@ describe('validation', () => {
       setInputValue(datePicker, '1/1/2010');
       await waitForOverlayRender();
       enter(input);
+      await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.false;
     });
   });


### PR DESCRIPTION
## Description

This PR fixes most of tests that started to fail after converting `vaadin-date-picker-overlay` component to `LitElement`.
Note, while we can add `sync: true` to most of properties in `DatePickerMixin`, opening / closing overlay is still async.

## Type of change

- Tests