### PR TITLE
fix: restore list role attribute on side-nav and item lists

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -220,7 +220,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
           aria-labelledby="link i18n"
         ></button>
       </div>
-      <ul part="children" ?hidden="${!this.expanded}" aria-hidden="${this.expanded ? 'false' : 'true'}">
+      <ul part="children" role="list" ?hidden="${!this.expanded}" aria-hidden="${this.expanded ? 'false' : 'true'}">
         <slot name="children"></slot>
       </ul>
       <div class="sr-only" id="i18n">${this.i18n.toggle}</div>

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -157,7 +157,13 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
         <slot name="label" @slotchange="${this._onLabelSlotChange}"></slot>
         <span part="toggle-button" aria-hidden="true"></span>
       </button>
-      <ul id="children" part="children" ?hidden="${this.collapsed}" aria-hidden="${this.collapsed ? 'true' : 'false'}">
+      <ul
+        id="children"
+        role="list"
+        part="children"
+        ?hidden="${this.collapsed}"
+        aria-hidden="${this.collapsed ? 'true' : 'false'}"
+      >
         <slot></slot>
       </ul>
     `;

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -202,6 +202,7 @@ snapshots["vaadin-side-nav-item shadow default"] =
   aria-hidden="true"
   hidden=""
   part="children"
+  role="list"
 >
   <slot name="children">
   </slot>
@@ -241,6 +242,7 @@ snapshots["vaadin-side-nav-item shadow expanded"] =
 <ul
   aria-hidden="false"
   part="children"
+  role="list"
 >
   <slot name="children">
   </slot>
@@ -281,6 +283,7 @@ snapshots["vaadin-side-nav-item shadow current"] =
 <ul
   aria-hidden="false"
   part="children"
+  role="list"
 >
   <slot name="children">
   </slot>
@@ -322,6 +325,7 @@ snapshots["vaadin-side-nav-item shadow path"] =
   aria-hidden="true"
   hidden=""
   part="children"
+  role="list"
 >
   <slot name="children">
   </slot>
@@ -362,6 +366,7 @@ snapshots["vaadin-side-nav-item shadow i18n"] =
   aria-hidden="true"
   hidden=""
   part="children"
+  role="list"
 >
   <slot name="children">
   </slot>

--- a/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav.test.snap.js
@@ -87,6 +87,7 @@ snapshots["vaadin-side-nav shadow default"] =
   aria-hidden="false"
   id="children"
   part="children"
+  role="list"
 >
   <slot>
   </slot>
@@ -112,6 +113,7 @@ snapshots["vaadin-side-nav shadow collapsible"] =
   aria-hidden="false"
   id="children"
   part="children"
+  role="list"
 >
   <slot>
   </slot>
@@ -138,6 +140,7 @@ snapshots["vaadin-side-nav shadow collapsed"] =
   hidden=""
   id="children"
   part="children"
+  role="list"
 >
   <slot>
   </slot>


### PR DESCRIPTION
## Description

Closes #6311

Note, it's actually unclear to me whether this fix is needed - see https://github.com/vaadin/web-components/issues/6311#issuecomment-1669486093

## Type of change

- Bugfix