### PR TITLE
fix: remove empty spans used by Quill from htmlValue (#6434) (CP: 23.3)

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -907,6 +907,8 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
 
     // Remove Quill classes, e.g. ql-syntax, except for align
     content = content.replace(/\s*ql-(?!align)[\w-]*\s*/g, '');
+    // Remove meta spans, e.g. cursor which are empty after Quill classes removed
+    content = content.replace(/<\/?span[^>]*>/gu, '');
 
     // Replace Quill align classes with inline styles
     [this.__dir === 'rtl' ? 'left' : 'right', 'center', 'justify'].forEach((align) => {

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -682,6 +682,15 @@ describe('rich text editor', () => {
       expect(rte.htmlValue).to.equal('<h3><em>Foo</em>Bar</h3>');
     });
 
+    it('should filter out empty span elements from the resulting htmlValue', () => {
+      rte.dangerouslySetHtmlValue(
+        '<p><strong>Hello </strong></p><p><strong><span class="ql-cursor"></span>world</strong></p>',
+      );
+      flushValueDebouncer();
+      // Empty span should be stripped
+      expect(rte.htmlValue).to.equal('<p><strong>Hello </strong></p><p><strong>world</strong></p>');
+    });
+
     it('should return the quill editor innerHTML', () => {
       expect(rte.htmlValue).to.equal('<p><br></p>');
     });


### PR DESCRIPTION
## Description

Cherry-pick of #6434 to `23.3` branch. There was a merge conflict due to `u` flag in the RegExp on main branch.

## Type of change

- Cherry-pick