### PR TITLE
WIP: initial attempt to context-menu Lit conversion

### DIFF
--- a/dev/context-menu.html
+++ b/dev/context-menu.html
@@ -8,7 +8,10 @@
     <script type="module" src="./common.js"></script>
 
     <script type="module">
-      import '@vaadin/context-menu';
+      import '@vaadin/context-menu/theme/lumo/vaadin-context-menu-item-styles.js';
+      import '@vaadin/context-menu/theme/lumo/vaadin-context-menu-list-box-styles.js';
+      import '@vaadin/context-menu/theme/lumo/vaadin-context-menu-overlay-styles.js';
+      import '@vaadin/context-menu/src/vaadin-lit-context-menu.js';
 
       const menu = document.querySelector('vaadin-context-menu');
       menu.items = [

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -43,6 +43,7 @@ export const ContextMenuMixin = (superClass) =>
         openOn: {
           type: String,
           value: 'vaadin-contextmenu',
+          sync: true,
         },
 
         /**
@@ -54,6 +55,7 @@ export const ContextMenuMixin = (superClass) =>
          */
         listenOn: {
           type: Object,
+          sync: true,
           value() {
             return this;
           },
@@ -68,6 +70,7 @@ export const ContextMenuMixin = (superClass) =>
           type: String,
           value: 'click',
           observer: '_closeOnChanged',
+          sync: true,
         },
 
         /**
@@ -83,6 +86,7 @@ export const ContextMenuMixin = (superClass) =>
          */
         renderer: {
           type: Function,
+          sync: true,
         },
 
         /**
@@ -91,10 +95,14 @@ export const ContextMenuMixin = (superClass) =>
          */
         _modeless: {
           type: Boolean,
+          sync: true,
         },
 
         /** @private */
-        _context: Object,
+        _context: {
+          type: Object,
+          sync: true,
+        },
 
         /** @private */
         _phone: {

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -66,7 +66,10 @@ export const ItemsMixin = (superClass) =>
          * ----------------|----------------|----------------
          * `:host` | expanded | Expanded parent item
          */
-        items: Array,
+        items: {
+          type: Array,
+          sync: true,
+        },
       };
     }
 
@@ -300,7 +303,9 @@ export const ItemsMixin = (superClass) =>
 
       // Listen to the forwarded event from sub-menu.
       this.addEventListener('close-all-menus', () => {
-        this.close();
+        // Call `close()` on the overlay to close synchronously,
+        // as we can't have `sync: true` on `opened` property.
+        this._overlayElement.close();
       });
 
       // Listen to the forwarded event from sub-menu.

--- a/packages/context-menu/src/vaadin-lit-context-menu-item.js
+++ b/packages/context-menu/src/vaadin-lit-context-menu-item.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css, html, LitElement } from 'lit';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ItemMixin } from '@vaadin/item/src/vaadin-item-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
+ *
+ * @customElement
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes ItemMixin
+ * @mixes ThemableMixin
+ * @protected
+ */
+class ContextMenuItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-context-menu-item';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: inline-block;
+      }
+
+      :host([hidden]) {
+        display: none !important;
+      }
+    `;
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <span part="checkmark" aria-hidden="true"></span>
+      <div part="content">
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.setAttribute('role', 'menuitem');
+  }
+}
+
+defineCustomElement(ContextMenuItem);
+
+export { ContextMenuItem };

--- a/packages/context-menu/src/vaadin-lit-context-menu-list-box.js
+++ b/packages/context-menu/src/vaadin-lit-context-menu-list-box.js
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css, html, LitElement } from 'lit';
+import { ListMixin } from '@vaadin/a11y-base/src/list-mixin.js';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
+ *
+ * @customElement
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes ListMixin
+ * @mixes ThemableMixin
+ * @protected
+ */
+class ContextMenuListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-context-menu-list-box';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: flex;
+      }
+
+      :host([hidden]) {
+        display: none !important;
+      }
+
+      [part='items'] {
+        height: 100%;
+        width: 100%;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+    `;
+  }
+
+  static get properties() {
+    return {
+      // We don't need to define this property since super default is vertical,
+      // but we don't want it to be modified, or be shown in the API docs.
+      /** @private */
+      orientation: {
+        type: String,
+        readOnly: true,
+      },
+    };
+  }
+
+  /**
+   * @return {!HTMLElement}
+   * @protected
+   * @override
+   */
+  get _scrollerElement() {
+    return this.shadowRoot.querySelector('[part="items"]');
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div part="items">
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.setAttribute('role', 'menu');
+  }
+}
+
+defineCustomElement(ContextMenuListBox);
+
+export { ContextMenuListBox };

--- a/packages/context-menu/src/vaadin-lit-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-lit-context-menu-overlay.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
+import { styles } from './vaadin-menu-overlay-styles.js';
+
+/**
+ * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
+ *
+ * @customElement
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes MenuOverlayMixin
+ * @mixes OverlayMixin
+ * @mixes ThemableMixin
+ * @protected
+ */
+export class ContextMenuOverlay extends MenuOverlayMixin(
+  OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))),
+) {
+  static get is() {
+    return 'vaadin-context-menu-overlay';
+  }
+
+  static get properties() {
+    return {
+      /**
+       * When true, the overlay is visible and attached to body.
+       * This property config is overridden to set `sync: true`.
+       */
+      opened: {
+        type: Boolean,
+        notify: true,
+        observer: '_openedChanged',
+        reflectToAttribute: true,
+        sync: true,
+      },
+    };
+  }
+
+  static get styles() {
+    return [overlayStyles, styles];
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div id="backdrop" part="backdrop" ?hidden="${!this.withBackdrop}"></div>
+      <div part="overlay" id="overlay" tabindex="0">
+        <div part="content" id="content">
+          <slot></slot>
+        </div>
+      </div>
+    `;
+  }
+}
+
+defineCustomElement(ContextMenuOverlay);

--- a/packages/context-menu/src/vaadin-lit-context-menu.js
+++ b/packages/context-menu/src/vaadin-lit-context-menu.js
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import './vaadin-contextmenu-event.js';
+import './vaadin-lit-context-menu-item.js';
+import './vaadin-lit-context-menu-list-box.js';
+import './vaadin-lit-context-menu-overlay.js';
+import { css, html, LitElement } from 'lit';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { processTemplates } from '@vaadin/component-base/src/templates.js';
+import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-context-menu>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class ContextMenu extends ContextMenuMixin(
+  OverlayClassMixin(ElementMixin(ThemePropertyMixin(PolylitMixin(LitElement)))),
+) {
+  static get is() {
+    return 'vaadin-context-menu';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+      }
+
+      :host([hidden]) {
+        display: none !important;
+      }
+    `;
+  }
+
+  /** @protected */
+  render() {
+    return html`<slot id="slot"></slot>`;
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    processTemplates(this);
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  createRenderRoot() {
+    const root = super.createRenderRoot();
+    root.appendChild(this._overlayElement);
+    return root;
+  }
+
+  /**
+   * Fired when an item is selected when the context menu is populated using the `items` API.
+   *
+   * @event item-selected
+   * @param {Object} detail
+   * @param {Object} detail.value the selected menu item
+   */
+}
+
+defineCustomElement(ContextMenu);
+export { ContextMenu };

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -21,6 +21,15 @@ export const MenuOverlayMixin = (superClass) =>
           type: Object,
           readOnly: true,
         },
+
+        /**
+         * @protected
+         */
+        _theme: {
+          type: String,
+          readOnly: true,
+          sync: true,
+        },
       };
     }
 

--- a/packages/context-menu/test/a11y-lit.test.js
+++ b/packages/context-menu/test/a11y-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './a11y.common.js';

--- a/packages/context-menu/test/a11y-polymer.test.js
+++ b/packages/context-menu/test/a11y-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './a11y.common.js';

--- a/packages/context-menu/test/a11y.common.js
+++ b/packages/context-menu/test/a11y.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { getMenuItems } from './helpers.js';
 
@@ -10,7 +8,7 @@ describe('a11y', () => {
   describe('focus restoration', () => {
     let contextMenu, contextMenuButton, beforeButton, afterButton;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       const wrapper = fixtureSync(`
         <div>
           <button>Before</button>
@@ -18,9 +16,11 @@ describe('a11y', () => {
             <button>Open context menu</button>
           </vaadin-context-menu>
           <button>After</button>
+        </div>
       `);
       [beforeButton, contextMenu, afterButton] = wrapper.children;
       contextMenu.items = [{ text: 'Item 0' }, { text: 'Item 1', children: [{ text: 'Item 1/0' }] }];
+      await nextRender();
       contextMenuButton = contextMenu.querySelector('button');
       contextMenuButton.focus();
     });

--- a/packages/context-menu/test/context-lit.test.js
+++ b/packages/context-menu/test/context-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './context.common.js';

--- a/packages/context-menu/test/context-polymer.test.js
+++ b/packages/context-menu/test/context-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './context.common.js';

--- a/packages/context-menu/test/context.common.js
+++ b/packages/context-menu/test/context.common.js
@@ -1,10 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class XFoo extends PolymerElement {
@@ -22,7 +20,7 @@ customElements.define('x-foo', XFoo);
 describe('context', () => {
   let menu, foo, target, another;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     menu = fixtureSync(`
       <vaadin-context-menu>
         <div id="target">
@@ -39,19 +37,23 @@ describe('context', () => {
         </vaadin-list-box>
       `;
     };
+    await nextRender();
     foo = document.querySelector('x-foo');
     target = document.querySelector('#target');
     another = document.querySelector('#another');
   });
 
-  it('should use target as default context', () => {
+  it('should use target as default context', async () => {
     fire(target, 'vaadin-contextmenu');
+    await nextRender();
 
     expect(menu._context.target).to.eql(target);
     expect(menu._overlayElement.textContent).to.contain(target.textContent);
 
     menu.close();
+
     fire(another, 'vaadin-contextmenu');
+    await nextRender();
 
     expect(menu._context.target).to.eql(another);
     expect(menu._overlayElement.textContent).to.contain(another.textContent);

--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -1,4 +1,4 @@
-import { fire, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { fire, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 
 export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') {
@@ -8,7 +8,7 @@ export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') 
   }
   const { right, bottom } = target.getBoundingClientRect();
   fire(target, event, { x: right, y: bottom });
-  await nextFrame();
+  await nextRender();
 }
 
 export function getMenuItems(menu) {

--- a/packages/context-menu/test/integration-lit.test.js
+++ b/packages/context-menu/test/integration-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './integration.common.js';

--- a/packages/context-menu/test/integration-polymer.test.js
+++ b/packages/context-menu/test/integration-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './integration.common.js';

--- a/packages/context-menu/test/integration.common.js
+++ b/packages/context-menu/test/integration.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, click, fixtureSync, isIOS, makeSoloTouchEvent } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import { aTimeout, click, fixtureSync, isIOS, makeSoloTouchEvent, nextRender } from '@vaadin/testing-helpers';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class MenuWrapper extends PolymerElement {
@@ -30,8 +28,9 @@ customElements.define('menu-wrapper', MenuWrapper);
 describe('integration', () => {
   let wrapper, menu, button, overlay;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     wrapper = fixtureSync('<menu-wrapper></menu-wrapper>');
+    await nextRender();
     menu = wrapper.$.menu;
     button = wrapper.$.button;
     overlay = menu._overlayElement;

--- a/packages/context-menu/test/items-lit.test.js
+++ b/packages/context-menu/test/items-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './items.common.js';

--- a/packages/context-menu/test/items-polymer.test.js
+++ b/packages/context-menu/test/items-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './items.common.js';

--- a/packages/context-menu/test/items-theme-lit.test.js
+++ b/packages/context-menu/test/items-theme-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './items-theme.common.js';

--- a/packages/context-menu/test/items-theme-polymer.test.js
+++ b/packages/context-menu/test/items-theme-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './items-theme.common.js';

--- a/packages/context-menu/test/items-theme.common.js
+++ b/packages/context-menu/test/items-theme.common.js
@@ -1,9 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
 
@@ -43,6 +41,7 @@ describe('items theme', () => {
       },
       { text: 'foo-1' },
     ];
+    await nextRender();
     await openMenu(target);
     await openMenu(getMenuItems(rootMenu)[0]);
     subMenu = getSubMenu(rootMenu);
@@ -68,8 +67,9 @@ describe('items theme', () => {
     });
   });
 
-  it('should close the menu and submenu on theme changed', () => {
+  it('should close the menu and submenu on theme changed', async () => {
     rootMenu.setAttribute('theme', 'bar');
+    await nextRender();
     expect(rootMenu.opened).to.be.false;
     expect(subMenu.opened).to.be.false;
     expect(subMenu2.opened).to.be.false;
@@ -79,7 +79,7 @@ describe('items theme', () => {
     rootMenu.removeAttribute('theme');
 
     // Should wait until submenus will be opened again.
-    await nextFrame();
+    await nextRender();
     await openMenu(target);
     await openMenu(getMenuItems(rootMenu)[0]);
     await openMenu(getMenuItems(subMenu)[1]);

--- a/packages/context-menu/test/items.common.js
+++ b/packages/context-menu/test/items.common.js
@@ -16,8 +16,6 @@ import {
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
 
@@ -46,6 +44,7 @@ describe('items', () => {
       { text: 'foo-1' },
       { text: 'foo-2', keepOpen: true },
     ];
+    await nextRender();
     await openMenu(target);
     rootOverlay = rootMenu._overlayElement;
     await openMenu(getMenuItems(rootMenu)[0]);
@@ -196,27 +195,31 @@ describe('items', () => {
     expect(getMenuItems(subMenu)[0].hasAttribute('menu-item-checked')).to.be.true;
   });
 
-  it('should have a checked root item after click if keep open', () => {
+  it('should have a checked root item after click if keep open', async () => {
     rootMenu.items[2].checked = true;
     getMenuItems(rootMenu)[2].click();
+    await nextRender();
     expect(getMenuItems(rootMenu)[2].hasAttribute('menu-item-checked')).to.be.true;
   });
 
-  it('should have a focused root item after click if keep open', () => {
+  it('should have a focused root item after click if keep open', async () => {
     rootMenu.items[2].checked = true;
     getMenuItems(rootMenu)[2].click();
+    await nextRender();
     expect(getMenuItems(rootMenu)[2].hasAttribute('focused')).to.be.true;
   });
 
-  it('should have a checked sub menu item after click if keep open', () => {
+  it('should have a checked sub menu item after click if keep open', async () => {
     subMenu.items[4].checked = true;
     getMenuItems(subMenu)[4].click();
+    await nextRender();
     expect(getMenuItems(subMenu)[4].hasAttribute('menu-item-checked')).to.be.true;
   });
 
-  it('should have a focused sub menu item after click if keep open', () => {
+  it('should have a focused sub menu item after click if keep open', async () => {
     subMenu.items[4].checked = true;
     getMenuItems(subMenu)[4].click();
+    await nextRender();
     expect(getMenuItems(subMenu)[4].hasAttribute('focused')).to.be.true;
   });
 
@@ -377,15 +380,17 @@ describe('items', () => {
     expect(element).not.to.equal(document.documentElement);
   });
 
-  it('should close submenus', () => {
+  it('should close submenus', async () => {
     rootMenu.close();
+    await nextRender();
     expect(subMenu.opened).to.be.false;
   });
 
-  it('should fire an event for item selection', () => {
+  it('should fire an event for item selection', async () => {
     const eventSpy = sinon.spy();
     rootMenu.addEventListener('item-selected', eventSpy);
     getMenuItems(subMenu)[0].click();
+    await nextRender();
     expect(eventSpy.getCall(0).args[0].detail.value).to.equal(rootMenu.items[0].children[0]);
   });
 
@@ -428,10 +433,11 @@ describe('items', () => {
     expect(subMenu.opened).to.be.false;
   });
 
-  it('should have expanded attributes', () => {
+  it('should have expanded attributes', async () => {
     expect(getMenuItems(rootMenu)[0].hasAttribute('expanded')).to.be.true;
     expect(getMenuItems(rootMenu)[0].getAttribute('aria-expanded')).to.equal('true');
     subMenu.close();
+    await nextRender();
     expect(getMenuItems(rootMenu)[0].hasAttribute('expanded')).to.be.false;
     expect(getMenuItems(rootMenu)[0].getAttribute('aria-expanded')).to.equal('false');
   });

--- a/packages/context-menu/test/lit-renderer-directive-lit.test.js
+++ b/packages/context-menu/test/lit-renderer-directive-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './lit-renderer-directives.common.js';

--- a/packages/context-menu/test/lit-renderer-directive-polymer.test.js
+++ b/packages/context-menu/test/lit-renderer-directive-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './lit-renderer-directives.common.js';

--- a/packages/context-menu/test/lit-renderer-directives.common.js
+++ b/packages/context-menu/test/lit-renderer-directives.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { html, nothing, render } from 'lit';
 import { contextMenuRenderer } from '../lit.js';
 
@@ -15,7 +13,7 @@ async function renderContextMenu(container, { content }) {
     `,
     container,
   );
-  await nextFrame();
+  await nextRender();
   return container.querySelector('vaadin-context-menu');
 }
 
@@ -43,8 +41,9 @@ describe('lit renderer directives', () => {
         expect(contextMenu.renderer).not.to.exist;
       });
 
-      it('should render the content with the renderer when the menu is opened', () => {
+      it('should render the content with the renderer when the menu is opened', async () => {
         target.click();
+        await nextRender();
         expect(overlay.textContent).to.equal('Content');
       });
 

--- a/packages/context-menu/test/overlay-lit.test.js
+++ b/packages/context-menu/test/overlay-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './overlay.common.js';

--- a/packages/context-menu/test/overlay-polymer.test.js
+++ b/packages/context-menu/test/overlay-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './overlay.common.js';

--- a/packages/context-menu/test/overlay.common.js
+++ b/packages/context-menu/test/overlay.common.js
@@ -1,12 +1,10 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, isIOS, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import { fire, fixtureSync, isIOS, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 
 describe('overlay', () => {
   let menu, overlay, content, viewHeight, viewWidth;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     menu = fixtureSync(`
       <vaadin-context-menu>
         <div id="target">FOOOO</div>
@@ -15,6 +13,7 @@ describe('overlay', () => {
     menu.renderer = (root) => {
       root.textContent = 'OVERLAY CONTENT';
     };
+    await nextRender();
     overlay = menu._overlayElement;
     content = overlay.$.overlay.children[0];
     // Make content have a fixed size
@@ -272,6 +271,7 @@ describe('overlay', () => {
           await oneEvent(overlay, 'vaadin-overlay-open');
 
           overlay.opened = false;
+          await nextRender();
           contextmenu(16, 16);
           await oneEvent(overlay, 'vaadin-overlay-open');
 
@@ -329,8 +329,9 @@ describe('overlay', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
     });
 
-    it('should close on outside click', () => {
+    it('should close on outside click', async () => {
       fire(document.body, 'click');
+      await nextRender();
       expect(menu.opened).to.be.false;
     });
 

--- a/packages/context-menu/test/properties-lit.test.js
+++ b/packages/context-menu/test/properties-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './properties.common.js';

--- a/packages/context-menu/test/properties-polymer.test.js
+++ b/packages/context-menu/test/properties-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './properties.common.js';

--- a/packages/context-menu/test/properties.common.js
+++ b/packages/context-menu/test/properties.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 
 describe('properties', () => {
   let menu;
@@ -13,7 +11,7 @@ describe('properties', () => {
   describe('context', () => {
     let target;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       menu = fixtureSync(`
         <vaadin-context-menu>
           <section>
@@ -21,92 +19,109 @@ describe('properties', () => {
           </section>
         </vaadin-context-menu>
       `);
+      await nextRender();
       target = menu.querySelector('#target');
     });
 
-    it('should use event target as context target', () => {
+    it('should use event target as context target', async () => {
       fire(target, 'contextmenu');
+      await nextRender();
 
       expect(menu._context.target).to.eql(target);
     });
 
-    it('should use context-selector scope to target', () => {
+    it('should use context-selector scope to target', async () => {
       menu.selector = 'section';
 
       fire(target, 'contextmenu');
+      await nextRender();
 
       expect(menu._context.target).to.eql(target.parentElement);
     });
   });
 
   describe('openOn', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       menu = fixtureSync('<vaadin-context-menu></vaadin-context-menu>');
+      await nextRender();
     });
 
-    it('should open on custom event', () => {
+    it('should open on custom event', async () => {
       menu.openOn = 'click';
+      await nextRender();
 
       menu.click();
+      await nextRender();
 
       expect(menu.opened).to.eql(true);
     });
 
-    it('should not open on `contextmenu`', () => {
+    it('should not open on `contextmenu`', async () => {
       menu.openOn = 'click';
+      await nextRender();
 
       fire(menu, 'contextmenu');
+      await nextRender();
 
       expect(menu.opened).to.eql(false);
     });
 
     describe('event listener', () => {
-      it('should not add listener when set to empty', () => {
+      it('should not add listener when set to empty', async () => {
         expect(menu._oldOpenOn).to.be.ok;
         menu.openOn = '';
+        await nextRender();
         expect(menu._oldOpenOn).not.to.be.ok;
       });
     });
   });
 
   describe('opened', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       menu = fixtureSync('<vaadin-context-menu></vaadin-context-menu>');
+      await nextRender();
     });
 
-    it('should be read-only', () => {
+    it('should be read-only', async () => {
       expect(menu.opened).to.eql(false);
 
       menu.opened = true;
+      await nextRender();
       expect(menu.opened).to.eql(false);
     });
 
-    it('should be set using the private setter', () => {
+    it('should be set using the private setter', async () => {
       expect(menu.opened).to.eql(false);
 
       menu._setOpened(true);
+      await nextRender();
       expect(menu.opened).to.be.true;
     });
   });
 
   describe('closeOn', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       menu = fixtureSync('<vaadin-context-menu></vaadin-context-menu>');
+      await nextRender();
       menu._setOpened(true);
     });
 
-    it('should not close on `click`', () => {
+    it('should not close on `click`', async () => {
       menu.closeOn = '';
+      await nextRender();
 
       menu._overlayElement.dispatchEvent(new CustomEvent('click'));
+      await nextRender();
 
       expect(menu.opened).to.eql(true);
     });
 
-    it('should close on custom event', () => {
+    it('should close on custom event', async () => {
       menu.closeOn = 'foobar';
+      await nextRender();
 
       fire(menu._overlayElement, 'foobar');
+      await nextRender();
 
       expect(menu.opened).to.eql(false);
     });
@@ -115,7 +130,7 @@ describe('properties', () => {
   describe('external target', () => {
     let wrapper, target;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       wrapper = fixtureSync(`
         <div>
           <vaadin-context-menu></vaadin-context-menu>
@@ -124,44 +139,50 @@ describe('properties', () => {
           </section>
         </div>
       `);
+      await nextRender();
       menu = wrapper.firstElementChild;
       target = wrapper.querySelector('#target');
 
       menu.listenOn = target;
     });
 
-    it('should open on external target', () => {
+    it('should open on external target', async () => {
       fire(target, 'contextmenu');
+      await nextRender();
 
       expect(menu.opened).to.eql(true);
     });
 
-    it('should select context target on external target', () => {
+    it('should select context target on external target', async () => {
       fire(target, 'contextmenu');
+      await nextRender();
 
       expect(menu._context.target).to.eql(target);
     });
 
-    it('should use context selector on external target', () => {
+    it('should use context selector on external target', async () => {
       menu.selector = 'section'; // Parent of #target
       menu.listenOn = menu.parentElement;
       fire(target, 'contextmenu');
+      await nextRender();
 
       expect(menu._context.target).to.eql(target.parentElement);
     });
 
     describe('event listeners', () => {
-      it('should not target listeners when set to null', () => {
+      it('should not target listeners when set to null', async () => {
         expect(menu._oldOpenOn).to.be.ok;
         menu.listenOn = null;
+        await nextRender();
         expect(menu._oldOpenOn).not.to.be.ok;
       });
     });
   });
 
   describe('theme attribute', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       menu = fixtureSync('<vaadin-context-menu theme="foo"></vaadin-context-menu>');
+      await nextRender();
     });
 
     it('should propagate theme attribute to overlay', () => {

--- a/packages/context-menu/test/renderer-lit.test.js
+++ b/packages/context-menu/test/renderer-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './renderer.common.js';

--- a/packages/context-menu/test/renderer-polymer.test.js
+++ b/packages/context-menu/test/renderer-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './renderer.common.js';

--- a/packages/context-menu/test/selection-lit.test.js
+++ b/packages/context-menu/test/selection-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './selection.common.js';

--- a/packages/context-menu/test/selection-polymer.test.js
+++ b/packages/context-menu/test/selection-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './selection.common.js';

--- a/packages/context-menu/test/selection.common.js
+++ b/packages/context-menu/test/selection.common.js
@@ -3,13 +3,11 @@ import { click, enter, fire, fixtureSync, isIOS, nextRender, oneEvent } from '@v
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 
 describe('selection', () => {
   let menu, overlay;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     menu = fixtureSync('<vaadin-context-menu></vaadin-context-menu>');
     overlay = menu._overlayElement;
     menu.renderer = (root) => {
@@ -21,6 +19,7 @@ describe('selection', () => {
         </vaadin-list-box>
       `;
     };
+    await nextRender();
   });
 
   it('should close on item click', async () => {
@@ -43,6 +42,7 @@ describe('selection', () => {
 
     const item = overlay.querySelector('#menu vaadin-item');
     enter(item);
+    await nextRender();
     expect(spy.calledOnce).to.be.true;
   });
 

--- a/packages/context-menu/test/touch-lit.test.js
+++ b/packages/context-menu/test/touch-lit.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-lit-context-menu.js';
+import './touch.common.js';

--- a/packages/context-menu/test/touch-polymer.test.js
+++ b/packages/context-menu/test/touch-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './touch.common.js';

--- a/packages/context-menu/test/touch.common.js
+++ b/packages/context-menu/test/touch.common.js
@@ -6,12 +6,11 @@ import {
   listenOnce,
   makeSoloTouchEvent,
   middleOfNode,
+  nextRender,
   touchend,
   touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { gestures } from '@vaadin/component-base/src/gestures.js';
 
@@ -38,8 +37,9 @@ customElements.define('menu-touch-wrapper', MenuTouchWrapper);
 describe('mobile support', () => {
   let menu, target;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     const testWrapper = fixtureSync('<menu-touch-wrapper></menu-touch-wrapper>');
+    await nextRender();
     menu = testWrapper.$.menu;
     target = menu.querySelector('#target');
     menu._phone = true;

--- a/packages/context-menu/theme/lumo/vaadin-lit-context-menu.js
+++ b/packages/context-menu/theme/lumo/vaadin-lit-context-menu.js
@@ -1,0 +1,4 @@
+import './vaadin-context-menu-item-styles.js';
+import './vaadin-context-menu-list-box-styles.js';
+import './vaadin-context-menu-overlay-styles.js';
+import '../../src/vaadin-lit-context-menu.js';

--- a/packages/context-menu/theme/material/vaadin-lit-context-menu.js
+++ b/packages/context-menu/theme/material/vaadin-lit-context-menu.js
@@ -1,0 +1,4 @@
+import './vaadin-context-menu-item-styles.js';
+import './vaadin-context-menu-list-box-styles.js';
+import './vaadin-context-menu-overlay-styles.js';
+import '../../src/vaadin-lit-context-menu.js';


### PR DESCRIPTION
## Description

Here's an incomplete prototype of the `vaadin-context-menu` version based on LitElement. Some things that need fixing:

- When converting `vaadin-context-menu-overlay` to LitElement, `PositionMixin` throws an error due to `__margins` not being set in the first `_updatePosition()` call for nested submenu (can be reproduced in the dev page).

## Type of change

- Prototype