### PR TITLE
refactor!: ensure validation between value-changed and change events

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -664,13 +664,11 @@ export const DatePickerMixin = (subclass) =>
      * @protected
      */
     _selectDate(dateToSelect) {
-      const value = this._formatISO(dateToSelect);
-
-      const shouldDispatchChange = this.value !== value;
+      const prevValue = this.value;
 
       this._selectedDate = dateToSelect;
 
-      if (shouldDispatchChange) {
+      if (prevValue !== this.value) {
         this.dirty = true;
         this.__dispatchChange();
       }
@@ -753,13 +751,12 @@ export const DatePickerMixin = (subclass) =>
       if (selectedDate === undefined || i18n === undefined) {
         return;
       }
-      const value = this._formatISO(selectedDate);
 
       if (!this.__keepInputValue) {
         this._applyInputValue(selectedDate);
       }
 
-      this.value = value;
+      this.value = this._formatISO(selectedDate);
       this._ignoreFocusedDateChange = true;
       this._focusedDate = selectedDate;
       this._ignoreFocusedDateChange = false;

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -504,12 +504,6 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /** @private */
-    __dispatchChange() {
-      this.validate();
-      this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
-    }
-
-    /** @private */
     _overlayRenderer(root) {
       if (root.firstChild) {
         return;
@@ -654,6 +648,12 @@ export const DatePickerMixin = (subclass) =>
       super._setFocused(focused);
 
       this._shouldKeepFocusRing = focused && this._keyboardActive;
+    }
+
+    /** @private */
+    __dispatchChange() {
+      this.validate();
+      this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
     }
 
     /**
@@ -1025,8 +1025,7 @@ export const DatePickerMixin = (subclass) =>
       this.dirty = true;
       this._inputElementValue = '';
       this.value = '';
-      this.validate();
-      this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+      this.__dispatchChange();
     }
 
     /**

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -488,39 +488,6 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /**
-     * Override Polymer lifecycle callback to dispatch `change` event if needed.
-     * This is necessary to ensure `change` is fired after `value-changed`.
-     *
-     * @param {!Object} currentProps Current accessor values
-     * @param {?Object} changedProps Properties changed since the last call
-     * @param {?Object} oldProps Previous values for each changed property
-     * @protected
-     * @override
-     */
-    _propertiesChanged(currentProps, changedProps, oldProps) {
-      super._propertiesChanged(currentProps, changedProps, oldProps);
-
-      if ('value' in changedProps && this.__dispatchChangePending) {
-        this.__dispatchChange();
-      }
-    }
-
-    /**
-     * Override LitElement lifecycle callback to dispatch `change` event if needed.
-     * This is necessary to ensure `change` is fired after `value-changed`.
-     *
-     * @protected
-     * @override
-     */
-    updated(props) {
-      super.updated(props);
-
-      if (props.has('value') && this.__dispatchChangePending) {
-        this.__dispatchChange();
-      }
-    }
-
-    /**
      * Opens the dropdown.
      */
     open() {
@@ -540,7 +507,6 @@ export const DatePickerMixin = (subclass) =>
     __dispatchChange() {
       this.validate();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
-      this.__dispatchChangePending = false;
     }
 
     /** @private */
@@ -700,13 +666,14 @@ export const DatePickerMixin = (subclass) =>
     _selectDate(dateToSelect) {
       const value = this._formatISO(dateToSelect);
 
-      // Only set flag if the value will change.
-      if (this.value !== value) {
-        this.dirty = true;
-        this.__dispatchChangePending = true;
-      }
+      const shouldDispatchChange = this.value !== value;
 
       this._selectedDate = dateToSelect;
+
+      if (shouldDispatchChange) {
+        this.dirty = true;
+        this.__dispatchChange();
+      }
     }
 
     /** @private */


### PR DESCRIPTION
## Description

The PR ensures that the `validated` event is fired between `value-changed` and `change` events to align `date-picker` with the other components in this aspect.

> **Warning**
> As a consequence, the invalid state may be still outdated in `value-changed` event listeners. The updated invalid state is available in `change` event listeners anyway. This behavior is in line with the majority of components.

Part of https://github.com/vaadin/web-components/issues/6324

## Type of change

- [x] Refactor
