### PR TITLE
fix!: link every checkbox in a group with the tooltip overlay

### DIFF
--- a/integration/tests/checkbox-group-tooltip.test.js
+++ b/integration/tests/checkbox-group-tooltip.test.js
@@ -1,0 +1,62 @@
+import { expect } from '@esm-bundle/chai';
+import { nextRender } from '@vaadin/testing-helpers';
+import '@vaadin/checkbox-group';
+import '@vaadin/tooltip';
+
+describe('checkbox-group with tooltip', () => {
+  let group, tooltip, checkbox1, checkbox2, overlay;
+
+  beforeEach(async () => {
+    group = document.createElement('vaadin-checkbox-group');
+    group.label = 'Language';
+    document.body.appendChild(group);
+
+    checkbox1 = document.createElement('vaadin-checkbox');
+    checkbox1.value = 'en';
+    checkbox1.label = 'English';
+    group.appendChild(checkbox1);
+
+    checkbox2 = document.createElement('vaadin-checkbox');
+    checkbox2.value = 'fr';
+    checkbox2.label = 'Français';
+    group.appendChild(checkbox2);
+
+    tooltip = document.createElement('vaadin-tooltip');
+    tooltip.slot = 'tooltip';
+    tooltip.text = 'If not selected, English is used';
+    group.appendChild(tooltip);
+
+    await nextRender();
+    overlay = tooltip._overlayElement;
+  });
+
+  afterEach(() => {
+    group.remove();
+  });
+
+  it('should link tooltip with input elements using aria-describedby', () => {
+    expect(checkbox1.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+    expect(checkbox2.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+  });
+
+  it('should set aria-describedby on the newly added checkbox input', async () => {
+    const checkbox = document.createElement('vaadin-checkbox');
+    checkbox.value = 'de';
+    group.appendChild(checkbox);
+    await nextRender();
+    expect(checkbox.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+  });
+
+  it('should remove aria-describedby from the removed checkbox input', async () => {
+    group.removeChild(checkbox1);
+    await nextRender();
+    expect(checkbox1.inputElement.hasAttribute('aria-describedby')).to.be.false;
+  });
+
+  it('should remove aria-describedby when the tooltip element is removed', async () => {
+    group.removeChild(tooltip);
+    await nextRender();
+    expect(checkbox1.inputElement.hasAttribute('aria-describedby')).to.be.false;
+    expect(checkbox2.inputElement.hasAttribute('aria-describedby')).to.be.false;
+  });
+});

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -162,6 +162,19 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
     this.__unregisterCheckbox = this.__unregisterCheckbox.bind(this);
     this.__onCheckboxChange = this.__onCheckboxChange.bind(this);
     this.__onCheckboxCheckedChanged = this.__onCheckboxCheckedChanged.bind(this);
+
+    this._tooltipController = new TooltipController(this);
+    this._tooltipController.addEventListener('tooltip-changed', (event) => {
+      const tooltip = event.detail.node;
+      if (tooltip && tooltip.isConnected) {
+        // Tooltip element has been added to the DOM
+        const inputs = this.__checkboxes.map((checkbox) => checkbox.inputElement);
+        this._tooltipController.setAriaTarget(inputs);
+      } else {
+        // Tooltip element is no longer connected
+        this._tooltipController.setAriaTarget([]);
+      }
+    });
   }
 
   /**
@@ -191,10 +204,12 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
       addedCheckboxes.forEach(this.__registerCheckbox);
       removedCheckboxes.forEach(this.__unregisterCheckbox);
 
+      const inputs = this.__checkboxes.map((checkbox) => checkbox.inputElement);
+      this._tooltipController.setAriaTarget(inputs);
+
       this.__warnOfCheckboxesWithoutValue(addedCheckboxes);
     });
 
-    this._tooltipController = new TooltipController(this);
     this.addController(this._tooltipController);
   }
 


### PR DESCRIPTION
## Description

Part of #6286

## Type of change

- Behavior altering fix

## Note

Here are the outcomes of testing in screen readers.

### NVDA

<img width="514" alt="nvda-cbg-tooltip" src="https://github.com/vaadin/web-components/assets/10589913/f6f82432-4a9d-4704-98c1-267773838bb9">

### JAWS

<img width="477" alt="jaws-cbg-tooltip" src="https://github.com/vaadin/web-components/assets/10589913/9804ea91-7efe-48a9-b1dd-e4cfa06886aa">

### VoiceOver

https://github.com/vaadin/web-components/assets/10589913/4148e3fd-b039-42bf-91b7-e390ff1e9636