### PR TITLE
feat: add dirty state implementation for radio-button

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -104,18 +104,6 @@ export const CheckboxMixin = (superclass) =>
     }
 
     /**
-     * Override to mark the field as dirty on change.
-     *
-     * @param {Event} event
-     * @protected
-     * @override
-     */
-    _onChange(event) {
-      this.dirty = true;
-      super._onChange(event);
-    }
-
-    /**
      * Override method inherited from `CheckedMixin` to reset
      * `indeterminate` state checkbox is toggled by the user.
      *

--- a/packages/checkbox/test/checkbox.common.js
+++ b/packages/checkbox/test/checkbox.common.js
@@ -236,26 +236,4 @@ describe('checkbox', () => {
       expect(input.indeterminate).to.be.false;
     });
   });
-
-  describe('dirty state', () => {
-    beforeEach(async () => {
-      checkbox = fixtureSync(`<vaadin-checkbox></vaadin-checkbox>`);
-      await nextRender();
-      input = checkbox.inputElement;
-    });
-
-    it('should not be dirty by default', () => {
-      expect(checkbox.dirty).to.be.false;
-    });
-
-    it('should not be dirty after changing checked state programmatically', () => {
-      checkbox.checked = true;
-      expect(checkbox.dirty).to.be.false;
-    });
-
-    it('should be dirty after click', () => {
-      input.click();
-      expect(checkbox.dirty).to.be.true;
-    });
-  });
 });

--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -47,6 +47,8 @@ export const CheckedMixin = dedupingMixin(
       _onChange(event) {
         const input = event.target;
 
+        this.dirty = true;
+
         this._toggleChecked(input.checked);
 
         // Clicking the checkbox or radio-button in Safari

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -127,4 +127,25 @@ describe('checked-mixin', () => {
       expect(document.activeElement).to.eql(input);
     });
   });
+
+  describe('dirty state', () => {
+    beforeEach(async () => {
+      element = fixtureSync(`<checked-mixin-element></checked-mixin-element>`);
+      input = element.querySelector('[slot=input]');
+    });
+
+    it('should not be dirty by default', () => {
+      expect(element.dirty).to.be.false;
+    });
+
+    it('should not be dirty after changing checked state programmatically', () => {
+      element.checked = true;
+      expect(element.dirty).to.be.false;
+    });
+
+    it('should be dirty after click', () => {
+      input.click();
+      expect(element.dirty).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Description

I've missed adding a dirty state implementation for `radio-button` in https://github.com/vaadin/web-components/pull/6160. The dirty state of this component doesn't affect anything because the component doesn't support validation. It's there for the sake of consistency.

The component automatically becomes dirty once the user triggers a change event. Additionally, the component can be manually marked as dirty by setting the property to `true`.

Part of #6146 

## Type of change

- [x] Feature
