### PR TITLE
refactor!: rename overlay custom-fields slot to custom-form-area

### DIFF
--- a/packages/login/src/vaadin-lit-login-form-wrapper.js
+++ b/packages/login/src/vaadin-lit-login-form-wrapper.js
@@ -58,7 +58,7 @@ class LoginFormWrapper extends ThemableMixin(PolylitMixin(LitElement)) {
 
         <slot name="form"></slot>
 
-        <slot name="custom-fields"></slot>
+        <slot name="custom-form-area"></slot>
 
         <slot name="submit"></slot>
 

--- a/packages/login/src/vaadin-lit-login-overlay.js
+++ b/packages/login/src/vaadin-lit-login-overlay.js
@@ -57,7 +57,7 @@ class LoginOverlay extends LoginOverlayMixin(ElementMixin(ThemableMixin(PolylitM
       </vaadin-login-overlay-wrapper>
 
       <div hidden>
-        <slot name="custom-fields"></slot>
+        <slot name="custom-form-area"></slot>
         <slot name="footer"></slot>
       </div>
     `;

--- a/packages/login/src/vaadin-login-form-mixin.js
+++ b/packages/login/src/vaadin-login-form-mixin.js
@@ -17,7 +17,7 @@ export const LoginFormMixin = (superClass) =>
 
     get _customFields() {
       return [...this.$.vaadinLoginFormWrapper.children].filter((node) => {
-        return node.getAttribute('slot') === 'custom-fields' && node.hasAttribute('name');
+        return node.getAttribute('slot') === 'custom-form-area' && node.hasAttribute('name');
       });
     }
 

--- a/packages/login/src/vaadin-login-form-wrapper.js
+++ b/packages/login/src/vaadin-login-form-wrapper.js
@@ -30,7 +30,7 @@ class LoginFormWrapper extends ThemableMixin(PolymerElement) {
 
         <slot name="form"></slot>
 
-        <slot name="custom-fields"></slot>
+        <slot name="custom-form-area"></slot>
 
         <slot name="submit"></slot>
 

--- a/packages/login/src/vaadin-login-overlay-mixin.js
+++ b/packages/login/src/vaadin-login-overlay-mixin.js
@@ -135,7 +135,7 @@ export const LoginOverlayMixin = (superClass) =>
         this._undoTitleTeleport = this._teleport('title', this.$.vaadinLoginOverlayWrapper);
 
         this._undoFieldsTeleport = this._teleport(
-          'custom-fields',
+          'custom-form-area',
           form.$.vaadinLoginFormWrapper,
           form.querySelector('vaadin-button'),
         );

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -77,7 +77,7 @@ class LoginOverlay extends LoginOverlayMixin(ElementMixin(ThemableMixin(PolymerE
       </vaadin-login-overlay-wrapper>
 
       <div hidden>
-        <slot name="custom-fields"></slot>
+        <slot name="custom-form-area"></slot>
         <slot name="footer"></slot>
       </div>
     `;

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -583,7 +583,7 @@ snapshots["vaadin-login-form shadow default"] =
   </div>
   <slot name="form">
   </slot>
-  <slot name="custom-fields">
+  <slot name="custom-form-area">
   </slot>
   <slot name="submit">
   </slot>
@@ -614,7 +614,7 @@ snapshots["vaadin-login-form shadow error"] =
   </div>
   <slot name="form">
   </slot>
-  <slot name="custom-fields">
+  <slot name="custom-form-area">
   </slot>
   <slot name="submit">
   </slot>
@@ -648,7 +648,7 @@ snapshots["vaadin-login-form shadow i18n"] =
   </div>
   <slot name="form">
   </slot>
-  <slot name="custom-fields">
+  <slot name="custom-form-area">
   </slot>
   <slot name="submit">
   </slot>

--- a/packages/login/test/login-overlay.common.js
+++ b/packages/login/test/login-overlay.common.js
@@ -221,14 +221,14 @@ describe('title slot', () => {
   });
 });
 
-describe('custom-fields slot', () => {
+describe('custom-form-area slot', () => {
   let overlay, inputs, form;
 
   beforeEach(async () => {
     overlay = fixtureSync(`
       <vaadin-login-overlay>
-        <input id="one" slot="custom-fields" />
-        <input id="two" slot="custom-fields" />
+        <input id="one" slot="custom-form-area" />
+        <input id="two" slot="custom-form-area" />
       </vaadin-login-overlay>
     `);
     await nextRender();

--- a/packages/login/test/login-submit.common.js
+++ b/packages/login/test/login-submit.common.js
@@ -106,7 +106,7 @@ describe('login form submit', () => {
       login = overlay.$.vaadinLoginForm;
     });
 
-    it('should add custom fields values to the login event detail', () => {
+    it('should add values of fields in the custom form area to the login event detail', () => {
       const loginSpy = sinon.spy();
 
       overlay.addEventListener('login', loginSpy);
@@ -127,7 +127,7 @@ describe('login form submit', () => {
         await nextRender();
       });
 
-      it('should submit custom fields values to the native form', (done) => {
+      it('should submit values of fields in the custom form area to the native form', (done) => {
         testFormSubmitValues(false, true, done, { foo: 'bar', code: '1234' });
       });
     });

--- a/packages/login/test/login-submit.common.js
+++ b/packages/login/test/login-submit.common.js
@@ -92,14 +92,14 @@ describe('login form submit', () => {
     });
   });
 
-  describe('custom fields', () => {
+  describe('custom form area', () => {
     let overlay;
 
     beforeEach(async () => {
       overlay = fixtureSync(`
         <vaadin-login-overlay opened>
-          <input name="foo" value="bar" slot="custom-fields">
-          <vaadin-text-field name="code" value="1234" slot="custom-fields"></vaadin-text-field>
+          <input name="foo" value="bar" slot="custom-form-area">
+          <vaadin-text-field name="code" value="1234" slot="custom-form-area"></vaadin-text-field>
         </vaadin-login-overlay>
       `);
       await nextRender();

--- a/packages/login/test/visual/lumo/login-overlay.test.js
+++ b/packages/login/test/visual/lumo/login-overlay.test.js
@@ -25,7 +25,7 @@ describe('login-overlay', () => {
 
   it('additional field', async () => {
     const field = document.createElement('vaadin-text-field');
-    field.setAttribute('slot', 'custom-fields');
+    field.setAttribute('slot', 'custom-form-area');
     field.label = 'One-time code';
     element.appendChild(field);
     element.opened = true;

--- a/packages/login/test/visual/material/login-overlay.test.js
+++ b/packages/login/test/visual/material/login-overlay.test.js
@@ -25,7 +25,7 @@ describe('login-overlay', () => {
 
   it('additional field', async () => {
     const field = document.createElement('vaadin-text-field');
-    field.setAttribute('slot', 'custom-fields');
+    field.setAttribute('slot', 'custom-form-area');
     field.label = 'One-time code';
     element.appendChild(field);
     element.opened = true;


### PR DESCRIPTION
## Description

As discussed internally, we are going to use `getCustomFormArea()` for Java API, so let's align the slot name with it.

## Type of change

- Refactor