### PR TITLE
test: use themed date picker in the tests

### DIFF
--- a/packages/date-picker/test/value-commit-lit.test.js
+++ b/packages/date-picker/test/value-commit-lit.test.js
@@ -1,3 +1,9 @@
+import '../theme/lumo/vaadin-date-picker-styles.js';
+import '../theme/lumo/vaadin-date-picker-overlay-styles.js';
+import '../theme/lumo/vaadin-date-picker-overlay-content-styles.js';
+import '../theme/lumo/vaadin-month-calendar-styles.js';
+import '../theme/lumo/vaadin-date-picker-styles.js';
+import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import './not-animated-styles.js';
 import '../src/vaadin-lit-date-picker.js';
 import './value-commit.common.js';

--- a/packages/date-picker/test/value-commit-polymer.test.js
+++ b/packages/date-picker/test/value-commit-polymer.test.js
@@ -1,3 +1,3 @@
 import './not-animated-styles.js';
-import '../src/vaadin-date-picker.js';
+import '../vaadin-date-picker.js';
 import './value-commit.common.js';


### PR DESCRIPTION
## Description

Use themed `<vaadin-date-picker>` in the value-commit tests. This fixes the current test failures in `main` branch.

## Type of change

Tests