### PR TITLE
refactor: remove obsolete change dispatch logic

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -1014,16 +1014,12 @@ export const DatePickerMixin = (subclass) =>
 
     /**
      * Override an event listener from `InputConstraintsMixin`
-     * to have date-picker fully control when to fire a change event.
+     * to have date-picker fully control when to fire a change event
+     * and trigger validation.
+     *
      * @protected
      */
     _onChange(event) {
-      // For change event on the native <input> blur, after the input is cleared,
-      // we schedule change event to be dispatched on date-picker blur.
-      if (this._inputElementValue === '') {
-        this.__dispatchChange = true;
-      }
-
       event.stopPropagation();
     }
 


### PR DESCRIPTION
## Description

Removes the obsolete change dispatch logic from the `_onChange()` override.  Long time ago, the date-picker had the corresponding `__dispatchChange` check in the blur listener ([PR](https://github.com/vaadin/web-components/pull/2532)):

https://github.com/vaadin/web-components/blob/e67a1a10d00ab5a949c2880e041854a28d096c51/packages/vaadin-date-picker/src/vaadin-date-picker-mixin.js#L410-L414

This check was eventually removed, so scheduling a change dispatch isn't necessary anymore.

## Type of change

- [x] Refactor
