### PR TITLE
fix: only use container queries fallback with font icons

### DIFF
--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -254,10 +254,8 @@ class Icon extends ThemableMixin(
     this._tooltipController = new TooltipController(this);
     this.addController(this._tooltipController);
 
-    if (needsFontIconSizingFallback) {
-      // Call once initially to avoid a fouc
-      this._onResize();
-    }
+    // Call once initially to avoid a fouc
+    this._onResize();
   }
 
   /** @protected */
@@ -370,10 +368,13 @@ class Icon extends ThemableMixin(
       this.classList.add(...this.__addedFontClasses);
     }
 
-    // The "icon" attribute needs to be set on the host also when using font icons
-    // to avoid issues such as https://github.com/vaadin/web-components/issues/6301
-    if ((font || char) && !this.icon) {
-      this.icon = '';
+    if (font || char) {
+      if (!this.icon) {
+        // The "icon" attribute needs to be set on the host also when using font icons
+        // to avoid issues such as https://github.com/vaadin/web-components/issues/6301
+        this.icon = '';
+      }
+      this._onResize();
     }
   }
 
@@ -387,7 +388,9 @@ class Icon extends ThemableMixin(
    * @override
    */
   _onResize() {
-    this.style.setProperty('--_vaadin-font-icon-size', `${this.offsetHeight}px`);
+    if (needsFontIconSizingFallback && (this.char || this.font)) {
+      this.style.setProperty('--_vaadin-font-icon-size', `${this.offsetHeight}px`);
+    }
   }
 }
 

--- a/packages/icon/test/icon-font.test.js
+++ b/packages/icon/test/icon-font.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-icon.js';
 import { isSafari } from '@vaadin/component-base/src/browser-utils.js';
@@ -167,6 +167,56 @@ describe('vaadin-icon - icon fonts', () => {
       icon.fontFamily = 'My icons';
       const fontIconStyle = getComputedStyle(icon, ':before');
       expect(['"My icons"', 'My icons']).to.include(fontIconStyle.fontFamily);
+    });
+  });
+
+  // These tests make sure that the heavy container query fallback is only used
+  // when font icons are used.
+  (usesFontIconSizingFallback ? describe : describe.skip)('container query fallback', () => {
+    let icon;
+
+    it('should have the custom property (font)', async () => {
+      icon = fixtureSync('<vaadin-icon font="foo"></vaadin-icon>');
+      await nextFrame();
+      expect(icon.style.getPropertyValue('--_vaadin-font-icon-size')).to.equal('24px');
+    });
+
+    it('should have the custom property (char)', async () => {
+      icon = fixtureSync('<vaadin-icon char="foo"></vaadin-icon>');
+      await nextFrame();
+      expect(icon.style.getPropertyValue('--_vaadin-font-icon-size')).to.equal('24px');
+    });
+
+    it('should not have the custom property', async () => {
+      icon = fixtureSync('<vaadin-icon></vaadin-icon>');
+      await nextFrame();
+      expect(icon.style.getPropertyValue('--_vaadin-font-icon-size')).to.equal('');
+    });
+
+    it('should set the custom property', async () => {
+      icon = fixtureSync('<vaadin-icon></vaadin-icon>');
+      await nextFrame();
+      icon.font = 'foo';
+      expect(icon.style.getPropertyValue('--_vaadin-font-icon-size')).to.equal('24px');
+    });
+
+    it('should update the custom property', async () => {
+      icon = fixtureSync('<vaadin-icon font="foo"></vaadin-icon>');
+      await nextFrame();
+      icon.style.width = '100px';
+      icon.style.height = '100px';
+      await onceResized(icon);
+      expect(icon.style.getPropertyValue('--_vaadin-font-icon-size')).to.equal('100px');
+    });
+
+    it('should not update the custom property', async () => {
+      icon = fixtureSync('<vaadin-icon></vaadin-icon>');
+      await nextFrame();
+      icon.style.width = '100px';
+      icon.style.height = '100px';
+      await nextFrame(icon);
+      await nextFrame(icon);
+      expect(icon.style.getPropertyValue('--_vaadin-font-icon-size')).to.equal('');
     });
   });
 });


### PR DESCRIPTION
## Description

The container queries fallback mechanism in `<vaadin-icon>` only needs to be used with font icons. In the case of working with SVG icons, it doesn't need to do anything.

This PR changes the logic so that the heavy lifting of the fallback mechanism is only active when font icons are used (either `font` or `char` property is set).

Part of https://github.com/vaadin/web-components/issues/6212

## Type of change

- Bugfix (performance)