### PR TITLE
feat: add ariaTarget property for setting aria-describedby

### DIFF
--- a/packages/component-base/src/tooltip-controller.d.ts
+++ b/packages/component-base/src/tooltip-controller.d.ts
@@ -24,6 +24,12 @@ type TooltipPosition =
  */
 export class TooltipController extends SlotController {
   /**
+   * An HTML element to attach the tooltip to.
+   * When not set, defaults to `target`.
+   */
+  ariaTarget: HTMLElement;
+
+  /**
    * Object with properties passed to `generator`
    * function to be used for generating tooltip text.
    */
@@ -50,6 +56,11 @@ export class TooltipController extends SlotController {
    * An HTML element to attach the tooltip to.
    */
   target: HTMLElement;
+
+  /**
+   * Set an HTML element to link the tooltip to.
+   */
+  setAriaTarget(ariaTarget: HTMLElement): void;
 
   /**
    * Set a context object to be used by generator.

--- a/packages/component-base/src/tooltip-controller.d.ts
+++ b/packages/component-base/src/tooltip-controller.d.ts
@@ -24,7 +24,8 @@ type TooltipPosition =
  */
 export class TooltipController extends SlotController {
   /**
-   * An HTML element to attach the tooltip to.
+   * An HTML element for linking with the tooltip overlay
+   * via `aria-describedby` attribute used by screen readers.
    * When not set, defaults to `target`.
    */
   ariaTarget: HTMLElement;
@@ -58,7 +59,8 @@ export class TooltipController extends SlotController {
   target: HTMLElement;
 
   /**
-   * Set an HTML element to link the tooltip to.
+   * Set an HTML element for linking with the tooltip overlay
+   * via `aria-describedby` attribute used by screen readers.
    */
   setAriaTarget(ariaTarget: HTMLElement): void;
 

--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -52,8 +52,8 @@ export class TooltipController extends SlotController {
   }
 
   /**
-   * Set an HTML element to link the tooltip to.
-   * When not set, defaults to `target`.
+   * Set an HTML element for linking with the tooltip overlay
+   * via `aria-describedby` attribute used by screen readers.
    * @param {HTMLElement} ariaTarget
    */
   setAriaTarget(ariaTarget) {

--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -26,6 +26,10 @@ export class TooltipController extends SlotController {
   initCustomNode(tooltipNode) {
     tooltipNode.target = this.target;
 
+    if (this.ariaTarget !== undefined) {
+      tooltipNode.ariaTarget = this.ariaTarget;
+    }
+
     if (this.context !== undefined) {
       tooltipNode.context = this.context;
     }
@@ -44,6 +48,20 @@ export class TooltipController extends SlotController {
 
     if (this.shouldShow !== undefined) {
       tooltipNode.shouldShow = this.shouldShow;
+    }
+  }
+
+  /**
+   * Set an HTML element to link the tooltip to.
+   * When not set, defaults to `target`.
+   * @param {HTMLElement} ariaTarget
+   */
+  setAriaTarget(ariaTarget) {
+    this.ariaTarget = ariaTarget;
+
+    const tooltipNode = this.node;
+    if (tooltipNode) {
+      tooltipNode.ariaTarget = ariaTarget;
     }
   }
 

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -79,6 +79,13 @@ describe('TooltipController', () => {
       controller.setPosition('top-start');
       expect(tooltip.position).to.not.eql('top-start');
     });
+
+    it('should update tooltip ariaTarget using controller setAriaTarget method', () => {
+      const input = document.createElement('input');
+      host.appendChild(input);
+      controller.setAriaTarget(input);
+      expect(tooltip.ariaTarget).to.equal(input);
+    });
   });
 
   describe('slotted tooltip', () => {

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -79,6 +79,12 @@ declare class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(
   static setDefaultHoverDelay(delay: number): void;
 
   /**
+   * Element used to link with the `aria-describedby`
+   * attribute. When not set, defaults to `target`.
+   */
+  ariaTarget: HTMLElement | undefined;
+
+  /**
    * Object with properties passed to `generator` and
    * `shouldShow` functions for generating tooltip text
    * or detecting whether to show the tooltip or not.

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -436,7 +436,7 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
       _effectiveAriaTarget: {
         type: Object,
         computed: '__computeAriaTarget(ariaTarget, target)',
-        observer: '__ariaTargetChanged',
+        observer: '__effectiveAriaTargetChanged',
       },
 
       /** @private */
@@ -578,7 +578,7 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
   }
 
   /** @private */
-  __ariaTargetChanged(ariaTarget, oldAriaTarget) {
+  __effectiveAriaTargetChanged(ariaTarget, oldAriaTarget) {
     if (oldAriaTarget) {
       removeValueFromAttribute(oldAriaTarget, 'aria-describedby', this._uniqueId);
     }

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -282,6 +282,14 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
   static get properties() {
     return {
       /**
+       * Element used to link with the `aria-describedby`
+       * attribute. When not set, defaults to `target`.
+       */
+      ariaTarget: {
+        type: Object,
+      },
+
+      /**
        * Object with properties passed to `generator` and
        * `shouldShow` functions for generating tooltip text
        * or detecting whether to show the tooltip or not.
@@ -402,6 +410,17 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
       },
 
       /**
+       * Element used to link with the `aria-describedby`
+       * attribute. When not set, defaults to `target`.
+       * @protected
+       */
+      _ariaTarget: {
+        type: Object,
+        computed: '__computeAriaTarget(ariaTarget, target)',
+        observer: '__ariaTargetChanged',
+      },
+
+      /**
        * Set to true when the overlay is opened using auto-added
        * event listeners: mouseenter and focusin (keyboard only).
        * @protected
@@ -519,6 +538,11 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
   }
 
   /** @private */
+  __computeAriaTarget(ariaTarget, target) {
+    return ariaTarget || target;
+  }
+
+  /** @private */
   __computeHorizontalAlign(position) {
     return ['top-end', 'bottom-end', 'start-top', 'start', 'start-bottom'].includes(position) ? 'end' : 'start';
   }
@@ -551,6 +575,17 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
   /** @private */
   __tooltipRenderer(root) {
     root.textContent = typeof this.generator === 'function' ? this.generator(this.context) : this.text;
+  }
+
+  /** @private */
+  __ariaTargetChanged(ariaTarget, oldAriaTarget) {
+    if (oldAriaTarget) {
+      removeValueFromAttribute(oldAriaTarget, 'aria-describedby', this._uniqueId);
+    }
+
+    if (ariaTarget) {
+      addValueToAttribute(ariaTarget, 'aria-describedby', this._uniqueId);
+    }
   }
 
   /** @private */
@@ -596,8 +631,6 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
       oldTarget.removeEventListener('mousedown', this.__onMouseDown);
 
       this.__targetVisibilityObserver.unobserve(oldTarget);
-
-      removeValueFromAttribute(oldTarget, 'aria-describedby', this._uniqueId);
     }
 
     if (target) {
@@ -611,8 +644,6 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
       requestAnimationFrame(() => {
         this.__targetVisibilityObserver.observe(target);
       });
-
-      addValueToAttribute(target, 'aria-describedby', this._uniqueId);
     }
   }
 

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -410,17 +410,6 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
       },
 
       /**
-       * Element used to link with the `aria-describedby`
-       * attribute. When not set, defaults to `target`.
-       * @protected
-       */
-      _ariaTarget: {
-        type: Object,
-        computed: '__computeAriaTarget(ariaTarget, target)',
-        observer: '__ariaTargetChanged',
-      },
-
-      /**
        * Set to true when the overlay is opened using auto-added
        * event listeners: mouseenter and focusin (keyboard only).
        * @protected
@@ -437,6 +426,17 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
       _position: {
         type: String,
         value: 'bottom',
+      },
+
+      /**
+       * Element used to link with the `aria-describedby`
+       * attribute. When not set, defaults to `target`.
+       * @protected
+       */
+      _effectiveAriaTarget: {
+        type: Object,
+        computed: '__computeAriaTarget(ariaTarget, target)',
+        observer: '__ariaTargetChanged',
       },
 
       /** @private */

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -158,6 +158,40 @@ describe('vaadin-tooltip', () => {
     });
   });
 
+  describe('ariaTarget', () => {
+    let target, ariaTarget;
+
+    beforeEach(() => {
+      target = document.createElement('div');
+      target.textContent = 'Target';
+      document.body.appendChild(target);
+
+      ariaTarget = document.createElement('input');
+      target.appendChild(ariaTarget);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(target);
+    });
+
+    it('should set aria-describedby on the ariaTarget element', () => {
+      tooltip.target = target;
+      tooltip.ariaTarget = ariaTarget;
+
+      expect(ariaTarget.getAttribute('aria-describedby')).to.equal(overlay.id);
+    });
+
+    it('should remove aria-describedby when the ariaTarget is cleared', () => {
+      tooltip.target = target;
+      tooltip.ariaTarget = ariaTarget;
+
+      tooltip.ariaTarget = null;
+
+      expect(ariaTarget.hasAttribute('aria-describedby')).to.be.false;
+      expect(target.getAttribute('aria-describedby')).to.equal(overlay.id);
+    });
+  });
+
   describe('for', () => {
     let target;
 

--- a/packages/tooltip/test/typings/tooltip.types.ts
+++ b/packages/tooltip/test/typings/tooltip.types.ts
@@ -15,6 +15,7 @@ assertType<ThemePropertyMixinClass>(tooltip);
 
 // Properties
 assertType<string | undefined>(tooltip.for);
+assertType<HTMLElement | undefined>(tooltip.ariaTarget);
 assertType<HTMLElement | undefined>(tooltip.target);
 assertType<string | null | undefined>(tooltip.text);
 assertType<Record<string, unknown>>(tooltip.context);


### PR DESCRIPTION
## Description

Related to #6287

In case of input field components, we want the tooltip to be shown on top of the element including label, so `target` is set to the `vaadin-text-field` itself. However, `aria-describedby` element needs to be set on the `<input>` element itself.

This PR adds missing API to allow configuring where to set `aria-describedby` attribute.

## Type of change

- Feature

## Note

We could just check if the component has its own `ariaTarget` (the one that comes from `FieldMixin`) and use that to set the attribute. This would allow us to avoid adding new API at this point. However, that solution doesn't sound nice to me as it makes `vaadin-tooltip` coupled with the underlying implementation details of field components.