### PR TITLE
refactor: remove unnecessary method abstraction

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -1173,14 +1173,10 @@ export const DatePickerMixin = (subclass) =>
      * @protected
      */
     _onInput() {
-      if (!this.opened && this.inputElement.value && !this.autoOpenDisabled) {
+      if (!this.opened && this._inputElementValue && !this.autoOpenDisabled) {
         this.open();
       }
-      this._userInputValueChanged();
-    }
 
-    /** @private */
-    _userInputValueChanged() {
       if (this._inputElementValue) {
         const parsedDate = this._getParsedDate();
 


### PR DESCRIPTION
## Description

The PR inlines `_userInputValueChanged()` into `_onInput()` to remove unnecessary method abstraction.

## Type of change

- [x] Internal
