### PR TITLE
refactor!: do not validate when closing on Escape press

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -822,6 +822,7 @@ export const ComboBoxMixin = (subclass) =>
           this._revertInputValue();
         } else {
           // No item is focused, cancel the change and close the overlay
+          this.__escPressed = true;
           this.cancel();
         }
       } else if (this.clearButtonVisible && !!this.value) {
@@ -1092,9 +1093,12 @@ export const ComboBoxMixin = (subclass) =>
         this.dirty = true;
       }
 
-      // Do not validate when focusout is caused by document
-      // losing focus, which happens on browser tab switch.
-      if (document.hasFocus()) {
+      // Do not validate when closing overlay on Escape.
+      if (this.__escPressed) {
+        this.__escPressed = null;
+      } else if (document.hasFocus()) {
+        // Do not validate when focusout is caused by document
+        // losing focus, which happens on browser tab switch.
         this.validate();
       }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -867,7 +867,7 @@ export const ComboBoxMixin = (subclass) =>
       this._revertInputValueToValue();
       // In the next _detectAndDispatchChange() call, the change detection should not pass
       this._lastCommittedValue = this.value;
-      this._closeOrCommit();
+      this.close();
     }
 
     /** @private */

--- a/packages/combo-box/test/validation.test.js
+++ b/packages/combo-box/test/validation.test.js
@@ -39,6 +39,20 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
+    it('should not validate on close with Escape', async () => {
+      input.focus();
+      input.click();
+      await sendKeys({ press: 'Escape' });
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate once on close with Tab', async () => {
+      input.focus();
+      input.click();
+      await sendKeys({ press: 'Tab' });
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
     it('should validate before change event on outside click', async () => {
       input.focus();
       input.click();

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { enter, fixtureSync, focusout, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { TimePicker } from '../src/vaadin-time-picker.js';
 import { setInputValue } from './helpers.js';
@@ -98,6 +99,20 @@ describe('validation', () => {
       input.focus();
       input.click();
       outsideClick();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should not validate on close with Escape', async () => {
+      input.focus();
+      input.click();
+      await sendKeys({ press: 'Escape' });
+      expect(validateSpy.called).to.be.false;
+    });
+
+    it('should validate once on close with Tab', async () => {
+      input.focus();
+      input.click();
+      await sendKeys({ press: 'Tab' });
       expect(validateSpy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
## Description

Closes #5436

This PR changes `vaadin-combo-box` and `vaadin-time-picker` to not validate on <kbd>Esc</kbd> press.

## Type of change

- Refactor