### PR TITLE
refactor: cleanup unused date-picker imports and variables

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-year-scroller.js
+++ b/packages/date-picker/src/vaadin-date-picker-year-scroller.js
@@ -42,8 +42,6 @@ stylesTemplate.innerHTML = `
   </style>
 `;
 
-let memoizedTemplate;
-
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *

--- a/packages/date-picker/src/vaadin-lit-month-calendar.js
+++ b/packages/date-picker/src/vaadin-lit-month-calendar.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2022 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { dateAllowed, dateEquals } from './vaadin-date-picker-helper.js';

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -6,7 +6,7 @@
 import '@polymer/polymer/lib/elements/dom-repeat.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { dateAllowed, dateEquals, getISOWeekNumber } from './vaadin-date-picker-helper.js';
+import { dateAllowed, dateEquals } from './vaadin-date-picker-helper.js';
 import { MonthCalendarMixin } from './vaadin-month-calendar-mixin.js';
 import { monthCalendarStyles } from './vaadin-month-calendar-styles.js';
 

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, enter, fixtureSync, listenOnce, nextRender, nextUpdate, tap } from '@vaadin/testing-helpers';
+import { aTimeout, enter, fixtureSync, nextRender, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';


### PR DESCRIPTION
## Description

Looks like our current ESLint setup does not catch these, apparently the corresponding rule isn't enabled.

## Type of change

- Refactor