### PR TITLE
refactor!: do not validate when closing on Escape press

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -389,7 +389,8 @@ export const SelectBaseMixin = (superClass) =>
 
         // Skip validation when a change event is scheduled, as validation
         // will be triggered by `__dispatchChange()` in that case.
-        if (!this.__dispatchChangePending) {
+        // Also, skip validation when closed on Escape or Tab keys.
+        if (!this.__dispatchChangePending && !this._keyboardActive) {
           this.validate();
         }
       }

--- a/packages/select/test/validation.common.js
+++ b/packages/select/test/validation.common.js
@@ -45,6 +45,26 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
+    it('should not validate on Escape press', async () => {
+      select.focus();
+      select.click();
+      await nextRender();
+
+      await sendKeys({ press: 'Escape' });
+      await nextUpdate(select);
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate once on Tab press', async () => {
+      select.focus();
+      select.click();
+      await nextRender();
+
+      await sendKeys({ press: 'Tab' });
+      await nextUpdate(select);
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
     it('should validate between value-changed and change events on Enter', async () => {
       select.focus();
       select.click();


### PR DESCRIPTION
## Description

Part of #5436

This PR changes the logic so that `validate()` is not called in `opened` set to `false` by pressing <kbd>Esc</kbd>,

## Type of change

- Refactor

## Note

- On pressing <kbd>Tab</kbd> while opened, `validate()` is now called only once (previously, it used to be called twice)
- On outside click, `validate()` is still called. We could consider removing it too, but preferably in a separate PR