### PR TITLE
fix: ensure only one value change on arrow key press

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -463,14 +463,11 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     const objWithStep = this.__addStep(this.__getMsec(this.__memoValue), step, true);
     this.__memoValue = objWithStep;
 
-    // Setting `value` property triggers the synchronous observer
-    // that in turn updates `_comboBoxValue` (actual input value)
-    // with its own observer where the value can be parsed again,
-    // so we set this flag to ensure it does not alter the value.
+    // Setting `_comboBoxValue` property triggers the synchronous
+    // observer where the value can be parsed again, so we set
+    // this flag to ensure it does not alter the value.
     this.__useMemo = true;
-    this.__skipCommittedValueUpdate = true;
-    this.value = this.__formatISO(objWithStep);
-    this.__skipCommittedValueUpdate = false;
+    this._comboBoxValue = this.i18n.formatTime(objWithStep);
     this.__useMemo = false;
 
     this.validate();

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -69,13 +69,15 @@ describe('validation', () => {
   });
 
   describe('basic', () => {
-    let validateSpy, changeSpy, input;
+    let validateSpy, changeSpy, valueChangedSpy, input;
 
     beforeEach(() => {
       timePicker = fixtureSync(`<vaadin-time-picker></vaadin-time-picker>`);
       validateSpy = sinon.spy(timePicker, 'validate');
       changeSpy = sinon.spy();
       timePicker.addEventListener('change', changeSpy);
+      valueChangedSpy = sinon.spy();
+      timePicker.addEventListener('value-changed', valueChangedSpy);
       input = timePicker.inputElement;
     });
 
@@ -198,20 +200,24 @@ describe('validation', () => {
         timePicker.step = 1;
       });
 
-      it('should validate before change event on ArrowDown', async () => {
+      it('should validate between value-changed and change events on ArrowDown', async () => {
         input.focus();
         await sendKeys({ press: 'ArrowDown' });
-        expect(changeSpy).to.be.calledOnce;
+        expect(valueChangedSpy).to.be.calledOnce;
         expect(validateSpy).to.be.calledOnce;
-        expect(validateSpy).to.be.calledBefore(changeSpy);
+        expect(validateSpy).to.be.calledAfter(valueChangedSpy);
+        expect(changeSpy).to.be.calledOnce;
+        expect(changeSpy).to.be.calledAfter(validateSpy);
       });
 
-      it('should validate before change event on ArrowUp', async () => {
+      it('should validate between value-changed and change events on ArrowUp', async () => {
         input.focus();
         await sendKeys({ press: 'ArrowUp' });
-        expect(changeSpy).to.be.calledOnce;
+        expect(valueChangedSpy).to.be.calledOnce;
         expect(validateSpy).to.be.calledOnce;
-        expect(validateSpy).to.be.calledBefore(changeSpy);
+        expect(validateSpy).to.be.calledAfter(valueChangedSpy);
+        expect(changeSpy).to.be.calledOnce;
+        expect(changeSpy).to.be.calledAfter(validateSpy);
       });
     });
   });


### PR DESCRIPTION
## Description

The PR ensures that there is only one `value-changed` when adjusting the value with arrow keys. 

Previously, several value changes could take place when `step` >= 1 sec. With such steps, the `__onArrowPressWithStep` method updated the value property always appending `.000` to the end whereas the following `__comboBoxValueChanged` always removed that part, which resulted in two value changes.

## Type of change

- [x] Bugfix
