### PR TITLE
experiment: add Lit version of date-picker month calendar

### DIFF
--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -22,6 +22,7 @@
   "files": [
     "src",
     "!src/vaadin-lit-date-picker-overlay-content.js",
+    "!src/vaadin-lit-month-calendar.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -324,15 +324,13 @@ export const DatePickerOverlayContentMixin = (superClass) =>
     ) {
       if (calendars && calendars.length) {
         calendars.forEach((calendar) => {
-          calendar.setProperties({
-            i18n,
-            minDate,
-            maxDate,
-            focusedDate,
-            selectedDate,
-            showWeekNumbers,
-            ignoreTaps,
-          });
+          calendar.i18n = i18n;
+          calendar.minDate = minDate;
+          calendar.maxDate = maxDate;
+          calendar.focusedDate = focusedDate;
+          calendar.selectedDate = selectedDate;
+          calendar.showWeekNumbers = showWeekNumbers;
+          calendar.ignoreTaps = ignoreTaps;
 
           if (theme) {
             calendar.setAttribute('theme', theme);

--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { isFirefox } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
@@ -349,7 +348,7 @@ export class InfiniteScroller extends HTMLElement {
       }
     });
 
-    afterNextRender(this, () => {
+    requestAnimationFrame(() => {
       this._finishInit();
     });
   }

--- a/packages/date-picker/src/vaadin-lit-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-lit-date-picker-overlay-content.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/button/src/vaadin-button.js';
-import './vaadin-month-calendar.js';
+import './vaadin-lit-month-calendar.js';
 import './vaadin-date-picker-month-scroller.js';
 import './vaadin-date-picker-year-scroller.js';
 import './vaadin-date-picker-year.js';

--- a/packages/date-picker/src/vaadin-lit-month-calendar.js
+++ b/packages/date-picker/src/vaadin-lit-month-calendar.js
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2022 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css, html, LitElement } from 'lit';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { dateAllowed, dateEquals } from './vaadin-date-picker-helper.js';
+import { MonthCalendarMixin } from './vaadin-month-calendar-mixin.js';
+import { monthCalendarStyles } from './vaadin-month-calendar-styles.js';
+
+/**
+ * @extends HTMLElement
+ * @private
+ */
+class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolylitMixin(LitElement))) {
+  static get is() {
+    return 'vaadin-month-calendar';
+  }
+
+  static get styles() {
+    return monthCalendarStyles;
+  }
+
+  /** @protected */
+  render() {
+    const weekDayNames = this._getWeekDayNames(this.i18n, this.showWeekNumbers);
+    const weeks = this._weeks;
+    const hideWeekSeparator = !this._showWeekNumbers;
+
+    return html`
+      <div part="month-header" id="month-header" aria-hidden="true">${this._getTitle(this.month, this.i18n)}</div>
+      <table
+        id="monthGrid"
+        role="grid"
+        aria-labelledby="month-header"
+        @touchend="${this._preventDefault}"
+        @touchstart="${this._onMonthGridTouchStart}"
+      >
+        <thead id="weekdays-container">
+          <tr role="row" part="weekdays">
+            <th part="weekday" aria-hidden="true" ?hidden="${hideWeekSeparator}"></th>
+            ${weekDayNames.map(
+              (item) => html`
+                <th role="columnheader" part="weekday" scope="col" abbr="${item.weekDay}" aria-hidden="true">
+                  ${item.weekDayShort}
+                </th>
+              `,
+            )}
+          </tr>
+        </thead>
+        <tbody id="days-container">
+          ${weeks.map(
+            (week) => html`
+              <tr role="row">
+                <td part="week-number" aria-hidden="true" ?hidden="${hideWeekSeparator}">
+                  ${this.__getWeekNumber(week)}
+                </td>
+                ${week.map((date) => {
+                  const isFocused = dateEquals(date, this.focusedDate);
+                  const isSelected = dateEquals(date, this.selectedDate);
+                  const isDisabled = !dateAllowed(date, this.minDate, this.maxDate);
+
+                  const parts = [
+                    'date',
+                    isDisabled && 'disabled',
+                    isFocused && 'focused',
+                    isSelected && 'selected',
+                    this._isToday(date) && 'today',
+                  ].filter(Boolean);
+
+                  return html`
+                    <td
+                      role="gridcell"
+                      part="${parts.join(' ')}"
+                      .date="${date}"
+                      ?disabled="${isDisabled}"
+                      tabindex="${isFocused ? '0' : '-1'}"
+                      aria-selected="${isSelected ? 'true' : 'false'}"
+                      aria-disabled="${isDisabled ? 'true' : 'false'}"
+                      aria-label="${this.__getDayAriaLabel(date)}"
+                      >${this._getDate(date)}</td
+                    >
+                  `;
+                })}
+              </tr>
+            `,
+          )}
+        </tbody>
+      </table>
+    `;
+  }
+
+  /** @protected */
+  willUpdate(props) {
+    // Calculate these properties in `willUpdate()` instead of marking
+    // them as `computed` to avoid extra update because of `sync: true`
+    if (props.has('month') || props.has('i18n')) {
+      this._days = this._getDays(this.month, this.i18n);
+      this._weeks = this._getWeeks(this._days);
+    }
+
+    if (props.has('month') || props.has('minDate') || props.has('maxDate')) {
+      this.disabled = this._isDisabled(this.month, this.minDate, this.maxDate);
+    }
+
+    if (props.has('showWeekNumbers') || props.has('i18n')) {
+      // Currently only supported for locales that start the week on Monday.
+      this._showWeekNumbers = this.showWeekNumbers && this.i18n && this.i18n.firstDayOfWeek === 1;
+      this.toggleAttribute('week-numbers', this._showWeekNumbers);
+    }
+  }
+}
+
+customElements.define(MonthCalendar.is, MonthCalendar);

--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -1,0 +1,303 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
+import { addListener } from '@vaadin/component-base/src/gestures.js';
+import { dateAllowed, dateEquals, getISOWeekNumber } from './vaadin-date-picker-helper.js';
+
+/**
+ * @polymerMixin
+ * @mixes FocusMixin
+ */
+export const MonthCalendarMixin = (superClass) =>
+  class MonthCalendarMixinClass extends FocusMixin(superClass) {
+    static get properties() {
+      return {
+        /**
+         * A `Date` object defining the month to be displayed. Only year and
+         * month properties are actually used.
+         */
+        month: {
+          type: Object,
+          value: new Date(),
+          sync: true,
+        },
+
+        /**
+         * A `Date` object for the currently selected date.
+         */
+        selectedDate: {
+          type: Object,
+          notify: true,
+          sync: true,
+        },
+
+        /**
+         * A `Date` object for the currently focused date.
+         */
+        focusedDate: {
+          type: Object,
+        },
+
+        /**
+         * Set true to display ISO-8601 week numbers in the calendar. Notice that
+         * displaying week numbers is only supported when `i18n.firstDayOfWeek`
+         * is 1 (Monday).
+         */
+        showWeekNumbers: {
+          type: Boolean,
+          value: false,
+        },
+
+        i18n: {
+          type: Object,
+        },
+
+        /**
+         * Flag stating whether taps on the component should be ignored.
+         */
+        ignoreTaps: {
+          type: Boolean,
+        },
+
+        /**
+         * The earliest date that can be selected. All earlier dates will be disabled.
+         */
+        minDate: {
+          type: Date,
+          value: null,
+          sync: true,
+        },
+
+        /**
+         * The latest date that can be selected. All later dates will be disabled.
+         */
+        maxDate: {
+          type: Date,
+          value: null,
+          sync: true,
+        },
+
+        disabled: {
+          type: Boolean,
+          reflectToAttribute: true,
+        },
+
+        /** @protected */
+        _days: {
+          type: Array,
+        },
+
+        /** @protected */
+        _weeks: {
+          type: Array,
+        },
+
+        /** @private */
+        _notTapping: {
+          type: Boolean,
+        },
+      };
+    }
+
+    static get observers() {
+      return ['__focusedDateChanged(focusedDate, _days)'];
+    }
+
+    get focusableDateElement() {
+      return [...this.shadowRoot.querySelectorAll('[part~=date]')].find((datePart) => {
+        return dateEquals(datePart.date, this.focusedDate);
+      });
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+      addListener(this.$.monthGrid, 'tap', this._handleTap.bind(this));
+    }
+
+    /**
+     * Returns true if all the dates in the month are out of the allowed range
+     * @protected
+     */
+    _isDisabled(month, minDate, maxDate) {
+      // First day of the month
+      const firstDate = new Date(0, 0);
+      firstDate.setFullYear(month.getFullYear());
+      firstDate.setMonth(month.getMonth());
+      firstDate.setDate(1);
+
+      // Last day of the month
+      const lastDate = new Date(0, 0);
+      lastDate.setFullYear(month.getFullYear());
+      lastDate.setMonth(month.getMonth() + 1);
+      lastDate.setDate(0);
+
+      if (
+        minDate &&
+        maxDate &&
+        minDate.getMonth() === maxDate.getMonth() &&
+        minDate.getMonth() === month.getMonth() &&
+        maxDate.getDate() - minDate.getDate() >= 0
+      ) {
+        return false;
+      }
+
+      return !dateAllowed(firstDate, minDate, maxDate) && !dateAllowed(lastDate, minDate, maxDate);
+    }
+
+    /** @protected */
+    _getTitle(month, i18n) {
+      if (month === undefined || i18n === undefined) {
+        return;
+      }
+      return i18n.formatTitle(i18n.monthNames[month.getMonth()], month.getFullYear());
+    }
+
+    /** @protected */
+    _onMonthGridTouchStart() {
+      this._notTapping = false;
+      setTimeout(() => {
+        this._notTapping = true;
+      }, 300);
+    }
+
+    /** @private */
+    _dateAdd(date, delta) {
+      date.setDate(date.getDate() + delta);
+    }
+
+    /** @private */
+    _applyFirstDayOfWeek(weekDayNames, firstDayOfWeek) {
+      if (weekDayNames === undefined || firstDayOfWeek === undefined) {
+        return;
+      }
+
+      return weekDayNames.slice(firstDayOfWeek).concat(weekDayNames.slice(0, firstDayOfWeek));
+    }
+
+    /** @protected */
+    _getWeekDayNames(i18n, showWeekNumbers) {
+      if (i18n === undefined || showWeekNumbers === undefined) {
+        return [];
+      }
+      const { weekdays, weekdaysShort, firstDayOfWeek } = i18n;
+
+      const weekDayNamesShort = this._applyFirstDayOfWeek(weekdaysShort, firstDayOfWeek);
+      const weekDayNames = this._applyFirstDayOfWeek(weekdays, firstDayOfWeek);
+
+      return weekDayNames.map((day, index) => {
+        return {
+          weekDay: day,
+          weekDayShort: weekDayNamesShort[index],
+        };
+      });
+    }
+
+    /** @private */
+    __focusedDateChanged(focusedDate, days) {
+      if (Array.isArray(days) && days.some((date) => dateEquals(date, focusedDate))) {
+        this.removeAttribute('aria-hidden');
+      } else {
+        this.setAttribute('aria-hidden', 'true');
+      }
+    }
+
+    /** @protected */
+    _getDate(date) {
+      return date ? date.getDate() : '';
+    }
+
+    /** @protected */
+    _showWeekSeparator(showWeekNumbers, i18n) {
+      // Currently only supported for locales that start the week on Monday.
+      return showWeekNumbers && i18n && i18n.firstDayOfWeek === 1;
+    }
+
+    /** @protected */
+    _isToday(date) {
+      return dateEquals(new Date(), date);
+    }
+
+    /** @protected */
+    _getDays(month, i18n) {
+      if (month === undefined || i18n === undefined) {
+        return [];
+      }
+      // First day of the month (at midnight).
+      const date = new Date(0, 0);
+      date.setFullYear(month.getFullYear());
+      date.setMonth(month.getMonth());
+      date.setDate(1);
+
+      // Rewind to first day of the week.
+      while (date.getDay() !== i18n.firstDayOfWeek) {
+        this._dateAdd(date, -1);
+      }
+
+      const days = [];
+      const startMonth = date.getMonth();
+      const targetMonth = month.getMonth();
+      while (date.getMonth() === targetMonth || date.getMonth() === startMonth) {
+        days.push(date.getMonth() === targetMonth ? new Date(date.getTime()) : null);
+
+        // Advance to next day.
+        this._dateAdd(date, 1);
+      }
+      return days;
+    }
+
+    /** @protected */
+    _getWeeks(days) {
+      return days.reduce((acc, day, i) => {
+        if (i % 7 === 0) {
+          acc.push([]);
+        }
+        acc[acc.length - 1].push(day);
+        return acc;
+      }, []);
+    }
+
+    /** @protected */
+    _handleTap(e) {
+      if (!this.ignoreTaps && !this._notTapping && e.target.date && !e.target.hasAttribute('disabled')) {
+        this.selectedDate = e.target.date;
+        this.dispatchEvent(
+          new CustomEvent('date-tap', { detail: { date: e.target.date }, bubbles: true, composed: true }),
+        );
+      }
+    }
+
+    /** @protected */
+    _preventDefault(e) {
+      e.preventDefault();
+    }
+
+    /** @protected */
+    __getWeekNumber(days) {
+      const date = days.reduce((acc, d) => {
+        return !acc && d ? d : acc;
+      });
+
+      return getISOWeekNumber(date);
+    }
+
+    /** @protected */
+    __getDayAriaLabel(date) {
+      if (!date) {
+        return '';
+      }
+
+      let ariaLabel = `${this._getDate(date)} ${this.i18n.monthNames[date.getMonth()]} ${date.getFullYear()}, ${
+        this.i18n.weekdays[date.getDay()]
+      }`;
+
+      if (this._isToday(date)) {
+        ariaLabel += `, ${this.i18n.today}`;
+      }
+
+      return ariaLabel;
+    }
+  };

--- a/packages/date-picker/test/month-calendar-lit.test.js
+++ b/packages/date-picker/test/month-calendar-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-month-calendar.js';
+import './month-calendar.common.js';

--- a/packages/date-picker/test/month-calendar-polymer.test.js
+++ b/packages/date-picker/test/month-calendar-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-month-calendar.js';
+import './month-calendar.common.js';

--- a/packages/date-picker/test/month-calendar.common.js
+++ b/packages/date-picker/test/month-calendar.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, makeSoloTouchEvent, nextRender, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../src/vaadin-month-calendar.js';
 import { getDefaultI18n } from './helpers.js';
 
 describe('vaadin-month-calendar', () => {

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -556,27 +556,27 @@ snapshots["vaadin-date-time-picker host overlay class date-picker"] =
     </vaadin-button>
     <vaadin-date-picker-month-scroller slot="months">
       <div slot="vaadin-infinite-scroller-item-content-12">
-        <vaadin-month-calendar>
+        <vaadin-month-calendar aria-hidden="true">
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-13">
-        <vaadin-month-calendar>
+        <vaadin-month-calendar aria-hidden="true">
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-14">
-        <vaadin-month-calendar>
+        <vaadin-month-calendar aria-hidden="true">
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-15">
-        <vaadin-month-calendar>
+        <vaadin-month-calendar aria-hidden="true">
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-16">
-        <vaadin-month-calendar>
+        <vaadin-month-calendar aria-hidden="true">
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-17">
-        <vaadin-month-calendar>
+        <vaadin-month-calendar aria-hidden="true">
         </vaadin-month-calendar>
       </div>
     </vaadin-date-picker-month-scroller>


### PR DESCRIPTION
## Description

Depends on #6273

1. Created `MonthCalendarMixin` and `vaadin-lit-month-calendar` component,
3. Modified `month-calendar.test.js` to run for both Polymer and Lit versions.

## Type of change

- Experiment