### PR TITLE
fix: do not scroll to the first column on focus

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -682,7 +682,26 @@ export const KeyboardNavigationMixin = (superClass) =>
         }
       }
 
-      return tabOrder[index];
+      let focusStepTarget = tabOrder[index];
+
+      // If the target focusable is tied to a column that is not visible,
+      // find the first visible column and update the target in order to
+      // prevent scrolling to the start of the row.
+      if (focusStepTarget && focusStepTarget._column && !this.__isColumnInViewport(focusStepTarget._column)) {
+        const firstVisibleColumn = this._getColumnsInOrder().find((column) => this.__isColumnInViewport(column));
+        if (firstVisibleColumn) {
+          if (focusStepTarget === this._headerFocusable) {
+            focusStepTarget = firstVisibleColumn._headerCell;
+          } else if (focusStepTarget === this._itemsFocusable) {
+            const rowIndex = focusStepTarget._column._cells.indexOf(focusStepTarget);
+            focusStepTarget = firstVisibleColumn._cells[rowIndex];
+          } else if (focusStepTarget === this._footerFocusable) {
+            focusStepTarget = firstVisibleColumn._footerCell;
+          }
+        }
+      }
+
+      return focusStepTarget;
     }
 
     /** @private */

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1118,6 +1118,34 @@ describe('keyboard navigation', () => {
         left();
         expect(grid.$.table.scrollLeft).to.equal(0);
       });
+
+      it('should not scroll to the start when tabbed from header to body', () => {
+        tabToHeader();
+        end();
+        tab();
+        expect(grid.$.table.scrollLeft).to.be.at.least(100);
+      });
+
+      it('should not scroll to the start when shift-tabbed from footer to body', () => {
+        shiftTabToFooter();
+        end();
+        shiftTab();
+        expect(grid.$.table.scrollLeft).to.be.at.least(100);
+      });
+
+      it('should not scroll to the start when tabbed from body to footer', () => {
+        tabToBody();
+        end();
+        tab();
+        expect(grid.$.table.scrollLeft).to.be.at.least(100);
+      });
+
+      it('should not scroll to the start when shift-tabbed from body to header', () => {
+        tabToBody();
+        end();
+        shiftTab();
+        expect(grid.$.table.scrollLeft).to.be.at.least(100);
+      });
     });
 
     describe('vertical scrolling', () => {


### PR DESCRIPTION
## Description

When focusing on the grid by clicking on the horizontal scroll or tabbing between the focusable elements of the grid, it always scrolls back to the start of the grid. 

This PR updates the focus target prediction logic in order to prevent scrolling to the start of the row. If the target focusable is tied to a column that is not visible:
- find the first visible column
- update the target based on the type of the focusable (header, body, or footer)

Fixes #6405 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.