### PR TITLE
fix: reset pointer-events: none for header slot children

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -24,6 +24,10 @@ const confirmDialogOverlay = css`
     height: var(--_vaadin-confirm-dialog-content-height);
   }
 
+  ::slotted([slot='header']) {
+    pointer-events: auto;
+  }
+
   /* Make buttons clickable */
   [part='footer'] > * {
     pointer-events: all;

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -166,6 +166,11 @@ describe('vaadin-confirm-dialog', () => {
         const headerNode = headerSlot.assignedNodes()[0];
         expect(headerNode.textContent.trim()).to.equal('Slotted header');
       });
+
+      it('should set pointer-events on the element to auto', () => {
+        const headerNode = headerSlot.assignedNodes()[0];
+        expect(getComputedStyle(headerNode).pointerEvents).to.equal('auto');
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5277

Unlike `vaadin-dialog`, the slot in `vaadin-confirm-dialog` is named `header` and not `header-content`, so [this CSS](https://github.com/vaadin/web-components/blob/7072364960f0f5be719b41ae6bbd8f3750bd8fe8/packages/dialog/src/vaadin-dialog-styles.js#L24-L29) does not apply. This PR adds corresponding styles to `vaadin-confirm-dialog-overlay`.

## Type of change

- Bugfix