### PR TITLE
fix: allow to set default value for readOnly property

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -93,17 +93,6 @@ const PolylitMixinImplementation = (superclass) => {
 
       let result = defaultDescriptor;
 
-      if ('value' in options) {
-        // Set the default value
-        this.addCheckedInitializer((instance) => {
-          if (typeof options.value === 'function') {
-            instance[name] = options.value.call(instance);
-          } else {
-            instance[name] = options.value;
-          }
-        });
-      }
-
       if (options.sync) {
         result = {
           get: defaultDescriptor.get,
@@ -144,6 +133,19 @@ const PolylitMixinImplementation = (superclass) => {
           configurable: true,
           enumerable: true,
         };
+      }
+
+      if ('value' in options) {
+        // Set the default value
+        this.addCheckedInitializer((instance) => {
+          const value = typeof options.value === 'function' ? options.value.call(instance) : options.value;
+
+          if (options.readOnly) {
+            instance[`_set${upper(name)}`](value);
+          } else {
+            instance[name] = value;
+          }
+        });
       }
 
       if (options.observer) {

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -176,6 +176,12 @@ describe('PolylitMixin', () => {
               type: String,
               readOnly: true,
             },
+
+            opened: {
+              type: Boolean,
+              value: false,
+              readOnly: true,
+            },
           };
         }
 
@@ -209,6 +215,10 @@ describe('PolylitMixin', () => {
       await element.updateComplete;
       expect(element.helper).to.equal('bar');
       expect(element.shadowRoot.textContent).to.equal('bar');
+    });
+
+    it('should set initial value for the property marked as readOnly', () => {
+      expect(element.opened).to.equal(false);
     });
   });
 


### PR DESCRIPTION
## Description

This is a finding from the `vaadin-context-menu` Lit conversion research.

## Type of change

- Bugfix