### PR TITLE
fix: add missing mixins to DetailsBaseMixin types

### DIFF
--- a/packages/details/src/vaadin-details-base-mixin.d.ts
+++ b/packages/details/src/vaadin-details-base-mixin.d.ts
@@ -5,6 +5,9 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { DelegateFocusMixinClass } from '@vaadin/a11y-base/src/delegate-focus-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
+import type { TabindexMixinClass } from '@vaadin/a11y-base/src/tabindex-mixin.js';
 import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import type { CollapsibleMixinClass } from './collapsible-mixin.js';
 
@@ -14,6 +17,9 @@ export declare function DetailsBaseMixin<T extends Constructor<HTMLElement>>(
   Constructor<DelegateFocusMixinClass> &
   Constructor<DelegateStateMixinClass> &
   Constructor<DetailsBaseMixinClass> &
+  Constructor<DisabledMixinClass> &
+  Constructor<FocusMixinClass> &
+  Constructor<TabindexMixinClass> &
   T;
 
 export declare class DetailsBaseMixinClass {

--- a/packages/details/test/typings/details.types.ts
+++ b/packages/details/test/typings/details.types.ts
@@ -1,4 +1,12 @@
 import '../../vaadin-details.js';
+import type { DelegateFocusMixinClass } from '@vaadin/a11y-base/src/delegate-focus-mixin.js';
+import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
+import type { TabindexMixinClass } from '@vaadin/a11y-base/src/tabindex-mixin.js';
+import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { CollapsibleMixinClass } from '../../src/collapsible-mixin.js';
 import type { DetailsOpenedChangedEvent } from '../../vaadin-details.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
@@ -9,3 +17,13 @@ details.addEventListener('opened-changed', (event) => {
   assertType<DetailsOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
+
+// Mixins
+assertType<CollapsibleMixinClass>(details);
+assertType<DelegateFocusMixinClass>(details);
+assertType<DelegateStateMixinClass>(details);
+assertType<DisabledMixinClass>(details);
+assertType<ElementMixinClass>(details);
+assertType<FocusMixinClass>(details);
+assertType<TabindexMixinClass>(details);
+assertType<ThemableMixinClass>(details);


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/6352

This fixes a regression in `vaadin-details` types that I accidentally introduced while creating `DetailsBaseMixin`.

## Type of change

- Bugfix