### PR TITLE
fix: introduce delay to login form autofocus (24.1)

### DIFF
--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -120,7 +120,9 @@ class LoginForm extends LoginMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     super.connectedCallback();
 
     if (!this.noAutofocus) {
-      this.$.vaadinLoginUsername.focus();
+      requestAnimationFrame(() => {
+        this.$.vaadinLoginUsername.focus();
+      });
     }
   }
 

--- a/packages/login/test/dom/login-form.test.js
+++ b/packages/login/test/dom/login-form.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../vaadin-login-form.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -23,9 +23,10 @@ describe('vaadin-login-form', () => {
     additionalInformation: 'Jos tarvitset lisätietoja käyttäjälle.',
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetUniqueId();
     form = fixtureSync('<vaadin-login-form></vaadin-login-form>');
+    await nextRender();
   });
 
   describe('host', () => {

--- a/packages/login/test/login-form.test.js
+++ b/packages/login/test/login-form.test.js
@@ -216,7 +216,9 @@ describe('login form', () => {
     expect(login.disabled).to.be.true;
   });
 
-  it('should focus the username field', () => {
+  it('should focus the username field', async () => {
+    // Apply same delay that is used for auto-focus
+    await new Promise(requestAnimationFrame);
     const usernameElement = login.$.vaadinLoginUsername;
     expect(document.activeElement).to.equal(usernameElement.inputElement);
   });
@@ -230,9 +232,11 @@ describe('login form', () => {
 describe('no autofocus', () => {
   let activeElement;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     activeElement = document.activeElement;
     fixtureSync('<vaadin-login-form no-autofocus></vaadin-login-form>');
+    // Apply same delay that is used for auto-focus
+    await new Promise(requestAnimationFrame);
   });
 
   it('should not focus the username field', () => {

--- a/packages/login/test/login-form.test.js
+++ b/packages/login/test/login-form.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, fixtureSync, tap } from '@vaadin/testing-helpers';
+import { enter, fixtureSync, nextFrame, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-login-form.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -218,7 +218,7 @@ describe('login form', () => {
 
   it('should focus the username field', async () => {
     // Apply same delay that is used for auto-focus
-    await new Promise(requestAnimationFrame);
+    await nextFrame();
     const usernameElement = login.$.vaadinLoginUsername;
     expect(document.activeElement).to.equal(usernameElement.inputElement);
   });
@@ -236,7 +236,7 @@ describe('no autofocus', () => {
     activeElement = document.activeElement;
     fixtureSync('<vaadin-login-form no-autofocus></vaadin-login-form>');
     // Apply same delay that is used for auto-focus
-    await new Promise(requestAnimationFrame);
+    await nextFrame();
   });
 
   it('should not focus the username field', () => {

--- a/packages/login/test/login-overlay.test.js
+++ b/packages/login/test/login-overlay.test.js
@@ -111,7 +111,9 @@ describe('opened overlay', () => {
     expect(submitStub.called).to.be.false;
   });
 
-  it('should focus the username field', () => {
+  it('should focus the username field', async () => {
+    // Apply same delay that is used for auto-focus
+    await new Promise(requestAnimationFrame);
     const usernameElement = overlay.$.vaadinLoginForm.$.vaadinLoginUsername;
     expect(document.activeElement).to.equal(usernameElement.inputElement);
   });
@@ -124,9 +126,11 @@ describe('no autofocus', () => {
     overlay = fixtureSync('<vaadin-login-overlay no-autofocus></vaadin-login-overlay>');
   });
 
-  it('should not focus the username field', () => {
+  it('should not focus the username field', async () => {
     const activeElement = document.activeElement;
     overlay.opened = true;
+    // Apply same delay that is used for auto-focus
+    await new Promise(requestAnimationFrame);
     expect(document.activeElement).to.equal(activeElement);
   });
 });

--- a/packages/login/test/login-overlay.test.js
+++ b/packages/login/test/login-overlay.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, esc, fixtureSync, tap } from '@vaadin/testing-helpers';
+import { enter, esc, fixtureSync, nextFrame, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-login-overlay.js';
 import { fillUsernameAndPassword } from './helpers.js';
@@ -113,7 +113,7 @@ describe('opened overlay', () => {
 
   it('should focus the username field', async () => {
     // Apply same delay that is used for auto-focus
-    await new Promise(requestAnimationFrame);
+    await nextFrame();
     const usernameElement = overlay.$.vaadinLoginForm.$.vaadinLoginUsername;
     expect(document.activeElement).to.equal(usernameElement.inputElement);
   });
@@ -130,7 +130,7 @@ describe('no autofocus', () => {
     const activeElement = document.activeElement;
     overlay.opened = true;
     // Apply same delay that is used for auto-focus
-    await new Promise(requestAnimationFrame);
+    await nextFrame();
     expect(document.activeElement).to.equal(activeElement);
   });
 });


### PR DESCRIPTION
## Description

Introduces a delay to the login form autofocus logic, which aligns it with how other components implement autofocus via `DelegateFocusMixin`. This resolves an issue with Vaadin Router, where the element would otherwise validate itself due to a focus out event being caused by the router moving the element within the DOM, immediately after the element has been added initially.

This fix is not necessary in `main`, where a delay has already been added as part of the Lit migration: https://github.com/vaadin/web-components/blob/7c43f3608b306bfff0b58802179e5175739f665c/packages/login/src/vaadin-login-form-mixin.js#L23-L24

Fixes https://github.com/vaadin/flow-components/issues/5266

## Type of change

- Bugfix