### PR TITLE
fix: validate on value change triggered by arrow key (#6476) (CP: 23.3)

### DIFF
--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -341,6 +341,7 @@ export class NumberField extends InputFieldMixin(ThemableMixin(ElementMixin(Poly
   /** @private */
   _setValue(value) {
     this.value = this.inputElement.value = String(parseFloat(value));
+    this.validate();
     this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
   }
 

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -42,17 +42,17 @@ describe('validation', () => {
     it('should validate before change event on ArrowDown', async () => {
       field.focus();
       await sendKeys({ press: 'ArrowDown' });
-      expect(validateSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledAfter(validateSpy);
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledAfter(validateSpy)).to.be.true;
     });
 
     it('should validate before change event on ArrowUp', async () => {
       field.focus();
       await sendKeys({ press: 'ArrowUp' });
-      expect(validateSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledOnce;
-      expect(changeSpy).to.be.calledAfter(validateSpy);
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledAfter(validateSpy)).to.be.true;
     });
 
     it('should be valid with numeric values', async () => {

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -10,7 +10,7 @@ describe('validation', () => {
   describe('basic', () => {
     let validateSpy, changeSpy;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
       input = field.inputElement;
       validateSpy = sinon.spy(field, 'validate');
@@ -55,7 +55,7 @@ describe('validation', () => {
       expect(changeSpy.calledAfter(validateSpy)).to.be.true;
     });
 
-    it('should be valid with numeric values', async () => {
+    it('should be valid with numeric values', () => {
       field.value = '1';
       expect(input.value).to.be.equal('1');
       expect(field.validate()).to.be.true;
@@ -117,7 +117,7 @@ describe('validation', () => {
       expect(field.validate(), 'value should not be greater than max').to.be.false;
     });
 
-    it('should dispatch change event after validation', async () => {
+    it('should dispatch change event after validation', () => {
       field.required = true;
       field.addEventListener('change', changeSpy);
       field.value = '123';

--- a/packages/number-field/test/validation.test.js
+++ b/packages/number-field/test/validation.test.js
@@ -8,9 +8,14 @@ describe('validation', () => {
   let field, input;
 
   describe('basic', () => {
-    beforeEach(() => {
+    let validateSpy, changeSpy;
+
+    beforeEach(async () => {
       field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
       input = field.inputElement;
+      validateSpy = sinon.spy(field, 'validate');
+      changeSpy = sinon.spy().named('changeSpy');
+      field.addEventListener('change', changeSpy);
     });
 
     it('should pass validation by default', () => {
@@ -34,7 +39,23 @@ describe('validation', () => {
       expect(field.invalid).to.be.false;
     });
 
-    it('should be valid with numeric values', () => {
+    it('should validate before change event on ArrowDown', async () => {
+      field.focus();
+      await sendKeys({ press: 'ArrowDown' });
+      expect(validateSpy).to.be.calledOnce;
+      expect(changeSpy).to.be.calledOnce;
+      expect(changeSpy).to.be.calledAfter(validateSpy);
+    });
+
+    it('should validate before change event on ArrowUp', async () => {
+      field.focus();
+      await sendKeys({ press: 'ArrowUp' });
+      expect(validateSpy).to.be.calledOnce;
+      expect(changeSpy).to.be.calledOnce;
+      expect(changeSpy).to.be.calledAfter(validateSpy);
+    });
+
+    it('should be valid with numeric values', async () => {
       field.value = '1';
       expect(input.value).to.be.equal('1');
       expect(field.validate()).to.be.true;
@@ -96,9 +117,7 @@ describe('validation', () => {
       expect(field.validate(), 'value should not be greater than max').to.be.false;
     });
 
-    it('should dispatch change event after validation', () => {
-      const validateSpy = sinon.spy(field, 'validate');
-      const changeSpy = sinon.spy();
+    it('should dispatch change event after validation', async () => {
       field.required = true;
       field.addEventListener('change', changeSpy);
       field.value = '123';


### PR DESCRIPTION
## Description

A cherry-pick of #6476 to `23.3`.

Fixes https://github.com/vaadin/web-components/issues/6430

## Type of change

- [x] Bugfix
