### PR TITLE
fix: do not fire change event if the value has not changed (#6396) (CP: 24.0) 

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -666,14 +666,8 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   /** @private */
   __onComboBoxChange(event) {
     event.stopPropagation();
-
     this.validate();
-
-    const { value } = event.target;
-    // Do not fire change for bad input.
-    if (value === '' || this.i18n.parseTime(value)) {
-      this.__commitPendingValue();
-    }
+    this.__commitPendingValue();
   }
 
   /**

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -485,6 +485,14 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   }
 
   /** @private */
+  __commitPendingValue() {
+    if (this.__committedValue !== this.value) {
+      this.__dispatchChange();
+      this.__committedValue = this.value;
+    }
+  }
+
+  /** @private */
   __dispatchChange() {
     this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
   }
@@ -615,6 +623,12 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       this.__updateInputValue(parsedObj);
     }
 
+    // Mark value set programmatically by the user
+    // as committed for the change event detection.
+    if (!this.__skipCommittedValueUpdate) {
+      this.__committedValue = this.value;
+    }
+
     this._toggleHasValue(this._hasValue);
   }
 
@@ -631,7 +645,9 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       if (value !== newValue) {
         this._comboBoxValue = newValue;
       } else {
+        this.__skipCommittedValueUpdate = true;
         this.__updateValue(parsedObj);
+        this.__skipCommittedValueUpdate = false;
       }
     } else {
       // If the user input can not be parsed, set a flag
@@ -641,7 +657,9 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
         this.__keepInvalidInput = true;
       }
 
+      this.__skipCommittedValueUpdate = true;
       this.value = '';
+      this.__skipCommittedValueUpdate = false;
     }
   }
 
@@ -651,7 +669,11 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
 
     this.validate();
 
-    this.__dispatchChange();
+    const { value } = event.target;
+    // Do not fire change for bad input.
+    if (value === '' || this.i18n.parseTime(value)) {
+      this.__commitPendingValue();
+    }
   }
 
   /**

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -136,6 +136,15 @@ describe('events', () => {
       await sendKeys({ press: 'Enter' });
       expect(changeSpy.called).to.be.false;
     });
+
+    it('should be fired on Enter when trying to commit bad input and field has value', async () => {
+      timePicker.value = '10:00';
+      inputElement.focus();
+      inputElement.select();
+      await sendKeys({ type: 'foo' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy.calledOnce).to.be.true;
+    });
   });
 
   describe('has-input-value-changed event', () => {

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -105,6 +105,37 @@ describe('events', () => {
       inputElement.blur();
       expect(changeSpy.callCount).to.equal(1);
     });
+
+    it('should not be fired again on Enter if the value has not changed', async () => {
+      inputElement.focus();
+      await sendKeys({ type: '10:00' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy).to.be.calledOnce;
+
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy).to.be.calledOnce;
+    });
+
+    it('should not be fired again on blur if the value has not changed', async () => {
+      timePicker.step = 0.5;
+      inputElement.focus();
+
+      await sendKeys({ press: 'ArrowDown' });
+      expect(changeSpy).to.be.calledOnce;
+
+      inputElement.blur();
+      expect(changeSpy).to.be.calledOnce;
+    });
+
+    it('should not be fired on Enter after value set programmatically', async () => {
+      timePicker.value = '10:00';
+      inputElement.focus();
+
+      await sendKeys({ press: 'Backspace' });
+      await sendKeys({ press: 'Enter' });
+      expect(changeSpy.called).to.be.false;
+    });
   });
 
   describe('has-input-value-changed event', () => {


### PR DESCRIPTION
## Description

The PR cherry-picks the following fixes to `24.1`:

- https://github.com/vaadin/web-components/pull/6396/
- https://github.com/vaadin/web-components/pull/6420

## Type of change

- [x] Bugfix
