### PR TITLE
fix: correctly handle aria-hidden with nested shadow roots

### DIFF
--- a/packages/a11y-base/src/aria-hidden.js
+++ b/packages/a11y-base/src/aria-hidden.js
@@ -24,12 +24,6 @@ let markerMap = {};
 let lockCount = 0;
 
 /**
- * @param {Element | ShadowRoot} node
- * @return {Element | null}
- */
-const unwrapHost = (node) => (node ? node.host || unwrapHost(node.parentNode) : null);
-
-/**
  * @param {?Node} node
  * @return {boolean}
  */

--- a/packages/a11y-base/src/aria-hidden.js
+++ b/packages/a11y-base/src/aria-hidden.js
@@ -24,7 +24,7 @@ let markerMap = {};
 let lockCount = 0;
 
 /**
- * @param {Element | Shadow} node
+ * @param {Element | ShadowRoot} node
  * @return {Element | null}
  */
 const unwrapHost = (node) => (node ? node.host || unwrapHost(node.parentNode) : null);
@@ -60,13 +60,13 @@ const correctTargets = (parent, targets) => {
         return null;
       }
 
-      if (parent.contains(target)) {
-        return target;
-      }
+      while (target) {
+        if (parent.contains(target)) {
+          return target;
+        }
 
-      const correctedTarget = unwrapHost(target);
-      if (correctedTarget && parent.contains(correctedTarget)) {
-        return correctedTarget;
+        // Unwrap nested shadow roots
+        target = unwrapHost(target);
       }
 
       logError(target, 'is not contained inside', parent);

--- a/packages/a11y-base/src/aria-hidden.js
+++ b/packages/a11y-base/src/aria-hidden.js
@@ -60,13 +60,12 @@ const correctTargets = (parent, targets) => {
         return null;
       }
 
-      while (target) {
-        if (parent.contains(target)) {
+      let node = target;
+      while (node && node !== parent) {
+        if (parent.contains(node)) {
           return target;
         }
-
-        // Unwrap nested shadow roots
-        target = unwrapHost(target);
+        node = node.parentNode || node.host;
       }
 
       logError(target, 'is not contained inside', parent);
@@ -110,7 +109,7 @@ const applyAttributeToOthers = (originalTarget, parentNode, markerName, controlA
     }
 
     elementsToKeep.add(el);
-    keep(el.parentNode);
+    keep(el.parentNode || el.host);
   };
 
   targets.forEach(keep);
@@ -123,7 +122,9 @@ const applyAttributeToOthers = (originalTarget, parentNode, markerName, controlA
       return;
     }
 
-    [...parent.children].forEach((node) => {
+    const root = parent.shadowRoot;
+    const children = root ? [...parent.children, ...root.children] : [...parent.children];
+    children.forEach((node) => {
       // Skip elements that don't need to be hidden
       if (['template', 'script', 'style'].includes(node.localName)) {
         return;

--- a/packages/a11y-base/src/aria-hidden.js
+++ b/packages/a11y-base/src/aria-hidden.js
@@ -59,7 +59,7 @@ const correctTargets = (parent, targets) => {
         if (parent.contains(node)) {
           return target;
         }
-        node = node.parentNode || node.host;
+        node = node.getRootNode().host;
       }
 
       logError(target, 'is not contained inside', parent);

--- a/packages/a11y-base/src/aria-hidden.js
+++ b/packages/a11y-base/src/aria-hidden.js
@@ -103,6 +103,12 @@ const applyAttributeToOthers = (originalTarget, parentNode, markerName, controlA
     }
 
     elementsToKeep.add(el);
+
+    const slot = el.assignedSlot;
+    if (slot) {
+      keep(slot);
+    }
+
     keep(el.parentNode || el.host);
   };
 

--- a/packages/a11y-base/test/aria-hidden.test.js
+++ b/packages/a11y-base/test/aria-hidden.test.js
@@ -212,6 +212,22 @@ describe('aria-hidden', () => {
           expect(sibling.hasAttribute(attr)).to.be.false;
         });
 
+        it(`should set ${attr} attribute on elements except the one in deep shadow DOM`, () => {
+          const deepRoot = nested.attachShadow({ mode: 'open' });
+          const deep = document.createElement('div');
+          deepRoot.appendChild(deep);
+
+          const unhide = hideFunc(deep, parent);
+          callbacks.add(unhide);
+
+          // All the elements are hidden
+          expect(target1.getAttribute(attr)).to.equal('true');
+          expect(target2.parentNode.getAttribute(attr)).to.equal('true');
+
+          // Shadow root host isn't hidden
+          expect(sibling.hasAttribute(attr)).to.be.false;
+        });
+
         it(`should remove ${attr} attribute from elements outside the shadow DOM`, () => {
           const unhide = hideFunc(nested, parent);
 

--- a/packages/a11y-base/test/aria-hidden.test.js
+++ b/packages/a11y-base/test/aria-hidden.test.js
@@ -222,15 +222,30 @@ describe('aria-hidden', () => {
           const unhide = hideFunc(deep1, parent);
           callbacks.add(unhide);
 
-          // All the elements are hidden
-          expect(target1.getAttribute(attr)).to.equal('true');
-          expect(target2.parentNode.getAttribute(attr)).to.equal('true');
-
           // Shadow root host isn't hidden
           expect(sibling.hasAttribute(attr)).to.be.false;
+          expect(nested.hasAttribute(attr)).to.be.false;
 
           // Sibling in shadow root is hidden
           expect(deep2.hasAttribute(attr)).to.be.true;
+        });
+
+        it(`should not set ${attr} attribute on assigned slot elements of target`, () => {
+          const deepRoot = nested.attachShadow({ mode: 'open' });
+          deepRoot.innerHTML = '<slot></slot><span></span>';
+          const [slot, span] = deepRoot.children;
+
+          const deep = document.createElement('div');
+          nested.appendChild(deep);
+
+          const unhide = hideFunc(deep, parent);
+          callbacks.add(unhide);
+
+          // Slot in the shadow root isn't hidden
+          expect(slot.hasAttribute(attr)).to.be.false;
+
+          // Sibling in the shadow root is hidden
+          expect(span.hasAttribute(attr)).to.be.true;
         });
 
         it(`should remove ${attr} attribute from elements outside the shadow DOM`, () => {

--- a/packages/a11y-base/test/aria-hidden.test.js
+++ b/packages/a11y-base/test/aria-hidden.test.js
@@ -214,10 +214,12 @@ describe('aria-hidden', () => {
 
         it(`should set ${attr} attribute on elements except the one in deep shadow DOM`, () => {
           const deepRoot = nested.attachShadow({ mode: 'open' });
-          const deep = document.createElement('div');
-          deepRoot.appendChild(deep);
+          const deep1 = document.createElement('div');
+          const deep2 = document.createElement('div');
+          deepRoot.appendChild(deep1);
+          deepRoot.appendChild(deep2);
 
-          const unhide = hideFunc(deep, parent);
+          const unhide = hideFunc(deep1, parent);
           callbacks.add(unhide);
 
           // All the elements are hidden
@@ -226,6 +228,9 @@ describe('aria-hidden', () => {
 
           // Shadow root host isn't hidden
           expect(sibling.hasAttribute(attr)).to.be.false;
+
+          // Sibling in shadow root is hidden
+          expect(deep2.hasAttribute(attr)).to.be.true;
         });
 
         it(`should remove ${attr} attribute from elements outside the shadow DOM`, () => {


### PR DESCRIPTION
## Description

Fixes #6410

This PR changes the logic to unwrap shadow host recursively until we get an element contained in `<body>`.
Original library only unwraps it once - see https://github.com/theKashey/aria-hidden/commit/3dd2b665330362366a6712553097aec564398400 for the implementation.

UPD: the second commit in the PR changes the above behavior to consider elements in shadow root.
This is done in order to allow `aria-hidden` to be set on the shadow root target's sibling elements.

## Type of change

- Bugfix