### PR TITLE
chore: add default icon font smoothing

### DIFF
--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -80,6 +80,9 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
         :host::before {
           line-height: 1;
           font-size: 100cqh;
+          -webkit-font-smoothing: antialiased;
+          text-rendering: optimizeLegibility;
+          -moz-osx-font-smoothing: grayscale;
         }
 
         :host([hidden]) {


### PR DESCRIPTION
## Description

Popular icon collections, like Font Awesome and Material Icons, apply [font-smoothing](https://github.com/FortAwesome/Font-Awesome/blob/6.x/css/all.css#L19-L20) to font icons when used with the built-in class names.
If you use font icons with `fontFamily` and `char`, font-smoothing CSS does not get applied to the icons automatically. This PR adds default styles to ensure consistent font smoothing for all icons.