### PR TITLE
chore: fix ESLint errors for require-await rule in tests

### DIFF
--- a/packages/a11y-base/test/focus-utils.test.js
+++ b/packages/a11y-base/test/focus-utils.test.js
@@ -237,7 +237,7 @@ describe('focus-utils', () => {
         `);
       });
 
-      it('should handle document level elements', async () => {
+      it('should handle document level elements', () => {
         [...element.children].forEach((el) => {
           el.focus();
           expect(getDeepActiveElement()).to.eql(el);

--- a/packages/board/test/redraw.test.js
+++ b/packages/board/test/redraw.test.js
@@ -203,7 +203,7 @@ describe('redraw', () => {
       expect(first.className).to.equal('large');
     });
 
-    it('should not recalculate flex basis for a directly hidden row', async () => {
+    it('should not recalculate flex basis for a directly hidden row', () => {
       first.style.display = 'none';
       container.style.width = '100px';
       first._onResize();
@@ -211,7 +211,7 @@ describe('redraw', () => {
       expect(first.className).to.equal('large');
     });
 
-    it('should not recalculate flex basis for a row hidden through an ancestor', async () => {
+    it('should not recalculate flex basis for a row hidden through an ancestor', () => {
       container.style.display = 'none';
       container.style.width = '100px';
       first._onResize();

--- a/packages/combo-box/test/dirty-state.test.js
+++ b/packages/combo-box/test/dirty-state.test.js
@@ -16,7 +16,7 @@ describe('dirty state', () => {
     expect(comboBox.dirty).to.be.false;
   });
 
-  it('should not be dirty after programmatic value change', async () => {
+  it('should not be dirty after programmatic value change', () => {
     comboBox.value = 'Item 1';
     expect(comboBox.dirty).to.be.false;
   });
@@ -33,7 +33,7 @@ describe('dirty state', () => {
     expect(comboBox.dirty).to.be.false;
   });
 
-  it('should not be dirty after closing the dropdown without change', async () => {
+  it('should not be dirty after closing the dropdown without change', () => {
     comboBox.focus();
     comboBox.click();
     outsideClick();

--- a/packages/combo-box/test/lit.test.js
+++ b/packages/combo-box/test/lit.test.js
@@ -67,7 +67,7 @@ describe('lit', () => {
       selector = comboBox._scroller.shadowRoot.children.selector;
     });
 
-    it('should not show horizontal scrollbar when placed in slotted container', async () => {
+    it('should not show horizontal scrollbar when placed in slotted container', () => {
       comboBox.open();
 
       expect(getComputedStyle(selector).position).to.equal('relative');

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -383,7 +383,7 @@ describe('slot-controller', () => {
         expect(nodes[0]).to.equal(controller.defaultNode);
       });
 
-      it('should remove default node from nodes array when adding new element', async () => {
+      it('should remove default node from nodes array when adding new element', () => {
         const nodes = controller.nodes;
         expect(nodes).to.be.instanceOf(Array);
         expect(nodes.length).to.equal(1);

--- a/packages/custom-field/test/custom-field.common.js
+++ b/packages/custom-field/test/custom-field.common.js
@@ -160,17 +160,17 @@ describe('custom field', () => {
       expect(customField.dirty).to.be.false;
     });
 
-    it('should not be dirty after programmatic value change', async () => {
+    it('should not be dirty after programmatic value change', () => {
       customField.value = 'foo,1';
       expect(customField.dirty).to.be.false;
     });
 
-    it('should be dirty after sub-field input', async () => {
+    it('should be dirty after sub-field input', () => {
       fire(input, 'input');
       expect(customField.dirty).to.be.true;
     });
 
-    it('should be dirty after sub-field change', async () => {
+    it('should be dirty after sub-field change', () => {
       fire(input, 'change');
       expect(customField.dirty).to.be.true;
     });

--- a/packages/date-picker/test/dirty-state.test.js
+++ b/packages/date-picker/test/dirty-state.test.js
@@ -16,7 +16,7 @@ describe('dirty state', () => {
     expect(datePicker.dirty).to.be.false;
   });
 
-  it('should not be dirty after programmatic value change', async () => {
+  it('should not be dirty after programmatic value change', () => {
     datePicker.value = '2023-01-01';
     expect(datePicker.dirty).to.be.false;
   });

--- a/packages/date-time-picker/test/dirty-state.test.js
+++ b/packages/date-time-picker/test/dirty-state.test.js
@@ -31,7 +31,7 @@ describe('dirty state', () => {
         expect(dateTimePicker.dirty).to.be.false;
       });
 
-      it('should not be dirty after programmatic value change', async () => {
+      it('should not be dirty after programmatic value change', () => {
         dateTimePicker.value = '2023-01-01T00:00';
         expect(dateTimePicker.dirty).to.be.false;
       });

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -129,7 +129,7 @@ describe('checked-mixin', () => {
   });
 
   describe('dirty state', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       element = fixtureSync(`<checked-mixin-element></checked-mixin-element>`);
       input = element.querySelector('[slot=input]');
     });

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -854,7 +854,7 @@ const runTests = (defineHelper, baseMixin) => {
         input = element.querySelector('[slot=input]');
       });
 
-      it('should contain accessibleNameRef in aria-labelledby', async () => {
+      it('should contain accessibleNameRef in aria-labelledby', () => {
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
 

--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -94,7 +94,7 @@ describe('column groups', () => {
     describe('header', () => {
       let emptyGroup;
 
-      beforeEach(async () => {
+      beforeEach(() => {
         emptyGroup = grid.querySelector('vaadin-grid-column-group');
         emptyGroup.header = 'Header';
       });

--- a/packages/grid/test/column-rendering.test.js
+++ b/packages/grid/test/column-rendering.test.js
@@ -307,7 +307,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
         expectCellsDomOrderToMatchColumnOrder();
       });
 
-      it('should visually position the rendered cells correctly', async () => {
+      it('should visually position the rendered cells correctly', () => {
         expectCellsVisualOrderToMatchColumnOrder();
       });
 

--- a/packages/grid/test/hidden-grid.test.js
+++ b/packages/grid/test/hidden-grid.test.js
@@ -49,7 +49,7 @@ describe('hidden grid', () => {
       grid.dataProvider.resetHistory();
     });
 
-    it('should keep scroll position when hiding while triggering a scroll event', async () => {
+    it('should keep scroll position when hiding while triggering a scroll event', () => {
       // Scroll grid
       grid.$.table.scrollTop = 300;
       flushGrid(grid);

--- a/packages/grid/test/light-dom-observing.test.js
+++ b/packages/grid/test/light-dom-observing.test.js
@@ -422,7 +422,7 @@ describe('light dom observing', () => {
             await nextFrame();
           });
 
-          it('should provide initial state', async () => {
+          it('should provide initial state', () => {
             expect(getHeaderCellContent(grid, inGroup ? 2 : 1, 0).textContent).to.equal('first foo header');
             expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('first foo body foo0');
             expect(getFooterCellContent(grid, 0, 0).textContent).to.equal('first foo footer');

--- a/packages/icon/test/icon-font.test.js
+++ b/packages/icon/test/icon-font.test.js
@@ -65,7 +65,7 @@ describe('vaadin-icon - icon fonts', () => {
       expect(parseInt(fontIconStyle.height)).to.be.closeTo(100, 1);
     });
 
-    it('should not overflow host - line height', async () => {
+    it('should not overflow host - line height', () => {
       const fontIconStyle = getComputedStyle(icon, ':before');
       expect(parseInt(fontIconStyle.height)).to.be.closeTo(24, 1);
     });
@@ -268,15 +268,15 @@ describe('vaadin-icon - icon fonts', () => {
 
     let icon;
 
-    supportedIt('should support CQ width units on pseudo elements', async () => {
+    supportedIt('should support CQ width units on pseudo elements', () => {
       expect(supportsCQUnitsForPseudoElements()).to.be.true;
     });
 
-    supportedIt('should not need the fallback', async () => {
+    supportedIt('should not need the fallback', () => {
       expect(needsFontIconSizingFallback()).to.be.false;
     });
 
-    fallBackIt('should not support CQ width units on pseudo elements', async () => {
+    fallBackIt('should not support CQ width units on pseudo elements', () => {
       expect(supportsCQUnitsForPseudoElements()).to.be.false;
     });
 

--- a/packages/menu-bar/test/a11y.test.js
+++ b/packages/menu-bar/test/a11y.test.js
@@ -7,7 +7,7 @@ describe('a11y', () => {
   describe('focus restoration', () => {
     let menuBar, overlay, buttons;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       menuBar = fixtureSync(`<vaadin-menu-bar></vaadin-menu-bar>`);
       menuBar.items = [
         {

--- a/packages/multi-select-combo-box/test/dirty-state.test.js
+++ b/packages/multi-select-combo-box/test/dirty-state.test.js
@@ -16,7 +16,7 @@ describe('dirty state', () => {
     expect(comboBox.dirty).to.be.false;
   });
 
-  it('should not be dirty after programmatic value change', async () => {
+  it('should not be dirty after programmatic value change', () => {
     comboBox.value = ['Item 1'];
     expect(comboBox.dirty).to.be.false;
   });
@@ -33,7 +33,7 @@ describe('dirty state', () => {
     expect(comboBox.dirty).to.be.false;
   });
 
-  it('should not be dirty after closing the dropdown without change', async () => {
+  it('should not be dirty after closing the dropdown without change', () => {
     comboBox.focus();
     comboBox.click();
     outsideClick();

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -141,7 +141,7 @@ describe('selecting items', () => {
       expect(stopPropagationSpy.called).to.equal(!allowPropagation);
     };
 
-    beforeEach(async () => {
+    beforeEach(() => {
       comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
     });
 

--- a/packages/select/test/accessibility.common.js
+++ b/packages/select/test/accessibility.common.js
@@ -57,7 +57,7 @@ describe('accessibility', () => {
     expect(valueButton.getAttribute('aria-labelledby').split(' ')).to.have.members([select._itemId, labelId]);
   });
 
-  describe('accessible-name', async () => {
+  describe('accessible-name', () => {
     beforeEach(async () => {
       select = fixtureSync('<vaadin-select label="label"></vaadin-select>');
       await nextRender();
@@ -191,7 +191,7 @@ describe('accessibility', () => {
     });
   });
 
-  describe('accessible-name-ref', async () => {
+  describe('accessible-name-ref', () => {
     beforeEach(async () => {
       select = fixtureSync('<vaadin-select label="label"></vaadin-select>');
       await nextRender();

--- a/packages/select/test/dirty-state.common.js
+++ b/packages/select/test/dirty-state.common.js
@@ -32,7 +32,7 @@ describe('dirty state', () => {
     expect(select.dirty).to.be.false;
   });
 
-  it('should not be dirty after outside click without change', async () => {
+  it('should not be dirty after outside click without change', () => {
     select.focus();
     select.click();
     outsideClick();

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -82,7 +82,7 @@ describe('vaadin-select', () => {
       expect(listBox.parentNode).to.equal(select._overlayElement);
     });
 
-    it('should have position set to relative', async () => {
+    it('should have position set to relative', () => {
       expect(getComputedStyle(select).position).to.equal('relative');
     });
   });

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -286,7 +286,7 @@ describe('side-nav-item', () => {
       expect(anchor.getAttribute('href')).to.be.ok;
     });
 
-    it('should not trigger navigation when toggle button is clicked', async () => {
+    it('should not trigger navigation when toggle button is clicked', () => {
       const spy = sinon.spy();
       anchor.addEventListener('click', spy);
       toggle.click();

--- a/packages/tabs/test/scroll.test.js
+++ b/packages/tabs/test/scroll.test.js
@@ -80,7 +80,7 @@ describe('scrollable tabs', () => {
           await nextFrame();
         });
 
-        it('should have displayed all the items fully when scrolled forward to the end via button', async () => {
+        it('should have displayed all the items fully when scrolled forward to the end via button', () => {
           const forwardButton = tabs.shadowRoot.querySelector('[part="forward-button"]');
 
           expect(-tabs.__direction * tabs._scrollerElement.scrollLeft).to.equal(0);
@@ -92,7 +92,7 @@ describe('scrollable tabs', () => {
           expect(-tabs.__direction * tabs._scrollerElement.scrollLeft).to.be.approximately(537, 10);
         });
 
-        it('should have displayed all the items fully when scrolled back to the start via button', async () => {
+        it('should have displayed all the items fully when scrolled back to the start via button', () => {
           // Initially scroll to the end
           tabs._scrollToItem(items.length - 1);
 
@@ -107,7 +107,7 @@ describe('scrollable tabs', () => {
           expect(tabs._scrollerElement.scrollLeft).to.equal(0);
         });
 
-        it('should not get stuck with wide tabs when scrolled forward to the end via button', async () => {
+        it('should not get stuck with wide tabs when scrolled forward to the end via button', () => {
           tabs.style.width = '100px';
 
           const forwardButton = tabs.shadowRoot.querySelector('[part="forward-button"]');
@@ -125,7 +125,7 @@ describe('scrollable tabs', () => {
           expect(scrollerEndPosition).to.be.approximately(tabs._scrollerElement.scrollWidth, 1);
         });
 
-        it('should not get stuck with wide tabs when scrolled back to the start via button', async () => {
+        it('should not get stuck with wide tabs when scrolled back to the start via button', () => {
           tabs.style.width = '100px';
 
           // Initially scroll to the end

--- a/packages/time-picker/test/dirty-state.test.js
+++ b/packages/time-picker/test/dirty-state.test.js
@@ -21,7 +21,7 @@ describe('dirty state', () => {
     expect(timePicker.dirty).to.be.false;
   });
 
-  it('should not be dirty after outside click without change', async () => {
+  it('should not be dirty after outside click without change', () => {
     timePicker.focus();
     timePicker.click();
     outsideClick();

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -11,7 +11,7 @@ describe('events', () => {
   describe('has-input-value-changed event', () => {
     let clearButton, hasInputValueChangedSpy, valueChangedSpy;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       hasInputValueChangedSpy = sinon.spy();
       valueChangedSpy = sinon.spy();
       timePicker = fixtureSync('<vaadin-time-picker clear-button-visible></vaadin-time-picker>');
@@ -43,7 +43,7 @@ describe('events', () => {
         });
       });
 
-      describe('with bad user input', async () => {
+      describe('with bad user input', () => {
         beforeEach(async () => {
           await sendKeys({ type: 'foo' });
           hasInputValueChangedSpy.resetHistory();

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -238,7 +238,7 @@ describe('time-picker', () => {
     });
 
     // WebKit returns true for isTouch in the test envirnoment. This test fails when isTouch == true, which is a correct behavior
-    (isTouch ? it.skip : it)('should focus input element on toggle button click', async () => {
+    (isTouch ? it.skip : it)('should focus input element on toggle button click', () => {
       toggleButton.click();
       expect(comboBox.opened).to.be.true;
       expect(document.activeElement).to.equal(inputElement);

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -41,7 +41,7 @@ describe('timers', () => {
       await nextRender();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       resetGlobalTooltipState();
     });
 
@@ -71,7 +71,7 @@ describe('timers', () => {
       await nextRender();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       resetGlobalTooltipState();
     });
 
@@ -101,7 +101,7 @@ describe('timers', () => {
       await nextRender();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       resetGlobalTooltipState();
     });
 
@@ -438,7 +438,7 @@ describe('timers', () => {
       await nextRender();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       resetGlobalTooltipState();
     });
 


### PR DESCRIPTION
## Description

Fixed errors for `require-await` rule which is enabled in the latest version of `eslint-config-vaadin`.

## Type of change

- Internal change