### PR TITLE
fix: wrap nodes correctly to ensure proper initialization

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -13,6 +13,7 @@
     "@vaadin/checkbox": "24.2.0-alpha13",
     "@vaadin/checkbox-group": "24.2.0-alpha13",
     "@vaadin/combo-box": "24.2.0-alpha13",
+    "@vaadin/confirm-dialog": "24.2.0-alpha13",
     "@vaadin/context-menu": "24.2.0-alpha13",
     "@vaadin/custom-field": "24.2.0-alpha13",
     "@vaadin/date-picker": "24.2.0-alpha13",

--- a/integration/tests/confirm-dialog-fields.test.js
+++ b/integration/tests/confirm-dialog-fields.test.js
@@ -1,0 +1,51 @@
+import { expect } from '@esm-bundle/chai';
+import { nextRender } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
+import '@vaadin/checkbox';
+import '@vaadin/combo-box';
+import '@vaadin/confirm-dialog';
+import '@vaadin/date-picker';
+import '@vaadin/multi-select-combo-box';
+import '@vaadin/number-field';
+import '@vaadin/radio-group';
+import '@vaadin/text-area';
+import '@vaadin/text-field';
+import '@vaadin/time-picker';
+
+describe('confirm-dialog with fields', () => {
+  let dialog, field;
+
+  [
+    'checkbox',
+    'combo-box',
+    'date-picker',
+    'number-field',
+    'radio-button',
+    'text-area',
+    'text-field',
+    'time-picker',
+  ].forEach((component) => {
+    describe(`confirm-dialog with ${component}`, () => {
+      beforeEach(async () => {
+        dialog = document.createElement('vaadin-confirm-dialog');
+        field = document.createElement(`vaadin-${component}`);
+        field.label = 'Label';
+        dialog.appendChild(field);
+        document.body.appendChild(dialog);
+        dialog.opened = true;
+        await nextRender();
+      });
+
+      afterEach(() => {
+        dialog.opened = false;
+        document.body.removeChild(dialog);
+      });
+
+      it(`should not throw error on ${component} label click`, () => {
+        expect(() => {
+          field.querySelector('label').click();
+        }).to.not.throw(Error);
+      });
+    });
+  });
+});

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -359,8 +359,8 @@ class ConfirmDialog extends ElementMixin(ThemePropertyMixin(ControllerMixin(Poly
         wrapper.style.display = 'contents';
         const wrapperId = `confirm-dialog-message-${generateUniqueId()}`;
         wrapper.id = wrapperId;
-        wrapper.appendChild(node);
         this.appendChild(wrapper);
+        wrapper.appendChild(node);
         setAriaIDReference(this._overlayElement, 'aria-describedby', { newId: wrapperId });
         this._messageNodes = [...this._messageNodes, wrapper];
       },


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5412

This PR changes the order of `appendChild()` calls to ensure `ready()` is called as expected.

The actual issue is related to how `vaadin-confirm-dialog` moves elements added to it:

1. The `<vaadin-checkbox>` element is added to the dialog,
2. The element is then [wrapped](https://github.com/vaadin/web-components/blob/57c1bd640dd037db9188cfdb1c04856df64addb1/packages/confirm-dialog/src/vaadin-confirm-dialog.js#L362) with the `<div>` element,
3. On open, the element is then [teleported](https://github.com/vaadin/web-components/blob/57c1bd640dd037db9188cfdb1c04856df64addb1/packages/confirm-dialog/src/vaadin-confirm-dialog.js#L412) to the overlay.

I don't think we can easily change the confirm-dialog logic, so I came up with a simpler fix.

## Type of change

- Bugfix