### PR TITLE
refactor: extract vaadin-upload-file-list logic to the mixin

### DIFF
--- a/packages/upload/src/vaadin-upload-file-list-mixin.js
+++ b/packages/upload/src/vaadin-upload-file-list-mixin.js
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, render } from 'lit';
+
+/**
+ * @polymerMixin
+ */
+export const UploadFileListMixin = (superClass) =>
+  class UploadFileListMixin extends superClass {
+    static get properties() {
+      return {
+        /**
+         * The array of files being processed, or already uploaded.
+         */
+        items: {
+          type: Array,
+        },
+
+        /**
+         * The object used to localize upload files.
+         */
+        i18n: {
+          type: Object,
+        },
+      };
+    }
+
+    static get observers() {
+      return ['__updateItems(items, i18n)'];
+    }
+
+    /** @private */
+    __updateItems(items, i18n) {
+      if (items && i18n) {
+        this.requestContentUpdate();
+      }
+    }
+
+    /**
+     * Requests an update for the `vaadin-upload-file` elements.
+     *
+     * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+     */
+    requestContentUpdate() {
+      const { items, i18n } = this;
+
+      render(
+        html`
+          ${items.map(
+            (file) => html`
+              <li>
+                <vaadin-upload-file
+                  .file="${file}"
+                  .complete="${file.complete}"
+                  .errorMessage="${file.error}"
+                  .fileName="${file.name}"
+                  .held="${file.held}"
+                  .indeterminate="${file.indeterminate}"
+                  .progress="${file.progress}"
+                  .status="${file.status}"
+                  .uploading="${file.uploading}"
+                  .i18n="${i18n}"
+                ></vaadin-upload-file>
+              </li>
+            `,
+          )}
+        `,
+        this,
+      );
+    }
+  };

--- a/packages/upload/src/vaadin-upload-file-list.js
+++ b/packages/upload/src/vaadin-upload-file-list.js
@@ -4,24 +4,25 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './vaadin-upload-file.js';
-import { html as legacyHtml, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { html, render } from 'lit';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { UploadFileListMixin } from './vaadin-upload-file-list-mixin.js';
 
 /**
  * An element used internally by `<vaadin-upload>`. Not intended to be used separately.
  *
  * @extends HTMLElement
- * @mixes FocusMixin
+ * @mixes ThemableMixin
+ * @mixes UploadFileListMixin
  * @private
  */
-class UploadFileList extends ThemableMixin(PolymerElement) {
+class UploadFileList extends UploadFileListMixin(ThemableMixin(PolymerElement)) {
   static get is() {
     return 'vaadin-upload-file-list';
   }
 
   static get template() {
-    return legacyHtml`
+    return html`
       <style>
         :host {
           display: block;
@@ -41,68 +42,6 @@ class UploadFileList extends ThemableMixin(PolymerElement) {
         <slot></slot>
       </ul>
     `;
-  }
-
-  static get properties() {
-    return {
-      /**
-       * The array of files being processed, or already uploaded.
-       */
-      items: {
-        type: Array,
-      },
-
-      /**
-       * The object used to localize upload files.
-       */
-      i18n: {
-        type: Object,
-      },
-    };
-  }
-
-  static get observers() {
-    return ['__updateItems(items, i18n)'];
-  }
-
-  /** @private */
-  __updateItems(items, i18n) {
-    if (items && i18n) {
-      this.requestContentUpdate();
-    }
-  }
-
-  /**
-   * Requests an update for the `vaadin-upload-file` elements.
-   *
-   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
-   */
-  requestContentUpdate() {
-    const { items, i18n } = this;
-
-    render(
-      html`
-        ${items.map(
-          (file) => html`
-            <li>
-              <vaadin-upload-file
-                .file="${file}"
-                .complete="${file.complete}"
-                .errorMessage="${file.error}"
-                .fileName="${file.name}"
-                .held="${file.held}"
-                .indeterminate="${file.indeterminate}"
-                .progress="${file.progress}"
-                .status="${file.status}"
-                .uploading="${file.uploading}"
-                .i18n="${i18n}"
-              ></vaadin-upload-file>
-            </li>
-          `,
-        )}
-      `,
-      this,
-    );
   }
 }
 


### PR DESCRIPTION
## Description

Same as #6281 but for `vaadin-upload-file-list`. 

No typings added for now since this is an internal component.

## Type of change

- Refactor