### PR TITLE
experiment: add LitElement version of vaadin-upload-file

### DIFF
--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -21,6 +21,7 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-upload-file.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/upload/src/vaadin-lit-upload-file.js
+++ b/packages/upload/src/vaadin-lit-upload-file.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '@vaadin/progress-bar/src/vaadin-progress-bar.js';
+import './vaadin-upload-icons.js';
+import { html, LitElement } from 'lit';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
+import { uploadFileStyles } from './vaadin-upload-file-styles.js';
+
+/**
+ * LitElement based version of `<vaadin-upload-file>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class UploadFile extends UploadFileMixin(ThemableMixin(PolylitMixin(LitElement))) {
+  static get is() {
+    return 'vaadin-upload-file';
+  }
+
+  static get styles() {
+    return uploadFileStyles;
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div part="row">
+        <div part="info">
+          <div part="done-icon" ?hidden="${!this.complete}" aria-hidden="true"></div>
+          <div part="warning-icon" ?hidden="${!this.errorMessage}" aria-hidden="true"></div>
+
+          <div part="meta">
+            <div part="name" id="name">${this.fileName}</div>
+            <div part="status" ?hidden="${!this.status}" id="status">${this.status}</div>
+            <div part="error" id="error" ?hidden="${!this.errorMessage}">${this.errorMessage}</div>
+          </div>
+        </div>
+        <div part="commands">
+          <button
+            type="button"
+            part="start-button"
+            file-event="file-start"
+            @click="${this._fireFileEvent}"
+            ?hidden="${!this.held}"
+            aria-label="${this.i18n.file.start}"
+            aria-describedby="name"
+          ></button>
+          <button
+            type="button"
+            part="retry-button"
+            file-event="file-retry"
+            @click="${this._fireFileEvent}"
+            ?hidden="${!this.errorMessage}"
+            aria-label="${this.i18n.file.retry}"
+            aria-describedby="name"
+          ></button>
+          <button
+            type="button"
+            part="remove-button"
+            file-event="file-abort"
+            @click="${this._fireFileEvent}"
+            aria-label="${this.i18n.file.remove}"
+            aria-describedby="name"
+          ></button>
+        </div>
+      </div>
+
+      <slot name="progress"></slot>
+    `;
+  }
+}
+
+customElements.define(UploadFile.is, UploadFile);
+
+export { UploadFile };

--- a/packages/upload/src/vaadin-upload-file-styles.d.ts
+++ b/packages/upload/src/vaadin-upload-file-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd..
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const uploadFileStyles: CSSResult;

--- a/packages/upload/src/vaadin-upload-file-styles.js
+++ b/packages/upload/src/vaadin-upload-file-styles.js
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const uploadFileStyles = css`
+  :host {
+    display: block;
+  }
+
+  [hidden] {
+    display: none;
+  }
+
+  [part='row'] {
+    list-style-type: none;
+  }
+
+  button {
+    background: transparent;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+  }
+
+  :host([complete]) ::slotted([slot='progress']),
+  :host([error]) ::slotted([slot='progress']) {
+    display: none !important;
+  }
+`;

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -7,8 +7,11 @@ import '@vaadin/progress-bar/src/vaadin-progress-bar.js';
 import './vaadin-upload-icons.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
+import { uploadFileStyles } from './vaadin-upload-file-styles.js';
+
+registerStyles('vaadin-upload-file', uploadFileStyles, { moduleId: 'vaadin-upload-file-styles' });
 
 /**
  * `<vaadin-upload-file>` element represents a file in the file list of `<vaadin-upload>`.
@@ -53,32 +56,6 @@ import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
 class UploadFile extends UploadFileMixin(ThemableMixin(ControllerMixin(PolymerElement))) {
   static get template() {
     return html`
-      <style>
-        :host {
-          display: block;
-        }
-
-        [hidden] {
-          display: none;
-        }
-
-        [part='row'] {
-          list-style-type: none;
-        }
-
-        button {
-          background: transparent;
-          padding: 0;
-          border: none;
-          box-shadow: none;
-        }
-
-        :host([complete]) ::slotted([slot='progress']),
-        :host([error]) ::slotted([slot='progress']) {
-          display: none !important;
-        }
-      </style>
-
       <div part="row">
         <div part="info">
           <div part="done-icon" hidden$="[[!complete]]" aria-hidden="true"></div>

--- a/packages/upload/test/file-lit.test.js
+++ b/packages/upload/test/file-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-upload-file.js';
+import './file.common.js';

--- a/packages/upload/test/file-polymer.test.js
+++ b/packages/upload/test/file-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-upload-file.js';
+import './file.common.js';

--- a/packages/upload/test/file.common.js
+++ b/packages/upload/test/file.common.js
@@ -1,16 +1,23 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
-import '../vaadin-upload.js';
 import { createFile } from './helpers.js';
 
 describe('<vaadin-upload-file> element', () => {
   let fileElement, fileObject;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     fileElement = fixtureSync(`<vaadin-upload-file></vaadin-upload-file>`);
+    fileElement.i18n = {
+      file: {
+        start: 'Start',
+        retry: 'Retry',
+        remove: 'Remove',
+      },
+    };
     fileObject = createFile(100000, 'application/unknown');
     fileElement.file = fileObject;
+    await nextRender();
   });
 
   describe('state attributes', () => {
@@ -18,8 +25,9 @@ describe('<vaadin-upload-file> element', () => {
       expect(fileElement.hasAttribute('uploading')).to.be.false;
     });
 
-    it('should reflect uploading', () => {
+    it('should reflect uploading', async () => {
       fileElement.uploading = true;
+      await nextUpdate(fileElement);
       expect(fileElement.hasAttribute('uploading')).to.be.true;
     });
 
@@ -27,8 +35,9 @@ describe('<vaadin-upload-file> element', () => {
       expect(fileElement.hasAttribute('indeterminate')).to.be.false;
     });
 
-    it('should reflect indeterminate', () => {
+    it('should reflect indeterminate', async () => {
       fileElement.indeterminate = true;
+      await nextUpdate(fileElement);
       expect(fileElement.hasAttribute('indeterminate')).to.be.true;
     });
 
@@ -36,8 +45,9 @@ describe('<vaadin-upload-file> element', () => {
       expect(fileElement.hasAttribute('complete')).to.be.false;
     });
 
-    it('should reflect complete', () => {
+    it('should reflect complete', async () => {
       fileElement.complete = true;
+      await nextUpdate(fileElement);
       expect(fileElement.hasAttribute('complete')).to.be.true;
     });
 
@@ -45,16 +55,18 @@ describe('<vaadin-upload-file> element', () => {
       expect(fileElement.hasAttribute('error')).to.be.false;
     });
 
-    it('should reflect error', () => {
+    it('should reflect error', async () => {
       fileElement.errorMessage = 'Server error';
+      await nextUpdate(fileElement);
       expect(fileElement.hasAttribute('error')).to.be.true;
     });
   });
 
   describe('focus', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       // Show the "Start" button
       fileElement.held = true;
+      await nextUpdate(fileElement);
     });
 
     it('should not add focus-ring to the host on programmatic focus', () => {


### PR DESCRIPTION
## Description

Extracted `vaadin-upload-file` styles to separate CSS literal and created a `LitElement` based version of it.

Note: `vaadin-upload` and `vaadin-upload-file-list` components will be covered in a separate PR.

## Type of change

- Experiment