### PR TITLE
test: update combo-box tests to close using outsideClick

### DIFF
--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
@@ -31,7 +31,7 @@ describe('internal filtering', () => {
     });
 
     it('should open the popup if closed', () => {
-      comboBox.close();
+      expect(comboBox.opened).to.equal(false);
 
       setInputValue(comboBox, 'foo');
 
@@ -40,7 +40,6 @@ describe('internal filtering', () => {
 
     it('should not open the popup if closed and autoOpenDisabled is true', () => {
       comboBox.autoOpenDisabled = true;
-      comboBox.close();
 
       setInputValue(comboBox, 'foo');
 
@@ -49,7 +48,6 @@ describe('internal filtering', () => {
 
     it('should filter items when filter is changed regardless of autoOpenDisabled', () => {
       comboBox.autoOpenDisabled = true;
-      comboBox.close();
 
       comboBox.value = 'foo';
       comboBox.open();
@@ -60,7 +58,6 @@ describe('internal filtering', () => {
 
     it('should open the popup when the value of the input field is set to none', () => {
       comboBox.value = 'foo';
-      comboBox.close();
       expect(comboBox.opened).to.equal(false);
 
       setInputValue(comboBox, '');
@@ -71,7 +68,6 @@ describe('internal filtering', () => {
     it('should not open the popup when the value of the input field is set to none and autoOpenDisabled is true', () => {
       comboBox.autoOpenDisabled = true;
       comboBox.value = 'foo';
-      comboBox.close();
       expect(comboBox.opened).to.equal(false);
 
       setInputValue(comboBox, '');
@@ -89,7 +85,7 @@ describe('internal filtering', () => {
       comboBox.value = 'foo';
       setInputValue(comboBox, 'bar');
 
-      comboBox.close();
+      outsideClick();
 
       expect(comboBox.value).to.equal('bar');
     });
@@ -98,7 +94,7 @@ describe('internal filtering', () => {
       comboBox.value = 'foo';
       setInputValue(comboBox, 'BAR');
 
-      comboBox.close();
+      outsideClick();
 
       expect(comboBox.value).to.equal('bar');
     });
@@ -116,7 +112,8 @@ describe('internal filtering', () => {
       comboBox.value = 'foo';
 
       setInputValue(comboBox, 'FOO');
-      comboBox.close();
+
+      outsideClick();
 
       expect(comboBox.inputElement.value).to.equal('foo');
     });
@@ -194,7 +191,7 @@ describe('internal filtering', () => {
     it('should be reset after closing the dropdown', () => {
       setInputValue(comboBox, 'foo');
 
-      comboBox.close();
+      outsideClick();
 
       expect(comboBox.filter).to.be.empty;
     });

--- a/packages/combo-box/test/selecting-items.test.js
+++ b/packages/combo-box/test/selecting-items.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fire, fixtureSync } from '@vaadin/testing-helpers';
+import { aTimeout, fire, fixtureSync, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
@@ -171,13 +171,13 @@ describe('selecting items', () => {
 
       comboBox.open();
       comboBox.value = 'foo';
-      comboBox.close();
+      outsideClick();
     });
 
     it('should fire exactly one `change` event', () => {
       comboBox.open();
       comboBox.value = 'foo';
-      comboBox.close();
+      outsideClick();
 
       expect(changeSpy.callCount).to.equal(1);
     });
@@ -215,7 +215,7 @@ describe('selecting items', () => {
       comboBox.value = 'foo';
 
       comboBox.open();
-      comboBox.close();
+      outsideClick();
 
       expect(changeSpy.callCount).to.equal(0);
     });
@@ -234,7 +234,7 @@ describe('selecting items', () => {
 
       comboBox.open();
       comboBox.value = 'foo';
-      comboBox.close();
+      clickItem(comboBox, 0);
     });
 
     it('should fire when selecting an item via click', () => {
@@ -319,7 +319,7 @@ describe('selecting a custom value', () => {
   it('should select a value when closing when having a single exact match', () => {
     setInputValue(comboBox, 'barbar');
 
-    comboBox.close();
+    outsideClick();
 
     expect(comboBox.value).to.eql('barbar');
   });
@@ -327,7 +327,7 @@ describe('selecting a custom value', () => {
   it('should select a value when closing when having multiple matches', () => {
     setInputValue(comboBox, 'BAR');
 
-    comboBox.close();
+    outsideClick();
 
     expect(comboBox.value).to.eql('bar');
   });
@@ -337,7 +337,7 @@ describe('selecting a custom value', () => {
 
     setInputValue(comboBox, '');
 
-    comboBox.close();
+    outsideClick();
 
     expect(comboBox.value).to.be.empty;
     expect(comboBox.selectedItem).to.be.null;
@@ -347,7 +347,7 @@ describe('selecting a custom value', () => {
   it('should select a custom value', () => {
     comboBox.value = 'foobar';
 
-    comboBox.close();
+    outsideClick();
 
     expect(comboBox.value).to.eql('foobar');
     expect(comboBox.selectedItem).to.be.null;
@@ -360,7 +360,7 @@ describe('selecting a custom value', () => {
 
     setInputValue(comboBox, '');
 
-    comboBox.close();
+    outsideClick();
 
     expect(comboBox.value).to.be.empty;
     expect(comboBox.selectedItem).to.be.null;
@@ -369,7 +369,7 @@ describe('selecting a custom value', () => {
   it('should allow changing value to existing item when custom value is set', () => {
     comboBox.value = 'foobar';
 
-    comboBox.close();
+    outsideClick();
 
     comboBox.value = 'foo';
     expect(comboBox.value).to.eql('foo');

--- a/packages/combo-box/test/selecting-items.test.js
+++ b/packages/combo-box/test/selecting-items.test.js
@@ -234,7 +234,7 @@ describe('selecting items', () => {
 
       comboBox.open();
       comboBox.value = 'foo';
-      clickItem(comboBox, 0);
+      outsideClick();
     });
 
     it('should fire when selecting an item via click', () => {


### PR DESCRIPTION
## Description

Updated some of the unit tests to use `outsideClick()` helper instead of calling `close()` method.
This is done in order to better emulate the actual user behavior in case of filtering / item selection.

## Type of change

- Test