### PR TITLE
fix: ensure correct event sequence on value commit in Lit version

### DIFF
--- a/packages/checkbox/test/checkbox.common.js
+++ b/packages/checkbox/test/checkbox.common.js
@@ -41,24 +41,29 @@ describe('checkbox', () => {
       expect(getComputedStyle(checkbox).display).to.equal('none');
     });
 
-    it('should toggle checked property on input click', () => {
+    it('should toggle checked property on input click', async () => {
       input.click();
+      await nextUpdate(checkbox);
       expect(checkbox.checked).to.be.true;
 
       input.click();
+      await nextUpdate(checkbox);
       expect(checkbox.checked).to.be.false;
     });
 
-    it('should toggle checked property on label click', () => {
+    it('should toggle checked property on label click', async () => {
       label.click();
+      await nextUpdate(checkbox);
       expect(checkbox.checked).to.be.true;
 
       label.click();
+      await nextUpdate(checkbox);
       expect(checkbox.checked).to.be.false;
     });
 
-    it('should not toggle checked property on label link click', () => {
+    it('should not toggle checked property on label link click', async () => {
       link.click();
+      await nextUpdate(checkbox);
       expect(checkbox.checked).to.be.false;
     });
 

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -51,6 +51,7 @@ export const InputMixin = dedupingMixin(
             value: '',
             observer: '_valueChanged',
             notify: true,
+            sync: true,
           },
 
           /**

--- a/packages/number-field/test/validation.common.js
+++ b/packages/number-field/test/validation.common.js
@@ -161,14 +161,6 @@ describe('validation', () => {
       expect(field.invalid).to.be.true;
     });
 
-    it('should set an empty value when trying to commit an invalid number', async () => {
-      field.value = '1';
-      await nextUpdate(field);
-      await sendKeys({ type: '1--' });
-      await sendKeys({ type: 'Enter' });
-      expect(field.value).to.equal('');
-    });
-
     it('should be valid after removing an invalid number', async () => {
       await sendKeys({ type: '1--' });
       input.blur();

--- a/packages/number-field/test/value-commit-lit.test.js
+++ b/packages/number-field/test/value-commit-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-number-field.js';
+import './value-commit.common.js';

--- a/packages/number-field/test/value-commit-polymer.test.js
+++ b/packages/number-field/test/value-commit-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-number-field.js';
+import './value-commit.common.js';

--- a/packages/number-field/test/value-commit.common.js
+++ b/packages/number-field/test/value-commit.common.js
@@ -1,8 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../src/vaadin-number-field.js';
 
 describe('value commit', () => {
   let numberField, valueChangedSpy, validateSpy, changeSpy;
@@ -155,15 +154,17 @@ describe('value commit', () => {
   });
 
   describe('value set programmatically', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       numberField.value = '1234';
+      await nextUpdate(numberField);
       valueChangedSpy.resetHistory();
       validateSpy.resetHistory();
     });
 
     describe('default', () => {
-      it('should not commit but validate on blur', () => {
+      it('should not commit but validate on blur', async () => {
         numberField.blur();
+        await nextUpdate(numberField);
         expectValidationOnly();
       });
 
@@ -216,13 +217,14 @@ describe('value commit', () => {
   });
 
   describe('with clear button', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       numberField.value = '1';
       numberField.clearButtonVisible = true;
+      await nextUpdate(numberField);
       valueChangedSpy.resetHistory();
     });
 
-    it('should clear on clear button click', () => {
+    it('should clear on clear button click', async () => {
       numberField.$.clearButton.click();
       expectValueCommit('');
     });

--- a/packages/number-field/test/value-commit.common.js
+++ b/packages/number-field/test/value-commit.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
@@ -154,17 +154,15 @@ describe('value commit', () => {
   });
 
   describe('value set programmatically', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       numberField.value = '1234';
-      await nextUpdate(numberField);
       valueChangedSpy.resetHistory();
       validateSpy.resetHistory();
     });
 
     describe('default', () => {
-      it('should not commit but validate on blur', async () => {
+      it('should not commit but validate on blur', () => {
         numberField.blur();
-        await nextUpdate(numberField);
         expectValidationOnly();
       });
 
@@ -217,14 +215,13 @@ describe('value commit', () => {
   });
 
   describe('with clear button', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       numberField.value = '1';
       numberField.clearButtonVisible = true;
-      await nextUpdate(numberField);
       valueChangedSpy.resetHistory();
     });
 
-    it('should clear on clear button click', async () => {
+    it('should clear on clear button click', () => {
       numberField.$.clearButton.click();
       expectValueCommit('');
     });

--- a/packages/number-field/test/value-commit.common.js
+++ b/packages/number-field/test/value-commit.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
@@ -43,18 +43,21 @@ describe('value commit', () => {
   });
 
   describe('default', () => {
-    it('should not commit but validate on blur', () => {
+    it('should not commit but validate on blur', async () => {
       numberField.blur();
+      await nextUpdate(numberField);
       expectValidationOnly();
     });
 
     it('should not commit on Enter', async () => {
       await sendKeys({ press: 'Enter' });
+      await nextUpdate(numberField);
       expectNoValueCommit();
     });
 
     it('should not commit on Escape', async () => {
       await sendKeys({ press: 'Escape' });
+      await nextUpdate(numberField);
       expectNoValueCommit();
     });
   });
@@ -62,15 +65,18 @@ describe('value commit', () => {
   describe('parsable input entered', () => {
     beforeEach(async () => {
       await sendKeys({ type: '1' });
+      await nextUpdate(numberField);
     });
 
-    it('should commit on blur', () => {
+    it('should commit on blur', async () => {
       numberField.blur();
+      await nextUpdate(numberField);
       expectValueCommit('1');
     });
 
     it('should commit on Enter', async () => {
       await sendKeys({ press: 'Enter' });
+      await nextUpdate(numberField);
       expectValueCommit('1');
     });
   });
@@ -79,6 +85,7 @@ describe('value commit', () => {
     beforeEach(async () => {
       await sendKeys({ type: '1' });
       await sendKeys({ press: 'Enter' });
+      await nextUpdate(numberField);
       changeSpy.resetHistory();
       valueChangedSpy.resetHistory();
       validateSpy.resetHistory();
@@ -88,15 +95,18 @@ describe('value commit', () => {
       beforeEach(async () => {
         numberField.inputElement.select();
         await sendKeys({ press: 'Backspace' });
+        await nextUpdate(numberField);
       });
 
-      it('should commit on blur', () => {
+      it('should commit on blur', async () => {
         numberField.blur();
+        await nextUpdate(numberField);
         expectValueCommit('');
       });
 
       it('should commit on Enter', async () => {
         await sendKeys({ press: 'Enter' });
+        await nextUpdate(numberField);
         expectValueCommit('');
       });
     });
@@ -105,14 +115,17 @@ describe('value commit', () => {
   describe('unparsable input entered', () => {
     beforeEach(async () => {
       await sendKeys({ type: '-' });
+      await nextUpdate(numberField);
     });
 
-    it('should not commit by default', () => {
+    it('should not commit by default', async () => {
+      await nextUpdate(numberField);
       expectNoValueCommit();
     });
 
-    it('should not commit but validate on blur', () => {
+    it('should not commit but validate on blur', async () => {
       numberField.blur();
+      await nextUpdate(numberField);
       expectValidationOnly();
       expect(numberField.inputElement.validity.badInput).to.be.true;
     });
@@ -120,6 +133,7 @@ describe('value commit', () => {
     // FIXME: https://github.com/vaadin/web-components/issues/5113
     it.skip('should not commit but validate on Enter', async () => {
       await sendKeys({ press: 'Enter' });
+      await nextUpdate(numberField);
       expectValidationOnly();
       expect(numberField.inputElement.validity.badInput).to.be.true;
     });
@@ -129,6 +143,7 @@ describe('value commit', () => {
     beforeEach(async () => {
       await sendKeys({ type: '-' });
       numberField.blur();
+      await nextUpdate(numberField);
       validateSpy.resetHistory();
     });
 
@@ -137,42 +152,49 @@ describe('value commit', () => {
         numberField.focus();
         numberField.inputElement.select();
         await sendKeys({ press: 'Backspace' });
+        await nextUpdate(numberField);
         validateSpy.resetHistory();
       });
 
-      it('should not commit but validate on blur', () => {
+      it('should not commit but validate on blur', async () => {
         numberField.blur();
+        await nextUpdate(numberField);
         expectValidationOnly();
       });
 
       // FIXME: https://github.com/vaadin/web-components/issues/5113
       it.skip('should not commit but validate on Enter', async () => {
         await sendKeys({ press: 'Enter' });
+        await nextUpdate(numberField);
         expectValidationOnly();
       });
     });
   });
 
   describe('value set programmatically', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       numberField.value = '1234';
+      await nextUpdate(numberField);
       valueChangedSpy.resetHistory();
       validateSpy.resetHistory();
     });
 
     describe('default', () => {
-      it('should not commit but validate on blur', () => {
+      it('should not commit but validate on blur', async () => {
         numberField.blur();
+        await nextUpdate(numberField);
         expectValidationOnly();
       });
 
       it('should not commit on Enter', async () => {
         await sendKeys({ press: 'Enter' });
+        await nextUpdate(numberField);
         expectNoValueCommit();
       });
 
       it('should not commit on Escape', async () => {
         await sendKeys({ press: 'Escape' });
+        await nextUpdate(numberField);
         expectNoValueCommit();
       });
     });
@@ -181,15 +203,18 @@ describe('value commit', () => {
       beforeEach(async () => {
         numberField.inputElement.select();
         await sendKeys({ type: '1' });
+        await nextUpdate(numberField);
       });
 
-      it('should commit on blur', () => {
+      it('should commit on blur', async () => {
         numberField.blur();
+        await nextUpdate(numberField);
         expectValueCommit('1');
       });
 
       it('should commit on Enter', async () => {
         await sendKeys({ press: 'Enter' });
+        await nextUpdate(numberField);
         expectValueCommit('1');
       });
     });
@@ -198,16 +223,19 @@ describe('value commit', () => {
       beforeEach(async () => {
         numberField.inputElement.select();
         await sendKeys({ type: '-' });
+        await nextUpdate(numberField);
       });
 
-      it('should commit an empty value on blur', () => {
+      it('should commit an empty value on blur', async () => {
         numberField.blur();
+        await nextUpdate(numberField);
         expectValueCommit('');
         expect(numberField.inputElement.validity.badInput).to.be.true;
       });
 
       it('should commit an empty value on Enter', async () => {
         await sendKeys({ press: 'Enter' });
+        await nextUpdate(numberField);
         expectValueCommit('');
         expect(numberField.inputElement.validity.badInput).to.be.true;
       });
@@ -215,19 +243,22 @@ describe('value commit', () => {
   });
 
   describe('with clear button', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       numberField.value = '1';
       numberField.clearButtonVisible = true;
+      await nextUpdate(numberField);
       valueChangedSpy.resetHistory();
     });
 
-    it('should clear on clear button click', () => {
+    it('should clear on clear button click', async () => {
       numberField.$.clearButton.click();
+      await nextUpdate(numberField);
       expectValueCommit('');
     });
 
     it('should clear on Escape', async () => {
       await sendKeys({ press: 'Escape' });
+      await nextUpdate(numberField);
       expectValueCommit('');
     });
   });
@@ -235,29 +266,34 @@ describe('value commit', () => {
   describe('keyboard stepping', () => {
     it('should commit on ArrowUp', async () => {
       await sendKeys({ press: 'ArrowUp' });
+      await nextUpdate(numberField);
       expectValueCommit('1');
     });
 
     it('should commit on ArrowDown', async () => {
       await sendKeys({ press: 'ArrowDown' });
+      await nextUpdate(numberField);
       expectValueCommit('-1');
     });
 
     describe('arrow key committed', () => {
       beforeEach(async () => {
         await sendKeys({ press: 'ArrowUp' });
+        await nextUpdate(numberField);
         valueChangedSpy.resetHistory();
         validateSpy.resetHistory();
         changeSpy.resetHistory();
       });
 
-      it('should not commit but validate on blur', () => {
+      it('should not commit but validate on blur', async () => {
         numberField.blur();
+        await nextUpdate(numberField);
         expectValidationOnly();
       });
 
       it('should not commit on Enter', async () => {
         await sendKeys({ press: 'Enter' });
+        await nextUpdate(numberField);
         expectNoValueCommit();
       });
     });
@@ -271,31 +307,36 @@ describe('value commit', () => {
       decreaseButton = numberField.shadowRoot.querySelector('[part=decrease-button]');
     });
 
-    it('should commit on increase button click', () => {
+    it('should commit on increase button click', async () => {
       increaseButton.click();
+      await nextUpdate(numberField);
       expectValueCommit('1');
     });
 
-    it('should commit on decrease button click', () => {
+    it('should commit on decrease button click', async () => {
       decreaseButton.click();
+      await nextUpdate(numberField);
       expectValueCommit('-1');
     });
 
     describe('click committed', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         increaseButton.click();
+        await nextUpdate(numberField);
         valueChangedSpy.resetHistory();
         validateSpy.resetHistory();
         changeSpy.resetHistory();
       });
 
-      it('should not commit but validate on blur', () => {
+      it('should not commit but validate on blur', async () => {
         numberField.blur();
+        await nextUpdate(numberField);
         expectValidationOnly();
       });
 
       it('should not commit on Enter', async () => {
         await sendKeys({ press: 'Enter' });
+        await nextUpdate(numberField);
         expectNoValueCommit();
       });
     });


### PR DESCRIPTION
## Description

The PR ensures that the Lit version of `number-field` dispatches events in the same sequences as the Polymer version when committing a value:

1. `value-changed`
2. `validated`
3. `change`

Follow-up to https://github.com/vaadin/web-components/pull/6429

## Type of change

- [x] Bugfix
