### PR TITLE
feat: dispatch an event when tooltip is added or removed

### DIFF
--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -49,6 +49,19 @@ export class TooltipController extends SlotController {
     if (this.shouldShow !== undefined) {
       tooltipNode.shouldShow = this.shouldShow;
     }
+
+    this.__notifyChange();
+  }
+
+  /**
+   * Override to notify the host when the tooltip is removed.
+   *
+   * @param {Node} tooltipNode
+   * @protected
+   * @override
+   */
+  teardownNode() {
+    this.__notifyChange();
   }
 
   /**
@@ -144,5 +157,10 @@ export class TooltipController extends SlotController {
     if (tooltipNode) {
       tooltipNode.target = target;
     }
+  }
+
+  /** @private */
+  __notifyChange() {
+    this.dispatchEvent(new CustomEvent('tooltip-changed', { detail: { node: this.node } }));
   }
 }

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { TooltipController } from '../src/tooltip-controller.js';
@@ -169,6 +170,25 @@ describe('TooltipController', () => {
       await nextFrame();
 
       expect(tooltip._position).to.eql('top-start');
+    });
+
+    it('should fire tooltip-changed event on the host when the tooltip is added', async () => {
+      const spy = sinon.spy();
+      controller.addEventListener('tooltip-changed', spy);
+      host.appendChild(tooltip);
+      await nextFrame();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire tooltip-changed event on the host when the tooltip is removed', async () => {
+      const spy = sinon.spy();
+      controller.addEventListener('tooltip-changed', spy);
+      host.appendChild(tooltip);
+      await nextFrame();
+
+      host.removeChild(tooltip);
+      await nextFrame();
+      expect(spy).to.be.calledTwice;
     });
   });
 });


### PR DESCRIPTION
## Description

In some cases, we might want to handle `vaadin-tooltip` node lazily (e.g. `vaadin-checkbox` inside of `vaadin-checkbox-group`). Currently there is no API for that. This PR adds the `tooltip-changed` event on the `TooltipController`.


## Type of change

- Internal feature.