### PR TITLE
fix: reflect icon as an attribute

### DIFF
--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -57,6 +57,8 @@ declare class Icon extends ThemableMixin(ElementMixin(ControllerMixin(HTMLElemen
    * values provided by the corresponding `vaadin-iconset` element.
    *
    * See also [`name`](#/elements/vaadin-iconset#property-name) property of `vaadin-iconset`.
+   *
+   * @attr {string} icon
    */
   icon: string | null;
 

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -108,9 +108,13 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(PolymerElement))) 
        * values provided by the corresponding `vaadin-iconset` element.
        *
        * See also [`name`](#/elements/vaadin-iconset#property-name) property of `vaadin-iconset`.
+       *
+       * @attr {string} icon
+       * @type {string}
        */
       icon: {
         type: String,
+        reflectToAttribute: true,
         observer: '__iconChanged',
       },
 

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -146,6 +146,13 @@ describe('vaadin-icon', () => {
         svgElement = icon.shadowRoot.querySelector('svg');
       });
 
+      it('should reflect the icon as an attribute', () => {
+        icons.forEach((svgIcon) => {
+          icon.icon = svgIcon.getAttribute('id');
+          expect(icon.getAttribute('icon')).to.equal(icon.icon);
+        });
+      });
+
       it('should render icon from the iconset', () => {
         icons.forEach((svgIcon) => {
           icon.icon = svgIcon.getAttribute('id');


### PR DESCRIPTION
## Description

Reflect `icon` property of a `<vaadin-icon>` as an attribute.

Fixes #6301 

## Type of change

Bugfix