### PR TITLE
fix: validate on arrow keys when field has step

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -471,6 +471,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     const parsedObj = this.i18n.parseTime(this._comboBoxValue);
     const objWithStep = this.__addStep(this.__getMsec(parsedObj), step, true);
     this._comboBoxValue = this.i18n.formatTime(objWithStep);
+    this.validate();
     this.__commitPendingValue();
   }
 

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { enter, fixtureSync, focusout, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { TimePicker } from '../src/vaadin-time-picker.js';
 import { setInputValue } from './helpers.js';
@@ -190,6 +191,28 @@ describe('validation', () => {
       expect(validatedSpy.calledOnce).to.be.true;
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
+    });
+
+    describe('with step', () => {
+      beforeEach(() => {
+        timePicker.step = 1;
+      });
+
+      it('should validate before change event on ArrowDown', async () => {
+        input.focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(changeSpy).to.be.calledOnce;
+        expect(validateSpy).to.be.calledOnce;
+        expect(validateSpy).to.be.calledBefore(changeSpy);
+      });
+
+      it('should validate before change event on ArrowUp', async () => {
+        input.focus();
+        await sendKeys({ press: 'ArrowUp' });
+        expect(changeSpy).to.be.calledOnce;
+        expect(validateSpy).to.be.calledOnce;
+        expect(validateSpy).to.be.calledBefore(changeSpy);
+      });
     });
   });
 


### PR DESCRIPTION
## Description

The PR ensures `time-picker` validates when pressing <kbd>ArrowUp</kbd> / <kbd>ArrowDown</kbd> to increase / decrease the time. Validation is expected because there is a change event in that case.

## Type of change

- [x] Bugfix
