### PR TITLE
test: improve test coverage for value commit scenarios

### DIFF
--- a/packages/number-field/test/validation.common.js
+++ b/packages/number-field/test/validation.common.js
@@ -41,24 +41,6 @@ describe('validation', () => {
       expect(field.invalid).to.be.false;
     });
 
-    it('should validate before change event on ArrowDown', async () => {
-      field.focus();
-      await sendKeys({ press: 'ArrowDown' });
-      await nextUpdate(field);
-      expect(validateSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledAfter(validateSpy);
-    });
-
-    it('should validate before change event on ArrowUp', async () => {
-      field.focus();
-      await sendKeys({ press: 'ArrowUp' });
-      await nextUpdate(field);
-      expect(validateSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledAfter(validateSpy);
-    });
-
     it('should be valid with numeric values', async () => {
       field.value = '1';
       await nextUpdate(field);
@@ -132,16 +114,6 @@ describe('validation', () => {
       field.value = '5';
       await nextUpdate(field);
       expect(field.validate(), 'value should not be greater than max').to.be.false;
-    });
-
-    it('should dispatch change event after validation', async () => {
-      field.required = true;
-      field.addEventListener('change', changeSpy);
-      input.value = '123';
-      input.dispatchEvent(new CustomEvent('change'));
-      await nextUpdate(field);
-      expect(validateSpy.calledOnce).to.be.true;
-      expect(changeSpy.calledAfter(validateSpy)).to.be.true;
     });
 
     it('should fire a validated event on validation success', () => {

--- a/packages/number-field/test/value-commit.test.js
+++ b/packages/number-field/test/value-commit.test.js
@@ -191,11 +191,6 @@ describe('value commit', () => {
         await sendKeys({ press: 'Enter' });
         expectValueCommit('1');
       });
-
-      it('should commit on close with outside click', () => {
-        outsideClick();
-        expectValueCommit('1');
-      });
     });
 
     describe('unparsable input entered', () => {

--- a/packages/number-field/test/value-commit.test.js
+++ b/packages/number-field/test/value-commit.test.js
@@ -118,7 +118,8 @@ describe('value commit', () => {
       expect(numberField.inputElement.validity.badInput).to.be.true;
     });
 
-    it('should not commit but validate on Enter', async () => {
+    // FIXME: https://github.com/vaadin/web-components/issues/5113
+    it.skip('should not commit but validate on Enter', async () => {
       await sendKeys({ press: 'Enter' });
       expectValidationOnly();
       expect(numberField.inputElement.validity.badInput).to.be.true;
@@ -143,7 +144,8 @@ describe('value commit', () => {
         expectValidationOnly();
       });
 
-      it('should not commit but validate on Enter', async () => {
+      // FIXME: https://github.com/vaadin/web-components/issues/5113
+      it.skip('should not commit but validate on Enter', async () => {
         await sendKeys({ press: 'Enter' });
         expectValidationOnly();
       });

--- a/packages/number-field/test/value-commit.test.js
+++ b/packages/number-field/test/value-commit.test.js
@@ -283,7 +283,7 @@ describe('value commit', () => {
     });
 
     describe('click committed', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         increaseButton.click();
         valueChangedSpy.resetHistory();
         validateSpy.resetHistory();

--- a/packages/number-field/test/value-commit.test.js
+++ b/packages/number-field/test/value-commit.test.js
@@ -264,7 +264,7 @@ describe('value commit', () => {
     });
   });
 
-  describe('spinner buttons', () => {
+  describe('value control buttons', () => {
     let increaseButton, decreaseButton;
 
     beforeEach(() => {

--- a/packages/number-field/test/value-commit.test.js
+++ b/packages/number-field/test/value-commit.test.js
@@ -129,14 +129,16 @@ describe('value commit', () => {
   describe('unparsable input committed', () => {
     beforeEach(async () => {
       await sendKeys({ type: '-' });
-      await sendKeys({ type: 'Enter' });
+      numberField.blur();
       validateSpy.resetHistory();
     });
 
     describe('input cleared with Backspace', () => {
       beforeEach(async () => {
+        numberField.focus();
         numberField.inputElement.select();
         await sendKeys({ press: 'Backspace' });
+        validateSpy.resetHistory();
       });
 
       it('should not commit but validate on blur', () => {

--- a/packages/number-field/test/value-commit.test.js
+++ b/packages/number-field/test/value-commit.test.js
@@ -1,0 +1,251 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
+import sinon from 'sinon';
+import '../src/vaadin-number-field.js';
+
+describe('value commit', () => {
+  let numberField, valueChangedSpy, validateSpy, changeSpy;
+
+  function expectNoValueCommit() {
+    expect(valueChangedSpy).to.be.not.called;
+    expect(validateSpy).to.be.not.called;
+    expect(changeSpy).to.be.not.called;
+  }
+
+  function expectValueCommit(value) {
+    expect(valueChangedSpy).to.be.calledOnce;
+    // TODO: Optimize the number of validation runs.
+    expect(validateSpy).to.be.called;
+    expect(validateSpy.firstCall).to.be.calledAfter(valueChangedSpy.firstCall);
+    expect(changeSpy).to.be.calledOnce;
+    expect(changeSpy.firstCall).to.be.calledAfter(validateSpy.firstCall);
+    expect(numberField.value).to.equal(value);
+  }
+
+  function expectValidationOnly() {
+    expect(valueChangedSpy).to.be.not.called;
+    expect(validateSpy).to.be.calledOnce;
+    expect(changeSpy).to.be.not.called;
+  }
+
+  beforeEach(async () => {
+    numberField = fixtureSync(`<vaadin-number-field></vaadin-number-field>`);
+    await nextRender();
+    validateSpy = sinon.spy(numberField, 'validate').named('validateSpy');
+
+    valueChangedSpy = sinon.spy().named('valueChangedSpy');
+    numberField.addEventListener('value-changed', valueChangedSpy);
+
+    changeSpy = sinon.spy().named('changeSpy');
+    numberField.addEventListener('change', changeSpy);
+
+    numberField.focus();
+  });
+
+  describe('default', () => {
+    it('should not commit but validate on blur', () => {
+      numberField.blur();
+      expectValidationOnly();
+    });
+
+    it('should not commit on Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expectNoValueCommit();
+    });
+
+    it('should not commit on Escape', async () => {
+      await sendKeys({ press: 'Escape' });
+      expectNoValueCommit();
+    });
+  });
+
+  describe('entering parsable input', () => {
+    beforeEach(async () => {
+      await sendKeys({ type: '1' });
+    });
+
+    it('should commit on blur', () => {
+      numberField.blur();
+      expectValueCommit('1');
+    });
+
+    it('should commit on Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expectValueCommit('1');
+    });
+  });
+
+  describe('entering unparsable input', () => {
+    beforeEach(async () => {
+      await sendKeys({ type: '-' });
+    });
+
+    it('should not commit by default', () => {
+      expectNoValueCommit();
+    });
+
+    it('should not commit but validate on blur', () => {
+      numberField.blur();
+      expectValidationOnly();
+      expect(numberField.inputElement.validity.badInput).to.be.true;
+    });
+
+    it('should not commit but validate on Enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expectValidationOnly();
+      expect(numberField.inputElement.validity.badInput).to.be.true;
+    });
+
+    describe('clearing input with Backspace', () => {
+      beforeEach(async () => {
+        await sendKeys({ press: 'Enter' });
+        valueChangedSpy.resetHistory();
+        validateSpy.resetHistory();
+
+        numberField.inputElement.select();
+        await sendKeys({ press: 'Backspace' });
+      });
+
+      it('should not commit but validate on blur', () => {
+        numberField.blur();
+        expectValidationOnly();
+      });
+
+      it('should not commit but validate on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValidationOnly();
+      });
+    });
+  });
+
+  describe('with value', () => {
+    beforeEach(() => {
+      numberField.value = '1234';
+      valueChangedSpy.resetHistory();
+      validateSpy.resetHistory();
+    });
+
+    describe('default', () => {
+      it('should not commit but validate on blur', () => {
+        numberField.blur();
+        expectValidationOnly();
+      });
+
+      it('should not commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectNoValueCommit();
+      });
+
+      it('should not commit on Escape', async () => {
+        await sendKeys({ press: 'Escape' });
+        expectNoValueCommit();
+      });
+    });
+
+    describe('entering parsable input', () => {
+      beforeEach(async () => {
+        numberField.inputElement.select();
+        await sendKeys({ type: '1' });
+      });
+
+      it('should commit on blur', () => {
+        numberField.blur();
+        expectValueCommit('1');
+      });
+
+      it('should commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValueCommit('1');
+      });
+
+      it('should commit on close with outside click', () => {
+        outsideClick();
+        expectValueCommit('1');
+      });
+    });
+
+    describe('entering unparsable input', () => {
+      beforeEach(async () => {
+        numberField.inputElement.select();
+        await sendKeys({ type: '-' });
+      });
+
+      it('should commit an empty value on blur', () => {
+        numberField.blur();
+        expectValueCommit('');
+        expect(numberField.inputElement.validity.badInput).to.be.true;
+      });
+
+      it('should commit an empty value on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValueCommit('');
+        expect(numberField.inputElement.validity.badInput).to.be.true;
+      });
+    });
+
+    describe('clearing input with Backspace', () => {
+      beforeEach(async () => {
+        numberField.inputElement.select();
+        await sendKeys({ press: 'Backspace' });
+      });
+
+      it('should commit on blur', () => {
+        numberField.blur();
+        expectValueCommit('');
+      });
+
+      it('should commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValueCommit('');
+      });
+    });
+
+    describe('with clear button', () => {
+      beforeEach(() => {
+        numberField.clearButtonVisible = true;
+      });
+
+      it('should clear on clear button click', () => {
+        numberField.$.clearButton.click();
+        expectValueCommit('');
+      });
+
+      it('should clear on Escape', async () => {
+        await sendKeys({ press: 'Escape' });
+        expectValueCommit('');
+      });
+    });
+  });
+
+  describe('stepping', () => {
+    it('should commit on ArrowDown', async () => {
+      await sendKeys({ press: 'ArrowDown' });
+      expectValueCommit('-1');
+    });
+
+    it('should commit on ArrowUp', async () => {
+      await sendKeys({ press: 'ArrowUp' });
+      expectValueCommit('1');
+    });
+
+    describe('with value committed using an arrow key', () => {
+      beforeEach(async () => {
+        await sendKeys({ press: 'ArrowDown' });
+        valueChangedSpy.resetHistory();
+        validateSpy.resetHistory();
+        changeSpy.resetHistory();
+      });
+
+      it('should not commit but validate on blur', () => {
+        numberField.blur();
+        expectValidationOnly();
+      });
+
+      it('should not commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectNoValueCommit();
+      });
+    });
+  });
+});

--- a/packages/number-field/test/value-commit.test.js
+++ b/packages/number-field/test/value-commit.test.js
@@ -60,7 +60,7 @@ describe('value commit', () => {
     });
   });
 
-  describe('entering parsable input', () => {
+  describe('parsable input entered', () => {
     beforeEach(async () => {
       await sendKeys({ type: '1' });
     });
@@ -76,7 +76,34 @@ describe('value commit', () => {
     });
   });
 
-  describe('entering unparsable input', () => {
+  describe('parsable input committed', () => {
+    beforeEach(async () => {
+      await sendKeys({ type: '1' });
+      await sendKeys({ press: 'Enter' });
+      changeSpy.resetHistory();
+      valueChangedSpy.resetHistory();
+      validateSpy.resetHistory();
+    });
+
+    describe('input cleared with Backspace', () => {
+      beforeEach(async () => {
+        numberField.inputElement.select();
+        await sendKeys({ press: 'Backspace' });
+      });
+
+      it('should commit on blur', () => {
+        numberField.blur();
+        expectValueCommit('');
+      });
+
+      it('should commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectValueCommit('');
+      });
+    });
+  });
+
+  describe('unparsable input entered', () => {
     beforeEach(async () => {
       await sendKeys({ type: '-' });
     });
@@ -96,13 +123,17 @@ describe('value commit', () => {
       expectValidationOnly();
       expect(numberField.inputElement.validity.badInput).to.be.true;
     });
+  });
 
-    describe('clearing input with Backspace', () => {
+  describe('unparsable input committed', () => {
+    beforeEach(async () => {
+      await sendKeys({ type: '-' });
+      await sendKeys({ type: 'Enter' });
+      validateSpy.resetHistory();
+    });
+
+    describe('input cleared with Backspace', () => {
       beforeEach(async () => {
-        await sendKeys({ press: 'Enter' });
-        valueChangedSpy.resetHistory();
-        validateSpy.resetHistory();
-
         numberField.inputElement.select();
         await sendKeys({ press: 'Backspace' });
       });
@@ -119,7 +150,7 @@ describe('value commit', () => {
     });
   });
 
-  describe('with value', () => {
+  describe('value set programmatically', () => {
     beforeEach(() => {
       numberField.value = '1234';
       valueChangedSpy.resetHistory();
@@ -143,7 +174,7 @@ describe('value commit', () => {
       });
     });
 
-    describe('entering parsable input', () => {
+    describe('parsable input entered', () => {
       beforeEach(async () => {
         numberField.inputElement.select();
         await sendKeys({ type: '1' });
@@ -165,7 +196,7 @@ describe('value commit', () => {
       });
     });
 
-    describe('entering unparsable input', () => {
+    describe('unparsable input entered', () => {
       beforeEach(async () => {
         numberField.inputElement.select();
         await sendKeys({ type: '-' });
@@ -183,55 +214,78 @@ describe('value commit', () => {
         expect(numberField.inputElement.validity.badInput).to.be.true;
       });
     });
+  });
 
-    describe('clearing input with Backspace', () => {
-      beforeEach(async () => {
-        numberField.inputElement.select();
-        await sendKeys({ press: 'Backspace' });
-      });
-
-      it('should commit on blur', () => {
-        numberField.blur();
-        expectValueCommit('');
-      });
-
-      it('should commit on Enter', async () => {
-        await sendKeys({ press: 'Enter' });
-        expectValueCommit('');
-      });
+  describe('with clear button', () => {
+    beforeEach(() => {
+      numberField.value = '1';
+      numberField.clearButtonVisible = true;
+      valueChangedSpy.resetHistory();
     });
 
-    describe('with clear button', () => {
-      beforeEach(() => {
-        numberField.clearButtonVisible = true;
-      });
+    it('should clear on clear button click', () => {
+      numberField.$.clearButton.click();
+      expectValueCommit('');
+    });
 
-      it('should clear on clear button click', () => {
-        numberField.$.clearButton.click();
-        expectValueCommit('');
-      });
-
-      it('should clear on Escape', async () => {
-        await sendKeys({ press: 'Escape' });
-        expectValueCommit('');
-      });
+    it('should clear on Escape', async () => {
+      await sendKeys({ press: 'Escape' });
+      expectValueCommit('');
     });
   });
 
-  describe('stepping', () => {
-    it('should commit on ArrowDown', async () => {
-      await sendKeys({ press: 'ArrowDown' });
-      expectValueCommit('-1');
-    });
-
+  describe('keyboard stepping', () => {
     it('should commit on ArrowUp', async () => {
       await sendKeys({ press: 'ArrowUp' });
       expectValueCommit('1');
     });
 
-    describe('with value committed using an arrow key', () => {
+    it('should commit on ArrowDown', async () => {
+      await sendKeys({ press: 'ArrowDown' });
+      expectValueCommit('-1');
+    });
+
+    describe('arrow key committed', () => {
       beforeEach(async () => {
-        await sendKeys({ press: 'ArrowDown' });
+        await sendKeys({ press: 'ArrowUp' });
+        valueChangedSpy.resetHistory();
+        validateSpy.resetHistory();
+        changeSpy.resetHistory();
+      });
+
+      it('should not commit but validate on blur', () => {
+        numberField.blur();
+        expectValidationOnly();
+      });
+
+      it('should not commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectNoValueCommit();
+      });
+    });
+  });
+
+  describe('spinner buttons', () => {
+    let increaseButton, decreaseButton;
+
+    beforeEach(() => {
+      increaseButton = numberField.shadowRoot.querySelector('[part=increase-button]');
+      decreaseButton = numberField.shadowRoot.querySelector('[part=decrease-button]');
+    });
+
+    it('should commit on increase button click', () => {
+      increaseButton.click();
+      expectValueCommit('1');
+    });
+
+    it('should commit on decrease button click', () => {
+      decreaseButton.click();
+      expectValueCommit('-1');
+    });
+
+    describe('click committed', () => {
+      beforeEach(async () => {
+        increaseButton.click();
         valueChangedSpy.resetHistory();
         validateSpy.resetHistory();
         changeSpy.resetHistory();

--- a/packages/number-field/test/value-control-buttons.common.js
+++ b/packages/number-field/test/value-control-buttons.common.js
@@ -23,46 +23,6 @@ describe('value control buttons', () => {
       expect(numberField.value).to.equal('1');
     });
 
-    it('should dispatch change event on minus button click', async () => {
-      const changeSpy = sinon.spy();
-      numberField.addEventListener('change', changeSpy);
-
-      decreaseButton.click();
-      await nextUpdate(numberField);
-
-      expect(changeSpy).to.be.calledOnce;
-    });
-
-    it('should dispatch change event on plus button click', async () => {
-      const changeSpy = sinon.spy();
-      numberField.addEventListener('change', changeSpy);
-
-      increaseButton.click();
-      await nextUpdate(numberField);
-
-      expect(changeSpy).to.be.calledOnce;
-    });
-
-    it('should dispatch single value-changed event on minus button click', async () => {
-      const spy = sinon.spy();
-      numberField.addEventListener('value-changed', spy);
-
-      decreaseButton.click();
-      await nextUpdate(numberField);
-
-      expect(spy).to.be.calledOnce;
-    });
-
-    it('should dispatch single value-changed event on plus button click', async () => {
-      const spy = sinon.spy();
-      numberField.addEventListener('value-changed', spy);
-
-      increaseButton.click();
-      await nextUpdate(numberField);
-
-      expect(spy).to.be.calledOnce;
-    });
-
     it('should not focus input when a button is clicked', () => {
       const spy = sinon.spy(input, 'focus');
       increaseButton.click();


### PR DESCRIPTION
## Description

The idea is to create a test file that would collect all the tests related to the user committing a value. Currently, such tests are scattered across different places, making it difficult to know what might cause the value to change and feel confident about the test coverage when refactoring something.

The new tests aim to cover all main scenarios where the user commits a value using actions like blur, Enter.

Depends on 
- https://github.com/vaadin/web-components/pull/6476

Part of https://github.com/vaadin/web-components/issues/6426

## Type of change

- [x] Internal
