### PR TITLE
refactor!: do not validate when closing on Escape press

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -940,8 +940,9 @@ export const DatePickerMixin = (subclass) =>
         this._nativeInput.selectionStart = this._nativeInput.selectionEnd;
       }
       // No need to revalidate the value after `_selectedDateChanged`
-      // Needed in case the value was not changed: open and close dropdown.
-      if (!this.value) {
+      // Needed in case the value was not changed: open and close dropdown,
+      // especially on outside click. On Esc key press, do not validate.
+      if (!this.value && !this._keyboardActive) {
         this.validate();
       }
     }

--- a/packages/date-picker/test/keyboard-input.common.js
+++ b/packages/date-picker/test/keyboard-input.common.js
@@ -652,13 +652,13 @@ describe('keyboard', () => {
         await nextRender(datePicker);
       });
 
-      it('should validate without change on Esc', async () => {
+      it('should not validate without change on Esc', async () => {
         await sendKeys({ press: 'Escape' });
 
         // Wait for overlay to finish closing
         await nextRender(datePicker);
 
-        expect(validateSpy.calledOnce).to.be.true;
+        expect(validateSpy.called).to.be.false;
         expect(changeSpy.called).to.be.false;
       });
 


### PR DESCRIPTION
## Description

Part of #5436

Same as #6363 but for `vaadin-date-picker`.

This PR changes the logic so that `validate()` is not called in `opened` set to `false` by pressing <kbd>Esc</kbd>.

## Type of change

- Refactor

## Note

- On outside click, `validate()` is still called. We could consider removing it too, but preferably in a separate PR
- When <kbd>Esc</kbd> is used to clear value when closed and `clearButtonVisible` set to `true`, `validate()` is still called