### PR TITLE
fix!: link every radio button with the tooltip overlay

### DIFF
--- a/integration/tests/radio-group-tooltip.test.js
+++ b/integration/tests/radio-group-tooltip.test.js
@@ -1,0 +1,62 @@
+import { expect } from '@esm-bundle/chai';
+import { nextRender } from '@vaadin/testing-helpers';
+import '@vaadin/radio-group';
+import '@vaadin/tooltip';
+
+describe('radio-group with tooltip', () => {
+  let group, tooltip, radio1, radio2, overlay;
+
+  beforeEach(async () => {
+    group = document.createElement('vaadin-radio-group');
+    group.label = 'Size';
+    document.body.appendChild(group);
+
+    radio1 = document.createElement('vaadin-radio-button');
+    radio1.value = 's';
+    radio1.label = 'S';
+    group.appendChild(radio1);
+
+    radio2 = document.createElement('vaadin-radio-button');
+    radio2.value = 'm';
+    radio2.label = 'M';
+    group.appendChild(radio2);
+
+    tooltip = document.createElement('vaadin-tooltip');
+    tooltip.slot = 'tooltip';
+    tooltip.text = 'If not selected, M is used';
+    group.appendChild(tooltip);
+
+    await nextRender();
+    overlay = tooltip._overlayElement;
+  });
+
+  afterEach(() => {
+    group.remove();
+  });
+
+  it('should link tooltip with input elements using aria-describedby', () => {
+    expect(radio1.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+    expect(radio2.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+  });
+
+  it('should set aria-describedby on the newly added radio button input', async () => {
+    const radio = document.createElement('vaadin-radio-button');
+    radio.value = 'xl';
+    group.appendChild(radio);
+    await nextRender();
+    expect(radio.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+  });
+
+  it('should remove aria-describedby from the removed radio button input', async () => {
+    group.removeChild(radio1);
+    await nextRender();
+    expect(radio1.inputElement.hasAttribute('aria-describedby')).to.be.false;
+  });
+
+  it('should remove aria-describedby when the tooltip element is removed', async () => {
+    group.removeChild(tooltip);
+    await nextRender();
+    expect(radio1.inputElement.hasAttribute('aria-describedby')).to.be.false;
+    expect(radio2.inputElement.hasAttribute('aria-describedby')).to.be.false;
+  });
+});

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -186,6 +186,19 @@ class RadioGroup extends FieldMixin(
     this.__unregisterRadioButton = this.__unregisterRadioButton.bind(this);
     this.__onRadioButtonChange = this.__onRadioButtonChange.bind(this);
     this.__onRadioButtonCheckedChange = this.__onRadioButtonCheckedChange.bind(this);
+
+    this._tooltipController = new TooltipController(this);
+    this._tooltipController.addEventListener('tooltip-changed', (event) => {
+      const tooltip = event.detail.node;
+      if (tooltip && tooltip.isConnected) {
+        // Tooltip element has been added to the DOM
+        const inputs = this.__radioButtons.map((checkbox) => checkbox.inputElement);
+        this._tooltipController.setAriaTarget(inputs);
+      } else {
+        // Tooltip element is no longer connected
+        this._tooltipController.setAriaTarget([]);
+      }
+    });
   }
 
   /**
@@ -235,9 +248,11 @@ class RadioGroup extends FieldMixin(
 
       // Unregisters the removed radio buttons.
       this.__filterRadioButtons(removedNodes).forEach(this.__unregisterRadioButton);
+
+      const inputs = this.__radioButtons.map((checkbox) => checkbox.inputElement);
+      this._tooltipController.setAriaTarget(inputs);
     });
 
-    this._tooltipController = new TooltipController(this);
     this.addController(this._tooltipController);
   }
 


### PR DESCRIPTION
## Description

Part of #6286

Same as #6456 but for `vaadin-radio-button`. 

Tested in Chrome + NVDA (the problematic combination) and this approach works as expected:

<img width="613" alt="Screenshot 2023-09-12 at 15 37 40" src="https://github.com/vaadin/web-components/assets/10589913/2869546a-d08a-45f1-8624-18bccb326e2a">

## Type of change

- Behavior altering fix