### PR TITLE
fix: hide button from screen readers when not collapsible

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -152,6 +152,7 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
         part="label"
         @click="${this._onLabelClick}"
         aria-expanded="${ifDefined(this.collapsible ? !this.collapsed : null)}"
+        aria-hidden="${ifDefined(this.collapsible === false ? true : null)}"
         aria-controls="children"
       >
         <slot name="label" @slotchange="${this._onLabelSlotChange}"></slot>

--- a/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
@@ -73,6 +73,7 @@ snapshots["vaadin-side-nav host collapsed"] =
 snapshots["vaadin-side-nav shadow default"] = 
 `<button
   aria-controls="children"
+  aria-hidden="true"
   part="label"
 >
   <slot name="label">


### PR DESCRIPTION
## Description

Fixes #6309

## Type of change

- Bugfix