### PR TITLE
test: improve test coverage for value commit scenarios

### DIFF
--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDown, arrowUp, enter, esc, fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
@@ -7,31 +7,6 @@ import '../vaadin-time-picker.js';
 
 describe('events', () => {
   let timePicker;
-
-  describe('change event', () => {
-    let changeSpy, inputElement;
-
-    beforeEach(() => {
-      timePicker = fixtureSync(`<vaadin-time-picker></vaadin-time-picker>`);
-      inputElement = timePicker.inputElement;
-      changeSpy = sinon.spy();
-      timePicker.addEventListener('change', changeSpy);
-    });
-
-    it('should not be fired on programmatic value change after manual one', () => {
-      timePicker.value = '00:00';
-      timePicker.open();
-      inputElement.value = '';
-      arrowDown(inputElement);
-      arrowDown(inputElement);
-      enter(inputElement);
-      expect(changeSpy.calledOnce).to.be.true;
-      // Mimic native change happening on text-field blur
-      document.body.click();
-      timePicker.value = '02:00';
-      expect(changeSpy.calledOnce).to.be.true;
-    });
-  });
 
   describe('has-input-value-changed event', () => {
     let clearButton, hasInputValueChangedSpy, valueChangedSpy;

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -18,11 +18,6 @@ describe('events', () => {
       timePicker.addEventListener('change', changeSpy);
     });
 
-    it('should not be fired on programmatic value change', () => {
-      timePicker.value = '01:00';
-      expect(changeSpy.called).to.be.false;
-    });
-
     it('should not be fired on programmatic value change after manual one', () => {
       timePicker.value = '00:00';
       timePicker.open();
@@ -45,17 +40,6 @@ describe('events', () => {
 
       await sendKeys({ press: 'Backspace' });
       await sendKeys({ press: 'Enter' });
-      expect(changeSpy).to.be.calledOnce;
-    });
-
-    it('should not be fired again on blur if the value has not changed', async () => {
-      timePicker.step = 0.5;
-      inputElement.focus();
-
-      await sendKeys({ press: 'ArrowDown' });
-      expect(changeSpy).to.be.calledOnce;
-
-      inputElement.blur();
       expect(changeSpy).to.be.calledOnce;
     });
   });

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -31,17 +31,6 @@ describe('events', () => {
       timePicker.value = '02:00';
       expect(changeSpy.calledOnce).to.be.true;
     });
-
-    it('should not be fired again on Enter if the value has not changed', async () => {
-      inputElement.focus();
-      await sendKeys({ type: '10:00' });
-      await sendKeys({ press: 'Enter' });
-      expect(changeSpy).to.be.calledOnce;
-
-      await sendKeys({ press: 'Backspace' });
-      await sendKeys({ press: 'Enter' });
-      expect(changeSpy).to.be.calledOnce;
-    });
   });
 
   describe('has-input-value-changed event', () => {

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -18,51 +18,6 @@ describe('events', () => {
       timePicker.addEventListener('change', changeSpy);
     });
 
-    it('should be fired when committing user input with Enter', async () => {
-      inputElement.focus();
-      await sendKeys({ type: '00:00' });
-      await sendKeys({ press: 'Enter' });
-      expect(changeSpy.calledOnce).to.be.true;
-    });
-
-    it('should be fired when selecting a time with arrows and committing with Enter', () => {
-      arrowDown(inputElement);
-      arrowDown(inputElement);
-      enter(inputElement);
-      expect(changeSpy.calledOnce).to.be.true;
-    });
-
-    it('should be fired on clear button click', () => {
-      timePicker.clearButtonVisible = true;
-      timePicker.value = '00:00';
-      timePicker.$.clearButton.click();
-      expect(changeSpy.calledOnce).to.be.true;
-    });
-
-    it('should be fired on arrow keys when no dropdown opens', () => {
-      timePicker.step = 1;
-      arrowDown(inputElement);
-      expect(changeSpy.calledOnce).to.be.true;
-      arrowUp(inputElement);
-      expect(changeSpy.calledTwice).to.be.true;
-    });
-
-    it('should be fired after value-changed event on arrow keys', () => {
-      timePicker.step = 0.5;
-      const valueChangedSpy = sinon.spy();
-      timePicker.addEventListener('value-changed', valueChangedSpy);
-      arrowDown(inputElement);
-      expect(valueChangedSpy.calledOnce).to.be.true;
-      expect(changeSpy.calledOnce).to.be.true;
-      expect(valueChangedSpy.calledBefore(changeSpy)).to.be.true;
-    });
-
-    it('should not be fired on focused time change', async () => {
-      inputElement.focus();
-      await sendKeys({ type: '00:00' });
-      expect(changeSpy.called).to.be.false;
-    });
-
     it('should not be fired on programmatic value change', () => {
       timePicker.value = '01:00';
       expect(changeSpy.called).to.be.false;
@@ -80,30 +35,6 @@ describe('events', () => {
       document.body.click();
       timePicker.value = '02:00';
       expect(changeSpy.calledOnce).to.be.true;
-    });
-
-    it('should not be fired on Enter if the value has not changed', () => {
-      timePicker.value = '01:00';
-      timePicker.open();
-      enter(inputElement);
-      expect(changeSpy.called).to.be.false;
-    });
-
-    it('should not be fired on revert', () => {
-      timePicker.open();
-      timePicker.value = '01:00';
-      esc(inputElement);
-      esc(inputElement);
-      expect(changeSpy.called).to.be.false;
-    });
-
-    it('should be fired only once', async () => {
-      timePicker.focus();
-      timePicker.open();
-      await sendKeys({ type: '0' });
-      enter(inputElement);
-      inputElement.blur();
-      expect(changeSpy.callCount).to.equal(1);
     });
 
     it('should not be fired again on Enter if the value has not changed', async () => {
@@ -126,24 +57,6 @@ describe('events', () => {
 
       inputElement.blur();
       expect(changeSpy).to.be.calledOnce;
-    });
-
-    it('should not be fired on Enter after value set programmatically', async () => {
-      timePicker.value = '10:00';
-      inputElement.focus();
-
-      await sendKeys({ press: 'Backspace' });
-      await sendKeys({ press: 'Enter' });
-      expect(changeSpy.called).to.be.false;
-    });
-
-    it('should be fired on Enter when trying to commit bad input and field has value', async () => {
-      timePicker.value = '10:00';
-      inputElement.focus();
-      inputElement.select();
-      await sendKeys({ type: 'foo' });
-      await sendKeys({ press: 'Enter' });
-      expect(changeSpy.calledOnce).to.be.true;
     });
   });
 

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -37,25 +37,10 @@ describe('time-picker', () => {
       expect(timePicker.value).to.be.equal('');
     });
 
-    it('should not set value if the format is invalid', () => {
-      setInputValue(timePicker, 'invalid');
-      enter(inputElement);
-      expect(timePicker.value).to.be.equal('');
-      expect(inputElement.value).to.be.equal('invalid');
-    });
-
     it('should not allow setting invalid value programmatically', () => {
       timePicker.value = 'invalid';
       expect(timePicker.value).to.be.equal('');
       expect(inputElement.value).to.be.equal('');
-    });
-
-    it('should change value to empty string when setting invalid value', () => {
-      setInputValue(timePicker, '09:00');
-      enter(inputElement);
-      setInputValue(timePicker, 'invalid');
-      enter(inputElement);
-      expect(timePicker.value).to.be.equal('');
     });
 
     it('should not allow setting invalid time value', () => {
@@ -91,30 +76,10 @@ describe('time-picker', () => {
       expect(inputElement.value).to.be.equal('12:00');
     });
 
-    it('should preserve invalid input value while resetting value to empty string', () => {
-      timePicker.value = '12:00';
-      setInputValue(timePicker, 'foo');
-      enter(inputElement);
-      expect(timePicker.value).to.equal('');
-      expect(inputElement.value).to.equal('foo');
-    });
-
-    it('should not restore the previous value in input field if input value is invalid', () => {
+    it('should restore the previous value when setting invalid value', () => {
       timePicker.value = '12:00';
       timePicker.value = 'foo';
       expect(timePicker.value).to.be.equal('12:00');
-      setInputValue(timePicker, 'bar');
-      enter(inputElement);
-      expect(timePicker.value).to.be.equal('');
-      expect(inputElement.value).to.be.equal('bar');
-    });
-
-    it('should set empty value on outside click after clearing input value', () => {
-      timePicker.value = '12:00';
-      setInputValue(timePicker, '');
-      outsideClick();
-      expect(timePicker.value).to.be.equal('');
-      expect(inputElement.value).to.be.equal('');
     });
 
     it('should dispatch value-changed when value changes', () => {
@@ -122,13 +87,6 @@ describe('time-picker', () => {
       timePicker.addEventListener('value-changed', spy);
       timePicker.value = '12:00';
       expect(spy.calledOnce).to.be.true;
-    });
-
-    it('should not call value-changed on keystroke input', () => {
-      const spy = sinon.spy();
-      timePicker.addEventListener('value-changed', spy);
-      inputElement.value = '12:00';
-      expect(spy.called).to.be.false;
     });
 
     it('should be possible to update value', () => {
@@ -172,14 +130,6 @@ describe('time-picker', () => {
       expect(spy.callCount).to.equal(1);
       timePicker.value = '';
       expect(spy.callCount).to.equal(2);
-    });
-
-    it('should commit user input on Enter', async () => {
-      inputElement.focus();
-      await sendKeys({ type: '00:00' });
-      expect(timePicker.value).to.equal('');
-      await sendKeys({ press: 'Enter' });
-      expect(timePicker.value).to.equal('00:00');
     });
 
     it('should clear value with null', () => {

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -278,13 +278,6 @@ describe('time-picker', () => {
       timePicker.clearButtonVisible = false;
       expect(comboBox.clearButtonVisible).to.be.false;
     });
-
-    it('should clear value on Escape if clear button is visible', async () => {
-      timePicker.value = '00:00';
-      inputElement.focus();
-      await sendKeys({ press: 'Escape' });
-      expect(timePicker.value).to.equal('');
-    });
   });
 
   describe('toggle button', () => {

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -86,70 +86,6 @@ describe('validation', () => {
       expect(timePicker.validate()).to.be.true;
     });
 
-    it('should not validate on user input', () => {
-      setInputValue(timePicker, '12:00');
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should validate on blur', () => {
-      input.focus();
-      input.blur();
-      expect(validateSpy.calledOnce).to.be.true;
-    });
-
-    it('should validate on outside click', () => {
-      input.focus();
-      input.click();
-      outsideClick();
-      expect(validateSpy.calledOnce).to.be.true;
-    });
-
-    it('should validate before change event on outside click', () => {
-      input.focus();
-      input.click();
-      setInputValue(timePicker, '12:00');
-      outsideClick();
-      expect(changeSpy.calledOnce).to.be.true;
-      expect(validateSpy.calledOnce).to.be.true;
-      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
-    });
-
-    it('should validate without change event on bad input', () => {
-      input.focus();
-      input.click();
-      setInputValue(timePicker, 'foo');
-      outsideClick();
-      expect(changeSpy.called).to.be.false;
-      expect(validateSpy.calledOnce).to.be.true;
-    });
-
-    it('should validate before change event on blur', () => {
-      input.focus();
-      setInputValue(timePicker, '12:00');
-      input.blur();
-      expect(changeSpy.calledOnce).to.be.true;
-      expect(validateSpy.calledOnce).to.be.true;
-      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
-    });
-
-    it('should validate before change event on Enter', () => {
-      setInputValue(timePicker, '12:00');
-      enter(timePicker.inputElement);
-      expect(changeSpy.calledOnce).to.be.true;
-      expect(validateSpy.calledOnce).to.be.true;
-      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
-    });
-
-    it('should validate before change event on clear button click', () => {
-      timePicker.clearButtonVisible = true;
-      timePicker.value = '12:00';
-      validateSpy.resetHistory();
-      timePicker.$.clearButton.click();
-      expect(changeSpy.calledOnce).to.be.true;
-      expect(validateSpy.calledOnce).to.be.true;
-      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
-    });
-
     it('should not validate on min change without value', () => {
       timePicker.min = '12:00';
       expect(validateSpy.called).to.be.false;
@@ -194,32 +130,6 @@ describe('validation', () => {
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
     });
-
-    describe('with step', () => {
-      beforeEach(() => {
-        timePicker.step = 1;
-      });
-
-      it('should validate between value-changed and change events on ArrowDown', async () => {
-        input.focus();
-        await sendKeys({ press: 'ArrowDown' });
-        expect(valueChangedSpy).to.be.calledOnce;
-        expect(validateSpy).to.be.calledOnce;
-        expect(validateSpy).to.be.calledAfter(valueChangedSpy);
-        expect(changeSpy).to.be.calledOnce;
-        expect(changeSpy).to.be.calledAfter(validateSpy);
-      });
-
-      it('should validate between value-changed and change events on ArrowUp', async () => {
-        input.focus();
-        await sendKeys({ press: 'ArrowUp' });
-        expect(valueChangedSpy).to.be.calledOnce;
-        expect(validateSpy).to.be.calledOnce;
-        expect(validateSpy).to.be.calledAfter(valueChangedSpy);
-        expect(changeSpy).to.be.calledOnce;
-        expect(changeSpy).to.be.calledAfter(validateSpy);
-      });
-    });
   });
 
   describe('input value', () => {
@@ -260,20 +170,6 @@ describe('validation', () => {
       timePicker.value = '12:00';
       expect(timePicker.checkValidity()).to.be.true;
     });
-
-    it('should be valid when committing a non-empty value', () => {
-      setInputValue(timePicker, '12:00');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.false;
-    });
-
-    it('should be invalid when committing an empty value', () => {
-      setInputValue(timePicker, '12:00');
-      enter(timePicker.inputElement);
-      setInputValue(timePicker, '');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.true;
-    });
   });
 
   describe('min', () => {
@@ -298,24 +194,6 @@ describe('validation', () => {
     it('should pass validation with a value = min', () => {
       timePicker.value = '10:00';
       expect(timePicker.checkValidity()).to.be.true;
-    });
-
-    it('should be invalid when committing a value < min', () => {
-      setInputValue(timePicker, '08:00');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.true;
-    });
-
-    it('should be valid when committing a value > min', () => {
-      setInputValue(timePicker, '12:00');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.false;
-    });
-
-    it('should be valid when committing a value = min', () => {
-      setInputValue(timePicker, '10:00');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.false;
     });
   });
 
@@ -342,24 +220,6 @@ describe('validation', () => {
       timePicker.value = '10:00';
       expect(timePicker.checkValidity()).to.be.true;
     });
-
-    it('should be invalid when committing a value > max', () => {
-      setInputValue(timePicker, '12:00');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.true;
-    });
-
-    it('should be valid when committing a value < max', () => {
-      setInputValue(timePicker, '08:00');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.false;
-    });
-
-    it('should be valid when committing a value = max', () => {
-      setInputValue(timePicker, '10:00');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.false;
-    });
   });
 
   describe('pattern', () => {
@@ -379,18 +239,6 @@ describe('validation', () => {
     it('should pass validation with a value matching the pattern', () => {
       timePicker.value = '10:00';
       expect(timePicker.checkValidity()).to.be.true;
-    });
-
-    it('should be invalid when committing a value not matching the pattern', () => {
-      setInputValue(timePicker, '20:00');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.true;
-    });
-
-    it('should be valid when committing a value matching the pattern', () => {
-      setInputValue(timePicker, '10:00');
-      enter(timePicker.inputElement);
-      expect(timePicker.invalid).to.be.false;
     });
   });
 

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, fixtureSync, focusout, nextRender, outsideClick } from '@vaadin/testing-helpers';
-import { sendKeys } from '@web/test-runner-commands';
+import { enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { TimePicker } from '../src/vaadin-time-picker.js';
 import { setInputValue } from './helpers.js';

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -164,22 +164,22 @@ describe('value commit', () => {
         await sendKeys({ press: 'Backspace' });
       });
 
-      it('should not commit but validate on blur after clearing', () => {
+      it('should not commit but validate on blur', () => {
         timePicker.blur();
         expectValidationOnly();
       });
 
-      it('should not commit but validate on Enter after clearing', async () => {
+      it('should not commit but validate on Enter', async () => {
         await sendKeys({ press: 'Enter' });
         expectValidationOnly();
       });
 
-      it('should not commit but validate on close with outside click after clearing', () => {
+      it('should not commit but validate on close with outside click', () => {
         outsideClick();
         expectValidationOnly();
       });
 
-      it('should revert and validate on close with Escape after clearing', async () => {
+      it('should revert and validate on close with Escape', async () => {
         await sendKeys({ press: 'Escape' });
         expectValidationOnly();
         expect(timePicker.inputElement.value).to.equal('INVALID');
@@ -309,22 +309,22 @@ describe('value commit', () => {
         await sendKeys({ press: 'Backspace' });
       });
 
-      it('should commit on blur after clearing', () => {
+      it('should commit on blur', () => {
         timePicker.blur();
         expectValueCommit('');
       });
 
-      it('should commit on Enter after clearing', async () => {
+      it('should commit on Enter', async () => {
         await sendKeys({ press: 'Enter' });
         expectValueCommit('');
       });
 
-      it('should commit on outside click after clearing', () => {
+      it('should commit on outside click', () => {
         outsideClick();
         expectValueCommit('');
       });
 
-      it('should revert and validate on close with Escape after clearing', async () => {
+      it('should revert and validate on close with Escape', async () => {
         await sendKeys({ press: 'Escape' });
         expectValidationOnly();
         expect(timePicker.inputElement.value).to.equal(initialInputElementValue);

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -1,0 +1,326 @@
+import { expect } from '@esm-bundle/chai';
+import { aTimeout, fixtureSync, nextRender, outsideClick, tap } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import '../src/vaadin-time-picker.js';
+import { getAllItems } from './helpers.js';
+
+describe('value commit', () => {
+  let timePicker, valueChangedSpy, validateSpy, changeSpy;
+
+  function expectNoValueCommit() {
+    expect(valueChangedSpy).to.be.not.called;
+    expect(validateSpy).to.be.not.called;
+    expect(changeSpy).to.be.not.called;
+  }
+
+  function expectValueCommit(value) {
+    expect(valueChangedSpy).to.be.calledOnce;
+    expect(validateSpy).to.be.calledOnce;
+    expect(validateSpy.firstCall).to.be.calledAfter(valueChangedSpy.firstCall);
+    expect(changeSpy).to.be.calledOnce;
+    expect(changeSpy.firstCall).to.be.calledAfter(validateSpy.firstCall);
+    expect(timePicker.value).to.equal(value);
+  }
+
+  function expectValidationOnly() {
+    expect(valueChangedSpy).to.be.not.called;
+    expect(validateSpy).to.be.calledOnce;
+    expect(changeSpy).to.be.not.called;
+  }
+
+  beforeEach(async () => {
+    timePicker = fixtureSync(`<vaadin-time-picker></vaadin-time-picker>`);
+    await nextRender();
+    validateSpy = sinon.spy(timePicker, 'validate').named('validateSpy');
+
+    valueChangedSpy = sinon.spy().named('valueChangedSpy');
+    timePicker.addEventListener('value-changed', valueChangedSpy);
+
+    changeSpy = sinon.spy().named('changeSpy');
+    timePicker.addEventListener('change', changeSpy);
+
+    timePicker.focus();
+  });
+
+  describe('default', () => {
+    it('should not commit but validate on blur', () => {
+      timePicker.blur();
+      expectValidationOnly();
+    });
+
+    it('should not commit but validate on Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expectValidationOnly();
+    });
+
+    it('should not commit on Escape', async () => {
+      await sendKeys({ press: 'Escape' });
+      expectNoValueCommit();
+    });
+
+    it('should not commit but validate on close with outside click', () => {
+      timePicker.click();
+      outsideClick();
+      expectValidationOnly();
+    });
+
+    it('should not commit but validate on close with Escape', async () => {
+      timePicker.click();
+      await sendKeys({ press: 'Escape' });
+      expectValidationOnly();
+    });
+  });
+
+  describe('entering parsable input', () => {
+    beforeEach(async () => {
+      await sendKeys({ type: '12:00' });
+    });
+
+    it('should commit on blur', () => {
+      timePicker.blur();
+      expectValueCommit('12:00');
+    });
+
+    it('should commit on Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expectValueCommit('12:00');
+    });
+
+    it('should commit on close with outside click', () => {
+      outsideClick();
+      expectValueCommit('12:00');
+    });
+
+    it('should revert and validate on close with Escape', async () => {
+      await sendKeys({ press: 'Escape' });
+      await sendKeys({ press: 'Escape' });
+      expectValidationOnly();
+      expect(timePicker.inputElement.value).to.equal('');
+    });
+  });
+
+  describe('entering unparsable input', () => {
+    beforeEach(async () => {
+      await sendKeys({ type: 'INVALID' });
+    });
+
+    it('should not commit but validate on blur', () => {
+      timePicker.blur();
+      expectValidationOnly();
+      expect(timePicker.inputElement.value).to.equal('INVALID');
+    });
+
+    it('should not commit but validate on Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expectValidationOnly();
+      expect(timePicker.inputElement.value).to.equal('INVALID');
+    });
+
+    it('should not commit but validate on close with outside click', () => {
+      outsideClick();
+      expectValidationOnly();
+      expect(timePicker.inputElement.value).to.equal('INVALID');
+    });
+
+    it('should revert and validate on close with Escape', async () => {
+      await sendKeys({ press: 'Escape' });
+      await sendKeys({ press: 'Escape' });
+      expectValidationOnly();
+      expect(timePicker.inputElement.value).to.equal('');
+    });
+
+    describe('clearing input with Backspace', () => {
+      beforeEach(async () => {
+        await sendKeys({ press: 'Enter' });
+        valueChangedSpy.resetHistory();
+        validateSpy.resetHistory();
+
+        timePicker.inputElement.select();
+        await sendKeys({ press: 'Backspace' });
+      });
+
+      it('should not commit but validate on blur after clearing', () => {
+        timePicker.blur();
+        expectValidationOnly();
+      });
+
+      it('should not commit but validate on Enter after clearing', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValidationOnly();
+      });
+
+      it('should not commit but validate on close with outside click after clearing', () => {
+        outsideClick();
+        expectValidationOnly();
+      });
+
+      it('should revert and validate on close with Escape after clearing', async () => {
+        await sendKeys({ press: 'Escape' });
+        expectValidationOnly();
+        expect(timePicker.inputElement.value).to.equal('INVALID');
+      });
+    });
+  });
+
+  describe('overlay', () => {
+    beforeEach(async () => {
+      timePicker.click();
+      await sendKeys({ press: 'ArrowDown' });
+    });
+
+    it('should commit on selection with click', () => {
+      getAllItems(timePicker)[0].click();
+      expectValueCommit('00:00');
+    });
+
+    it('should commit on selection with Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expectValueCommit('00:00');
+    });
+  });
+
+  describe('with value', () => {
+    let initialInputElementValue;
+
+    beforeEach(() => {
+      timePicker.value = '00:00';
+      initialInputElementValue = timePicker.inputElement.value;
+      valueChangedSpy.resetHistory();
+      validateSpy.resetHistory();
+    });
+
+    describe('default', () => {
+      it('should not commit but validate on blur', () => {
+        timePicker.blur();
+        expectValidationOnly();
+      });
+
+      it('should not commit but validate on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValidationOnly();
+      });
+
+      it('should not commit on Escape', async () => {
+        await sendKeys({ press: 'Escape' });
+        expectNoValueCommit();
+      });
+
+      it('should not commit but validate on close with outside click', async () => {
+        timePicker.click();
+        outsideClick();
+        expectValidationOnly();
+      });
+
+      it('should not commit but validate on close with Escape', async () => {
+        timePicker.click();
+        await sendKeys({ press: 'Escape' });
+        expectValidationOnly();
+      });
+    });
+
+    describe('entering parsable input', () => {
+      beforeEach(async () => {
+        timePicker.inputElement.select();
+        await sendKeys({ type: '12:00' });
+      });
+
+      it('should commit on blur', async () => {
+        timePicker.blur();
+        expectValueCommit('12:00');
+      });
+
+      it('should commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValueCommit('12:00');
+      });
+
+      it('should commit on close with outside click', () => {
+        outsideClick();
+        expectValueCommit('12:00');
+      });
+
+      it('should revert and validate on close with Escape', async () => {
+        await sendKeys({ press: 'Escape' });
+        await sendKeys({ press: 'Escape' });
+        expectValidationOnly();
+        expect(timePicker.inputElement.value).to.equal(initialInputElementValue);
+      });
+    });
+
+    describe('entering unparsable input', () => {
+      beforeEach(async () => {
+        timePicker.inputElement.select();
+        await sendKeys({ type: 'INVALID' });
+      });
+
+      it('should commit an empty value on blur', async () => {
+        timePicker.blur();
+        expectValueCommit('');
+        expect(timePicker.inputElement.value).to.equal('INVALID');
+      });
+
+      it('should commit an empty value on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValueCommit('');
+        expect(timePicker.inputElement.value).to.equal('INVALID');
+      });
+
+      it('should commit an empty value on close with outside click', () => {
+        outsideClick();
+        expectValueCommit('');
+        expect(timePicker.inputElement.value).to.equal('INVALID');
+      });
+
+      it('should revert and validate on close with Escape', async () => {
+        await sendKeys({ press: 'Escape' });
+        expectValidationOnly();
+        expect(timePicker.inputElement.value).to.equal(initialInputElementValue);
+      });
+    });
+
+    describe('clearing input with Backspace', () => {
+      beforeEach(async () => {
+        timePicker.inputElement.select();
+        await sendKeys({ press: 'Backspace' });
+      });
+
+      it('should commit on blur after clearing', () => {
+        timePicker.blur();
+        expectValueCommit('');
+      });
+
+      it('should commit on Enter after clearing', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValueCommit('');
+      });
+
+      it('should commit on outside click after clearing', async () => {
+        outsideClick();
+        expectValueCommit('');
+      });
+
+      it('should revert and validate on close with Escape after clearing', async () => {
+        await sendKeys({ press: 'Escape' });
+        expectValidationOnly();
+        expect(timePicker.inputElement.value).to.equal(initialInputElementValue);
+      });
+    });
+
+    describe('with clear button', () => {
+      beforeEach(() => {
+        timePicker.clearButtonVisible = true;
+      });
+
+      it('should clear on clear button click', () => {
+        timePicker.$.clearButton.click();
+        expectValueCommit('');
+      });
+
+      it('should clear on Escape', async () => {
+        await sendKeys({ press: 'Escape' });
+        expectValueCommit('');
+      });
+    });
+  });
+});

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -88,7 +88,7 @@ describe('value commit', () => {
     });
   });
 
-  describe('entering parsable input', () => {
+  describe('parsable input entered', () => {
     beforeEach(async () => {
       await sendKeys({ type: '12:00' });
     });
@@ -122,9 +122,47 @@ describe('value commit', () => {
     });
   });
 
-  describe('entering unparsable input', () => {
+  describe('parsable input committed', () => {
     beforeEach(async () => {
-      await sendKeys({ type: 'INVALID' });
+      await sendKeys({ type: '12:00' });
+      await sendKeys({ press: 'Enter' });
+      valueChangedSpy.resetHistory();
+      validateSpy.resetHistory();
+      changeSpy.resetHistory();
+    });
+
+    describe('input cleared with Backspace', () => {
+      beforeEach(async () => {
+        timePicker.inputElement.select();
+        await sendKeys({ press: 'Backspace' });
+      });
+
+      it('should commit on blur', () => {
+        timePicker.blur();
+        expectValueCommit('');
+      });
+
+      it('should commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValueCommit('');
+      });
+
+      it('should commit on outside click', () => {
+        outsideClick();
+        expectValueCommit('');
+      });
+
+      it('should revert and validate on close with Escape', async () => {
+        await sendKeys({ press: 'Escape' });
+        expectValidationOnly();
+        expect(timePicker.inputElement.value).to.equal('12:00');
+      });
+    });
+  });
+
+  describe('unparsable input entered', () => {
+    beforeEach(async () => {
+      await sendKeys({ type: 'foo' });
     });
 
     it('should not commit by default', () => {
@@ -134,19 +172,19 @@ describe('value commit', () => {
     it('should not commit but validate on blur', () => {
       timePicker.blur();
       expectValidationOnly();
-      expect(timePicker.inputElement.value).to.equal('INVALID');
+      expect(timePicker.inputElement.value).to.equal('foo');
     });
 
     it('should not commit but validate on Enter', async () => {
       await sendKeys({ press: 'Enter' });
       expectValidationOnly();
-      expect(timePicker.inputElement.value).to.equal('INVALID');
+      expect(timePicker.inputElement.value).to.equal('foo');
     });
 
     it('should not commit but validate on close with outside click', () => {
       outsideClick();
       expectValidationOnly();
-      expect(timePicker.inputElement.value).to.equal('INVALID');
+      expect(timePicker.inputElement.value).to.equal('foo');
     });
 
     it('should revert and validate on close with Escape', async () => {
@@ -154,13 +192,17 @@ describe('value commit', () => {
       expectValidationOnly();
       expect(timePicker.inputElement.value).to.equal('');
     });
+  });
 
-    describe('clearing input with Backspace', () => {
+  describe('unparsable input committed', () => {
+    beforeEach(async () => {
+      await sendKeys({ type: 'foo' });
+      await sendKeys({ press: 'Enter' });
+      validateSpy.resetHistory();
+    });
+
+    describe('input cleared with Backspace', () => {
       beforeEach(async () => {
-        await sendKeys({ press: 'Enter' });
-        valueChangedSpy.resetHistory();
-        validateSpy.resetHistory();
-
         timePicker.inputElement.select();
         await sendKeys({ press: 'Backspace' });
       });
@@ -183,7 +225,7 @@ describe('value commit', () => {
       it('should revert and validate on close with Escape', async () => {
         await sendKeys({ press: 'Escape' });
         expectValidationOnly();
-        expect(timePicker.inputElement.value).to.equal('INVALID');
+        expect(timePicker.inputElement.value).to.equal('foo');
       });
     });
   });
@@ -194,28 +236,28 @@ describe('value commit', () => {
       await sendKeys({ press: 'ArrowDown' });
     });
 
-    it('should commit on selection with click', () => {
+    it('should commit on item selection with click', () => {
       getAllItems(timePicker)[0].click();
       expectValueCommit('00:00');
     });
 
-    it('should commit on selection with Enter', async () => {
+    it('should commit on item selection with Enter', async () => {
       await sendKeys({ press: 'Enter' });
       expectValueCommit('00:00');
     });
   });
 
-  describe('with value', () => {
-    let initialInputElementValue;
-
+  describe('value set programmatically', () => {
     beforeEach(() => {
       timePicker.value = '00:00';
-      initialInputElementValue = timePicker.inputElement.value;
       valueChangedSpy.resetHistory();
-      validateSpy.resetHistory();
     });
 
     describe('default', () => {
+      it('should not commit by default', () => {
+        expectNoValueCommit();
+      });
+
       it('should not commit but validate on blur', () => {
         timePicker.blur();
         expectValidationOnly();
@@ -244,7 +286,7 @@ describe('value commit', () => {
       });
     });
 
-    describe('entering parsable input', () => {
+    describe('parsable input entered', () => {
       beforeEach(async () => {
         timePicker.inputElement.select();
         await sendKeys({ type: '12:00' });
@@ -271,83 +313,57 @@ describe('value commit', () => {
         // Close the dropdown.
         await sendKeys({ press: 'Escape' });
         expectValidationOnly();
-        expect(timePicker.inputElement.value).to.equal(initialInputElementValue);
+        expect(timePicker.inputElement.value).to.equal('00:00');
       });
     });
 
-    describe('entering unparsable input', () => {
+    describe('unparsable input entered', () => {
       beforeEach(async () => {
         timePicker.inputElement.select();
-        await sendKeys({ type: 'INVALID' });
+        await sendKeys({ type: 'foo' });
       });
 
       it('should commit an empty value on blur', () => {
         timePicker.blur();
         expectValueCommit('');
-        expect(timePicker.inputElement.value).to.equal('INVALID');
+        expect(timePicker.inputElement.value).to.equal('foo');
       });
 
       it('should commit an empty value on Enter', async () => {
         await sendKeys({ press: 'Enter' });
         expectValueCommit('');
-        expect(timePicker.inputElement.value).to.equal('INVALID');
+        expect(timePicker.inputElement.value).to.equal('foo');
       });
 
       it('should commit an empty value on close with outside click', () => {
         outsideClick();
         expectValueCommit('');
-        expect(timePicker.inputElement.value).to.equal('INVALID');
+        expect(timePicker.inputElement.value).to.equal('foo');
       });
 
       it('should revert and validate on close with Escape', async () => {
         await sendKeys({ press: 'Escape' });
         expectValidationOnly();
-        expect(timePicker.inputElement.value).to.equal(initialInputElementValue);
+        expect(timePicker.inputElement.value).to.equal('00:00');
       });
     });
+  });
 
-    describe('clearing input with Backspace', () => {
-      beforeEach(async () => {
-        timePicker.inputElement.select();
-        await sendKeys({ press: 'Backspace' });
-      });
-
-      it('should commit on blur', () => {
-        timePicker.blur();
-        expectValueCommit('');
-      });
-
-      it('should commit on Enter', async () => {
-        await sendKeys({ press: 'Enter' });
-        expectValueCommit('');
-      });
-
-      it('should commit on outside click', () => {
-        outsideClick();
-        expectValueCommit('');
-      });
-
-      it('should revert and validate on close with Escape', async () => {
-        await sendKeys({ press: 'Escape' });
-        expectValidationOnly();
-        expect(timePicker.inputElement.value).to.equal(initialInputElementValue);
-      });
+  describe('with clear button', () => {
+    beforeEach(() => {
+      timePicker.value = '00:00';
+      timePicker.clearButtonVisible = true;
+      valueChangedSpy.resetHistory();
     });
 
-    describe('with clear button', () => {
-      beforeEach(() => {
-        timePicker.clearButtonVisible = true;
-      });
+    it('should clear on clear button click', () => {
+      timePicker.$.clearButton.click();
+      expectValueCommit('');
+    });
 
-      it('should clear on clear button click', () => {
-        timePicker.$.clearButton.click();
-        expectValueCommit('');
-      });
-
-      it('should clear on Escape', async () => {
-        await sendKeys({ press: 'Escape' });
-        expectValueCommit('');
-      });
+    it('should clear on Escape', async () => {
+      await sendKeys({ press: 'Escape' });
+      expectValueCommit('');
     });
   });
 
@@ -366,7 +382,7 @@ describe('value commit', () => {
       expectValueCommit('23:59:59');
     });
 
-    describe('with value committed using an arrow key', () => {
+    describe('with arrow key committed', () => {
       beforeEach(async () => {
         await sendKeys({ press: 'ArrowDown' });
         valueChangedSpy.resetHistory();

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -149,7 +149,6 @@ describe('value commit', () => {
 
     it('should revert and validate on close with Escape', async () => {
       await sendKeys({ press: 'Escape' });
-      await sendKeys({ press: 'Escape' });
       expectValidationOnly();
       expect(timePicker.inputElement.value).to.equal('');
     });

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -355,20 +355,12 @@ describe('value commit', () => {
 
     it('should commit on ArrowDown', async () => {
       await sendKeys({ press: 'ArrowUp' });
-      // TODO: Fix validation
-      // expectValueCommit('00:00:01');
-      expect(valueChangedSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledAfter(valueChangedSpy);
+      expectValueCommit('00:00:01');
     });
 
     it('should commit on ArrowUp', async () => {
       await sendKeys({ press: 'ArrowDown' });
-      // TODO: Fix validation
-      // expectValueCommit('23:59:59');
-      expect(valueChangedSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledAfter(valueChangedSpy);
+      expectValueCommit('23:59:59');
     });
 
     describe('with value committed using an arrow key', () => {

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -81,9 +81,9 @@ describe('value commit', () => {
 
     it('should not commit on ArrowUp', async () => {
       // Open the dropdown
-      await sendKeys({ press: 'ArrowDown' });
+      await sendKeys({ press: 'ArrowUp' });
       // Focus an item
-      await sendKeys({ press: 'ArrowDown' });
+      await sendKeys({ press: 'ArrowUp' });
       expectNoValueCommit();
     });
   });
@@ -230,7 +230,7 @@ describe('value commit', () => {
         expectNoValueCommit();
       });
 
-      it('should not commit but validate on close with outside click', async () => {
+      it('should not commit but validate on close with outside click', () => {
         timePicker.click();
         outsideClick();
         expectValidationOnly();
@@ -249,7 +249,7 @@ describe('value commit', () => {
         await sendKeys({ type: '12:00' });
       });
 
-      it('should commit on blur', async () => {
+      it('should commit on blur', () => {
         timePicker.blur();
         expectValueCommit('12:00');
       });
@@ -278,7 +278,7 @@ describe('value commit', () => {
         await sendKeys({ type: 'INVALID' });
       });
 
-      it('should commit an empty value on blur', async () => {
+      it('should commit an empty value on blur', () => {
         timePicker.blur();
         expectValueCommit('');
         expect(timePicker.inputElement.value).to.equal('INVALID');
@@ -319,7 +319,7 @@ describe('value commit', () => {
         expectValueCommit('');
       });
 
-      it('should commit on outside click after clearing', async () => {
+      it('should commit on outside click after clearing', () => {
         outsideClick();
         expectValueCommit('');
       });
@@ -353,12 +353,12 @@ describe('value commit', () => {
       timePicker.step = 1;
     });
 
-    it('should commit on ArrowDown', async () => {
+    it('should commit on ArrowUp', async () => {
       await sendKeys({ press: 'ArrowUp' });
       expectValueCommit('00:00:01');
     });
 
-    it('should commit on ArrowUp', async () => {
+    it('should commit on ArrowDown', async () => {
       await sendKeys({ press: 'ArrowDown' });
       expectValueCommit('23:59:59');
     });

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -113,7 +113,9 @@ describe('value commit', () => {
     });
 
     it('should revert and validate on close with Escape', async () => {
+      // Remove focus from the item.
       await sendKeys({ press: 'Escape' });
+      // Close the dropdown.
       await sendKeys({ press: 'Escape' });
       expectValidationOnly();
       expect(timePicker.inputElement.value).to.equal('');
@@ -264,7 +266,9 @@ describe('value commit', () => {
       });
 
       it('should revert and validate on close with Escape', async () => {
+        // Remove focus from the item.
         await sendKeys({ press: 'Escape' });
+        // Close the dropdown.
         await sendKeys({ press: 'Escape' });
         expectValidationOnly();
         expect(timePicker.inputElement.value).to.equal(initialInputElementValue);


### PR DESCRIPTION
## Description

The idea is to create a test file that would collect all the tests related to the user committing a value. Currently, such tests are scattered across different places, making it difficult to know what might cause the value to change and feel confident about the test coverage when refactoring something.

The new tests aim to cover all main scenarios where the user commits a value using actions like blur, outside click, Enter or Escape.

Part of https://github.com/vaadin/web-components/issues/6426

## New test suite structure

```
value-commit.test.js
│
├── default
├── parsable input entered
├── parsable input committed
│   └── input cleared with Backspace
├── unparsable input entered
├── unparsable input commited
│   └── input cleared with Backspace
├── value set programmatically
│   ├── default
│   ├── parsable input entered
│   └── unparsable input entered
├── with clear button
└── with step
```

## Type of change

- [x] Internal
