### PR TITLE
fix: do not throw when removing sort column after sorting

### DIFF
--- a/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -112,7 +112,7 @@ export const DynamicColumnsMixin = (superClass) =>
         if (hasColumnElements(info.addedNodes) || hasColumnElements(info.removedNodes)) {
           const allRemovedCells = info.removedNodes.flatMap((c) => c._allCells);
           const filterNotConnected = (element) =>
-            allRemovedCells.filter((cell) => cell._content.contains(element)).length;
+            allRemovedCells.filter((cell) => cell && cell._content.contains(element)).length;
 
           this.__removeSorters(this._sorters.filter(filterNotConnected));
           this.__removeFilters(this._filters.filter(filterNotConnected));

--- a/packages/grid/test/lit.test.js
+++ b/packages/grid/test/lit.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
+import '../vaadin-grid-sort-column.js';
 import '../vaadin-grid.js';
 import { html, render } from 'lit';
 import { getPhysicalItems } from './helpers.js';
@@ -31,5 +32,32 @@ describe('lit', () => {
     await aTimeout(0);
     const grid = wrapper.firstElementChild;
     expect(getPhysicalItems(grid).length).to.equal(1);
+  });
+
+  it('should not throw when dynamically removing sort columns after sorting', async () => {
+    const wrapper = fixtureSync(`<div></div>`);
+
+    function renderGrid(columnPaths, items) {
+      render(
+        html`
+          <vaadin-grid .items=${items}>
+            ${columnPaths.map((columnPath) => {
+              return html`<vaadin-grid-sort-column path="${columnPath}"></vaadin-grid-sort-column>`;
+            })}
+          </vaadin-grid>
+        `,
+        wrapper,
+      );
+    }
+
+    // First render with two columns
+    renderGrid(['c1', 'c2'], [{ c1: '1-1', c2: '1-2' }]);
+
+    await aTimeout(0);
+
+    document.querySelector('vaadin-grid-sorter').click();
+
+    // Then render a grid with one column
+    renderGrid(['c1'], [{ c1: '1-1', c2: '1-2' }]);
   });
 });


### PR DESCRIPTION
## Description

Fixes #6112

Added a check to ensure `cell` is not `undefined` which can happen when removing a column.

## Type of change

- Bugfix

## Note

Without the fix, the newly added test fails due to `TypeError` - this isn't ideal but does the job:

```
packages/grid/test/lit.test.js:

 🚧 Browser logs:
      TypeError: Cannot read properties of undefined (reading '_content')
        at packages/grid/src/vaadin-grid-dynamic-columns-mixin.js:115:51
        at Array.filter (<anonymous>)
        at filterNotConnected (packages/grid/src/vaadin-grid-dynamic-columns-mixin.js:115:29)
        at Array.filter (<anonymous>)
        at Grid.<anonymous> (packages/grid/src/vaadin-grid-dynamic-columns-mixin.js:117:46)
        at FlattenedNodesObserver.flush (node_modules/@polymer/polymer/lib/utils/flattened-nodes-observer.js:281:21)
        at FlattenedNodesObserver._processMutations (node_modules/@polymer/polymer/lib/utils/flattened-nodes-observer.js:213:10)
        at MutationObserver.<anonymous> (node_modules/@polymer/polymer/lib/utils/flattened-nodes-observer.js:161:18)

 ❌ lit > should not throw when dynamically removing sort columns after sorting
      Error: Uncaught TypeError: Cannot read properties of undefined (reading '_content')
``` 