### PR TITLE
revert: "refactor!: reject steps incompatible with formatter" (#6408)

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -18,13 +18,6 @@ import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaa
 const MIN_ALLOWED_TIME = '00:00:00.000';
 const MAX_ALLOWED_TIME = '23:59:59.999';
 
-const TEST_TIME_OBJ = {
-  hours: 0,
-  minutes: 0,
-  seconds: 0,
-  milliseconds: 0,
-};
-
 registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-picker-styles' });
 
 /**
@@ -235,7 +228,6 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
        */
       step: {
         type: Number,
-        observer: '__stepChanged',
       },
 
       /**
@@ -468,9 +460,19 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
 
   /** @private */
   __onArrowPressWithStep(step) {
-    const parsedObj = this.i18n.parseTime(this._comboBoxValue);
-    const objWithStep = this.__addStep(this.__getMsec(parsedObj), step, true);
-    this._comboBoxValue = this.i18n.formatTime(objWithStep);
+    const objWithStep = this.__addStep(this.__getMsec(this.__memoValue), step, true);
+    this.__memoValue = objWithStep;
+
+    // Setting `value` property triggers the synchronous observer
+    // that in turn updates `_comboBoxValue` (actual input value)
+    // with its own observer where the value can be parsed again,
+    // so we set this flag to ensure it does not alter the value.
+    this.__useMemo = true;
+    this.__skipCommittedValueUpdate = true;
+    this.value = this.__formatISO(objWithStep);
+    this.__skipCommittedValueUpdate = false;
+    this.__useMemo = false;
+
     this.validate();
     this.__commitPendingValue();
   }
@@ -597,7 +599,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
    * @override
    */
   _valueChanged(value, oldValue) {
-    const parsedObj = this.__parseISO(value);
+    const parsedObj = (this.__memoValue = this.__parseISO(value));
     const newValue = this.__formatISO(parsedObj) || '';
 
     // Mark value set programmatically by the user
@@ -629,7 +631,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
       return;
     }
 
-    const parsedObj = this.i18n.parseTime(value);
+    const parsedObj = this.__useMemo ? this.__memoValue : this.i18n.parseTime(value);
     const newValue = this.i18n.formatTime(parsedObj) || '';
 
     if (parsedObj) {
@@ -672,28 +674,6 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   /** @private */
   __onComboBoxValidated() {
     this.validate();
-  }
-
-  /** @private */
-  __stepChanged(step) {
-    if (step == null) {
-      return;
-    }
-
-    const parsedObj = this.i18n.parseTime(this.i18n.formatTime(TEST_TIME_OBJ));
-    if (
-      (step % 1 !== 0 && !parsedObj.milliseconds) ||
-      (step % 60 !== 0 && !parsedObj.seconds) ||
-      (step % (60 * 60) !== 0 && !parsedObj.minutes)
-    ) {
-      console.warn(
-        `<vaadin-time-picker> The step ${step} seconds has been rejected because it's not compatible with the provided time formatter.`,
-      );
-      this.step = this.__previousStep;
-      return;
-    }
-
-    this.__previousStep = step;
   }
 
   /** @private */

--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -106,6 +106,42 @@ describe('keyboard navigation', () => {
       arrowUp(inputElement);
       expect(spy.callCount).to.eql(2);
     });
+
+    describe('with custom parser and formatter', () => {
+      beforeEach(() => {
+        timePicker.i18n.parseTime = (text) => {
+          const parts = text.split('.');
+          return {
+            hours: parts[0],
+            minutes: parts[1],
+          };
+        };
+        timePicker.i18n.formatTime = (time) => {
+          return `${time.hours}.${time.minutes}`;
+        };
+      });
+
+      it('should correctly add the step with custom parser and formatter', () => {
+        timePicker.value = '12:0';
+        timePicker.step = 20;
+        for (let inc = 1; inc < 4; inc++) {
+          expect(inputElement.value).to.be.equal('12.0');
+          arrowUp(inputElement);
+        }
+        expect(inputElement.value).to.be.equal('12.1');
+      });
+
+      it('should correctly subtract the step with custom parser and formatter', () => {
+        timePicker.value = '12:0';
+        timePicker.step = 20;
+        for (let inc = 1; inc < 4; inc++) {
+          arrowDown(inputElement);
+          expect(inputElement.value).to.be.equal('11.59');
+        }
+        arrowDown(inputElement);
+        expect(inputElement.value).to.be.equal('11.58');
+      });
+    });
   });
 
   describe('with dropdown', () => {

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -445,62 +445,6 @@ describe('time-picker', () => {
       timePicker.value = '12:12:12.100';
       expect(timePicker.value).to.be.equal('12:12:12.100');
     });
-
-    describe('with custom formatter', () => {
-      beforeEach(() => {
-        sinon.stub(console, 'warn');
-        timePicker.step = 7200;
-      });
-
-      afterEach(() => {
-        console.warn.restore();
-      });
-
-      it('should reject and warn about steps incompatible with the formatter (milliseconds)', () => {
-        timePicker.i18n.formatTime = ({ hours, minutes, seconds }) => `${hours}:${minutes}:${seconds}`;
-
-        [0.5, 1.5, 60.5, 3600.5].forEach((step) => {
-          console.warn.resetHistory();
-          timePicker.step = step;
-
-          expect(timePicker.step).to.equal(7200);
-          expect(console.warn).to.be.calledOnce;
-          expect(console.warn.args[0][0]).to.include(
-            `<vaadin-time-picker> The step ${step} seconds has been rejected because it's not compatible with the provided time formatter.`,
-          );
-        });
-      });
-
-      it('should reject and warn about steps incompatible with the formatter (seconds)', () => {
-        timePicker.i18n.formatTime = ({ hours, minutes }) => `${hours}:${minutes}`;
-
-        [1, 61, 3601].forEach((step) => {
-          console.warn.resetHistory();
-          timePicker.step = step;
-
-          expect(timePicker.step).to.equal(7200);
-          expect(console.warn).to.be.calledOnce;
-          expect(console.warn.args[0][0]).to.include(
-            `<vaadin-time-picker> The step ${step} seconds has been rejected because it's not compatible with the provided time formatter.`,
-          );
-        });
-      });
-
-      it('should reject and warn about steps incompatible with the formatter (minutes)', () => {
-        timePicker.i18n.formatTime = ({ hours }) => `${hours}`;
-
-        [60, 3660].forEach((step) => {
-          console.warn.resetHistory();
-          timePicker.step = step;
-
-          expect(timePicker.step).to.equal(7200);
-          expect(console.warn).to.be.calledOnce;
-          expect(console.warn.args[0][0]).to.include(
-            `<vaadin-time-picker> The step ${step} seconds has been rejected because it's not compatible with the provided time formatter.`,
-          );
-        });
-      });
-    });
   });
 
   describe('custom functions', () => {


### PR DESCRIPTION
## Description

The PR reverts #6408 because the heuristic that was used there to detect incompatible steps isn't 100% reliable. For example, the parser can return `0` as milliseconds even though the formatter doesn't display them.

Related to https://github.com/vaadin/web-components/issues/6397

## Type of change

- [x] Revert
