### PR TITLE
fix: set tabindex -1 on the link without href attribute

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -202,7 +202,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
         <a
           id="link"
           ?disabled="${this.disabled}"
-          tabindex="${this.disabled ? '-1' : '0'}"
+          tabindex="${this.disabled || !this.path ? '-1' : '0'}"
           href="${ifDefined(this.disabled ? null : this.path)}"
           part="link"
           aria-current="${this.current ? 'page' : 'false'}"

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -181,7 +181,7 @@ snapshots["vaadin-side-nav-item shadow default"] =
     aria-current="false"
     id="link"
     part="link"
-    tabindex="0"
+    tabindex="-1"
   >
     <slot name="prefix">
     </slot>
@@ -221,7 +221,7 @@ snapshots["vaadin-side-nav-item shadow expanded"] =
     aria-current="false"
     id="link"
     part="link"
-    tabindex="0"
+    tabindex="-1"
   >
     <slot name="prefix">
     </slot>
@@ -261,7 +261,7 @@ snapshots["vaadin-side-nav-item shadow current"] =
     href=""
     id="link"
     part="link"
-    tabindex="0"
+    tabindex="-1"
   >
     <slot name="prefix">
     </slot>
@@ -341,7 +341,7 @@ snapshots["vaadin-side-nav-item shadow i18n"] =
     aria-current="false"
     id="link"
     part="link"
-    tabindex="0"
+    tabindex="-1"
   >
     <slot name="prefix">
     </slot>


### PR DESCRIPTION
## Description

Fixes #6310

Previously, `tabindex` was set to `0` unless the item was disabled. 
This PR changes the behavior to take `path` into account as expected.

## Type of change

- Bugfix