### PR TITLE
fix: fire change event on arrow keys when step >= 1

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -599,6 +599,12 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     const parsedObj = this.__parseISO(value);
     const newValue = this.__formatISO(parsedObj) || '';
 
+    // Mark value set programmatically by the user
+    // as committed for the change event detection.
+    if (!this.__skipCommittedValueUpdate) {
+      this.__committedValue = value;
+    }
+
     if (value !== '' && value !== null && !parsedObj) {
       // Value can not be parsed, reset to the old one.
       this.value = oldValue === undefined ? '' : oldValue;
@@ -611,12 +617,6 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       delete this.__keepInvalidInput;
     } else {
       this.__updateInputValue(parsedObj);
-    }
-
-    // Mark value set programmatically by the user
-    // as committed for the change event detection.
-    if (!this.__skipCommittedValueUpdate) {
-      this.__committedValue = this.value;
     }
 
     this._toggleHasValue(this._hasValue);

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -40,7 +40,7 @@ describe('events', () => {
     });
 
     it('should be fired on arrow keys when no dropdown opens', () => {
-      timePicker.step = 0.5;
+      timePicker.step = 1;
       arrowDown(inputElement);
       expect(changeSpy.calledOnce).to.be.true;
       arrowUp(inputElement);


### PR DESCRIPTION
## Description

The PR fixes the regression introduced in https://github.com/vaadin/web-components/pull/6408 which caused the change event not to be fired when `step` >= 1.

## Type of change

- [x] Bugfix
