### PR TITLE
refactor: extract upload-file logic to the mixin, add typings

### DIFF
--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -35,6 +35,7 @@
     "polymer"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "24.2.0-alpha6",
     "@vaadin/button": "24.2.0-alpha6",

--- a/packages/upload/src/vaadin-upload-file-mixin.d.ts
+++ b/packages/upload/src/vaadin-upload-file-mixin.d.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
+
+export interface UploadFileI18n {
+  file: {
+    retry: string;
+    start: string;
+    remove: string;
+  };
+}
+
+export declare function UploadFileMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<FocusMixinClass> & Constructor<UploadFileMixinClass> & T;
+
+export declare class UploadFileMixinClass {
+  /**
+   * True if uploading is completed, false otherwise.
+   */
+  complete: boolean;
+
+  /**
+   * Error message returned by the server, if any.
+   */
+  errorMessage: string;
+
+  /**
+   * The object representing a file.
+   */
+  file: File;
+
+  /**
+   * Name of the uploading file.
+   */
+  fileName: string;
+
+  /**
+   * True if uploading is not started, false otherwise.
+   */
+  held: boolean;
+
+  /**
+   * True if remaining time is unknown, false otherwise.
+   */
+  indeterminate: boolean;
+
+  /**
+   * The object used to localize this component.
+   */
+  i18n: UploadFileI18n;
+
+  /**
+   * Number representing the uploading progress.
+   */
+  progress: number;
+
+  /**
+   * Uploading status.
+   */
+  status: string;
+
+  /**
+   * True if uploading is in progress, false otherwise.
+   */
+  uploading: boolean;
+}

--- a/packages/upload/src/vaadin-upload-file-mixin.js
+++ b/packages/upload/src/vaadin-upload-file-mixin.js
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+/**
+ * @polymerMixin
+ * @mixes FocusMixin
+ */
+export const UploadFileMixin = (superClass) =>
+  class UploadFileMixin extends FocusMixin(superClass) {
+    static get properties() {
+      return {
+        /**
+         * True if uploading is completed, false otherwise.
+         */
+        complete: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+        },
+
+        /**
+         * Error message returned by the server, if any.
+         */
+        errorMessage: {
+          type: String,
+          value: '',
+          observer: '_errorMessageChanged',
+        },
+
+        /**
+         * The object representing a file.
+         */
+        file: {
+          type: Object,
+        },
+
+        /**
+         * Name of the uploading file.
+         */
+        fileName: {
+          type: String,
+        },
+
+        /**
+         * True if uploading is not started, false otherwise.
+         */
+        held: {
+          type: Boolean,
+          value: false,
+        },
+
+        /**
+         * True if remaining time is unknown, false otherwise.
+         */
+        indeterminate: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+        },
+
+        /**
+         * The object used to localize this component.
+         */
+        i18n: {
+          type: Object,
+        },
+
+        /**
+         * Number representing the uploading progress.
+         */
+        progress: {
+          type: Number,
+        },
+
+        /**
+         * Uploading status.
+         */
+        status: {
+          type: String,
+        },
+
+        /**
+         * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
+         * @protected
+         */
+        tabindex: {
+          type: Number,
+          value: 0,
+          reflectToAttribute: true,
+        },
+
+        /**
+         * True if uploading is in progress, false otherwise.
+         */
+        uploading: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+        },
+
+        /** @private */
+        _progress: {
+          type: Object,
+        },
+      };
+    }
+
+    static get observers() {
+      return ['__updateProgress(_progress, progress, indeterminate)'];
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.addController(
+        new SlotController(this, 'progress', 'vaadin-progress-bar', {
+          initializer: (progress) => {
+            this._progress = progress;
+          },
+        }),
+      );
+
+      // Handle moving focus to the button on Tab.
+      this.shadowRoot.addEventListener('focusin', (e) => {
+        const target = e.composedPath()[0];
+
+        if (target.getAttribute('part').endsWith('button')) {
+          this._setFocused(false);
+        }
+      });
+
+      // Handle moving focus from the button on Shift Tab.
+      this.shadowRoot.addEventListener('focusout', (e) => {
+        if (e.relatedTarget === this) {
+          this._setFocused(true);
+        }
+      });
+    }
+
+    /**
+     * Override method inherited from `FocusMixin` to mark the file as focused
+     * only when the host is focused.
+     * @param {Event} event
+     * @return {boolean}
+     * @protected
+     */
+    _shouldSetFocus(event) {
+      return event.composedPath()[0] === this;
+    }
+
+    /** @private */
+    _errorMessageChanged(errorMessage) {
+      this.toggleAttribute('error', Boolean(errorMessage));
+    }
+
+    /** @private */
+    __updateProgress(progress, value, indeterminate) {
+      if (progress) {
+        progress.value = isNaN(value) ? 0 : value / 100;
+        progress.indeterminate = indeterminate;
+      }
+    }
+
+    /** @private */
+    _fireFileEvent(e) {
+      e.preventDefault();
+      return this.dispatchEvent(
+        new CustomEvent(e.target.getAttribute('file-event'), {
+          detail: { file: this.file },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  };

--- a/packages/upload/src/vaadin-upload-file.d.ts
+++ b/packages/upload/src/vaadin-upload-file.d.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
+
+export type { UploadFileI18n } from './vaadin-upload-file-mixin.js';
+
+/**
+ * Fired when the retry button is pressed.
+ */
+export type UploadFileRetryEvent = CustomEvent<{ file: File }>;
+
+/**
+ * Fired when the start button is pressed.
+ */
+export type UploadFileStartEvent = CustomEvent<{ file: File }>;
+
+/**
+ * Fired when the abort button is pressed.
+ */
+export type UploadFileAbortEvent = CustomEvent<{ file: File }>;
+
+export interface UploadFileCustomEventMap {
+  'file-retry': UploadFileRetryEvent;
+
+  'file-start': UploadFileStartEvent;
+
+  'file-abort': UploadFileAbortEvent;
+}
+
+export interface UploadFileEventMap extends HTMLElementEventMap, UploadFileCustomEventMap {}
+
+/**
+ * `<vaadin-upload-file>` element represents a file in the file list of `<vaadin-upload>`.
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name        | Description
+ * -----------------|-------------
+ * `row`            | File container
+ * `info`           | Container for file status icon, file name, status and error messages
+ * `done-icon`      | File done status icon
+ * `warning-icon`   | File warning status icon
+ * `meta`           | Container for file name, status and error messages
+ * `name`           | File name
+ * `error`          | Error message, shown when error happens
+ * `status`         | Status message
+ * `commands`       | Container for file command buttons
+ * `start-button`   | Start file upload button
+ * `retry-button`   | Retry file upload button
+ * `remove-button`  | Remove file button
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute        | Description
+ * -----------------|-------------
+ * `focus-ring`     | Set when the element is focused using the keyboard.
+ * `focused`        | Set when the element is focused.
+ * `error`          | An error has happened during uploading.
+ * `indeterminate`  | Uploading is in progress, but the progress value is unknown.
+ * `uploading`      | Uploading is in progress.
+ * `complete`       | Uploading has finished successfully.
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ */
+declare class UploadFile extends UploadFileMixin(ThemableMixin(ControllerMixin(HTMLElement))) {
+  addEventListener<K extends keyof UploadFileEventMap>(
+    type: K,
+    listener: (this: UploadFile, ev: UploadFileEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof UploadFileEventMap>(
+    type: K,
+    listener: (this: UploadFile, ev: UploadFileEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-upload-file': UploadFile;
+  }
+}
+
+export { UploadFile };

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -6,10 +6,9 @@
 import '@vaadin/progress-bar/src/vaadin-progress-bar.js';
 import './vaadin-upload-icons.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
 
 /**
  * `<vaadin-upload-file>` element represents a file in the file list of `<vaadin-upload>`.
@@ -48,10 +47,10 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * @extends HTMLElement
  * @mixes ControllerMixin
- * @mixes FocusMixin
+ * @mixes UploadFileMixin
  * @mixes ThemableMixin
  */
-class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement))) {
+class UploadFile extends UploadFileMixin(ThemableMixin(ControllerMixin(PolymerElement))) {
   static get template() {
     return html`
       <style>
@@ -127,173 +126,6 @@ class UploadFile extends FocusMixin(ThemableMixin(ControllerMixin(PolymerElement
 
   static get is() {
     return 'vaadin-upload-file';
-  }
-
-  static get properties() {
-    return {
-      /**
-       * True if uploading is completed, false otherwise.
-       */
-      complete: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true,
-      },
-
-      /**
-       * Error message returned by the server, if any.
-       */
-      errorMessage: {
-        type: String,
-        value: '',
-        observer: '_errorMessageChanged',
-      },
-
-      /**
-       * The object representing a file.
-       */
-      file: {
-        type: Object,
-      },
-
-      /**
-       * Name of the uploading file.
-       */
-      fileName: {
-        type: String,
-      },
-
-      /**
-       * True if uploading is not started, false otherwise.
-       */
-      held: {
-        type: Boolean,
-        value: false,
-      },
-
-      /**
-       * True if remaining time is unknown, false otherwise.
-       */
-      indeterminate: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true,
-      },
-
-      /**
-       * The object used to localize this component.
-       */
-      i18n: {
-        type: Object,
-      },
-
-      /**
-       * Number representing the uploading progress.
-       */
-      progress: {
-        type: Number,
-      },
-
-      /**
-       * Uploading status.
-       */
-      status: {
-        type: String,
-      },
-
-      /**
-       * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
-       * @protected
-       */
-      tabindex: {
-        type: Number,
-        value: 0,
-        reflectToAttribute: true,
-      },
-
-      /**
-       * True if uploading is in progress, false otherwise.
-       */
-      uploading: {
-        type: Boolean,
-        value: false,
-        reflectToAttribute: true,
-      },
-
-      /** @private */
-      _progress: {
-        type: Object,
-      },
-    };
-  }
-
-  static get observers() {
-    return ['__updateProgress(_progress, progress, indeterminate)'];
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this.addController(
-      new SlotController(this, 'progress', 'vaadin-progress-bar', {
-        initializer: (progress) => {
-          this._progress = progress;
-        },
-      }),
-    );
-
-    // Handle moving focus to the button on Tab.
-    this.shadowRoot.addEventListener('focusin', (e) => {
-      const target = e.composedPath()[0];
-
-      if (target.getAttribute('part').endsWith('button')) {
-        this._setFocused(false);
-      }
-    });
-
-    // Handle moving focus from the button on Shift Tab.
-    this.shadowRoot.addEventListener('focusout', (e) => {
-      if (e.relatedTarget === this) {
-        this._setFocused(true);
-      }
-    });
-  }
-
-  /**
-   * Override method inherited from `FocusMixin` to mark the file as focused
-   * only when the host is focused.
-   * @param {Event} event
-   * @return {boolean}
-   * @protected
-   */
-  _shouldSetFocus(event) {
-    return event.composedPath()[0] === this;
-  }
-
-  /** @private */
-  _errorMessageChanged(errorMessage) {
-    this.toggleAttribute('error', Boolean(errorMessage));
-  }
-
-  /** @private */
-  __updateProgress(progress, value, indeterminate) {
-    if (progress) {
-      progress.value = isNaN(value) ? 0 : value / 100;
-      progress.indeterminate = indeterminate;
-    }
-  }
-
-  /** @private */
-  _fireFileEvent(e) {
-    e.preventDefault();
-    return this.dispatchEvent(
-      new CustomEvent(e.target.getAttribute('file-event'), {
-        detail: { file: this.file },
-        bubbles: true,
-        composed: true,
-      }),
-    );
   }
 
   /**

--- a/packages/upload/test/typings/upload-file.types.ts
+++ b/packages/upload/test/typings/upload-file.types.ts
@@ -1,0 +1,38 @@
+import '../../src/vaadin-upload-file.js';
+import type {
+  UploadFileAbortEvent,
+  UploadFileI18n,
+  UploadFileRetryEvent,
+  UploadFileStartEvent,
+} from '../../src/vaadin-upload-file.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const uploadFile = document.createElement('vaadin-upload-file');
+
+// Properties
+assertType<boolean>(uploadFile.complete);
+assertType<boolean>(uploadFile.held);
+assertType<boolean>(uploadFile.indeterminate);
+assertType<boolean>(uploadFile.uploading);
+assertType<string>(uploadFile.errorMessage);
+assertType<string>(uploadFile.fileName);
+assertType<string>(uploadFile.status);
+assertType<File>(uploadFile.file);
+assertType<UploadFileI18n>(uploadFile.i18n);
+
+// Events
+uploadFile.addEventListener('file-retry', (event) => {
+  assertType<UploadFileRetryEvent>(event);
+  assertType<File>(event.detail.file);
+});
+
+uploadFile.addEventListener('file-start', (event) => {
+  assertType<UploadFileStartEvent>(event);
+  assertType<File>(event.detail.file);
+});
+
+uploadFile.addEventListener('file-abort', (event) => {
+  assertType<UploadFileAbortEvent>(event);
+  assertType<File>(event.detail.file);
+});


### PR DESCRIPTION
## Description

1. Created `UploadFileMixin` to be used by Polymer and Lit versions of `vaadin-upload-file`,
2. Added missing `vaadin-upload-file` type definitions with corresponding tests.

## Type of change

- Refactor