### PR TITLE
refactor: move font icon size fallback to a mixin

### DIFF
--- a/packages/icon/src/vaadin-icon-font-size-mixin.d.ts
+++ b/packages/icon/src/vaadin-icon-font-size-mixin.d.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+/**
+ * Mixin which enables the font icon sizing fallback for browsers that do not support CSS Container Queries.
+ * The mixin does nothing if the browser supports CSS Container Query units for pseudo elements.
+ */
+export declare function IconFontSizeMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<IconFontSizeMixinClass> & T;
+
+export declare class IconFontSizeMixinClass {}

--- a/packages/icon/src/vaadin-icon-font-size-mixin.js
+++ b/packages/icon/src/vaadin-icon-font-size-mixin.js
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { needsFontIconSizingFallback } from './vaadin-icon-helpers.js';
+
+const usesFontIconSizingFallback = needsFontIconSizingFallback();
+
+if (usesFontIconSizingFallback) {
+  registerStyles(
+    'vaadin-icon',
+    css`
+      :host::after,
+      :host::before {
+        font-size: var(--_vaadin-font-icon-size);
+      }
+    `,
+    'vaadin-icon-font-size-mixin-styles',
+  );
+}
+
+/**
+ * Mixin which enables the font icon sizing fallback for browsers that do not support CSS Container Queries.
+ * The mixin does nothing if the browser supports CSS Container Query units for pseudo elements.
+ *
+ * @polymerMixin
+ */
+export const IconFontSizeMixin = dedupingMixin((superclass) =>
+  !usesFontIconSizingFallback
+    ? superclass
+    : class extends ResizeMixin(superclass) {
+        static get observers() {
+          return ['__iconFontSizeMixinfontChanged(font, char)'];
+        }
+
+        /** @protected */
+        ready() {
+          super.ready();
+
+          // Update once initially to avoid a fouc
+          this.__updateFontIconSize();
+        }
+
+        /** @private */
+        __iconFontSizeMixinfontChanged(font, char) {
+          // Update when font or char changes
+          this.__updateFontIconSize();
+        }
+
+        /**
+         * @protected
+         * @override
+         */
+        _onResize() {
+          // Update when the element is resized
+          this.__updateFontIconSize();
+        }
+
+        /**
+         * Updates the --_vaadin-font-icon-size CSS variable value if char or font is set (font icons in use).
+         *
+         * @private
+         */
+        __updateFontIconSize() {
+          if (this.char || this.font) {
+            const { paddingTop, paddingBottom, height } = getComputedStyle(this);
+            const fontIconSize = parseFloat(height) - parseFloat(paddingTop) - parseFloat(paddingBottom);
+            this.style.setProperty('--_vaadin-font-icon-size', `${fontIconSize}px`);
+          }
+        }
+      },
+);

--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -7,6 +7,7 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { IconFontSizeMixin } from './vaadin-icon-font-size-mixin.js';
 import type { IconSvgLiteral } from './vaadin-icon-svg.js';
 
 /**
@@ -48,7 +49,9 @@ import type { IconSvgLiteral } from './vaadin-icon-svg.js';
  * }
  * ```
  */
-declare class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(HTMLElement)))) {
+declare class Icon extends ThemableMixin(
+  ElementMixin(ControllerMixin(SlotStylesMixin(IconFontSizeMixin(HTMLElement)))),
+) {
   /**
    * The name of the icon to use. The name should be of the form:
    * `iconset_name:icon_name`. When using `vaadin-icons` it is possible


### PR DESCRIPTION
## Description

This PR moves all logic related to the `<vaadin-icon>`'s Container Queries [fallback](https://github.com/vaadin/web-components/blob/main/packages/icon/src/vaadin-icon.js#L391-L393) to a separate mixin.

Once Safari 15 is no longer on the list of supported browsers (all supported browsers have CSS CQ), everything related to the fallback can be cleaned up by removing the mixin.

## Type of change

Refactor