### PR TITLE
fix: remove button role from link in Cookie Consent

### DIFF
--- a/dev/cookie-consent.html
+++ b/dev/cookie-consent.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cookie Consent</title>
+    <script type="module" src="./common.js"></script>
+    <script type="module">
+      import '@vaadin/cookie-consent';
+    </script>
+  </head>
+  <body>
+    <vaadin-cookie-consent></vaadin-cookie-consent>
+  </body>
+</html>

--- a/packages/cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.js
@@ -177,6 +177,9 @@ class CookieConsent extends ElementMixin(PolymerElement) {
         name: this.cookieName,
       },
       position: this.position,
+      elements: {
+        messagelink: `<span id="cookieconsent:desc" class="cc-message">${this.message} <a aria-label="learn more about cookies" tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,
+      },
     });
 
     const popup = this._getPopup();

--- a/packages/cookie-consent/test/cookie-consent.test.js
+++ b/packages/cookie-consent/test/cookie-consent.test.js
@@ -89,6 +89,11 @@ describe('vaadin-cookie-consent', () => {
       expect(link.textContent).to.be.equal('Learn more');
       expect(link.href).to.be.equal('https://cookiesandyou.com/');
     });
+
+    it('learn more link should not have role', () => {
+      const link = ccWindow.querySelector('.cc-link');
+      expect(link.hasAttribute('role')).to.be.false;
+    });
   });
 
   describe('custom texts', () => {


### PR DESCRIPTION
## Description

Override the `messagelink` ("message with link") html in cookie consent configuration to remove the role attribute from the learn more link

Fixes #6308 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
