### PR TITLE
fix: do not fire change event if the value has not changed

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -475,11 +475,16 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   }
 
   /** @private */
-  __dispatchChange() {
-    if (this.value !== this._lastCommittedValue) {
-      this._lastCommittedValue = this.value;
-      this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+  __commitPendingValue() {
+    if (this.__committedValue !== this.value) {
+      this.__dispatchChange();
+      this.__committedValue = this.value;
     }
+  }
+
+  /** @private */
+  __dispatchChange() {
+    this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
   }
 
   /**
@@ -608,6 +613,12 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       this.__updateInputValue(parsedObj);
     }
 
+    // Mark value set programmatically by the user
+    // as committed for the change event detection.
+    if (!this.__skipCommittedValueUpdate) {
+      this.__committedValue = this.value;
+    }
+
     this._toggleHasValue(this._hasValue);
   }
 
@@ -624,7 +635,9 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       if (value !== newValue) {
         this._comboBoxValue = newValue;
       } else {
+        this.__skipCommittedValueUpdate = true;
         this.__updateValue(parsedObj);
+        this.__skipCommittedValueUpdate = false;
       }
     } else {
       // If the user input can not be parsed, set a flag
@@ -634,7 +647,9 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
         this.__keepInvalidInput = true;
       }
 
+      this.__skipCommittedValueUpdate = true;
       this.value = '';
+      this.__skipCommittedValueUpdate = false;
     }
   }
 
@@ -645,7 +660,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     const { value } = event.target;
     // Do not fire change for bad input.
     if (value === '' || this.i18n.parseTime(value)) {
-      this.__dispatchChange();
+      this.__commitPendingValue();
     }
   }
 

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -476,7 +476,10 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
 
   /** @private */
   __dispatchChange() {
-    this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+    if (this.value !== this._lastCommittedValue) {
+      this._lastCommittedValue = this.value;
+      this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+    }
   }
 
   /**

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -105,6 +105,28 @@ describe('events', () => {
       inputElement.blur();
       expect(changeSpy.callCount).to.equal(1);
     });
+
+    it('should not be fired again on Enter if the value has not changed', async () => {
+      inputElement.focus();
+      await sendKeys({ type: '10:00' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy).to.be.calledOnce;
+
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy).to.be.calledOnce;
+    });
+
+    it('should not be fired again on blur if the value has not changed', async () => {
+      timePicker.step = 0.5;
+      inputElement.focus();
+
+      await sendKeys({ press: 'ArrowDown' });
+      expect(changeSpy).to.be.calledOnce;
+
+      inputElement.blur();
+      expect(changeSpy).to.be.calledOnce;
+    });
   });
 
   describe('has-input-value-changed event', () => {

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -127,6 +127,15 @@ describe('events', () => {
       inputElement.blur();
       expect(changeSpy).to.be.calledOnce;
     });
+
+    it('should not be fired on Enter after value set programmatically', async () => {
+      timePicker.value = '10:00';
+      inputElement.focus();
+
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy.called).to.be.false;
+    });
   });
 
   describe('has-input-value-changed event', () => {


### PR DESCRIPTION
## Description

Fixes #6347 

This PR addresses finding from https://github.com/vaadin/web-components/issues/6347#issuecomment-1686439630

## Type of change

- Bugfix