### PR TITLE
fix: reset pointer-events: none for header slot children (#6357) (CP: 24.0)

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -21,6 +21,10 @@ registerStyles(
       height: var(--_vaadin-confirm-dialog-content-height);
     }
 
+    ::slotted([slot='header']) {
+      pointer-events: auto;
+    }
+
     /* Make buttons clickable */
     [part='footer'] > * {
       pointer-events: all;

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -141,6 +141,11 @@ describe('vaadin-confirm-dialog', () => {
         const headerNode = headerSlot.assignedNodes()[0];
         expect(headerNode.textContent.trim()).to.equal('Slotted header');
       });
+
+      it('should set pointer-events on the element to auto', () => {
+        const headerNode = headerSlot.assignedNodes()[0];
+        expect(getComputedStyle(headerNode).pointerEvents).to.equal('auto');
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Manual cherry-pick of #6357 to `24.0` branch.

## Type of change

- Cherry-pick