### PR TITLE
refactor!: reject steps incompatible with formatter, show a warning

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -679,7 +679,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   }
 
   __stepChanged(step) {
-    if (step === undefined) {
+    if (step == null) {
       return;
     }
 
@@ -690,10 +690,13 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       (step % (60 * 60) !== 0 && !parsedObj.minutes)
     ) {
       console.warn(
-        `<vaadin-time-picker> The step ${step} seconds is not compatible with the provided time formatter, so it has been unset.`,
+        `<vaadin-time-picker> The step ${step} seconds has been rejected because it's not compatible with the provided time formatter.`,
       );
-      this.step = undefined;
+      this.step = this.__previousStep;
+      return;
     }
+
+    this.__previousStep = step;
   }
 
   /** @private */

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -678,6 +678,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     this.validate();
   }
 
+  /** @private */
   __stepChanged(step) {
     if (step == null) {
       return;

--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -106,42 +106,6 @@ describe('keyboard navigation', () => {
       arrowUp(inputElement);
       expect(spy.callCount).to.eql(2);
     });
-
-    describe('with custom parser and formatter', () => {
-      beforeEach(() => {
-        timePicker.i18n.parseTime = (text) => {
-          const parts = text.split('.');
-          return {
-            hours: parts[0],
-            minutes: parts[1],
-          };
-        };
-        timePicker.i18n.formatTime = (time) => {
-          return `${time.hours}.${time.minutes}`;
-        };
-      });
-
-      it('should correctly add the step with custom parser and formatter', () => {
-        timePicker.value = '12:0';
-        timePicker.step = 20;
-        for (let inc = 1; inc < 4; inc++) {
-          expect(inputElement.value).to.be.equal('12.0');
-          arrowUp(inputElement);
-        }
-        expect(inputElement.value).to.be.equal('12.1');
-      });
-
-      it('should correctly subtract the step with custom parser and formatter', () => {
-        timePicker.value = '12:0';
-        timePicker.step = 20;
-        for (let inc = 1; inc < 4; inc++) {
-          arrowDown(inputElement);
-          expect(inputElement.value).to.be.equal('11.59');
-        }
-        arrowDown(inputElement);
-        expect(inputElement.value).to.be.equal('11.58');
-      });
-    });
   });
 
   describe('with dropdown', () => {

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -449,53 +449,54 @@ describe('time-picker', () => {
     describe('with custom formatter', () => {
       beforeEach(() => {
         sinon.stub(console, 'warn');
+        timePicker.step = 7200;
       });
 
       afterEach(() => {
         console.warn.restore();
       });
 
-      it('should unset and warn when step is not compatible with the formatter (milliseconds)', () => {
+      it('should reject and warn about steps incompatible with the formatter (milliseconds)', () => {
         timePicker.i18n.formatTime = ({ hours, minutes, seconds }) => `${hours}:${minutes}:${seconds}`;
 
         [0.5, 1.5, 60.5, 3600.5].forEach((step) => {
           console.warn.resetHistory();
           timePicker.step = step;
 
-          expect(timePicker.step).to.be.undefined;
+          expect(timePicker.step).to.equal(7200);
           expect(console.warn).to.be.calledOnce;
           expect(console.warn.args[0][0]).to.include(
-            `<vaadin-time-picker> The step ${step} seconds is not compatible with the provided time formatter, so it has been unset`,
+            `<vaadin-time-picker> The step ${step} seconds has been rejected because it's not compatible with the provided time formatter.`,
           );
         });
       });
 
-      it('should unset and warn when step is not compatible with the formatter (seconds)', () => {
+      it('should reject and warn about steps incompatible with the formatter (seconds)', () => {
         timePicker.i18n.formatTime = ({ hours, minutes }) => `${hours}:${minutes}`;
 
         [1, 61, 3601].forEach((step) => {
           console.warn.resetHistory();
           timePicker.step = step;
 
-          expect(timePicker.step).to.be.undefined;
+          expect(timePicker.step).to.equal(7200);
           expect(console.warn).to.be.calledOnce;
           expect(console.warn.args[0][0]).to.include(
-            `<vaadin-time-picker> The step ${step} seconds is not compatible with the provided time formatter, so it has been unset`,
+            `<vaadin-time-picker> The step ${step} seconds has been rejected because it's not compatible with the provided time formatter.`,
           );
         });
       });
 
-      it('should unset and warn when step is not compatible with the formatter (minutes)', () => {
+      it('should reject and warn about steps incompatible with the formatter (minutes)', () => {
         timePicker.i18n.formatTime = ({ hours }) => `${hours}`;
 
         [60, 3660].forEach((step) => {
           console.warn.resetHistory();
           timePicker.step = step;
 
-          expect(timePicker.step).to.be.undefined;
+          expect(timePicker.step).to.equal(7200);
           expect(console.warn).to.be.calledOnce;
           expect(console.warn.args[0][0]).to.include(
-            `<vaadin-time-picker> The step ${step} seconds is not compatible with the provided time formatter, so it has been unset`,
+            `<vaadin-time-picker> The step ${step} seconds has been rejected because it's not compatible with the provided time formatter.`,
           );
         });
       });

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -445,6 +445,61 @@ describe('time-picker', () => {
       timePicker.value = '12:12:12.100';
       expect(timePicker.value).to.be.equal('12:12:12.100');
     });
+
+    describe('with custom formatter', () => {
+      beforeEach(() => {
+        sinon.stub(console, 'warn');
+      });
+
+      afterEach(() => {
+        console.warn.restore();
+      });
+
+      it('should unset and warn when step is not compatible with the formatter (milliseconds)', () => {
+        timePicker.i18n.formatTime = ({ hours, minutes, seconds }) => `${hours}:${minutes}:${seconds}`;
+
+        [0.5, 1.5, 60.5, 3600.5].forEach((step) => {
+          console.warn.resetHistory();
+          timePicker.step = step;
+
+          expect(timePicker.step).to.be.undefined;
+          expect(console.warn).to.be.calledOnce;
+          expect(console.warn.args[0][0]).to.include(
+            `<vaadin-time-picker> The step ${step} seconds is not compatible with the provided time formatter, so it has been unset`,
+          );
+        });
+      });
+
+      it('should unset and warn when step is not compatible with the formatter (seconds)', () => {
+        timePicker.i18n.formatTime = ({ hours, minutes }) => `${hours}:${minutes}`;
+
+        [1, 61, 3601].forEach((step) => {
+          console.warn.resetHistory();
+          timePicker.step = step;
+
+          expect(timePicker.step).to.be.undefined;
+          expect(console.warn).to.be.calledOnce;
+          expect(console.warn.args[0][0]).to.include(
+            `<vaadin-time-picker> The step ${step} seconds is not compatible with the provided time formatter, so it has been unset`,
+          );
+        });
+      });
+
+      it('should unset and warn when step is not compatible with the formatter (minutes)', () => {
+        timePicker.i18n.formatTime = ({ hours }) => `${hours}`;
+
+        [60, 3660].forEach((step) => {
+          console.warn.resetHistory();
+          timePicker.step = step;
+
+          expect(timePicker.step).to.be.undefined;
+          expect(console.warn).to.be.calledOnce;
+          expect(console.warn.args[0][0]).to.include(
+            `<vaadin-time-picker> The step ${step} seconds is not compatible with the provided time formatter, so it has been unset`,
+          );
+        });
+      });
+    });
   });
 
   describe('custom functions', () => {


### PR DESCRIPTION
## Description

The PR updates `time-picker` to reject steps that the custom formatter cannot represent. When setting such a step, the component now displays a warning and restores the previous step.

> **Warning**
> It's a behavior altering change, as keyboard stepping no longer works for such steps.

Fixes https://github.com/vaadin/web-components/issues/6397

## Type of change

- [x] Refactor
