### PR TITLE
fix!: prevent default for wheel events on focused input element

### DIFF
--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -11,6 +11,28 @@ describe('integer-field', () => {
     input = integerField.inputElement;
   });
 
+  describe('basic', () => {
+    it('should not prevent default for input wheel events when not focused', () => {
+      const event = new CustomEvent('wheel', { cancelable: true });
+      input.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.false;
+    });
+
+    it('should prevent default for input wheel events when focused', () => {
+      const event = new CustomEvent('wheel', { cancelable: true });
+      input.focus();
+      input.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should not prevent default for host wheel events when focused', () => {
+      const event = new CustomEvent('wheel', { cancelable: true });
+      input.focus();
+      integerField.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.false;
+    });
+  });
+
   describe('keyboard input', () => {
     let keydownSpy;
 

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -66,6 +66,7 @@ export const NumberFieldMixin = (superClass) =>
     constructor() {
       super();
       this._setType('number');
+      this.__onWheel = this.__onWheel.bind(this);
     }
 
     /** @protected */
@@ -132,6 +133,50 @@ export const NumberFieldMixin = (superClass) =>
       }
 
       return !this.invalid;
+    }
+
+    /**
+     * Override the method from `InputMixin` to add
+     * a wheel event listener to the input element.
+     *
+     * @param {HTMLElement} input
+     * @override
+     * @protected
+     */
+    _addInputListeners(input) {
+      super._addInputListeners(input);
+      input.addEventListener('wheel', this.__onWheel);
+    }
+
+    /**
+     * Override the method from `InputMixin` to remove
+     * the wheel event listener from the input element.
+     *
+     * @param {HTMLElement} input
+     * @override
+     * @protected
+     */
+    _removeInputListeners(input) {
+      super._removeInputListeners(input);
+      input.removeEventListener('wheel', this.__onWheel);
+    }
+
+    /**
+     * Prevents default browser behavior for wheel events on the input element
+     * when it's focused. More precisely, this prevents the browser from attempting
+     * to increment or decrement the value when the mouse wheel is used within
+     * the input element.
+     *
+     * CAVEAT: As a side-effect, this also prevents page scrolling when
+     * the pointer is positioned over the field and the field is focused.
+     *
+     * @param {WheelEvent} event
+     * @private
+     */
+    __onWheel(event) {
+      if (this.hasAttribute('focused')) {
+        event.preventDefault();
+      }
     }
 
     /** @protected */

--- a/packages/number-field/test/number-field.common.js
+++ b/packages/number-field/test/number-field.common.js
@@ -65,6 +65,26 @@ describe('number-field', () => {
       arrowDown(input);
       expect(numberField.value).to.be.equal('0');
     });
+
+    it('should not prevent default for input wheel events when not focused', () => {
+      const event = new CustomEvent('wheel', { cancelable: true });
+      input.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.false;
+    });
+
+    it('should prevent default for input wheel events when focused', () => {
+      const event = new CustomEvent('wheel', { cancelable: true });
+      input.focus();
+      input.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should not prevent default for host wheel events when focused', () => {
+      const event = new CustomEvent('wheel', { cancelable: true });
+      input.focus();
+      numberField.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.false;
+    });
   });
 
   describe('has-input-value-changed event', () => {


### PR DESCRIPTION
## Description

The PR prevents default browser behavior for wheel events on the number-field's input element when it's focused. More precisely, this prevents the browser from attempting to increment or decrement the value when the mouse wheel is used within the input element.

> **Warning**
> This is a behavior altering change. 

> **Warning**
>  The change also prevents page scrolling when the pointer is positioned over the field and the field is focused. This issue will be resolved when switching the number field from `[type=number]` to `[type=text]` ([ticket](https://github.com/vaadin/web-components/issues/3102)).

Fixes #6158, https://github.com/vaadin/web-components/issues/919

## Type of change

- [x] Bugfix
