### PR TITLE
fix: update time-picker value on arrow up and down key

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -462,7 +462,15 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   __onArrowPressWithStep(step) {
     const objWithStep = this.__addStep(this.__getMsec(this.__memoValue), step, true);
     this.__memoValue = objWithStep;
-    this.inputElement.value = this.i18n.formatTime(this.__validateTime(objWithStep));
+
+    // Setting `value` property triggers the synchronous observer
+    // that in turn updates `_comboBoxValue` (actual input value)
+    // with its own observer where the value can be parsed again,
+    // so we set this flag to ensure it does not alter the value.
+    this.__useMemo = true;
+    this.value = this.__formatISO(objWithStep);
+    this.__useMemo = false;
+
     this.__dispatchChange();
   }
 
@@ -606,7 +614,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       return;
     }
 
-    const parsedObj = this.i18n.parseTime(value);
+    const parsedObj = this.__useMemo ? this.__memoValue : this.i18n.parseTime(value);
     const newValue = this.i18n.formatTime(parsedObj) || '';
 
     if (parsedObj) {

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -47,6 +47,16 @@ describe('events', () => {
       expect(changeSpy.calledTwice).to.be.true;
     });
 
+    it('should be fired after value-changed event on arrow keys', () => {
+      timePicker.step = 0.5;
+      const valueChangedSpy = sinon.spy();
+      timePicker.addEventListener('value-changed', valueChangedSpy);
+      arrowDown(inputElement);
+      expect(valueChangedSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(valueChangedSpy.calledBefore(changeSpy)).to.be.true;
+    });
+
     it('should not be fired on focused time change', async () => {
       inputElement.focus();
       await sendKeys({ type: '00:00' });

--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -34,16 +34,16 @@ describe('keyboard navigation', () => {
       timePicker.step = 720;
     });
 
-    it('should not change the value on arrow up', () => {
+    it('should update the value on arrow up', () => {
       timePicker.value = '00:00';
       arrowUp(inputElement);
-      expect(timePicker.value).to.be.equal('00:00');
+      expect(timePicker.value).to.be.equal('00:12');
     });
 
-    it('should not change the value on arrow down', () => {
+    it('should update the value on arrow down', () => {
       timePicker.value = '00:00';
       arrowDown(inputElement);
-      expect(timePicker.value).to.be.equal('00:00');
+      expect(timePicker.value).to.be.equal('23:48');
     });
 
     it('on arrow up should update the input value to 00:12', () => {
@@ -220,14 +220,6 @@ describe('keyboard navigation', () => {
       timePicker.step = 0.5;
       arrowUp(inputElement);
       expect(document.querySelector('vaadin-combo-box-overlay')).not.to.be.ok;
-    });
-
-    it('should not change value on escape', () => {
-      timePicker.step = 0.5;
-      arrowUp(inputElement);
-      expect(inputElement.value).to.be.equal('00:00:00.500');
-      esc(inputElement);
-      expect(inputElement.value).to.be.equal('');
     });
   });
 });


### PR DESCRIPTION
## Description

Related to #6347

This PR changes the logic of Arrow Up and Arrow Down keys to make it consistent:

### Before

Currently, there is a `change` event introduced as per https://github.com/vaadin/vaadin-time-picker/pull/110#pullrequestreview-244190551
At the same time, there is no `value-changed` event as the value doesn't change.

This is quite an old (5 years) decision from the initial version, see https://github.com/vaadin/vaadin-time-picker/pull/29#issuecomment-391421671

> Value should not be changing on arrows to follow the same behaviour logic as combo-box has: it's not selecting/changing the value on arrows. Discussed with Jouni.

### After

The `value` property is updated when pressing arrow keys with no dropdown, followed by the `change` event.

## Type of change

- Bugfix