### PR TITLE
refactor: move path utils to separate file and use them

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -10,6 +10,7 @@ import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { get } from '@vaadin/component-base/src/path-utils.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
 import { ValidateMixin } from '@vaadin/field-base/src/validate-mixin.js';
@@ -661,7 +662,7 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _getItemLabel(item) {
-      let label = item && this.itemLabelPath ? this.get(this.itemLabelPath, item) : undefined;
+      let label = item && this.itemLabelPath ? get(this.itemLabelPath, item) : undefined;
       if (label === undefined || label === null) {
         label = item ? item.toString() : '';
       }
@@ -670,7 +671,7 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _getItemValue(item) {
-      let value = item && this.itemValuePath ? this.get(this.itemValuePath, item) : undefined;
+      let value = item && this.itemValuePath ? get(this.itemValuePath, item) : undefined;
       if (value === undefined) {
         value = item ? item.toString() : '';
       }

--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2015 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { get } from '@vaadin/component-base/src/path-utils.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
@@ -202,7 +203,7 @@ export const ComboBoxScrollerMixin = (superClass) =>
       if (item instanceof ComboBoxPlaceholder) {
         return false;
       } else if (itemIdPath && item !== undefined && selectedItem !== undefined) {
-        return this.get(itemIdPath, item) === this.get(itemIdPath, selectedItem);
+        return get(itemIdPath, item) === get(itemIdPath, selectedItem);
       }
       return item === selectedItem;
     }

--- a/packages/component-base/src/path-utils.d.ts
+++ b/packages/component-base/src/path-utils.d.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Convenience method for reading a value from a path.
+ */
+export function get(path: string, object: object): unknown;
+
+/**
+ * Convenience method for setting a value to a path.
+ */
+export function set(path: string, value: unknown, object: object): void;

--- a/packages/component-base/src/path-utils.js
+++ b/packages/component-base/src/path-utils.js
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright (c) 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Convenience method for reading a value from a path.
+ *
+ * @param {string} path
+ * @param {object} object
+ */
+export function get(path, object) {
+  return path.split('.').reduce((obj, property) => (obj ? obj[property] : undefined), object);
+}
+
+/**
+ * Convenience method for setting a value to a path.
+ *
+ * @param {string} path
+ * @param {unknown} value
+ * @param {object} object
+ */
+export function set(path, value, object) {
+  const pathParts = path.split('.');
+  const lastPart = pathParts.pop();
+  const target = pathParts.reduce((target, part) => target[part], object);
+  target[lastPart] = value;
+}

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { dedupeMixin } from '@open-wc/dedupe-mixin';
+import { get, set } from './path-utils.js';
 
 const caseMap = {};
 
@@ -272,15 +273,12 @@ const PolylitMixinImplementation = (superclass) => {
 
     /** @protected */
     _get(path, object) {
-      return path.split('.').reduce((obj, property) => (obj ? obj[property] : undefined), object);
+      return get(path, object);
     }
 
     /** @protected */
     _set(path, value, object) {
-      const pathParts = path.split('.');
-      const lastPart = pathParts.pop();
-      const target = pathParts.reduce((target, part) => target[part], object);
-      target[lastPart] = value;
+      set(path, value, object);
     }
   }
 

--- a/packages/component-base/test/path-utils.test.js
+++ b/packages/component-base/test/path-utils.test.js
@@ -1,0 +1,26 @@
+import { expect } from '@esm-bundle/chai';
+import { get, set } from '../src/path-utils.js';
+
+describe('path-utils', () => {
+  describe('get', () => {
+    const object = { foo: { bar: { baz: 42 } } };
+
+    it('should return correct value from an object', () => {
+      expect(get('foo.bar.baz', object)).to.equal(42);
+      expect(get('foo.bar', object)).to.eql({ baz: 42 });
+    });
+
+    it('should return undefined for a non-existent path', () => {
+      expect(get('foo.bar.qux', object)).to.be.undefined;
+    });
+  });
+
+  describe('set', () => {
+    const object = { foo: {} };
+
+    it('should set the nested sub-property to the object', () => {
+      set('foo.bar', 'baz', object);
+      expect(object.foo.bar).to.equal('baz');
+    });
+  });
+});

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -7,6 +7,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { animationFrame } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { get } from '@vaadin/component-base/src/path-utils.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { updateCellState } from './vaadin-grid-helpers.js';
 
@@ -713,7 +714,7 @@ export const ColumnBaseMixin = (superClass) =>
         return;
       }
 
-      this.__setTextContent(root, this.get(this.path, item));
+      this.__setTextContent(root, get(this.path, item));
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -5,6 +5,7 @@
  */
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { get } from '@vaadin/component-base/src/path-utils.js';
 import { getBodyRowCells, updateCellsPart, updateState } from './vaadin-grid-helpers.js';
 
 /**
@@ -307,7 +308,7 @@ export const DataProviderMixin = (superClass) =>
      * @return {!GridItem | !unknown}
      */
     getItemId(item) {
-      return this.itemIdPath ? this.get(this.itemIdPath, item) : item;
+      return this.itemIdPath ? get(this.itemIdPath, item) : item;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -5,6 +5,7 @@
  */
 import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
+import { get } from '@vaadin/component-base/src/path-utils.js';
 
 /**
  * @polymerMixin
@@ -266,7 +267,7 @@ export const KeyboardNavigationMixin = (superClass) =>
     __isRowExpandable(row) {
       if (this.itemHasChildrenPath) {
         const item = row._item;
-        return item && this.get(this.itemHasChildrenPath, item) && !this._isExpanded(item);
+        return item && get(this.itemHasChildrenPath, item) && !this._isExpanded(item);
       }
     }
 

--- a/packages/grid/src/vaadin-grid-tree-column.js
+++ b/packages/grid/src/vaadin-grid-tree-column.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './vaadin-grid-tree-toggle.js';
+import { get } from '@vaadin/component-base/src/path-utils.js';
 import { GridColumn } from './vaadin-grid-column.js';
 
 /**
@@ -101,7 +102,7 @@ class GridTreeColumn extends GridColumn {
 
   /** @private */
   __getToggleContent(path, item) {
-    return path && this.get(path, item);
+    return path && get(path, item);
   }
 }
 


### PR DESCRIPTION
## Description

Updated to use custom `get()` and `set()` implementation instead of `this.get()` that we still have.

This is needed for LitElement based versions of `vaadin-combo-box` and `vaadin-time-picker`.

## Type of change

- Refactor