### PR TITLE
fix: wrap icon font family in quotes

### DIFF
--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -386,7 +386,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
 
   /** @private */
   __fontFamilyChanged(fontFamily) {
-    this.style.fontFamily = fontFamily;
+    this.style.fontFamily = `'${fontFamily}'`;
   }
 }
 

--- a/packages/icon/test/icon-font.test.js
+++ b/packages/icon/test/icon-font.test.js
@@ -198,6 +198,13 @@ describe('vaadin-icon - icon fonts', () => {
       const fontIconStyle = getComputedStyle(icon, ':before');
       expect(['"My icons"', 'My icons']).to.include(fontIconStyle.fontFamily);
     });
+
+    it('should set font-family with numbers for the icon element', () => {
+      icon = fixtureSync('<vaadin-icon char="\\e900"></vaadin-icon>');
+      icon.fontFamily = 'My icons 6';
+      const fontIconStyle = getComputedStyle(icon, ':before');
+      expect(['"My icons 6"', 'My icons 6']).to.include(fontIconStyle.fontFamily);
+    });
   });
 
   // These tests make sure that the heavy container query fallback is only used


### PR DESCRIPTION
## Description

It appears that if your font family name contains spaces and numbers (for example "Font Awesome 6 Free"), `element.style.fontFamily = fontFamily` does nothing. See https://stackoverflow.com/questions/8951584/assigning-a-css-fontfamily-ending-with-a-number. This PR fixes the issue by wrapping the font family name in single quotes.

## Type of change

Bugfix