### PR TITLE
fix: set correct ariaTarget for the checkbox tooltip

### DIFF
--- a/integration/tests/component-tooltip.test.js
+++ b/integration/tests/component-tooltip.test.js
@@ -27,7 +27,7 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
 
 [
   { tagName: Button.is },
-  { tagName: Checkbox.is },
+  { tagName: Checkbox.is, ariaTargetSelector: 'input' },
   { tagName: CheckboxGroup.is },
   {
     tagName: ComboBox.is,

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -70,6 +70,7 @@ export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolymerEl
     super.ready();
 
     this._tooltipController = new TooltipController(this);
+    this._tooltipController.setAriaTarget(this.inputElement);
     this.addController(this._tooltipController);
   }
 }

--- a/packages/checkbox/src/vaadin-lit-checkbox.js
+++ b/packages/checkbox/src/vaadin-lit-checkbox.js
@@ -46,6 +46,7 @@ export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMi
     super.ready();
 
     this._tooltipController = new TooltipController(this);
+    this._tooltipController.setAriaTarget(this.inputElement);
     this.addController(this._tooltipController);
   }
 }


### PR DESCRIPTION
## Description

Follow-up to #6321

The `vaadin-checkbox` component also uses `<input>` element, so `aria-describedby` should be set on it.

## Type of change

- Bugfix