### PR TITLE
fix: subtract padding from the fallback font icon height

### DIFF
--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -389,7 +389,9 @@ class Icon extends ThemableMixin(
    */
   _onResize() {
     if (needsFontIconSizingFallback && (this.char || this.font)) {
-      this.style.setProperty('--_vaadin-font-icon-size', `${this.offsetHeight}px`);
+      const { paddingTop, paddingBottom, height } = getComputedStyle(this);
+      const fontIconSize = parseFloat(height) - parseFloat(paddingTop) - parseFloat(paddingBottom);
+      this.style.setProperty('--_vaadin-font-icon-size', `${fontIconSize}px`);
     }
   }
 }

--- a/packages/icon/test/icon-font.test.js
+++ b/packages/icon/test/icon-font.test.js
@@ -71,6 +71,16 @@ describe('vaadin-icon - icon fonts', () => {
       const fontIconStyle = getComputedStyle(icon, ':before');
       expect(parseInt(fontIconStyle.height)).to.be.closeTo(24, 1);
     });
+
+    it('should subtract vertical padding from height', async () => {
+      icon.style.padding = '5px';
+      await onceResized(icon);
+      expect(parseInt(getComputedStyle(icon, ':before').height)).to.be.closeTo(14, 1);
+
+      icon.style.padding = '7px';
+      await onceResized(icon);
+      expect(parseInt(getComputedStyle(icon, ':before').height)).to.be.closeTo(10, 1);
+    });
   });
 
   describe('font', () => {


### PR DESCRIPTION
## Description

Padding can be used on the `<vaadin-icon>` host element to add spacing around the wrapped icon. This generally works fine with both SVG icons and font icons.

The Container Queries [fallback mechanism](https://github.com/vaadin/web-components/blob/cdab2a57b38092541ed946e0b6fe610e0ce14b9b/packages/icon/src/vaadin-icon.js#L392) used with font icons on Safari, however, doesn't currently take padding into account in the font size calculation. This PR fixes the issue.

## Type of change

Bugfix