### PR TITLE
feat: split char into ligature and char

### DIFF
--- a/dev/icon.html
+++ b/dev/icon.html
@@ -52,7 +52,10 @@
     <h6>Custom iconset icon</h6>
     <vaadin-icon icon="my-icons-iconset:logo"></vaadin-icon>
 
-    <h6>Font icon</h6>
+    <h6>Font icon (unprefixed char)</h6>
+    <vaadin-icon font-family="lumo-icons" char="ea0e"></vaadin-icon>
+
+    <h6>Font icon (prefixed char)</h6>
     <vaadin-icon font-family="lumo-icons" char="&#xea0e;"></vaadin-icon>
 
     <h6>SVG Standalone</h6>

--- a/packages/icon/src/vaadin-icon-font-size-mixin.js
+++ b/packages/icon/src/vaadin-icon-font-size-mixin.js
@@ -34,7 +34,7 @@ export const IconFontSizeMixin = dedupingMixin((superclass) =>
     ? superclass
     : class extends ResizeMixin(superclass) {
         static get observers() {
-          return ['__iconFontSizeMixinfontChanged(font, char)'];
+          return ['__iconFontSizeMixinfontChanged(font, char, ligature)'];
         }
 
         /** @protected */
@@ -46,7 +46,7 @@ export const IconFontSizeMixin = dedupingMixin((superclass) =>
         }
 
         /** @private */
-        __iconFontSizeMixinfontChanged(font, char) {
+        __iconFontSizeMixinfontChanged(_font, _char, _ligature) {
           // Update when font or char changes
           this.__updateFontIconSize();
         }
@@ -66,7 +66,7 @@ export const IconFontSizeMixin = dedupingMixin((superclass) =>
          * @private
          */
         __updateFontIconSize() {
-          if (this.char || this.font) {
+          if (this.char || this.font || this.ligature) {
             const { paddingTop, paddingBottom, height } = getComputedStyle(this);
             const fontIconSize = parseFloat(height) - parseFloat(paddingTop) - parseFloat(paddingBottom);
             this.style.setProperty('--_vaadin-font-icon-size', `${fontIconSize}px`);

--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -89,7 +89,7 @@ declare class Icon extends ThemableMixin(
   font: string | null;
 
   /**
-   * A character code that specifies an icon from an icon font.
+   * A hexadecimal code point that specifies a glyph from an icon font.
    *
    * Example: "e001"
    */

--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -89,12 +89,18 @@ declare class Icon extends ThemableMixin(
   font: string | null;
 
   /**
-   * The specific glyph from a font to use as an icon.
-   * Can be a code point or a ligature name.
+   * A character code that specifies an icon from an icon font.
    *
-   * @attr {string} char
+   * Example: "e001"
    */
   char: string | null;
+
+  /**
+   * A ligature name that specifies an icon from an icon font with support for ligatures.
+   *
+   * Example: "home".
+   */
+  ligature: string | null;
 
   /**
    * The font family to use for the font icon.

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -92,12 +92,12 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
           height: 100%;
         }
 
-        :host(:is([font], [char])) svg {
+        :host(:is([font], [font-icon-content])) svg {
           display: none;
         }
 
-        :host([char])::before {
-          content: attr(char);
+        :host([font-icon-content])::before {
+          content: attr(font-icon-content);
         }
       </style>
       <svg
@@ -169,15 +169,25 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
       },
 
       /**
-       * The specific glyph from a font to use as an icon.
-       * Can be a code point or a ligature name.
+       * A character code that specifies an icon from an icon font.
        *
-       * @attr {string} char
+       * Example: "e001"
+       *
        * @type {string}
        */
       char: {
         type: String,
-        reflectToAttribute: true,
+      },
+
+      /**
+       * A ligature name that specifies an icon from an icon font with support for ligatures.
+       *
+       * Example: "home".
+       *
+       * @type {string}
+       */
+      ligature: {
+        type: String,
       },
 
       /**
@@ -216,7 +226,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
   }
 
   static get observers() {
-    return ['__svgChanged(svg, __svgElement)', '__fontChanged(font, char)', '__srcChanged(src)'];
+    return ['__svgChanged(svg, __svgElement)', '__fontChanged(font, char, ligature)', '__srcChanged(src)'];
   }
 
   static get observedAttributes() {
@@ -360,14 +370,22 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
   }
 
   /** @private */
-  __fontChanged(font, char) {
+  __fontChanged(font, char, ligature) {
     this.classList.remove(...(this.__addedFontClasses || []));
     if (font) {
       this.__addedFontClasses = [...this.__fontClasses];
       this.classList.add(...this.__addedFontClasses);
     }
 
-    if ((font || char) && !this.icon) {
+    if (char) {
+      this.setAttribute('font-icon-content', char.length > 1 ? String.fromCodePoint(parseInt(char, 16)) : char);
+    } else if (ligature) {
+      this.setAttribute('font-icon-content', ligature);
+    } else {
+      this.removeAttribute('font-icon-content');
+    }
+
+    if ((font || char || ligature) && !this.icon) {
       // The "icon" attribute needs to be set on the host also when using font icons
       // to avoid issues such as https://github.com/vaadin/web-components/issues/6301
       this.icon = '';

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -169,7 +169,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
       },
 
       /**
-       * A character code that specifies an icon from an icon font.
+       * A hexadecimal code point that specifies a glyph from an icon font.
        *
        * Example: "e001"
        *

--- a/packages/icon/test/icon-font.test.js
+++ b/packages/icon/test/icon-font.test.js
@@ -161,10 +161,23 @@ describe('vaadin-icon - icon fonts', () => {
   describe('char', () => {
     let icon;
 
-    it('should reflect char as an attribute', () => {
+    it('should reflect unprefixed char as font-icon-content attribute', () => {
+      icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
+      icon.char = 'e900';
+      expect(icon.getAttribute('font-icon-content')).to.equal('\ue900');
+    });
+
+    it('should reflect prefixed char as font-icon-content attribute', () => {
       icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
       icon.char = '\ue900';
-      expect(icon.getAttribute('char')).to.equal('\ue900');
+      expect(icon.getAttribute('font-icon-content')).to.equal('\ue900');
+    });
+
+    it('should remove font-icon-content attribute', () => {
+      icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
+      icon.char = 'e900';
+      icon.char = null;
+      expect(icon.hasAttribute('font-icon-content')).to.be.false;
     });
 
     it('should add icon attribute if char is set', () => {
@@ -174,7 +187,7 @@ describe('vaadin-icon - icon fonts', () => {
       expect(icon.hasAttribute('icon')).to.be.true;
     });
 
-    it('should not add icon attribute if font is not set', () => {
+    it('should not add icon attribute if char is not set', () => {
       icon = fixtureSync('<vaadin-icon></vaadin-icon>');
       icon.char = null;
       icon.style.fontFamily = 'My icons';
@@ -189,11 +202,49 @@ describe('vaadin-icon - icon fonts', () => {
     });
   });
 
+  describe('ligature', () => {
+    let icon;
+
+    it('should reflect ligature as font-icon-content attribute', () => {
+      icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
+      icon.ligature = 'foo';
+      expect(icon.getAttribute('font-icon-content')).to.equal('foo');
+    });
+
+    it('should remove font-icon-content attribute', () => {
+      icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
+      icon.ligature = 'foo';
+      icon.ligature = null;
+      expect(icon.hasAttribute('font-icon-content')).to.be.false;
+    });
+
+    it('should add icon attribute if ligature is set', () => {
+      icon = fixtureSync('<vaadin-icon></vaadin-icon>');
+      icon.ligature = '\ue900';
+      icon.style.fontFamily = 'My icons';
+      expect(icon.hasAttribute('icon')).to.be.true;
+    });
+
+    it('should not add icon attribute if ligature is not set', () => {
+      icon = fixtureSync('<vaadin-icon></vaadin-icon>');
+      icon.ligature = null;
+      icon.style.fontFamily = 'My icons';
+      expect(icon.hasAttribute('icon')).to.be.false;
+    });
+
+    it('should not override existing icon', () => {
+      icon = fixtureSync('<vaadin-icon icon="foo:bar"></vaadin-icon>');
+      icon.ligature = 'foo';
+      icon.style.fontFamily = 'My icons';
+      expect(icon.icon).to.equal('foo:bar');
+    });
+  });
+
   describe('fontFamily', () => {
     let icon;
 
     it('should set font-family for the icon element', () => {
-      icon = fixtureSync('<vaadin-icon char="\\e900"></vaadin-icon>');
+      icon = fixtureSync('<vaadin-icon char="e900"></vaadin-icon>');
       icon.fontFamily = 'My icons';
       const fontIconStyle = getComputedStyle(icon, ':before');
       expect(['"My icons"', 'My icons']).to.include(fontIconStyle.fontFamily);

--- a/packages/icon/test/typings/icon.types.ts
+++ b/packages/icon/test/typings/icon.types.ts
@@ -11,5 +11,6 @@ assertType<IconSvgLiteral | null>(icon.svg);
 
 assertType<string | null>(icon.font);
 assertType<string | null>(icon.char);
+assertType<string | null>(icon.ligature);
 assertType<string | null>(icon.fontFamily);
 assertType<string | null>(icon.src);

--- a/packages/icon/test/visual/icon.common.js
+++ b/packages/icon/test/visual/icon.common.js
@@ -32,14 +32,14 @@ describe('icon', () => {
         <vaadin-icon font="my-icon-font icon-after"></vaadin-icon>
         <vaadin-icon font="my-icon-font icon-ligature"></vaadin-icon>
 
-        <!-- Font icons using char -->
-        <vaadin-icon font="my-icon-font" char="\ue900"></vaadin-icon>
-        <vaadin-icon font="my-icon-font" char="figma"></vaadin-icon>
-        <vaadin-icon style="font-family: 'My icons'" char="\ue900"></vaadin-icon>
+        <!-- Font icons using char and ligature -->
+        <vaadin-icon font="my-icon-font" char="e900"></vaadin-icon>
+        <vaadin-icon font="my-icon-font" ligature="figma"></vaadin-icon>
+        <vaadin-icon style="font-family: 'My icons'" char="e900"></vaadin-icon>
 
         <!-- Font icons using fontFamily -->
         <vaadin-icon font-family="My icons" char="\ue900"></vaadin-icon>
-        <vaadin-icon font-family="My icons" char="figma"></vaadin-icon>
+        <vaadin-icon font-family="My icons" ligature="figma"></vaadin-icon>
         `,
         div,
       );


### PR DESCRIPTION
## Description

As a follow-up of the `<vaadin-icon>` font icon support DX test results, we decided to split the `icon.char`, which currently accepts either a code point or a ligature, into separate `char` and `ligature` properties.

Since `char` can no longer be a ligature name, the updated `char` property now also supports unprefixed code points (like "ea0e").

Before:
```html
<vaadin-icon font-family="lumo-icons" char="&#xea0e;"></vaadin-icon>
<vaadin-icon font-family="Material Icons" char="face"></vaadin-icon>
```

After:
```html
<vaadin-icon font-family="lumo-icons" char="ea0e"></vaadin-icon>
<vaadin-icon font-family="Material Icons" ligature="face"></vaadin-icon>
```



## Type of change

Feature