### PR TITLE
fix: add missing dirty-changed event typings and JSDoc

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -17,6 +17,11 @@ export type CustomFieldChangeEvent = Event & {
 };
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type CustomFieldDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type CustomFieldInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -39,6 +44,8 @@ export type CustomFieldInternalTabEvent = Event & {
 };
 
 export interface CustomFieldCustomEventMap {
+  'dirty-changed': CustomFieldDirtyChangedEvent;
+
   'invalid-changed': CustomFieldInvalidChangedEvent;
 
   'value-changed': CustomFieldValueChangedEvent;
@@ -91,6 +98,7 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  *
  * @fires {Event} change - Fired when the user commits a value change for any of the internal inputs.
  * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -50,6 +50,7 @@ registerStyles('vaadin-custom-field', customFieldStyles, { moduleId: 'vaadin-cus
  *
  * @fires {Event} change - Fired when the user commits a value change for any of the internal inputs.
  * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.

--- a/packages/custom-field/test/typings/custom-field.types.ts
+++ b/packages/custom-field/test/typings/custom-field.types.ts
@@ -2,6 +2,7 @@ import '../../vaadin-custom-field.js';
 import type {
   CustomField,
   CustomFieldChangeEvent,
+  CustomFieldDirtyChangedEvent,
   CustomFieldInternalTabEvent,
   CustomFieldInvalidChangedEvent,
   CustomFieldValidatedEvent,
@@ -15,6 +16,11 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 customField.addEventListener('change', (event) => {
   assertType<CustomFieldChangeEvent>(event);
   assertType<CustomField>(event.target);
+});
+
+customField.addEventListener('invalid-changed', (event) => {
+  assertType<CustomFieldDirtyChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 customField.addEventListener('invalid-changed', (event) => {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -54,6 +54,11 @@ export type MultiSelectComboBoxChangeEvent<TItem> = Event & {
 export type MultiSelectComboBoxCustomValueSetEvent = CustomEvent<string>;
 
 /**
+ * Fired when the `dirty` property changes.
+ */
+export type MultiSelectComboBoxDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `filter` property changes.
  */
 export type MultiSelectComboBoxFilterChangedEvent = CustomEvent<{ value: string }>;
@@ -77,6 +82,8 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
   change: MultiSelectComboBoxChangeEvent<TItem>;
 
   'custom-value-set': MultiSelectComboBoxCustomValueSetEvent;
+
+  'dirty-changed': MultiSelectComboBoxDirtyChangedEvent;
 
   'filter-changed': MultiSelectComboBoxFilterChangedEvent;
 

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -24,6 +24,7 @@ import type {
   MultiSelectComboBox,
   MultiSelectComboBoxChangeEvent,
   MultiSelectComboBoxCustomValueSetEvent,
+  MultiSelectComboBoxDirtyChangedEvent,
   MultiSelectComboBoxFilterChangedEvent,
   MultiSelectComboBoxI18n,
   MultiSelectComboBoxInvalidChangedEvent,
@@ -52,6 +53,11 @@ narrowedComboBox.addEventListener('change', (event) => {
 narrowedComboBox.addEventListener('custom-value-set', (event) => {
   assertType<MultiSelectComboBoxCustomValueSetEvent>(event);
   assertType<string>(event.detail);
+});
+
+narrowedComboBox.addEventListener('dirty-changed', (event) => {
+  assertType<MultiSelectComboBoxDirtyChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
 });
 
 narrowedComboBox.addEventListener('filter-changed', (event) => {

--- a/packages/radio-group/src/vaadin-radio-button.d.ts
+++ b/packages/radio-group/src/vaadin-radio-button.d.ts
@@ -16,8 +16,15 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  */
 export type RadioButtonCheckedChangedEvent = CustomEvent<{ value: boolean }>;
 
+/**
+ * Fired when the `dirty` property changes.
+ */
+export type RadioButtonDirtyChangedEvent = CustomEvent<{ value: boolean }>;
+
 export interface RadioButtonCustomEventMap {
   'checked-changed': RadioButtonCheckedChangedEvent;
+
+  'dirty-changed': RadioButtonDirtyChangedEvent;
 }
 
 export interface RadioButtonEventMap extends HTMLElementEventMap, RadioButtonCustomEventMap {}
@@ -56,6 +63,7 @@ export interface RadioButtonEventMap extends HTMLElementEventMap, RadioButtonCus
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  */
 declare class RadioButton extends LabelMixin(
   CheckedMixin(DelegateFocusMixin(ActiveMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))))),

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -48,6 +48,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
+ * @fires {CustomEvent} dirty-changed - Fired when the `dirty` property changes.
  *
  * @extends HTMLElement
  * @mixes ControllerMixin

--- a/packages/radio-group/test/typings/radio-button.types.ts
+++ b/packages/radio-group/test/typings/radio-button.types.ts
@@ -10,7 +10,7 @@ import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin
 import type { CheckedMixinClass } from '@vaadin/field-base/src/checked-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import type { RadioButtonCheckedChangedEvent } from '../../vaadin-radio-button.js';
+import type { RadioButtonCheckedChangedEvent, RadioButtonDirtyChangedEvent } from '../../vaadin-radio-button.js';
 import type {
   RadioGroupDirtyChangedEvent,
   RadioGroupInvalidChangedEvent,
@@ -45,6 +45,11 @@ assertType<ThemableMixinClass>(radio);
 // Radio events
 radio.addEventListener('checked-changed', (event) => {
   assertType<RadioButtonCheckedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+radio.addEventListener('dirty-changed', (event) => {
+  assertType<RadioButtonDirtyChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
 


### PR DESCRIPTION
## Description

These components have `dirty` property, but missing the types for the corresponding event.

## Type of change

- Bugfix / documentation