### PR TITLE
fix: set vaadin-select position to relative

### DIFF
--- a/packages/select/src/vaadin-lit-select.js
+++ b/packages/select/src/vaadin-lit-select.js
@@ -39,6 +39,10 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(Lit
       inputFieldContainer,
       screenReaderOnly,
       css`
+        :host {
+          position: relative;
+        }
+
         ::slotted([slot='value']) {
           flex-grow: 1;
         }

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -139,6 +139,10 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolymerElement))
   static get template() {
     return html`
       <style>
+        :host {
+          position: relative;
+        }
+
         ::slotted([slot='value']) {
           flex-grow: 1;
         }

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -81,6 +81,10 @@ describe('vaadin-select', () => {
       expect(listBox.isConnected).to.be.true;
       expect(listBox.parentNode).to.equal(select._overlayElement);
     });
+
+    it('should have position set to relative', async () => {
+      expect(getComputedStyle(select).position).to.equal('relative');
+    });
   });
 
   describe('with items', () => {


### PR DESCRIPTION
## Description

This ensures that the sr-only element is always placed inside the select element

Fixes #6300

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
