### PR TITLE
test: restore date-picker Lumo styles to fix date-tap test

### DIFF
--- a/packages/date-picker/test/keyboard-input-lit.test.js
+++ b/packages/date-picker/test/keyboard-input-lit.test.js
@@ -1,3 +1,7 @@
+import '../theme/lumo/vaadin-date-picker-overlay-content-styles.js';
+import '../theme/lumo/vaadin-date-picker-overlay-styles.js';
+import '../theme/lumo/vaadin-month-calendar-styles.js';
+import '../theme/lumo/vaadin-date-picker-styles.js';
 import './not-animated-styles.js';
 import '../src/vaadin-lit-date-picker.js';
 import './keyboard-input.common.js';

--- a/packages/date-picker/test/keyboard-input-polymer.test.js
+++ b/packages/date-picker/test/keyboard-input-polymer.test.js
@@ -1,3 +1,7 @@
+import '../theme/lumo/vaadin-date-picker-overlay-content-styles.js';
+import '../theme/lumo/vaadin-date-picker-overlay-styles.js';
+import '../theme/lumo/vaadin-month-calendar-styles.js';
+import '../theme/lumo/vaadin-date-picker-styles.js';
 import './not-animated-styles.js';
 import '../src/vaadin-date-picker.js';
 import './keyboard-input.common.js';


### PR DESCRIPTION
## Description

This fixes the following test that started to fail after the recent LitElement experimental PRs:

```
packages/date-picker/test/keyboard-input-lit.test.js:

 ❌ keyboard > overlay opened > should move focus back to the input on calendar date tap
      AssertionError: expected false to be true
      + expected - actual

      -false
      +true

      at Ka.<anonymous> (packages/date-picker/test/keyboard-input.common.js:218:35)

packages/date-picker/test/keyboard-input-polymer.test.js:

 ❌ keyboard > overlay opened > should move focus back to the input on calendar date tap
      AssertionError: expected false to be true
      + expected - actual

      -false
      +true

      at Ka.<anonymous> (packages/date-picker/test/keyboard-input.common.js:218:35)
```

The reason why the test started to fail was that unstyled version caused scroll, and that set `ignoreTaps` to `true`.
It's unfortunate that we rely on Lumo in this case, but there are many other examples like that 🤷‍♂️ 

## Type of change

- Test