### PR TITLE
fix: do not expose LitElement API from SideNav

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -3,10 +3,8 @@
  * Copyright (c) 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LitElement } from 'lit';
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
 
@@ -79,9 +77,7 @@ export type SideNavItemEventMap = HTMLElementEventMap & SideNavItemCustomEventMa
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  */
-declare class SideNavItem extends SideNavChildrenMixin(
-  DisabledMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))),
-) {
+declare class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(ThemableMixin(HTMLElement)))) {
   /**
    * The path to navigate to
    */

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -72,8 +72,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  *
- * @extends LitElement
- * @mixes PolylitMixin
+ * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes DisabledMixin
  * @mixes ElementMixin

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -6,7 +6,7 @@
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { type SideNavI18n, SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
+import { SideNavChildrenMixin, type SideNavI18n } from './vaadin-side-nav-children-mixin.js';
 
 export type { SideNavI18n };
 

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -3,12 +3,10 @@
  * Copyright (c) 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { LitElement } from 'lit';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { SideNavChildrenMixin, type SideNavI18n } from './vaadin-side-nav-children-mixin.js';
+import { type SideNavI18n, SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
 
 export type { SideNavI18n };
 
@@ -74,7 +72,7 @@ export type SideNavEventMap = HTMLElementEventMap & SideNavCustomEventMap;
  *
  * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.
  */
-declare class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement))))) {
+declare class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin(HTMLElement)))) {
   /**
    * Whether the side nav is collapsible. When enabled, the toggle icon is shown.
    */

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -64,8 +64,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  *
  * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.
  *
- * @extends LitElement
- * @mixes PolylitMixin
+ * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin
  * @mixes SideNavChildrenMixin

--- a/packages/side-nav/test/typings/side-nav.types.ts
+++ b/packages/side-nav/test/typings/side-nav.types.ts
@@ -2,7 +2,6 @@ import '../../vaadin-side-nav.js';
 import '../../vaadin-side-nav-item.js';
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
-import type { PolylitMixinClass } from '@vaadin/component-base/src/polylit-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { SideNav, SideNavCollapsedChangedEvent, SideNavI18n } from '../../src/vaadin-side-nav';
 import type { SideNavChildrenMixinClass } from '../../src/vaadin-side-nav-children-mixin.js';
@@ -19,7 +18,6 @@ assertType<SideNavI18n>(sideNav.i18n);
 
 // Mixins
 assertType<ElementMixinClass>(sideNav);
-assertType<PolylitMixinClass>(sideNav);
 assertType<ThemableMixinClass>(sideNav);
 assertType<SideNavChildrenMixinClass>(sideNav);
 
@@ -41,7 +39,6 @@ assertType<SideNavI18n>(sideNavItem.i18n);
 // Item mixins
 assertType<DisabledMixinClass>(sideNavItem);
 assertType<ElementMixinClass>(sideNavItem);
-assertType<PolylitMixinClass>(sideNavItem);
 assertType<ThemableMixinClass>(sideNavItem);
 assertType<SideNavChildrenMixinClass>(sideNavItem);
 


### PR DESCRIPTION
## Description

The `SideNav` component being built on `LitElement` is a technical detail. Currently, it [exposes API from `LitElement`](https://cdn.vaadin.com/vaadin-web-components/24.2.0-alpha11/#/elements/vaadin-side-nav#methods) which is not desired.

This PR changes the parent type of `SideNav` and `SideNavItem` to `HTMLElement`, which aligns them with other Vaadin web components.