### PR TITLE
fix: do not toggle opened state on summary anchor click (CP: 23.3)

### DIFF
--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -170,7 +170,11 @@ class Details extends ShadowFocusMixin(ElementMixin(ThemableMixin(ControllerMixi
   }
 
   /** @private */
-  _onToggleClick() {
+  _onToggleClick(event) {
+    if (event.target.localName === 'a') {
+      return;
+    }
+
     this.opened = !this.opened;
   }
 

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -64,6 +64,13 @@ describe('vaadin-details', () => {
       expect(details.opened).to.be.false;
     });
 
+    it('should not toggle opened state on link click', () => {
+      const link = document.createElement('a');
+      details.firstElementChild.appendChild(link);
+      link.click();
+      expect(details.opened).to.be.false;
+    });
+
     it('should update opened on toggle button enter', () => {
       keyDownOn(toggle, 13, [], 'Enter');
       expect(details.opened).to.be.true;


### PR DESCRIPTION
## Description

Manual cherry-pick of #6354 to `23.3` branch that has a totally different DOM structure.

## Type of change

- Cherry-pick