### PR TITLE
experiment: add LitElement version of vaadin-date-picker

### DIFF
--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -23,6 +23,7 @@
     "src",
     "!src/vaadin-lit-date-picker-overlay-content.js",
     "!src/vaadin-lit-month-calendar.js",
+    "!src/vaadin-lit-date-picker.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -42,14 +42,18 @@ export const DatePickerMixin = (subclass) =>
          * @protected
          */
         _selectedDate: {
-          type: Date,
+          type: Object,
+          sync: true,
         },
 
         /**
          * @type {Date | undefined}
          * @protected
          */
-        _focusedDate: Date,
+        _focusedDate: {
+          type: Object,
+          sync: true,
+        },
 
         /**
          * Selected date.
@@ -64,6 +68,7 @@ export const DatePickerMixin = (subclass) =>
           type: String,
           notify: true,
           value: '',
+          sync: true,
         },
 
         /**
@@ -82,6 +87,7 @@ export const DatePickerMixin = (subclass) =>
           reflectToAttribute: true,
           notify: true,
           observer: '_openedChanged',
+          sync: true,
         },
 
         /**
@@ -99,6 +105,7 @@ export const DatePickerMixin = (subclass) =>
         showWeekNumbers: {
           type: Boolean,
           value: false,
+          sync: true,
         },
 
         /**
@@ -108,6 +115,7 @@ export const DatePickerMixin = (subclass) =>
         _fullscreen: {
           type: Boolean,
           value: false,
+          sync: true,
         },
 
         /**
@@ -206,6 +214,7 @@ export const DatePickerMixin = (subclass) =>
          */
         i18n: {
           type: Object,
+          sync: true,
           value: () => {
             return {
               monthNames: [
@@ -276,6 +285,7 @@ export const DatePickerMixin = (subclass) =>
          */
         min: {
           type: String,
+          sync: true,
         },
 
         /**
@@ -289,6 +299,7 @@ export const DatePickerMixin = (subclass) =>
          */
         max: {
           type: String,
+          sync: true,
         },
 
         /**
@@ -299,6 +310,7 @@ export const DatePickerMixin = (subclass) =>
         _minDate: {
           type: Date,
           computed: '__computeMinOrMaxDate(min)',
+          sync: true,
         },
 
         /**
@@ -309,6 +321,7 @@ export const DatePickerMixin = (subclass) =>
         _maxDate: {
           type: Date,
           computed: '__computeMinOrMaxDate(max)',
+          sync: true,
         },
 
         /** @private */
@@ -327,7 +340,10 @@ export const DatePickerMixin = (subclass) =>
         _focusOverlayOnOpen: Boolean,
 
         /** @private */
-        _overlayContent: Object,
+        _overlayContent: {
+          type: Object,
+          sync: true,
+        },
 
         /**
          * In date-picker, unlike other components extending `InputMixin`,
@@ -485,6 +501,22 @@ export const DatePickerMixin = (subclass) =>
       super._propertiesChanged(currentProps, changedProps, oldProps);
 
       if ('value' in changedProps && this.__dispatchChange) {
+        this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+        this.__dispatchChange = false;
+      }
+    }
+
+    /**
+     * Override LitElement lifecycle callback to dispatch `change` event if needed.
+     * This is necessary to ensure `change` is fired after `value-changed`.
+     *
+     * @protected
+     * @override
+     */
+    updated(props) {
+      super.updated(props);
+
+      if (props.has('value') && this.__dispatchChange) {
         this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
         this.__dispatchChange = false;
       }

--- a/packages/date-picker/src/vaadin-lit-date-picker.js
+++ b/packages/date-picker/src/vaadin-lit-date-picker.js
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '@vaadin/input-container/src/vaadin-input-container.js';
+import './vaadin-date-picker-overlay.js';
+import './vaadin-lit-date-picker-overlay-content.js';
+import { html, LitElement } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js';
+import { InputController } from '@vaadin/field-base/src/input-controller.js';
+import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
+import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
+import { datePickerStyles } from './vaadin-date-picker-styles.js';
+
+/**
+ * LitElement based version of `<vaadin-date-picker>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement))))) {
+  static get is() {
+    return 'vaadin-date-picker';
+  }
+
+  static get styles() {
+    return [inputFieldShared, datePickerStyles];
+  }
+
+  static get properties() {
+    return {
+      /** @private */
+      _positionTarget: {
+        type: Object,
+        sync: true,
+      },
+    };
+  }
+
+  /**
+   * Used by `InputControlMixin` as a reference to the clear button element.
+   * @protected
+   * @return {!HTMLElement}
+   */
+  get clearElement() {
+    return this.$.clearButton;
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div class="vaadin-date-picker-container">
+        <div part="label">
+          <slot name="label"></slot>
+          <span part="required-indicator" aria-hidden="true" @click="${this.focus}"></span>
+        </div>
+
+        <vaadin-input-container
+          part="input-field"
+          .readonly="${this.readonly}"
+          .disabled="${this.disabled}"
+          .invalid="${this.invalid}"
+          theme="${ifDefined(this._theme)}"
+        >
+          <slot name="prefix" slot="prefix"></slot>
+          <slot name="input"></slot>
+          <div id="clearButton" part="clear-button" slot="suffix" aria-hidden="true"></div>
+          <div part="toggle-button" slot="suffix" aria-hidden="true" @click="${this._toggle}"></div>
+        </vaadin-input-container>
+
+        <div part="helper-text">
+          <slot name="helper"></slot>
+        </div>
+
+        <div part="error-message">
+          <slot name="error-message"></slot>
+        </div>
+      </div>
+
+      <vaadin-date-picker-overlay
+        id="overlay"
+        ?fullscreen="${this._fullscreen}"
+        theme="${ifDefined(this._theme)}"
+        .opened="${this.opened}"
+        @opened-changed="${this._onOpenedChanged}"
+        @vaadin-overlay-escape-press="${this._onOverlayEscapePress}"
+        @vaadin-overlay-open="${this._onOverlayOpened}"
+        @vaadin-overlay-close="${this._onVaadinOverlayClose}"
+        @vaadin-overlay-closing="${this._onOverlayClosed}"
+        restore-focus-on-close
+        no-vertical-overlap
+        .restoreFocusNode="${this.inputElement}"
+        .positionTarget="${this._positionTarget}"
+      ></vaadin-date-picker-overlay>
+
+      <slot name="tooltip"></slot>
+    `;
+  }
+
+  /** @protected */
+  firstUpdated() {
+    super.firstUpdated();
+
+    this.addController(
+      new InputController(this, (input) => {
+        this._setInputElement(input);
+        this._setFocusElement(input);
+        this.stateTarget = input;
+        this.ariaTarget = input;
+      }),
+    );
+    this.addController(new LabelledInputController(this.inputElement, this._labelController));
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+    this._tooltipController.setPosition('top');
+    this._tooltipController.setShouldShow((target) => !target.opened);
+
+    this._positionTarget = this.shadowRoot.querySelector('[part="input-field"]');
+
+    const toggleButton = this.shadowRoot.querySelector('[part="toggle-button"]');
+    toggleButton.addEventListener('mousedown', (e) => e.preventDefault());
+  }
+
+  /** @private */
+  _onOpenedChanged(event) {
+    this.opened = event.detail.value;
+  }
+
+  /** @private */
+  _onVaadinOverlayClose(e) {
+    if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this)) {
+      e.preventDefault();
+    }
+  }
+
+  /** @private */
+  _toggle(e) {
+    e.stopPropagation();
+    if (this.$.overlay.opened) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+}
+
+customElements.define(DatePicker.is, DatePicker);
+
+export { DatePicker };

--- a/packages/date-picker/test/basic-lit.test.js
+++ b/packages/date-picker/test/basic-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-date-picker.js';
+import './basic.common.js';

--- a/packages/date-picker/test/basic-polymer.test.js
+++ b/packages/date-picker/test/basic-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-date-picker.js';
+import './basic.common.js';

--- a/packages/date-picker/test/basic.common.js
+++ b/packages/date-picker/test/basic.common.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { click, escKeyDown, fixtureSync, keyboardEventFor, nextRender, oneEvent, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../src/vaadin-date-picker.js';
 import { parseDate } from '../src/vaadin-date-picker-helper.js';
 import { close, open, touchTap, waitForOverlayRender } from './helpers.js';
 

--- a/packages/date-picker/test/dropdown-lit.test.js
+++ b/packages/date-picker/test/dropdown-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-date-picker.js';
+import './dropdown.common.js';

--- a/packages/date-picker/test/dropdown-polymer.test.js
+++ b/packages/date-picker/test/dropdown-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-date-picker.js';
+import './dropdown.common.js';

--- a/packages/date-picker/test/dropdown.common.js
+++ b/packages/date-picker/test/dropdown.common.js
@@ -12,7 +12,6 @@ import {
 } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../src/vaadin-date-picker.js';
 import { getFocusedCell, monthsEqual, open, waitForOverlayRender } from './helpers.js';
 
 describe('dropdown', () => {

--- a/packages/date-picker/test/events-lit.test.js
+++ b/packages/date-picker/test/events-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-date-picker.js';
+import './events.common.js';

--- a/packages/date-picker/test/events-polymer.test.js
+++ b/packages/date-picker/test/events-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-date-picker.js';
+import './events.common.js';

--- a/packages/date-picker/test/events.common.js
+++ b/packages/date-picker/test/events.common.js
@@ -2,8 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-date-picker.js';
 import { close, open, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
 
 describe('events', () => {

--- a/packages/date-picker/test/fullscreen-lit.test.js
+++ b/packages/date-picker/test/fullscreen-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-date-picker.js';
+import './fullscreen.common.js';

--- a/packages/date-picker/test/fullscreen-polymer.test.js
+++ b/packages/date-picker/test/fullscreen-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-date-picker.js';
+import './fullscreen.common.js';

--- a/packages/date-picker/test/fullscreen.common.js
+++ b/packages/date-picker/test/fullscreen.common.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, nextUpdate, tap } from '@vaadin/testing-helpers';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../src/vaadin-date-picker.js';
 import { getFocusedCell, open, touchTap, waitForOverlayRender } from './helpers.js';
 
 describe('fullscreen mode', () => {

--- a/packages/date-picker/test/keyboard-input-lit.test.js
+++ b/packages/date-picker/test/keyboard-input-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-date-picker.js';
+import './keyboard-input.common.js';

--- a/packages/date-picker/test/keyboard-input-polymer.test.js
+++ b/packages/date-picker/test/keyboard-input-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-date-picker.js';
+import './keyboard-input.common.js';

--- a/packages/date-picker/test/keyboard-input.common.js
+++ b/packages/date-picker/test/keyboard-input.common.js
@@ -2,8 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { aTimeout, enter, fixtureSync, nextRender, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-date-picker.js';
 import { getAdjustedYear } from '../src/vaadin-date-picker-helper.js';
 import { close, getFocusedCell, idleCallback, open, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
 

--- a/packages/date-picker/test/keyboard-navigation-lit.test.js
+++ b/packages/date-picker/test/keyboard-navigation-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-date-picker.js';
+import './keyboard-navigation.common.js';

--- a/packages/date-picker/test/keyboard-navigation-polymer.test.js
+++ b/packages/date-picker/test/keyboard-navigation-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-date-picker.js';
+import './keyboard-navigation.common.js';

--- a/packages/date-picker/test/keyboard-navigation.common.js
+++ b/packages/date-picker/test/keyboard-navigation.common.js
@@ -2,8 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-date-picker.js';
 import {
   getDefaultI18n,
   getFocusedCell,

--- a/packages/date-picker/test/theme-propagation-lit.test.js
+++ b/packages/date-picker/test/theme-propagation-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-date-picker.js';
+import './theme-propagation.common.js';

--- a/packages/date-picker/test/theme-propagation-polymer.test.js
+++ b/packages/date-picker/test/theme-propagation-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-date-picker.js';
+import './theme-propagation.common.js';

--- a/packages/date-picker/test/theme-propagation.common.js
+++ b/packages/date-picker/test/theme-propagation.common.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import '../src/vaadin-date-picker.js';
 import { open, waitForScrollToFinish } from './helpers.js';
 
 describe('theme attribute', () => {

--- a/packages/date-picker/test/validation-lit-test.js
+++ b/packages/date-picker/test/validation-lit-test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-date-picker.js';
+import './validation.common.js';

--- a/packages/date-picker/test/validation-pollymer.test.js
+++ b/packages/date-picker/test/validation-pollymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-date-picker.js';
+import './validation.common.js';

--- a/packages/date-picker/test/validation.common.js
+++ b/packages/date-picker/test/validation.common.js
@@ -2,11 +2,9 @@ import { expect } from '@esm-bundle/chai';
 import { enter, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import { DatePicker } from '../vaadin-date-picker.js';
 import { close, open, setInputValue, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
 
-class DatePicker2016 extends DatePicker {
+class DatePicker2016 extends customElements.get('vaadin-date-picker') {
   checkValidity() {
     return new Date(this.value).getFullYear() === 2016;
   }

--- a/packages/date-picker/test/wai-aria-lit.test.js
+++ b/packages/date-picker/test/wai-aria-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-date-picker.js';
+import './wai-aria.common.js';

--- a/packages/date-picker/test/wai-aria-polymer.test.js
+++ b/packages/date-picker/test/wai-aria-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-date-picker.js';
+import './wai-aria.common.js';

--- a/packages/date-picker/test/wai-aria.common.js
+++ b/packages/date-picker/test/wai-aria.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-date-picker.js';
 import { activateScroller, close, getDefaultI18n, open } from './helpers.js';
 
 describe('WAI-ARIA', () => {


### PR DESCRIPTION
## Description

Added `vaadin-date-picker` version based on `LitElement` and updated tests to cover both versions.

## Type of change

- Experiment

## Note

There are still `vaadin-date-picker-overlay` using Polymer, and I'm going to cover it in a separate PR.