### PR TITLE
fix: prevent toggling opened state on click when disabled (#6331)

### DIFF
--- a/packages/accordion/test/accordion-panel.test.js
+++ b/packages/accordion/test/accordion-panel.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { click, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-accordion-panel.js';
@@ -81,6 +81,12 @@ describe('vaadin-accordion-panel', () => {
         expect(panel.opened).to.be.true;
 
         toggle.click();
+        expect(panel.opened).to.be.false;
+      });
+
+      it(`should not update opened on ${type} heading button click when disabled`, () => {
+        panel.disabled = true;
+        click(toggle);
         expect(panel.opened).to.be.false;
       });
 

--- a/packages/details/src/collapsible-mixin.js
+++ b/packages/details/src/collapsible-mixin.js
@@ -64,6 +64,10 @@ export const CollapsibleMixin = (superClass) =>
       // Only handle click and not keydown, because `vaadin-details-summary` uses `ButtonMixin`
       // that already covers this logic, and `vaadin-accordion-heading` uses native `<button>`.
       this.addEventListener('click', ({ target }) => {
+        if (this.disabled) {
+          return;
+        }
+
         const summary = this.focusElement;
 
         if (summary && (target === summary || summary.contains(target))) {

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { click, fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-details.js';
@@ -105,6 +105,12 @@ describe('vaadin-details', () => {
         expect(details.opened).to.be.true;
 
         summary.click();
+        expect(details.opened).to.be.false;
+      });
+
+      it(`should not update opened on ${type} summary click when disabled`, () => {
+        details.disabled = true;
+        click(summary);
         expect(details.opened).to.be.false;
       });
 


### PR DESCRIPTION
## Description

Manual cherry-pick of #6331 to 24.0 branch.

## Type of change

- Cherry-pick