### PR TITLE
fix: fire change event when value changes to empty string due to bad input

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -656,12 +656,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   /** @private */
   __onComboBoxChange(event) {
     event.stopPropagation();
-
-    const { value } = event.target;
-    // Do not fire change for bad input.
-    if (value === '' || this.i18n.parseTime(value)) {
-      this.__commitPendingValue();
-    }
+    this.__commitPendingValue();
   }
 
   /**

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -136,6 +136,15 @@ describe('events', () => {
       await sendKeys({ press: 'Enter' });
       expect(changeSpy.called).to.be.false;
     });
+
+    it('should be fired on Enter when trying to commit bad input and field has value', async () => {
+      timePicker.value = '10:00';
+      inputElement.focus();
+      inputElement.select();
+      await sendKeys({ type: 'foo' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy.calledOnce).to.be.true;
+    });
   });
 
   describe('has-input-value-changed event', () => {


### PR DESCRIPTION
## Description

The PR fixes the regression where `time-picker` didn't fire a `change` event when its value changed to an empty string due to a bad input commit attempt.

Fixes #6417

## Type of change

- [x] Bugfix
