### PR TITLE
fix: Remove empty spans used by Quill internally from htmlValue

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -935,6 +935,8 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
 
     // Remove Quill classes, e.g. ql-syntax, except for align
     content = content.replace(/\s*ql-(?!align)[\w-]*\s*/gu, '');
+    // Remove meta spans, e.g. cursor which are empty after Quill classes removed
+    content = content.replace(/<\/?span[^>]*>/g,"");
 
     // Replace Quill align classes with inline styles
     [this.__dir === 'rtl' ? 'left' : 'right', 'center', 'justify'].forEach((align) => {

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -936,7 +936,7 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     // Remove Quill classes, e.g. ql-syntax, except for align
     content = content.replace(/\s*ql-(?!align)[\w-]*\s*/gu, '');
     // Remove meta spans, e.g. cursor which are empty after Quill classes removed
-    content = content.replace(/<\/?span[^>]*>/g,"");
+    content = content.replace(/<\/?span[^>]*>/gu, '');
 
     // Replace Quill align classes with inline styles
     [this.__dir === 'rtl' ? 'left' : 'right', 'center', 'justify'].forEach((align) => {

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -681,8 +681,10 @@ describe('rich text editor', () => {
       expect(rte.htmlValue).to.equal('<h3><em>Foo</em>Bar</h3>');
     });
 
-    it('should update htmlValue and value on dangerously setting of the editor htmlValue', () => {
-      rte.dangerouslySetHtmlValue('<p><strong>Hello </strong></p><p><strong><span class="ql-cursor"></span>world</strong></p>');
+    it('should filter out empty span elements from the resulting htmlValue', () => {
+      rte.dangerouslySetHtmlValue(
+        '<p><strong>Hello </strong></p><p><strong><span class="ql-cursor"></span>world</strong></p>',
+      );
       flushValueDebouncer();
       // Empty span should be stripped
       expect(rte.htmlValue).to.equal('<p><strong>Hello </strong></p><p><strong>world</strong></p>');

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -681,6 +681,13 @@ describe('rich text editor', () => {
       expect(rte.htmlValue).to.equal('<h3><em>Foo</em>Bar</h3>');
     });
 
+    it('should update htmlValue and value on dangerously setting of the editor htmlValue', () => {
+      rte.dangerouslySetHtmlValue('<p><strong>Hello </strong></p><p><strong><span class="ql-cursor"></span>world</strong></p>');
+      flushValueDebouncer();
+      // Empty span should be stripped
+      expect(rte.htmlValue).to.equal('<p><strong>Hello </strong></p><p><strong>world</strong></p>');
+    });
+
     it('should return the quill editor innerHTML', () => {
       expect(rte.htmlValue).to.equal('<p><br></p>');
     });


### PR DESCRIPTION
Fixes: https://github.com/vaadin/web-components/issues/6435