### PR TITLE
fix: do not clear selected items on Escape when readonly

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -190,6 +190,25 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
+   * Override Escape handler to not clear
+   * selected items when readonly.
+   * @param {!Event} event
+   * @protected
+   * @override
+   */
+  _onEscape(event) {
+    if (this.readonly) {
+      event.stopPropagation();
+      if (this.opened) {
+        this.close();
+      }
+      return;
+    }
+
+    super._onEscape(event);
+  }
+
+  /**
    * @protected
    * @override
    */

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -54,7 +54,7 @@ describe('readonly', () => {
 
     it('should not clear on Esc when readonly and clear button visible', async () => {
       comboBox.clearButtonVisible = true;
-      await sendKeys({ down: 'Escape' });
+      await sendKeys({ press: 'Escape' });
       expect(comboBox.selectedItems).to.eql(['apple', 'orange']);
     });
 

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -52,6 +52,12 @@ describe('readonly', () => {
       expect(internal.opened).to.be.false;
     });
 
+    it('should not clear on Esc when readonly and clear button visible', async () => {
+      comboBox.clearButtonVisible = true;
+      await sendKeys({ down: 'Escape' });
+      expect(comboBox.selectedItems).to.eql(['apple', 'orange']);
+    });
+
     it('should not pre-fill focused item label on Arrow Down', async () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'ArrowDown' });


### PR DESCRIPTION
## Description

Currently, pressing <kbd>Esc</kbd> in readonly `vaadin-multi-select-combo-box` clears the selection. This PR fixes that.

## Type of change

- Bugfix