### PR TITLE
fix: reset selected item attributes, add keyboard tests

### DIFF
--- a/packages/select/src/vaadin-lit-select-item.js
+++ b/packages/select/src/vaadin-lit-select-item.js
@@ -35,6 +35,23 @@ class SelectItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LitElemen
     `;
   }
 
+  static get properties() {
+    return {
+      /**
+       * Use property instead of setting an attribute in `ready()`
+       * to ensure that `role` can be removed from the item clone,
+       * which is done synchronously after the clone is attached.
+       *
+       * @protected
+       */
+      role: {
+        type: String,
+        value: 'option',
+        reflectToAttribute: true,
+      },
+    };
+  }
+
   /** @protected */
   render() {
     return html`
@@ -43,13 +60,6 @@ class SelectItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LitElemen
         <slot></slot>
       </div>
     `;
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this.setAttribute('role', 'option');
   }
 }
 

--- a/packages/select/src/vaadin-lit-select-item.js
+++ b/packages/select/src/vaadin-lit-select-item.js
@@ -39,8 +39,9 @@ class SelectItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LitElemen
     return {
       /**
        * Use property instead of setting an attribute in `ready()`
-       * to ensure that `role` can be removed from the item clone,
-       * which is done synchronously after the clone is attached.
+       * for cloning the selected item attached to the value button:
+       * in this case, `role` attribute is removed synchronously, and
+       * using `ready()` would incorrectly restore the attribute.
        *
        * @protected
        */

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -266,7 +266,10 @@ export const SelectBaseMixin = (superClass) =>
           this.__initMenuItems(menuElement);
         });
 
-        menuElement.addEventListener('selected-changed', () => this.__updateValueButton());
+        menuElement.addEventListener('selected-changed', (event) => {
+          // console.log('selected changed', event);
+          this.__updateValueButton();
+        });
         // Use capture phase to make it possible for `<vaadin-grid-pro-edit-select>`
         // to override and handle the keydown event before the value change happens.
         menuElement.addEventListener('keydown', (e) => this._onKeyDownInside(e), true);
@@ -461,6 +464,9 @@ export const SelectBaseMixin = (superClass) =>
       itemElement.removeAttribute('tabindex');
       itemElement.removeAttribute('aria-selected');
       itemElement.removeAttribute('role');
+      itemElement.removeAttribute('focused');
+      itemElement.removeAttribute('focus-ring');
+      itemElement.removeAttribute('active');
       itemElement.setAttribute('id', this._itemId);
     }
 

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -266,9 +266,7 @@ export const SelectBaseMixin = (superClass) =>
           this.__initMenuItems(menuElement);
         });
 
-        menuElement.addEventListener('selected-changed', (event) => {
-          this.__updateValueButton();
-        });
+        menuElement.addEventListener('selected-changed', () => this.__updateValueButton());
         // Use capture phase to make it possible for `<vaadin-grid-pro-edit-select>`
         // to override and handle the keydown event before the value change happens.
         menuElement.addEventListener('keydown', (e) => this._onKeyDownInside(e), true);

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -267,7 +267,6 @@ export const SelectBaseMixin = (superClass) =>
         });
 
         menuElement.addEventListener('selected-changed', (event) => {
-          // console.log('selected changed', event);
           this.__updateValueButton();
         });
         // Use capture phase to make it possible for `<vaadin-grid-pro-edit-select>`

--- a/packages/select/test/keyboard-lit.test.js
+++ b/packages/select/test/keyboard-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-lit-select.js';
+import './keyboard.common.js';

--- a/packages/select/test/keyboard-polymer.test.js
+++ b/packages/select/test/keyboard-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-select.js';
+import './keyboard.common.js';

--- a/packages/select/test/keyboard.common.js
+++ b/packages/select/test/keyboard.common.js
@@ -1,0 +1,155 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+
+describe('keyboard', () => {
+  let select, overlay, menu, valueButton;
+
+  beforeEach(async () => {
+    select = fixtureSync('<vaadin-select></vaadin-select>');
+    select.items = [
+      { label: 'Option 1', value: 'option-1' },
+      { label: 'Option 2', value: 'option-2' },
+    ];
+    await nextRender();
+    valueButton = select.focusElement;
+    menu = select._menuElement;
+    overlay = select._overlayElement;
+  });
+
+  describe('focus', () => {
+    it('should focus the value button on Tab', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      expect(document.activeElement).to.equal(valueButton);
+    });
+
+    it('should set focused attribute on both host and value button', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      expect(select.hasAttribute('focused')).to.be.true;
+      expect(valueButton.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should set focus-ring attribute on both host and value button', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      expect(select.hasAttribute('focus-ring')).to.be.true;
+      expect(valueButton.hasAttribute('focus-ring')).to.be.true;
+    });
+  });
+
+  describe('overlay', () => {
+    [('ArrowDown', 'ArrowUp', 'Enter', 'Space')].forEach((key) => {
+      it(`should open overlay on ${key} key`, async () => {
+        await sendKeys({ press: 'Tab' });
+
+        await sendKeys({ press: key });
+        await nextRender();
+
+        expect(overlay.opened).to.be.true;
+      });
+    });
+
+    ['Enter', 'Escape'].forEach((key) => {
+      it(`should close the overlay on ${key} key`, async () => {
+        await sendKeys({ press: 'Tab' });
+
+        await sendKeys({ press: 'Enter' });
+        await nextRender();
+
+        await sendKeys({ press: key });
+        await nextUpdate(select);
+
+        expect(select.opened).to.be.false;
+        expect(overlay.opened).to.be.false;
+      });
+    });
+
+    it('should focus value button element on overlay closing', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+
+      const focusedSpy = sinon.spy(valueButton, 'focus');
+
+      await sendKeys({ press: 'Escape' });
+      await nextUpdate(select);
+
+      expect(focusedSpy.calledOnce).to.be.true;
+    });
+
+    it('should restore focus-ring attribute on overlay closing', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+
+      await sendKeys({ press: 'Escape' });
+      await nextRender();
+
+      expect(select.hasAttribute('focus-ring')).to.be.true;
+      expect(valueButton.hasAttribute('focus-ring')).to.be.true;
+    });
+  });
+
+  describe('selection', () => {
+    it('should focus the first item on open', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+
+      const item = menu.items[0];
+      expect(document.activeElement).to.equal(item);
+      expect(item.hasAttribute('focused')).to.be.true;
+      expect(item.hasAttribute('focus-ring')).to.be.true;
+    });
+
+    it('should select the item on Enter', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+
+      await sendKeys({ press: 'Enter' });
+      await nextUpdate(select);
+
+      expect(select.value).to.equal('option-1');
+    });
+
+    it('should append clone of the selected item to the button', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+
+      await sendKeys({ press: 'Enter' });
+      await nextUpdate(select);
+
+      const item = menu.items[0];
+      const clone = valueButton.firstChild;
+      expect(clone).not.to.be.equal(item);
+      expect(clone.localName).to.be.equal(item.localName);
+      expect(clone.textContent).to.be.equal(item.textContent);
+    });
+
+    ['active', 'focused', 'focus-ring', 'role', 'tabindex'].forEach((attr) => {
+      it(`should remove ${attr} attribute from the item clone`, async () => {
+        await sendKeys({ press: 'Tab' });
+
+        // Open overlay and wait
+        await sendKeys({ press: 'Enter' });
+        await nextRender();
+
+        await sendKeys({ press: 'Enter' });
+        await nextUpdate(select);
+
+        const clone = valueButton.firstChild;
+        expect(clone.hasAttribute(attr)).to.be.false;
+      });
+    });
+  });
+});

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -1,11 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 import {
-  arrowDown,
   arrowUp,
   click,
   enterKeyDown,
   enterKeyUp,
-  escKeyDown,
   fire,
   fixtureSync,
   keyboardEventFor,
@@ -13,7 +11,6 @@ import {
   nextRender,
   nextUpdate,
   oneEvent,
-  spaceKeyDown,
   tab,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
@@ -131,16 +128,6 @@ describe('vaadin-select', () => {
         expect(select._overlayElement.opened).to.be.false;
       });
 
-      it('should update selection slot with a clone of the selected item', async () => {
-        menu.selected = 2;
-        await nextUpdate(select);
-        const itemElement = select._items[menu.selected];
-        const valueElement = valueButton.firstChild;
-        expect(valueElement).not.to.be.equal(itemElement);
-        expect(valueElement.localName).to.be.equal(itemElement.localName);
-        expect(valueElement.textContent).to.be.equal(itemElement.textContent);
-      });
-
       it('should preserve the selected attribute when selecting the disabled item', async () => {
         menu.selected = 5;
         await nextUpdate(select);
@@ -167,24 +154,6 @@ describe('vaadin-select', () => {
         menu.selected = 3;
         await nextUpdate(select);
         expect(select.value).to.be.empty;
-      });
-
-      it('should remove tabindex when cloning the selected element', async () => {
-        menu.selected = 2;
-        await nextUpdate(select);
-        const itemElement = select._items[menu.selected];
-        const valueElement = valueButton.firstChild;
-        expect(itemElement.tabIndex).to.be.equal(0);
-        expect(valueElement.hasAttribute('tabindex')).to.be.false;
-      });
-
-      it('should remove role when cloning the selected element', async () => {
-        menu.selected = 2;
-        await nextUpdate(select);
-        const itemElement = select._items[menu.selected];
-        const valueElement = valueButton.firstChild;
-        expect(itemElement.tabIndex).to.be.equal(0);
-        expect(valueElement.hasAttribute('role')).to.be.false;
       });
 
       it('should update selection slot textContent with the selected item `label` string', async () => {
@@ -355,34 +324,6 @@ describe('vaadin-select', () => {
         expect(spy.calledOnce).to.be.true;
       });
 
-      it('should open the overlay on ArrowUp', () => {
-        arrowUp(valueButton);
-        expect(select.opened).to.be.true;
-      });
-
-      it('should open the overlay on Down', () => {
-        arrowDown(valueButton);
-        expect(select.opened).to.be.true;
-      });
-
-      it('should open the overlay on Space', () => {
-        spaceKeyDown(valueButton);
-        expect(select.opened).to.be.true;
-      });
-
-      it('should open the overlay on Enter', () => {
-        enterKeyDown(valueButton);
-        expect(select.opened).to.be.true;
-      });
-
-      it('should close the overlay on Escape', async () => {
-        select.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        escKeyDown(select._items[0]);
-        await nextUpdate(select);
-        expect(select.opened).to.be.false;
-      });
-
       it('should not open the overlay on helper click', async () => {
         select.helperText = 'Helper Text';
         await nextUpdate(select);
@@ -448,15 +389,6 @@ describe('vaadin-select', () => {
         click(select._items[0]);
         await nextRender();
         expect(overlay.opened).to.be.false;
-      });
-
-      it('should focus the input on selecting value and closing the overlay', async () => {
-        const focusedSpy = sinon.spy(valueButton, 'focus');
-        click(select._items[1]);
-        await nextRender();
-        expect(select.value).to.be.equal(select._items[1].value);
-        expect(overlay.opened).to.be.false;
-        expect(focusedSpy.called).to.be.true;
       });
 
       it('should restore focused state on closing the overlay if phone', async () => {


### PR DESCRIPTION
## Description

Fixes #6337

Added a new `keyboard` test suite which covers selected item attributes.

I'm not exactly sure what was the change that introduced the regression. 
However, I feel like explicit removal of all the attributes still makes sense.

## Type of change

- Bugfix