### PR TITLE
fix: revert icon font-size applied by an icon font class

### DIFF
--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -241,6 +241,7 @@ class Icon extends ThemableMixin(
         ${tag}[font] {
           display: inline-flex;
           vertical-align: middle;
+          font-size: inherit;
         }
       `,
     ];

--- a/packages/icon/test/test-icon-font.js
+++ b/packages/icon/test/test-icon-font.js
@@ -22,6 +22,7 @@ export const iconFontCss = css`
     line-height: 1.5;
     display: inline-block;
     vertical-align: top;
+    font-size: 24px;
   }
 
   .icon-before::before {


### PR DESCRIPTION
## Description

`<vaadin-icon>` currently has `width: var(--lumo-icon-size-m);` as the [default in Lumo styles](https://github.com/vaadin/web-components/blob/cdab2a57b38092541ed946e0b6fe610e0ce14b9b/packages/icon/theme/lumo/vaadin-icon-styles.js#L8-L9).

The [default use of Material icons](https://developers.google.com/fonts/docs/material_icons) would apply `font-size: 24px` to the `<vaadin-icon>` element which would effectively make the icon have 36px size (= 24px * 1.5 (`--lumo-icon-size-m`)). This may be unexpected.

This PR adds `font-size: inherit` to the `<vaadin-icon>` slot styles to resolve the issue.

## Type of change

Bugfix