### PR TITLE
refactor: remove no longer needed dom-repeat from upload

### DIFF
--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@polymer/polymer/lib/elements/dom-repeat.js';
 import '@vaadin/button/src/vaadin-button.js';
 import './vaadin-upload-icon.js';
 import './vaadin-upload-icons.js';


### PR DESCRIPTION
## Description

Usage of `dom-repeat` was removed in #4870 so this import is now unused. Let's remove it.

## Type of change

- Refactor