### PR TITLE
refactor: rename icon.font to icon.iconClass

### DIFF
--- a/packages/icon/src/vaadin-icon-font-size-mixin.js
+++ b/packages/icon/src/vaadin-icon-font-size-mixin.js
@@ -34,7 +34,7 @@ export const IconFontSizeMixin = dedupingMixin((superclass) =>
     ? superclass
     : class extends ResizeMixin(superclass) {
         static get observers() {
-          return ['__iconFontSizeMixinfontChanged(font, char, ligature)'];
+          return ['__iconFontSizeMixinfontChanged(iconClass, char, ligature)'];
         }
 
         /** @protected */
@@ -46,8 +46,8 @@ export const IconFontSizeMixin = dedupingMixin((superclass) =>
         }
 
         /** @private */
-        __iconFontSizeMixinfontChanged(_font, _char, _ligature) {
-          // Update when font or char changes
+        __iconFontSizeMixinfontChanged(_iconClass, _char, _ligature) {
+          // Update when iconClass, char or ligature changes
           this.__updateFontIconSize();
         }
 
@@ -61,12 +61,12 @@ export const IconFontSizeMixin = dedupingMixin((superclass) =>
         }
 
         /**
-         * Updates the --_vaadin-font-icon-size CSS variable value if char or font is set (font icons in use).
+         * Updates the --_vaadin-font-icon-size CSS variable value if font icons are used.
          *
          * @private
          */
         __updateFontIconSize() {
-          if (this.char || this.font || this.ligature) {
+          if (this.char || this.iconClass || this.ligature) {
             const { paddingTop, paddingBottom, height } = getComputedStyle(this);
             const fontIconSize = parseFloat(height) - parseFloat(paddingTop) - parseFloat(paddingBottom);
             this.style.setProperty('--_vaadin-font-icon-size', `${fontIconSize}px`);

--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -84,9 +84,11 @@ declare class Icon extends ThemableMixin(
   /**
    * Class names defining an icon font and/or a specific glyph inside an icon font.
    *
-   * @attr {string} font
+   * Example: "fa-solid fa-user"
+   *
+   * @attr {string} icon-class
    */
-  font: string | null;
+  iconClass: string | null;
 
   /**
    * A hexadecimal code point that specifies a glyph from an icon font.

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -92,7 +92,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
           height: 100%;
         }
 
-        :host(:is([font], [font-icon-content])) svg {
+        :host(:is([icon-class], [font-icon-content])) svg {
           display: none;
         }
 
@@ -160,10 +160,12 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
       /**
        * Class names defining an icon font and/or a specific glyph inside an icon font.
        *
-       * @attr {string} font
+       * Example: "fa-solid fa-user"
+       *
+       * @attr {string} icon-class
        * @type {string}
        */
-      font: {
+      iconClass: {
         type: String,
         reflectToAttribute: true,
       },
@@ -226,7 +228,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
   }
 
   static get observers() {
-    return ['__svgChanged(svg, __svgElement)', '__fontChanged(font, char, ligature)', '__srcChanged(src)'];
+    return ['__svgChanged(svg, __svgElement)', '__fontChanged(iconClass, char, ligature)', '__srcChanged(src)'];
   }
 
   static get observedAttributes() {
@@ -244,7 +246,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
     const tag = this.localName;
     return [
       `
-        ${tag}[font] {
+        ${tag}[icon-class] {
           display: inline-flex;
           vertical-align: middle;
           font-size: inherit;
@@ -254,8 +256,8 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
   }
 
   /** @private */
-  get __fontClasses() {
-    return this.font ? this.font.split(' ') : [];
+  get __iconClasses() {
+    return this.iconClass ? this.iconClass.split(' ') : [];
   }
 
   /** @protected */
@@ -370,11 +372,11 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
   }
 
   /** @private */
-  __fontChanged(font, char, ligature) {
-    this.classList.remove(...(this.__addedFontClasses || []));
-    if (font) {
-      this.__addedFontClasses = [...this.__fontClasses];
-      this.classList.add(...this.__addedFontClasses);
+  __fontChanged(iconClass, char, ligature) {
+    this.classList.remove(...(this.__addedIconClasses || []));
+    if (iconClass) {
+      this.__addedIconClasses = [...this.__iconClasses];
+      this.classList.add(...this.__addedIconClasses);
     }
 
     if (char) {
@@ -385,7 +387,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
       this.removeAttribute('font-icon-content');
     }
 
-    if ((font || char || ligature) && !this.icon) {
+    if ((iconClass || char || ligature) && !this.icon) {
       // The "icon" attribute needs to be set on the host also when using font icons
       // to avoid issues such as https://github.com/vaadin/web-components/issues/6301
       this.icon = '';
@@ -397,8 +399,8 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
     super.attributeChangedCallback(name, oldValue, newValue);
 
     // Make sure class list always contains all the font class names
-    if (name === 'class' && this.__fontClasses.some((className) => !this.classList.contains(className))) {
-      this.classList.add(...this.__fontClasses);
+    if (name === 'class' && this.__iconClasses.some((className) => !this.classList.contains(className))) {
+      this.classList.add(...this.__iconClasses);
     }
   }
 

--- a/packages/icon/test/icon-font.test.js
+++ b/packages/icon/test/icon-font.test.js
@@ -40,7 +40,7 @@ describe('vaadin-icon - icon fonts', () => {
     let icon;
 
     beforeEach(async () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font icon-before"></vaadin-icon>');
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font icon-before"></vaadin-icon>');
       await onceResized(icon);
     });
 
@@ -81,79 +81,79 @@ describe('vaadin-icon - icon fonts', () => {
     });
   });
 
-  describe('font', () => {
+  describe('iconClass', () => {
     let icon;
 
-    it('should add the font to element class list', () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font icon-before"></vaadin-icon>');
+    it('should add the icon class to element class list', () => {
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font icon-before"></vaadin-icon>');
       expect(icon.classList.contains('my-icon-font')).to.be.true;
       expect(icon.classList.contains('icon-before')).to.be.true;
     });
 
     it('should not overwrite existing classes', () => {
       icon = fixtureSync('<vaadin-icon class="foo"></vaadin-icon>');
-      icon.font = 'my-icon-font icon-before';
+      icon.iconClass = 'my-icon-font icon-before';
       expect(icon.classList.contains('foo')).to.be.true;
     });
 
-    it('should change font classes', () => {
-      icon = fixtureSync('<vaadin-icon class="foo" font="my-icon-font icon-before"></vaadin-icon>');
-      icon.font = 'my-icon-font icon-after';
+    it('should change icon classes', () => {
+      icon = fixtureSync('<vaadin-icon class="foo" icon-class="my-icon-font icon-before"></vaadin-icon>');
+      icon.iconClass = 'my-icon-font icon-after';
       expect(icon.classList.contains('icon-before')).to.be.false;
       expect(icon.classList.contains('icon-after')).to.be.true;
     });
 
-    it('should remove all font classes', () => {
-      icon = fixtureSync('<vaadin-icon class="foo" font="my-icon-font icon-before"></vaadin-icon>');
-      icon.font = '';
+    it('should remove all icon classes', () => {
+      icon = fixtureSync('<vaadin-icon class="foo" icon-class="my-icon-font icon-before"></vaadin-icon>');
+      icon.iconClass = '';
       expect(icon.classList.contains('my-icon-font')).to.be.false;
       expect(icon.classList.contains('icon-before')).to.be.false;
       expect(icon.classList.contains('foo')).to.be.true;
     });
 
-    it('should restore the font to element class list', () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font icon-before"></vaadin-icon>');
+    it('should restore the icon class to element class list', () => {
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font icon-before"></vaadin-icon>');
       icon.className = 'foo';
       expect(icon.classList.contains('my-icon-font')).to.be.true;
       expect(icon.classList.contains('icon-before')).to.be.true;
       expect(icon.classList.contains('foo')).to.be.true;
     });
 
-    it('should restore the missing font to element class list', () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font icon-before"></vaadin-icon>');
+    it('should restore the missing icon class to element class list', () => {
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font icon-before"></vaadin-icon>');
       icon.className = 'my-icon-font';
       expect(icon.classList.contains('my-icon-font')).to.be.true;
       expect(icon.classList.contains('icon-before')).to.be.true;
     });
 
-    it('should restore the removed font to element class list', () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font icon-before"></vaadin-icon>');
+    it('should restore the removed icon class to element class list', () => {
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font icon-before"></vaadin-icon>');
       icon.classList.remove('my-icon-font');
       expect(icon.classList.contains('my-icon-font')).to.be.true;
       expect(icon.classList.contains('icon-before')).to.be.true;
     });
 
-    it('should reflect font as an attribute', () => {
+    it('should reflect icon class as an attribute', () => {
       icon = fixtureSync('<vaadin-icon></vaadin-icon>');
-      icon.font = 'my-icon-font icon-before';
-      expect(icon.getAttribute('font')).to.equal('my-icon-font icon-before');
+      icon.iconClass = 'my-icon-font icon-before';
+      expect(icon.getAttribute('icon-class')).to.equal('my-icon-font icon-before');
     });
 
-    it('should add icon attribute if font is set', () => {
+    it('should add icon attribute if icon class is set', () => {
       icon = fixtureSync('<vaadin-icon></vaadin-icon>');
-      icon.font = 'my-icon-font icon-before';
+      icon.iconClass = 'my-icon-font icon-before';
       expect(icon.hasAttribute('icon')).to.be.true;
     });
 
-    it('should not add icon attribute if font is not set', () => {
+    it('should not add icon attribute if icon class is not set', () => {
       icon = fixtureSync('<vaadin-icon></vaadin-icon>');
-      icon.font = null;
+      icon.iconClass = null;
       expect(icon.hasAttribute('icon')).to.be.false;
     });
 
     it('should not override existing icon', () => {
       icon = fixtureSync('<vaadin-icon icon="foo:bar"></vaadin-icon>');
-      icon.font = 'my-icon-font icon-before';
+      icon.iconClass = 'my-icon-font icon-before';
       expect(icon.icon).to.equal('foo:bar');
     });
   });
@@ -162,19 +162,19 @@ describe('vaadin-icon - icon fonts', () => {
     let icon;
 
     it('should reflect unprefixed char as font-icon-content attribute', () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font"></vaadin-icon>');
       icon.char = 'e900';
       expect(icon.getAttribute('font-icon-content')).to.equal('\ue900');
     });
 
     it('should reflect prefixed char as font-icon-content attribute', () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font"></vaadin-icon>');
       icon.char = '\ue900';
       expect(icon.getAttribute('font-icon-content')).to.equal('\ue900');
     });
 
     it('should remove font-icon-content attribute', () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font"></vaadin-icon>');
       icon.char = 'e900';
       icon.char = null;
       expect(icon.hasAttribute('font-icon-content')).to.be.false;
@@ -206,13 +206,13 @@ describe('vaadin-icon - icon fonts', () => {
     let icon;
 
     it('should reflect ligature as font-icon-content attribute', () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font"></vaadin-icon>');
       icon.ligature = 'foo';
       expect(icon.getAttribute('font-icon-content')).to.equal('foo');
     });
 
     it('should remove font-icon-content attribute', () => {
-      icon = fixtureSync('<vaadin-icon font="my-icon-font"></vaadin-icon>');
+      icon = fixtureSync('<vaadin-icon icon-class="my-icon-font"></vaadin-icon>');
       icon.ligature = 'foo';
       icon.ligature = null;
       expect(icon.hasAttribute('font-icon-content')).to.be.false;
@@ -280,8 +280,8 @@ describe('vaadin-icon - icon fonts', () => {
       expect(supportsCQUnitsForPseudoElements()).to.be.false;
     });
 
-    fallBackIt('should have the custom property (font)', async () => {
-      icon = fixtureSync('<vaadin-icon font="foo"></vaadin-icon>');
+    fallBackIt('should have the custom property (iconClass)', async () => {
+      icon = fixtureSync('<vaadin-icon icon-class="foo"></vaadin-icon>');
       await nextFrame();
       expect(icon.style.getPropertyValue('--_vaadin-font-icon-size')).to.equal('24px');
     });
@@ -301,12 +301,12 @@ describe('vaadin-icon - icon fonts', () => {
     fallBackIt('should set the custom property', async () => {
       icon = fixtureSync('<vaadin-icon></vaadin-icon>');
       await nextFrame();
-      icon.font = 'foo';
+      icon.iconClass = 'foo';
       expect(icon.style.getPropertyValue('--_vaadin-font-icon-size')).to.equal('24px');
     });
 
     fallBackIt('should update the custom property', async () => {
-      icon = fixtureSync('<vaadin-icon font="foo"></vaadin-icon>');
+      icon = fixtureSync('<vaadin-icon icon-class="foo"></vaadin-icon>');
       await nextFrame();
       icon.style.width = '100px';
       icon.style.height = '100px';

--- a/packages/icon/test/typings/icon.types.ts
+++ b/packages/icon/test/typings/icon.types.ts
@@ -9,7 +9,7 @@ assertType<ControllerMixinClass>(icon);
 
 assertType<IconSvgLiteral | null>(icon.svg);
 
-assertType<string | null>(icon.font);
+assertType<string | null>(icon.iconClass);
 assertType<string | null>(icon.char);
 assertType<string | null>(icon.ligature);
 assertType<string | null>(icon.fontFamily);

--- a/packages/icon/test/visual/icon.common.js
+++ b/packages/icon/test/visual/icon.common.js
@@ -27,14 +27,14 @@ describe('icon', () => {
 
       fixtureSync(
         `
-        <!-- Font icons using class names -->
-        <vaadin-icon font="my-icon-font icon-before"></vaadin-icon>
-        <vaadin-icon font="my-icon-font icon-after"></vaadin-icon>
-        <vaadin-icon font="my-icon-font icon-ligature"></vaadin-icon>
+        <!-- Font icons using icon class -->
+        <vaadin-icon icon-class="my-icon-font icon-before"></vaadin-icon>
+        <vaadin-icon icon-class="my-icon-font icon-after"></vaadin-icon>
+        <vaadin-icon icon-class="my-icon-font icon-ligature"></vaadin-icon>
 
         <!-- Font icons using char and ligature -->
-        <vaadin-icon font="my-icon-font" char="e900"></vaadin-icon>
-        <vaadin-icon font="my-icon-font" ligature="figma"></vaadin-icon>
+        <vaadin-icon icon-class="my-icon-font" char="e900"></vaadin-icon>
+        <vaadin-icon icon-class="my-icon-font" ligature="figma"></vaadin-icon>
         <vaadin-icon style="font-family: 'My icons'" char="e900"></vaadin-icon>
 
         <!-- Font icons using fontFamily -->


### PR DESCRIPTION
## Description

As a follow-up of the `<vaadin-icon>` font icon support DX test results, we decided to rename the `icon.font` as `icon.iconClass`

Before:
```html
<vaadin-icon font="fa-solid fa-user"></vaadin-icon>
```

After:
```html
<vaadin-icon icon-class="fa-solid fa-user"></vaadin-icon>
```

## Type of change

Refactor