### PR TITLE
fix: prevent closing the tooltip on overlay mouseenter

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -273,6 +273,7 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
         no-vertical-overlap$="[[__computeNoVerticalOverlap(__effectivePosition)]]"
         horizontal-align="[[__computeHorizontalAlign(__effectivePosition)]]"
         vertical-align="[[__computeVerticalAlign(__effectivePosition)]]"
+        on-mouseenter="__onOverlayMouseEnter"
         on-mouseleave="__onOverlayMouseLeave"
         modeless
       ></vaadin-tooltip-overlay>
@@ -700,6 +701,19 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
   __onMouseLeave(event) {
     if (event.relatedTarget !== this._overlayElement) {
       this.__handleMouseLeave();
+    }
+  }
+
+  /** @private */
+  __onOverlayMouseEnter(event) {
+    if (this.manual) {
+      return;
+    }
+
+    // Retain opened state when moving pointer over the overlay.
+    // See https://github.com/vaadin/web-components/issues/6316
+    if (!this.__isTargetHidden && !this.__hoverInside) {
+      this._stateController.open({ immediate: true });
     }
   }
 

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -70,6 +70,14 @@ class TooltipStateController {
   }
 
   /**
+   * Whether closing is currently in progress.
+   * @return {boolean}
+   */
+  get isClosing() {
+    return closing.has(this.host);
+  }
+
+  /**
    * Schedule opening the tooltip.
    * @param {Object} options
    */
@@ -705,14 +713,10 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
   }
 
   /** @private */
-  __onOverlayMouseEnter(event) {
-    if (this.manual) {
-      return;
-    }
-
+  __onOverlayMouseEnter() {
     // Retain opened state when moving pointer over the overlay.
     // See https://github.com/vaadin/web-components/issues/6316
-    if (!this.__isTargetHidden && !this.__hoverInside) {
+    if (this._stateController.isClosing) {
       this._stateController.open({ immediate: true });
     }
   }

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -715,6 +715,8 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
   /** @private */
   __onOverlayMouseEnter() {
     // Retain opened state when moving pointer over the overlay.
+    // Closing can start due to an offset between the target and
+    // the overlay itself. If that's the case, re-open overlay.
     // See https://github.com/vaadin/web-components/issues/6316
     if (this._stateController.isClosing) {
       this._stateController.open({ immediate: true });

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -137,6 +137,16 @@ describe('timers', () => {
       escKeyDown(target);
       expect(overlay.opened).to.be.false;
     });
+
+    it('should not close on overlay mouseenter during hide delay', async () => {
+      mouseenter(target);
+      mouseleave(target, document.body);
+
+      mouseenter(overlay);
+
+      await aTimeout(1);
+      expect(overlay.opened).to.be.true;
+    });
   });
 
   describe('setDefaultHoverDelay', () => {


### PR DESCRIPTION
## Description

Fixes #6316

## Type of change

- Bugfix

## Note

Use `vaadin-button` dev page for testing:

### Before

https://github.com/vaadin/web-components/assets/10589913/0c249465-e29b-4c58-b042-4dbafd6f235c

### After

https://github.com/vaadin/web-components/assets/10589913/d419d261-6340-45bd-8d4d-0aa64c037920