### PR TITLE
feat: submit custom login fields values as part of the form

### DIFF
--- a/packages/login/src/vaadin-lit-login-form.js
+++ b/packages/login/src/vaadin-lit-login-form.js
@@ -50,7 +50,7 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolylitMixin(L
         .error="${this.error}"
         .i18n="${this.i18n}"
       >
-        <form method="POST" action="${this.action}" slot="form">
+        <form method="POST" action="${this.action}" @formdata="${this._onFormData}" slot="form">
           <input id="csrf" type="hidden" />
           <vaadin-text-field
             name="username"

--- a/packages/login/src/vaadin-login-form-mixin.js
+++ b/packages/login/src/vaadin-login-form-mixin.js
@@ -11,18 +11,14 @@ import { LoginMixin } from './vaadin-login-mixin.js';
  */
 export const LoginFormMixin = (superClass) =>
   class LoginFormMixin extends LoginMixin(superClass) {
-    static get properties() {
-      return {
-        /** @private */
-        _customFields: {
-          type: Array,
-          value: () => [],
-        },
-      };
-    }
-
     static get observers() {
       return ['_errorChanged(error)'];
+    }
+
+    get _customFields() {
+      return [...this.$.vaadinLoginFormWrapper.children].filter((node) => {
+        return node.getAttribute('slot') === 'custom-fields' && node.hasAttribute('name');
+      });
     }
 
     /** @protected */
@@ -34,19 +30,6 @@ export const LoginFormMixin = (superClass) =>
         await new Promise(requestAnimationFrame);
         this.$.vaadinLoginUsername.focus();
       }
-    }
-
-    /** @protected */
-    ready() {
-      super.ready();
-
-      this.__setCustomFields();
-
-      this.__observer = new MutationObserver(() => {
-        this.__setCustomFields();
-      });
-
-      this.__observer.observe(this.$.vaadinLoginFormWrapper, { childList: true });
     }
 
     /** @private */
@@ -75,10 +58,11 @@ export const LoginFormMixin = (superClass) =>
         password: password.value,
       };
 
-      if (this._customFields.length) {
+      const fields = this._customFields;
+      if (fields.length) {
         detail.custom = {};
 
-        this._customFields.forEach((field) => {
+        fields.forEach((field) => {
           detail.custom[field.name] = field.value;
         });
       }
@@ -139,12 +123,5 @@ export const LoginFormMixin = (superClass) =>
     /** @protected */
     _onForgotPasswordClick() {
       this.dispatchEvent(new CustomEvent('forgot-password'));
-    }
-
-    /** @private */
-    __setCustomFields() {
-      this._customFields = [...this.$.vaadinLoginFormWrapper.children].filter((node) => {
-        return node.getAttribute('slot') === 'custom-fields' && node.hasAttribute('name');
-      });
     }
   };

--- a/packages/login/src/vaadin-login-form-mixin.js
+++ b/packages/login/src/vaadin-login-form-mixin.js
@@ -102,6 +102,17 @@ export const LoginFormMixin = (superClass) =>
     }
 
     /** @protected */
+    _onFormData(event) {
+      const { formData } = event;
+
+      if (this._customFields.length) {
+        this._customFields.forEach((field) => {
+          formData.append(field.name, field.value);
+        });
+      }
+    }
+
+    /** @protected */
     _handleInputKeydown(e) {
       if (e.key === 'Enter') {
         const { currentTarget: inputActive } = e;

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -60,7 +60,7 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolymerElement
         }
       </style>
       <vaadin-login-form-wrapper id="vaadinLoginFormWrapper" theme$="[[_theme]]" error="[[error]]" i18n="[[i18n]]">
-        <form method="POST" action$="[[action]]" slot="form">
+        <form method="POST" action$="[[action]]" on-formdata="_onFormData" slot="form">
           <input id="csrf" type="hidden" />
           <vaadin-text-field
             name="username"

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -27,7 +27,11 @@ export type LoginOverlayErrorChangedEvent = CustomEvent<{ value: boolean }>;
 /**
  * Fired when a user submits the login.
  */
-export type LoginOverlayLoginEvent = CustomEvent<{ username: string; password: string }>;
+export type LoginOverlayLoginEvent = CustomEvent<{
+  username: string;
+  password: string;
+  custom?: Record<string, unknown>;
+}>;
 
 export interface LoginOverlayCustomEventMap {
   'description-changed': LoginOverlayDescriptionChangedEvent;

--- a/packages/login/test/login-submit.common.js
+++ b/packages/login/test/login-submit.common.js
@@ -6,8 +6,14 @@ import { fillUsernameAndPassword } from './helpers.js';
 describe('login form submit', () => {
   let login, iframe;
 
-  function testFormSubmitValues(preventDefault, expectation, done) {
+  function testFormSubmitValues(preventDefault, expectation, done, data = {}) {
     fillUsernameAndPassword(login);
+
+    const formData = { username: 'username', password: 'password', ...data };
+
+    const urlParams = Object.entries(formData)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('&');
 
     const loginForm = login.querySelector('form');
     loginForm.setAttribute('method', 'GET');
@@ -19,7 +25,7 @@ describe('login form submit', () => {
     }
 
     iframe.onload = () => {
-      expect(iframe.contentWindow.location.href).to.include('login-action?username=username&password=password');
+      expect(iframe.contentWindow.location.href).to.include(`login-action?${urlParams}`);
       done();
     };
 
@@ -113,6 +119,17 @@ describe('login form submit', () => {
       const { detail } = loginSpy.firstCall.args[0];
       expect(detail.custom.foo).to.be.equal('bar');
       expect(detail.custom.code).to.be.equal('1234');
+    });
+
+    describe('form submit', () => {
+      beforeEach(async () => {
+        overlay.action = 'login-action';
+        await nextRender();
+      });
+
+      it('should submit custom fields values to the native form', (done) => {
+        testFormSubmitValues(false, true, done, { foo: 'bar', code: '1234' });
+      });
     });
   });
 });

--- a/packages/login/test/login-submit.common.js
+++ b/packages/login/test/login-submit.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, tabKeyUp } from '@vaadin/testing-helpers';
+import { enter, fixtureSync, nextRender, tabKeyUp } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { fillUsernameAndPassword } from './helpers.js';
 
@@ -83,6 +83,36 @@ describe('login form submit', () => {
 
     it('should submit form values from overlay element', (done) => {
       testFormSubmitValues(false, true, done);
+    });
+  });
+
+  describe('custom fields', () => {
+    let overlay;
+
+    beforeEach(async () => {
+      overlay = fixtureSync(`
+        <vaadin-login-overlay opened>
+          <input name="foo" value="bar" slot="custom-fields">
+          <vaadin-text-field name="code" value="1234" slot="custom-fields"></vaadin-text-field>
+        </vaadin-login-overlay>
+      `);
+      await nextRender();
+      login = overlay.$.vaadinLoginForm;
+    });
+
+    it('should add custom fields values to the login event detail', () => {
+      const loginSpy = sinon.spy();
+
+      overlay.addEventListener('login', loginSpy);
+
+      const { vaadinLoginUsername } = fillUsernameAndPassword(login);
+
+      enter(vaadinLoginUsername);
+      expect(loginSpy.called).to.be.true;
+
+      const { detail } = loginSpy.firstCall.args[0];
+      expect(detail.custom.foo).to.be.equal('bar');
+      expect(detail.custom.code).to.be.equal('1234');
     });
   });
 });

--- a/packages/login/test/typings/login.types.ts
+++ b/packages/login/test/typings/login.types.ts
@@ -24,6 +24,7 @@ overlay.addEventListener('login', (event) => {
   assertType<LoginOverlayLoginEvent>(event);
   assertType<string>(event.detail.username);
   assertType<string>(event.detail.password);
+  assertType<Record<string, unknown> | undefined>(event.detail.custom);
 });
 
 overlay.addEventListener('error-changed', (event) => {


### PR DESCRIPTION
## Description

Depends on #6403

This PR adds the following improvements to `vaadin-login-form`:

1. Store custom fields and collect values from them on `submit()` call,
2. Add `custom` object to the `login` event detail with these values,
3. Append custom fields values with the `<form>` using [`formdata`](https://web.dev/more-capable-form-controls/#event-based-api).

## Type of change

- Feature