### PR TITLE
feat: add symbol property to icon

### DIFF
--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -82,7 +82,7 @@ declare class Icon extends ThemableMixin(
   src: string | null;
 
   /**
-   * The symbol identifier that references to an ID of an element contained in the SVG element assigned to the
+   * The symbol identifier that references an ID of an element contained in the SVG element assigned to the
    * `src` property
    */
   symbol: string | null;

--- a/packages/icon/src/vaadin-icon.d.ts
+++ b/packages/icon/src/vaadin-icon.d.ts
@@ -82,6 +82,12 @@ declare class Icon extends ThemableMixin(
   src: string | null;
 
   /**
+   * The symbol identifier that references to an ID of an element contained in the SVG element assigned to the
+   * `src` property
+   */
+  symbol: string | null;
+
+  /**
    * Class names defining an icon font and/or a specific glyph inside an icon font.
    *
    * Example: "fa-solid fa-user"

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -240,9 +240,6 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
       __preserveAspectRatio: String,
 
       /** @private */
-      __useGroupElement: Object,
-
-      /** @private */
       __useRef: Object,
 
       /** @private */

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { svg } from 'lit';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -111,7 +111,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
         aria-hidden="true"
       >
         <g id="svg-group"></g>
-        <g id="use-group" hidden="[[!__useRef]]">
+        <g id="use-group" visibility$="[[__computeVisibility(__useRef, svg)]]">
           <use href$="[[__useRef]]" />
         </g>
       </svg>
@@ -392,6 +392,11 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
   /** @private */
   __computePAR(defaultPAR, preserveAspectRatio) {
     return preserveAspectRatio || defaultPAR;
+  }
+
+  /** @private */
+  __computeVisibility(__useRef) {
+    return __useRef ? 'visible' : 'hidden';
   }
 
   /** @private */

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -112,7 +112,9 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
         aria-hidden="true"
       >
         <g id="svg-group"></g>
-        <g id="use-group"></g>
+        <g id="use-group" hidden="[[!__useRef]]">
+          <use href$="[[__useRef]]" />
+        </g>
       </svg>
 
       <slot name="tooltip"></slot>
@@ -166,7 +168,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
       },
 
       /**
-       * The symbol identifier that references to an ID of an element contained in the SVG element assigned to the
+       * The symbol identifier that references an ID of an element contained in the SVG element assigned to the
        * `src` property
        *
        * @type {string}
@@ -244,7 +246,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
       __useRef: Object,
 
       /** @private */
-      __svgElement: Object,
+      __svgElement: String,
 
       /** @private */
       __viewBox: String,
@@ -252,12 +254,7 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
   }
 
   static get observers() {
-    return [
-      '__svgChanged(svg, __svgElement)',
-      '__fontChanged(iconClass, char, ligature)',
-      '__srcChanged(src, symbol)',
-      '__useRefChanged(__useRef, __useGroupElement)',
-    ];
+    return ['__svgChanged(svg, __svgElement)', '__fontChanged(iconClass, char, ligature)', '__srcChanged(src, symbol)'];
   }
 
   static get observedAttributes() {
@@ -293,7 +290,6 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
   ready() {
     super.ready();
     this.__svgElement = this.shadowRoot.querySelector('#svg-group');
-    this.__useGroupElement = this.shadowRoot.querySelector('#use-group');
 
     this._tooltipController = new TooltipController(this);
     this.addController(this._tooltipController);
@@ -352,11 +348,9 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
     // https://github.com/vaadin/web-components/issues/6301
     this.icon = '';
 
-    if (src.includes('.svg') && (symbol || src.includes('#'))) {
+    if (!src.startsWith('data:') && (symbol || src.includes('#'))) {
       const [path, iconId] = src.split('#');
-      const symbolSrc = `${path}#${symbol ? symbol : iconId}`;
-
-      this.__useRef = svg`<use href="${symbolSrc}"/>`;
+      this.__useRef = `${path}#${symbol || iconId}`;
     } else {
       try {
         const data = await this.__fetch(src, { mode: 'cors' });
@@ -377,8 +371,9 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
         }
 
         this.svg = unsafeSvgLiteral(svgElement.innerHTML);
+
         if (symbol) {
-          this.__useRef = svg`<use href="#${symbol}"/>`;
+          this.__useRef = `#${symbol}`;
         }
 
         this.__viewBox = svgElement.getAttribute('viewBox');
@@ -396,15 +391,6 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
     }
 
     renderSvg(svg, svgElement);
-  }
-
-  /** @private */
-  __useRefChanged(useRef, useGroupElement) {
-    if (!useGroupElement) {
-      return;
-    }
-
-    renderSvg(useRef, useGroupElement);
   }
 
   /** @private */

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -246,6 +246,16 @@ describe('vaadin-icon', () => {
       // We expect a 404 error log from this test, but the test is simply to check
       // that the <use> element is added when the source provided has the file#id pattern
       expect(svgElement.querySelector(`use[href="${icon.src}"]`)).to.exist;
+      expect(svgElement.querySelector('#use-group').getAttribute('visibility')).to.be.equal('visible');
+    });
+
+    it('should set use group visibility to hidden when src is a standalone SVG', () => {
+      sinon.stub(icon, '__fetch').resolves({ ok: true, text: () => Promise.resolve(`<svg></svg>`) });
+
+      icon.src = 'icon.svg';
+      expect(svgElement.querySelector('#use-group').getAttribute('visibility')).to.be.equal('hidden');
+
+      icon.__fetch.restore();
     });
   });
 

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -177,7 +177,7 @@ describe('vaadin-icon', () => {
       icon.src = './icon.svg#id-0';
       icon.symbol = 'id-1';
 
-      expect(svgElement.querySelector(`use[href="${icon.src.split('#')[0]}#${icon.symbol}"]`));
+      expect(svgElement.querySelector(`use[href="${icon.src.split('#')[0]}#${icon.symbol}"]`)).to.exist;
     });
 
     it('should render SVG content and <use> if src is given in data format with symbol prop defined', async () => {

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -181,8 +181,7 @@ describe('vaadin-icon', () => {
     });
 
     it('should render SVG content and <use> if src is given in data format with symbol prop defined', async () => {
-      const svgSpriteBase64 = btoa(`
-        <svg xmlns="http://www.w3.org/2000/svg">
+      const svgSprite = `<svg xmlns="http://www.w3.org/2000/svg">
           <defs>
             <symbol id="icon-cog" viewBox="0 0 32 32">
               <path
@@ -193,7 +192,12 @@ describe('vaadin-icon', () => {
               <path d="m18 22.082v-1.649c2.203-1.241 4-4.337 4-7.432 0-4.971 0-9-6-9s-6 4.029-6 9c0 3.096 1.797 6.191 4 7.432v1.649c-6.784 0.555-12 3.888-12 7.918h28c0-4.030-5.216-7.364-12-7.918z"></path>
             </symbol>
           </defs>
-        </svg>`);
+        </svg>`;
+      const svgSpriteBase64 = btoa(svgSprite);
+      sinon.stub(icon, '__fetch').resolves({
+        ok: true,
+        text: () => Promise.resolve(svgSprite),
+      });
 
       icon.src = `data:image/svg+xml;base64,${svgSpriteBase64}`;
       icon.symbol = 'icon-cog';
@@ -203,6 +207,8 @@ describe('vaadin-icon', () => {
       expect(svgElement.querySelectorAll('symbol')).to.have.lengthOf(2);
       expect(svgElement.querySelectorAll('#icon-cog')).to.exist;
       expect(svgElement.querySelector('use[href="#icon-cog"]')).to.exist;
+
+      icon.__fetch.restore();
     });
 
     it('should fail if SVG is not found', async () => {

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -15,7 +15,12 @@ describe('vaadin-icon', () => {
   let icon, svgElement;
 
   function expectIcon(content) {
-    expect(svgElement.innerHTML.trim().replace(/<!--[^>]*-->/gu, '')).to.equal(content);
+    expect(
+      svgElement
+        .querySelector('#svg-group')
+        .innerHTML.trim()
+        .replace(/<!--[^>]*-->/gu, ''),
+    ).to.equal(content);
   }
 
   describe('custom element definition', () => {
@@ -161,6 +166,31 @@ describe('vaadin-icon', () => {
       icon.__fetch.restore();
     });
 
+    it('should append value from symbol property to src', () => {
+      icon.src = './icon.svg';
+      icon.symbol = 'symbol-id';
+
+      expect(svgElement.querySelector(`use[href="${icon.src}#${icon.symbol}"]`)).to.exist;
+    });
+
+    it('should use value from symbol when src path has a hash value', () => {
+      icon.src = './icon.svg#id-0';
+      icon.symbol = 'id-1';
+
+      expect(svgElement.querySelector(`use[href="${icon.src.split('#')[0]}#${icon.symbol}"]`));
+    });
+
+    it('should render SVG content and <use> if src is given in data format with symbol prop defined', async () => {
+      icon.src = `data:image/svg+xml;base64,PHN2ZyBhcmlhLWhpZGRlbj0idHJ1ZSIgc3R5bGU9InBvc2l0aW9uOiBhYnNvbHV0ZTsgd2lkdGg6IDA7IGhlaWdodDogMDsgb3ZlcmZsb3c6IGhpZGRlbjsiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+DQo8ZGVmcz4NCjxzeW1ib2wgaWQ9Imljb24taG9tZSIgdmlld2JveD0iMCAwIDMyIDMyIj4NCjxwYXRoIGQ9Im0zMiAxOWwtNi02di05aC00djVsLTYtNi0xNiAxNnYxaDR2MTBoMTB2LTZoNHY2aDEwdi0xMGg0eiI+PC9wYXRoPg0KPC9zeW1ib2w+DQo8c3ltYm9sIGlkPSJpY29uLXVzZXIiIHZpZXdib3g9IjAgMCAzMiAzMiI+DQo8cGF0aCBkPSJtMTggMjIuMDgydi0xLjY0OWMyLjIwMy0xLjI0MSA0LTQuMzM3IDQtNy40MzIgMC00Ljk3MSAwLTktNi05cy02IDQuMDI5LTYgOWMwIDMuMDk2IDEuNzk3IDYuMTkxIDQgNy40MzJ2MS42NDljLTYuNzg0IDAuNTU1LTEyIDMuODg4LTEyIDcuOTE4aDI4YzAtNC4wMzAtNS4yMTYtNy4zNjQtMTItNy45MTh6Ij48L3BhdGg+DQo8L3N5bWJvbD4NCjxzeW1ib2wgaWQ9Imljb24tY29nIiB2aWV3Ym94PSIwIDAgMzIgMzIiPg0KPHBhdGggZD0ibTI5LjE4MSAxOS4wNzBjLTEuNjc5LTIuOTA4LTAuNjY5LTYuNjM0IDIuMjU1LTguMzI4bC0zLjE0NS01LjQ0N2MtMC44OTggMC41MjctMS45NDMgMC44MjktMy4wNTggMC44MjktMy4zNjEgMC02LjA4NS0yLjc0Mi02LjA4NS02LjEyNWgtNi4yODljMC4wMDggMS4wNDQtMC4yNTIgMi4xMDMtMC44MTEgMy4wNzAtMS42NzkgMi45MDgtNS40MTEgMy44OTctOC4zMzkgMi4yMTFsLTMuMTQ0IDUuNDQ3YzAuOTA1IDAuNTE1IDEuNjg5IDEuMjY4IDIuMjQ2IDIuMjM0IDEuNjc2IDIuOTAzIDAuNjcyIDYuNjIzLTIuMjQxIDguMzE5bDMuMTQ1IDUuNDQ3YzAuODk1LTAuNTIyIDEuOTM1LTAuODIgMy4wNDQtMC44MiAzLjM1IDAgNi4wNjcgMi43MjUgNi4wODQgNi4wOTJoNi4yODljLTAuMDAzLTEuMDM0IDAuMjU5LTIuMDgwIDAuODExLTMuMDM4IDEuNjc2LTIuOTAzIDUuMzk5LTMuODk0IDguMzI1LTIuMjE5bDMuMTQ1LTUuNDQ3Yy0wLjg5OS0wLjUxNS0xLjY3OC0xLjI2Ni0yLjIzMi0yLjIyNnptMTYgMjIuNDc5Yy0zLjU3OCAwLTYuNDc5LTIuOTAxLTYuNDc5LTYuNDc5czIuOTAxLTYuNDc5IDYuNDc5LTYuNDc5YzMuNTc4IDAgNi40NzkgMi45MDEgNi40NzkgNi40NzlzLTIuOTAxIDYuNDc5LTYuNDc5IDYuNDc5eiI+PC9wYXRoPg0KPC9zeW1ib2w+DQo8L2RlZnM+DQo8L3N2Zz4=`;
+      icon.symbol = 'icon-cog';
+
+      await nextRender();
+
+      expect(svgElement.querySelectorAll('symbol')).to.have.lengthOf(3);
+      expect(svgElement.querySelectorAll('#icon-cog')).to.exist;
+      expect(svgElement.querySelector('use[href="#icon-cog"]')).to.exist;
+    });
+
     it('should fail if SVG is not found', async () => {
       sinon.stub(console, 'error');
       sinon.stub(icon, '__fetch').resolves({ ok: false });
@@ -195,7 +225,7 @@ describe('vaadin-icon', () => {
       icon.src = 'icon.svg#symbol-id';
       // We expect a 404 error log from this test, but the test is simply to check
       // that the <use> element is added when the source provided has the file#id pattern
-      expectIcon(`<use href="${icon.src}"></use>`);
+      expect(svgElement.querySelector(`use[href="${icon.src}"]`)).to.exist;
     });
   });
 
@@ -288,7 +318,7 @@ describe('vaadin-icon', () => {
 
       it('should support rendering custom svg element inside the icon', () => {
         icon.icon = 'vaadin:minus';
-        const child = svgElement.firstElementChild;
+        const child = svgElement.querySelector('#svg-group').firstElementChild;
         expect(child.getAttribute('fill')).to.equal('red');
       });
 

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -181,12 +181,26 @@ describe('vaadin-icon', () => {
     });
 
     it('should render SVG content and <use> if src is given in data format with symbol prop defined', async () => {
-      icon.src = `data:image/svg+xml;base64,PHN2ZyBhcmlhLWhpZGRlbj0idHJ1ZSIgc3R5bGU9InBvc2l0aW9uOiBhYnNvbHV0ZTsgd2lkdGg6IDA7IGhlaWdodDogMDsgb3ZlcmZsb3c6IGhpZGRlbjsiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+DQo8ZGVmcz4NCjxzeW1ib2wgaWQ9Imljb24taG9tZSIgdmlld2JveD0iMCAwIDMyIDMyIj4NCjxwYXRoIGQ9Im0zMiAxOWwtNi02di05aC00djVsLTYtNi0xNiAxNnYxaDR2MTBoMTB2LTZoNHY2aDEwdi0xMGg0eiI+PC9wYXRoPg0KPC9zeW1ib2w+DQo8c3ltYm9sIGlkPSJpY29uLXVzZXIiIHZpZXdib3g9IjAgMCAzMiAzMiI+DQo8cGF0aCBkPSJtMTggMjIuMDgydi0xLjY0OWMyLjIwMy0xLjI0MSA0LTQuMzM3IDQtNy40MzIgMC00Ljk3MSAwLTktNi05cy02IDQuMDI5LTYgOWMwIDMuMDk2IDEuNzk3IDYuMTkxIDQgNy40MzJ2MS42NDljLTYuNzg0IDAuNTU1LTEyIDMuODg4LTEyIDcuOTE4aDI4YzAtNC4wMzAtNS4yMTYtNy4zNjQtMTItNy45MTh6Ij48L3BhdGg+DQo8L3N5bWJvbD4NCjxzeW1ib2wgaWQ9Imljb24tY29nIiB2aWV3Ym94PSIwIDAgMzIgMzIiPg0KPHBhdGggZD0ibTI5LjE4MSAxOS4wNzBjLTEuNjc5LTIuOTA4LTAuNjY5LTYuNjM0IDIuMjU1LTguMzI4bC0zLjE0NS01LjQ0N2MtMC44OTggMC41MjctMS45NDMgMC44MjktMy4wNTggMC44MjktMy4zNjEgMC02LjA4NS0yLjc0Mi02LjA4NS02LjEyNWgtNi4yODljMC4wMDggMS4wNDQtMC4yNTIgMi4xMDMtMC44MTEgMy4wNzAtMS42NzkgMi45MDgtNS40MTEgMy44OTctOC4zMzkgMi4yMTFsLTMuMTQ0IDUuNDQ3YzAuOTA1IDAuNTE1IDEuNjg5IDEuMjY4IDIuMjQ2IDIuMjM0IDEuNjc2IDIuOTAzIDAuNjcyIDYuNjIzLTIuMjQxIDguMzE5bDMuMTQ1IDUuNDQ3YzAuODk1LTAuNTIyIDEuOTM1LTAuODIgMy4wNDQtMC44MiAzLjM1IDAgNi4wNjcgMi43MjUgNi4wODQgNi4wOTJoNi4yODljLTAuMDAzLTEuMDM0IDAuMjU5LTIuMDgwIDAuODExLTMuMDM4IDEuNjc2LTIuOTAzIDUuMzk5LTMuODk0IDguMzI1LTIuMjE5bDMuMTQ1LTUuNDQ3Yy0wLjg5OS0wLjUxNS0xLjY3OC0xLjI2Ni0yLjIzMi0yLjIyNnptMTYgMjIuNDc5Yy0zLjU3OCAwLTYuNDc5LTIuOTAxLTYuNDc5LTYuNDc5czIuOTAxLTYuNDc5IDYuNDc5LTYuNDc5YzMuNTc4IDAgNi40NzkgMi45MDEgNi40NzkgNi40NzlzLTIuOTAxIDYuNDc5LTYuNDc5IDYuNDc5eiI+PC9wYXRoPg0KPC9zeW1ib2w+DQo8L2RlZnM+DQo8L3N2Zz4=`;
+      const svgSpriteBase64 = btoa(`
+        <svg xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <symbol id="icon-cog" viewBox="0 0 32 32">
+              <path
+                d="m29.181 19.070c-1.679-2.908-0.669-6.634 2.255-8.328l-3.145-5.447c-0.898 0.527-1.943 0.829-3.058 0.829-3.361 0-6.085-2.742-6.085-6.125h-6.289c0.008 1.044-0.252 2.103-0.811 3.070-1.679 2.908-5.411 3.897-8.339 2.211l-3.144 5.447c0.905 0.515 1.689 1.268 2.246 2.234 1.676 2.903 0.672 6.623-2.241 8.319l3.145 5.447c0.895-0.522 1.935-0.82 3.044-0.82 3.35 0 6.067 2.725 6.084 6.092h6.289c-0.003-1.034 0.259-2.080 0.811-3.038 1.676-2.903 5.399-3.894 8.325-2.219l3.145-5.447c-0.899-0.515-1.678-1.266-2.232-2.226zm16 22.479c-3.578 0-6.479-2.901-6.479-6.479s2.901-6.479 6.479-6.479c3.578 0 6.479 2.901 6.479 6.479s-2.901 6.479-6.479 6.479z"
+              ></path>
+            </symbol>
+            <symbol id="icon-user" viewbox="0 0 32 32">
+              <path d="m18 22.082v-1.649c2.203-1.241 4-4.337 4-7.432 0-4.971 0-9-6-9s-6 4.029-6 9c0 3.096 1.797 6.191 4 7.432v1.649c-6.784 0.555-12 3.888-12 7.918h28c0-4.030-5.216-7.364-12-7.918z"></path>
+            </symbol>
+          </defs>
+        </svg>`);
+
+      icon.src = `data:image/svg+xml;base64,${svgSpriteBase64}`;
       icon.symbol = 'icon-cog';
 
       await nextRender();
 
-      expect(svgElement.querySelectorAll('symbol')).to.have.lengthOf(3);
+      expect(svgElement.querySelectorAll('symbol')).to.have.lengthOf(2);
       expect(svgElement.querySelectorAll('#icon-cog')).to.exist;
       expect(svgElement.querySelector('use[href="#icon-cog"]')).to.exist;
     });


### PR DESCRIPTION
## Description

The new `symbol` property enables passing the symbol identifier separated from the src value, which enables defining icons based on sprites that are not only restricted to format `/path/to/file.svg#symbol-id`, but also if the src is defined as a data object (`data:image/svg+xml...`).

## Type of change

- [ ] Bugfix
- [X] Feature
